### PR TITLE
feat: make agent release poll interval configurable

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -732,7 +732,12 @@ func parseFlags() *Config {
 		cfg.DisableAutoUpdate = true
 	}
 	if v := os.Getenv("CONTROL_AUTO_UPDATE_POLL_INTERVAL"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil && d >= 1*time.Minute {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			slog.Warn("invalid CONTROL_AUTO_UPDATE_POLL_INTERVAL, using default", "value", v, "error", err)
+		} else if d < 1*time.Minute {
+			slog.Warn("CONTROL_AUTO_UPDATE_POLL_INTERVAL too short (min 1m), using default", "value", v)
+		} else {
 			cfg.AutoUpdatePollInterval = d
 		}
 	}

--- a/internal/agentrelease/cache.go
+++ b/internal/agentrelease/cache.go
@@ -63,9 +63,12 @@ func WithHTTPClient(client *http.Client) Option {
 }
 
 // WithPollInterval overrides the default poll interval.
+// Non-positive values are ignored to prevent ticker panics.
 func WithPollInterval(d time.Duration) Option {
 	return func(c *Cache) {
-		c.pollInterval = d
+		if d > 0 {
+			c.pollInterval = d
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `CONTROL_AUTO_UPDATE_POLL_INTERVAL` env var (default: `1h`, minimum: `1m`)
- Add `WithPollInterval` option to `agentrelease.Cache`
- Change default from 5 minutes to 1 hour
- Log the configured interval on startup

Fixes #17

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-update polling interval is now configurable (default changed to 1 hour) so update checks run on a customizable schedule.
  * Users can set the interval via an environment variable; invalid or too-short values (<1 minute) are ignored and a warning is emitted.

* **Bug Fixes**
  * Startup logs now report the effective polling interval for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->