### PR TITLE
fix: manual agent update trigger bypasses auto-update settings check

### DIFF
--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -240,14 +240,16 @@ func (h *InternalHandler) GetAutoUpdateInfo(ctx context.Context, req *connect.Re
 		return connect.NewResponse(&pm.GetAutoUpdateInfoResponse{}), nil
 	}
 
-	// Check if auto-update is enabled in server settings.
-	settings, err := h.store.Queries().GetServerSettings(ctx)
-	if err != nil {
-		h.logger.Warn("failed to read server settings for auto-update check", "error", err)
-		return connect.NewResponse(&pm.GetAutoUpdateInfoResponse{}), nil
-	}
-	if !settings.AutoUpdateAgents {
-		return connect.NewResponse(&pm.GetAutoUpdateInfoResponse{}), nil
+	// Check if auto-update is enabled in server settings (skip when force=true for manual triggers).
+	if !req.Msg.Force {
+		settings, err := h.store.Queries().GetServerSettings(ctx)
+		if err != nil {
+			h.logger.Warn("failed to read server settings for auto-update check", "error", err)
+			return connect.NewResponse(&pm.GetAutoUpdateInfoResponse{}), nil
+		}
+		if !settings.AutoUpdateAgents {
+			return connect.NewResponse(&pm.GetAutoUpdateInfoResponse{}), nil
+		}
 	}
 
 	arch := req.Msg.AgentArch

--- a/internal/gateway/task_handlers.go
+++ b/internal/gateway/task_handlers.go
@@ -19,7 +19,7 @@ import (
 
 // UpdateInfoProvider fetches auto-update info from the control server.
 type UpdateInfoProvider interface {
-	GetAutoUpdateInfo(ctx context.Context, agentArch string) (*pm.GetAutoUpdateInfoResponse, error)
+	GetAutoUpdateInfo(ctx context.Context, agentArch string, force bool) (*pm.GetAutoUpdateInfoResponse, error)
 }
 
 // TaskHandlerFactory creates per-device Asynq ServeMux instances.
@@ -214,7 +214,7 @@ func (h *deviceTaskHandler) handleLogQueryDispatch(_ context.Context, t *asynq.T
 
 func (h *deviceTaskHandler) handleTriggerUpdate(ctx context.Context, _ *asynq.Task) error {
 	// Fetch latest update info from control server.
-	updateInfo, err := h.updateProvider.GetAutoUpdateInfo(ctx, "amd64")
+	updateInfo, err := h.updateProvider.GetAutoUpdateInfo(ctx, "amd64", true)
 	if err != nil {
 		return fmt.Errorf("get auto-update info: %w", err)
 	}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -216,7 +216,7 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 	if arch == "" {
 		arch = "amd64"
 	}
-	updateInfo, err := h.controlProxy.GetAutoUpdateInfo(ctx, arch)
+	updateInfo, err := h.controlProxy.GetAutoUpdateInfo(ctx, arch, false)
 	if err != nil {
 		h.logger.Warn("failed to get auto-update info", "device_id", deviceID, "error", err)
 	} else if updateInfo.LatestAgentVersion != "" && updateInfo.LatestAgentVersion != hello.AgentVersion {

--- a/internal/handler/control_proxy.go
+++ b/internal/handler/control_proxy.go
@@ -82,9 +82,11 @@ func (p *ControlProxy) StoreLuksKey(ctx context.Context, deviceID, actionID, dev
 }
 
 // GetAutoUpdateInfo returns the latest agent release info for the given architecture.
-func (p *ControlProxy) GetAutoUpdateInfo(ctx context.Context, agentArch string) (*pm.GetAutoUpdateInfoResponse, error) {
+// When force is true, the server skips the auto_update_agents settings check.
+func (p *ControlProxy) GetAutoUpdateInfo(ctx context.Context, agentArch string, force bool) (*pm.GetAutoUpdateInfoResponse, error) {
 	resp, err := p.client.GetAutoUpdateInfo(ctx, connect.NewRequest(&pm.GetAutoUpdateInfoRequest{
 		AgentArch: agentArch,
+		Force:     force,
 	}))
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Manual `TriggerAgentUpdate` from the UI now works even when the global auto-update toggle is disabled. The gateway passes `force=true` to `GetAutoUpdateInfo`, which skips the `auto_update_agents` settings check.

Automatic Welcome-based updates still respect the setting.

Requires manchtools/power-manage-sdk#6

Fixes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Triggered update operations can now force retrieval of update information, allowing manual triggers to bypass server auto-update restrictions.
* **Bug Fixes / Behavior**
  * Regular agent connections continue to respect server auto-update settings; forced retrieval applies only when explicitly requested (e.g., manual trigger).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->