### PR TITLE
refactor: server code simplification and maintainability (round 2)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -688,8 +688,12 @@ func envString(target *string, key string) {
 }
 
 // envBool sets target based on the environment variable matching true or false values.
+// Logs a warning if the value is set but doesn't match any recognized value.
 func envBool(target *bool, key string, trueValues, falseValues []string) {
 	v := os.Getenv(key)
+	if v == "" {
+		return
+	}
 	for _, tv := range trueValues {
 		if v == tv {
 			*target = true
@@ -702,6 +706,7 @@ func envBool(target *bool, key string, trueValues, falseValues []string) {
 			return
 		}
 	}
+	slog.Warn("unrecognized boolean env var value, keeping default", "key", key, "value", v)
 }
 
 // envDuration overrides target with the parsed duration if the environment variable is set.

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -146,7 +146,7 @@ func main() {
 		if err := st.Queries().CleanupExpiredRevocations(ctx); err != nil {
 			logger.Error("failed to cleanup expired token revocations", "error", err)
 		}
-	})
+	}, false)
 
 	// Start periodic evaluation of queued dynamic groups.
 	// evaluateDynamicGroups drains the queue in batches of 1000 until empty.
@@ -210,7 +210,7 @@ func main() {
 			} else {
 				logger.Info("queued full dynamic group re-evaluation")
 			}
-		})
+		}, false)
 	} else {
 		logger.Info("dynamic group evaluation worker disabled")
 	}
@@ -256,7 +256,7 @@ func main() {
 		if err := st.Queries().DeleteOldOSQueryResults(ctx); err != nil {
 			logger.Error("failed to cleanup old osquery results", "error", err)
 		}
-	})
+	}, false)
 
 	// Initialize secret encryptor
 	encryptor, err := crypto.NewEncryptor(os.Getenv("PM_ENCRYPTION_KEY"))
@@ -570,7 +570,7 @@ func parseFlags() *Config {
 	envString(&cfg.CACertPath, "CONTROL_CA_CERT")
 	envString(&cfg.CAKeyPath, "CONTROL_CA_KEY")
 	envString(&cfg.CATrustBundlePath, "CONTROL_CA_TRUST_BUNDLE")
-	envBool(&cfg.TLSEnabled, "CONTROL_TLS_ENABLED", "true", "1")
+	envBool(&cfg.TLSEnabled, "CONTROL_TLS_ENABLED", []string{"true", "1"}, nil)
 	envString(&cfg.TLSCert, "CONTROL_TLS_CERT")
 	envString(&cfg.TLSKey, "CONTROL_TLS_KEY")
 	envString(&cfg.InternalListenAddr, "CONTROL_INTERNAL_LISTEN_ADDR")
@@ -586,9 +586,7 @@ func parseFlags() *Config {
 
 	// SSO / Identity Provider configuration
 	cfg.PasswordAuthEnabled = true // default enabled
-	if v := os.Getenv("CONTROL_PASSWORD_AUTH_ENABLED"); v == "false" || v == "0" {
-		cfg.PasswordAuthEnabled = false
-	}
+	envBool(&cfg.PasswordAuthEnabled, "CONTROL_PASSWORD_AUTH_ENABLED", nil, []string{"false", "0"})
 	envString(&cfg.SSOCallbackBaseURL, "CONTROL_SSO_CALLBACK_BASE_URL")
 	if cfg.SSOCallbackBaseURL == "" && len(cfg.CORSOrigins) > 0 {
 		cfg.SSOCallbackBaseURL = cfg.CORSOrigins[0]
@@ -689,12 +687,18 @@ func envString(target *string, key string) {
 	}
 }
 
-// envBool sets target to true if the environment variable matches any of the given values.
-func envBool(target *bool, key string, trueValues ...string) {
+// envBool sets target based on the environment variable matching true or false values.
+func envBool(target *bool, key string, trueValues, falseValues []string) {
 	v := os.Getenv(key)
 	for _, tv := range trueValues {
 		if v == tv {
 			*target = true
+			return
+		}
+	}
+	for _, fv := range falseValues {
+		if v == fv {
+			*target = false
 			return
 		}
 	}
@@ -703,34 +707,49 @@ func envBool(target *bool, key string, trueValues ...string) {
 // envDuration overrides target with the parsed duration if the environment variable is set.
 func envDuration(target *time.Duration, key string) {
 	if v := os.Getenv(key); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			*target = d
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			slog.Warn("invalid duration for env var, keeping default", "key", key, "value", v, "error", err)
+			return
 		}
+		*target = d
 	}
 }
 
-// envCSV overrides target with a comma-separated environment variable, trimming whitespace.
+// envCSV overrides target with a comma-separated environment variable, trimming whitespace
+// and filtering empty entries.
 func envCSV(target *[]string, key string) {
 	if v := os.Getenv(key); v != "" {
 		parts := strings.Split(v, ",")
-		for i := range parts {
-			parts[i] = strings.TrimSpace(parts[i])
+		var filtered []string
+		for _, p := range parts {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				filtered = append(filtered, p)
+			}
 		}
-		*target = parts
+		*target = filtered
 	}
 }
 
 // envInt overrides target with the parsed integer if the environment variable is set.
 func envInt(target *int, key string) {
 	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			*target = n
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			slog.Warn("invalid integer for env var, keeping default", "key", key, "value", v, "error", err)
+			return
 		}
+		*target = n
 	}
 }
 
 // runPeriodic calls fn on every tick until ctx is cancelled.
-func runPeriodic(ctx context.Context, interval time.Duration, fn func()) {
+// If runImmediately is true, fn is called once before the first tick.
+func runPeriodic(ctx context.Context, interval time.Duration, fn func(), runImmediately bool) {
+	if runImmediately {
+		fn()
+	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 	for {

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -142,20 +142,11 @@ func main() {
 	})
 
 	// Start periodic cleanup of expired revoked tokens
-	go func() {
-		ticker := time.NewTicker(1 * time.Hour)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				if err := st.Queries().CleanupExpiredRevocations(ctx); err != nil {
-					logger.Error("failed to cleanup expired token revocations", "error", err)
-				}
-			case <-ctx.Done():
-				return
-			}
+	go runPeriodic(ctx, 1*time.Hour, func() {
+		if err := st.Queries().CleanupExpiredRevocations(ctx); err != nil {
+			logger.Error("failed to cleanup expired token revocations", "error", err)
 		}
-	}()
+	})
 
 	// Start periodic evaluation of queued dynamic groups.
 	// evaluateDynamicGroups drains the queue in batches of 1000 until empty.
@@ -213,22 +204,13 @@ func main() {
 
 		// Periodic full re-evaluation as a safety net (every 24h).
 		// Queues all dynamic groups for evaluation; the worker above drains them.
-		go func() {
-			ticker := time.NewTicker(24 * time.Hour)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					if err := st.Queries().QueueAllDynamicGroups(ctx); err != nil {
-						logger.Error("failed to queue full dynamic group re-evaluation", "error", err)
-					} else {
-						logger.Info("queued full dynamic group re-evaluation")
-					}
-				case <-ctx.Done():
-					return
-				}
+		go runPeriodic(ctx, 24*time.Hour, func() {
+			if err := st.Queries().QueueAllDynamicGroups(ctx); err != nil {
+				logger.Error("failed to queue full dynamic group re-evaluation", "error", err)
+			} else {
+				logger.Info("queued full dynamic group re-evaluation")
 			}
-		}()
+		})
 	} else {
 		logger.Info("dynamic group evaluation worker disabled")
 	}
@@ -270,20 +252,11 @@ func main() {
 	}()
 
 	// Start periodic cleanup of stale OSQuery results
-	go func() {
-		ticker := time.NewTicker(5 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				if err := st.Queries().DeleteOldOSQueryResults(ctx); err != nil {
-					logger.Error("failed to cleanup old osquery results", "error", err)
-				}
-			case <-ctx.Done():
-				return
-			}
+	go runPeriodic(ctx, 5*time.Minute, func() {
+		if err := st.Queries().DeleteOldOSQueryResults(ctx); err != nil {
+			logger.Error("failed to cleanup old osquery results", "error", err)
 		}
-	}()
+	})
 
 	// Initialize secret encryptor
 	encryptor, err := crypto.NewEncryptor(os.Getenv("PM_ENCRYPTION_KEY"))
@@ -821,6 +794,20 @@ func corsMiddleware(allowedOrigins []string, logger *slog.Logger) func(http.Hand
 
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+// runPeriodic calls fn on every tick until ctx is cancelled.
+func runPeriodic(ctx context.Context, interval time.Duration, fn func()) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			fn()
+		case <-ctx.Done():
+			return
+		}
 	}
 }
 

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -422,7 +422,8 @@ func main() {
 	mux.Handle("/scim/v2/", scimHandler)
 
 	// Wrap with CORS and security headers middleware
-	corsHandler := middleware.CORS(cfg.CORSOrigins, logger)(mux)
+	corsAllowAll := os.Getenv("CONTROL_CORS_ALLOW_ALL") == "true"
+	corsHandler := middleware.CORS(cfg.CORSOrigins, corsAllowAll, logger)(mux)
 	securedHandler := middleware.RequestID(middleware.SecurityHeaders(corsHandler))
 
 	server := &http.Server{
@@ -570,7 +571,7 @@ func parseFlags() *Config {
 	envString(&cfg.CACertPath, "CONTROL_CA_CERT")
 	envString(&cfg.CAKeyPath, "CONTROL_CA_KEY")
 	envString(&cfg.CATrustBundlePath, "CONTROL_CA_TRUST_BUNDLE")
-	envBool(&cfg.TLSEnabled, "CONTROL_TLS_ENABLED", []string{"true", "1"}, nil)
+	envBool(&cfg.TLSEnabled, "CONTROL_TLS_ENABLED", []string{"true", "1"}, []string{"false", "0"})
 	envString(&cfg.TLSCert, "CONTROL_TLS_CERT")
 	envString(&cfg.TLSKey, "CONTROL_TLS_KEY")
 	envString(&cfg.InternalListenAddr, "CONTROL_INTERNAL_LISTEN_ADDR")
@@ -586,7 +587,7 @@ func parseFlags() *Config {
 
 	// SSO / Identity Provider configuration
 	cfg.PasswordAuthEnabled = true // default enabled
-	envBool(&cfg.PasswordAuthEnabled, "CONTROL_PASSWORD_AUTH_ENABLED", nil, []string{"false", "0"})
+	envBool(&cfg.PasswordAuthEnabled, "CONTROL_PASSWORD_AUTH_ENABLED", []string{"true", "1"}, []string{"false", "0"})
 	envString(&cfg.SSOCallbackBaseURL, "CONTROL_SSO_CALLBACK_BASE_URL")
 	if cfg.SSOCallbackBaseURL == "" && len(cfg.CORSOrigins) > 0 {
 		cfg.SSOCallbackBaseURL = cfg.CORSOrigins[0]

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -564,104 +564,42 @@ func parseFlags() *Config {
 	flag.Parse()
 
 	// Environment variable overrides
-	if v := os.Getenv("CONTROL_LISTEN_ADDR"); v != "" {
-		cfg.ListenAddr = v
-	}
-	if v := os.Getenv("CONTROL_DATABASE_URL"); v != "" {
-		cfg.DatabaseURL = v
-	}
-	if v := os.Getenv("CONTROL_JWT_SECRET"); v != "" {
-		cfg.JWTSecret = v
-	}
-	if v := os.Getenv("CONTROL_CA_CERT"); v != "" {
-		cfg.CACertPath = v
-	}
-	if v := os.Getenv("CONTROL_CA_KEY"); v != "" {
-		cfg.CAKeyPath = v
-	}
-	if v := os.Getenv("CONTROL_CA_TRUST_BUNDLE"); v != "" {
-		cfg.CATrustBundlePath = v
-	}
-	if v := os.Getenv("CONTROL_TLS_ENABLED"); v == "true" || v == "1" {
-		cfg.TLSEnabled = true
-	}
-	if v := os.Getenv("CONTROL_TLS_CERT"); v != "" {
-		cfg.TLSCert = v
-	}
-	if v := os.Getenv("CONTROL_TLS_KEY"); v != "" {
-		cfg.TLSKey = v
-	}
-	if v := os.Getenv("CONTROL_INTERNAL_LISTEN_ADDR"); v != "" {
-		cfg.InternalListenAddr = v
-	}
-	if v := os.Getenv("CONTROL_INTERNAL_TLS_CERT"); v != "" {
-		cfg.InternalTLSCert = v
-	}
-	if v := os.Getenv("CONTROL_INTERNAL_TLS_KEY"); v != "" {
-		cfg.InternalTLSKey = v
-	}
-	if v := os.Getenv("CONTROL_ADMIN_EMAIL"); v != "" {
-		cfg.AdminEmail = v
-	}
-	if v := os.Getenv("CONTROL_ADMIN_PASSWORD"); v != "" {
-		cfg.AdminPassword = v
-	}
-	if v := os.Getenv("CONTROL_LOG_LEVEL"); v != "" {
-		cfg.LogLevel = v
-	}
-	if v := os.Getenv("CONTROL_LOG_FORMAT"); v != "" {
-		cfg.LogFormat = v
-	}
-	if v := os.Getenv("CONTROL_GATEWAY_URL"); v != "" {
-		cfg.GatewayURL = v
-	}
-	if v := os.Getenv("CONTROL_CORS_ORIGINS"); v != "" {
-		origins := strings.Split(v, ",")
-		for i := range origins {
-			origins[i] = strings.TrimSpace(origins[i])
-		}
-		cfg.CORSOrigins = origins
-	}
-	if v := os.Getenv("CONTROL_DYNAMIC_GROUP_EVAL_INTERVAL"); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			cfg.DynamicGroupEvalInterval = d
-		}
-	}
+	envString(&cfg.ListenAddr, "CONTROL_LISTEN_ADDR")
+	envString(&cfg.DatabaseURL, "CONTROL_DATABASE_URL")
+	envString(&cfg.JWTSecret, "CONTROL_JWT_SECRET")
+	envString(&cfg.CACertPath, "CONTROL_CA_CERT")
+	envString(&cfg.CAKeyPath, "CONTROL_CA_KEY")
+	envString(&cfg.CATrustBundlePath, "CONTROL_CA_TRUST_BUNDLE")
+	envBool(&cfg.TLSEnabled, "CONTROL_TLS_ENABLED", "true", "1")
+	envString(&cfg.TLSCert, "CONTROL_TLS_CERT")
+	envString(&cfg.TLSKey, "CONTROL_TLS_KEY")
+	envString(&cfg.InternalListenAddr, "CONTROL_INTERNAL_LISTEN_ADDR")
+	envString(&cfg.InternalTLSCert, "CONTROL_INTERNAL_TLS_CERT")
+	envString(&cfg.InternalTLSKey, "CONTROL_INTERNAL_TLS_KEY")
+	envString(&cfg.AdminEmail, "CONTROL_ADMIN_EMAIL")
+	envString(&cfg.AdminPassword, "CONTROL_ADMIN_PASSWORD")
+	envString(&cfg.LogLevel, "CONTROL_LOG_LEVEL")
+	envString(&cfg.LogFormat, "CONTROL_LOG_FORMAT")
+	envString(&cfg.GatewayURL, "CONTROL_GATEWAY_URL")
+	envCSV(&cfg.CORSOrigins, "CONTROL_CORS_ORIGINS")
+	envDuration(&cfg.DynamicGroupEvalInterval, "CONTROL_DYNAMIC_GROUP_EVAL_INTERVAL")
 
 	// SSO / Identity Provider configuration
 	cfg.PasswordAuthEnabled = true // default enabled
 	if v := os.Getenv("CONTROL_PASSWORD_AUTH_ENABLED"); v == "false" || v == "0" {
 		cfg.PasswordAuthEnabled = false
 	}
-	if v := os.Getenv("CONTROL_SSO_CALLBACK_BASE_URL"); v != "" {
-		cfg.SSOCallbackBaseURL = v
-	} else if len(cfg.CORSOrigins) > 0 {
-		// Derive from first CORS origin
+	envString(&cfg.SSOCallbackBaseURL, "CONTROL_SSO_CALLBACK_BASE_URL")
+	if cfg.SSOCallbackBaseURL == "" && len(cfg.CORSOrigins) > 0 {
 		cfg.SSOCallbackBaseURL = cfg.CORSOrigins[0]
 	}
-	if v := os.Getenv("CONTROL_SCIM_BASE_URL"); v != "" {
-		cfg.SCIMBaseURL = v
-	}
-	if v := os.Getenv("CONTROL_TRUSTED_PROXIES"); v != "" {
-		proxies := strings.Split(v, ",")
-		for i := range proxies {
-			proxies[i] = strings.TrimSpace(proxies[i])
-		}
-		cfg.TrustedProxies = proxies
-	}
+	envString(&cfg.SCIMBaseURL, "CONTROL_SCIM_BASE_URL")
+	envCSV(&cfg.TrustedProxies, "CONTROL_TRUSTED_PROXIES")
 
 	// Valkey (Asynq task queue) configuration
-	if v := os.Getenv("CONTROL_VALKEY_ADDR"); v != "" {
-		cfg.ValkeyAddr = v
-	}
-	if v := os.Getenv("CONTROL_VALKEY_PASSWORD"); v != "" {
-		cfg.ValkeyPassword = v
-	}
-	if v := os.Getenv("CONTROL_VALKEY_DB"); v != "" {
-		if db, err := strconv.Atoi(v); err == nil {
-			cfg.ValkeyDB = db
-		}
-	}
+	envString(&cfg.ValkeyAddr, "CONTROL_VALKEY_ADDR")
+	envString(&cfg.ValkeyPassword, "CONTROL_VALKEY_PASSWORD")
+	envInt(&cfg.ValkeyDB, "CONTROL_VALKEY_DB")
 
 	// Validate dynamic group evaluation interval (0 to disable, min 30m, max 8h)
 	if cfg.DynamicGroupEvalInterval != 0 {
@@ -794,6 +732,53 @@ func corsMiddleware(allowedOrigins []string, logger *slog.Logger) func(http.Hand
 
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+// envString overrides target with the environment variable value if set.
+func envString(target *string, key string) {
+	if v := os.Getenv(key); v != "" {
+		*target = v
+	}
+}
+
+// envBool sets target to true if the environment variable matches any of the given values.
+func envBool(target *bool, key string, trueValues ...string) {
+	v := os.Getenv(key)
+	for _, tv := range trueValues {
+		if v == tv {
+			*target = true
+			return
+		}
+	}
+}
+
+// envDuration overrides target with the parsed duration if the environment variable is set.
+func envDuration(target *time.Duration, key string) {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			*target = d
+		}
+	}
+}
+
+// envCSV overrides target with a comma-separated environment variable, trimming whitespace.
+func envCSV(target *[]string, key string) {
+	if v := os.Getenv(key); v != "" {
+		parts := strings.Split(v, ",")
+		for i := range parts {
+			parts[i] = strings.TrimSpace(parts[i])
+		}
+		*target = parts
+	}
+}
+
+// envInt overrides target with the parsed integer if the environment variable is set.
+func envInt(target *int, key string) {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			*target = n
+		}
 	}
 }
 

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -70,6 +70,9 @@ type Config struct {
 	InternalTLSCert    string
 	InternalTLSKey     string
 
+	// CORS
+	CORSAllowAll bool // Allow all origins (development only)
+
 	// Valkey (Asynq task queue)
 	ValkeyAddr     string
 	ValkeyPassword string
@@ -422,8 +425,7 @@ func main() {
 	mux.Handle("/scim/v2/", scimHandler)
 
 	// Wrap with CORS and security headers middleware
-	corsAllowAll := os.Getenv("CONTROL_CORS_ALLOW_ALL") == "true"
-	corsHandler := middleware.CORS(cfg.CORSOrigins, corsAllowAll, logger)(mux)
+	corsHandler := middleware.CORS(cfg.CORSOrigins, cfg.CORSAllowAll, logger)(mux)
 	securedHandler := middleware.RequestID(middleware.SecurityHeaders(corsHandler))
 
 	server := &http.Server{
@@ -594,6 +596,7 @@ func parseFlags() *Config {
 	}
 	envString(&cfg.SCIMBaseURL, "CONTROL_SCIM_BASE_URL")
 	envCSV(&cfg.TrustedProxies, "CONTROL_TRUSTED_PROXIES")
+	envBool(&cfg.CORSAllowAll, "CONTROL_CORS_ALLOW_ALL", []string{"true", "1"}, []string{"false", "0"})
 
 	// Valkey (Asynq task queue) configuration
 	envString(&cfg.ValkeyAddr, "CONTROL_VALKEY_ADDR")

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -422,7 +422,7 @@ func main() {
 	mux.Handle("/scim/v2/", scimHandler)
 
 	// Wrap with CORS and security headers middleware
-	corsHandler := corsMiddleware(cfg.CORSOrigins, logger)(mux)
+	corsHandler := middleware.CORS(cfg.CORSOrigins, logger)(mux)
 	securedHandler := middleware.RequestID(middleware.SecurityHeaders(corsHandler))
 
 	server := &http.Server{
@@ -680,59 +680,6 @@ func ensureAdminUser(ctx context.Context, st *store.Store, email, password strin
 
 	logger.Info("admin user created", "email", email, "id", id)
 	return nil
-}
-
-// corsMiddleware returns a middleware that adds CORS headers for cross-origin requests.
-// If allowedOrigins is empty, all origins are allowed (development mode) with a warning.
-// Set CONTROL_CORS_ORIGINS=https://app.example.com,https://other.example.com for production.
-func corsMiddleware(allowedOrigins []string, logger *slog.Logger) func(http.Handler) http.Handler {
-	originSet := make(map[string]bool, len(allowedOrigins))
-	for _, o := range allowedOrigins {
-		originSet[o] = true
-	}
-
-	allowAll := len(allowedOrigins) == 0
-	if allowAll {
-		logger.Warn("CORS: no origins configured (CONTROL_CORS_ORIGINS), allowing all origins -- set this in production")
-	} else {
-		logger.Info("CORS: allowed origins configured", "origins", allowedOrigins)
-	}
-
-	return func(next http.Handler) http.Handler {
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			origin := r.Header.Get("Origin")
-
-			if origin != "" {
-				if allowAll || originSet[origin] {
-					w.Header().Set("Access-Control-Allow-Origin", origin)
-					w.Header().Set("Access-Control-Allow-Credentials", "true")
-				} else {
-					// Origin not allowed - do not set CORS headers
-					if r.Method == http.MethodOptions {
-						w.WriteHeader(http.StatusForbidden)
-						return
-					}
-					next.ServeHTTP(w, r)
-					return
-				}
-			}
-
-			// Handle preflight requests
-			if r.Method == http.MethodOptions {
-				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Connect-Protocol-Version, Connect-Timeout-Ms, Cookie")
-				w.Header().Set("Access-Control-Expose-Headers", "Connect-Content-Encoding, Connect-Protocol-Version")
-				w.Header().Set("Access-Control-Max-Age", "86400")
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-
-			// Set headers for actual requests
-			w.Header().Set("Access-Control-Expose-Headers", "Connect-Content-Encoding, Connect-Protocol-Version")
-
-			next.ServeHTTP(w, r)
-		})
-	}
 }
 
 // envString overrides target with the environment variable value if set.

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage/sdk/go/logging"
 	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/asynqutil"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/control"
@@ -407,7 +408,7 @@ func main() {
 				Queues: map[string]int{
 					taskqueue.ControlInboxQueue: 2,
 				},
-				Logger: newAsynqLogger(aqLogger),
+				Logger: asynqutil.NewLogger(aqLogger),
 				ErrorHandler: asynq.ErrorHandlerFunc(func(ctx context.Context, task *asynq.Task, err error) {
 					retried, _ := asynq.GetRetryCount(ctx)
 					maxRetry, _ := asynq.GetMaxRetry(ctx)
@@ -822,21 +823,6 @@ func corsMiddleware(allowedOrigins []string, logger *slog.Logger) func(http.Hand
 		})
 	}
 }
-
-// asynqLogger adapts slog.Logger to asynq.Logger interface.
-type asynqLogger struct {
-	logger *slog.Logger
-}
-
-func newAsynqLogger(l *slog.Logger) *asynqLogger {
-	return &asynqLogger{logger: l}
-}
-
-func (l *asynqLogger) Debug(args ...any) { l.logger.Debug(fmt.Sprint(args...)) }
-func (l *asynqLogger) Info(args ...any)  { l.logger.Info(fmt.Sprint(args...)) }
-func (l *asynqLogger) Warn(args ...any)  { l.logger.Warn(fmt.Sprint(args...)) }
-func (l *asynqLogger) Error(args ...any) { l.logger.Error(fmt.Sprint(args...)) }
-func (l *asynqLogger) Fatal(args ...any) { l.logger.Error(fmt.Sprint(args...)) }
 
 // maskDatabaseURL masks the password in a database URL for logging.
 func maskDatabaseURL(url string) string {

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -1329,9 +1329,6 @@ func serializeActionParamsToMap(action *pm.Action) map[string]any {
 
 // enqueueActionReindex enqueues a search index update for an action.
 func (h *ActionHandler) enqueueActionReindex(ctx context.Context, a db.ActionsProjection) {
-	if h.searchIdx == nil {
-		return
-	}
 	desc := ""
 	if a.Description != nil {
 		desc = *a.Description
@@ -1350,16 +1347,14 @@ func (h *ActionHandler) enqueueActionReindex(ctx context.Context, a db.ActionsPr
 	if a.UpdatedAt != nil {
 		updatedAt = a.UpdatedAt.Unix()
 	}
-	if err := h.searchIdx.EnqueueReindex(ctx, "action", a.ID, &taskqueue.SearchEntityData{
+	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeAction, a.ID, &taskqueue.SearchEntityData{
 		Name:         a.Name,
 		Description:  desc,
 		Type:         a.ActionType,
 		IsCompliance: isCompliance,
 		CreatedAt:    createdAt,
 		UpdatedAt:    updatedAt,
-	}); err != nil {
-		h.logger.Warn("failed to enqueue search reindex", "scope", "action", "error", err)
-	}
+	})
 }
 
 func (h *ActionHandler) actionToProto(a db.ActionsProjection) *pm.ManagedAction {

--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -379,9 +379,6 @@ func (h *ActionSetHandler) ReorderActionInSet(ctx context.Context, req *connect.
 
 // enqueueSetReindex enqueues a search index update for an action set.
 func (h *ActionSetHandler) enqueueSetReindex(ctx context.Context, s db.ActionSetsProjection) {
-	if h.searchIdx == nil {
-		return
-	}
 	var createdAt, updatedAt int64
 	if s.CreatedAt != nil {
 		createdAt = s.CreatedAt.Unix()
@@ -389,15 +386,13 @@ func (h *ActionSetHandler) enqueueSetReindex(ctx context.Context, s db.ActionSet
 	if s.UpdatedAt != nil {
 		updatedAt = s.UpdatedAt.Unix()
 	}
-	if err := h.searchIdx.EnqueueReindex(ctx, "action_set", s.ID, &taskqueue.SearchEntityData{
+	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeActionSet, s.ID, &taskqueue.SearchEntityData{
 		Name:        s.Name,
 		Description: s.Description,
 		MemberCount: s.MemberCount,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
-	}); err != nil {
-		h.logger.Warn("failed to enqueue search reindex", "scope", "action_set", "error", err)
-	}
+	})
 }
 
 func (h *ActionSetHandler) actionSetToProto(s db.ActionSetsProjection) *pm.ActionSet {

--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -42,9 +42,6 @@ func (h *CompliancePolicyHandler) SetSearchIndex(idx *search.Index) {
 // When rules is non-nil, action_names is included in the update. When nil, it is skipped
 // (HSET is additive, so existing action_names stays unchanged).
 func (h *CompliancePolicyHandler) enqueueCompliancePolicyReindex(ctx context.Context, p db.CompliancePoliciesProjection, rules []db.CompliancePolicyRulesProjection) {
-	if h.searchIdx == nil {
-		return
-	}
 	data := &taskqueue.SearchEntityData{
 		Name:        p.Name,
 		Description: p.Description,
@@ -59,9 +56,7 @@ func (h *CompliancePolicyHandler) enqueueCompliancePolicyReindex(ctx context.Con
 		data.ActionNames = strings.Join(actionNames, " ")
 		data.HasActionNames = true
 	}
-	if err := h.searchIdx.EnqueueReindex(ctx, search.ScopeCompliancePolicy, p.ID, data); err != nil {
-		h.logger.Warn("failed to enqueue compliance policy reindex", "id", p.ID, "error", err)
-	}
+	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeCompliancePolicy, p.ID, data)
 }
 
 // CreateCompliancePolicy creates a new compliance policy.

--- a/internal/api/definition_handler.go
+++ b/internal/api/definition_handler.go
@@ -377,9 +377,6 @@ func (h *DefinitionHandler) ReorderActionSetInDefinition(ctx context.Context, re
 
 // enqueueDefinitionReindex enqueues a search index update for a definition.
 func (h *DefinitionHandler) enqueueDefinitionReindex(ctx context.Context, d db.DefinitionsProjection) {
-	if h.searchIdx == nil {
-		return
-	}
 	var createdAt, updatedAt int64
 	if d.CreatedAt != nil {
 		createdAt = d.CreatedAt.Unix()
@@ -387,15 +384,13 @@ func (h *DefinitionHandler) enqueueDefinitionReindex(ctx context.Context, d db.D
 	if d.UpdatedAt != nil {
 		updatedAt = d.UpdatedAt.Unix()
 	}
-	if err := h.searchIdx.EnqueueReindex(ctx, "definition", d.ID, &taskqueue.SearchEntityData{
+	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeDefinition, d.ID, &taskqueue.SearchEntityData{
 		Name:        d.Name,
 		Description: d.Description,
 		MemberCount: d.MemberCount,
 		CreatedAt:   createdAt,
 		UpdatedAt:   updatedAt,
-	}); err != nil {
-		h.logger.Warn("failed to enqueue search reindex", "scope", "definition", "error", err)
-	}
+	})
 }
 
 func (h *DefinitionHandler) definitionToProto(d db.DefinitionsProjection) *pm.Definition {

--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -39,9 +39,6 @@ func (h *DeviceGroupHandler) SetSearchIndex(idx *search.Index) {
 
 // enqueueDeviceGroupReindex enqueues a search index update for a device group.
 func (h *DeviceGroupHandler) enqueueDeviceGroupReindex(ctx context.Context, g db.DeviceGroupsProjection) {
-	if h.searchIdx == nil {
-		return
-	}
 	isDynamic := "false"
 	if g.IsDynamic {
 		isDynamic = "true"
@@ -50,16 +47,13 @@ func (h *DeviceGroupHandler) enqueueDeviceGroupReindex(ctx context.Context, g db
 	if g.CreatedAt != nil {
 		createdAt = g.CreatedAt.Unix()
 	}
-	data := &taskqueue.SearchEntityData{
+	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeDeviceGroup, g.ID, &taskqueue.SearchEntityData{
 		Name:        g.Name,
 		Description: g.Description,
 		IsDynamic:   isDynamic,
 		MemberCount: g.MemberCount,
 		CreatedAt:   createdAt,
-	}
-	if err := h.searchIdx.EnqueueReindex(ctx, search.ScopeDeviceGroup, g.ID, data); err != nil {
-		h.logger.Warn("failed to enqueue search reindex", "scope", "device_group", "error", err)
-	}
+	})
 }
 
 // CreateDeviceGroup creates a new device group.

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -83,9 +83,7 @@ func (h *DeviceHandler) enqueueDeviceReindex(ctx context.Context, d db.DevicesPr
 			search.EnrichDeviceInventory(data, t.TableName, t.Rows)
 		}
 	}
-	if err := h.searchIdx.EnqueueReindex(ctx, search.ScopeDevice, d.ID, data); err != nil {
-		h.logger.Warn("failed to enqueue search reindex", "scope", "device", "error", err)
-	}
+	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeDevice, d.ID, data)
 }
 
 // ListDevices returns a paginated list of devices.

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -15,7 +15,6 @@ import (
 	"connectrpc.com/connect"
 	"github.com/hibiken/asynq"
 	"github.com/jackc/pgx/v5"
-	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -897,7 +896,7 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 	if userCtx != nil {
 		actorID = userCtx.ID
 	}
-	luksStreamID := ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String()
+	luksStreamID := newULID()
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "luks_key",
 		StreamID:   luksStreamID,

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -11,7 +11,9 @@ import (
 
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/middleware"
+	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
 // requireAuth extracts the authenticated user from context.
@@ -72,4 +74,15 @@ func buildNextPageToken(resultCount int32, offset int32, pageSize int32, totalCo
 		return formatPageToken(int64(offset) + int64(pageSize))
 	}
 	return ""
+}
+
+// enqueueSearchReindex enqueues a search reindex if the index is available.
+// Logs a warning on failure but does not return an error (best-effort).
+func enqueueSearchReindex(ctx context.Context, idx *search.Index, logger *slog.Logger, scope, id string, data *taskqueue.SearchEntityData) {
+	if idx == nil {
+		return
+	}
+	if err := idx.EnqueueReindex(ctx, scope, id, data); err != nil {
+		logger.Warn("failed to enqueue search reindex", "scope", scope, "id", id, "error", err)
+	}
 }

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -2,13 +2,9 @@ package api
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"time"
-
-	"github.com/oklog/ulid/v2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -262,7 +258,7 @@ func (m *SystemActionManager) cleanupSshAction(ctx context.Context, user db.User
 
 // createSystemAction emits an ActionCreated event with is_system=true.
 func (m *SystemActionManager) createSystemAction(ctx context.Context, name string, actionType, desiredState int32, paramsJSON []byte) (string, error) {
-	id := ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String()
+	id := newULID()
 
 	var params map[string]any
 	if err := json.Unmarshal(paramsJSON, &params); err != nil {
@@ -293,7 +289,7 @@ func (m *SystemActionManager) createSystemAction(ctx context.Context, name strin
 
 // assignActionToUser emits an AssignmentCreated event.
 func (m *SystemActionManager) assignActionToUser(ctx context.Context, actionID, userID string) error {
-	assignmentID := ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String()
+	assignmentID := newULID()
 
 	return m.store.AppendEvent(ctx, store.Event{
 		StreamType: "assignment",

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -42,9 +42,6 @@ func (h *UserGroupHandler) SetSearchIndex(idx *search.Index) {
 
 // enqueueUserGroupReindex enqueues a search index update for a user group.
 func (h *UserGroupHandler) enqueueUserGroupReindex(ctx context.Context, g db.UserGroupsProjection) {
-	if h.searchIdx == nil {
-		return
-	}
 	isDynamic := "false"
 	if g.IsDynamic {
 		isDynamic = "true"
@@ -53,16 +50,13 @@ func (h *UserGroupHandler) enqueueUserGroupReindex(ctx context.Context, g db.Use
 	if !g.CreatedAt.IsZero() {
 		createdAt = g.CreatedAt.Unix()
 	}
-	data := &taskqueue.SearchEntityData{
+	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeUserGroup, g.ID, &taskqueue.SearchEntityData{
 		Name:        g.Name,
 		Description: g.Description,
 		IsDynamic:   isDynamic,
 		MemberCount: g.MemberCount,
 		CreatedAt:   createdAt,
-	}
-	if err := h.searchIdx.EnqueueReindex(ctx, search.ScopeUserGroup, g.ID, data); err != nil {
-		h.logger.Warn("failed to enqueue search reindex", "scope", "user_group", "error", err)
-	}
+	})
 }
 
 // CreateUserGroup creates a new user group.

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -33,9 +33,6 @@ func (h *UserHandler) SetSearchIndex(idx *search.Index) {
 
 // enqueueUserReindex enqueues a search index update for a user.
 func (h *UserHandler) enqueueUserReindex(ctx context.Context, u db.UsersProjection) {
-	if h.searchIdx == nil {
-		return
-	}
 	disabled := "false"
 	if u.Disabled {
 		disabled = "true"
@@ -44,15 +41,13 @@ func (h *UserHandler) enqueueUserReindex(ctx context.Context, u db.UsersProjecti
 	if u.CreatedAt != nil {
 		createdAt = u.CreatedAt.Unix()
 	}
-	if err := h.searchIdx.EnqueueReindex(ctx, search.ScopeUser, u.ID, &taskqueue.SearchEntityData{
+	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeUser, u.ID, &taskqueue.SearchEntityData{
 		Email:         u.Email,
 		DisplayName:   u.DisplayName,
 		LinuxUsername: u.LinuxUsername,
 		Disabled:      disabled,
 		CreatedAt:     createdAt,
-	}); err != nil {
-		h.logger.Warn("failed to enqueue search reindex", "scope", "user", "error", err)
-	}
+	})
 }
 
 // NewUserHandler creates a new user handler.

--- a/internal/asynqutil/logger.go
+++ b/internal/asynqutil/logger.go
@@ -3,7 +3,6 @@ package asynqutil
 import (
 	"fmt"
 	"log/slog"
-	"os"
 )
 
 // Logger adapts slog.Logger to the asynq.Logger interface.
@@ -25,7 +24,8 @@ func (l *Logger) Info(args ...any)  { l.logger.Info(fmt.Sprint(args...)) }
 func (l *Logger) Warn(args ...any)  { l.logger.Warn(fmt.Sprint(args...)) }
 func (l *Logger) Error(args ...any) { l.logger.Error(fmt.Sprint(args...)) }
 
-func (l *Logger) Fatal(args ...any) {
-	l.logger.Error(fmt.Sprint(args...))
-	os.Exit(1)
-}
+// Fatal logs at error level. We intentionally do not call os.Exit here —
+// asynq may call Fatal on configuration errors, and killing the process
+// without cleanup (deferred DB close, graceful shutdown) is worse than
+// logging and letting the caller handle it.
+func (l *Logger) Fatal(args ...any) { l.logger.Error(fmt.Sprint(args...)) }

--- a/internal/asynqutil/logger.go
+++ b/internal/asynqutil/logger.go
@@ -1,0 +1,22 @@
+package asynqutil
+
+import (
+	"fmt"
+	"log/slog"
+)
+
+// Logger adapts slog.Logger to the asynq.Logger interface.
+type Logger struct {
+	logger *slog.Logger
+}
+
+// NewLogger creates a new asynq-compatible logger.
+func NewLogger(l *slog.Logger) *Logger {
+	return &Logger{logger: l}
+}
+
+func (l *Logger) Debug(args ...any) { l.logger.Debug(fmt.Sprint(args...)) }
+func (l *Logger) Info(args ...any)  { l.logger.Info(fmt.Sprint(args...)) }
+func (l *Logger) Warn(args ...any)  { l.logger.Warn(fmt.Sprint(args...)) }
+func (l *Logger) Error(args ...any) { l.logger.Error(fmt.Sprint(args...)) }
+func (l *Logger) Fatal(args ...any) { l.logger.Error(fmt.Sprint(args...)) }

--- a/internal/asynqutil/logger.go
+++ b/internal/asynqutil/logger.go
@@ -3,6 +3,7 @@ package asynqutil
 import (
 	"fmt"
 	"log/slog"
+	"os"
 )
 
 // Logger adapts slog.Logger to the asynq.Logger interface.
@@ -11,7 +12,11 @@ type Logger struct {
 }
 
 // NewLogger creates a new asynq-compatible logger.
+// If l is nil, a default logger writing to stderr is used.
 func NewLogger(l *slog.Logger) *Logger {
+	if l == nil {
+		l = slog.Default()
+	}
 	return &Logger{logger: l}
 }
 
@@ -19,4 +24,8 @@ func (l *Logger) Debug(args ...any) { l.logger.Debug(fmt.Sprint(args...)) }
 func (l *Logger) Info(args ...any)  { l.logger.Info(fmt.Sprint(args...)) }
 func (l *Logger) Warn(args ...any)  { l.logger.Warn(fmt.Sprint(args...)) }
 func (l *Logger) Error(args ...any) { l.logger.Error(fmt.Sprint(args...)) }
-func (l *Logger) Fatal(args ...any) { l.logger.Error(fmt.Sprint(args...)) }
+
+func (l *Logger) Fatal(args ...any) {
+	l.logger.Error(fmt.Sprint(args...))
+	os.Exit(1)
+}

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -60,8 +60,13 @@ func (w *InboxWorker) handleDeviceHello(ctx context.Context, t *asynq.Task) erro
 	logger := w.logger.With("device_id", payload.DeviceID, "hostname", payload.Hostname)
 
 	// Skip processing for deleted devices.
-	if deleted, err := w.store.Queries().IsDeviceDeleted(ctx, payload.DeviceID); err != nil || deleted {
-		logger.Debug("ignoring hello from deleted or unknown device")
+	deleted, err := w.store.Queries().IsDeviceDeleted(ctx, payload.DeviceID)
+	if err != nil {
+		logger.Error("failed to check device deletion status", "error", err)
+		return err
+	}
+	if deleted {
+		logger.Debug("ignoring hello from deleted device")
 		return nil
 	}
 
@@ -97,8 +102,13 @@ func (w *InboxWorker) handleDeviceHeartbeat(ctx context.Context, t *asynq.Task) 
 	}
 
 	// Skip processing for deleted devices.
-	if deleted, err := w.store.Queries().IsDeviceDeleted(ctx, payload.DeviceID); err != nil || deleted {
-		w.logger.Debug("ignoring heartbeat from deleted or unknown device", "device_id", payload.DeviceID)
+	deleted, err := w.store.Queries().IsDeviceDeleted(ctx, payload.DeviceID)
+	if err != nil {
+		w.logger.Error("failed to check device deletion status", "device_id", payload.DeviceID, "error", err)
+		return err
+	}
+	if deleted {
+		w.logger.Debug("ignoring heartbeat from deleted device", "device_id", payload.DeviceID)
 		return nil
 	}
 
@@ -510,21 +520,6 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 	logger.Debug("found pending executions", "count", len(executions))
 
 	for _, exec := range executions {
-		// Emit ExecutionDispatched event
-		if err := w.store.AppendEvent(ctx, store.Event{
-			StreamType: "execution",
-			StreamID:   exec.ID,
-			EventType:  "ExecutionDispatched",
-			Data: map[string]any{
-				"device_id": deviceID,
-			},
-			ActorType: "system",
-			ActorID:   "dispatcher",
-		}); err != nil {
-			logger.Error("failed to append dispatch event", "error", err, "execution_id", exec.ID)
-			continue
-		}
-
 		// Parse params from []byte to avoid base64 encoding
 		var params json.RawMessage
 		if len(exec.Params) > 0 {
@@ -540,7 +535,8 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			}
 		}
 
-		// Enqueue action dispatch to device queue via Asynq
+		// Enqueue to device queue first — only record the event after the
+		// task is durably queued so we never mark "dispatched" without delivery.
 		if err := w.aqClient.EnqueueToDevice(deviceID, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
 			ExecutionID:     exec.ID,
 			ActionType:      exec.ActionType,
@@ -552,6 +548,20 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 		}, asynq.MaxRetry(3)); err != nil {
 			logger.Error("failed to enqueue action dispatch", "error", err, "execution_id", exec.ID)
 			continue
+		}
+
+		// Record the dispatch event now that the task is in the queue.
+		if err := w.store.AppendEvent(ctx, store.Event{
+			StreamType: "execution",
+			StreamID:   exec.ID,
+			EventType:  "ExecutionDispatched",
+			Data: map[string]any{
+				"device_id": deviceID,
+			},
+			ActorType: "system",
+			ActorID:   "dispatcher",
+		}); err != nil {
+			logger.Error("failed to append dispatch event", "error", err, "execution_id", exec.ID)
 		}
 
 		logger.Info("dispatched pending execution via Asynq",

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -3,11 +3,13 @@ package control
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"time"
 
 	"github.com/hibiken/asynq"
+	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -59,7 +61,7 @@ func (w *InboxWorker) handleDeviceHello(ctx context.Context, t *asynq.Task) erro
 
 	// Skip processing for deleted devices.
 	if deleted, err := w.store.Queries().IsDeviceDeleted(ctx, payload.DeviceID); err != nil || deleted {
-		logger.Warn("ignoring hello from deleted or unknown device")
+		logger.Debug("ignoring hello from deleted or unknown device")
 		return nil
 	}
 
@@ -82,7 +84,9 @@ func (w *InboxWorker) handleDeviceHello(ctx context.Context, t *asynq.Task) erro
 	}
 
 	// Dispatch pending actions to the device via Asynq
-	w.dispatchPendingActions(ctx, payload.DeviceID, logger)
+	if err := w.dispatchPendingActions(ctx, payload.DeviceID, logger); err != nil {
+		logger.Error("failed to dispatch pending actions", "error", err)
+	}
 	return nil
 }
 
@@ -94,7 +98,7 @@ func (w *InboxWorker) handleDeviceHeartbeat(ctx context.Context, t *asynq.Task) 
 
 	// Skip processing for deleted devices.
 	if deleted, err := w.store.Queries().IsDeviceDeleted(ctx, payload.DeviceID); err != nil || deleted {
-		w.logger.Warn("ignoring heartbeat from deleted or unknown device", "device_id", payload.DeviceID)
+		w.logger.Debug("ignoring heartbeat from deleted or unknown device", "device_id", payload.DeviceID)
 		return nil
 	}
 
@@ -148,7 +152,9 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 
 	logger := w.logger.With("device_id", deviceID, "result_id", resultID)
 
-	// Determine execution ID and action ID
+	// Determine execution ID and action ID.
+	// resultID may be an execution ID (dispatched by API) or an action ID
+	// (scheduled locally by the agent). We try execution first.
 	var executionID, actionID string
 	var needsCreate bool
 
@@ -159,10 +165,14 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 			actionID = *existingExec.ActionID
 		}
 		needsCreate = false
-	} else {
+	} else if errors.Is(err, pgx.ErrNoRows) {
+		// Not an execution ID — treat as action ID (agent-scheduled action)
 		actionID = resultID
 		executionID = ulid.Make().String()
 		needsCreate = true
+	} else {
+		// Transient DB error — let Asynq retry
+		return fmt.Errorf("lookup execution %s: %w", resultID, err)
 	}
 
 	// Calculate timestamps
@@ -179,10 +189,11 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 	if needsCreate {
 		action, err := w.store.Queries().GetActionByID(ctx, actionID)
 		if err != nil {
-			logger.Warn("could not look up action", "error", err)
-			action.ActionType = 0
-			action.Params = nil
-			action.TimeoutSeconds = 300
+			if errors.Is(err, pgx.ErrNoRows) {
+				logger.Warn("action not found, cannot create execution", "action_id", actionID)
+				return fmt.Errorf("action %s not found", actionID)
+			}
+			return fmt.Errorf("lookup action %s: %w", actionID, err)
 		}
 
 		createdData := map[string]any{
@@ -488,13 +499,12 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 // dispatchPendingActions finds pending executions for a device and enqueues them
 // to the device's Asynq queue. This mirrors the logic from Handler.dispatchPendingActions
 // but uses Asynq instead of PostgreSQL NOTIFY.
-func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID string, logger *slog.Logger) {
+func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID string, logger *slog.Logger) error {
 	logger.Debug("checking for pending executions")
 
 	executions, err := w.store.Queries().ListPendingExecutionsForDevice(ctx, deviceID)
 	if err != nil {
-		logger.Error("failed to list pending executions", "error", err)
-		return
+		return fmt.Errorf("list pending executions: %w", err)
 	}
 
 	logger.Debug("found pending executions", "count", len(executions))
@@ -549,6 +559,7 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			"action_type", exec.ActionType,
 		)
 	}
+	return nil
 }
 
 // commandOutputToMap converts a CommandOutput proto to a map for event data.

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -2,7 +2,6 @@ package control
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -162,7 +161,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		needsCreate = false
 	} else {
 		actionID = resultID
-		executionID = ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String()
+		executionID = ulid.Make().String()
 		needsCreate = true
 	}
 
@@ -485,7 +484,7 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 		"success", payload.Success,
 	)
 
-	luksStreamID := ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String()
+	luksStreamID := ulid.Make().String()
 	if payload.Success {
 		return w.store.AppendEvent(ctx, store.Event{
 			StreamType: "luks_key",

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -61,9 +61,13 @@ func (w *InboxWorker) handleDeviceHello(ctx context.Context, t *asynq.Task) erro
 
 	logger := w.logger.With("device_id", payload.DeviceID, "hostname", payload.Hostname)
 
-	// Skip processing for deleted devices.
+	// Skip processing for deleted or unknown devices.
 	deleted, err := w.store.Queries().IsDeviceDeleted(ctx, payload.DeviceID)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			logger.Debug("ignoring hello from unknown device")
+			return nil
+		}
 		logger.Error("failed to check device deletion status", "error", err)
 		return err
 	}
@@ -104,9 +108,13 @@ func (w *InboxWorker) handleDeviceHeartbeat(ctx context.Context, t *asynq.Task) 
 		return fmt.Errorf("unmarshal device heartbeat: %w", err)
 	}
 
-	// Skip processing for deleted devices.
+	// Skip processing for deleted or unknown devices.
 	deleted, err := w.store.Queries().IsDeviceDeleted(ctx, payload.DeviceID)
 	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			w.logger.Debug("ignoring heartbeat from unknown device", "device_id", payload.DeviceID)
+			return nil
+		}
 		w.logger.Error("failed to check device deletion status", "device_id", payload.DeviceID, "error", err)
 		return err
 	}

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -184,12 +184,18 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		// retries of the same result don't create duplicates, but separate
 		// scheduled runs of the same action get unique IDs.
 		actionID = resultID
-		var completedStr string
+		completedStr := time.Now().Format(time.RFC3339Nano) // fallback
 		if result.CompletedAt != nil && result.CompletedAt.IsValid() {
 			completedStr = result.CompletedAt.AsTime().Format(time.RFC3339Nano)
 		}
 		executionID = stableExecutionID(deviceID, actionID, completedStr)
-		needsCreate = true
+
+		// Check if this derived execution already exists (retry of a previously processed result)
+		if _, checkErr := w.store.Queries().GetExecutionByID(ctx, executionID); checkErr == nil {
+			needsCreate = false
+		} else {
+			needsCreate = true
+		}
 	} else {
 		// Transient DB error — let Asynq retry
 		return fmt.Errorf("lookup execution %s: %w", resultID, err)
@@ -560,7 +566,7 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			Signature:       signature,
 			ParamsCanonical: paramsCanonical,
 		}, asynq.MaxRetry(3), asynq.TaskID("dispatch:"+exec.ID)); err != nil {
-			if errors.Is(err, asynq.ErrDuplicateTask) {
+			if errors.Is(err, asynq.ErrTaskIDConflict) {
 				// Task already in queue — still need to record the dispatch event
 				// so the execution isn't stuck in "pending" state.
 				logger.Debug("action already enqueued", "execution_id", exec.ID)

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -219,20 +219,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 			"changed":      result.Changed,
 			"compliant":    result.Compliant,
 		}
-		if result.Output != nil {
-			data["output"] = map[string]any{
-				"stdout":    result.Output.Stdout,
-				"stderr":    result.Output.Stderr,
-				"exit_code": result.Output.ExitCode,
-			}
-		}
-		if result.DetectionOutput != nil {
-			data["detection_output"] = map[string]any{
-				"stdout":    result.DetectionOutput.Stdout,
-				"stderr":    result.DetectionOutput.Stderr,
-				"exit_code": result.DetectionOutput.ExitCode,
-			}
-		}
+		addCommandOutputs(data, &result)
 
 	case pm.ExecutionStatus_EXECUTION_STATUS_FAILED:
 		eventType = "ExecutionFailed"
@@ -243,20 +230,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 			"changed":      result.Changed,
 			"compliant":    result.Compliant,
 		}
-		if result.Output != nil {
-			data["output"] = map[string]any{
-				"stdout":    result.Output.Stdout,
-				"stderr":    result.Output.Stderr,
-				"exit_code": result.Output.ExitCode,
-			}
-		}
-		if result.DetectionOutput != nil {
-			data["detection_output"] = map[string]any{
-				"stdout":    result.DetectionOutput.Stdout,
-				"stderr":    result.DetectionOutput.Stderr,
-				"exit_code": result.DetectionOutput.ExitCode,
-			}
-		}
+		addCommandOutputs(data, &result)
 
 	case pm.ExecutionStatus_EXECUTION_STATUS_RUNNING:
 		eventType = "ExecutionStarted"
@@ -269,12 +243,8 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 			"duration_ms":  result.DurationMs,
 			"completed_at": completedAt.Format(time.RFC3339Nano),
 		}
-		if result.Output != nil {
-			data["output"] = map[string]any{
-				"stdout":    result.Output.Stdout,
-				"stderr":    result.Output.Stderr,
-				"exit_code": result.Output.ExitCode,
-			}
+		if m := commandOutputToMap(result.Output); m != nil {
+			data["output"] = m
 		}
 
 	case pm.ExecutionStatus_EXECUTION_STATUS_SKIPPED:
@@ -578,5 +548,28 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			"execution_id", exec.ID,
 			"action_type", exec.ActionType,
 		)
+	}
+}
+
+// commandOutputToMap converts a CommandOutput proto to a map for event data.
+// Returns nil if the output is nil.
+func commandOutputToMap(o *pm.CommandOutput) map[string]any {
+	if o == nil {
+		return nil
+	}
+	return map[string]any{
+		"stdout":    o.Stdout,
+		"stderr":    o.Stderr,
+		"exit_code": o.ExitCode,
+	}
+}
+
+// addCommandOutputs adds output and detection_output fields to the event data map.
+func addCommandOutputs(data map[string]any, result *pm.ActionResult) {
+	if m := commandOutputToMap(result.Output); m != nil {
+		data["output"] = m
+	}
+	if m := commandOutputToMap(result.DetectionOutput); m != nil {
+		data["detection_output"] = m
 	}
 }

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -551,7 +551,9 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 		}
 
 		// Record the dispatch event now that the task is in the queue.
-		if err := w.store.AppendEvent(ctx, store.Event{
+		// Retry on transient failures — the task is already enqueued, so
+		// failing to record the event could cause duplicate dispatch on reconnect.
+		dispatchEvt := store.Event{
 			StreamType: "execution",
 			StreamID:   exec.ID,
 			EventType:  "ExecutionDispatched",
@@ -560,8 +562,14 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			},
 			ActorType: "system",
 			ActorID:   "dispatcher",
-		}); err != nil {
-			logger.Error("failed to append dispatch event", "error", err, "execution_id", exec.ID)
+		}
+		for attempt := 0; attempt < 3; attempt++ {
+			if err := w.store.AppendEvent(ctx, dispatchEvt); err != nil {
+				logger.Warn("failed to append dispatch event, retrying",
+					"error", err, "execution_id", exec.ID, "attempt", attempt+1)
+				continue
+			}
+			break
 		}
 
 		logger.Info("dispatched pending execution via Asynq",

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -206,15 +206,20 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		executedAt = completedAt.Add(-time.Duration(result.DurationMs) * time.Millisecond)
 	}
 
+	// Cache the action lookup — reused for both execution creation and compliance check.
+	var cachedAction *db.ActionsProjection
+
 	if needsCreate {
 		action, err := w.store.Queries().GetActionByID(ctx, actionID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
-				logger.Warn("action not found, cannot create execution", "action_id", actionID)
-				return fmt.Errorf("action %s not found", actionID)
+				// Action was deleted while agent was offline — skip, don't retry.
+				logger.Warn("action not found, skipping execution creation", "action_id", actionID)
+				return nil
 			}
 			return fmt.Errorf("lookup action %s: %w", actionID, err)
 		}
+		cachedAction = &action
 
 		createdData := map[string]any{
 			"device_id":       deviceID,
@@ -302,41 +307,38 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 
 	// Emit compliance event for actions with is_compliance=true
 	if result.DetectionOutput != nil && actionID != "" {
-		actionName := ""
-		isCompliance := false
-		action, err := w.store.Queries().GetActionByID(ctx, actionID)
-		if err != nil {
-			logger.Warn("failed to look up action for compliance check", "action_id", actionID, "error", err)
-		} else {
-			actionName = action.Name
-			var params map[string]any
-			if err := json.Unmarshal(action.Params, &params); err != nil {
-				logger.Warn("failed to unmarshal action params for compliance check", "action_id", actionID, "error", err)
+		// Reuse cached action if available, otherwise fetch
+		if cachedAction == nil {
+			if a, err := w.store.Queries().GetActionByID(ctx, actionID); err != nil {
+				logger.Warn("failed to look up action for compliance check", "action_id", actionID, "error", err)
 			} else {
-				isCompliance, _ = params["isCompliance"].(bool)
+				cachedAction = &a
 			}
 		}
-		if isCompliance {
-			complianceData := map[string]any{
-				"device_id":   deviceID,
-				"action_id":   actionID,
-				"action_name": actionName,
-				"compliant":   result.Compliant,
-				"detection_output": map[string]any{
-					"stdout":    result.DetectionOutput.Stdout,
-					"stderr":    result.DetectionOutput.Stderr,
-					"exit_code": result.DetectionOutput.ExitCode,
-				},
+		if cachedAction != nil {
+			isCompliance := false
+			var params map[string]any
+			if err := json.Unmarshal(cachedAction.Params, &params); err == nil {
+				isCompliance, _ = params["isCompliance"].(bool)
 			}
-			if err := w.store.AppendEvent(ctx, store.Event{
-				StreamType: "compliance",
-				StreamID:   deviceID + "_" + actionID,
-				EventType:  "ComplianceResultUpdated",
-				Data:       complianceData,
-				ActorType:  "device",
-				ActorID:    deviceID,
-			}); err != nil {
-				logger.Error("failed to append compliance event", "error", err)
+			if isCompliance {
+				complianceData := map[string]any{
+					"device_id":        deviceID,
+					"action_id":        actionID,
+					"action_name":      cachedAction.Name,
+					"compliant":        result.Compliant,
+					"detection_output": commandOutputToMap(result.DetectionOutput),
+				}
+				if err := w.store.AppendEvent(ctx, store.Event{
+					StreamType: "compliance",
+					StreamID:   deviceID + "_" + actionID,
+					EventType:  "ComplianceResultUpdated",
+					Data:       complianceData,
+					ActorType:  "device",
+					ActorID:    deviceID,
+				}); err != nil {
+					logger.Error("failed to append compliance event", "error", err)
+				}
 			}
 		}
 	}
@@ -632,6 +634,8 @@ func addCommandOutputs(data map[string]any, result *pm.ActionResult) {
 // and completed-at timestamp. Including completedAt ensures separate scheduled
 // runs of the same action get unique IDs, while retries of the same result
 // (same completedAt) produce the same ID for deduplication.
+// Note: returns a 32-char hex string, not a ULID. This is intentional —
+// deterministic IDs cannot be ULIDs (which encode timestamps).
 func stableExecutionID(deviceID, actionID, completedAt string) string {
 	h := sha256.Sum256([]byte("exec:" + deviceID + ":" + actionID + ":" + completedAt))
 	return hex.EncodeToString(h[:16])

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -559,12 +559,14 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			ParamsCanonical: paramsCanonical,
 		}, asynq.MaxRetry(3), asynq.TaskID("dispatch:"+exec.ID)); err != nil {
 			if errors.Is(err, asynq.ErrDuplicateTask) {
-				logger.Debug("action already enqueued, skipping", "execution_id", exec.ID)
+				// Task already in queue — still need to record the dispatch event
+				// so the execution isn't stuck in "pending" state.
+				logger.Debug("action already enqueued", "execution_id", exec.ID)
 			} else {
 				logger.Error("failed to enqueue action dispatch", "error", err, "execution_id", exec.ID)
 				enqueueErrs = append(enqueueErrs, err)
+				continue
 			}
-			continue
 		}
 
 		// Record the dispatch event now that the task is in the queue.

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -180,10 +180,15 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		needsCreate = false
 	} else if errors.Is(err, pgx.ErrNoRows) {
 		// Not an execution ID — treat as action ID (agent-scheduled action).
-		// Derive a stable execution ID from device+action so retries don't
-		// create duplicate executions.
+		// Derive a stable execution ID from device+action+completedAt so
+		// retries of the same result don't create duplicates, but separate
+		// scheduled runs of the same action get unique IDs.
 		actionID = resultID
-		executionID = stableExecutionID(deviceID, actionID)
+		var completedStr string
+		if result.CompletedAt != nil && result.CompletedAt.IsValid() {
+			completedStr = result.CompletedAt.AsTime().Format(time.RFC3339Nano)
+		}
+		executionID = stableExecutionID(deviceID, actionID, completedStr)
 		needsCreate = true
 	} else {
 		// Transient DB error — let Asynq retry
@@ -524,6 +529,7 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 
 	logger.Debug("found pending executions", "count", len(executions))
 
+	var enqueueErrs []error
 	for _, exec := range executions {
 		// Parse params from []byte to avoid base64 encoding
 		var params json.RawMessage
@@ -542,6 +548,7 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 
 		// Enqueue to device queue first — only record the event after the
 		// task is durably queued so we never mark "dispatched" without delivery.
+		// Use a stable TaskID so retries don't create duplicate tasks.
 		if err := w.aqClient.EnqueueToDevice(deviceID, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
 			ExecutionID:     exec.ID,
 			ActionType:      exec.ActionType,
@@ -550,8 +557,13 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			TimeoutSeconds:  exec.TimeoutSeconds,
 			Signature:       signature,
 			ParamsCanonical: paramsCanonical,
-		}, asynq.MaxRetry(3)); err != nil {
-			logger.Error("failed to enqueue action dispatch", "error", err, "execution_id", exec.ID)
+		}, asynq.MaxRetry(3), asynq.TaskID("dispatch:"+exec.ID)); err != nil {
+			if errors.Is(err, asynq.ErrDuplicateTask) {
+				logger.Debug("action already enqueued, skipping", "execution_id", exec.ID)
+			} else {
+				logger.Error("failed to enqueue action dispatch", "error", err, "execution_id", exec.ID)
+				enqueueErrs = append(enqueueErrs, err)
+			}
 			continue
 		}
 
@@ -585,6 +597,9 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			"action_type", exec.ActionType,
 		)
 	}
+	if len(enqueueErrs) > 0 {
+		return fmt.Errorf("%d dispatch(es) failed, first: %w", len(enqueueErrs), enqueueErrs[0])
+	}
 	return nil
 }
 
@@ -611,10 +626,11 @@ func addCommandOutputs(data map[string]any, result *pm.ActionResult) {
 	}
 }
 
-// stableExecutionID derives a deterministic execution ID from device and action IDs.
-// This ensures that retries of the same agent-scheduled result don't create
-// duplicate executions. The event store's optimistic locking handles conflicts.
-func stableExecutionID(deviceID, actionID string) string {
-	h := sha256.Sum256([]byte("exec:" + deviceID + ":" + actionID))
+// stableExecutionID derives a deterministic execution ID from device, action,
+// and completed-at timestamp. Including completedAt ensures separate scheduled
+// runs of the same action get unique IDs, while retries of the same result
+// (same completedAt) produce the same ID for deduplication.
+func stableExecutionID(deviceID, actionID, completedAt string) string {
+	h := sha256.Sum256([]byte("exec:" + deviceID + ":" + actionID + ":" + completedAt))
 	return hex.EncodeToString(h[:16])
 }

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -184,17 +184,22 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		// retries of the same result don't create duplicates, but separate
 		// scheduled runs of the same action get unique IDs.
 		actionID = resultID
-		completedStr := time.Now().Format(time.RFC3339Nano) // fallback
+		// Use CompletedAt for per-run uniqueness. Fall back to DurationMs+Status
+		// (stable across retries of the same result) when CompletedAt is absent.
+		completedStr := fmt.Sprintf("%d:%s", result.DurationMs, result.Status.String())
 		if result.CompletedAt != nil && result.CompletedAt.IsValid() {
 			completedStr = result.CompletedAt.AsTime().Format(time.RFC3339Nano)
 		}
 		executionID = stableExecutionID(deviceID, actionID, completedStr)
 
 		// Check if this derived execution already exists (retry of a previously processed result)
-		if _, checkErr := w.store.Queries().GetExecutionByID(ctx, executionID); checkErr == nil {
+		_, checkErr := w.store.Queries().GetExecutionByID(ctx, executionID)
+		if checkErr == nil {
 			needsCreate = false
-		} else {
+		} else if errors.Is(checkErr, pgx.ErrNoRows) {
 			needsCreate = true
+		} else {
+			return fmt.Errorf("check derived execution %s: %w", executionID, checkErr)
 		}
 	} else {
 		// Transient DB error — let Asynq retry

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -2,6 +2,8 @@ package control
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -91,6 +93,7 @@ func (w *InboxWorker) handleDeviceHello(ctx context.Context, t *asynq.Task) erro
 	// Dispatch pending actions to the device via Asynq
 	if err := w.dispatchPendingActions(ctx, payload.DeviceID, logger); err != nil {
 		logger.Error("failed to dispatch pending actions", "error", err)
+		return err
 	}
 	return nil
 }
@@ -176,9 +179,11 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		}
 		needsCreate = false
 	} else if errors.Is(err, pgx.ErrNoRows) {
-		// Not an execution ID — treat as action ID (agent-scheduled action)
+		// Not an execution ID — treat as action ID (agent-scheduled action).
+		// Derive a stable execution ID from device+action so retries don't
+		// create duplicate executions.
 		actionID = resultID
-		executionID = ulid.Make().String()
+		executionID = stableExecutionID(deviceID, actionID)
 		needsCreate = true
 	} else {
 		// Transient DB error — let Asynq retry
@@ -563,13 +568,16 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			ActorType: "system",
 			ActorID:   "dispatcher",
 		}
+		var appendErr error
 		for attempt := 0; attempt < 3; attempt++ {
-			if err := w.store.AppendEvent(ctx, dispatchEvt); err != nil {
-				logger.Warn("failed to append dispatch event, retrying",
-					"error", err, "execution_id", exec.ID, "attempt", attempt+1)
-				continue
+			if appendErr = w.store.AppendEvent(ctx, dispatchEvt); appendErr == nil {
+				break
 			}
-			break
+			logger.Warn("failed to append dispatch event, retrying",
+				"error", appendErr, "execution_id", exec.ID, "attempt", attempt+1)
+		}
+		if appendErr != nil {
+			return fmt.Errorf("append dispatch event for %s after 3 attempts: %w", exec.ID, appendErr)
 		}
 
 		logger.Info("dispatched pending execution via Asynq",
@@ -601,4 +609,12 @@ func addCommandOutputs(data map[string]any, result *pm.ActionResult) {
 	if m := commandOutputToMap(result.DetectionOutput); m != nil {
 		data["detection_output"] = m
 	}
+}
+
+// stableExecutionID derives a deterministic execution ID from device and action IDs.
+// This ensures that retries of the same agent-scheduled result don't create
+// duplicate executions. The event store's optimistic locking handles conflicts.
+func stableExecutionID(deviceID, actionID string) string {
+	h := sha256.Sum256([]byte("exec:" + deviceID + ":" + actionID))
+	return hex.EncodeToString(h[:16])
 }

--- a/internal/gateway/device_worker.go
+++ b/internal/gateway/device_worker.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hibiken/asynq"
 
+	"github.com/manchtools/power-manage/server/internal/asynqutil"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
@@ -63,7 +64,7 @@ func (m *DeviceWorkerManager) StartWorker(deviceID string) error {
 		asynq.Config{
 			Concurrency: 1,
 			Queues:      map[string]int{queue: 1},
-			Logger:      newAsynqLogger(devLogger),
+			Logger:      asynqutil.NewLogger(devLogger),
 			ErrorHandler: asynq.ErrorHandlerFunc(func(ctx context.Context, task *asynq.Task, err error) {
 				retried, _ := asynq.GetRetryCount(ctx)
 				maxRetry, _ := asynq.GetMaxRetry(ctx)
@@ -117,18 +118,3 @@ func (m *DeviceWorkerManager) StopAll() {
 		m.logger.Debug("device worker stopped", "device_id", deviceID)
 	}
 }
-
-// asynqLogger adapts slog.Logger to the asynq.Logger interface.
-type asynqLogger struct {
-	logger *slog.Logger
-}
-
-func newAsynqLogger(l *slog.Logger) *asynqLogger {
-	return &asynqLogger{logger: l}
-}
-
-func (l *asynqLogger) Debug(args ...any) { l.logger.Debug(fmt.Sprint(args...)) }
-func (l *asynqLogger) Info(args ...any)  { l.logger.Info(fmt.Sprint(args...)) }
-func (l *asynqLogger) Warn(args ...any)  { l.logger.Warn(fmt.Sprint(args...)) }
-func (l *asynqLogger) Error(args ...any) { l.logger.Error(fmt.Sprint(args...)) }
-func (l *asynqLogger) Fatal(args ...any) { l.logger.Error(fmt.Sprint(args...)) }

--- a/internal/gateway/task_handlers.go
+++ b/internal/gateway/task_handlers.go
@@ -2,11 +2,9 @@ package gateway
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/hibiken/asynq"
 	"github.com/oklog/ulid/v2"
@@ -83,7 +81,7 @@ func (h *deviceTaskHandler) handleActionDispatch(_ context.Context, t *asynq.Tas
 
 	// Wrap in ServerMessage
 	msg := &pm.ServerMessage{
-		Id: ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String(),
+		Id: ulid.Make().String(),
 		Payload: &pm.ServerMessage_Action{
 			Action: &pm.ActionDispatch{
 				Action: action,
@@ -109,7 +107,7 @@ func (h *deviceTaskHandler) handleOSQueryDispatch(_ context.Context, t *asynq.Ta
 	}
 
 	msg := &pm.ServerMessage{
-		Id: ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String(),
+		Id: ulid.Make().String(),
 		Payload: &pm.ServerMessage_Query{
 			Query: &pm.OSQuery{
 				QueryId: payload.QueryID,
@@ -131,7 +129,7 @@ func (h *deviceTaskHandler) handleOSQueryDispatch(_ context.Context, t *asynq.Ta
 
 func (h *deviceTaskHandler) handleInventoryRequest(_ context.Context, _ *asynq.Task) error {
 	msg := &pm.ServerMessage{
-		Id: ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String(),
+		Id: ulid.Make().String(),
 		Payload: &pm.ServerMessage_RequestInventory{
 			RequestInventory: &pm.RequestInventory{},
 		},
@@ -152,7 +150,7 @@ func (h *deviceTaskHandler) handleRevokeLuksDeviceKey(_ context.Context, t *asyn
 	}
 
 	msg := &pm.ServerMessage{
-		Id: ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String(),
+		Id: ulid.Make().String(),
 		Payload: &pm.ServerMessage_RevokeLuksDeviceKey{
 			RevokeLuksDeviceKey: &pm.RevokeLuksDeviceKey{
 				ActionId: payload.ActionID,
@@ -175,7 +173,7 @@ func (h *deviceTaskHandler) handleLogQueryDispatch(_ context.Context, t *asynq.T
 	}
 
 	msg := &pm.ServerMessage{
-		Id: ulid.MustNew(ulid.Timestamp(time.Now()), rand.Reader).String(),
+		Id: ulid.Make().String(),
 		Payload: &pm.ServerMessage_LogQuery{
 			LogQuery: &pm.LogQuery{
 				QueryId:  payload.QueryID,

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -284,7 +284,11 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 					RotatedAt string `json:"rotated_at"`
 					Reason    string `json:"reason"`
 				}
-				if err := json.Unmarshal([]byte(rotationsJSON), &rotations); err == nil && len(rotations) > 0 {
+				if err := json.Unmarshal([]byte(rotationsJSON), &rotations); err != nil {
+					// Strip malformed rotation data to prevent plaintext leaking to Valkey
+					delete(result.Metadata, "lps.rotations")
+					h.logger.Error("failed to unmarshal lps.rotations metadata", "error", err)
+				} else if len(rotations) > 0 {
 					protoRotations := make([]*pm.LpsPasswordRotation, len(rotations))
 					for i, r := range rotations {
 						protoRotations[i] = &pm.LpsPasswordRotation{

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -274,8 +274,14 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 			"duration_ms", result.DurationMs,
 		)
 
-		// Extract and proxy LPS password rotations via RPC (credentials never touch Valkey).
-		// Only strip the metadata key after successful storage so retries can re-process.
+		// Extract and proxy LPS password rotations via encrypted RPC.
+		// Retry semantics: handleAgentMessage is called from the streaming
+		// message loop. Unmarshal failures strip the key immediately (data is
+		// malformed, retry won't help). StoreLpsPasswords failures return an
+		// error — the agent will resend the result via SendActionResult on
+		// reconnect, preserving the metadata for retry. The key is only
+		// deleted after successful storage so plaintext passwords never reach
+		// Valkey.
 		if result.Metadata != nil {
 			if rotationsJSON, ok := result.Metadata["lps.rotations"]; ok && rotationsJSON != "" {
 				var rotations []struct {
@@ -285,7 +291,7 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 					Reason    string `json:"reason"`
 				}
 				if err := json.Unmarshal([]byte(rotationsJSON), &rotations); err != nil {
-					// Strip malformed rotation data to prevent plaintext leaking to Valkey
+					// Malformed — strip to prevent plaintext leaking to Valkey
 					delete(result.Metadata, "lps.rotations")
 					h.logger.Error("failed to unmarshal lps.rotations metadata", "error", err)
 				} else if len(rotations) > 0 {
@@ -298,11 +304,12 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 							Reason:    r.Reason,
 						}
 					}
-					// Use resultID as actionID — for agent-scheduled actions it IS the action ID.
-					// Return on failure to prevent plaintext passwords reaching Valkey.
 					if err := h.controlProxy.StoreLpsPasswords(ctx, deviceID, resultID, protoRotations); err != nil {
 						return fmt.Errorf("store lps passwords: %w", err)
 					}
+					delete(result.Metadata, "lps.rotations")
+				} else {
+					// Empty rotations array — strip unnecessary metadata
 					delete(result.Metadata, "lps.rotations")
 				}
 			}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -294,12 +294,12 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 							Reason:    r.Reason,
 						}
 					}
-					// Use resultID as actionID — for agent-scheduled actions it IS the action ID
+					// Use resultID as actionID — for agent-scheduled actions it IS the action ID.
+					// Return on failure to prevent plaintext passwords reaching Valkey.
 					if err := h.controlProxy.StoreLpsPasswords(ctx, deviceID, resultID, protoRotations); err != nil {
-						h.logger.Error("failed to proxy LPS password rotations", "error", err)
-					} else {
-						delete(result.Metadata, "lps.rotations")
+						return fmt.Errorf("store lps passwords: %w", err)
 					}
+					delete(result.Metadata, "lps.rotations")
 				}
 			}
 		}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -274,7 +274,8 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 			"duration_ms", result.DurationMs,
 		)
 
-		// Extract and proxy LPS password rotations via RPC (credentials never touch Valkey)
+		// Extract and proxy LPS password rotations via RPC (credentials never touch Valkey).
+		// Only strip the metadata key after successful storage so retries can re-process.
 		if result.Metadata != nil {
 			if rotationsJSON, ok := result.Metadata["lps.rotations"]; ok && rotationsJSON != "" {
 				var rotations []struct {
@@ -296,12 +297,11 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 					// Use resultID as actionID — for agent-scheduled actions it IS the action ID
 					if err := h.controlProxy.StoreLpsPasswords(ctx, deviceID, resultID, protoRotations); err != nil {
 						h.logger.Error("failed to proxy LPS password rotations", "error", err)
+					} else {
+						delete(result.Metadata, "lps.rotations")
 					}
 				}
 			}
-
-			// Strip sensitive data before enqueueing to Valkey
-			delete(result.Metadata, "lps.rotations")
 		}
 
 		// Serialize ActionResult to protojson and enqueue to control:inbox

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -291,7 +291,7 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 					Reason    string `json:"reason"`
 				}
 				if err := json.Unmarshal([]byte(rotationsJSON), &rotations); err != nil {
-					// Malformed — strip to prevent plaintext leaking to Valkey
+					// Malformed — strip and log, retry won't help
 					delete(result.Metadata, "lps.rotations")
 					h.logger.Error("failed to unmarshal lps.rotations metadata", "error", err)
 				} else if len(rotations) > 0 {
@@ -305,11 +305,13 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 						}
 					}
 					if err := h.controlProxy.StoreLpsPasswords(ctx, deviceID, resultID, protoRotations); err != nil {
+						// Return to preserve metadata for retry on reconnect
 						return fmt.Errorf("store lps passwords: %w", err)
 					}
+					// Stored successfully — safe to strip
 					delete(result.Metadata, "lps.rotations")
 				} else {
-					// Empty rotations array — strip unnecessary metadata
+					// Empty array — strip unnecessary metadata
 					delete(result.Metadata, "lps.rotations")
 				}
 			}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -299,6 +299,9 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 					}
 				}
 			}
+
+			// Strip sensitive data before enqueueing to Valkey
+			delete(result.Metadata, "lps.rotations")
 		}
 
 		// Serialize ActionResult to protojson and enqueue to control:inbox

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -18,17 +18,18 @@ const (
 )
 
 // CORS returns a middleware that adds CORS headers for cross-origin requests.
-// If allowedOrigins is empty, all origins are allowed (development mode) with a warning.
-// Set CONTROL_CORS_ORIGINS=https://app.example.com,https://other.example.com for production.
-func CORS(allowedOrigins []string, logger *slog.Logger) func(http.Handler) http.Handler {
+// If allowedOrigins is empty and allowAll is false, CORS requests are denied (fail-closed).
+// Set allowAll to true only for local development.
+func CORS(allowedOrigins []string, allowAll bool, logger *slog.Logger) func(http.Handler) http.Handler {
 	originSet := make(map[string]bool, len(allowedOrigins))
 	for _, o := range allowedOrigins {
 		originSet[o] = true
 	}
 
-	allowAll := len(allowedOrigins) == 0
 	if allowAll {
-		logger.Warn("CORS: no origins configured (CONTROL_CORS_ORIGINS), allowing all origins -- set this in production")
+		logger.Warn("CORS: allow-all mode enabled — do not use in production")
+	} else if len(allowedOrigins) == 0 {
+		logger.Warn("CORS: no origins configured (CONTROL_CORS_ORIGINS), all cross-origin requests will be denied")
 	} else {
 		logger.Info("CORS: allowed origins configured", "origins", allowedOrigins)
 	}
@@ -47,6 +48,7 @@ func CORS(allowedOrigins []string, logger *slog.Logger) func(http.Handler) http.
 				if allowAll || originSet[origin] {
 					w.Header().Set("Access-Control-Allow-Origin", origin)
 					w.Header().Set("Access-Control-Allow-Credentials", "true")
+					w.Header().Add("Vary", "Origin")
 				} else {
 					// Origin not allowed - do not set CORS headers
 					if r.Method == http.MethodOptions {
@@ -64,6 +66,8 @@ func CORS(allowedOrigins []string, logger *slog.Logger) func(http.Handler) http.
 				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeaders)
 				w.Header().Set("Access-Control-Expose-Headers", corsExposeHeaders)
 				w.Header().Set("Access-Control-Max-Age", corsMaxAge)
+				w.Header().Add("Vary", "Access-Control-Request-Method")
+				w.Header().Add("Vary", "Access-Control-Request-Headers")
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -5,6 +5,18 @@ import (
 	"net/http"
 )
 
+// CORS header constants for Connect-RPC compatibility.
+const (
+	// corsAllowMethods lists HTTP methods allowed in cross-origin requests.
+	corsAllowMethods = "GET, POST, PUT, DELETE, OPTIONS"
+	// corsAllowHeaders lists request headers the client may send.
+	corsAllowHeaders = "Accept, Authorization, Content-Type, Connect-Protocol-Version, Connect-Timeout-Ms, Cookie"
+	// corsExposeHeaders lists response headers the browser may access.
+	corsExposeHeaders = "Connect-Content-Encoding, Connect-Protocol-Version"
+	// corsMaxAge is the preflight cache duration in seconds (24 hours).
+	corsMaxAge = "86400"
+)
+
 // CORS returns a middleware that adds CORS headers for cross-origin requests.
 // If allowedOrigins is empty, all origins are allowed (development mode) with a warning.
 // Set CONTROL_CORS_ORIGINS=https://app.example.com,https://other.example.com for production.
@@ -25,6 +37,12 @@ func CORS(allowedOrigins []string, logger *slog.Logger) func(http.Handler) http.
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 
+			// OPTIONS without Origin is not a CORS preflight — return early.
+			if r.Method == http.MethodOptions && origin == "" {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
 			if origin != "" {
 				if allowAll || originSet[origin] {
 					w.Header().Set("Access-Control-Allow-Origin", origin)
@@ -42,16 +60,16 @@ func CORS(allowedOrigins []string, logger *slog.Logger) func(http.Handler) http.
 
 			// Handle preflight requests
 			if r.Method == http.MethodOptions {
-				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-				w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Connect-Protocol-Version, Connect-Timeout-Ms, Cookie")
-				w.Header().Set("Access-Control-Expose-Headers", "Connect-Content-Encoding, Connect-Protocol-Version")
-				w.Header().Set("Access-Control-Max-Age", "86400")
+				w.Header().Set("Access-Control-Allow-Methods", corsAllowMethods)
+				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeaders)
+				w.Header().Set("Access-Control-Expose-Headers", corsExposeHeaders)
+				w.Header().Set("Access-Control-Max-Age", corsMaxAge)
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}
 
 			// Set headers for actual requests
-			w.Header().Set("Access-Control-Expose-Headers", "Connect-Content-Encoding, Connect-Protocol-Version")
+			w.Header().Set("Access-Control-Expose-Headers", corsExposeHeaders)
 
 			next.ServeHTTP(w, r)
 		})

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -1,0 +1,59 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+)
+
+// CORS returns a middleware that adds CORS headers for cross-origin requests.
+// If allowedOrigins is empty, all origins are allowed (development mode) with a warning.
+// Set CONTROL_CORS_ORIGINS=https://app.example.com,https://other.example.com for production.
+func CORS(allowedOrigins []string, logger *slog.Logger) func(http.Handler) http.Handler {
+	originSet := make(map[string]bool, len(allowedOrigins))
+	for _, o := range allowedOrigins {
+		originSet[o] = true
+	}
+
+	allowAll := len(allowedOrigins) == 0
+	if allowAll {
+		logger.Warn("CORS: no origins configured (CONTROL_CORS_ORIGINS), allowing all origins -- set this in production")
+	} else {
+		logger.Info("CORS: allowed origins configured", "origins", allowedOrigins)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+
+			if origin != "" {
+				if allowAll || originSet[origin] {
+					w.Header().Set("Access-Control-Allow-Origin", origin)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
+				} else {
+					// Origin not allowed - do not set CORS headers
+					if r.Method == http.MethodOptions {
+						w.WriteHeader(http.StatusForbidden)
+						return
+					}
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			// Handle preflight requests
+			if r.Method == http.MethodOptions {
+				w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
+				w.Header().Set("Access-Control-Allow-Headers", "Accept, Authorization, Content-Type, Connect-Protocol-Version, Connect-Timeout-Ms, Cookie")
+				w.Header().Set("Access-Control-Expose-Headers", "Connect-Content-Encoding, Connect-Protocol-Version")
+				w.Header().Set("Access-Control-Max-Age", "86400")
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			// Set headers for actual requests
+			w.Header().Set("Access-Control-Expose-Headers", "Connect-Content-Encoding, Connect-Protocol-Version")
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -48,7 +48,6 @@ func CORS(allowedOrigins []string, allowAll bool, logger *slog.Logger) func(http
 				if allowAll || originSet[origin] {
 					w.Header().Set("Access-Control-Allow-Origin", origin)
 					w.Header().Set("Access-Control-Allow-Credentials", "true")
-					w.Header().Add("Vary", "Origin")
 				} else {
 					// Origin not allowed - do not set CORS headers
 					if r.Method == http.MethodOptions {
@@ -71,6 +70,9 @@ func CORS(allowedOrigins []string, allowAll bool, logger *slog.Logger) func(http
 				w.WriteHeader(http.StatusNoContent)
 				return
 			}
+
+			// Always set Vary: Origin so caches key by origin presence
+			w.Header().Add("Vary", "Origin")
 
 			// Set headers for actual requests
 			w.Header().Set("Access-Control-Expose-Headers", corsExposeHeaders)

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -38,12 +38,6 @@ func CORS(allowedOrigins []string, allowAll bool, logger *slog.Logger) func(http
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			origin := r.Header.Get("Origin")
 
-			// OPTIONS without Origin is not a CORS preflight — return early.
-			if r.Method == http.MethodOptions && origin == "" {
-				w.WriteHeader(http.StatusNoContent)
-				return
-			}
-
 			if origin != "" {
 				if allowAll || originSet[origin] {
 					w.Header().Set("Access-Control-Allow-Origin", origin)
@@ -61,6 +55,7 @@ func CORS(allowedOrigins []string, allowAll bool, logger *slog.Logger) func(http
 
 			// Handle preflight requests
 			if r.Method == http.MethodOptions {
+				w.Header().Add("Vary", "Origin")
 				w.Header().Set("Access-Control-Allow-Methods", corsAllowMethods)
 				w.Header().Set("Access-Control-Allow-Headers", corsAllowHeaders)
 				w.Header().Set("Access-Control-Expose-Headers", corsExposeHeaders)


### PR DESCRIPTION
## Summary

Second round of server refactoring addressing issue #30. Covers boilerplate reduction and logic/correctness improvements across the codebase.

### Boilerplate
- Extract duplicate `asynqLogger` adapter to shared `internal/asynqutil` package
- Replace 13+ verbose `ulid.MustNew(ulid.Timestamp(...))` calls with `ulid.Make().String()`
- Extract `commandOutputToMap`/`addCommandOutputs` helpers in inbox worker
- Extract `runPeriodic` helper for 3 identical background ticker goroutines
- Extract `envString`/`envBool`/`envDuration`/`envCSV`/`envInt` config helpers (26 blocks → one-liners)
- Extract `enqueueSearchReindex` wrapper across 8 handlers; fix string literal scopes to constants
- Move CORS middleware to `internal/middleware/cors.go`

### Logic fixes
- **handleExecutionResult**: distinguish `pgx.ErrNoRows` from transient DB errors — transient errors now retry instead of creating phantom executions with `action_type=0`
- **dispatchPendingActions**: return error so callers can log failures
- **Deleted device logs**: change from Warn to Debug (expected condition, not alertable)
- **lps.rotations**: strip plaintext passwords from ActionResult metadata before enqueueing to Valkey

Closes #30

## Test plan
- [x] `go build -o /dev/null ./cmd/control && go build -o /dev/null ./cmd/gateway`
- [x] `go vet ./...`
- [x] `go test ./internal/gateway/... ./internal/handler/... ./internal/middleware/...`
- [ ] Full `go test ./...` in CI (requires PostgreSQL)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CORS middleware added with a runtime "allow all" toggle.

* **Bug Fixes**
  * More reliable device/execution processing with stricter error propagation, ordered dispatching, retries, and reduced duplicates/loss.
  * Stricter metadata handling and safer, deterministic ID generation.

* **Chores**
  * Centralized periodic task runner, unified background-task logging, shared search-reindex enqueueing, and consolidated environment parsing helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->