### PR TITLE
refactor: simplify complex codepaths

### DIFF
--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -661,7 +661,10 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		action := source.InlineAction
 		actionType = action.Type
 		desiredState = action.DesiredState
-		params, _ = serializeProtoParams(extractActionParamsMsg(action))
+		params, err = serializeProtoParams(extractActionParamsMsg(action))
+		if err != nil {
+			return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, fmt.Sprintf("failed to serialize inline action params: %v", err))
+		}
 		timeoutSeconds = action.TimeoutSeconds
 		if timeoutSeconds <= 0 {
 			timeoutSeconds = 300
@@ -1289,6 +1292,8 @@ func extractActionParamsMsg(action *pm.Action) proto.Message {
 		return p.Lps
 	case *pm.Action_Luks:
 		return p.Luks
+	case *pm.Action_Group:
+		return p.Group
 	case *pm.Action_Wifi:
 		return p.Wifi
 	case *pm.Action_AgentUpdate:

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -257,7 +258,7 @@ func (h *ActionHandler) CreateAction(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
-	params, err := h.serializeCreateActionParams(req.Msg)
+	params, err := serializeProtoParams(extractCreateActionParamsMsg(req.Msg))
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, err.Error())
 	}
@@ -484,7 +485,7 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}
 
-	params, err := h.serializeUpdateActionParams(req.Msg)
+	params, err := serializeProtoParams(extractUpdateActionParamsMsg(req.Msg))
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, err.Error())
 	}
@@ -660,7 +661,7 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		action := source.InlineAction
 		actionType = action.Type
 		desiredState = action.DesiredState
-		params = serializeActionParamsToMap(action)
+		params, _ = serializeProtoParams(extractActionParamsMsg(action))
 		timeoutSeconds = action.TimeoutSeconds
 		if timeoutSeconds <= 0 {
 			timeoutSeconds = 300
@@ -1150,181 +1151,151 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 	}), nil
 }
 
-func (h *ActionHandler) serializeCreateActionParams(req *pm.CreateActionRequest) (map[string]any, error) {
-	params := map[string]any{}
+// serializeProtoParams marshals a proto.Message to a map[string]any via protojson.
+// Returns an empty map if msg is nil.
+func serializeProtoParams(msg proto.Message) (map[string]any, error) {
+	if msg == nil {
+		return map[string]any{}, nil
+	}
+	data, err := protojson.Marshal(msg)
+	if err != nil {
+		return nil, fmt.Errorf("marshal params: %w", err)
+	}
+	var params map[string]any
+	if err := json.Unmarshal(data, &params); err != nil {
+		return nil, fmt.Errorf("unmarshal params to map: %w", err)
+	}
+	return params, nil
+}
 
-	var data []byte
-	var err error
-
+// extractCreateActionParamsMsg returns the concrete proto.Message from a CreateActionRequest oneof.
+func extractCreateActionParamsMsg(req *pm.CreateActionRequest) proto.Message {
 	switch p := req.Params.(type) {
 	case *pm.CreateActionRequest_Package:
-		data, err = protojson.Marshal(p.Package)
+		return p.Package
 	case *pm.CreateActionRequest_App:
-		data, err = protojson.Marshal(p.App)
+		return p.App
 	case *pm.CreateActionRequest_Flatpak:
-		data, err = protojson.Marshal(p.Flatpak)
+		return p.Flatpak
 	case *pm.CreateActionRequest_Shell:
-		data, err = protojson.Marshal(p.Shell)
+		return p.Shell
 	case *pm.CreateActionRequest_Systemd:
-		data, err = protojson.Marshal(p.Systemd)
+		return p.Systemd
 	case *pm.CreateActionRequest_File:
-		data, err = protojson.Marshal(p.File)
+		return p.File
 	case *pm.CreateActionRequest_Update:
-		data, err = protojson.Marshal(p.Update)
+		return p.Update
 	case *pm.CreateActionRequest_Repository:
-		data, err = protojson.Marshal(p.Repository)
+		return p.Repository
 	case *pm.CreateActionRequest_Directory:
-		data, err = protojson.Marshal(p.Directory)
+		return p.Directory
 	case *pm.CreateActionRequest_User:
-		data, err = protojson.Marshal(p.User)
+		return p.User
 	case *pm.CreateActionRequest_Ssh:
-		data, err = protojson.Marshal(p.Ssh)
+		return p.Ssh
 	case *pm.CreateActionRequest_Sshd:
-		data, err = protojson.Marshal(p.Sshd)
+		return p.Sshd
 	case *pm.CreateActionRequest_Sudo:
-		data, err = protojson.Marshal(p.Sudo)
+		return p.Sudo
 	case *pm.CreateActionRequest_Lps:
-		data, err = protojson.Marshal(p.Lps)
+		return p.Lps
 	case *pm.CreateActionRequest_Luks:
-		data, err = protojson.Marshal(p.Luks)
+		return p.Luks
 	case *pm.CreateActionRequest_Group:
-		data, err = protojson.Marshal(p.Group)
+		return p.Group
 	case *pm.CreateActionRequest_Wifi:
-		data, err = protojson.Marshal(p.Wifi)
+		return p.Wifi
 	case *pm.CreateActionRequest_AgentUpdate:
-		data, err = protojson.Marshal(p.AgentUpdate)
+		return p.AgentUpdate
 	default:
-		return params, nil
+		return nil
 	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal params: %w", err)
-	}
-	if err := json.Unmarshal(data, &params); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal params to map: %w", err)
-	}
-
-	return params, nil
 }
 
-func (h *ActionHandler) serializeUpdateActionParams(req *pm.UpdateActionParamsRequest) (map[string]any, error) {
-	params := map[string]any{}
-
-	var data []byte
-	var err error
-
+// extractUpdateActionParamsMsg returns the concrete proto.Message from an UpdateActionParamsRequest oneof.
+func extractUpdateActionParamsMsg(req *pm.UpdateActionParamsRequest) proto.Message {
 	switch p := req.Params.(type) {
 	case *pm.UpdateActionParamsRequest_Package:
-		data, err = protojson.Marshal(p.Package)
+		return p.Package
 	case *pm.UpdateActionParamsRequest_App:
-		data, err = protojson.Marshal(p.App)
+		return p.App
 	case *pm.UpdateActionParamsRequest_Flatpak:
-		data, err = protojson.Marshal(p.Flatpak)
+		return p.Flatpak
 	case *pm.UpdateActionParamsRequest_Shell:
-		data, err = protojson.Marshal(p.Shell)
+		return p.Shell
 	case *pm.UpdateActionParamsRequest_Systemd:
-		data, err = protojson.Marshal(p.Systemd)
+		return p.Systemd
 	case *pm.UpdateActionParamsRequest_File:
-		data, err = protojson.Marshal(p.File)
+		return p.File
 	case *pm.UpdateActionParamsRequest_Update:
-		data, err = protojson.Marshal(p.Update)
+		return p.Update
 	case *pm.UpdateActionParamsRequest_Repository:
-		data, err = protojson.Marshal(p.Repository)
+		return p.Repository
 	case *pm.UpdateActionParamsRequest_Directory:
-		data, err = protojson.Marshal(p.Directory)
+		return p.Directory
 	case *pm.UpdateActionParamsRequest_User:
-		data, err = protojson.Marshal(p.User)
+		return p.User
 	case *pm.UpdateActionParamsRequest_Ssh:
-		data, err = protojson.Marshal(p.Ssh)
+		return p.Ssh
 	case *pm.UpdateActionParamsRequest_Sshd:
-		data, err = protojson.Marshal(p.Sshd)
+		return p.Sshd
 	case *pm.UpdateActionParamsRequest_Sudo:
-		data, err = protojson.Marshal(p.Sudo)
+		return p.Sudo
 	case *pm.UpdateActionParamsRequest_Lps:
-		data, err = protojson.Marshal(p.Lps)
+		return p.Lps
 	case *pm.UpdateActionParamsRequest_Luks:
-		data, err = protojson.Marshal(p.Luks)
+		return p.Luks
 	case *pm.UpdateActionParamsRequest_Group:
-		data, err = protojson.Marshal(p.Group)
+		return p.Group
 	case *pm.UpdateActionParamsRequest_Wifi:
-		data, err = protojson.Marshal(p.Wifi)
+		return p.Wifi
 	case *pm.UpdateActionParamsRequest_AgentUpdate:
-		data, err = protojson.Marshal(p.AgentUpdate)
+		return p.AgentUpdate
 	default:
-		return params, nil
+		return nil
 	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal params: %w", err)
-	}
-	if err := json.Unmarshal(data, &params); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal params to map: %w", err)
-	}
-
-	return params, nil
 }
 
-func serializeActionParams(action *pm.Action) (string, error) {
-	params := serializeActionParamsToMap(action)
-	data, err := json.Marshal(params)
-	return string(data), err
-}
-
-func serializeActionParamsToMap(action *pm.Action) map[string]any {
-	params := map[string]any{}
-
+// extractActionParamsMsg returns the concrete proto.Message from an Action oneof.
+func extractActionParamsMsg(action *pm.Action) proto.Message {
 	switch p := action.Params.(type) {
 	case *pm.Action_Package:
-		data, _ := protojson.Marshal(p.Package)
-		json.Unmarshal(data, &params)
+		return p.Package
 	case *pm.Action_App:
-		data, _ := protojson.Marshal(p.App)
-		json.Unmarshal(data, &params)
+		return p.App
 	case *pm.Action_Flatpak:
-		data, _ := protojson.Marshal(p.Flatpak)
-		json.Unmarshal(data, &params)
+		return p.Flatpak
 	case *pm.Action_Shell:
-		data, _ := protojson.Marshal(p.Shell)
-		json.Unmarshal(data, &params)
+		return p.Shell
 	case *pm.Action_Systemd:
-		data, _ := protojson.Marshal(p.Systemd)
-		json.Unmarshal(data, &params)
+		return p.Systemd
 	case *pm.Action_File:
-		data, _ := protojson.Marshal(p.File)
-		json.Unmarshal(data, &params)
+		return p.File
 	case *pm.Action_Update:
-		data, _ := protojson.Marshal(p.Update)
-		json.Unmarshal(data, &params)
+		return p.Update
 	case *pm.Action_Repository:
-		data, _ := protojson.Marshal(p.Repository)
-		json.Unmarshal(data, &params)
+		return p.Repository
 	case *pm.Action_Directory:
-		data, _ := protojson.Marshal(p.Directory)
-		json.Unmarshal(data, &params)
+		return p.Directory
 	case *pm.Action_User:
-		data, _ := protojson.Marshal(p.User)
-		json.Unmarshal(data, &params)
+		return p.User
 	case *pm.Action_Ssh:
-		data, _ := protojson.Marshal(p.Ssh)
-		json.Unmarshal(data, &params)
+		return p.Ssh
 	case *pm.Action_Sshd:
-		data, _ := protojson.Marshal(p.Sshd)
-		json.Unmarshal(data, &params)
+		return p.Sshd
 	case *pm.Action_Sudo:
-		data, _ := protojson.Marshal(p.Sudo)
-		json.Unmarshal(data, &params)
+		return p.Sudo
 	case *pm.Action_Lps:
-		data, _ := protojson.Marshal(p.Lps)
-		json.Unmarshal(data, &params)
+		return p.Lps
 	case *pm.Action_Luks:
-		data, _ := protojson.Marshal(p.Luks)
-		json.Unmarshal(data, &params)
+		return p.Luks
 	case *pm.Action_Wifi:
-		data, _ := protojson.Marshal(p.Wifi)
-		json.Unmarshal(data, &params)
+		return p.Wifi
+	case *pm.Action_AgentUpdate:
+		return p.AgentUpdate
+	default:
+		return nil
 	}
-
-	return params
 }
 
 // enqueueActionReindex enqueues a search index update for an action.

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -240,267 +240,281 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, msg *pm.AgentMessage) error {
 	switch p := msg.Payload.(type) {
 	case *pm.AgentMessage_Heartbeat:
-		payload := taskqueue.DeviceHeartbeatPayload{
-			DeviceID: deviceID,
-		}
-		if p.Heartbeat.Uptime != nil {
-			payload.UptimeSeconds = p.Heartbeat.Uptime.Seconds
-		}
-		if p.Heartbeat.CpuPercent > 0 {
-			payload.CpuPercent = p.Heartbeat.CpuPercent
-		}
-		if p.Heartbeat.MemoryPercent > 0 {
-			payload.MemoryPercent = p.Heartbeat.MemoryPercent
-		}
-		if p.Heartbeat.DiskPercent > 0 {
-			payload.DiskPercent = p.Heartbeat.DiskPercent
-		}
-		return h.aqClient.EnqueueToControl(taskqueue.TypeDeviceHeartbeat, payload)
-
+		return h.handleHeartbeat(deviceID, p.Heartbeat)
 	case *pm.AgentMessage_ActionResult:
-		result := p.ActionResult
-		if result.ActionId == nil {
-			return fmt.Errorf("action result missing action ID")
-		}
-		resultID := result.ActionId.GetValue()
-		if resultID == "" {
-			return fmt.Errorf("action result has empty action ID")
-		}
-
-		h.logger.Info("received action result",
-			"device_id", deviceID,
-			"result_id", resultID,
-			"status", result.Status.String(),
-			"duration_ms", result.DurationMs,
-		)
-
-		// Extract and proxy LPS password rotations via encrypted RPC.
-		// Retry semantics: handleAgentMessage is called from the streaming
-		// message loop. Unmarshal failures strip the key immediately (data is
-		// malformed, retry won't help). StoreLpsPasswords failures return an
-		// error — the agent will resend the result via SendActionResult on
-		// reconnect, preserving the metadata for retry. The key is only
-		// deleted after successful storage so plaintext passwords never reach
-		// Valkey.
-		if result.Metadata != nil {
-			if rotationsJSON, ok := result.Metadata["lps.rotations"]; ok && rotationsJSON != "" {
-				var rotations []struct {
-					Username  string `json:"username"`
-					Password  string `json:"password"`
-					RotatedAt string `json:"rotated_at"`
-					Reason    string `json:"reason"`
-				}
-				if err := json.Unmarshal([]byte(rotationsJSON), &rotations); err != nil {
-					// Malformed — strip and log, retry won't help
-					delete(result.Metadata, "lps.rotations")
-					h.logger.Error("failed to unmarshal lps.rotations metadata", "error", err)
-				} else if len(rotations) > 0 {
-					protoRotations := make([]*pm.LpsPasswordRotation, len(rotations))
-					for i, r := range rotations {
-						protoRotations[i] = &pm.LpsPasswordRotation{
-							Username:  r.Username,
-							Password:  r.Password,
-							RotatedAt: r.RotatedAt,
-							Reason:    r.Reason,
-						}
-					}
-					if err := h.controlProxy.StoreLpsPasswords(ctx, deviceID, resultID, protoRotations); err != nil {
-						// Return to preserve metadata for retry on reconnect
-						return fmt.Errorf("store lps passwords: %w", err)
-					}
-					// Stored successfully — safe to strip
-					delete(result.Metadata, "lps.rotations")
-				} else {
-					// Empty array — strip unnecessary metadata
-					delete(result.Metadata, "lps.rotations")
-				}
-			}
-		}
-
-		// Serialize ActionResult to protojson and enqueue to control:inbox
-		resultJSON, err := protojson.Marshal(result)
-		if err != nil {
-			return fmt.Errorf("marshal action result: %w", err)
-		}
-
-		return h.aqClient.EnqueueToControl(taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
-			DeviceID:         deviceID,
-			ActionResultJSON: resultJSON,
-		})
-
+		return h.handleActionResult(ctx, deviceID, p.ActionResult)
 	case *pm.AgentMessage_OutputChunk:
-		chunk := p.OutputChunk
-		if chunk.ExecutionId == "" {
-			return fmt.Errorf("output chunk missing execution ID")
-		}
-
-		streamType := "stdout"
-		if chunk.Stream == pm.OutputStreamType_OUTPUT_STREAM_TYPE_STDERR {
-			streamType = "stderr"
-		}
-
-		h.logger.Debug("received output chunk",
-			"device_id", deviceID,
-			"execution_id", chunk.ExecutionId,
-			"stream", streamType,
-			"sequence", chunk.Sequence,
-			"size", len(chunk.Data),
-		)
-
-		return h.aqClient.EnqueueToControl(taskqueue.TypeExecutionOutputChunk, taskqueue.ExecutionOutputChunkPayload{
-			DeviceID:    deviceID,
-			ExecutionID: chunk.ExecutionId,
-			Stream:      streamType,
-			Data:        string(chunk.Data),
-			Sequence:    int64(chunk.Sequence),
-		})
-
+		return h.handleOutputChunk(deviceID, p.OutputChunk)
 	case *pm.AgentMessage_QueryResult:
-		result := p.QueryResult
-		h.logger.Info("received query result",
-			"device_id", deviceID,
-			"query_id", result.QueryId,
-			"success", result.Success,
-		)
+		return h.handleQueryResult(deviceID, p.QueryResult)
+	case *pm.AgentMessage_Inventory:
+		return h.handleInventory(deviceID, p.Inventory)
+	case *pm.AgentMessage_SecurityAlert:
+		return h.handleSecurityAlert(deviceID, p.SecurityAlert)
+	case *pm.AgentMessage_GetLuksKey:
+		return h.handleGetLuksKey(ctx, deviceID, msg.Id, p.GetLuksKey)
+	case *pm.AgentMessage_StoreLuksKey:
+		return h.handleStoreLuksKey(ctx, deviceID, msg.Id, p.StoreLuksKey)
+	case *pm.AgentMessage_RevokeLuksDeviceKeyResult:
+		return h.handleRevokeLuksResult(deviceID, p.RevokeLuksDeviceKeyResult)
+	case *pm.AgentMessage_LogQueryResult:
+		return h.handleLogQueryResult(deviceID, p.LogQueryResult)
+	default:
+		return fmt.Errorf("unknown message type: %T", msg.Payload)
+	}
+}
 
-		// Convert rows to JSON for storage
+func (h *AgentHandler) handleHeartbeat(deviceID string, hb *pm.Heartbeat) error {
+	payload := taskqueue.DeviceHeartbeatPayload{DeviceID: deviceID}
+	if hb.Uptime != nil {
+		payload.UptimeSeconds = hb.Uptime.Seconds
+	}
+	if hb.CpuPercent > 0 {
+		payload.CpuPercent = hb.CpuPercent
+	}
+	if hb.MemoryPercent > 0 {
+		payload.MemoryPercent = hb.MemoryPercent
+	}
+	if hb.DiskPercent > 0 {
+		payload.DiskPercent = hb.DiskPercent
+	}
+	return h.aqClient.EnqueueToControl(taskqueue.TypeDeviceHeartbeat, payload)
+}
+
+func (h *AgentHandler) handleActionResult(ctx context.Context, deviceID string, result *pm.ActionResult) error {
+	if result.ActionId == nil {
+		return fmt.Errorf("action result missing action ID")
+	}
+	resultID := result.ActionId.GetValue()
+	if resultID == "" {
+		return fmt.Errorf("action result has empty action ID")
+	}
+
+	h.logger.Info("received action result",
+		"device_id", deviceID,
+		"result_id", resultID,
+		"status", result.Status.String(),
+		"duration_ms", result.DurationMs,
+	)
+
+	if err := h.proxyLpsRotations(ctx, deviceID, resultID, result); err != nil {
+		return err
+	}
+
+	resultJSON, err := protojson.Marshal(result)
+	if err != nil {
+		return fmt.Errorf("marshal action result: %w", err)
+	}
+	return h.aqClient.EnqueueToControl(taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
+		DeviceID:         deviceID,
+		ActionResultJSON: resultJSON,
+	})
+}
+
+// proxyLpsRotations extracts LPS password rotations from metadata, proxies them
+// via encrypted RPC, and strips the key before the result is enqueued to Valkey.
+// Unmarshal failures strip immediately (malformed, retry won't help).
+// StoreLpsPasswords failures return an error — the agent will resend the result
+// on reconnect, preserving the metadata for retry.
+func (h *AgentHandler) proxyLpsRotations(ctx context.Context, deviceID, resultID string, result *pm.ActionResult) error {
+	if result.Metadata == nil {
+		return nil
+	}
+	rotationsJSON, ok := result.Metadata["lps.rotations"]
+	if !ok || rotationsJSON == "" {
+		return nil
+	}
+
+	var rotations []struct {
+		Username  string `json:"username"`
+		Password  string `json:"password"`
+		RotatedAt string `json:"rotated_at"`
+		Reason    string `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(rotationsJSON), &rotations); err != nil {
+		delete(result.Metadata, "lps.rotations")
+		h.logger.Error("failed to unmarshal lps.rotations metadata", "error", err)
+		return nil
+	}
+	if len(rotations) == 0 {
+		delete(result.Metadata, "lps.rotations")
+		return nil
+	}
+
+	protoRotations := make([]*pm.LpsPasswordRotation, len(rotations))
+	for i, r := range rotations {
+		protoRotations[i] = &pm.LpsPasswordRotation{
+			Username:  r.Username,
+			Password:  r.Password,
+			RotatedAt: r.RotatedAt,
+			Reason:    r.Reason,
+		}
+	}
+	if err := h.controlProxy.StoreLpsPasswords(ctx, deviceID, resultID, protoRotations); err != nil {
+		return fmt.Errorf("store lps passwords: %w", err)
+	}
+	delete(result.Metadata, "lps.rotations")
+	return nil
+}
+
+func (h *AgentHandler) handleOutputChunk(deviceID string, chunk *pm.OutputChunk) error {
+	if chunk.ExecutionId == "" {
+		return fmt.Errorf("output chunk missing execution ID")
+	}
+	streamType := "stdout"
+	if chunk.Stream == pm.OutputStreamType_OUTPUT_STREAM_TYPE_STDERR {
+		streamType = "stderr"
+	}
+	h.logger.Debug("received output chunk",
+		"device_id", deviceID,
+		"execution_id", chunk.ExecutionId,
+		"stream", streamType,
+		"sequence", chunk.Sequence,
+		"size", len(chunk.Data),
+	)
+	return h.aqClient.EnqueueToControl(taskqueue.TypeExecutionOutputChunk, taskqueue.ExecutionOutputChunkPayload{
+		DeviceID:    deviceID,
+		ExecutionID: chunk.ExecutionId,
+		Stream:      streamType,
+		Data:        string(chunk.Data),
+		Sequence:    int64(chunk.Sequence),
+	})
+}
+
+func (h *AgentHandler) handleQueryResult(deviceID string, result *pm.OSQueryResult) error {
+	h.logger.Info("received query result",
+		"device_id", deviceID,
+		"query_id", result.QueryId,
+		"success", result.Success,
+	)
+	var rowsJSON []map[string]string
+	for _, row := range result.Rows {
+		rowsJSON = append(rowsJSON, row.Data)
+	}
+	rowsBytes, err := json.Marshal(rowsJSON)
+	if err != nil {
+		rowsBytes = []byte("[]")
+	}
+	return h.aqClient.EnqueueToControl(taskqueue.TypeOSQueryResult, taskqueue.OSQueryResultPayload{
+		DeviceID: deviceID,
+		QueryID:  result.QueryId,
+		Success:  result.Success,
+		Error:    result.Error,
+		RowsJSON: rowsBytes,
+	})
+}
+
+func (h *AgentHandler) handleInventory(deviceID string, inventory *pm.DeviceInventory) error {
+	h.logger.Info("received device inventory",
+		"device_id", deviceID,
+		"tables", len(inventory.Tables),
+	)
+	tables := make([]taskqueue.InventoryTable, 0, len(inventory.Tables))
+	for _, table := range inventory.Tables {
 		var rowsJSON []map[string]string
-		for _, row := range result.Rows {
+		for _, row := range table.Rows {
 			rowsJSON = append(rowsJSON, row.Data)
 		}
 		rowsBytes, err := json.Marshal(rowsJSON)
 		if err != nil {
-			rowsBytes = []byte("[]")
+			continue
 		}
-
-		return h.aqClient.EnqueueToControl(taskqueue.TypeOSQueryResult, taskqueue.OSQueryResultPayload{
-			DeviceID: deviceID,
-			QueryID:  result.QueryId,
-			Success:  result.Success,
-			Error:    result.Error,
-			RowsJSON: rowsBytes,
+		tables = append(tables, taskqueue.InventoryTable{
+			TableName: table.TableName,
+			RowsJSON:  rowsBytes,
 		})
-
-	case *pm.AgentMessage_Inventory:
-		inventory := p.Inventory
-		h.logger.Info("received device inventory",
-			"device_id", deviceID,
-			"tables", len(inventory.Tables),
-		)
-
-		tables := make([]taskqueue.InventoryTable, 0, len(inventory.Tables))
-		for _, table := range inventory.Tables {
-			var rowsJSON []map[string]string
-			for _, row := range table.Rows {
-				rowsJSON = append(rowsJSON, row.Data)
-			}
-			rowsBytes, err := json.Marshal(rowsJSON)
-			if err != nil {
-				continue
-			}
-			tables = append(tables, taskqueue.InventoryTable{
-				TableName: table.TableName,
-				RowsJSON:  rowsBytes,
-			})
-		}
-
-		return h.aqClient.EnqueueToControl(taskqueue.TypeInventoryUpdate, taskqueue.InventoryUpdatePayload{
-			DeviceID: deviceID,
-			Tables:   tables,
-		})
-
-	case *pm.AgentMessage_SecurityAlert:
-		alert := p.SecurityAlert
-		h.logger.Warn("received security alert from device",
-			"device_id", deviceID,
-			"alert_type", alert.Type.String(),
-			"message", alert.Message,
-			"details", alert.Details,
-		)
-
-		return h.aqClient.EnqueueToControl(taskqueue.TypeSecurityAlert, taskqueue.SecurityAlertPayload{
-			DeviceID:  deviceID,
-			AlertType: alert.Type.String(),
-			Message:   alert.Message,
-			Details:   alert.Details,
-		})
-
-	case *pm.AgentMessage_GetLuksKey:
-		resp, err := h.controlProxy.GetLuksKey(ctx, deviceID, p.GetLuksKey.ActionId)
-		if err != nil {
-			return h.manager.Send(deviceID, &pm.ServerMessage{
-				Id: msg.Id,
-				Payload: &pm.ServerMessage_Error{
-					Error: &pm.Error{
-						Code:    connect.CodeNotFound.String(),
-						Message: "no LUKS key found for this action",
-					},
-				},
-			})
-		}
-		return h.manager.Send(deviceID, &pm.ServerMessage{
-			Id: msg.Id,
-			Payload: &pm.ServerMessage_GetLuksKey{
-				GetLuksKey: resp,
-			},
-		})
-
-	case *pm.AgentMessage_StoreLuksKey:
-		req := p.StoreLuksKey
-		resp, err := h.controlProxy.StoreLuksKey(ctx, deviceID, req.ActionId, req.DevicePath, req.Passphrase, req.RotationReason)
-		if err != nil {
-			return h.manager.Send(deviceID, &pm.ServerMessage{
-				Id: msg.Id,
-				Payload: &pm.ServerMessage_Error{
-					Error: &pm.Error{
-						Code:    connect.CodeInternal.String(),
-						Message: fmt.Sprintf("failed to store LUKS key: %v", err),
-					},
-				},
-			})
-		}
-		return h.manager.Send(deviceID, &pm.ServerMessage{
-			Id: msg.Id,
-			Payload: &pm.ServerMessage_StoreLuksKey{
-				StoreLuksKey: resp,
-			},
-		})
-
-	case *pm.AgentMessage_RevokeLuksDeviceKeyResult:
-		result := p.RevokeLuksDeviceKeyResult
-		h.logger.Info("received LUKS device key revocation result",
-			"device_id", deviceID,
-			"action_id", result.ActionId,
-			"success", result.Success,
-			"error", result.Error,
-		)
-
-		return h.aqClient.EnqueueToControl(taskqueue.TypeRevokeLuksDeviceKeyResult, taskqueue.RevokeLuksDeviceKeyResultPayload{
-			DeviceID: deviceID,
-			ActionID: result.ActionId,
-			Success:  result.Success,
-			Error:    result.Error,
-		})
-
-	case *pm.AgentMessage_LogQueryResult:
-		result := p.LogQueryResult
-		h.logger.Info("received log query result",
-			"device_id", deviceID,
-			"query_id", result.QueryId,
-			"success", result.Success,
-		)
-
-		return h.aqClient.EnqueueToControl(taskqueue.TypeLogQueryResult, taskqueue.LogQueryResultPayload{
-			DeviceID: deviceID,
-			QueryID:  result.QueryId,
-			Success:  result.Success,
-			Error:    result.Error,
-			Logs:     result.Logs,
-		})
-
-	default:
-		return fmt.Errorf("unknown message type: %T", msg.Payload)
 	}
+	return h.aqClient.EnqueueToControl(taskqueue.TypeInventoryUpdate, taskqueue.InventoryUpdatePayload{
+		DeviceID: deviceID,
+		Tables:   tables,
+	})
+}
+
+func (h *AgentHandler) handleSecurityAlert(deviceID string, alert *pm.SecurityAlert) error {
+	h.logger.Warn("received security alert from device",
+		"device_id", deviceID,
+		"alert_type", alert.Type.String(),
+		"message", alert.Message,
+		"details", alert.Details,
+	)
+	return h.aqClient.EnqueueToControl(taskqueue.TypeSecurityAlert, taskqueue.SecurityAlertPayload{
+		DeviceID:  deviceID,
+		AlertType: alert.Type.String(),
+		Message:   alert.Message,
+		Details:   alert.Details,
+	})
+}
+
+func (h *AgentHandler) handleGetLuksKey(ctx context.Context, deviceID, msgID string, req *pm.GetLuksKeyRequest) error {
+	resp, err := h.controlProxy.GetLuksKey(ctx, deviceID, req.ActionId)
+	if err != nil {
+		return h.manager.Send(deviceID, &pm.ServerMessage{
+			Id: msgID,
+			Payload: &pm.ServerMessage_Error{
+				Error: &pm.Error{
+					Code:    connect.CodeNotFound.String(),
+					Message: "no LUKS key found for this action",
+				},
+			},
+		})
+	}
+	return h.manager.Send(deviceID, &pm.ServerMessage{
+		Id: msgID,
+		Payload: &pm.ServerMessage_GetLuksKey{
+			GetLuksKey: resp,
+		},
+	})
+}
+
+func (h *AgentHandler) handleStoreLuksKey(ctx context.Context, deviceID, msgID string, req *pm.StoreLuksKeyRequest) error {
+	resp, err := h.controlProxy.StoreLuksKey(ctx, deviceID, req.ActionId, req.DevicePath, req.Passphrase, req.RotationReason)
+	if err != nil {
+		return h.manager.Send(deviceID, &pm.ServerMessage{
+			Id: msgID,
+			Payload: &pm.ServerMessage_Error{
+				Error: &pm.Error{
+					Code:    connect.CodeInternal.String(),
+					Message: fmt.Sprintf("failed to store LUKS key: %v", err),
+				},
+			},
+		})
+	}
+	return h.manager.Send(deviceID, &pm.ServerMessage{
+		Id: msgID,
+		Payload: &pm.ServerMessage_StoreLuksKey{
+			StoreLuksKey: resp,
+		},
+	})
+}
+
+func (h *AgentHandler) handleRevokeLuksResult(deviceID string, result *pm.RevokeLuksDeviceKeyResult) error {
+	h.logger.Info("received LUKS device key revocation result",
+		"device_id", deviceID,
+		"action_id", result.ActionId,
+		"success", result.Success,
+		"error", result.Error,
+	)
+	return h.aqClient.EnqueueToControl(taskqueue.TypeRevokeLuksDeviceKeyResult, taskqueue.RevokeLuksDeviceKeyResultPayload{
+		DeviceID: deviceID,
+		ActionID: result.ActionId,
+		Success:  result.Success,
+		Error:    result.Error,
+	})
+}
+
+func (h *AgentHandler) handleLogQueryResult(deviceID string, result *pm.LogQueryResult) error {
+	h.logger.Info("received log query result",
+		"device_id", deviceID,
+		"query_id", result.QueryId,
+		"success", result.Success,
+	)
+	return h.aqClient.EnqueueToControl(taskqueue.TypeLogQueryResult, taskqueue.LogQueryResultPayload{
+		DeviceID: deviceID,
+		QueryID:  result.QueryId,
+		Success:  result.Success,
+		Error:    result.Error,
+		Logs:     result.Logs,
+	})
 }
 
 // ValidateLuksToken validates and consumes a one-time LUKS token via the control server.


### PR DESCRIPTION
## Summary

Simplifies the two most complex server codepaths identified in #32.

### 1. Consolidate serialization functions (-29 lines)

Replaced three near-identical functions with a single `serializeProtoParams(proto.Message)`:
- `serializeCreateActionParams` (55 lines, 18-case switch)
- `serializeUpdateActionParams` (55 lines, 18-case switch)
- `serializeActionParamsToMap` (55 lines, 16-case switch with silent error swallowing)

Callers now extract the concrete `proto.Message` from the oneof via type-specific extractors (`extractCreateActionParamsMsg`, `extractUpdateActionParamsMsg`, `extractActionParamsMsg`) and pass it to the shared serializer.

### 2. Split handleAgentMessage (265 lines → 11 methods)

The monolithic switch with 11 cases is now a dispatcher routing to focused methods:
- `handleHeartbeat` (12 lines)
- `handleActionResult` (25 lines) + `proxyLpsRotations` (30 lines)
- `handleOutputChunk` (18 lines)
- `handleQueryResult` (18 lines)
- `handleInventory` (20 lines)
- `handleSecurityAlert` (12 lines)
- `handleGetLuksKey` (16 lines)
- `handleStoreLuksKey` (18 lines)
- `handleRevokeLuksResult` (12 lines)
- `handleLogQueryResult` (12 lines)

No behavior change — same logic, same error handling, same return values.

### Item 3 (agent executePackage)

Already implemented in manchtools/power-manage-agent#34.

Closes #32

## Test plan
- [x] `go build -o /dev/null ./cmd/control && go build -o /dev/null ./cmd/gateway`
- [x] `go vet ./...`
- [x] `go test ./internal/handler/... ./internal/gateway/...`
- [ ] Full `go test ./...` in CI (requires PostgreSQL)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined parameter serialization to be more consistent and reliable across actions.
  * Reorganized agent message processing into a clearer dispatch flow, improving maintainability and reducing complexity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->