### PR TITLE
feat: stub remote terminal RPCs on ControlService

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -768,3 +768,29 @@ func (s *ControlService) SetUserProvisioningEnabled(ctx context.Context, req *co
 	return s.user.SetUserProvisioningEnabled(ctx, req)
 }
 
+// Remote Terminal (PTY) sessions — stub implementations
+//
+// The proto contract for these RPCs lives in
+// manchtools/power-manage-sdk#25 and addresses
+// manchtools/power-manage-server#6 / manchtools/power-manage-sdk#16.
+// Real implementations (TTY user provisioning, session token minting,
+// gateway URL resolution, admin session management) land in a follow-up
+// PR. Until then these stubs return CodeUnimplemented so the
+// ControlServiceHandler interface stays satisfied after the SDK update.
+
+func (s *ControlService) StartTerminal(ctx context.Context, req *connect.Request[pm.StartTerminalRequest]) (*connect.Response[pm.StartTerminalResponse], error) {
+	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented, "remote terminal sessions are not yet implemented")
+}
+
+func (s *ControlService) StopTerminal(ctx context.Context, req *connect.Request[pm.StopTerminalRequest]) (*connect.Response[pm.StopTerminalResponse], error) {
+	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented, "remote terminal sessions are not yet implemented")
+}
+
+func (s *ControlService) ListActiveTerminalSessions(ctx context.Context, req *connect.Request[pm.ListActiveTerminalSessionsRequest]) (*connect.Response[pm.ListActiveTerminalSessionsResponse], error) {
+	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented, "remote terminal sessions are not yet implemented")
+}
+
+func (s *ControlService) TerminateTerminalSession(ctx context.Context, req *connect.Request[pm.TerminateTerminalSessionRequest]) (*connect.Response[pm.TerminateTerminalSessionResponse], error) {
+	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented, "remote terminal sessions are not yet implemented")
+}
+

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -259,6 +259,16 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 		return h.handleRevokeLuksResult(deviceID, p.RevokeLuksDeviceKeyResult)
 	case *pm.AgentMessage_LogQueryResult:
 		return h.handleLogQueryResult(deviceID, p.LogQueryResult)
+	case *pm.AgentMessage_TerminalOutput, *pm.AgentMessage_TerminalStateChange:
+		// Remote terminal traffic — proto contract is in
+		// manchtools/power-manage-sdk#25, real handler lands as part of
+		// manchtools/power-manage-server#6 / manchtools/power-manage-sdk#16
+		// step 5. Until then we accept the message and drop it instead
+		// of erroring out, so an agent that ships the terminal handler
+		// first does not get disconnected by the gateway.
+		h.logger.Debug("received terminal message before handler is implemented",
+			"device_id", deviceID, "type", fmt.Sprintf("%T", msg.Payload))
+		return nil
 	default:
 		return fmt.Errorf("unknown message type: %T", msg.Payload)
 	}


### PR DESCRIPTION
## Summary

Coordinated companion to manchtools/power-manage-sdk#25 (SDK proto contract for the remote terminal feature). Without this PR, the server stops compiling once the SDK update lands because \`*ControlService\` no longer satisfies \`pmv1connect.ControlServiceHandler\`.

This PR adds no-op stub implementations for the 4 new RPCs that return \`CodeUnimplemented\` via the existing \`apiErrorCtx\` helper. Real implementations land as part of step 5 of manchtools/power-manage-sdk#16: TTY user provisioning, session token minting, gateway URL resolution, and admin session management.

## What changes

\`internal/api/service.go\` — 4 new methods at the bottom of the file, following the existing one-method-per-RPC pattern:

- \`StartTerminal\`
- \`StopTerminal\`
- \`ListActiveTerminalSessions\`
- \`TerminateTerminalSession\`

All four return:

\`\`\`go
return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented, "remote terminal sessions are not yet implemented")
\`\`\`

so the web client gets a clear, structured error code rather than a panic or "method not found" from Connect-RPC.

## Why now

Issue manchtools/power-manage-server#6 (Remote Shell / Live Terminal) is the server-side counterpart of manchtools/power-manage-sdk#16. The proto contract is shared between them and was deliberately split out from both feature implementations because it has to land first — every other piece (agent terminal handler, gateway WebSocket bridge, control implementation, web xterm.js component) depends on the generated types being available.

This PR is intentionally minimal: only enough to keep CI green after manchtools/power-manage-sdk#25 merges. The actual feature implementation will be a separate, larger PR that:

- Adds the \`TerminalAccess\` permission and wires it through the auth system
- Implements TTY user auto-provisioning via the existing system action manager
- Mints short-lived session tokens
- Adds the gateway WebSocket endpoint and stdin audit tee
- Implements list/terminate fan-out via the new \`GatewayService\` from manchtools/power-manage-sdk#25

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] No existing tests change behavior — the stubs are uncalled by anything in the suite

## Refs

- manchtools/power-manage-server#6 — Remote Shell / Live Terminal (parent server feature)
- manchtools/power-manage-sdk#16 — parent SDK feature
- manchtools/power-manage-sdk#24 — step 1 (SDK Go terminal package)
- manchtools/power-manage-sdk#25 — step 2 (SDK proto contract — must merge alongside this PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infrastructure for remote terminal session management (coming soon).

* **Improvements**
  * Enhanced stability in agent message handling to prevent disconnections from terminal-related communications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->