### PR TITLE
feat: ControlService.StartTerminal/StopTerminal real implementation

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/scim"
 	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/terminal"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
@@ -53,6 +54,7 @@ type Config struct {
 	AdminPassword                string
 	CORSOrigins                  []string
 	GatewayURL                   string
+	TerminalGatewayURL           string // public WebSocket URL of the gateway terminal endpoint, e.g. wss://gw.example.com/terminal
 	DynamicGroupEvalInterval     time.Duration
 	PasswordAuthEnabled          bool
 	SSOCallbackBaseURL           string
@@ -346,6 +348,26 @@ func main() {
 		searchIdx := search.New(rdb, st, aqClient, logger.With("component", "search"))
 		svc.SetSearchIndex(searchIdx)
 
+		// Wire the remote terminal session token store IF the operator
+		// has configured a public terminal gateway URL. Tokens live in
+		// Valkey under pm:terminal:session:* with a short TTL; minted
+		// by ControlService.StartTerminal and consumed by the gateway
+		// when the web client opens its WebSocket. The URL is returned
+		// to clients in StartTerminalResponse — GatewayBaseURL strips
+		// any query string defensively so the client controls token
+		// placement. When TerminalGatewayURL is empty, the terminal
+		// handler is left nil and StartTerminal returns CodeUnavailable.
+		if cfg.TerminalGatewayURL != "" {
+			terminalStore := terminal.NewTokenStore(terminal.NewValkeyBackend(rdb))
+			svc.SetTerminalHandler(api.NewTerminalHandler(
+				st,
+				terminalStore,
+				api.GatewayBaseURL(cfg.TerminalGatewayURL),
+				logger.With("component", "terminal_handler"),
+			))
+			logger.Info("remote terminal sessions enabled", "gateway_url", cfg.TerminalGatewayURL)
+		}
+
 		// Index audit events on insertion — the hook fires after every AppendEvent
 		// and enqueues the persisted row directly (no DB lookup in the search worker).
 		st.OnEventAppended = func(ctx context.Context, ev store.PersistedEvent) {
@@ -555,6 +577,7 @@ func parseFlags() *Config {
 	flag.StringVar(&cfg.AdminEmail, "admin-email", "", "Initial admin user email")
 	flag.StringVar(&cfg.AdminPassword, "admin-password", "", "Initial admin user password")
 	flag.StringVar(&cfg.GatewayURL, "gateway-url", "", "Gateway URL returned to agents during registration")
+	flag.StringVar(&cfg.TerminalGatewayURL, "terminal-gateway-url", "", "Public WebSocket URL of the gateway terminal endpoint (e.g. wss://gw.example.com/terminal). When empty, ControlService.StartTerminal returns CodeUnavailable.")
 	flag.DurationVar(&cfg.DynamicGroupEvalInterval, "dynamic-group-eval-interval", time.Hour, "Interval for evaluating dynamic groups (min 30m, max 8h, 0 to disable)")
 	flag.StringVar(&cfg.CATrustBundlePath, "ca-trust-bundle", "", "PEM file with trusted CA certificates for verification (supports CA rotation)")
 	flag.BoolVar(&cfg.TLSEnabled, "tls", false, "Enable TLS on public listener")
@@ -584,6 +607,7 @@ func parseFlags() *Config {
 	envString(&cfg.LogLevel, "CONTROL_LOG_LEVEL")
 	envString(&cfg.LogFormat, "CONTROL_LOG_FORMAT")
 	envString(&cfg.GatewayURL, "CONTROL_GATEWAY_URL")
+	envString(&cfg.TerminalGatewayURL, "CONTROL_TERMINAL_GATEWAY_URL")
 	envCSV(&cfg.CORSOrigins, "CONTROL_CORS_ORIGINS")
 	envDuration(&cfg.DynamicGroupEvalInterval, "CONTROL_DYNAMIC_GROUP_EVAL_INTERVAL")
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
+	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/manchtools/power-manage/sdk v0.0.0
@@ -35,6 +36,7 @@ require (
 	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.2 // indirect
 	github.com/cpuguy83/dockercfg v0.3.2 // indirect
+	github.com/creack/pty v1.1.24 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect
@@ -50,7 +52,6 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/coreos/go-oidc/v3 v3.17.0 h1:hWBGaQfbi0iVviX4ibC7bk8OKT5qNr4klBaCHVNv
 github.com/coreos/go-oidc/v3 v3.17.0/go.mod h1:wqPbKFrVnE90vty060SB40FCJ8fTHTxSwyXJqZH+sI8=
 github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
 github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
-github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
-github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
+github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
+github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -75,6 +75,9 @@ const (
 	ErrDeviceNotConnected       = "device_not_connected"
 	ErrCannotUnlinkOtherUser    = "cannot_unlink_other_user"
 	ErrLastAuthMethod            = "last_auth_method"
+
+	// Remote terminal sessions
+	ErrTerminalLinuxUsernameNotSet = "terminal_linux_username_not_set"
 )
 
 // Compliance policy error codes.

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -78,6 +78,7 @@ const (
 
 	// Remote terminal sessions
 	ErrTerminalLinuxUsernameNotSet = "terminal_linux_username_not_set"
+	ErrTerminalNotConfigured       = "terminal_not_configured"
 )
 
 // Compliance policy error codes.

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -44,7 +44,7 @@ type ControlService struct {
 	search           *SearchHandler
 	settings         *SettingsHandler
 	systemActions    *SystemActionManager
-	terminal         *TerminalHandler // nil until SetTerminal is called from main.go after Valkey wiring
+	terminal         *TerminalHandler // nil until SetTerminalHandler is called from main.go after Valkey wiring
 }
 
 // ControlServiceConfig holds configuration for the control service.

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -788,7 +788,7 @@ func (s *ControlService) SetUserProvisioningEnabled(ctx context.Context, req *co
 
 func (s *ControlService) StartTerminal(ctx context.Context, req *connect.Request[pm.StartTerminalRequest]) (*connect.Response[pm.StartTerminalResponse], error) {
 	if s.terminal == nil {
-		return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnavailable,
+		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
 			"remote terminal sessions are not configured on this control instance")
 	}
 	return s.terminal.StartTerminal(ctx, req)
@@ -796,7 +796,7 @@ func (s *ControlService) StartTerminal(ctx context.Context, req *connect.Request
 
 func (s *ControlService) StopTerminal(ctx context.Context, req *connect.Request[pm.StopTerminalRequest]) (*connect.Response[pm.StopTerminalResponse], error) {
 	if s.terminal == nil {
-		return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnavailable,
+		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
 			"remote terminal sessions are not configured on this control instance")
 	}
 	return s.terminal.StopTerminal(ctx, req)

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -44,6 +44,7 @@ type ControlService struct {
 	search           *SearchHandler
 	settings         *SettingsHandler
 	systemActions    *SystemActionManager
+	terminal         *TerminalHandler // nil until SetTerminal is called from main.go after Valkey wiring
 }
 
 // ControlServiceConfig holds configuration for the control service.
@@ -100,6 +101,15 @@ func (s *ControlService) SetTaskQueueClient(c *taskqueue.Client) {
 	s.osquery.SetTaskQueueClient(c)
 	s.logs.SetTaskQueueClient(c)
 	s.device.SetTaskQueueClient(c)
+}
+
+// SetTerminalHandler wires the terminal session RPC handler. Called
+// from main.go after the Valkey-backed token store is constructed.
+// Until this is called, the terminal RPCs return Unavailable rather
+// than panicking on a nil pointer — this is the same fail-soft
+// pattern used for the optional task queue and search index.
+func (s *ControlService) SetTerminalHandler(h *TerminalHandler) {
+	s.terminal = h
 }
 
 // SetSearchIndex propagates the search index to all sub-handlers that
@@ -768,29 +778,37 @@ func (s *ControlService) SetUserProvisioningEnabled(ctx context.Context, req *co
 	return s.user.SetUserProvisioningEnabled(ctx, req)
 }
 
-// Remote Terminal (PTY) sessions — stub implementations
+// Remote Terminal (PTY) sessions
 //
-// The proto contract for these RPCs lives in
-// manchtools/power-manage-sdk#25 and addresses
-// manchtools/power-manage-server#6 / manchtools/power-manage-sdk#16.
-// Real implementations (TTY user provisioning, session token minting,
-// gateway URL resolution, admin session management) land in a follow-up
-// PR. Until then these stubs return CodeUnimplemented so the
-// ControlServiceHandler interface stays satisfied after the SDK update.
+// StartTerminal and StopTerminal route to TerminalHandler when it is
+// configured (Valkey-backed token store wired in main.go). The List
+// and Terminate admin RPCs still return Unimplemented; they require
+// the gateway-side session inventory and the GatewayService fan-out
+// path which land in a follow-up PR.
 
 func (s *ControlService) StartTerminal(ctx context.Context, req *connect.Request[pm.StartTerminalRequest]) (*connect.Response[pm.StartTerminalResponse], error) {
-	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented, "remote terminal sessions are not yet implemented")
+	if s.terminal == nil {
+		return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnavailable,
+			"remote terminal sessions are not configured on this control instance")
+	}
+	return s.terminal.StartTerminal(ctx, req)
 }
 
 func (s *ControlService) StopTerminal(ctx context.Context, req *connect.Request[pm.StopTerminalRequest]) (*connect.Response[pm.StopTerminalResponse], error) {
-	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented, "remote terminal sessions are not yet implemented")
+	if s.terminal == nil {
+		return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnavailable,
+			"remote terminal sessions are not configured on this control instance")
+	}
+	return s.terminal.StopTerminal(ctx, req)
 }
 
 func (s *ControlService) ListActiveTerminalSessions(ctx context.Context, req *connect.Request[pm.ListActiveTerminalSessionsRequest]) (*connect.Response[pm.ListActiveTerminalSessionsResponse], error) {
-	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented, "remote terminal sessions are not yet implemented")
+	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented,
+		"admin terminal session listing is not yet implemented (requires gateway fan-out)")
 }
 
 func (s *ControlService) TerminateTerminalSession(ctx context.Context, req *connect.Request[pm.TerminateTerminalSessionRequest]) (*connect.Response[pm.TerminateTerminalSessionResponse], error) {
-	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented, "remote terminal sessions are not yet implemented")
+	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented,
+		"admin terminal session termination is not yet implemented (requires gateway fan-out)")
 }
 

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -243,7 +243,16 @@ func GatewayBaseURL(raw string) string {
 	}
 	u, err := url.Parse(raw)
 	if err != nil {
-		return strings.TrimRight(raw, "/")
+		// Even on parse failure, strip query/fragment so tokens
+		// can't leak through the fallback path.
+		s := raw
+		if i := strings.IndexByte(s, '?'); i >= 0 {
+			s = s[:i]
+		}
+		if i := strings.IndexByte(s, '#'); i >= 0 {
+			s = s[:i]
+		}
+		return strings.TrimRight(s, "/")
 	}
 	u.RawQuery = ""
 	u.Fragment = ""

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -42,7 +42,7 @@ func NewTerminalHandler(st *store.Store, tokenStore *terminal.TokenStore, gatewa
 	return &TerminalHandler{
 		store:      st,
 		tokenStore: tokenStore,
-		gatewayURL: gatewayURL,
+		gatewayURL: GatewayBaseURL(gatewayURL),
 		logger:     logger,
 	}
 }
@@ -78,9 +78,18 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 	}
 	ttyUser := sdkterminal.TTYUsername(linuxUsername)
 
-	if _, err := h.store.Queries().GetDeviceByID(ctx, generated.GetDeviceByIDParams{ID: req.Msg.DeviceId}); err != nil {
+	// Filter by the authenticated user's ID so users can only open
+	// terminal sessions on devices assigned to them (directly or via
+	// user groups). The SQL query's FilterUserID clause handles the
+	// assignment check — a non-assigned device looks like ErrNoRows,
+	// same as a genuinely missing device.
+	filterUserID := userCtx.ID
+	if _, err := h.store.Queries().GetDeviceByID(ctx, generated.GetDeviceByIDParams{
+		ID:           req.Msg.DeviceId,
+		FilterUserID: &filterUserID,
+	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
+			return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found or not assigned to you")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up device")
 	}
@@ -205,11 +214,14 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 	}
 
 	if err := h.tokenStore.Revoke(ctx, req.Msg.SessionId); err != nil {
-		// Event is persisted, so the audit trail is intact. The
-		// revoke failure is logged but doesn't fail the RPC — the
-		// Valkey TTL will clean up the token within seconds anyway.
-		h.logger.Warn("failed to revoke terminal session token (TTL will clean up)",
+		// The stop event is persisted, but the token remains valid
+		// until its Valkey TTL expires (up to 60s). That's a window
+		// where the session could theoretically be reconnected. Fail
+		// the RPC so the client knows the stop didn't fully land and
+		// can retry.
+		h.logger.Error("failed to revoke terminal session token",
 			"session_id", session.SessionID, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to revoke terminal session token")
 	}
 
 	h.logger.Info("terminal session stopped",

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -121,10 +121,14 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 		ActorType: "user",
 		ActorID:   user.ID,
 	}); err != nil {
-		// Audit failures are non-fatal: the session can still proceed,
-		// but the audit gap is logged for operators to investigate.
-		h.logger.Warn("failed to append TerminalSessionStarted event",
+		// Terminal sessions without an audit trail are a security gap:
+		// someone has interactive shell access with no record. Revoke
+		// the freshly-minted token and refuse the session so the
+		// invariant "every session has a start event" holds.
+		h.logger.Error("failed to append TerminalSessionStarted event; revoking session",
 			"session_id", mintRes.SessionID, "error", err)
+		_ = h.tokenStore.Revoke(ctx, mintRes.SessionID)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create audit record for terminal session")
 	}
 
 	h.logger.Info("terminal session started",
@@ -188,8 +192,12 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 		ActorType: "user",
 		ActorID:   userCtx.ID,
 	}); err != nil {
-		h.logger.Warn("failed to append TerminalSessionStopped event",
+		// The token is already revoked (above), so the session is
+		// stopped regardless. But we still fail the RPC so the client
+		// knows the audit gap exists and operators see a clear error.
+		h.logger.Error("failed to append TerminalSessionStopped event",
 			"session_id", session.SessionID, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create audit record for terminal session stop")
 	}
 
 	h.logger.Info("terminal session stopped",

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -266,6 +266,14 @@ func GatewayBaseURL(raw string) string {
 		}
 		return strings.TrimRight(s, "/")
 	}
+	// Reject non-WebSocket schemes so an http:// or ftp:// misconfig
+	// fails at startup rather than producing a broken URL in responses.
+	if u.Scheme != "ws" && u.Scheme != "wss" {
+		return ""
+	}
+	if u.Host == "" {
+		return ""
+	}
 	u.User = nil
 	u.RawQuery = ""
 	u.Fragment = ""

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -9,6 +9,7 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/jackc/pgx/v5"
+	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -93,7 +94,36 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 		rows = sdkterminal.DefaultRows
 	}
 
-	mintRes, err := h.tokenStore.Mint(ctx, terminal.MintParams{
+	// CQRS: the event is the source of truth for terminal session
+	// authorization. Write the event FIRST; if it fails, nothing
+	// happened — no token, no session, no audit gap. The Valkey
+	// token is derived state (like a projection), minted only after
+	// the event is safely persisted.
+	sessionID := ulid.Make().String()
+	if err := h.store.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   req.Msg.DeviceId,
+		EventType:  "TerminalSessionStarted",
+		Data: map[string]any{
+			"session_id": sessionID,
+			"tty_user":   ttyUser,
+			"cols":       cols,
+			"rows":       rows,
+		},
+		ActorType: "user",
+		ActorID:   user.ID,
+	}); err != nil {
+		h.logger.Error("failed to append TerminalSessionStarted event",
+			"session_id", sessionID, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to persist terminal session event")
+	}
+
+	// Derived state: mint the short-lived bearer token in Valkey.
+	// If this fails, the event is already persisted (recording the
+	// authorization intent), but the session is unusable. The client
+	// retries and gets a new session with a new event — the orphaned
+	// event is a harmless record of a failed attempt.
+	mintRes, err := h.tokenStore.MintWithID(ctx, sessionID, terminal.MintParams{
 		UserID:   user.ID,
 		DeviceID: req.Msg.DeviceId,
 		TtyUser:  ttyUser,
@@ -102,44 +132,20 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 	})
 	if err != nil {
 		h.logger.Error("failed to mint terminal session token",
-			"user_id", user.ID, "device_id", req.Msg.DeviceId, "error", err)
+			"session_id", sessionID, "user_id", user.ID,
+			"device_id", req.Msg.DeviceId, "error", err)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to mint session token")
 	}
 
-	// Audit: TerminalSessionStarted on the device stream so the
-	// existing audit/search infrastructure picks it up automatically.
-	if err := h.store.AppendEvent(ctx, store.Event{
-		StreamType: "device",
-		StreamID:   req.Msg.DeviceId,
-		EventType:  "TerminalSessionStarted",
-		Data: map[string]any{
-			"session_id": mintRes.SessionID,
-			"tty_user":   ttyUser,
-			"cols":       cols,
-			"rows":       rows,
-		},
-		ActorType: "user",
-		ActorID:   user.ID,
-	}); err != nil {
-		// Terminal sessions without an audit trail are a security gap:
-		// someone has interactive shell access with no record. Revoke
-		// the freshly-minted token and refuse the session so the
-		// invariant "every session has a start event" holds.
-		h.logger.Error("failed to append TerminalSessionStarted event; revoking session",
-			"session_id", mintRes.SessionID, "error", err)
-		_ = h.tokenStore.Revoke(ctx, mintRes.SessionID)
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create audit record for terminal session")
-	}
-
 	h.logger.Info("terminal session started",
-		"session_id", mintRes.SessionID,
+		"session_id", sessionID,
 		"user_id", user.ID,
 		"device_id", req.Msg.DeviceId,
 		"tty_user", ttyUser,
 	)
 
 	return connect.NewResponse(&pm.StartTerminalResponse{
-		SessionId:    mintRes.SessionID,
+		SessionId:    sessionID,
 		SessionToken: mintRes.Token,
 		GatewayUrl:   h.gatewayURL,
 		ExpiresAt:    timestamppb.New(mintRes.ExpiresAt),
@@ -177,10 +183,11 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 			"only the session owner may stop a terminal session; admins must use TerminateTerminalSession")
 	}
 
-	if err := h.tokenStore.Revoke(ctx, req.Msg.SessionId); err != nil {
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to revoke session")
-	}
-
+	// CQRS: event first (source of truth), then Valkey revoke
+	// (derived state). If the event fails, the session stays active
+	// — no silent stop without an audit trail. If the revoke fails,
+	// the event is recorded and the Valkey TTL will clean up the
+	// orphaned token anyway.
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   session.DeviceID,
@@ -192,12 +199,17 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 		ActorType: "user",
 		ActorID:   userCtx.ID,
 	}); err != nil {
-		// The token is already revoked (above), so the session is
-		// stopped regardless. But we still fail the RPC so the client
-		// knows the audit gap exists and operators see a clear error.
 		h.logger.Error("failed to append TerminalSessionStopped event",
 			"session_id", session.SessionID, "error", err)
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create audit record for terminal session stop")
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to persist terminal session stop event")
+	}
+
+	if err := h.tokenStore.Revoke(ctx, req.Msg.SessionId); err != nil {
+		// Event is persisted, so the audit trail is intact. The
+		// revoke failure is logged but doesn't fail the RPC — the
+		// Valkey TTL will clean up the token within seconds anyway.
+		h.logger.Warn("failed to revoke terminal session token (TTL will clean up)",
+			"session_id", session.SessionID, "error", err)
 	}
 
 	h.logger.Info("terminal session stopped",

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -61,7 +62,10 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 
 	user, err := h.store.Queries().GetUserByID(ctx, userCtx.ID)
 	if err != nil {
-		return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user not found")
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user not found")
+		}
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up user")
 	}
 	if user.Disabled || user.IsDeleted {
 		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "user account is disabled")
@@ -74,7 +78,10 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 	ttyUser := sdkterminal.TTYUsername(linuxUsername)
 
 	if _, err := h.store.Queries().GetDeviceByID(ctx, generated.GetDeviceByIDParams{ID: req.Msg.DeviceId}); err != nil {
-		return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
+		}
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up device")
 	}
 
 	cols := req.Msg.Cols

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -1,0 +1,213 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/url"
+	"strings"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	sdkterminal "github.com/manchtools/power-manage/sdk/go/sys/terminal"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/terminal"
+)
+
+// TerminalHandler handles the four ControlService terminal session
+// RPCs from manchtools/power-manage-sdk#16 step 5. The List/Terminate
+// admin RPCs land in a follow-up PR alongside the gateway-side
+// inventory; this handler implements the user-initiated open and
+// graceful stop paths.
+type TerminalHandler struct {
+	store      *store.Store
+	tokenStore *terminal.TokenStore
+	gatewayURL string
+	logger     *slog.Logger
+}
+
+// NewTerminalHandler constructs a TerminalHandler. gatewayURL is the
+// publicly-resolvable WebSocket URL of the gateway endpoint, e.g.
+// "wss://gateway.example.com/terminal". Clients append
+// ?token=<session_token> to it themselves; the handler returns the
+// token-free base URL per the StartTerminalResponse contract in the
+// SDK proto.
+func NewTerminalHandler(st *store.Store, tokenStore *terminal.TokenStore, gatewayURL string, logger *slog.Logger) *TerminalHandler {
+	return &TerminalHandler{
+		store:      st,
+		tokenStore: tokenStore,
+		gatewayURL: gatewayURL,
+		logger:     logger,
+	}
+}
+
+// StartTerminal verifies the caller is authenticated, resolves the
+// dedicated TTY username from the user's stored linux_username,
+// validates the target device, mints a short-lived session token, and
+// returns the gateway WebSocket URL the web client should connect to.
+//
+// Permission gating happens in the AuthzInterceptor (the permission
+// key is "StartTerminal" — same convention as every other handler),
+// so this method only runs for callers that already hold it.
+func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Request[pm.StartTerminalRequest]) (*connect.Response[pm.StartTerminalResponse], error) {
+	userCtx, ok := auth.UserFromContext(ctx)
+	if !ok {
+		return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, "not authenticated")
+	}
+
+	user, err := h.store.Queries().GetUserByID(ctx, userCtx.ID)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user not found")
+	}
+	if user.Disabled || user.IsDeleted {
+		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "user account is disabled")
+	}
+	linuxUsername := strings.TrimSpace(user.LinuxUsername)
+	if linuxUsername == "" {
+		return nil, apiErrorCtx(ctx, ErrTerminalLinuxUsernameNotSet, connect.CodeFailedPrecondition,
+			"user has no linux username configured; cannot resolve TTY user")
+	}
+	ttyUser := sdkterminal.TTYUsername(linuxUsername)
+
+	if _, err := h.store.Queries().GetDeviceByID(ctx, generated.GetDeviceByIDParams{ID: req.Msg.DeviceId}); err != nil {
+		return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
+	}
+
+	cols := req.Msg.Cols
+	if cols == 0 {
+		cols = sdkterminal.DefaultCols
+	}
+	rows := req.Msg.Rows
+	if rows == 0 {
+		rows = sdkterminal.DefaultRows
+	}
+
+	mintRes, err := h.tokenStore.Mint(ctx, terminal.MintParams{
+		UserID:   user.ID,
+		DeviceID: req.Msg.DeviceId,
+		TtyUser:  ttyUser,
+		Cols:     cols,
+		Rows:     rows,
+	})
+	if err != nil {
+		h.logger.Error("failed to mint terminal session token",
+			"user_id", user.ID, "device_id", req.Msg.DeviceId, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to mint session token")
+	}
+
+	// Audit: TerminalSessionStarted on the device stream so the
+	// existing audit/search infrastructure picks it up automatically.
+	if err := h.store.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   req.Msg.DeviceId,
+		EventType:  "TerminalSessionStarted",
+		Data: map[string]any{
+			"session_id": mintRes.SessionID,
+			"tty_user":   ttyUser,
+			"cols":       cols,
+			"rows":       rows,
+		},
+		ActorType: "user",
+		ActorID:   user.ID,
+	}); err != nil {
+		// Audit failures are non-fatal: the session can still proceed,
+		// but the audit gap is logged for operators to investigate.
+		h.logger.Warn("failed to append TerminalSessionStarted event",
+			"session_id", mintRes.SessionID, "error", err)
+	}
+
+	h.logger.Info("terminal session started",
+		"session_id", mintRes.SessionID,
+		"user_id", user.ID,
+		"device_id", req.Msg.DeviceId,
+		"tty_user", ttyUser,
+	)
+
+	return connect.NewResponse(&pm.StartTerminalResponse{
+		SessionId:    mintRes.SessionID,
+		SessionToken: mintRes.Token,
+		GatewayUrl:   h.gatewayURL,
+		ExpiresAt:    timestamppb.New(mintRes.ExpiresAt),
+		TtyUser:      ttyUser,
+	}), nil
+}
+
+// StopTerminal is the user-initiated graceful stop. The caller must
+// be the user that opened the session — admins kill someone else's
+// session via TerminateTerminalSession.
+//
+// Idempotent: an unknown or already-stopped session returns OK with
+// no body, NOT NotFound, so clients can fire and forget on disconnect.
+// This matches the contract documented above StopTerminalRequest in
+// the SDK proto.
+func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request[pm.StopTerminalRequest]) (*connect.Response[pm.StopTerminalResponse], error) {
+	userCtx, ok := auth.UserFromContext(ctx)
+	if !ok {
+		return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, "not authenticated")
+	}
+
+	session, err := h.tokenStore.Lookup(ctx, req.Msg.SessionId)
+	if err != nil {
+		if errors.Is(err, terminal.ErrTokenNotFound) {
+			// Idempotent: session already gone is success.
+			return connect.NewResponse(&pm.StopTerminalResponse{}), nil
+		}
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up session")
+	}
+
+	// Ownership check: only the user that opened the session may stop
+	// it. Admins use TerminateTerminalSession (separate permission).
+	if session.UserID != userCtx.ID {
+		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied,
+			"only the session owner may stop a terminal session; admins must use TerminateTerminalSession")
+	}
+
+	if err := h.tokenStore.Revoke(ctx, req.Msg.SessionId); err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to revoke session")
+	}
+
+	if err := h.store.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   session.DeviceID,
+		EventType:  "TerminalSessionStopped",
+		Data: map[string]any{
+			"session_id": session.SessionID,
+			"reason":     "user_stopped",
+		},
+		ActorType: "user",
+		ActorID:   userCtx.ID,
+	}); err != nil {
+		h.logger.Warn("failed to append TerminalSessionStopped event",
+			"session_id", session.SessionID, "error", err)
+	}
+
+	h.logger.Info("terminal session stopped",
+		"session_id", session.SessionID,
+		"user_id", userCtx.ID,
+		"device_id", session.DeviceID,
+	)
+	return connect.NewResponse(&pm.StopTerminalResponse{}), nil
+}
+
+// GatewayBaseURL normalises the configured gateway URL into the
+// token-free form returned by StartTerminalResponse.gateway_url:
+// any query string, fragment, or trailing slash is stripped so the
+// web client can safely append ?token=<session_token> when opening
+// its WebSocket. Exported so main.go can call it once at startup.
+func GatewayBaseURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return strings.TrimRight(raw, "/")
+	}
+	u.RawQuery = ""
+	u.Fragment = ""
+	s := u.String()
+	return strings.TrimRight(s, "/")
+}

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -56,6 +56,10 @@ func NewTerminalHandler(st *store.Store, tokenStore *terminal.TokenStore, gatewa
 // key is "StartTerminal" — same convention as every other handler),
 // so this method only runs for callers that already hold it.
 func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Request[pm.StartTerminalRequest]) (*connect.Response[pm.StartTerminalResponse], error) {
+	if h.gatewayURL == "" {
+		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
+			"terminal gateway URL is not configured")
+	}
 	userCtx, ok := auth.UserFromContext(ctx)
 	if !ok {
 		return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, "not authenticated")
@@ -243,9 +247,17 @@ func GatewayBaseURL(raw string) string {
 	}
 	u, err := url.Parse(raw)
 	if err != nil {
-		// Even on parse failure, strip query/fragment so tokens
-		// can't leak through the fallback path.
+		// Even on parse failure, strip userinfo/query/fragment so
+		// credentials and tokens can't leak through the fallback.
 		s := raw
+		if i := strings.IndexByte(s, '@'); i >= 0 {
+			// Strip everything up to and including the '@'. This is
+			// a best-effort heuristic — the parse already failed, so
+			// the URL is malformed anyway.
+			if schemeEnd := strings.Index(s, "://"); schemeEnd >= 0 && i > schemeEnd {
+				s = s[:schemeEnd+3] + s[i+1:]
+			}
+		}
 		if i := strings.IndexByte(s, '?'); i >= 0 {
 			s = s[:i]
 		}
@@ -254,6 +266,7 @@ func GatewayBaseURL(raw string) string {
 		}
 		return strings.TrimRight(s, "/")
 	}
+	u.User = nil
 	u.RawQuery = ""
 	u.Fragment = ""
 	s := u.String()

--- a/internal/api/terminal_handler_test.go
+++ b/internal/api/terminal_handler_test.go
@@ -1,0 +1,255 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/terminal"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// setLinuxUsername appends the UserLinuxUsernameChanged event so the
+// projection picks up the linux_username for tests that need
+// StartTerminal to resolve a TTY user.
+func setLinuxUsername(t *testing.T, st *store.Store, userID, linuxUsername string) {
+	t.Helper()
+	err := st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user",
+		StreamID:   userID,
+		EventType:  "UserLinuxUsernameChanged",
+		Data:       map[string]any{"linux_username": linuxUsername},
+		ActorType:  "system",
+		ActorID:    "test",
+	})
+	require.NoError(t, err)
+}
+
+// newTerminalHandler builds a TerminalHandler over the given store and
+// a fresh in-memory terminal token store. Returned alongside the token
+// store so individual tests can poke at it directly when they need to
+// assert mint/revoke side effects.
+func newTerminalHandler(t *testing.T, st *store.Store) (*api.TerminalHandler, *terminal.TokenStore) {
+	t.Helper()
+	tokenStore := terminal.NewTokenStore(terminal.NewFakeBackend(nil))
+	h := api.NewTerminalHandler(st, tokenStore, "wss://gateway.example.com/terminal", slog.Default())
+	return h, tokenStore
+}
+
+// authedCtx returns a context with a UserContext attached, mimicking
+// what AuthInterceptor produces in the real request pipeline.
+func authedCtx(userID string) context.Context {
+	return auth.WithUser(context.Background(), &auth.UserContext{ID: userID})
+}
+
+func TestStartTerminal_HappyPath(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, tokenStore := newTerminalHandler(t, st)
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, userID, "alice")
+	deviceID := testutil.CreateTestDevice(t, st, "host-1")
+
+	resp, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
+		DeviceId: deviceID,
+		Cols:     100,
+		Rows:     30,
+	}))
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Msg.SessionId)
+	assert.NotEmpty(t, resp.Msg.SessionToken)
+	assert.Equal(t, "wss://gateway.example.com/terminal", resp.Msg.GatewayUrl)
+	assert.Equal(t, "pm-tty-alice", resp.Msg.TtyUser)
+	assert.NotNil(t, resp.Msg.ExpiresAt)
+
+	// Token must be stored under the returned session id with matching
+	// metadata, and must validate against the bearer token returned to
+	// the client.
+	stored, err := tokenStore.Validate(context.Background(), resp.Msg.SessionId, resp.Msg.SessionToken)
+	require.NoError(t, err)
+	assert.Equal(t, userID, stored.UserID)
+	assert.Equal(t, deviceID, stored.DeviceID)
+	assert.Equal(t, "pm-tty-alice", stored.TtyUser)
+	assert.Equal(t, uint32(100), stored.Cols)
+	assert.Equal(t, uint32(30), stored.Rows)
+}
+
+func TestStartTerminal_DefaultsWhenColsRowsZero(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, tokenStore := newTerminalHandler(t, st)
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, userID, "bob")
+	deviceID := testutil.CreateTestDevice(t, st, "host-2")
+
+	resp, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
+		DeviceId: deviceID,
+		// no Cols/Rows
+	}))
+	require.NoError(t, err)
+
+	stored, err := tokenStore.Lookup(context.Background(), resp.Msg.SessionId)
+	require.NoError(t, err)
+	assert.Equal(t, uint32(80), stored.Cols)
+	assert.Equal(t, uint32(24), stored.Rows)
+}
+
+func TestStartTerminal_NoLinuxUsername(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _ := newTerminalHandler(t, st)
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	// Intentionally NOT calling setLinuxUsername.
+	deviceID := testutil.CreateTestDevice(t, st, "host-3")
+
+	_, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
+		DeviceId: deviceID,
+	}))
+	require.Error(t, err)
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	assert.Equal(t, connect.CodeFailedPrecondition, connectErr.Code())
+}
+
+func TestStartTerminal_DeviceNotFound(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _ := newTerminalHandler(t, st)
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, userID, "alice")
+
+	_, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
+		DeviceId: "non-existent-device",
+	}))
+	require.Error(t, err)
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
+}
+
+func TestStartTerminal_NotAuthenticated(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _ := newTerminalHandler(t, st)
+
+	deviceID := testutil.CreateTestDevice(t, st, "host-4")
+
+	_, err := h.StartTerminal(context.Background(), connect.NewRequest(&pm.StartTerminalRequest{
+		DeviceId: deviceID,
+	}))
+	require.Error(t, err)
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+}
+
+func TestStopTerminal_OwnerCanStop(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, tokenStore := newTerminalHandler(t, st)
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, userID, "alice")
+	deviceID := testutil.CreateTestDevice(t, st, "host-5")
+
+	startResp, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+
+	_, err = h.StopTerminal(authedCtx(userID), connect.NewRequest(&pm.StopTerminalRequest{
+		SessionId: startResp.Msg.SessionId,
+	}))
+	require.NoError(t, err)
+
+	// Session should be gone from the store.
+	_, lookupErr := tokenStore.Lookup(context.Background(), startResp.Msg.SessionId)
+	assert.ErrorIs(t, lookupErr, terminal.ErrTokenNotFound)
+}
+
+func TestStopTerminal_OtherUserCannotStop(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, tokenStore := newTerminalHandler(t, st)
+
+	ownerID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, ownerID, "alice")
+	otherID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, otherID, "bob")
+	deviceID := testutil.CreateTestDevice(t, st, "host-6")
+
+	startResp, err := h.StartTerminal(authedCtx(ownerID), connect.NewRequest(&pm.StartTerminalRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+
+	_, err = h.StopTerminal(authedCtx(otherID), connect.NewRequest(&pm.StopTerminalRequest{
+		SessionId: startResp.Msg.SessionId,
+	}))
+	require.Error(t, err)
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	assert.Equal(t, connect.CodePermissionDenied, connectErr.Code())
+
+	// Session must still be live — the rejected stop must not have
+	// revoked the token.
+	_, lookupErr := tokenStore.Lookup(context.Background(), startResp.Msg.SessionId)
+	require.NoError(t, lookupErr)
+}
+
+func TestStopTerminal_UnknownSessionIsIdempotent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _ := newTerminalHandler(t, st)
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	resp, err := h.StopTerminal(authedCtx(userID), connect.NewRequest(&pm.StopTerminalRequest{
+		SessionId: "no-such-session",
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+func TestStopTerminal_NotAuthenticated(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _ := newTerminalHandler(t, st)
+
+	_, err := h.StopTerminal(context.Background(), connect.NewRequest(&pm.StopTerminalRequest{
+		SessionId: "any",
+	}))
+	require.Error(t, err)
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
+}
+
+func TestGatewayBaseURL_StripsTokenAndTrailingSlash(t *testing.T) {
+	cases := map[string]string{
+		"":                                       "",
+		"wss://gw/terminal":                      "wss://gw/terminal",
+		"wss://gw/terminal/":                     "wss://gw/terminal",
+		"wss://gw/terminal?token=abc":            "wss://gw/terminal",
+		"wss://gw/terminal?token=abc&extra=1":    "wss://gw/terminal",
+		"wss://gw/terminal#frag":                 "wss://gw/terminal",
+	}
+	for in, want := range cases {
+		got := api.GatewayBaseURL(in)
+		if got != want {
+			t.Errorf("GatewayBaseURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+	// And the resulting base must contain neither '?' nor '#'.
+	for in := range cases {
+		out := api.GatewayBaseURL(in)
+		if strings.ContainsAny(out, "?#") {
+			t.Errorf("GatewayBaseURL(%q) leaked query/fragment: %q", in, out)
+		}
+	}
+}

--- a/internal/api/terminal_handler_test.go
+++ b/internal/api/terminal_handler_test.go
@@ -202,6 +202,10 @@ func TestStopTerminal_OtherUserCannotStop(t *testing.T) {
 	// revoked the token.
 	_, lookupErr := tokenStore.Lookup(context.Background(), startResp.Msg.SessionId)
 	require.NoError(t, lookupErr)
+
+	// TODO: add a test covering the admin TerminateTerminalSession path once
+	// that RPC is implemented (requires gateway-side session inventory and
+	// GatewayService fan-out — tracked in a follow-up PR).
 }
 
 func TestStopTerminal_UnknownSessionIsIdempotent(t *testing.T) {

--- a/internal/api/terminal_handler_test.go
+++ b/internal/api/terminal_handler_test.go
@@ -247,6 +247,9 @@ func TestGatewayBaseURL_StripsTokenAndTrailingSlash(t *testing.T) {
 		"wss://gw/terminal?token=abc":            "wss://gw/terminal",
 		"wss://gw/terminal?token=abc&extra=1":    "wss://gw/terminal",
 		"wss://gw/terminal#frag":                 "wss://gw/terminal",
+		// Userinfo credentials must be stripped.
+		"wss://admin:secret@gw/terminal":         "wss://gw/terminal",
+		"wss://user@gw/terminal?token=abc":       "wss://gw/terminal",
 	}
 	for in, want := range cases {
 		got := api.GatewayBaseURL(in)
@@ -254,11 +257,11 @@ func TestGatewayBaseURL_StripsTokenAndTrailingSlash(t *testing.T) {
 			t.Errorf("GatewayBaseURL(%q) = %q, want %q", in, got, want)
 		}
 	}
-	// And the resulting base must contain neither '?' nor '#'.
+	// The resulting base must contain neither '?', '#', nor '@'.
 	for in := range cases {
 		out := api.GatewayBaseURL(in)
-		if strings.ContainsAny(out, "?#") {
-			t.Errorf("GatewayBaseURL(%q) leaked query/fragment: %q", in, out)
+		if strings.ContainsAny(out, "?#@") {
+			t.Errorf("GatewayBaseURL(%q) leaked query/fragment/userinfo: %q", in, out)
 		}
 	}
 }

--- a/internal/api/terminal_handler_test.go
+++ b/internal/api/terminal_handler_test.go
@@ -59,6 +59,7 @@ func TestStartTerminal_HappyPath(t *testing.T) {
 	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	setLinuxUsername(t, st, userID, "alice")
 	deviceID := testutil.CreateTestDevice(t, st, "host-1")
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
 
 	resp, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
 		DeviceId: deviceID,
@@ -91,6 +92,7 @@ func TestStartTerminal_DefaultsWhenColsRowsZero(t *testing.T) {
 	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	setLinuxUsername(t, st, userID, "bob")
 	deviceID := testutil.CreateTestDevice(t, st, "host-2")
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
 
 	resp, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
 		DeviceId: deviceID,
@@ -111,6 +113,7 @@ func TestStartTerminal_NoLinuxUsername(t *testing.T) {
 	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	// Intentionally NOT calling setLinuxUsername.
 	deviceID := testutil.CreateTestDevice(t, st, "host-3")
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
 
 	_, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
 		DeviceId: deviceID,
@@ -159,6 +162,7 @@ func TestStopTerminal_OwnerCanStop(t *testing.T) {
 	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	setLinuxUsername(t, st, userID, "alice")
 	deviceID := testutil.CreateTestDevice(t, st, "host-5")
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
 
 	startResp, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
 		DeviceId: deviceID,
@@ -184,6 +188,7 @@ func TestStopTerminal_OtherUserCannotStop(t *testing.T) {
 	otherID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	setLinuxUsername(t, st, otherID, "bob")
 	deviceID := testutil.CreateTestDevice(t, st, "host-6")
+	testutil.AssignDeviceToUser(t, st, ownerID, deviceID, ownerID)
 
 	startResp, err := h.StartTerminal(authedCtx(ownerID), connect.NewRequest(&pm.StartTerminalRequest{
 		DeviceId: deviceID,

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -237,6 +237,7 @@ func DefaultUserPermissions() []string {
 		"UpdateUserLinuxUsername:self",
 		"AddUserSshKey:self",
 		"RemoveUserSshKey:self",
+		"StopTerminal",
 	}
 }
 

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -195,6 +195,11 @@ func AllPermissions() []PermissionInfo {
 		{"UpdateServerSettings", "Server Settings", "Update server settings"},
 		// User Provisioning
 		{"SetUserProvisioningEnabled", "Users", "Toggle user provisioning per user"},
+		// Remote Terminal
+		{"StartTerminal", "Remote Terminal", "Open a remote terminal session on a device"},
+		{"StopTerminal", "Remote Terminal", "Stop a remote terminal session you opened"},
+		{"ListActiveTerminalSessions", "Remote Terminal", "View active terminal sessions across all devices (admin)"},
+		{"TerminateTerminalSession", "Remote Terminal", "Forcibly terminate any terminal session (admin)"},
 	}
 }
 

--- a/internal/terminal/fake_backend.go
+++ b/internal/terminal/fake_backend.go
@@ -1,0 +1,72 @@
+package terminal
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// FakeBackend is an in-memory SessionBackend used by tests so the
+// handler suite doesn't need a real Valkey instance. It honours TTLs
+// using the supplied clock — pass time.Now in production-like tests
+// or a frozen clock for deterministic expiry assertions.
+//
+// Concurrency is the same as the production backend: independent
+// goroutines may call Set/Get/Delete simultaneously.
+type FakeBackend struct {
+	mu     sync.Mutex
+	now    func() time.Time
+	values map[string]fakeEntry
+}
+
+type fakeEntry struct {
+	payload   []byte
+	expiresAt time.Time
+}
+
+// NewFakeBackend constructs an empty in-memory backend. now defaults
+// to time.Now if nil.
+func NewFakeBackend(now func() time.Time) *FakeBackend {
+	if now == nil {
+		now = time.Now
+	}
+	return &FakeBackend{
+		now:    now,
+		values: make(map[string]fakeEntry),
+	}
+}
+
+// Set stores the payload with the given TTL.
+func (b *FakeBackend) Set(ctx context.Context, sessionID string, payload []byte, ttl time.Duration) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.values[sessionID] = fakeEntry{
+		payload:   append([]byte(nil), payload...), // defensive copy
+		expiresAt: b.now().Add(ttl),
+	}
+	return nil
+}
+
+// Get returns the stored payload, honouring TTL via lazy expiry on
+// read. Returns ErrTokenNotFound for unknown or expired entries.
+func (b *FakeBackend) Get(ctx context.Context, sessionID string) ([]byte, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry, ok := b.values[sessionID]
+	if !ok {
+		return nil, ErrTokenNotFound
+	}
+	if !b.now().Before(entry.expiresAt) {
+		delete(b.values, sessionID)
+		return nil, ErrTokenNotFound
+	}
+	return append([]byte(nil), entry.payload...), nil
+}
+
+// Delete is idempotent.
+func (b *FakeBackend) Delete(ctx context.Context, sessionID string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.values, sessionID)
+	return nil
+}

--- a/internal/terminal/hash.go
+++ b/internal/terminal/hash.go
@@ -1,0 +1,14 @@
+package terminal
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// hashToken returns the hex-encoded SHA-256 of the bearer token.
+// Used to store and compare tokens at rest without persisting the
+// plaintext anywhere.
+func hashToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/terminal/store.go
+++ b/internal/terminal/store.go
@@ -172,16 +172,27 @@ type MintResult struct {
 	ExpiresAt time.Time
 }
 
-// Mint creates a new session, stores its hashed token + metadata, and
-// returns the plaintext token to the caller. The plaintext is returned
-// exactly once and is not retrievable from Valkey (only the hash is
-// stored), so a Valkey dump cannot be used to forge connections.
+// Mint creates a new session with an auto-generated session ID,
+// stores its hashed token + metadata, and returns the plaintext
+// token to the caller. Use MintWithID when the caller needs to
+// control the session ID (e.g. to write a CQRS event before
+// minting the derived Valkey state).
 func (s *TokenStore) Mint(ctx context.Context, params MintParams) (*MintResult, error) {
+	return s.MintWithID(ctx, ulid.Make().String(), params)
+}
+
+// MintWithID is like Mint but uses the caller-supplied session ID
+// instead of generating one. This supports the CQRS pattern where
+// the event (source of truth) is written first with a known ID,
+// and the Valkey token (derived state) is minted afterwards.
+func (s *TokenStore) MintWithID(ctx context.Context, sessionID string, params MintParams) (*MintResult, error) {
+	if sessionID == "" {
+		return nil, errors.New("terminal: session_id is required")
+	}
 	if params.UserID == "" || params.DeviceID == "" || params.TtyUser == "" {
 		return nil, errors.New("terminal: mint requires user_id, device_id, and tty_user")
 	}
 
-	sessionID := ulid.Make().String()
 	token, err := generateOpaqueToken(32)
 	if err != nil {
 		return nil, fmt.Errorf("terminal: generate token: %w", err)

--- a/internal/terminal/store.go
+++ b/internal/terminal/store.go
@@ -1,0 +1,260 @@
+// Package terminal provides the control-server side of the remote
+// terminal feature: a session token store keyed in Valkey, the metadata
+// schema for active sessions, and the helpers used by the
+// ControlService RPC handlers (manchtools/power-manage-sdk#16,
+// manchtools/power-manage-server#6).
+//
+// The token store is intentionally a thin wrapper over a small
+// SessionBackend interface so handler tests can fake it without
+// pulling in miniredis. The production wiring uses Valkey via the
+// existing *redis.Client that the control server already maintains
+// for RediSearch.
+package terminal
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+)
+
+// DefaultTokenTTL is the lifetime of a freshly-minted session token.
+// The web client must connect to the gateway WebSocket endpoint
+// before this expires; the token is single-use after that and the
+// session lives until StopTerminal/TerminateTerminalSession or the
+// idle sweeper closes it.
+const DefaultTokenTTL = 60 * time.Second
+
+// keyPrefix is the Valkey key namespace for terminal session tokens.
+// One key per session: pm:terminal:session:<session_id>.
+const keyPrefix = "pm:terminal:session:"
+
+// Errors returned by the store. Wrap with %w in callers; check with
+// errors.Is.
+var (
+	// ErrTokenNotFound is returned when the supplied session_id has no
+	// matching token (expired, never minted, or already revoked).
+	ErrTokenNotFound = errors.New("terminal: session token not found")
+	// ErrTokenMismatch is returned when the supplied bearer token does
+	// not match the one stored under the session_id. Treated the same
+	// as ErrTokenNotFound by callers — both surface as Unauthenticated
+	// — but distinguished here so the audit log can record forgery
+	// attempts separately from expired sessions.
+	ErrTokenMismatch = errors.New("terminal: session token mismatch")
+)
+
+// Session is the persisted form of an active terminal session, stored
+// in Valkey under pm:terminal:session:<session_id>. The bearer Token is
+// hashed at rest, NOT stored verbatim, so a Valkey dump cannot be used
+// to forge connections.
+type Session struct {
+	// SessionID is the ULID identifying the session for its full
+	// lifetime (mint, validate, stop, audit).
+	SessionID string `json:"session_id"`
+	// UserID is the ID of the Power Manage user that opened the
+	// session. Used for ownership checks (StopTerminal must be called
+	// by the same user) and audit attribution.
+	UserID string `json:"user_id"`
+	// DeviceID is the target device the session will run on.
+	DeviceID string `json:"device_id"`
+	// TtyUser is the resolved dedicated TTY user
+	// (e.g. "pm-tty-pdotterer") that the agent will spawn the shell
+	// as. Carried in the session record so the gateway can pass it
+	// through to the agent without re-resolving.
+	TtyUser string `json:"tty_user"`
+	// Cols and Rows are the initial window size requested by the web
+	// client. Stored alongside the session so the gateway can include
+	// them in the TerminalStart it sends to the agent without an
+	// extra round-trip.
+	Cols uint32 `json:"cols"`
+	Rows uint32 `json:"rows"`
+	// CreatedAt is the mint time. Used for diagnostics and audit; the
+	// real expiry is enforced by Valkey TTL on the key.
+	CreatedAt time.Time `json:"created_at"`
+	// ExpiresAt is the absolute deadline for connecting. Mirrors the
+	// Valkey TTL but is convenient to surface in StartTerminal's
+	// response so the web client can decide when to retry.
+	ExpiresAt time.Time `json:"expires_at"`
+	// TokenHash is the SHA-256 hash of the bearer token. The plaintext
+	// token is returned to the web client exactly once (in the
+	// StartTerminal response) and never persisted.
+	TokenHash string `json:"token_hash"`
+}
+
+// SessionBackend is the storage interface the token store depends on.
+// Implementations must be safe for concurrent use. Two implementations
+// ship with this package: ValkeyBackend (production) and FakeBackend
+// (tests).
+type SessionBackend interface {
+	// Set stores the session with the given TTL. Implementations must
+	// support TTL eviction so expired entries do not accumulate.
+	Set(ctx context.Context, sessionID string, payload []byte, ttl time.Duration) error
+	// Get returns the raw payload for the given session_id, or
+	// ErrTokenNotFound if it has expired or was never set.
+	Get(ctx context.Context, sessionID string) ([]byte, error)
+	// Delete removes the session_id. Idempotent: returns nil whether
+	// or not the key existed.
+	Delete(ctx context.Context, sessionID string) error
+}
+
+// TokenStore is the high-level façade used by the API handlers. It
+// owns the SessionBackend, mints opaque bearer tokens, hashes them
+// before storage, and serializes the Session metadata.
+type TokenStore struct {
+	backend SessionBackend
+	ttl     time.Duration
+	now     func() time.Time
+}
+
+// TokenStoreOption configures a TokenStore at construction time.
+type TokenStoreOption func(*TokenStore)
+
+// WithTTL overrides the default token lifetime. A non-positive value
+// is treated as DefaultTokenTTL.
+func WithTTL(ttl time.Duration) TokenStoreOption {
+	return func(s *TokenStore) {
+		if ttl > 0 {
+			s.ttl = ttl
+		}
+	}
+}
+
+// WithClock overrides time.Now for tests.
+func WithClock(now func() time.Time) TokenStoreOption {
+	return func(s *TokenStore) {
+		if now != nil {
+			s.now = now
+		}
+	}
+}
+
+// NewTokenStore constructs a TokenStore over the given backend.
+func NewTokenStore(backend SessionBackend, opts ...TokenStoreOption) *TokenStore {
+	s := &TokenStore{
+		backend: backend,
+		ttl:     DefaultTokenTTL,
+		now:     time.Now,
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// MintParams holds the per-session metadata captured at StartTerminal
+// time. The TokenStore generates the SessionID and bearer token; the
+// caller supplies everything else.
+type MintParams struct {
+	UserID   string
+	DeviceID string
+	TtyUser  string
+	Cols     uint32
+	Rows     uint32
+}
+
+// MintResult is what the StartTerminal handler hands back to the web
+// client: the freshly-generated session_id and the plaintext bearer
+// token (which the client appends to the gateway URL as ?token=).
+type MintResult struct {
+	SessionID string
+	Token     string
+	ExpiresAt time.Time
+}
+
+// Mint creates a new session, stores its hashed token + metadata, and
+// returns the plaintext token to the caller. The plaintext is returned
+// exactly once and is not retrievable from Valkey (only the hash is
+// stored), so a Valkey dump cannot be used to forge connections.
+func (s *TokenStore) Mint(ctx context.Context, params MintParams) (*MintResult, error) {
+	if params.UserID == "" || params.DeviceID == "" || params.TtyUser == "" {
+		return nil, errors.New("terminal: mint requires user_id, device_id, and tty_user")
+	}
+
+	sessionID := ulid.Make().String()
+	token, err := generateOpaqueToken(32)
+	if err != nil {
+		return nil, fmt.Errorf("terminal: generate token: %w", err)
+	}
+
+	now := s.now()
+	expiresAt := now.Add(s.ttl)
+	session := Session{
+		SessionID: sessionID,
+		UserID:    params.UserID,
+		DeviceID:  params.DeviceID,
+		TtyUser:   params.TtyUser,
+		Cols:      params.Cols,
+		Rows:      params.Rows,
+		CreatedAt: now,
+		ExpiresAt: expiresAt,
+		TokenHash: hashToken(token),
+	}
+	payload, err := json.Marshal(session)
+	if err != nil {
+		return nil, fmt.Errorf("terminal: marshal session: %w", err)
+	}
+	if err := s.backend.Set(ctx, sessionID, payload, s.ttl); err != nil {
+		return nil, fmt.Errorf("terminal: persist session: %w", err)
+	}
+	return &MintResult{
+		SessionID: sessionID,
+		Token:     token,
+		ExpiresAt: expiresAt,
+	}, nil
+}
+
+// Lookup returns the stored Session for the given session_id, without
+// validating the bearer token. Used by StopTerminal (where the caller
+// is authenticated via JWT and ownership is checked against UserID),
+// admin paths, and tests.
+func (s *TokenStore) Lookup(ctx context.Context, sessionID string) (*Session, error) {
+	payload, err := s.backend.Get(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	var session Session
+	if err := json.Unmarshal(payload, &session); err != nil {
+		return nil, fmt.Errorf("terminal: decode session %s: %w", sessionID, err)
+	}
+	return &session, nil
+}
+
+// Validate verifies that the supplied bearer token matches the one
+// stored for the given session_id and returns the Session. Used by
+// the gateway-side validation path (will be wired via an internal
+// RPC in a follow-up PR). Distinguishes ErrTokenNotFound (expired or
+// never minted) from ErrTokenMismatch (forgery attempt) so the audit
+// log can record them differently.
+func (s *TokenStore) Validate(ctx context.Context, sessionID, bearerToken string) (*Session, error) {
+	session, err := s.Lookup(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if session.TokenHash != hashToken(bearerToken) {
+		return nil, ErrTokenMismatch
+	}
+	return session, nil
+}
+
+// Revoke removes the session entry, making subsequent Validate /
+// Lookup calls return ErrTokenNotFound. Idempotent — revoking an
+// unknown session returns nil.
+func (s *TokenStore) Revoke(ctx context.Context, sessionID string) error {
+	return s.backend.Delete(ctx, sessionID)
+}
+
+// generateOpaqueToken returns a base64url-encoded random byte string.
+// 32 bytes of entropy is well above the 128-bit threshold for
+// unguessable session tokens.
+func generateOpaqueToken(numBytes int) (string, error) {
+	buf := make([]byte, numBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
+}

--- a/internal/terminal/store.go
+++ b/internal/terminal/store.go
@@ -14,6 +14,7 @@ package terminal
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -235,7 +236,7 @@ func (s *TokenStore) Validate(ctx context.Context, sessionID, bearerToken string
 	if err != nil {
 		return nil, err
 	}
-	if session.TokenHash != hashToken(bearerToken) {
+	if subtle.ConstantTimeCompare([]byte(session.TokenHash), []byte(hashToken(bearerToken))) != 1 {
 		return nil, ErrTokenMismatch
 	}
 	return session, nil

--- a/internal/terminal/store.go
+++ b/internal/terminal/store.go
@@ -135,7 +135,12 @@ func WithClock(now func() time.Time) TokenStoreOption {
 }
 
 // NewTokenStore constructs a TokenStore over the given backend.
+// Panics if backend is nil so misconfiguration is caught at startup
+// rather than on the first Mint/Validate call.
 func NewTokenStore(backend SessionBackend, opts ...TokenStoreOption) *TokenStore {
+	if backend == nil {
+		panic("terminal: NewTokenStore requires a non-nil SessionBackend")
+	}
 	s := &TokenStore{
 		backend: backend,
 		ttl:     DefaultTokenTTL,

--- a/internal/terminal/store_test.go
+++ b/internal/terminal/store_test.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -62,7 +63,7 @@ func TestTokenStore_TokenIsHashedNotPlaintext(t *testing.T) {
 	if string(raw) == "" {
 		t.Fatal("backend payload empty")
 	}
-	if contains(string(raw), res.Token) {
+	if strings.Contains(string(raw), res.Token) {
 		t.Error("plaintext token must not appear in persisted payload")
 	}
 }
@@ -207,17 +208,3 @@ func TestTokenStore_MintGeneratesUniqueIDs(t *testing.T) {
 	}
 }
 
-// contains is a tiny strings.Contains stand-in to avoid pulling the
-// stdlib import just for one test (the test file is already big).
-func contains(s, sub string) bool {
-	return len(sub) <= len(s) && (s == sub || indexOf(s, sub) >= 0)
-}
-
-func indexOf(s, sub string) int {
-	for i := 0; i+len(sub) <= len(s); i++ {
-		if s[i:i+len(sub)] == sub {
-			return i
-		}
-	}
-	return -1
-}

--- a/internal/terminal/store_test.go
+++ b/internal/terminal/store_test.go
@@ -1,0 +1,223 @@
+package terminal
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestTokenStore_MintLookupRoundTrip(t *testing.T) {
+	store := NewTokenStore(NewFakeBackend(nil))
+	ctx := context.Background()
+
+	res, err := store.Mint(ctx, MintParams{
+		UserID:   "user-1",
+		DeviceID: "device-1",
+		TtyUser:  "pm-tty-alice",
+		Cols:     80,
+		Rows:     24,
+	})
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+	if res.SessionID == "" {
+		t.Error("session_id should be populated")
+	}
+	if res.Token == "" {
+		t.Error("token should be populated")
+	}
+
+	got, err := store.Lookup(ctx, res.SessionID)
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if got.UserID != "user-1" || got.DeviceID != "device-1" || got.TtyUser != "pm-tty-alice" {
+		t.Errorf("session metadata mismatch: %+v", got)
+	}
+	if got.Cols != 80 || got.Rows != 24 {
+		t.Errorf("size = %dx%d, want 80x24", got.Cols, got.Rows)
+	}
+}
+
+func TestTokenStore_TokenIsHashedNotPlaintext(t *testing.T) {
+	backend := NewFakeBackend(nil)
+	store := NewTokenStore(backend)
+	ctx := context.Background()
+
+	res, err := store.Mint(ctx, MintParams{
+		UserID:   "user-1",
+		DeviceID: "device-1",
+		TtyUser:  "pm-tty-alice",
+	})
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	// The persisted payload must NOT contain the plaintext token.
+	raw, err := backend.Get(ctx, res.SessionID)
+	if err != nil {
+		t.Fatalf("backend get: %v", err)
+	}
+	if string(raw) == "" {
+		t.Fatal("backend payload empty")
+	}
+	if contains(string(raw), res.Token) {
+		t.Error("plaintext token must not appear in persisted payload")
+	}
+}
+
+func TestTokenStore_Validate_RoundTrip(t *testing.T) {
+	store := NewTokenStore(NewFakeBackend(nil))
+	ctx := context.Background()
+
+	res, err := store.Mint(ctx, MintParams{
+		UserID:   "user-1",
+		DeviceID: "device-1",
+		TtyUser:  "pm-tty-alice",
+	})
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	session, err := store.Validate(ctx, res.SessionID, res.Token)
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if session.UserID != "user-1" {
+		t.Errorf("validated session = %+v", session)
+	}
+}
+
+func TestTokenStore_Validate_MismatchedToken(t *testing.T) {
+	store := NewTokenStore(NewFakeBackend(nil))
+	ctx := context.Background()
+
+	res, err := store.Mint(ctx, MintParams{
+		UserID:   "user-1",
+		DeviceID: "device-1",
+		TtyUser:  "pm-tty-alice",
+	})
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	_, err = store.Validate(ctx, res.SessionID, "wrong-token")
+	if !errors.Is(err, ErrTokenMismatch) {
+		t.Errorf("expected ErrTokenMismatch, got %v", err)
+	}
+}
+
+func TestTokenStore_Validate_UnknownSession(t *testing.T) {
+	store := NewTokenStore(NewFakeBackend(nil))
+	_, err := store.Validate(context.Background(), "no-such-session", "anything")
+	if !errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("expected ErrTokenNotFound, got %v", err)
+	}
+}
+
+func TestTokenStore_Revoke_IsIdempotent(t *testing.T) {
+	store := NewTokenStore(NewFakeBackend(nil))
+	ctx := context.Background()
+
+	res, err := store.Mint(ctx, MintParams{
+		UserID:   "user-1",
+		DeviceID: "device-1",
+		TtyUser:  "pm-tty-alice",
+	})
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	if err := store.Revoke(ctx, res.SessionID); err != nil {
+		t.Fatalf("first revoke: %v", err)
+	}
+	// Second revoke must succeed too.
+	if err := store.Revoke(ctx, res.SessionID); err != nil {
+		t.Errorf("second revoke (idempotent) returned %v", err)
+	}
+	// And subsequent lookup must report not found.
+	if _, err := store.Lookup(ctx, res.SessionID); !errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("after revoke, expected ErrTokenNotFound, got %v", err)
+	}
+}
+
+func TestTokenStore_TTLExpiry(t *testing.T) {
+	// Frozen clock so we can advance it deterministically.
+	now := time.Unix(0, 0)
+	clock := func() time.Time { return now }
+	backend := NewFakeBackend(clock)
+	store := NewTokenStore(backend, WithClock(clock), WithTTL(10*time.Second))
+	ctx := context.Background()
+
+	res, err := store.Mint(ctx, MintParams{
+		UserID:   "user-1",
+		DeviceID: "device-1",
+		TtyUser:  "pm-tty-alice",
+	})
+	if err != nil {
+		t.Fatalf("mint: %v", err)
+	}
+
+	// Still valid at t+5s.
+	now = now.Add(5 * time.Second)
+	if _, err := store.Lookup(ctx, res.SessionID); err != nil {
+		t.Errorf("lookup at t+5s: %v", err)
+	}
+
+	// Expired at t+11s.
+	now = now.Add(6 * time.Second)
+	if _, err := store.Lookup(ctx, res.SessionID); !errors.Is(err, ErrTokenNotFound) {
+		t.Errorf("lookup at t+11s: expected ErrTokenNotFound, got %v", err)
+	}
+}
+
+func TestTokenStore_Mint_RequiresFields(t *testing.T) {
+	store := NewTokenStore(NewFakeBackend(nil))
+	ctx := context.Background()
+	cases := []MintParams{
+		{DeviceID: "d", TtyUser: "u"},          // no UserID
+		{UserID: "u", TtyUser: "u"},            // no DeviceID
+		{UserID: "u", DeviceID: "d"},           // no TtyUser
+	}
+	for i, p := range cases {
+		if _, err := store.Mint(ctx, p); err == nil {
+			t.Errorf("case %d: expected error for %+v", i, p)
+		}
+	}
+}
+
+func TestTokenStore_MintGeneratesUniqueIDs(t *testing.T) {
+	store := NewTokenStore(NewFakeBackend(nil))
+	ctx := context.Background()
+	seen := make(map[string]struct{})
+	for i := 0; i < 100; i++ {
+		res, err := store.Mint(ctx, MintParams{
+			UserID:   "user-1",
+			DeviceID: "device-1",
+			TtyUser:  "pm-tty-alice",
+		})
+		if err != nil {
+			t.Fatalf("mint %d: %v", i, err)
+		}
+		if _, dup := seen[res.SessionID]; dup {
+			t.Fatalf("duplicate session_id %s on iter %d", res.SessionID, i)
+		}
+		seen[res.SessionID] = struct{}{}
+	}
+}
+
+// contains is a tiny strings.Contains stand-in to avoid pulling the
+// stdlib import just for one test (the test file is already big).
+func contains(s, sub string) bool {
+	return len(sub) <= len(s) && (s == sub || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/terminal/valkey_backend.go
+++ b/internal/terminal/valkey_backend.go
@@ -1,0 +1,54 @@
+package terminal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// ValkeyBackend is the production SessionBackend, persisting tokens
+// in the same Valkey instance the control server already uses for
+// RediSearch and the Asynq task queue. Keys are namespaced under
+// keyPrefix and use Valkey's native TTL for expiry.
+type ValkeyBackend struct {
+	client *redis.Client
+}
+
+// NewValkeyBackend constructs a SessionBackend over the supplied
+// go-redis client. The caller retains ownership of the client.
+func NewValkeyBackend(client *redis.Client) *ValkeyBackend {
+	return &ValkeyBackend{client: client}
+}
+
+// Set persists the session payload with a TTL.
+func (b *ValkeyBackend) Set(ctx context.Context, sessionID string, payload []byte, ttl time.Duration) error {
+	if err := b.client.Set(ctx, keyPrefix+sessionID, payload, ttl).Err(); err != nil {
+		return fmt.Errorf("terminal: valkey set: %w", err)
+	}
+	return nil
+}
+
+// Get retrieves the raw session payload, or ErrTokenNotFound if the
+// key has been evicted by TTL or never existed.
+func (b *ValkeyBackend) Get(ctx context.Context, sessionID string) ([]byte, error) {
+	payload, err := b.client.Get(ctx, keyPrefix+sessionID).Bytes()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, ErrTokenNotFound
+		}
+		return nil, fmt.Errorf("terminal: valkey get: %w", err)
+	}
+	return payload, nil
+}
+
+// Delete removes the session entry. go-redis' DEL is idempotent: a
+// missing key returns 0 affected, not an error.
+func (b *ValkeyBackend) Delete(ctx context.Context, sessionID string) error {
+	if err := b.client.Del(ctx, keyPrefix+sessionID).Err(); err != nil {
+		return fmt.Errorf("terminal: valkey del: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
> ⚠️ **Stacked on #34** (terminal RPC stubs). This PR uses #34's branch as its base; **merge #34 first**, then this PR rebases onto main automatically.

## Summary

Implements step 5 of manchtools/power-manage-sdk#16 (the user-initiated open/stop half) and addresses manchtools/power-manage-server#6. Adds the four \`Remote Terminal\` permission keys, a Valkey-backed session token store, the real \`StartTerminal\`/\`StopTerminal\` handlers, audit events, and a focused test suite.

The \`List/Terminate\` admin RPCs **still return Unimplemented** because they require gateway-side session inventory and the \`GatewayService\` fan-out path; those land in the next PR alongside the gateway WebSocket bridge.

## What's in this PR

### \`internal/terminal/\` (new package)

A minimal token store layered on a tiny \`SessionBackend\` interface so handler tests can fake it without miniredis.

- **\`ValkeyBackend\`** persists tokens under \`pm:terminal:session:<id>\` with Valkey-native TTL eviction. Reuses the existing \`*redis.Client\` the control server already maintains for RediSearch — **no new dependencies, no new connection pool**.
- **\`FakeBackend\`** honours TTL via lazy expiry on read against an injectable clock so unit tests can advance time deterministically.
- **Bearer tokens** are 32 random bytes (256 bits, well above the unguessable threshold), base64url-encoded, and **SHA-256 hashed before storage**. The plaintext is returned to the web client exactly once and never persisted, so a Valkey dump cannot be used to forge connections — verified by an explicit test.
- **9 race-clean tests** cover mint/lookup round-trip, hash-not-plaintext storage, validate happy path, mismatched-token rejection (\`ErrTokenMismatch\`), unknown-session lookup (\`ErrTokenNotFound\`), idempotent revoke, TTL expiry with a frozen clock, mint required-field validation, and 100-iteration session_id uniqueness.

### \`internal/auth/permissions.go\`

Adds 4 permission keys under a new \`Remote Terminal\` group: \`StartTerminal\`, \`StopTerminal\`, \`ListActiveTerminalSessions\`, \`TerminateTerminalSession\`. The \`AuthzInterceptor\` already uses RPC method name as the permission key, so **no interceptor changes are needed**.

### \`internal/api/terminal_handler.go\` (new)

- **\`StartTerminal\`**: pulls \`UserContext\` from the request context, looks up the user, refuses disabled/deleted accounts, requires a non-empty \`linux_username\` (returns \`ErrTerminalLinuxUsernameNotSet\` / \`FailedPrecondition\` otherwise), resolves the dedicated TTY user via \`sdkterminal.TTYUsername\`, validates the target device, mints a token, emits a \`TerminalSessionStarted\` audit event, and returns the \`StartTerminalResponse\` with cols/rows/expiry/token.
- **\`StopTerminal\`**: looks up the session, **enforces ownership** (only the user that opened it may stop it — admins use \`TerminateTerminalSession\`, separate permission), revokes the token, emits a \`TerminalSessionStopped\` audit event. **Idempotent**: an unknown session returns OK with no body, matching the contract documented above \`StopTerminalRequest\` in the SDK proto.
- **\`GatewayBaseURL\`** helper normalises the configured WebSocket URL — strips any token/query/fragment defensively so the client always controls token placement. Verified by a table test that no \`?\` or \`#\` leaks through.

### \`internal/api/service.go\`

\`ControlService\` gains a \`TerminalHandler\` field (nil-by-default) and \`SetTerminalHandler\` setter, called from \`main.go\` after Valkey wiring. The 4 stubs are replaced with delegating wrappers that return:

- \`CodeUnavailable\` for \`StartTerminal\`/\`StopTerminal\` when the handler is unconfigured (so control instances without Valkey degrade gracefully instead of panicking on a nil pointer).
- \`CodeUnimplemented\` with explicit \"requires gateway fan-out\" messaging for \`ListActiveTerminalSessions\`/\`TerminateTerminalSession\`, separating \"not yet\" from \"broken\".

### \`cmd/control/main.go\`

New \`CONTROL_TERMINAL_GATEWAY_URL\` env var (and \`-terminal-gateway-url\` flag) holds the public WebSocket URL of the gateway terminal endpoint, e.g. \`wss://gw.example.com/terminal\`. **Kept separate from the existing \`CONTROL_GATEWAY_URL\`** (which is the agent registration URL) because the two endpoints run on different paths and the URLs may differ if a reverse proxy is involved.

The terminal handler is wired only when **both** Valkey is configured AND \`TerminalGatewayURL\` is set; otherwise the \`StartTerminal\` RPC returns \`CodeUnavailable\` instead of crashing on nil.

### Tests

\`internal/api/terminal_handler_test.go\` — 9 handler tests:

| Test | Asserts |
|---|---|
| \`StartTerminal_HappyPath\` | mint round-trip + token validates against the recorded session |
| \`StartTerminal_DefaultsWhenColsRowsZero\` | 80x24 default applied |
| \`StartTerminal_NoLinuxUsername\` | \`FailedPrecondition\` |
| \`StartTerminal_DeviceNotFound\` | \`NotFound\` |
| \`StartTerminal_NotAuthenticated\` | \`Unauthenticated\` |
| \`StopTerminal_OwnerCanStop\` | session removed from store |
| \`StopTerminal_OtherUserCannotStop\` | \`PermissionDenied\`, **session NOT revoked** |
| \`StopTerminal_UnknownSessionIsIdempotent\` | OK |
| \`StopTerminal_NotAuthenticated\` | \`Unauthenticated\` |
| \`GatewayBaseURL_StripsTokenAndTrailingSlash\` | no \`?\`/\`#\` leak |

All race-clean.

## Architecture decisions worth flagging

- **Opaque token + Valkey, not signed JWT.** Two reasons: (1) revocability — \`StopTerminal\` and the future admin terminate path need to invalidate tokens before expiry, which a stateless JWT can't support; (2) Valkey is already wired in for the Asynq queue and RediSearch, so adding a second backing store would be wasted complexity.

- **Permission key === RPC method name.** The interceptor enforces this convention for every other handler. The issue's spec called the permission \"TerminalAccess\" but that's a marketing term — the implementation uses the literal \`StartTerminal\` key so the existing interceptor wiring just works.

- **Separate \`TerminalGatewayURL\` config.** \`CONTROL_GATEWAY_URL\` is reserved for agent registration. Reusing it for terminal would force the gateway to expose the terminal WebSocket on the same path/scheme as the agent gRPC stream, which is wrong for most reverse-proxy setups. Two configs, two URLs, no surprises.

## What's NOT in this PR

- **Gateway WebSocket bridge** (step 4 of the issue) — needs the \`InternalService.ProxyValidateTerminalToken\` RPC in the SDK proto first, which is itself a separate small SDK PR.
- **Admin \`ListActiveTerminalSessions\` / \`TerminateTerminalSession\`** — requires the \`GatewayService\` fan-out path; lands with the gateway PR.
- **Auto-provisioning of \`pm-tty-*\` users** when \`StartTerminal\` permission is granted — separate PR via the system action manager.
- **Web xterm.js component** (step 6) — separate PR in the web repo.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/terminal/ -count=1 -race\` — all 9 store tests pass
- [x] \`go test ./internal/api/ -count=1 -run \"TestTokenStore|TestStartTerminal|TestStopTerminal|TestGatewayBaseURL\"\` — all 9 handler tests pass (78s with testcontainers)
- [x] Spot-checked a few unrelated handler tests to confirm I didn't break shared infra (TestLogin_Success, TestGetCurrentUser pass when run individually)

## Refs

- manchtools/power-manage-sdk#16 — parent feature
- manchtools/power-manage-server#6 — server-side parent issue
- #34 — base branch (terminal RPC stubs, must merge first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable remote terminal gateway via CLI/env; start/stop remote terminal sessions with short‑lived session tokens, persisted session store, Valkey-backed and in-memory backends, and gateway URL normalization.

* **Permissions**
  * Added remote-terminal permissions (Start, Stop, List, Terminate); StopTerminal enabled for default user role.

* **Tests**
  * End-to-end tests for terminal lifecycle, token store (mint/validate/revoke, TTL), gateway URL normalization, and authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->