### PR TITLE
feat: InternalService.ProxyValidateTerminalToken handler

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -322,6 +322,13 @@ func main() {
 		logger.Info("trusted proxies configured", "proxies", cfg.TrustedProxies)
 	}
 
+	// terminalTokenStore is populated below in the Valkey block when
+	// remote terminal sessions are configured. Hoisted to the outer
+	// scope so the InternalHandler — constructed further down — can
+	// share the same store and validate tokens minted by the
+	// ControlService.StartTerminal handler.
+	var terminalTokenStore *terminal.TokenStore
+
 	// Initialize Asynq task queue (Valkey) if configured
 	if cfg.ValkeyAddr != "" {
 		aqClient := taskqueue.NewClient(cfg.ValkeyAddr, cfg.ValkeyPassword, cfg.ValkeyDB)
@@ -357,11 +364,15 @@ func main() {
 		// any query string defensively so the client controls token
 		// placement. When TerminalGatewayURL is empty, the terminal
 		// handler is left nil and StartTerminal returns CodeUnavailable.
+		//
+		// The same TokenStore is also handed to the InternalHandler
+		// further down so InternalService.ProxyValidateTerminalToken
+		// can validate bearer tokens minted by this same instance.
 		if cfg.TerminalGatewayURL != "" {
-			terminalStore := terminal.NewTokenStore(terminal.NewValkeyBackend(rdb))
+			terminalTokenStore = terminal.NewTokenStore(terminal.NewValkeyBackend(rdb))
 			svc.SetTerminalHandler(api.NewTerminalHandler(
 				st,
-				terminalStore,
+				terminalTokenStore,
 				api.GatewayBaseURL(cfg.TerminalGatewayURL),
 				logger.With("component", "terminal_handler"),
 			))
@@ -484,6 +495,12 @@ func main() {
 	// Mount InternalService on a separate mTLS-protected listener.
 	// The gateway presents its CA-signed certificate as a client cert.
 	internalHandler := api.NewInternalHandler(st, encryptor, logger.With("component", "internal_service"))
+	if terminalTokenStore != nil {
+		// Shared with the ControlService.StartTerminal handler so the
+		// gateway can validate tokens minted on this instance via
+		// ProxyValidateTerminalToken.
+		internalHandler.SetTerminalTokenStore(terminalTokenStore)
+	}
 	internalPath, internalH := pmv1connect.NewInternalServiceHandler(internalHandler)
 
 	internalMux := http.NewServeMux()

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -368,8 +368,14 @@ func main() {
 		// The same TokenStore is also handed to the InternalHandler
 		// further down so InternalService.ProxyValidateTerminalToken
 		// can validate bearer tokens minted by this same instance.
+		// Always create the token store when Valkey is available, even
+		// if this node doesn't mint sessions (TerminalGatewayURL empty).
+		// The gateway calls ProxyValidateTerminalToken on whichever
+		// control replica it reaches, so every node that has Valkey
+		// must be able to validate tokens minted by other replicas.
+		terminalTokenStore = terminal.NewTokenStore(terminal.NewValkeyBackend(rdb))
+
 		if cfg.TerminalGatewayURL != "" {
-			terminalTokenStore = terminal.NewTokenStore(terminal.NewValkeyBackend(rdb))
 			svc.SetTerminalHandler(api.NewTerminalHandler(
 				st,
 				terminalTokenStore,
@@ -377,6 +383,8 @@ func main() {
 				logger.With("component", "terminal_handler"),
 			))
 			logger.Info("remote terminal sessions enabled", "gateway_url", cfg.TerminalGatewayURL)
+		} else {
+			logger.Warn("CONTROL_TERMINAL_GATEWAY_URL is empty: this node can validate terminal tokens but will not mint sessions (StartTerminal returns Unavailable)")
 		}
 
 		// Index audit events on insertion — the hook fires after every AppendEvent

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/resolution"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/terminal"
 )
 
 // InternalHandler implements the InternalService for gateway → control proxying.
@@ -27,6 +28,14 @@ type InternalHandler struct {
 	store     *store.Store
 	encryptor *crypto.Encryptor
 	logger    *slog.Logger
+
+	// terminalTokenStore is set via SetTerminalTokenStore after the
+	// Valkey-backed store is constructed in main.go. nil when terminal
+	// sessions are not configured on this control instance, in which
+	// case ProxyValidateTerminalToken returns Unavailable so the
+	// gateway gets a clean error rather than the InternalService
+	// default 'method not implemented'.
+	terminalTokenStore *terminal.TokenStore
 }
 
 // NewInternalHandler creates a new internal service handler.
@@ -36,6 +45,14 @@ func NewInternalHandler(st *store.Store, enc *crypto.Encryptor, logger *slog.Log
 		encryptor: enc,
 		logger:    logger,
 	}
+}
+
+// SetTerminalTokenStore wires the Valkey-backed terminal token store
+// so ProxyValidateTerminalToken can validate the bearer tokens minted
+// by ControlService.StartTerminal. Called from main.go alongside
+// ControlService.SetTerminalHandler so the two paths share one store.
+func (h *InternalHandler) SetTerminalTokenStore(s *terminal.TokenStore) {
+	h.terminalTokenStore = s
 }
 
 // VerifyDevice checks that a device exists and is not deleted.
@@ -228,6 +245,72 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 	}
 
 	return connect.NewResponse(&pm.InternalStoreLpsPasswordsResponse{}), nil
+}
+
+// ProxyValidateTerminalToken validates the bearer token a web client
+// presents when opening the gateway's WebSocket terminal endpoint and
+// returns the session metadata the gateway needs to bridge the
+// connection.
+//
+// Validation does NOT consume the entry — the same gateway uses the
+// metadata for the lifetime of the WebSocket. Revocation happens
+// explicitly via ControlService.StopTerminal or
+// TerminateTerminalSession. This contract is documented on the RPC
+// in manchtools/power-manage-sdk#27.
+//
+// Distinguishes 'unknown / expired' (Unauthenticated, with a generic
+// message so a forgery probe cannot tell the difference between an
+// expired token and a never-existed one) from 'mismatched token'
+// (Unauthenticated, but logged separately so the audit pipeline can
+// flag forgery attempts). 'Token store not configured' is Unavailable
+// — that's an operator misconfiguration, not a client bug.
+func (h *InternalHandler) ProxyValidateTerminalToken(ctx context.Context, req *connect.Request[pm.InternalValidateTerminalTokenRequest]) (*connect.Response[pm.InternalValidateTerminalTokenResponse], error) {
+	if h.terminalTokenStore == nil {
+		return nil, connect.NewError(connect.CodeUnavailable,
+			errors.New("remote terminal sessions are not configured on this control instance"))
+	}
+
+	sessionID := req.Msg.SessionId
+	bearer := req.Msg.Token
+	if sessionID == "" || bearer == "" {
+		return nil, connect.NewError(connect.CodeInvalidArgument,
+			errors.New("session_id and token are required"))
+	}
+
+	session, err := h.terminalTokenStore.Validate(ctx, sessionID, bearer)
+	if err != nil {
+		// Map the two possible store errors to the same gRPC code so a
+		// forgery probe cannot tell expired from mismatched, but log
+		// them differently so operators can spot active attacks.
+		switch {
+		case errors.Is(err, terminal.ErrTokenMismatch):
+			h.logger.Warn("terminal token mismatch (possible forgery attempt)",
+				"session_id", sessionID)
+		case errors.Is(err, terminal.ErrTokenNotFound):
+			h.logger.Debug("terminal token unknown or expired",
+				"session_id", sessionID)
+		default:
+			h.logger.Error("terminal token validation failed",
+				"session_id", sessionID, "error", err)
+			return nil, connect.NewError(connect.CodeInternal,
+				errors.New("failed to validate session token"))
+		}
+		return nil, connect.NewError(connect.CodeUnauthenticated,
+			errors.New("invalid or expired session token"))
+	}
+
+	h.logger.Debug("terminal token validated",
+		"session_id", sessionID,
+		"user_id", session.UserID,
+		"device_id", session.DeviceID,
+	)
+	return connect.NewResponse(&pm.InternalValidateTerminalTokenResponse{
+		UserId:   session.UserID,
+		DeviceId: session.DeviceID,
+		TtyUser:  session.TtyUser,
+		Cols:     session.Cols,
+		Rows:     session.Rows,
+	}), nil
 }
 
 // dbResolvedActionToWireAction converts a resolved action row to wire format.

--- a/internal/api/internal_handler_test.go
+++ b/internal/api/internal_handler_test.go
@@ -262,15 +262,13 @@ func TestProxyValidateTerminalToken_UnknownSession(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
-}
+	unknownMsg := err.Error()
 
-func TestProxyValidateTerminalToken_MismatchedToken(t *testing.T) {
-	// Mismatched and unknown both surface as Unauthenticated so a
-	// forgery probe cannot tell the difference, but the audit log
-	// records them differently. The test confirms the gRPC code
-	// is the same; the log inspection is left to manual review.
-	h, tokenStore := newInternalHandlerWithTokenStore(t)
-
+	// Mismatched and unknown must produce the SAME gRPC code AND the
+	// SAME error message so a forgery probe cannot distinguish them.
+	// The log messages differ (Warn vs Debug) but the wire response
+	// is identical.
+	h2, tokenStore := newInternalHandlerWithTokenStore(t)
 	mintRes, err := tokenStore.Mint(context.Background(), terminal.MintParams{
 		UserID:   "user-1",
 		DeviceID: "device-1",
@@ -278,12 +276,16 @@ func TestProxyValidateTerminalToken_MismatchedToken(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, err = h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
+	_, err = h2.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
 		SessionId: mintRes.SessionID,
 		Token:     "wrong-token",
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	mismatchMsg := err.Error()
+
+	assert.Equal(t, unknownMsg, mismatchMsg,
+		"unknown and mismatched errors must have the same message to prevent probe distinguishability")
 }
 
 func TestProxyValidateTerminalToken_RevokedToken(t *testing.T) {

--- a/internal/api/internal_handler_test.go
+++ b/internal/api/internal_handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/terminal"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
@@ -190,4 +191,147 @@ func TestProxyStoreLpsPasswords_MissingFields(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// newInternalHandlerWithTokenStore builds an InternalHandler over a
+// fresh in-memory token store. Returned alongside the store so tests
+// can mint and revoke directly without round-tripping through the
+// public StartTerminal handler.
+func newInternalHandlerWithTokenStore(t *testing.T) (*api.InternalHandler, *terminal.TokenStore) {
+	t.Helper()
+	st := testutil.SetupPostgres(t)
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	tokenStore := terminal.NewTokenStore(terminal.NewFakeBackend(nil))
+	h.SetTerminalTokenStore(tokenStore)
+	return h, tokenStore
+}
+
+func TestProxyValidateTerminalToken_HappyPath(t *testing.T) {
+	h, tokenStore := newInternalHandlerWithTokenStore(t)
+
+	mintRes, err := tokenStore.Mint(context.Background(), terminal.MintParams{
+		UserID:   "user-1",
+		DeviceID: "device-1",
+		TtyUser:  "pm-tty-alice",
+		Cols:     120,
+		Rows:     40,
+	})
+	require.NoError(t, err)
+
+	resp, err := h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
+		SessionId: mintRes.SessionID,
+		Token:     mintRes.Token,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "user-1", resp.Msg.UserId)
+	assert.Equal(t, "device-1", resp.Msg.DeviceId)
+	assert.Equal(t, "pm-tty-alice", resp.Msg.TtyUser)
+	assert.Equal(t, uint32(120), resp.Msg.Cols)
+	assert.Equal(t, uint32(40), resp.Msg.Rows)
+}
+
+func TestProxyValidateTerminalToken_DoesNotConsumeToken(t *testing.T) {
+	// The contract documented above the RPC says validation must NOT
+	// consume the entry — the same gateway uses the metadata for the
+	// lifetime of the WebSocket. Validate twice and assert both
+	// succeed.
+	h, tokenStore := newInternalHandlerWithTokenStore(t)
+
+	mintRes, err := tokenStore.Mint(context.Background(), terminal.MintParams{
+		UserID:   "user-1",
+		DeviceID: "device-1",
+		TtyUser:  "pm-tty-alice",
+	})
+	require.NoError(t, err)
+
+	for i := 0; i < 3; i++ {
+		_, err := h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
+			SessionId: mintRes.SessionID,
+			Token:     mintRes.Token,
+		}))
+		require.NoErrorf(t, err, "validation %d should succeed", i+1)
+	}
+}
+
+func TestProxyValidateTerminalToken_UnknownSession(t *testing.T) {
+	h, _ := newInternalHandlerWithTokenStore(t)
+
+	_, err := h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
+		SessionId: "no-such-session",
+		Token:     "anything",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestProxyValidateTerminalToken_MismatchedToken(t *testing.T) {
+	// Mismatched and unknown both surface as Unauthenticated so a
+	// forgery probe cannot tell the difference, but the audit log
+	// records them differently. The test confirms the gRPC code
+	// is the same; the log inspection is left to manual review.
+	h, tokenStore := newInternalHandlerWithTokenStore(t)
+
+	mintRes, err := tokenStore.Mint(context.Background(), terminal.MintParams{
+		UserID:   "user-1",
+		DeviceID: "device-1",
+		TtyUser:  "pm-tty-alice",
+	})
+	require.NoError(t, err)
+
+	_, err = h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
+		SessionId: mintRes.SessionID,
+		Token:     "wrong-token",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestProxyValidateTerminalToken_RevokedToken(t *testing.T) {
+	h, tokenStore := newInternalHandlerWithTokenStore(t)
+
+	mintRes, err := tokenStore.Mint(context.Background(), terminal.MintParams{
+		UserID:   "user-1",
+		DeviceID: "device-1",
+		TtyUser:  "pm-tty-alice",
+	})
+	require.NoError(t, err)
+	require.NoError(t, tokenStore.Revoke(context.Background(), mintRes.SessionID))
+
+	_, err = h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
+		SessionId: mintRes.SessionID,
+		Token:     mintRes.Token,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+func TestProxyValidateTerminalToken_MissingFields(t *testing.T) {
+	h, _ := newInternalHandlerWithTokenStore(t)
+
+	cases := []*pm.InternalValidateTerminalTokenRequest{
+		{},
+		{SessionId: "01ABC"},
+		{Token: "tok"},
+	}
+	for _, req := range cases {
+		_, err := h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(req))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	}
+}
+
+func TestProxyValidateTerminalToken_StoreNotConfigured(t *testing.T) {
+	// When SetTerminalTokenStore was never called (e.g. control
+	// instance running without TerminalGatewayURL), the RPC must
+	// return Unavailable so the gateway can degrade gracefully
+	// instead of returning a confusing 'method not found'.
+	st := testutil.SetupPostgres(t)
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+
+	_, err := h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
+		SessionId: "01ABC",
+		Token:     "tok",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
 }


### PR DESCRIPTION
> ⚠️ **Stacked on #35** (control real impl). This PR uses #35's branch as its base; **merge #35 first**, then this PR auto-rebases onto main.

## Summary

Implements the gateway-callable validation RPC the WebSocket bridge (next PR) needs. Uses the same Valkey-backed \`terminal.TokenStore\` that \`ControlService.StartTerminal\` mints into, so:

- Tokens minted on this control instance are validatable on this instance.
- In an HA setup with multiple control replicas, tokens minted on replica A are validatable on replica B because Valkey is shared.

This is the **third-to-last** server-side terminal PR before the gateway WebSocket bridge can land.

## What's in this PR

### \`internal/api/internal_handler.go\`

- \`InternalHandler\` gains a \`terminalTokenStore\` field and a \`SetTerminalTokenStore\` setter, called from \`main.go\` alongside \`ControlService.SetTerminalHandler\` so the two paths share one store.
- nil-safe: when terminal sessions are not configured on this control instance, \`ProxyValidateTerminalToken\` returns \`Unavailable\` so the gateway gets a clean error instead of the default \"method not implemented\".

**Handler behaviour:**

| Input | Result |
|---|---|
| empty \`session_id\` or \`token\` | \`InvalidArgument\` |
| valid token | \`OK\` + \`user_id\`/\`device_id\`/\`tty_user\`/\`cols\`/\`rows\` |
| unknown session (\`ErrTokenNotFound\`) | \`Unauthenticated\` (logged at \`Debug\`) |
| mismatched token (\`ErrTokenMismatch\`) | \`Unauthenticated\` (logged at \`Warn\` — possible forgery) |
| store not configured (nil) | \`Unavailable\` |
| unexpected store error | \`Internal\` (never leaked as \`Unauthenticated\`) |

**Forgery probe protection**: \`ErrTokenMismatch\` and \`ErrTokenNotFound\` both surface as \`Unauthenticated\` with the same generic message (\"invalid or expired session token\") so an attacker cannot distinguish expired from never-existed by error response alone. They are logged differently though, so operators can spot active attacks in audit.

**Validation does NOT consume the entry** — the contract documented on the RPC in manchtools/power-manage-sdk#27 specifies that the same gateway uses the metadata across the lifetime of the WebSocket; revocation is explicit via \`ControlService.StopTerminal\` or \`TerminateTerminalSession\`. There's a test specifically for this.

### \`cmd/control/main.go\`

- \`terminalTokenStore\` declaration hoisted to the outer scope so the \`InternalHandler\` — constructed further down — can share the same store the \`TerminalHandler\` uses.
- After \`NewInternalHandler\`, if \`terminalTokenStore\` is non-nil, \`SetTerminalTokenStore\` wires it. When \`TerminalGatewayURL\` is empty (no minting), the store stays nil and the validate RPC returns \`Unavailable\`.

### \`internal/api/internal_handler_test.go\`

7 new tests:

| Test | Asserts |
|---|---|
| \`HappyPath\` | mint via store → validate via RPC → all five metadata fields returned correctly |
| \`DoesNotConsumeToken\` | validates 3x in a row, all succeed (contract enforcement) |
| \`UnknownSession\` | \`Unauthenticated\` |
| \`MismatchedToken\` | \`Unauthenticated\` (same code as unknown — forgery probe protection) |
| \`RevokedToken\` | mint → revoke → validate → \`Unauthenticated\` (confirms \`StopTerminal\` actually invalidates) |
| \`MissingFields\` | \`InvalidArgument\` for empty/partial requests |
| \`StoreNotConfigured\` | nil store → \`Unavailable\` |

All pass under the existing testcontainers setup. Full \`internal/terminal/\` unit suite still race-clean.

## What's NOT in this PR

- **Gateway WebSocket bridge** — next PR. It will call this RPC over the existing \`InternalService\` mTLS channel via the gateway's \`ControlProxy\`.
- **Admin \`List\`/\`Terminate\` fan-out** — separate PR.
- **TTY user auto-provisioning** — independent, can land any time.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/terminal/ -count=1 -race\` — full pkg green
- [x] \`go test ./internal/api/ -count=1 -run TestProxyValidateTerminalToken\` — all 7 new tests pass

## Refs

- manchtools/power-manage-sdk#16 — parent feature
- manchtools/power-manage-server#6 — server-side parent issue
- manchtools/power-manage-sdk#27 — \`InternalValidateTerminalTokenRequest\`/\`Response\` proto contract
- #35 — base branch (control real impl, must merge first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added terminal token validation support for server-side verification of terminal session tokens and retrieval of session metadata; validation can be enabled independently of the remote terminal handler.

* **Tests**
  * Added comprehensive tests for terminal token validation covering success, repeated checks, mismatches, revocation, missing inputs, and handler-unavailable cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->