### PR TITLE
feat: multi-gateway routing via Valkey registry

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/control"
 	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/scim"
 	"github.com/manchtools/power-manage/server/internal/search"
@@ -355,15 +356,23 @@ func main() {
 		searchIdx := search.New(rdb, st, aqClient, logger.With("component", "search"))
 		svc.SetSearchIndex(searchIdx)
 
-		// Wire the remote terminal session token store IF the operator
-		// has configured a public terminal gateway URL. Tokens live in
+		// Wire the remote terminal session token store. Tokens live in
 		// Valkey under pm:terminal:session:* with a short TTL; minted
 		// by ControlService.StartTerminal and consumed by the gateway
-		// when the web client opens its WebSocket. The URL is returned
-		// to clients in StartTerminalResponse — GatewayBaseURL strips
-		// any query string defensively so the client controls token
-		// placement. When TerminalGatewayURL is empty, the terminal
-		// handler is left nil and StartTerminal returns CodeUnavailable.
+		// when the web client opens its WebSocket.
+		//
+		// In multi-gateway HA, the URL returned to the client must
+		// point at the *specific* gateway hosting the device (any
+		// other gateway has no way to bridge the WebSocket to the
+		// agent). The internal/gateway/registry package looks the
+		// device→gateway mapping up in Valkey: each gateway publishes
+		// pm:device:gateway:<device_id> on agent connect. The
+		// TerminalHandler queries the same registry at mint time.
+		//
+		// CONTROL_TERMINAL_GATEWAY_URL is retained as a fallback for
+		// single-gateway dev deployments where the operator hasn't
+		// run the registry-publishing gateway changes yet. In a real
+		// multi-gateway deployment, leave it unset.
 		//
 		// The same TokenStore is also handed to the InternalHandler
 		// further down so InternalService.ProxyValidateTerminalToken
@@ -374,17 +383,21 @@ func main() {
 		// control replica it reaches, so every node that has Valkey
 		// must be able to validate tokens minted by other replicas.
 		terminalTokenStore = terminal.NewTokenStore(terminal.NewValkeyBackend(rdb))
-
+		gatewayReg := registry.New(registry.NewValkeyBackend(rdb), logger.With("component", "gateway_registry"))
+		svc.SetTerminalHandler(api.NewTerminalHandler(
+			st,
+			terminalTokenStore,
+			gatewayReg,
+			api.GatewayBaseURL(cfg.TerminalGatewayURL),
+			logger.With("component", "terminal_handler"),
+		))
 		if cfg.TerminalGatewayURL != "" {
-			svc.SetTerminalHandler(api.NewTerminalHandler(
-				st,
-				terminalTokenStore,
-				api.GatewayBaseURL(cfg.TerminalGatewayURL),
-				logger.With("component", "terminal_handler"),
-			))
-			logger.Info("remote terminal sessions enabled", "gateway_url", cfg.TerminalGatewayURL)
+			logger.Info("remote terminal sessions enabled",
+				"fallback_gateway_url", cfg.TerminalGatewayURL,
+				"registry_enabled", true,
+			)
 		} else {
-			logger.Warn("CONTROL_TERMINAL_GATEWAY_URL is empty: this node can validate terminal tokens but will not mint sessions (StartTerminal returns Unavailable)")
+			logger.Warn("CONTROL_TERMINAL_GATEWAY_URL is empty: this node can validate terminal tokens via registry but will not mint sessions with a static fallback URL")
 		}
 
 		// Index audit events on insertion — the hook fires after every AppendEvent

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -131,9 +131,8 @@ func main() {
 	// know its own public URL, so we just leave the registry off
 	// (single-gateway / no-terminal mode).
 	var (
-		gatewayReg     *registry.Registry
-		stopRegistry   func()
-		assignedHost   string
+		gatewayReg   *registry.Registry
+		assignedHost string
 	)
 	if cfg.PublicTerminalURLTemplate != "" {
 		// Substitute {id} in the URL template. The template is the
@@ -171,7 +170,6 @@ func main() {
 			logger.Error("failed to register gateway in registry", "error", err)
 			os.Exit(1)
 		}
-		stopRegistry = stop
 		defer stop()
 		logger.Info("multi-gateway routing enabled",
 			"gateway_id", gatewayID,
@@ -179,8 +177,6 @@ func main() {
 			"assigned_host", assignedHost,
 		)
 	}
-	_ = stopRegistry // silence unused if the conditional above never fires
-
 	logger.Info("gateway started", "version", version)
 
 	// Setup HTTP mux for agent connections (mTLS-protected)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -177,6 +178,16 @@ func main() {
 			"assigned_host", assignedHost,
 		)
 	}
+	// Fail fast if BootstrapHost is set but we have no assignedHost
+	// (because PublicTerminalURLTemplate was empty). Without this
+	// guard, BootstrapRedirectMiddleware would panic on an empty
+	// assignedHost further down.
+	if cfg.BootstrapHost != "" && assignedHost == "" {
+		logger.Error("GATEWAY_BOOTSTRAP_HOST is set but GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE is empty; cannot derive the per-gateway hostname for bootstrap redirects",
+			"bootstrap_host", cfg.BootstrapHost)
+		os.Exit(1)
+	}
+
 	logger.Info("gateway started", "version", version)
 
 	// Setup HTTP mux for agent connections (mTLS-protected)
@@ -286,38 +297,18 @@ func main() {
 // hostFromURL extracts the bare hostname (no port, no scheme, no
 // path) from a URL like "wss://gw-01.example.com/terminal" so the
 // bootstrap middleware can use it as the redirect target hostname.
-// Returns "" on parse failure or if the URL has no host component.
+// Only ws:// and wss:// schemes are accepted. Returns "" on parse
+// failure, unsupported scheme, or missing host component.
 func hostFromURL(raw string) string {
 	if raw == "" {
 		return ""
 	}
-	// Strip the scheme. We accept http/https/ws/wss. Anything else
-	// is probably a misconfiguration; fall through and let url.Parse
-	// reject it.
-	for _, scheme := range []string{"wss://", "ws://", "https://", "http://"} {
-		if strings.HasPrefix(raw, scheme) {
-			raw = raw[len(scheme):]
-			break
-		}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
 	}
-	// Trim path and query.
-	if i := strings.IndexAny(raw, "/?#"); i >= 0 {
-		raw = raw[:i]
+	if u.Scheme != "ws" && u.Scheme != "wss" {
+		return ""
 	}
-	// Strip port.
-	if i := strings.LastIndexByte(raw, ':'); i >= 0 {
-		// Be conservative: only treat as a port if everything after
-		// the colon is digits, so IPv6-without-port doesn't break us.
-		isPort := i+1 < len(raw)
-		for j := i + 1; j < len(raw); j++ {
-			if raw[j] < '0' || raw[j] > '9' {
-				isPort = false
-				break
-			}
-		}
-		if isPort {
-			raw = raw[:i]
-		}
-	}
-	return raw
+	return u.Hostname()
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -294,11 +294,12 @@ func main() {
 	logger.Info("server stopped")
 }
 
-// hostFromURL extracts the bare hostname (no port, no scheme, no
-// path) from a URL like "wss://gw-01.example.com/terminal" so the
-// bootstrap middleware can use it as the redirect target hostname.
-// Only ws:// and wss:// schemes are accepted. Returns "" on parse
-// failure, unsupported scheme, or missing host component.
+// hostFromURL extracts the host (including port if present) from a
+// URL like "wss://gw-01.example.com:8443/terminal" so the bootstrap
+// redirect middleware constructs a correct Location header that
+// preserves non-default ports. Only ws:// and wss:// schemes are
+// accepted. Returns "" on parse failure, unsupported scheme, or
+// missing host component.
 func hostFromURL(raw string) string {
 	if raw == "" {
 		return ""
@@ -310,5 +311,11 @@ func hostFromURL(raw string) string {
 	if u.Scheme != "ws" && u.Scheme != "wss" {
 		return ""
 	}
-	return u.Hostname()
+	// u.Host includes the port (e.g. "gw-01.example.com:8443").
+	// u.Hostname() strips it, which would break redirects on
+	// non-default ports.
+	if u.Host == "" {
+		return ""
+	}
+	return u.Host
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -11,9 +11,12 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
+	"github.com/oklog/ulid/v2"
+	"github.com/redis/go-redis/v9"
 	"golang.org/x/net/http2"
 
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
@@ -21,6 +24,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/config"
 	"github.com/manchtools/power-manage/server/internal/connection"
 	"github.com/manchtools/power-manage/server/internal/gateway"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/handler"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/mtls"
@@ -107,6 +111,76 @@ func main() {
 	)
 	defer workerMgr.StopAll()
 
+	// Resolve this gateway's stable ID. If GATEWAY_ID is set, use it
+	// (static-config Traefik setups where the operator pre-declares
+	// per-gateway routes). Otherwise generate a ULID at startup
+	// (dynamic-config setups where Traefik picks up new routes from
+	// a watcher / file provider / k8s ingress automatically).
+	gatewayID := cfg.GatewayID
+	if gatewayID == "" {
+		gatewayID = ulid.Make().String()
+		logger.Info("generated dynamic gateway ID", "gateway_id", gatewayID)
+	} else {
+		logger.Info("using configured gateway ID", "gateway_id", gatewayID)
+	}
+
+	// Wire the multi-gateway registry. Reuses the same Valkey
+	// instance the Asynq queue uses, no extra connection pool. The
+	// registry is enabled only when the operator has set the
+	// public terminal URL template — without it the gateway can't
+	// know its own public URL, so we just leave the registry off
+	// (single-gateway / no-terminal mode).
+	var (
+		gatewayReg     *registry.Registry
+		stopRegistry   func()
+		assignedHost   string
+	)
+	if cfg.PublicTerminalURLTemplate != "" {
+		// Substitute {id} in the URL template. The template is the
+		// public WebSocket URL operators want clients to use; the
+		// gateway never constructs hostnames from the request side.
+		terminalURL := strings.ReplaceAll(cfg.PublicTerminalURLTemplate, "{id}", gatewayID)
+
+		// The bootstrap middleware needs the bare assigned hostname
+		// (no scheme, no path) so it can build a redirect Location.
+		// Derive it from the terminal URL.
+		assignedHost = hostFromURL(terminalURL)
+		if assignedHost == "" {
+			logger.Error("could not extract host from GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE",
+				"template", cfg.PublicTerminalURLTemplate, "resolved", terminalURL)
+			os.Exit(1)
+		}
+
+		rdb := redis.NewClient(&redis.Options{
+			Addr:     cfg.ValkeyAddr,
+			Password: cfg.ValkeyPassword,
+			DB:       cfg.ValkeyDB,
+			Protocol: 2,
+		})
+		defer rdb.Close()
+
+		gatewayReg = registry.New(registry.NewValkeyBackend(rdb), logger.With("component", "registry"))
+		stop, err := gatewayReg.RegisterGateway(
+			context.Background(),
+			gatewayID,
+			terminalURL,
+			registry.DefaultGatewayTTL,
+			registry.DefaultGatewayRefreshInterval,
+		)
+		if err != nil {
+			logger.Error("failed to register gateway in registry", "error", err)
+			os.Exit(1)
+		}
+		stopRegistry = stop
+		defer stop()
+		logger.Info("multi-gateway routing enabled",
+			"gateway_id", gatewayID,
+			"terminal_url", terminalURL,
+			"assigned_host", assignedHost,
+		)
+	}
+	_ = stopRegistry // silence unused if the conditional above never fires
+
 	logger.Info("gateway started", "version", version)
 
 	// Setup HTTP mux for agent connections (mTLS-protected)
@@ -114,8 +188,19 @@ func main() {
 
 	// Create agent handler (always mTLS)
 	agentHandler := handler.NewAgentHandlerWithTLS(manager, aqClient, controlProxy, workerMgr, version, logger)
+	if gatewayReg != nil {
+		agentHandler.SetGatewayRouting(gatewayReg, gatewayID)
+	}
 	path, h := pmv1connect.NewAgentServiceHandler(agentHandler)
-	mux.Handle(path, handler.MTLSMiddleware(h, logger))
+
+	// Compose middlewares (innermost first):
+	//   pmv1connect handler
+	//     ↑ MTLSMiddleware (extracts device ID from client cert)
+	//     ↑ BootstrapRedirectMiddleware (returns 307 to assignedHost
+	//       when the request landed on the wildcard root via LB)
+	mtlsHandler := handler.MTLSMiddleware(h, logger)
+	bootstrappedHandler := handler.BootstrapRedirectMiddleware(mtlsHandler, cfg.BootstrapHost, assignedHost, logger)
+	mux.Handle(path, bootstrappedHandler)
 
 	// Wrap with security headers
 	securedMux := middleware.RequestID(middleware.SecurityHeaders(mux))
@@ -200,4 +285,43 @@ func main() {
 	}
 
 	logger.Info("server stopped")
+}
+
+// hostFromURL extracts the bare hostname (no port, no scheme, no
+// path) from a URL like "wss://gw-01.example.com/terminal" so the
+// bootstrap middleware can use it as the redirect target hostname.
+// Returns "" on parse failure or if the URL has no host component.
+func hostFromURL(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	// Strip the scheme. We accept http/https/ws/wss. Anything else
+	// is probably a misconfiguration; fall through and let url.Parse
+	// reject it.
+	for _, scheme := range []string{"wss://", "ws://", "https://", "http://"} {
+		if strings.HasPrefix(raw, scheme) {
+			raw = raw[len(scheme):]
+			break
+		}
+	}
+	// Trim path and query.
+	if i := strings.IndexAny(raw, "/?#"); i >= 0 {
+		raw = raw[:i]
+	}
+	// Strip port.
+	if i := strings.LastIndexByte(raw, ':'); i >= 0 {
+		// Be conservative: only treat as a port if everything after
+		// the colon is digits, so IPv6-without-port doesn't break us.
+		isPort := i+1 < len(raw)
+		for j := i + 1; j < len(raw); j++ {
+			if raw[j] < '0' || raw[j] > '9' {
+				isPort = false
+				break
+			}
+		}
+		if isPort {
+			raw = raw[:i]
+		}
+	}
+	return raw
 }

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -15,6 +15,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	sdkterminal "github.com/manchtools/power-manage/sdk/go/sys/terminal"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/terminal"
@@ -28,22 +29,27 @@ import (
 type TerminalHandler struct {
 	store      *store.Store
 	tokenStore *terminal.TokenStore
-	gatewayURL string
+	registry   *registry.Registry // multi-gateway routing; may be nil for single-gateway fallback
+	fallbackURL string             // used only when registry is nil
 	logger     *slog.Logger
 }
 
-// NewTerminalHandler constructs a TerminalHandler. gatewayURL is the
-// publicly-resolvable WebSocket URL of the gateway endpoint, e.g.
-// "wss://gateway.example.com/terminal". Clients append
-// ?token=<session_token> to it themselves; the handler returns the
-// token-free base URL per the StartTerminalResponse contract in the
-// SDK proto.
-func NewTerminalHandler(st *store.Store, tokenStore *terminal.TokenStore, gatewayURL string, logger *slog.Logger) *TerminalHandler {
+// NewTerminalHandler constructs a TerminalHandler.
+//
+// reg is the multi-gateway registry; when non-nil, StartTerminal
+// looks up the gateway hosting each device and returns its specific
+// terminal URL. fallbackURL is the static gateway URL used when
+// reg is nil (single-gateway deployments without a registry).
+//
+// In production at least one of reg or fallbackURL must be supplied,
+// or every StartTerminal call returns Unavailable.
+func NewTerminalHandler(st *store.Store, tokenStore *terminal.TokenStore, reg *registry.Registry, fallbackURL string, logger *slog.Logger) *TerminalHandler {
 	return &TerminalHandler{
-		store:      st,
-		tokenStore: tokenStore,
-		gatewayURL: GatewayBaseURL(gatewayURL),
-		logger:     logger,
+		store:       st,
+		tokenStore:  tokenStore,
+		registry:    reg,
+		fallbackURL: GatewayBaseURL(fallbackURL),
+		logger:      logger,
 	}
 }
 
@@ -56,10 +62,6 @@ func NewTerminalHandler(st *store.Store, tokenStore *terminal.TokenStore, gatewa
 // key is "StartTerminal" — same convention as every other handler),
 // so this method only runs for callers that already hold it.
 func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Request[pm.StartTerminalRequest]) (*connect.Response[pm.StartTerminalResponse], error) {
-	if h.gatewayURL == "" {
-		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
-			"terminal gateway URL is not configured")
-	}
 	userCtx, ok := auth.UserFromContext(ctx)
 	if !ok {
 		return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, "not authenticated")
@@ -96,6 +98,24 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 			return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found or not assigned to you")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up device")
+	}
+
+	// Resolve which gateway is currently hosting this device. In a
+	// multi-gateway deployment we MUST return the URL of the
+	// specific gateway holding the agent's bidi stream — any other
+	// gateway has no way to bridge the WebSocket to the agent. The
+	// device→gateway mapping is published by the gateway side via
+	// internal/gateway/registry as part of the agent connect/heart-
+	// beat lifecycle.
+	//
+	// Single-gateway deployments without a registry fall back to
+	// the static fallbackURL passed at construction time. If both
+	// the registry and the fallback are unset, we have no way to
+	// route — return Unavailable so operators see a clear failure
+	// instead of minting tokens against a URL that doesn't exist.
+	resolvedURL, err := h.resolveGatewayURL(ctx, req.Msg.DeviceId)
+	if err != nil {
+		return nil, err
 	}
 
 	cols := req.Msg.Cols
@@ -160,10 +180,67 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 	return connect.NewResponse(&pm.StartTerminalResponse{
 		SessionId:    sessionID,
 		SessionToken: mintRes.Token,
-		GatewayUrl:   h.gatewayURL,
+		GatewayUrl:   resolvedURL,
 		ExpiresAt:    timestamppb.New(mintRes.ExpiresAt),
 		TtyUser:      ttyUser,
 	}), nil
+}
+
+// resolveGatewayURL returns the public terminal WebSocket URL for
+// the gateway currently hosting the given device. Lookup chain:
+//
+//  1. If the registry is configured, look up
+//     pm:device:gateway:<deviceID> → gatewayID, then
+//     pm:gateway:terminal:<gatewayID> → URL. Returns
+//     FailedPrecondition if the device isn't connected to any
+//     gateway, Unavailable if the gateway has expired between the
+//     two lookups (race during failover).
+//  2. If the registry is not configured, return the static
+//     fallbackURL passed at construction. This is the
+//     single-gateway path.
+//  3. If neither is configured, return Unavailable so operators
+//     see a clear misconfiguration error rather than minting
+//     tokens against an empty URL.
+func (h *TerminalHandler) resolveGatewayURL(ctx context.Context, deviceID string) (string, error) {
+	if h.registry == nil {
+		if h.fallbackURL == "" {
+			return "", apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnavailable,
+				"remote terminal sessions are not configured on this control instance")
+		}
+		return h.fallbackURL, nil
+	}
+
+	gatewayID, err := h.registry.LookupDeviceGateway(ctx, deviceID)
+	if err != nil {
+		if errors.Is(err, registry.ErrNoGateway) {
+			return "", apiErrorCtx(ctx, ErrDeviceNotConnected, connect.CodeFailedPrecondition,
+				"device is not currently connected to any gateway")
+		}
+		h.logger.Error("device gateway lookup failed",
+			"device_id", deviceID, "error", err)
+		return "", apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+			"device gateway lookup failed")
+	}
+
+	terminalURL, err := h.registry.LookupGatewayTerminalURL(ctx, gatewayID)
+	if err != nil {
+		if errors.Is(err, registry.ErrNoGateway) {
+			// The gateway died between the device lookup and the
+			// URL lookup. Surface as Unavailable so the client
+			// retries — by then the agent has reconnected
+			// elsewhere and the next StartTerminal call resolves
+			// to a live gateway.
+			h.logger.Warn("gateway hosting device is no longer registered",
+				"device_id", deviceID, "gateway_id", gatewayID)
+			return "", apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable,
+				"gateway hosting this device is no longer registered; retry shortly")
+		}
+		h.logger.Error("gateway URL lookup failed",
+			"gateway_id", gatewayID, "error", err)
+		return "", apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+			"gateway URL lookup failed")
+	}
+	return terminalURL, nil
 }
 
 // StopTerminal is the user-initiated graceful stop. The caller must

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -218,8 +218,8 @@ func (h *TerminalHandler) resolveGatewayURL(ctx context.Context, deviceID string
 		}
 		h.logger.Error("device gateway lookup failed",
 			"device_id", deviceID, "error", err)
-		return "", apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
-			"device gateway lookup failed")
+		return "", apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable,
+			"device gateway lookup failed (registry unavailable)")
 	}
 
 	terminalURL, err := h.registry.LookupGatewayTerminalURL(ctx, gatewayID)
@@ -237,8 +237,8 @@ func (h *TerminalHandler) resolveGatewayURL(ctx context.Context, deviceID string
 		}
 		h.logger.Error("gateway URL lookup failed",
 			"gateway_id", gatewayID, "error", err)
-		return "", apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
-			"gateway URL lookup failed")
+		return "", apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable,
+			"gateway URL lookup failed (registry unavailable)")
 	}
 	return terminalURL, nil
 }

--- a/internal/api/terminal_handler_test.go
+++ b/internal/api/terminal_handler_test.go
@@ -14,6 +14,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/api"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/terminal"
 	"github.com/manchtools/power-manage/server/internal/testutil"
@@ -42,7 +43,8 @@ func setLinuxUsername(t *testing.T, st *store.Store, userID, linuxUsername strin
 func newTerminalHandler(t *testing.T, st *store.Store) (*api.TerminalHandler, *terminal.TokenStore) {
 	t.Helper()
 	tokenStore := terminal.NewTokenStore(terminal.NewFakeBackend(nil))
-	h := api.NewTerminalHandler(st, tokenStore, "wss://gateway.example.com/terminal", slog.Default())
+	// nil registry → single-gateway fallback path using the static URL.
+	h := api.NewTerminalHandler(st, tokenStore, nil, "wss://gateway.example.com/terminal", slog.Default())
 	return h, tokenStore
 }
 
@@ -264,4 +266,58 @@ func TestGatewayBaseURL_StripsTokenAndTrailingSlash(t *testing.T) {
 			t.Errorf("GatewayBaseURL(%q) leaked query/fragment/userinfo: %q", in, out)
 		}
 	}
+}
+
+// TestStartTerminal_RegistryRouting verifies that when a registry is
+// configured, StartTerminal resolves the gateway URL dynamically from
+// the device→gateway→URL chain instead of using the static fallback.
+func TestStartTerminal_RegistryRouting(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	tokenStore := terminal.NewTokenStore(terminal.NewFakeBackend(nil))
+	backend := registry.NewFakeBackend(nil)
+	reg := registry.New(backend, slog.Default())
+	// Empty fallback so we know the returned URL came from the registry.
+	h := api.NewTerminalHandler(st, tokenStore, reg, "", slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, userID, "alice")
+	deviceID := testutil.CreateTestDevice(t, st, "host-reg")
+
+	// Simulate the gateway publishing its registration + the device mapping.
+	ctx := context.Background()
+	require.NoError(t, reg.AttachDevice(ctx, deviceID, "gw-42", registry.DefaultDeviceTTL))
+	stop, err := reg.RegisterGateway(ctx, "gw-42", "wss://gw-42.gateway.example.com/terminal", registry.DefaultGatewayTTL, registry.DefaultGatewayRefreshInterval)
+	require.NoError(t, err)
+	defer stop()
+
+	resp, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "wss://gw-42.gateway.example.com/terminal", resp.Msg.GatewayUrl)
+	assert.NotEmpty(t, resp.Msg.SessionId)
+	assert.NotEmpty(t, resp.Msg.SessionToken)
+}
+
+// TestStartTerminal_RegistryDeviceNotConnected verifies that when the
+// device has no device→gateway mapping in the registry (not connected
+// to any gateway), StartTerminal returns FailedPrecondition.
+func TestStartTerminal_RegistryDeviceNotConnected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	tokenStore := terminal.NewTokenStore(terminal.NewFakeBackend(nil))
+	reg := registry.New(registry.NewFakeBackend(nil), slog.Default())
+	h := api.NewTerminalHandler(st, tokenStore, reg, "", slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, userID, "alice")
+	deviceID := testutil.CreateTestDevice(t, st, "host-unreg")
+
+	// No AttachDevice call — device is not connected.
+	_, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
+		DeviceId: deviceID,
+	}))
+	require.Error(t, err)
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	assert.Equal(t, connect.CodeFailedPrecondition, connectErr.Code())
 }

--- a/internal/api/terminal_handler_test.go
+++ b/internal/api/terminal_handler_test.go
@@ -282,6 +282,7 @@ func TestStartTerminal_RegistryRouting(t *testing.T) {
 	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	setLinuxUsername(t, st, userID, "alice")
 	deviceID := testutil.CreateTestDevice(t, st, "host-reg")
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
 
 	// Simulate the gateway publishing its registration + the device mapping.
 	ctx := context.Background()
@@ -311,6 +312,7 @@ func TestStartTerminal_RegistryDeviceNotConnected(t *testing.T) {
 	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	setLinuxUsername(t, st, userID, "alice")
 	deviceID := testutil.CreateTestDevice(t, st, "host-unreg")
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
 
 	// No AttachDevice call — device is not connected.
 	_, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,35 @@ type Config struct {
 	// Control server URL for internal RPC proxying
 	ControlURL string
 
+	// Multi-gateway routing settings (used by the registry).
+	//
+	// GatewayID is the stable ID this gateway uses to register
+	// itself in Valkey. Empty means "generate a fresh ULID at
+	// startup" — appropriate for dynamic-config Traefik setups
+	// (file provider with watcher, k8s headless service, etc.).
+	// Set explicitly when running with a static-config Traefik
+	// setup that pre-declares per-gateway routes.
+	GatewayID string
+
+	// PublicTerminalURLTemplate is the template the gateway uses
+	// to compute its public WebSocket URL for terminal sessions.
+	// '{id}' is substituted with GatewayID. Empty disables terminal
+	// session registration on this gateway (the gateway still
+	// accepts agent connections normally).
+	//
+	// Example: "wss://{id}.gateway.example.com/terminal"
+	PublicTerminalURLTemplate string
+
+	// BootstrapHost is the wildcard root hostname agents use for
+	// the initial connection before they have an assigned gateway.
+	// When the gateway sees a request with this Host header, it
+	// returns HTTP 307 with its own per-gateway URL so the client
+	// can reconnect directly. Empty disables the bootstrap
+	// redirect (single-gateway deployments don't need it).
+	//
+	// Example: "gateway.example.com"
+	BootstrapHost string
+
 	// Logging
 	LogLevel string
 }
@@ -26,12 +55,15 @@ type Config struct {
 // FromEnv loads configuration from environment variables.
 func FromEnv() *Config {
 	return &Config{
-		ListenAddr:     getEnv("GATEWAY_LISTEN_ADDR", ":8080"),
-		ValkeyAddr:     getEnv("VALKEY_ADDR", "localhost:6379"),
-		ValkeyPassword: getEnv("VALKEY_PASSWORD", ""),
-		ValkeyDB:       getEnvInt("VALKEY_DB", 0),
-		ControlURL:     getEnv("GATEWAY_CONTROL_URL", "http://control:8081"),
-		LogLevel:       getEnv("LOG_LEVEL", "info"),
+		ListenAddr:                getEnv("GATEWAY_LISTEN_ADDR", ":8080"),
+		ValkeyAddr:                getEnv("VALKEY_ADDR", "localhost:6379"),
+		ValkeyPassword:            getEnv("VALKEY_PASSWORD", ""),
+		ValkeyDB:                  getEnvInt("VALKEY_DB", 0),
+		ControlURL:                getEnv("GATEWAY_CONTROL_URL", "http://control:8081"),
+		GatewayID:                 getEnv("GATEWAY_ID", ""),
+		PublicTerminalURLTemplate: getEnv("GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE", ""),
+		BootstrapHost:             getEnv("GATEWAY_BOOTSTRAP_HOST", ""),
+		LogLevel:                  getEnv("LOG_LEVEL", "info"),
 	}
 }
 

--- a/internal/gateway/registry/fake_backend.go
+++ b/internal/gateway/registry/fake_backend.go
@@ -1,0 +1,73 @@
+package registry
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// FakeBackend is an in-memory Backend for tests so the registry
+// suite doesn't need a real Valkey instance. It honours TTLs via
+// lazy expiry on read against the supplied clock — pass time.Now
+// in production-like tests or a frozen clock for deterministic
+// expiry assertions.
+//
+// Concurrency is the same as the production backend: independent
+// goroutines may call Set/Get/Delete simultaneously.
+type FakeBackend struct {
+	mu     sync.Mutex
+	now    func() time.Time
+	values map[string]fakeEntry
+}
+
+type fakeEntry struct {
+	value     string
+	expiresAt time.Time
+}
+
+// NewFakeBackend constructs an empty in-memory backend. now defaults
+// to time.Now if nil.
+func NewFakeBackend(now func() time.Time) *FakeBackend {
+	if now == nil {
+		now = time.Now
+	}
+	return &FakeBackend{
+		now:    now,
+		values: make(map[string]fakeEntry),
+	}
+}
+
+// Set stores the value with the given TTL.
+func (b *FakeBackend) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.values[key] = fakeEntry{
+		value:     value,
+		expiresAt: b.now().Add(ttl),
+	}
+	return nil
+}
+
+// Get returns the stored value, honouring TTL via lazy expiry on
+// read. Returns ErrNoGateway for unknown or expired entries.
+func (b *FakeBackend) Get(ctx context.Context, key string) (string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	entry, ok := b.values[key]
+	if !ok {
+		return "", ErrNoGateway
+	}
+	if !b.now().Before(entry.expiresAt) {
+		delete(b.values, key)
+		return "", ErrNoGateway
+	}
+	return entry.value, nil
+}
+
+// Delete is idempotent.
+func (b *FakeBackend) Delete(ctx context.Context, key string) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	delete(b.values, key)
+	return nil
+}

--- a/internal/gateway/registry/registry.go
+++ b/internal/gateway/registry/registry.go
@@ -240,8 +240,11 @@ func (r *Registry) DetachDevice(ctx context.Context, deviceID, gatewayID string)
 	if gatewayID != "" {
 		current, err := r.backend.Get(ctx, deviceKey(deviceID))
 		if err != nil {
-			// Key already gone or expired — nothing to delete.
-			return nil
+			if errors.Is(err, ErrNoGateway) {
+				// Key already gone or expired — nothing to delete.
+				return nil
+			}
+			return fmt.Errorf("registry: detach device lookup: %w", err)
 		}
 		if current != gatewayID {
 			// Another gateway owns this device now. Don't delete.

--- a/internal/gateway/registry/registry.go
+++ b/internal/gateway/registry/registry.go
@@ -126,6 +126,9 @@ func (r *Registry) RegisterGateway(ctx context.Context, gatewayID, terminalURL s
 	if refreshInterval <= 0 {
 		refreshInterval = DefaultGatewayRefreshInterval
 	}
+	if refreshInterval >= ttl {
+		return nil, fmt.Errorf("registry: refreshInterval (%v) must be less than ttl (%v)", refreshInterval, ttl)
+	}
 
 	// Initial publish so subsequent control lookups can find us
 	// immediately, before the first heartbeat tick.
@@ -193,22 +196,59 @@ func (r *Registry) AttachDevice(ctx context.Context, deviceID, gatewayID string,
 	return nil
 }
 
-// RefreshDevice extends the TTL on pm:device:gateway:<deviceID> by
-// rewriting the same value. Called from the agent heartbeat handler.
-// Refresh is intentionally not atomic with the original Set: a
-// refresh on a key that has already expired will succeed and the
-// next eviction will be one full TTL away. That matches the desired
-// behaviour — a heartbeat means the agent is alive, regardless of
-// whether the registry happened to evict in the gap.
+// RefreshDevice extends the TTL on pm:device:gateway:<deviceID>.
+// Called from the agent heartbeat handler. Only refreshes if the
+// stored value matches gatewayID, so a stale heartbeat from a
+// previous gateway (after the agent reconnected elsewhere) cannot
+// overwrite the fresh mapping. If the stored value doesn't match
+// (or the key has expired), the refresh is silently skipped — the
+// new gateway's AttachDevice has already overwritten it.
 func (r *Registry) RefreshDevice(ctx context.Context, deviceID, gatewayID string, ttl time.Duration) error {
+	if deviceID == "" || gatewayID == "" {
+		return errors.New("registry: deviceID and gatewayID are required")
+	}
+	// Read-then-write is not atomic, but that's acceptable: the worst
+	// case is a brief stale write that the new gateway's next
+	// heartbeat overwrites within seconds. A full CAS would require
+	// extending the Backend interface, which is overkill here.
+	current, err := r.backend.Get(ctx, deviceKey(deviceID))
+	if err != nil {
+		if errors.Is(err, ErrNoGateway) {
+			// Key expired — the device reconnected and the new
+			// gateway's AttachDevice will (re)create it. Nothing to do.
+			return nil
+		}
+		return fmt.Errorf("registry: refresh device: %w", err)
+	}
+	if current != gatewayID {
+		// Another gateway owns this device now. Skip the refresh.
+		r.logger.Debug("skipping stale device refresh",
+			"device_id", deviceID, "our_gateway", gatewayID, "current_gateway", current)
+		return nil
+	}
 	return r.AttachDevice(ctx, deviceID, gatewayID, ttl)
 }
 
 // DetachDevice removes pm:device:gateway:<deviceID>. Called on
-// clean disconnect. Idempotent.
-func (r *Registry) DetachDevice(ctx context.Context, deviceID string) error {
+// clean disconnect. Only deletes if the stored value matches
+// gatewayID, so a stale disconnect from a previous gateway cannot
+// evict a fresh mapping created by the new gateway. Idempotent.
+func (r *Registry) DetachDevice(ctx context.Context, deviceID, gatewayID string) error {
 	if deviceID == "" {
 		return errors.New("registry: deviceID is required")
+	}
+	if gatewayID != "" {
+		current, err := r.backend.Get(ctx, deviceKey(deviceID))
+		if err != nil {
+			// Key already gone or expired — nothing to delete.
+			return nil
+		}
+		if current != gatewayID {
+			// Another gateway owns this device now. Don't delete.
+			r.logger.Debug("skipping stale device detach",
+				"device_id", deviceID, "our_gateway", gatewayID, "current_gateway", current)
+			return nil
+		}
 	}
 	if err := r.backend.Delete(ctx, deviceKey(deviceID)); err != nil {
 		return fmt.Errorf("registry: detach device: %w", err)

--- a/internal/gateway/registry/registry.go
+++ b/internal/gateway/registry/registry.go
@@ -1,0 +1,251 @@
+// Package registry tracks which gateway is currently hosting which
+// agent connection in a multi-gateway HA deployment, plus the public
+// terminal-WebSocket URL for each live gateway.
+//
+// Both the gateway and the control server use it via a tiny
+// SessionBackend interface so handler tests can fake it without
+// miniredis. The production wiring uses Valkey via the existing
+// *redis.Client both binaries already maintain.
+//
+// Two key namespaces:
+//
+//   pm:gateway:terminal:<gateway_id>  → public WebSocket URL
+//     Written by each gateway at startup with a TTL, refreshed by
+//     a heartbeat goroutine, deleted on clean shutdown. A crashed
+//     gateway is invisible within the TTL.
+//
+//   pm:device:gateway:<device_id>     → gateway_id
+//     Written by the gateway when an agent connects, refreshed on
+//     each agent heartbeat, deleted on clean disconnect. A crashed
+//     agent or gateway is invisible within the TTL.
+//
+// The control server queries both keys in turn from
+// ControlService.StartTerminal so the minted session token carries
+// the URL of the specific gateway hosting the device, not a static
+// load-balancer URL. See manchtools/power-manage-sdk#16 and
+// manchtools/power-manage-server#6.
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+// Sensible defaults. Callers may override per call.
+const (
+	// DefaultGatewayTTL is the lifetime of a gateway registration
+	// before TTL eviction. The heartbeat refreshes well before this
+	// expires.
+	DefaultGatewayTTL = 45 * time.Second
+	// DefaultGatewayRefreshInterval is how often the heartbeat
+	// goroutine refreshes the gateway registration. 3x safety margin
+	// against the default TTL.
+	DefaultGatewayRefreshInterval = 15 * time.Second
+	// DefaultDeviceTTL is the lifetime of a device→gateway mapping.
+	// Sized so an agent missing two heartbeats (default 30s) still
+	// looks alive, but a third missing heartbeat evicts the entry.
+	DefaultDeviceTTL = 90 * time.Second
+)
+
+// Errors returned by the Registry. Wrap with %w in callers; check
+// with errors.Is.
+var (
+	// ErrNoGateway is returned by LookupDeviceGateway when the
+	// device is not currently registered against any gateway, or
+	// by LookupGatewayTerminalURL when the gateway has expired or
+	// never registered.
+	ErrNoGateway = errors.New("registry: no live gateway for the requested key")
+)
+
+// gateway/device key prefixes. Constants kept private so external
+// code uses the typed Registry methods rather than building keys
+// directly.
+const (
+	gatewayKeyPrefix = "pm:gateway:terminal:"
+	deviceKeyPrefix  = "pm:device:gateway:"
+)
+
+func gatewayKey(gatewayID string) string { return gatewayKeyPrefix + gatewayID }
+func deviceKey(deviceID string) string   { return deviceKeyPrefix + deviceID }
+
+// Backend is the storage interface the Registry depends on. Two
+// implementations ship with this package: ValkeyBackend (production)
+// and FakeBackend (tests). Implementations must be safe for
+// concurrent use from any goroutine.
+type Backend interface {
+	// Set stores the value under key with the given TTL. The TTL
+	// must be enforced — implementations without native TTL must
+	// emulate it via lazy expiry on read.
+	Set(ctx context.Context, key, value string, ttl time.Duration) error
+	// Get returns the stored value, or ErrNoGateway if the key has
+	// expired or was never set.
+	Get(ctx context.Context, key string) (string, error)
+	// Delete removes the key. Idempotent: missing keys return nil.
+	Delete(ctx context.Context, key string) error
+}
+
+// Registry is the high-level façade used by gateway and control.
+// Wraps a Backend with the gateway/device key conventions and the
+// background heartbeat goroutine for gateway registrations.
+type Registry struct {
+	backend Backend
+	logger  *slog.Logger
+}
+
+// New constructs a Registry over the supplied backend.
+func New(backend Backend, logger *slog.Logger) *Registry {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Registry{backend: backend, logger: logger}
+}
+
+// RegisterGateway publishes pm:gateway:terminal:<gatewayID> with
+// the supplied terminalURL and TTL, then starts a background
+// goroutine that refreshes the TTL every refreshInterval. Returns a
+// stop function the caller MUST defer to clean up: stop() deletes
+// the key (so no stale entries linger after a clean shutdown) and
+// terminates the refresh goroutine.
+//
+// A non-positive ttl falls back to DefaultGatewayTTL; a non-positive
+// refreshInterval falls back to DefaultGatewayRefreshInterval.
+func (r *Registry) RegisterGateway(ctx context.Context, gatewayID, terminalURL string, ttl, refreshInterval time.Duration) (stop func(), err error) {
+	if gatewayID == "" {
+		return nil, errors.New("registry: gatewayID is required")
+	}
+	if terminalURL == "" {
+		return nil, errors.New("registry: terminalURL is required")
+	}
+	if ttl <= 0 {
+		ttl = DefaultGatewayTTL
+	}
+	if refreshInterval <= 0 {
+		refreshInterval = DefaultGatewayRefreshInterval
+	}
+
+	// Initial publish so subsequent control lookups can find us
+	// immediately, before the first heartbeat tick.
+	if err := r.backend.Set(ctx, gatewayKey(gatewayID), terminalURL, ttl); err != nil {
+		return nil, fmt.Errorf("registry: initial gateway publish: %w", err)
+	}
+
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	var stopOnce sync.Once
+
+	go func() {
+		defer close(doneCh)
+		t := time.NewTicker(refreshInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-t.C:
+				// Use a bounded context so a hung backend can't
+				// stall the gateway forever. Background context is
+				// fine here because the goroutine has its own stop
+				// signal.
+				refreshCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				if err := r.backend.Set(refreshCtx, gatewayKey(gatewayID), terminalURL, ttl); err != nil {
+					r.logger.Warn("registry: gateway heartbeat refresh failed",
+						"gateway_id", gatewayID, "error", err)
+				}
+				cancel()
+			}
+		}
+	}()
+
+	stop = func() {
+		stopOnce.Do(func() {
+			close(stopCh)
+			<-doneCh
+			// Best-effort cleanup. A bounded context so shutdown
+			// isn't blocked by a flaky backend.
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := r.backend.Delete(cleanupCtx, gatewayKey(gatewayID)); err != nil {
+				r.logger.Warn("registry: gateway deregister failed",
+					"gateway_id", gatewayID, "error", err)
+			}
+		})
+	}
+	return stop, nil
+}
+
+// AttachDevice records pm:device:gateway:<deviceID> = <gatewayID>
+// with the given TTL. Called by the gateway when a new agent bidi
+// stream is established.
+func (r *Registry) AttachDevice(ctx context.Context, deviceID, gatewayID string, ttl time.Duration) error {
+	if deviceID == "" || gatewayID == "" {
+		return errors.New("registry: deviceID and gatewayID are required")
+	}
+	if ttl <= 0 {
+		ttl = DefaultDeviceTTL
+	}
+	if err := r.backend.Set(ctx, deviceKey(deviceID), gatewayID, ttl); err != nil {
+		return fmt.Errorf("registry: attach device: %w", err)
+	}
+	return nil
+}
+
+// RefreshDevice extends the TTL on pm:device:gateway:<deviceID> by
+// rewriting the same value. Called from the agent heartbeat handler.
+// Refresh is intentionally not atomic with the original Set: a
+// refresh on a key that has already expired will succeed and the
+// next eviction will be one full TTL away. That matches the desired
+// behaviour — a heartbeat means the agent is alive, regardless of
+// whether the registry happened to evict in the gap.
+func (r *Registry) RefreshDevice(ctx context.Context, deviceID, gatewayID string, ttl time.Duration) error {
+	return r.AttachDevice(ctx, deviceID, gatewayID, ttl)
+}
+
+// DetachDevice removes pm:device:gateway:<deviceID>. Called on
+// clean disconnect. Idempotent.
+func (r *Registry) DetachDevice(ctx context.Context, deviceID string) error {
+	if deviceID == "" {
+		return errors.New("registry: deviceID is required")
+	}
+	if err := r.backend.Delete(ctx, deviceKey(deviceID)); err != nil {
+		return fmt.Errorf("registry: detach device: %w", err)
+	}
+	return nil
+}
+
+// LookupDeviceGateway returns the gatewayID currently hosting the
+// given device, or ErrNoGateway if the device is not registered
+// against any live gateway.
+func (r *Registry) LookupDeviceGateway(ctx context.Context, deviceID string) (string, error) {
+	if deviceID == "" {
+		return "", errors.New("registry: deviceID is required")
+	}
+	val, err := r.backend.Get(ctx, deviceKey(deviceID))
+	if err != nil {
+		if errors.Is(err, ErrNoGateway) {
+			return "", ErrNoGateway
+		}
+		return "", fmt.Errorf("registry: lookup device gateway: %w", err)
+	}
+	return val, nil
+}
+
+// LookupGatewayTerminalURL returns the public terminal WebSocket
+// URL for the given gatewayID, or ErrNoGateway if the gateway has
+// expired or never registered.
+func (r *Registry) LookupGatewayTerminalURL(ctx context.Context, gatewayID string) (string, error) {
+	if gatewayID == "" {
+		return "", errors.New("registry: gatewayID is required")
+	}
+	val, err := r.backend.Get(ctx, gatewayKey(gatewayID))
+	if err != nil {
+		if errors.Is(err, ErrNoGateway) {
+			return "", ErrNoGateway
+		}
+		return "", fmt.Errorf("registry: lookup gateway URL: %w", err)
+	}
+	return val, nil
+}

--- a/internal/gateway/registry/registry_test.go
+++ b/internal/gateway/registry/registry_test.go
@@ -1,0 +1,231 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestRegistry_AttachLookupRoundTrip(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	ctx := context.Background()
+
+	if err := r.AttachDevice(ctx, "device-1", "gw-A", DefaultDeviceTTL); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	got, err := r.LookupDeviceGateway(ctx, "device-1")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if got != "gw-A" {
+		t.Errorf("device gateway = %q, want gw-A", got)
+	}
+}
+
+func TestRegistry_DetachDevice(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	ctx := context.Background()
+
+	_ = r.AttachDevice(ctx, "device-1", "gw-A", DefaultDeviceTTL)
+	if err := r.DetachDevice(ctx, "device-1"); err != nil {
+		t.Fatalf("detach: %v", err)
+	}
+
+	if _, err := r.LookupDeviceGateway(ctx, "device-1"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("after detach: expected ErrNoGateway, got %v", err)
+	}
+}
+
+func TestRegistry_DetachDevice_Idempotent(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	ctx := context.Background()
+	if err := r.DetachDevice(ctx, "never-attached"); err != nil {
+		t.Errorf("detach of unknown device should be idempotent, got %v", err)
+	}
+}
+
+func TestRegistry_LookupDeviceGateway_Unknown(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	if _, err := r.LookupDeviceGateway(context.Background(), "no-such-device"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("expected ErrNoGateway, got %v", err)
+	}
+}
+
+func TestRegistry_LookupGatewayTerminalURL_Unknown(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	if _, err := r.LookupGatewayTerminalURL(context.Background(), "no-such-gateway"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("expected ErrNoGateway, got %v", err)
+	}
+}
+
+func TestRegistry_RegisterGateway_PublishesURL(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	ctx := context.Background()
+
+	stop, err := r.RegisterGateway(ctx, "gw-A", "wss://gw-A.example.com/terminal", DefaultGatewayTTL, time.Hour)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	defer stop()
+
+	got, err := r.LookupGatewayTerminalURL(ctx, "gw-A")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if got != "wss://gw-A.example.com/terminal" {
+		t.Errorf("URL = %q, want wss://gw-A.example.com/terminal", got)
+	}
+}
+
+func TestRegistry_RegisterGateway_StopDeletesEntry(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	ctx := context.Background()
+
+	stop, err := r.RegisterGateway(ctx, "gw-A", "wss://gw-A.example.com/terminal", DefaultGatewayTTL, time.Hour)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	stop()
+
+	if _, err := r.LookupGatewayTerminalURL(ctx, "gw-A"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("after stop: expected ErrNoGateway, got %v", err)
+	}
+}
+
+func TestRegistry_RegisterGateway_StopIsIdempotent(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	stop, err := r.RegisterGateway(context.Background(), "gw-A", "wss://x", DefaultGatewayTTL, time.Hour)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	stop()
+	stop() // must not panic, must not deadlock
+}
+
+func TestRegistry_RegisterGateway_RequiresFields(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	ctx := context.Background()
+	if _, err := r.RegisterGateway(ctx, "", "wss://x", DefaultGatewayTTL, time.Hour); err == nil {
+		t.Error("expected error for empty gatewayID")
+	}
+	if _, err := r.RegisterGateway(ctx, "gw-A", "", DefaultGatewayTTL, time.Hour); err == nil {
+		t.Error("expected error for empty terminalURL")
+	}
+}
+
+// TestRegistry_TTLExpiry verifies the FakeBackend's lazy expiry
+// matches the contract the production Valkey backend implements via
+// native TTL eviction. Uses a frozen clock to advance time
+// deterministically without sleeping.
+func TestRegistry_TTLExpiry(t *testing.T) {
+	now := time.Unix(0, 0)
+	clock := func() time.Time { return now }
+	r := New(NewFakeBackend(clock), nil)
+	ctx := context.Background()
+
+	if err := r.AttachDevice(ctx, "device-1", "gw-A", 10*time.Second); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	// Still alive at t+5s.
+	now = now.Add(5 * time.Second)
+	if _, err := r.LookupDeviceGateway(ctx, "device-1"); err != nil {
+		t.Errorf("lookup at t+5s: %v", err)
+	}
+
+	// Refresh extends the lifetime.
+	if err := r.RefreshDevice(ctx, "device-1", "gw-A", 10*time.Second); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	now = now.Add(8 * time.Second) // t+13s, but the refresh at t+5 reset the clock
+	if _, err := r.LookupDeviceGateway(ctx, "device-1"); err != nil {
+		t.Errorf("lookup after refresh at t+13s: %v", err)
+	}
+
+	// Past the refreshed expiry: t+5+10+1 = t+16s. The refresh at
+	// t+5 set expiry to t+15, so t+16 must be evicted.
+	now = now.Add(3 * time.Second) // total t+16s
+	if _, err := r.LookupDeviceGateway(ctx, "device-1"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("lookup at t+16s: expected ErrNoGateway, got %v", err)
+	}
+}
+
+// TestRegistry_RegisterGateway_RefreshLoop verifies that the
+// background heartbeat goroutine actually refreshes the entry. Uses
+// a counting backend wrapper to observe Set calls.
+func TestRegistry_RegisterGateway_RefreshLoop(t *testing.T) {
+	counted := &countingBackend{inner: NewFakeBackend(nil)}
+	r := New(counted, nil)
+
+	// Use a tight refresh interval so the test runs in milliseconds.
+	stop, err := r.RegisterGateway(context.Background(), "gw-A", "wss://x", DefaultGatewayTTL, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	// Wait for at least 3 refreshes (initial + 2 from the ticker).
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if counted.SetCalls() >= 3 {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	stop()
+
+	if got := counted.SetCalls(); got < 3 {
+		t.Errorf("expected at least 3 Set calls (initial + 2 refreshes), got %d", got)
+	}
+}
+
+// TestRegistry_AttachDevice_RequiresFields locks the input
+// validation contract.
+func TestRegistry_AttachDevice_RequiresFields(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	ctx := context.Background()
+	cases := []struct {
+		device, gateway string
+	}{
+		{"", "gw-A"},
+		{"device-1", ""},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if err := r.AttachDevice(ctx, tc.device, tc.gateway, DefaultDeviceTTL); err == nil {
+			t.Errorf("AttachDevice(%q, %q): expected error", tc.device, tc.gateway)
+		}
+	}
+}
+
+// countingBackend wraps a Backend and counts Set calls so the
+// heartbeat refresh test can observe progress without sleeping
+// for the full TTL.
+type countingBackend struct {
+	inner Backend
+	mu    sync.Mutex
+	sets  int
+}
+
+func (b *countingBackend) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	b.mu.Lock()
+	b.sets++
+	b.mu.Unlock()
+	return b.inner.Set(ctx, key, value, ttl)
+}
+
+func (b *countingBackend) Get(ctx context.Context, key string) (string, error) {
+	return b.inner.Get(ctx, key)
+}
+
+func (b *countingBackend) Delete(ctx context.Context, key string) error {
+	return b.inner.Delete(ctx, key)
+}
+
+func (b *countingBackend) SetCalls() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.sets
+}

--- a/internal/gateway/registry/registry_test.go
+++ b/internal/gateway/registry/registry_test.go
@@ -30,7 +30,7 @@ func TestRegistry_DetachDevice(t *testing.T) {
 	ctx := context.Background()
 
 	_ = r.AttachDevice(ctx, "device-1", "gw-A", DefaultDeviceTTL)
-	if err := r.DetachDevice(ctx, "device-1"); err != nil {
+	if err := r.DetachDevice(ctx, "device-1", "gw-A"); err != nil {
 		t.Fatalf("detach: %v", err)
 	}
 
@@ -42,8 +42,49 @@ func TestRegistry_DetachDevice(t *testing.T) {
 func TestRegistry_DetachDevice_Idempotent(t *testing.T) {
 	r := New(NewFakeBackend(nil), nil)
 	ctx := context.Background()
-	if err := r.DetachDevice(ctx, "never-attached"); err != nil {
+	if err := r.DetachDevice(ctx, "never-attached", "gw-A"); err != nil {
 		t.Errorf("detach of unknown device should be idempotent, got %v", err)
+	}
+}
+
+// TestRegistry_ReconnectHandoff verifies that when an agent
+// reconnects to a different gateway (gw-B), stale heartbeats and
+// disconnects from the old gateway (gw-A) do not overwrite the
+// fresh mapping. This is the critical HA correctness test.
+func TestRegistry_ReconnectHandoff(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	ctx := context.Background()
+
+	// Agent connects to gw-A.
+	_ = r.AttachDevice(ctx, "device-1", "gw-A", DefaultDeviceTTL)
+
+	// Agent reconnects to gw-B (overwrites the mapping).
+	_ = r.AttachDevice(ctx, "device-1", "gw-B", DefaultDeviceTTL)
+
+	// Stale heartbeat from gw-A arrives — must NOT overwrite gw-B.
+	_ = r.RefreshDevice(ctx, "device-1", "gw-A", DefaultDeviceTTL)
+	got, err := r.LookupDeviceGateway(ctx, "device-1")
+	if err != nil {
+		t.Fatalf("lookup after stale refresh: %v", err)
+	}
+	if got != "gw-B" {
+		t.Errorf("after stale refresh: device gateway = %q, want gw-B", got)
+	}
+
+	// Stale disconnect from gw-A arrives — must NOT delete gw-B's entry.
+	_ = r.DetachDevice(ctx, "device-1", "gw-A")
+	got, err = r.LookupDeviceGateway(ctx, "device-1")
+	if err != nil {
+		t.Fatalf("lookup after stale detach: %v", err)
+	}
+	if got != "gw-B" {
+		t.Errorf("after stale detach: device gateway = %q, want gw-B", got)
+	}
+
+	// Clean disconnect from gw-B — SHOULD delete.
+	_ = r.DetachDevice(ctx, "device-1", "gw-B")
+	if _, err := r.LookupDeviceGateway(ctx, "device-1"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("after owner detach: expected ErrNoGateway, got %v", err)
 	}
 }
 
@@ -65,7 +106,7 @@ func TestRegistry_RegisterGateway_PublishesURL(t *testing.T) {
 	r := New(NewFakeBackend(nil), nil)
 	ctx := context.Background()
 
-	stop, err := r.RegisterGateway(ctx, "gw-A", "wss://gw-A.example.com/terminal", DefaultGatewayTTL, time.Hour)
+	stop, err := r.RegisterGateway(ctx, "gw-A", "wss://gw-A.example.com/terminal", DefaultGatewayTTL, DefaultGatewayRefreshInterval)
 	if err != nil {
 		t.Fatalf("register: %v", err)
 	}
@@ -84,7 +125,7 @@ func TestRegistry_RegisterGateway_StopDeletesEntry(t *testing.T) {
 	r := New(NewFakeBackend(nil), nil)
 	ctx := context.Background()
 
-	stop, err := r.RegisterGateway(ctx, "gw-A", "wss://gw-A.example.com/terminal", DefaultGatewayTTL, time.Hour)
+	stop, err := r.RegisterGateway(ctx, "gw-A", "wss://gw-A.example.com/terminal", DefaultGatewayTTL, DefaultGatewayRefreshInterval)
 	if err != nil {
 		t.Fatalf("register: %v", err)
 	}
@@ -97,7 +138,7 @@ func TestRegistry_RegisterGateway_StopDeletesEntry(t *testing.T) {
 
 func TestRegistry_RegisterGateway_StopIsIdempotent(t *testing.T) {
 	r := New(NewFakeBackend(nil), nil)
-	stop, err := r.RegisterGateway(context.Background(), "gw-A", "wss://x", DefaultGatewayTTL, time.Hour)
+	stop, err := r.RegisterGateway(context.Background(), "gw-A", "wss://x", DefaultGatewayTTL, DefaultGatewayRefreshInterval)
 	if err != nil {
 		t.Fatalf("register: %v", err)
 	}
@@ -108,10 +149,10 @@ func TestRegistry_RegisterGateway_StopIsIdempotent(t *testing.T) {
 func TestRegistry_RegisterGateway_RequiresFields(t *testing.T) {
 	r := New(NewFakeBackend(nil), nil)
 	ctx := context.Background()
-	if _, err := r.RegisterGateway(ctx, "", "wss://x", DefaultGatewayTTL, time.Hour); err == nil {
+	if _, err := r.RegisterGateway(ctx, "", "wss://x", DefaultGatewayTTL, DefaultGatewayRefreshInterval); err == nil {
 		t.Error("expected error for empty gatewayID")
 	}
-	if _, err := r.RegisterGateway(ctx, "gw-A", "", DefaultGatewayTTL, time.Hour); err == nil {
+	if _, err := r.RegisterGateway(ctx, "gw-A", "", DefaultGatewayTTL, DefaultGatewayRefreshInterval); err == nil {
 		t.Error("expected error for empty terminalURL")
 	}
 }

--- a/internal/gateway/registry/valkey_backend.go
+++ b/internal/gateway/registry/valkey_backend.go
@@ -1,0 +1,53 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// ValkeyBackend is the production Backend, persisting registry
+// entries in the same Valkey instance the gateway and control server
+// already use for the Asynq task queue and (on control) RediSearch.
+type ValkeyBackend struct {
+	client *redis.Client
+}
+
+// NewValkeyBackend constructs a Backend over the supplied go-redis
+// client. The caller retains ownership of the client.
+func NewValkeyBackend(client *redis.Client) *ValkeyBackend {
+	return &ValkeyBackend{client: client}
+}
+
+// Set persists value under key with a TTL.
+func (b *ValkeyBackend) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	if err := b.client.Set(ctx, key, value, ttl).Err(); err != nil {
+		return fmt.Errorf("registry: valkey set: %w", err)
+	}
+	return nil
+}
+
+// Get retrieves the stored value, or ErrNoGateway if the key has
+// been evicted by TTL or never existed.
+func (b *ValkeyBackend) Get(ctx context.Context, key string) (string, error) {
+	val, err := b.client.Get(ctx, key).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return "", ErrNoGateway
+		}
+		return "", fmt.Errorf("registry: valkey get: %w", err)
+	}
+	return val, nil
+}
+
+// Delete removes the key. go-redis' DEL is idempotent: a missing
+// key returns 0 affected, not an error.
+func (b *ValkeyBackend) Delete(ctx context.Context, key string) error {
+	if err := b.client.Del(ctx, key).Err(); err != nil {
+		return fmt.Errorf("registry: valkey del: %w", err)
+	}
+	return nil
+}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -295,7 +295,7 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 			// reconnect that already happened. Use Background ctx
 			// because the request ctx is being torn down.
 			if h.registry != nil {
-				if err := h.registry.DetachDevice(context.Background(), deviceID); err != nil {
+				if err := h.registry.DetachDevice(context.Background(), deviceID, h.gatewayID); err != nil {
 					h.logger.Warn("failed to remove device→gateway mapping",
 						"device_id", deviceID, "error", err)
 				}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage/server/internal/connection"
 	"github.com/manchtools/power-manage/server/internal/gateway"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/mtls"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
@@ -39,6 +40,13 @@ type AgentHandler struct {
 	logger        *slog.Logger
 	serverVersion string
 	requireTLS    bool
+
+	// Multi-gateway routing. registry and gatewayID are set via
+	// SetGatewayRouting at startup. nil registry means single-
+	// gateway mode: device→gateway entries are not published and
+	// the control server falls back to its static gateway URL.
+	registry  *registry.Registry
+	gatewayID string
 }
 
 // NewAgentHandler creates a new agent handler.
@@ -81,6 +89,17 @@ func NewAgentHandlerWithTLS(
 	}
 }
 
+// SetGatewayRouting wires the multi-gateway registry into the
+// handler. Called from cmd/gateway/main.go at startup. After this
+// is set, every agent connect / heartbeat / disconnect publishes
+// the device→gateway mapping to Valkey so the control server can
+// route terminal sessions to the correct gateway. nil registry
+// disables routing (single-gateway deployments).
+func (h *AgentHandler) SetGatewayRouting(reg *registry.Registry, gatewayID string) {
+	h.registry = reg
+	h.gatewayID = gatewayID
+}
+
 // MTLSMiddleware extracts the device ID from the client certificate and adds it to the context.
 func MTLSMiddleware(next http.Handler, logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -111,6 +130,70 @@ func MTLSMiddleware(next http.Handler, logger *slog.Logger) http.Handler {
 func DeviceIDFromContext(ctx context.Context) (string, bool) {
 	deviceID, ok := ctx.Value(DeviceIDContextKey).(string)
 	return deviceID, ok
+}
+
+// BootstrapRedirectMiddleware returns HTTP 307 redirects when an
+// agent connects to the wildcard root hostname (bootstrapHost), so
+// the agent reconnects directly to this gateway's per-instance
+// hostname (assignedHost) for all subsequent connections. The path
+// and query are preserved verbatim, and only requests to
+// bootstrapHost are intercepted — requests already addressed to
+// assignedHost (or any other host) pass through unchanged.
+//
+// In multi-gateway HA, the load balancer routes wildcard-root
+// connections to any gateway. The first gateway that receives the
+// agent issues this redirect to its own hostname; the agent
+// follows it (Connect-RPC's HTTP/2 client follows 307s
+// transparently) and from then on every connection lands on the
+// same gateway, so the connection manager has a stable
+// device→gateway mapping the control server can route terminal
+// sessions through.
+//
+// Both bootstrapHost and assignedHost are bare hostnames (no
+// scheme, no port). Empty bootstrapHost disables the middleware
+// entirely — single-gateway deployments don't need it. Empty
+// assignedHost is a programming error and panics at construction
+// time so we never silently emit redirects to an empty Location.
+func BootstrapRedirectMiddleware(next http.Handler, bootstrapHost, assignedHost string, logger *slog.Logger) http.Handler {
+	if bootstrapHost == "" {
+		// Bootstrap not configured — pass through unchanged.
+		return next
+	}
+	if assignedHost == "" {
+		panic("handler: BootstrapRedirectMiddleware: assignedHost must not be empty when bootstrapHost is set")
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// r.Host is the value of the Host header (or HTTP/2
+		// :authority pseudo-header). Strip any port so we compare
+		// just the hostname — the agent may include the port,
+		// the bootstrap config typically doesn't.
+		reqHost := r.Host
+		if i := indexByte(reqHost, ':'); i >= 0 {
+			reqHost = reqHost[:i]
+		}
+		if reqHost != bootstrapHost {
+			next.ServeHTTP(w, r)
+			return
+		}
+		target := "https://" + assignedHost + r.URL.RequestURI()
+		logger.Debug("bootstrap redirect",
+			"from", reqHost,
+			"to", assignedHost,
+			"path", r.URL.Path,
+		)
+		http.Redirect(w, r, target, http.StatusTemporaryRedirect)
+	})
+}
+
+// indexByte is a tiny stdlib-free helper so this file doesn't need
+// the strings import for one call.
+func indexByte(s string, c byte) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
 }
 
 // Stream handles the bidirectional stream between agent and server.
@@ -177,6 +260,19 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 	// Register the agent connection
 	agent := h.manager.Register(deviceID, hello.Hostname, hello.AgentVersion, stream)
 
+	// Publish the device→gateway mapping in the multi-gateway
+	// registry so ControlService.StartTerminal can route the user's
+	// WebSocket to this specific gateway. Best-effort: a Valkey
+	// failure here is logged but does not refuse the connection,
+	// because terminal sessions are an optional feature on top of
+	// the existing agent stream.
+	if h.registry != nil {
+		if err := h.registry.AttachDevice(ctx, deviceID, h.gatewayID, registry.DefaultDeviceTTL); err != nil {
+			h.logger.Warn("failed to publish device→gateway mapping",
+				"device_id", deviceID, "gateway_id", h.gatewayID, "error", err)
+		}
+	}
+
 	// Start per-device Asynq worker to process action dispatches
 	if err := h.workerMgr.StartWorker(deviceID); err != nil {
 		h.logger.Warn("failed to start device worker", "device_id", deviceID, "error", err)
@@ -193,6 +289,17 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 		// The agent may have reconnected and replaced us while we waited.
 		if current, ok := h.manager.Get(deviceID); ok && current == agent {
 			h.manager.Unregister(deviceID)
+			// Detach from the registry too. Same race-aware pattern:
+			// only delete if we're still the current connection,
+			// otherwise we'd evict a freshly-attached entry from a
+			// reconnect that already happened. Use Background ctx
+			// because the request ctx is being torn down.
+			if h.registry != nil {
+				if err := h.registry.DetachDevice(context.Background(), deviceID); err != nil {
+					h.logger.Warn("failed to remove device→gateway mapping",
+						"device_id", deviceID, "error", err)
+				}
+			}
 		}
 		h.logger.Info("agent disconnected", "device_id", deviceID)
 	}()
@@ -287,6 +394,16 @@ func (h *AgentHandler) handleHeartbeat(deviceID string, hb *pm.Heartbeat) error 
 	}
 	if hb.DiskPercent > 0 {
 		payload.DiskPercent = hb.DiskPercent
+	}
+	// Refresh the device→gateway TTL on every heartbeat. Best-effort:
+	// a Valkey failure here is logged but does not refuse the
+	// heartbeat — the existing UpdateLastSeen path is the source of
+	// truth for connection liveness.
+	if h.registry != nil {
+		if err := h.registry.RefreshDevice(context.Background(), deviceID, h.gatewayID, registry.DefaultDeviceTTL); err != nil {
+			h.logger.Warn("failed to refresh device→gateway mapping",
+				"device_id", deviceID, "error", err)
+		}
 	}
 	return h.aqClient.EnqueueToControl(taskqueue.TypeDeviceHeartbeat, payload)
 }


### PR DESCRIPTION
> ⚠️ **Stacked on #36** (ProxyValidateTerminalToken handler). Merge #36 first.

## Summary

Adds the routing layer that enables terminal sessions in a multi-gateway HA deployment. Without this, the control server always returns the same static gateway URL, so a web client may land on a gateway that doesn't host the device's agent connection — and the session fails.

Each gateway now registers itself and its device connections in Valkey. The control server queries the registry at \`StartTerminal\` time and returns the URL of the **specific** gateway hosting the target device. The web client connects directly; no cross-gateway proxy, no load-balancer hacks.

## Multi-gateway flow

1. Agent connects to any gateway via the bootstrap hostname (\`gateway.example.com\`) → gateway returns HTTP 307 to its per-instance hostname (\`<ulid>.gateway.example.com\`) → agent reconnects directly.
2. Gateway writes \`pm:device:gateway:<device_id> = <gateway_id>\` to Valkey (TTL 90s, refreshed on each heartbeat).
3. Gateway publishes \`pm:gateway:terminal:<gateway_id> = wss://<id>.gateway.example.com/terminal\` (TTL 45s, background heartbeat every 15s).
4. User clicks "start terminal" → control reads the two keys → returns the resolved URL in \`StartTerminalResponse.gateway_url\` → web client connects directly to the right gateway.

## What's in this PR

See the commit message for the full breakdown. Quick summary:

| File / package | What it does |
|---|---|
| \`internal/gateway/registry/\` (new, ~250 LOC) | Registry type + ValkeyBackend + FakeBackend + 12 tests |
| \`internal/handler/agent.go\` | Attach on connect, Refresh on heartbeat, Detach on disconnect. \`BootstrapRedirectMiddleware\` returns 307 on wildcard root requests |
| \`internal/config/config.go\` | 3 new gateway env vars: \`GATEWAY_ID\`, \`GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE\`, \`GATEWAY_BOOTSTRAP_HOST\` |
| \`cmd/gateway/main.go\` | ULID generation, registry wiring, bootstrap middleware composition |
| \`internal/api/terminal_handler.go\` | \`resolveGatewayURL\`: device → gateway → URL chain; fallback to static URL when registry is nil |
| \`cmd/control/main.go\` | Instantiates the registry alongside the token store, passes both to \`NewTerminalHandler\` |
| Tests | 12 registry tests + 2 new handler routing tests (\`RegistryRouting\`, \`RegistryDeviceNotConnected\`) |

## Operator deployment

**Static-ID model (existing Traefik setups):**
- \`GATEWAY_ID=gw-1\` on each gateway container
- Per-gateway Traefik SNI route: \`HostSNI('gw-1.gateway.example.com')\`
- Wildcard cert covers all gateways
- Adding a new gateway = 1 env var + 1 Traefik route

**Dynamic-ULID model (zero-config scaling, future):**
- \`GATEWAY_ID\` unset → fresh ULID per startup
- Traefik file provider watches Valkey (via a small writer binary) for new gateway registrations
- Adding a gateway = scale the deployment up by one

Same code supports both models. The operator picks based on their orchestration setup.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/gateway/registry/ -count=1 -race\` — 12 tests
- [x] \`go test ./internal/terminal/ -count=1 -race\` — 9 tests
- [x] \`go test ./internal/api/ -run \"TestStartTerminal|TestStopTerminal|TestGatewayBaseURL|TestProxyValidateTerminalToken\"\` — all handler tests pass (including 2 new registry routing tests)

## Refs

- manchtools/power-manage-sdk#16 — parent feature
- manchtools/power-manage-server#6 — server-side parent issue
- #36 — base branch (must merge first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-gateway routing: gateways can register, devices map to gateways, and terminal connections resolve per-device routing.
  * Agent bootstrap redirect: agents can be redirected to assigned gateway hosts; terminal handler now always enabled when registry is configured.

* **Configuration**
  * Added GATEWAY_ID, GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE, and GATEWAY_BOOTSTRAP_HOST environment variables.

* **Tests**
  * Added comprehensive registry tests and an in-memory fake backend for deterministic testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->