### PR TITLE
fix: fail on TOTPBackupCodeUsed and UserSessionInvalidated event errors

### DIFF
--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -359,19 +359,30 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 		return nil, err
 	}
 
-	streamID := req.Msg.UserId + ":" + req.Msg.RoleId
-	if err := appendEvent(ctx, h.store, h.logger, store.Event{
-		StreamType: "user_role",
-		StreamID:   streamID,
-		EventType:  "UserRoleRevoked",
-		Data: map[string]any{
-			"user_id": req.Msg.UserId,
-			"role_id": req.Msg.RoleId,
-		},
-		ActorType: "user",
-		ActorID:   userCtx.ID,
-	}, "failed to revoke role"); err != nil {
-		return nil, err
+	// Check if the user currently has the role — skip the event on retry/idempotent call
+	hasRole, err := h.store.Queries().UserHasRole(ctx, db.UserHasRoleParams{
+		UserID: req.Msg.UserId,
+		RoleID: req.Msg.RoleId,
+	})
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
+	}
+
+	if hasRole {
+		streamID := req.Msg.UserId + ":" + req.Msg.RoleId
+		if err := appendEvent(ctx, h.store, h.logger, store.Event{
+			StreamType: "user_role",
+			StreamID:   streamID,
+			EventType:  "UserRoleRevoked",
+			Data: map[string]any{
+				"user_id": req.Msg.UserId,
+				"role_id": req.Msg.RoleId,
+			},
+			ActorType: "user",
+			ActorID:   userCtx.ID,
+		}, "failed to revoke role"); err != nil {
+			return nil, err
+		}
 	}
 
 	// Bump user's session version to invalidate cached permissions

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -285,6 +285,7 @@ func (h *RoleHandler) AssignRoleToUser(ctx context.Context, req *connect.Request
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
 
+	assignedAny := false
 	for _, roleID := range roleIDs {
 		// Verify role exists
 		_, err = q.GetRoleByID(ctx, roleID)
@@ -321,11 +322,16 @@ func (h *RoleHandler) AssignRoleToUser(ctx context.Context, req *connect.Request
 		}, "failed to assign role"); err != nil {
 			return nil, err
 		}
+		assignedAny = true
 	}
 
-	// Bump user's session version once to invalidate cached permissions
-	if err := h.bumpUserSessionVersion(ctx, req.Msg.UserId, userCtx.ID); err != nil {
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to invalidate user session after role assignment")
+	// Only bump the session version if we actually assigned at least
+	// one role. Idempotent no-op retries (all roles already assigned)
+	// should not force an unnecessary re-login.
+	if assignedAny {
+		if err := h.bumpUserSessionVersion(ctx, req.Msg.UserId, userCtx.ID); err != nil {
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to invalidate user session after role assignment")
+		}
 	}
 
 	return connect.NewResponse(&pm.AssignRoleToUserResponse{}), nil

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -324,7 +324,9 @@ func (h *RoleHandler) AssignRoleToUser(ctx context.Context, req *connect.Request
 	}
 
 	// Bump user's session version once to invalidate cached permissions
-	h.bumpUserSessionVersion(ctx, req.Msg.UserId, userCtx.ID)
+	if err := h.bumpUserSessionVersion(ctx, req.Msg.UserId, userCtx.ID); err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to invalidate user session after role assignment")
+	}
 
 	return connect.NewResponse(&pm.AssignRoleToUserResponse{}), nil
 }
@@ -373,7 +375,9 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 	}
 
 	// Bump user's session version to invalidate cached permissions
-	h.bumpUserSessionVersion(ctx, req.Msg.UserId, userCtx.ID)
+	if err := h.bumpUserSessionVersion(ctx, req.Msg.UserId, userCtx.ID); err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to invalidate user session after role revocation")
+	}
 
 	return connect.NewResponse(&pm.RevokeRoleFromUserResponse{}), nil
 }
@@ -395,8 +399,12 @@ func (h *RoleHandler) ListPermissions(ctx context.Context, req *connect.Request[
 	}), nil
 }
 
-// bumpUserSessionVersion increments a user's session_version to invalidate JWT/permission cache.
-func (h *RoleHandler) bumpUserSessionVersion(ctx context.Context, userID, actorID string) {
+// bumpUserSessionVersion increments a user's session_version to
+// invalidate JWT/permission cache. This is a primary CQRS mutation:
+// if the event fails to persist, the session is NOT invalidated and
+// existing JWTs keep working. Returns an error so callers can
+// surface the failure.
+func (h *RoleHandler) bumpUserSessionVersion(ctx context.Context, userID, actorID string) error {
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   userID,
@@ -405,18 +413,25 @@ func (h *RoleHandler) bumpUserSessionVersion(ctx context.Context, userID, actorI
 		ActorType:  "user",
 		ActorID:    actorID,
 	}); err != nil {
-		h.logger.Warn("failed to append UserSessionInvalidated event", "user_id", userID, "error", err)
-	} else {
-		h.logger.Debug("event appended",
-			"stream_type", "user",
-			"stream_id", userID,
-			"event_type", "UserSessionInvalidated",
-		)
+		h.logger.Error("failed to invalidate user session",
+			"user_id", userID, "error", err)
+		return err
 	}
+	h.logger.Debug("event appended",
+		"stream_type", "user",
+		"stream_id", userID,
+		"event_type", "UserSessionInvalidated",
+	)
+	return nil
 }
 
-// bumpSessionVersionForRole bumps session_version for all users with a given role
-// (directly assigned or via user groups).
+// bumpSessionVersionForRole bumps session_version for all users with
+// a given role (directly assigned or via user groups). Best-effort
+// across all members: logs failures but does not stop on the first
+// one, because a partial invalidation (some members bumped, some
+// not) is better than invalidating nobody. The callers that trigger
+// this (UpdateRole) are already committed — the role change event
+// is persisted. The session bumps are a follow-up consistency step.
 func (h *RoleHandler) bumpSessionVersionForRole(ctx context.Context, roleID, actorID string) {
 	seen := make(map[string]bool)
 
@@ -425,7 +440,10 @@ func (h *RoleHandler) bumpSessionVersionForRole(ctx context.Context, roleID, act
 	if err == nil {
 		for _, uid := range userIDs {
 			if !seen[uid] {
-				h.bumpUserSessionVersion(ctx, uid, actorID)
+				if err := h.bumpUserSessionVersion(ctx, uid, actorID); err != nil {
+					// Logged inside bumpUserSessionVersion. Continue
+					// to the next member — partial > none.
+				}
 				seen[uid] = true
 			}
 		}
@@ -436,7 +454,9 @@ func (h *RoleHandler) bumpSessionVersionForRole(ctx context.Context, roleID, act
 	if err == nil {
 		for _, uid := range groupUserIDs {
 			if !seen[uid] {
-				h.bumpUserSessionVersion(ctx, uid, actorID)
+				if err := h.bumpUserSessionVersion(ctx, uid, actorID); err != nil {
+					// Same — partial > none.
+				}
 				seen[uid] = true
 			}
 		}

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -448,7 +448,10 @@ func (h *RoleHandler) bumpSessionVersionForRole(ctx context.Context, roleID, act
 
 	// Direct role assignments
 	userIDs, err := h.store.Queries().ListUserIDsWithRole(ctx, roleID)
-	if err == nil {
+	if err != nil {
+		h.logger.Error("failed to list users with role for session invalidation",
+			"role_id", roleID, "error", err)
+	} else {
 		for _, uid := range userIDs {
 			if !seen[uid] {
 				if err := h.bumpUserSessionVersion(ctx, uid, actorID); err != nil {
@@ -462,7 +465,10 @@ func (h *RoleHandler) bumpSessionVersionForRole(ctx context.Context, roleID, act
 
 	// User group role assignments
 	groupUserIDs, err := h.store.Queries().ListUserIDsWithGroupRole(ctx, roleID)
-	if err == nil {
+	if err != nil {
+		h.logger.Error("failed to list group users with role for session invalidation",
+			"role_id", roleID, "error", err)
+	} else {
 		for _, uid := range groupUserIDs {
 			if !seen[uid] {
 				if err := h.bumpUserSessionVersion(ctx, uid, actorID); err != nil {

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -347,7 +347,12 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 		idx := totp.VerifyBackupCode(req.Msg.Code, totpRecord.BackupCodesHash, totpRecord.BackupCodesUsed)
 		if idx >= 0 {
 			codeValid = true
-			// Mark backup code as used
+			// Mark backup code as used. This is a primary CQRS
+			// mutation — the projection reads this event to know
+			// which codes are still valid. If the event fails to
+			// persist, the code is NOT consumed and can be used
+			// again (double-spend). Fail the RPC so the caller
+			// retries rather than silently leaving the code valid.
 			if err := h.store.AppendEvent(ctx, store.Event{
 				StreamType: "totp",
 				StreamID:   claims.UserID,
@@ -356,15 +361,17 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 				ActorType:  "user",
 				ActorID:    claims.UserID,
 			}); err != nil {
-				h.logger.Warn("failed to append TOTPBackupCodeUsed event", "user_id", claims.UserID, "error", err)
-			} else {
-				h.logger.Debug("event appended",
-					"request_id", middleware.RequestIDFromContext(ctx),
-					"stream_type", "totp",
-					"stream_id", claims.UserID,
-					"event_type", "TOTPBackupCodeUsed",
-				)
+				h.logger.Error("failed to consume backup code",
+					"user_id", claims.UserID, "index", idx, "error", err)
+				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+					"failed to consume backup code")
 			}
+			h.logger.Debug("event appended",
+				"request_id", middleware.RequestIDFromContext(ctx),
+				"stream_type", "totp",
+				"stream_id", claims.UserID,
+				"event_type", "TOTPBackupCodeUsed",
+			)
 		}
 	}
 

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -259,10 +259,6 @@ func (h *UserGroupHandler) DeleteUserGroup(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	// Bump session version for all members (they may lose permissions)
-	if err := h.bumpSessionVersionForGroupMembers(ctx, req.Msg.Id, userCtx.ID); err != nil {
-		h.logger.Warn("partial session invalidation", "error", err)
-	}
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_group",
 		StreamID:   req.Msg.Id,
@@ -272,6 +268,11 @@ func (h *UserGroupHandler) DeleteUserGroup(ctx context.Context, req *connect.Req
 		ActorID:    userCtx.ID,
 	}, "failed to delete user group"); err != nil {
 		return nil, err
+	}
+
+	// Bump session version for all members after the deletion is committed (they may lose permissions)
+	if err := h.bumpSessionVersionForGroupMembers(ctx, req.Msg.Id, userCtx.ID); err != nil {
+		h.logger.Warn("partial session invalidation", "error", err)
 	}
 
 	if h.searchIdx != nil {
@@ -746,24 +747,24 @@ func (h *UserGroupHandler) bumpUserSessionVersion(ctx context.Context, userID, a
 }
 
 // bumpSessionVersionForGroupMembers bumps session_version for all
-// members of a user group. Stops on the first failure and returns
-// the error so the caller can surface it. A partial bump (some
-// members invalidated, some not) is acceptable: the successfully-
-// bumped members see a forced re-login, the rest keep their
-// existing JWTs until the next successful attempt. The alternative
-// (rolling back the successful bumps) would require compensating
-// events and is worse than a partial invalidation.
+// members of a user group. Best-effort across all members: records
+// the first failure but continues through the rest so that a single
+// failing member does not prevent the remaining members from being
+// invalidated. A partial bump is better than stopping early.
 func (h *UserGroupHandler) bumpSessionVersionForGroupMembers(ctx context.Context, groupID, actorID string) error {
 	memberIDs, err := h.store.Queries().ListUserGroupMemberIDs(ctx, groupID)
 	if err != nil {
 		return err
 	}
+	var firstErr error
 	for _, uid := range memberIDs {
 		if err := h.bumpUserSessionVersion(ctx, uid, actorID); err != nil {
-			return err
+			if firstErr == nil {
+				firstErr = err
+			}
 		}
 	}
-	return nil
+	return firstErr
 }
 
 // userGroupToProto converts a database user group projection to a protobuf UserGroup.

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -260,8 +260,9 @@ func (h *UserGroupHandler) DeleteUserGroup(ctx context.Context, req *connect.Req
 	}
 
 	// Bump session version for all members (they may lose permissions)
-	h.bumpSessionVersionForGroupMembers(ctx, req.Msg.Id, userCtx.ID)
-
+	if err := h.bumpSessionVersionForGroupMembers(ctx, req.Msg.Id, userCtx.ID); err != nil {
+		h.logger.Warn("partial session invalidation", "error", err)
+	}
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_group",
 		StreamID:   req.Msg.Id,
@@ -351,8 +352,11 @@ func (h *UserGroupHandler) AddUserToGroup(ctx context.Context, req *connect.Requ
 			return nil, err
 		}
 
-		// Bump user's session version (they may gain new permissions from group roles)
-		h.bumpUserSessionVersion(ctx, userID, userCtx.ID)
+		// Bump user's session version (they may gain new permissions from group roles).
+		// Best-effort: the member-add event is already persisted.
+		if err := h.bumpUserSessionVersion(ctx, userID, userCtx.ID); err != nil {
+			h.logger.Warn("partial session invalidation after group member add", "user_id", userID, "error", err)
+		}
 	}
 
 	// Re-read group for updated member_count and enqueue reindex
@@ -411,8 +415,11 @@ func (h *UserGroupHandler) RemoveUserFromGroup(ctx context.Context, req *connect
 		return nil, err
 	}
 
-	// Bump user's session version (they may lose permissions from group roles)
-	h.bumpUserSessionVersion(ctx, req.Msg.UserId, userCtx.ID)
+	// Bump user's session version (they may lose permissions from group roles).
+	// Best-effort: the member-remove event is already persisted.
+	if err := h.bumpUserSessionVersion(ctx, req.Msg.UserId, userCtx.ID); err != nil {
+		h.logger.Warn("partial session invalidation after group member remove", "user_id", req.Msg.UserId, "error", err)
+	}
 
 	// Re-read group for updated member_count and enqueue reindex
 	if updatedGroup, err := h.store.Queries().GetUserGroupByID(ctx, req.Msg.GroupId); err == nil {
@@ -489,8 +496,9 @@ func (h *UserGroupHandler) AssignRoleToUserGroup(ctx context.Context, req *conne
 	}
 
 	// Bump session version for all group members once (they gain new permissions)
-	h.bumpSessionVersionForGroupMembers(ctx, req.Msg.GroupId, userCtx.ID)
-
+	if err := h.bumpSessionVersionForGroupMembers(ctx, req.Msg.GroupId, userCtx.ID); err != nil {
+		h.logger.Warn("partial session invalidation", "error", err)
+	}
 	return connect.NewResponse(&pm.AssignRoleToUserGroupResponse{}), nil
 }
 
@@ -533,8 +541,9 @@ func (h *UserGroupHandler) RevokeRoleFromUserGroup(ctx context.Context, req *con
 	}
 
 	// Bump session version for all group members (they may lose permissions)
-	h.bumpSessionVersionForGroupMembers(ctx, req.Msg.GroupId, userCtx.ID)
-
+	if err := h.bumpSessionVersionForGroupMembers(ctx, req.Msg.GroupId, userCtx.ID); err != nil {
+		h.logger.Warn("partial session invalidation", "error", err)
+	}
 	return connect.NewResponse(&pm.RevokeRoleFromUserGroupResponse{}), nil
 }
 
@@ -695,7 +704,9 @@ func (h *UserGroupHandler) EvaluateDynamicUserGroup(ctx context.Context, req *co
 
 	// Bump session versions for all current members (permissions may have changed)
 	if userCtx, ok := auth.UserFromContext(ctx); ok {
-		h.bumpSessionVersionForGroupMembers(ctx, req.Msg.Id, userCtx.ID)
+		if err := h.bumpSessionVersionForGroupMembers(ctx, req.Msg.Id, userCtx.ID); err != nil {
+			h.logger.Warn("partial session invalidation", "error", err)
+		}
 	}
 
 	return connect.NewResponse(&pm.EvaluateDynamicUserGroupResponse{
@@ -705,8 +716,14 @@ func (h *UserGroupHandler) EvaluateDynamicUserGroup(ctx context.Context, req *co
 	}), nil
 }
 
-// bumpUserSessionVersion increments a user's session_version to invalidate JWT/permission cache.
-func (h *UserGroupHandler) bumpUserSessionVersion(ctx context.Context, userID, actorID string) {
+// bumpUserSessionVersion increments a user's session_version to
+// invalidate JWT/permission cache. This is a primary CQRS mutation:
+// the projection reads this event to bump session_version and
+// reject existing JWTs. If the event fails to persist, the session
+// is NOT invalidated — the admin thinks they revoked access but
+// existing JWTs keep working. Returns an error so callers can
+// surface the failure.
+func (h *UserGroupHandler) bumpUserSessionVersion(ctx context.Context, userID, actorID string) error {
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   userID,
@@ -715,26 +732,38 @@ func (h *UserGroupHandler) bumpUserSessionVersion(ctx context.Context, userID, a
 		ActorType:  "user",
 		ActorID:    actorID,
 	}); err != nil {
-		h.logger.Warn("failed to append UserSessionInvalidated event", "user_id", userID, "error", err)
-	} else {
-		h.logger.Debug("event appended",
-			"request_id", middleware.RequestIDFromContext(ctx),
-			"stream_type", "user",
-			"stream_id", userID,
-			"event_type", "UserSessionInvalidated",
-		)
+		h.logger.Error("failed to invalidate user session",
+			"user_id", userID, "error", err)
+		return err
 	}
+	h.logger.Debug("event appended",
+		"request_id", middleware.RequestIDFromContext(ctx),
+		"stream_type", "user",
+		"stream_id", userID,
+		"event_type", "UserSessionInvalidated",
+	)
+	return nil
 }
 
-// bumpSessionVersionForGroupMembers bumps session_version for all members of a user group.
-func (h *UserGroupHandler) bumpSessionVersionForGroupMembers(ctx context.Context, groupID, actorID string) {
+// bumpSessionVersionForGroupMembers bumps session_version for all
+// members of a user group. Stops on the first failure and returns
+// the error so the caller can surface it. A partial bump (some
+// members invalidated, some not) is acceptable: the successfully-
+// bumped members see a forced re-login, the rest keep their
+// existing JWTs until the next successful attempt. The alternative
+// (rolling back the successful bumps) would require compensating
+// events and is worse than a partial invalidation.
+func (h *UserGroupHandler) bumpSessionVersionForGroupMembers(ctx context.Context, groupID, actorID string) error {
 	memberIDs, err := h.store.Queries().ListUserGroupMemberIDs(ctx, groupID)
 	if err != nil {
-		return
+		return err
 	}
 	for _, uid := range memberIDs {
-		h.bumpUserSessionVersion(ctx, uid, actorID)
+		if err := h.bumpUserSessionVersion(ctx, uid, actorID); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
 // userGroupToProto converts a database user group projection to a protobuf UserGroup.


### PR DESCRIPTION
## Summary

Two bugs where \`AppendEvent\` failures were silently swallowed via warn-and-continue, causing CQRS invariant violations. Both are **primary mutations** — the event IS the state change — not secondary audit records.

Closes #38.

## Bug 1: TOTP backup code double-spend

**\`totp_handler.go\` — \`TOTPBackupCodeUsed\`**

The event marks a backup code index as consumed in the TOTP projection. If \`AppendEvent\` failed, the code was NOT consumed — the same one-time code worked again on the next attempt.

**Fix:** Return \`ErrInternal/CodeInternal\` so the caller retries rather than proceeding with an unconsumed code. The TOTP verification succeeds but the login flow fails — the user retries and the backup code gets properly consumed on the second attempt.

## Bug 2: Session invalidation silently dropped

**\`user_group_handler.go\` + \`role_handler.go\` — \`UserSessionInvalidated\`**

The event bumps \`session_version\` on the user projection, which invalidates existing JWTs. If \`AppendEvent\` failed, \`session_version\` was NOT bumped — the admin thought they revoked access but existing JWTs kept working.

**Fix:** Both the \`UserGroupHandler\` and \`RoleHandler\` copies of \`bumpUserSessionVersion\` now return \`error\`.

| Caller type | Behaviour on failure |
|---|---|
| Direct (\`AssignRoleToUser\`, \`RevokeRoleFromUser\`) | **Fail the RPC.** The role change and session invalidation must be atomic from the admin's perspective. |
| Batch (\`bumpSessionVersionForGroupMembers\`, \`bumpSessionVersionForRole\`) | **Log and continue.** Partial invalidation (some members bumped) is better than no invalidation, and the primary mutation (role/group change) is already committed. |
| Post-mutation (\`AddUserToGroup\`, \`RemoveUserFromGroup\`, \`EvaluateDynamicUserGroup\`) | **Log and continue.** The member add/remove event is already persisted; the session bump is a follow-up consistency step. |

## What was NOT a bug

The \`UserLoggedIn\` events in \`auth_handler.go\`, \`sso_handler.go\`, and \`totp_handler.go\` only drive \`last_login_at\` on the projection (cosmetic). The login mutation (JWT issuance) is a stateless computation, not event-sourced. Warn-and-continue is correct for these.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/api/ -run \"TestAssignRole|TestRevokeRole|TestAddUserToGroup|TestRemoveUserFromGroup|TestVerifyLoginTOTP\"\` — all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Role assignment/revocation and TOTP backup-code verification now abort when the system cannot record required session or audit changes, preventing silent continuation and ensuring failures are surfaced.

* **Improvements**
  * Session invalidation for role and group operations now performs best-effort partial invalidation, reporting failures with clearer logging and propagated errors so problematic invalidation steps are visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->