### PR TITLE
feat: gateway WebSocket terminal bridge

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -188,6 +188,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Terminal session registry — shared between the agent bidi
+	// stream handler (routes TerminalOutput/StateChange to the
+	// matching bridge) and the WebSocket bridge handler (registers/
+	// unregisters sessions and reads output). Also used by the
+	// GatewayService for admin list/terminate.
+	terminalSessions := connection.NewTerminalSessionRegistry()
+
 	logger.Info("gateway started", "version", version)
 
 	// Setup HTTP mux for agent connections (mTLS-protected)
@@ -198,6 +205,7 @@ func main() {
 	if gatewayReg != nil {
 		agentHandler.SetGatewayRouting(gatewayReg, gatewayID)
 	}
+	agentHandler.SetTerminalSessions(terminalSessions)
 	path, h := pmv1connect.NewAgentServiceHandler(agentHandler)
 
 	// Compose middlewares (innermost first):
@@ -208,6 +216,12 @@ func main() {
 	mtlsHandler := handler.MTLSMiddleware(h, logger)
 	bootstrappedHandler := handler.BootstrapRedirectMiddleware(mtlsHandler, cfg.BootstrapHost, assignedHost, logger)
 	mux.Handle(path, bootstrappedHandler)
+
+	// Mount GatewayService on the mTLS listener (internal-only,
+	// called by the control server for admin list/terminate fan-out).
+	gwSvcHandler := handler.NewGatewayServiceHandler(terminalSessions, manager, logger.With("component", "gateway_service"))
+	gwSvcPath, gwSvcH := pmv1connect.NewGatewayServiceHandler(gwSvcHandler)
+	mux.Handle(gwSvcPath, gwSvcH)
 
 	// Wrap with security headers
 	securedMux := middleware.RequestID(middleware.SecurityHeaders(mux))
@@ -276,6 +290,49 @@ func main() {
 		}
 	}()
 
+	// Start web TLS server for terminal WebSocket (standard TLS, no
+	// mTLS — web browsers cannot present client certificates in
+	// WebSocket upgrades). The terminal bridge authenticates via
+	// session tokens validated against the control server.
+	var webServer *http.Server
+	if cfg.WebListenAddr != "" {
+		bridgeHandler := handler.NewTerminalBridgeHandler(
+			manager, terminalSessions, controlProxy, aqClient,
+			logger.With("component", "terminal_bridge"),
+		)
+		webMux := http.NewServeMux()
+		webMux.Handle("/terminal", bridgeHandler)
+		webMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("ok"))
+		})
+
+		// Standard TLS: same cert/key as the mTLS server, but no
+		// client cert requirement. The cert must include the *.gateway
+		// wildcard SAN so both per-gateway hostnames and the bootstrap
+		// hostname resolve to a valid cert.
+		webTLS := &tls.Config{
+			Certificates: []tls.Certificate{controlCert},
+			MinVersion:   tls.VersionTLS13,
+		}
+		webServer = &http.Server{
+			Addr:              cfg.WebListenAddr,
+			Handler:           middleware.RequestID(middleware.SecurityHeaders(webMux)),
+			TLSConfig:         webTLS,
+			ReadTimeout:       0,    // long-lived WebSocket
+			WriteTimeout:      0,    // long-lived WebSocket
+			IdleTimeout:       120 * time.Second,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		go func() {
+			logger.Info("web server listening (terminal WebSocket)",
+				"address", cfg.WebListenAddr)
+			if err := webServer.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+				logger.Error("web server error", "error", err)
+			}
+		}()
+	}
+
 	// Wait for shutdown signal
 	<-shutdownCtx.Done()
 	logger.Info("shutting down server")
@@ -286,6 +343,11 @@ func main() {
 
 	if err := opsServer.Shutdown(drainCtx); err != nil {
 		logger.Error("ops server shutdown error", "error", err)
+	}
+	if webServer != nil {
+		if err := webServer.Shutdown(drainCtx); err != nil {
+			logger.Error("web server shutdown error", "error", err)
+		}
 	}
 	if err := server.Shutdown(drainCtx); err != nil {
 		logger.Error("shutdown error", "error", err)

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -329,6 +329,7 @@ func main() {
 				"address", cfg.WebListenAddr)
 			if err := webServer.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
 				logger.Error("web server error", "error", err)
+				os.Exit(1)
 			}
 		}()
 	}

--- a/go.mod
+++ b/go.mod
@@ -96,6 +96,7 @@ require (
 	google.golang.org/grpc v1.78.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/sqlite v1.44.3 // indirect
+	nhooyr.io/websocket v1.8.17 // indirect
 )
 
 replace github.com/manchtools/power-manage/sdk => ../sdk

--- a/go.sum
+++ b/go.sum
@@ -256,3 +256,5 @@ modernc.org/memory v1.11.0 h1:o4QC8aMQzmcwCK3t3Ux/ZHmwFPzE6hf2Y5LbkRs+hbI=
 modernc.org/memory v1.11.0/go.mod h1:/JP4VbVC+K5sU2wZi9bHoq2MAkCnrt2r98UGeSK7Mjw=
 modernc.org/sqlite v1.44.3 h1:+39JvV/HWMcYslAwRxHb8067w+2zowvFOUrOWIy9PjY=
 modernc.org/sqlite v1.44.3/go.mod h1:CzbrU2lSB1DKUusvwGz7rqEKIq+NUd8GWuBBZDs9/nA=
+nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
+nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,12 @@ type Config struct {
 	// Example: "gateway.example.com"
 	BootstrapHost string
 
+	// Web listener for non-mTLS traffic (terminal WebSocket). Uses
+	// standard TLS (server cert only, no client cert) so web browsers
+	// can connect. Empty disables the web listener — terminal
+	// sessions won't work but agent connections are unaffected.
+	WebListenAddr string
+
 	// Logging
 	LogLevel string
 }
@@ -63,6 +69,7 @@ func FromEnv() *Config {
 		GatewayID:                 getEnv("GATEWAY_ID", ""),
 		PublicTerminalURLTemplate: getEnv("GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE", ""),
 		BootstrapHost:             getEnv("GATEWAY_BOOTSTRAP_HOST", ""),
+		WebListenAddr:             getEnv("GATEWAY_WEB_LISTEN_ADDR", ""),
 		LogLevel:                  getEnv("LOG_LEVEL", "info"),
 	}
 }

--- a/internal/connection/terminal_sessions.go
+++ b/internal/connection/terminal_sessions.go
@@ -117,9 +117,13 @@ func (r *TerminalSessionRegistry) Get(sessionID string) *TerminalSession {
 // block the receive loop, so a full channel drops the message
 // rather than blocking.
 func (r *TerminalSessionRegistry) RouteAgentMessage(sessionID string, msg *pm.AgentMessage) bool {
+	// Hold RLock through the entire send so Unregister (which takes
+	// the write lock before closing OutputCh) cannot race with us.
+	// Without this, Unregister can close OutputCh between our lookup
+	// and the select, causing a send-on-closed-channel panic.
 	r.mu.RLock()
+	defer r.mu.RUnlock()
 	s, ok := r.sessions[sessionID]
-	r.mu.RUnlock()
 	if !ok {
 		return false
 	}

--- a/internal/connection/terminal_sessions.go
+++ b/internal/connection/terminal_sessions.go
@@ -1,0 +1,152 @@
+package connection
+
+import (
+	"sync"
+	"time"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TerminalSession represents a live WebSocket terminal bridge session
+// registered by the gateway. The bridge goroutine reads from OutputCh;
+// the agent bidi stream handler writes to it via RouteAgentMessage.
+type TerminalSession struct {
+	SessionID string
+	DeviceID  string
+	UserID    string
+	TtyUser   string
+	Cols      uint32
+	Rows      uint32
+	StartedAt time.Time
+
+	// OutputCh carries TerminalOutput and TerminalStateChange messages
+	// from the agent to the WebSocket bridge goroutine. Buffered so a
+	// briefly-slow WebSocket client doesn't block the bidi stream
+	// receive loop. If the channel is full, RouteAgentMessage drops
+	// the message (the user sees a brief stutter, which is acceptable
+	// for a terminal UI).
+	OutputCh chan *pm.AgentMessage
+
+	mu             sync.Mutex
+	lastActivityAt time.Time
+}
+
+// NewTerminalSession constructs a session with a buffered output channel.
+func NewTerminalSession(sessionID, deviceID, userID, ttyUser string, cols, rows uint32) *TerminalSession {
+	return &TerminalSession{
+		SessionID:      sessionID,
+		DeviceID:       deviceID,
+		UserID:         userID,
+		TtyUser:        ttyUser,
+		Cols:           cols,
+		Rows:           rows,
+		StartedAt:      time.Now(),
+		lastActivityAt: time.Now(),
+		OutputCh:       make(chan *pm.AgentMessage, 64),
+	}
+}
+
+// Touch updates the last activity timestamp.
+func (s *TerminalSession) Touch() {
+	s.mu.Lock()
+	s.lastActivityAt = time.Now()
+	s.mu.Unlock()
+}
+
+// LastActivity returns the most recent activity timestamp.
+func (s *TerminalSession) LastActivity() time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastActivityAt
+}
+
+// TerminalSessionRegistry is a concurrent-safe map of active terminal
+// sessions on this gateway, keyed by session_id. The WebSocket bridge
+// handler registers/unregisters sessions; the agent bidi stream
+// handler routes TerminalOutput/TerminalStateChange messages through
+// it.
+type TerminalSessionRegistry struct {
+	mu       sync.RWMutex
+	sessions map[string]*TerminalSession
+}
+
+// NewTerminalSessionRegistry creates an empty registry.
+func NewTerminalSessionRegistry() *TerminalSessionRegistry {
+	return &TerminalSessionRegistry{
+		sessions: make(map[string]*TerminalSession),
+	}
+}
+
+// Register adds a session to the registry. Replaces any existing
+// session with the same ID (shouldn't happen with ULIDs, but
+// defensive).
+func (r *TerminalSessionRegistry) Register(s *TerminalSession) {
+	r.mu.Lock()
+	if old, exists := r.sessions[s.SessionID]; exists {
+		close(old.OutputCh)
+	}
+	r.sessions[s.SessionID] = s
+	r.mu.Unlock()
+}
+
+// Unregister removes a session and closes its OutputCh so any
+// blocked reader unblocks. Idempotent.
+func (r *TerminalSessionRegistry) Unregister(sessionID string) {
+	r.mu.Lock()
+	if s, ok := r.sessions[sessionID]; ok {
+		close(s.OutputCh)
+		delete(r.sessions, sessionID)
+	}
+	r.mu.Unlock()
+}
+
+// Get returns the session for the given ID, or nil.
+func (r *TerminalSessionRegistry) Get(sessionID string) *TerminalSession {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.sessions[sessionID]
+}
+
+// RouteAgentMessage sends the message to the session's OutputCh.
+// Returns true if the session exists and the message was delivered
+// (or dropped because the channel is full). Returns false if no
+// session with that ID is registered.
+//
+// This is the hot path: called from the bidi stream receive loop on
+// every TerminalOutput/TerminalStateChange frame. It must never
+// block the receive loop, so a full channel drops the message
+// rather than blocking.
+func (r *TerminalSessionRegistry) RouteAgentMessage(sessionID string, msg *pm.AgentMessage) bool {
+	r.mu.RLock()
+	s, ok := r.sessions[sessionID]
+	r.mu.RUnlock()
+	if !ok {
+		return false
+	}
+	select {
+	case s.OutputCh <- msg:
+	default:
+		// Channel full — drop the frame. The user sees a brief
+		// stutter in the terminal output, which is acceptable.
+	}
+	return true
+}
+
+// Count returns the number of active sessions.
+func (r *TerminalSessionRegistry) Count() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.sessions)
+}
+
+// List returns a snapshot of all active sessions for the admin
+// GatewayService.ListGatewayTerminalSessions RPC.
+func (r *TerminalSessionRegistry) List() []*TerminalSession {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]*TerminalSession, 0, len(r.sessions))
+	for _, s := range r.sessions {
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -47,6 +47,14 @@ type AgentHandler struct {
 	// the control server falls back to its static gateway URL.
 	registry  *registry.Registry
 	gatewayID string
+
+	// terminalSessions is the gateway-side registry of active
+	// WebSocket terminal bridge sessions. Set via
+	// SetTerminalSessions at startup. When the bidi stream handler
+	// receives TerminalOutput/TerminalStateChange from an agent,
+	// it routes the message to the matching bridge goroutine via
+	// this registry. nil means no terminal bridge is configured.
+	terminalSessions *connection.TerminalSessionRegistry
 }
 
 // NewAgentHandler creates a new agent handler.
@@ -98,6 +106,13 @@ func NewAgentHandlerWithTLS(
 func (h *AgentHandler) SetGatewayRouting(reg *registry.Registry, gatewayID string) {
 	h.registry = reg
 	h.gatewayID = gatewayID
+}
+
+// SetTerminalSessions wires the terminal session registry so the
+// bidi stream handler can route TerminalOutput/TerminalStateChange
+// messages from agents to the matching WebSocket bridge goroutine.
+func (h *AgentHandler) SetTerminalSessions(reg *connection.TerminalSessionRegistry) {
+	h.terminalSessions = reg
 }
 
 // MTLSMiddleware extracts the device ID from the client certificate and adds it to the context.
@@ -366,15 +381,22 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 		return h.handleRevokeLuksResult(deviceID, p.RevokeLuksDeviceKeyResult)
 	case *pm.AgentMessage_LogQueryResult:
 		return h.handleLogQueryResult(deviceID, p.LogQueryResult)
-	case *pm.AgentMessage_TerminalOutput, *pm.AgentMessage_TerminalStateChange:
-		// Remote terminal traffic — proto contract is in
-		// manchtools/power-manage-sdk#25, real handler lands as part of
-		// manchtools/power-manage-server#6 / manchtools/power-manage-sdk#16
-		// step 5. Until then we accept the message and drop it instead
-		// of erroring out, so an agent that ships the terminal handler
-		// first does not get disconnected by the gateway.
-		h.logger.Debug("received terminal message before handler is implemented",
-			"device_id", deviceID, "type", fmt.Sprintf("%T", msg.Payload))
+	case *pm.AgentMessage_TerminalOutput:
+		if h.terminalSessions != nil {
+			if !h.terminalSessions.RouteAgentMessage(p.TerminalOutput.SessionId, msg) {
+				h.logger.Debug("terminal output for unknown session",
+					"device_id", deviceID, "session_id", p.TerminalOutput.SessionId)
+			}
+		}
+		return nil
+	case *pm.AgentMessage_TerminalStateChange:
+		if h.terminalSessions != nil {
+			if !h.terminalSessions.RouteAgentMessage(p.TerminalStateChange.SessionId, msg) {
+				h.logger.Debug("terminal state change for unknown session",
+					"device_id", deviceID, "session_id", p.TerminalStateChange.SessionId,
+					"state", p.TerminalStateChange.State.String())
+			}
+		}
 		return nil
 	default:
 		return fmt.Errorf("unknown message type: %T", msg.Payload)

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -383,18 +383,34 @@ func (h *AgentHandler) handleAgentMessage(ctx context.Context, deviceID string, 
 		return h.handleLogQueryResult(deviceID, p.LogQueryResult)
 	case *pm.AgentMessage_TerminalOutput:
 		if h.terminalSessions != nil {
-			if !h.terminalSessions.RouteAgentMessage(p.TerminalOutput.SessionId, msg) {
+			sid := p.TerminalOutput.SessionId
+			sess := h.terminalSessions.Get(sid)
+			if sess == nil {
 				h.logger.Debug("terminal output for unknown session",
-					"device_id", deviceID, "session_id", p.TerminalOutput.SessionId)
+					"device_id", deviceID, "session_id", sid)
+			} else if sess.DeviceID != deviceID {
+				// A compromised agent is trying to inject output into
+				// a session belonging to a different device. Drop it.
+				h.logger.Warn("terminal output device mismatch — dropping",
+					"device_id", deviceID, "session_device", sess.DeviceID, "session_id", sid)
+			} else {
+				h.terminalSessions.RouteAgentMessage(sid, msg)
 			}
 		}
 		return nil
 	case *pm.AgentMessage_TerminalStateChange:
 		if h.terminalSessions != nil {
-			if !h.terminalSessions.RouteAgentMessage(p.TerminalStateChange.SessionId, msg) {
+			sid := p.TerminalStateChange.SessionId
+			sess := h.terminalSessions.Get(sid)
+			if sess == nil {
 				h.logger.Debug("terminal state change for unknown session",
-					"device_id", deviceID, "session_id", p.TerminalStateChange.SessionId,
+					"device_id", deviceID, "session_id", sid,
 					"state", p.TerminalStateChange.State.String())
+			} else if sess.DeviceID != deviceID {
+				h.logger.Warn("terminal state change device mismatch — dropping",
+					"device_id", deviceID, "session_device", sess.DeviceID, "session_id", sid)
+			} else {
+				h.terminalSessions.RouteAgentMessage(sid, msg)
 			}
 		}
 		return nil

--- a/internal/handler/control_proxy.go
+++ b/internal/handler/control_proxy.go
@@ -90,3 +90,19 @@ func (p *ControlProxy) StoreLpsPasswords(ctx context.Context, deviceID, actionID
 	}))
 	return err
 }
+
+// ValidateTerminalToken validates a session token presented by a web
+// client opening the gateway's WebSocket terminal endpoint. Returns
+// the session metadata (device_id, tty_user, cols, rows, user_id)
+// the bridge needs to set up the session. Returns an error (typically
+// connect.CodeUnauthenticated) if the token is invalid or expired.
+func (p *ControlProxy) ValidateTerminalToken(ctx context.Context, sessionID, token string) (*pm.InternalValidateTerminalTokenResponse, error) {
+	resp, err := p.client.ProxyValidateTerminalToken(ctx, connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
+		SessionId: sessionID,
+		Token:     token,
+	}))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Msg, nil
+}

--- a/internal/handler/gateway_service.go
+++ b/internal/handler/gateway_service.go
@@ -1,0 +1,94 @@
+package handler
+
+import (
+	"context"
+	"log/slog"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+	"github.com/manchtools/power-manage/server/internal/connection"
+)
+
+// GatewayServiceHandler implements the control → gateway RPCs for
+// terminal session admin (list/terminate). It runs on the gateway's
+// internal mTLS listener so it's only callable by the control server.
+type GatewayServiceHandler struct {
+	pmv1connect.UnimplementedGatewayServiceHandler
+
+	sessions *connection.TerminalSessionRegistry
+	manager  *connection.Manager
+	logger   *slog.Logger
+}
+
+// NewGatewayServiceHandler constructs the handler.
+func NewGatewayServiceHandler(
+	sessions *connection.TerminalSessionRegistry,
+	manager *connection.Manager,
+	logger *slog.Logger,
+) *GatewayServiceHandler {
+	return &GatewayServiceHandler{
+		sessions: sessions,
+		manager:  manager,
+		logger:   logger,
+	}
+}
+
+// ListGatewayTerminalSessions returns a snapshot of the terminal
+// sessions currently active on this gateway. The control server fans
+// this out to every known gateway and merges the results with user/
+// device metadata from its own database.
+func (h *GatewayServiceHandler) ListGatewayTerminalSessions(
+	ctx context.Context,
+	req *connect.Request[pm.ListGatewayTerminalSessionsRequest],
+) (*connect.Response[pm.ListGatewayTerminalSessionsResponse], error) {
+	active := h.sessions.List()
+	infos := make([]*pm.GatewayTerminalSessionInfo, 0, len(active))
+	for _, s := range active {
+		infos = append(infos, &pm.GatewayTerminalSessionInfo{
+			SessionId:      s.SessionID,
+			UserId:         s.UserID,
+			DeviceId:       s.DeviceID,
+			TtyUser:        s.TtyUser,
+			StartedAt:      timestamppb.New(s.StartedAt),
+			LastActivityAt: timestamppb.New(s.LastActivity()),
+		})
+	}
+	return connect.NewResponse(&pm.ListGatewayTerminalSessionsResponse{
+		Sessions: infos,
+	}), nil
+}
+
+// TerminateGatewayTerminalSession kills a session on this gateway.
+// The control server routes ControlService.TerminateTerminalSession
+// to whichever gateway owns the session_id (looked up via the prior
+// List call or via session affinity). Returns found=false (not an
+// error) if the session isn't on this gateway.
+func (h *GatewayServiceHandler) TerminateGatewayTerminalSession(
+	ctx context.Context,
+	req *connect.Request[pm.TerminateGatewayTerminalSessionRequest],
+) (*connect.Response[pm.TerminateGatewayTerminalSessionResponse], error) {
+	sess := h.sessions.Get(req.Msg.SessionId)
+	if sess == nil {
+		return connect.NewResponse(&pm.TerminateGatewayTerminalSessionResponse{
+			Found: false,
+		}), nil
+	}
+
+	h.logger.Info("admin terminating terminal session",
+		"session_id", req.Msg.SessionId,
+		"reason", req.Msg.Reason,
+		"device_id", sess.DeviceID,
+	)
+
+	// Unregister closes the OutputCh, which unblocks the bridge's
+	// agent→WS goroutine. The bridge's deferred cleanup then sends
+	// TerminalStop to the agent.
+	h.sessions.Unregister(req.Msg.SessionId)
+
+	return connect.NewResponse(&pm.TerminateGatewayTerminalSessionResponse{
+		Found: true,
+	}), nil
+}

--- a/internal/handler/terminal_bridge.go
+++ b/internal/handler/terminal_bridge.go
@@ -1,0 +1,392 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"nhooyr.io/websocket"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/connection"
+	"github.com/manchtools/power-manage/server/internal/taskqueue"
+
+	"github.com/oklog/ulid/v2"
+)
+
+const (
+	// terminalStartTimeout is how long we wait for the agent to
+	// respond with STARTED after sending TerminalStart.
+	terminalStartTimeout = 30 * time.Second
+)
+
+// TerminalBridgeHandler is the HTTP handler for the gateway's
+// WebSocket terminal endpoint. It validates the session token against
+// the control server, bridges WebSocket frames to/from the agent's
+// bidi stream via the connection manager and terminal session
+// registry, and tees stdin to the audit queue.
+type TerminalBridgeHandler struct {
+	manager       *connection.Manager
+	sessions      *connection.TerminalSessionRegistry
+	controlProxy  *ControlProxy
+	aqClient      *taskqueue.Client
+	logger        *slog.Logger
+}
+
+// NewTerminalBridgeHandler constructs a bridge handler.
+func NewTerminalBridgeHandler(
+	manager *connection.Manager,
+	sessions *connection.TerminalSessionRegistry,
+	controlProxy *ControlProxy,
+	aqClient *taskqueue.Client,
+	logger *slog.Logger,
+) *TerminalBridgeHandler {
+	return &TerminalBridgeHandler{
+		manager:      manager,
+		sessions:     sessions,
+		controlProxy: controlProxy,
+		aqClient:     aqClient,
+		logger:       logger,
+	}
+}
+
+// ServeHTTP handles the /terminal WebSocket endpoint.
+func (h *TerminalBridgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.URL.Query().Get("session_id")
+	token := r.URL.Query().Get("token")
+	if sessionID == "" || token == "" {
+		http.Error(w, "session_id and token query parameters are required", http.StatusBadRequest)
+		return
+	}
+
+	logger := h.logger.With("session_id", sessionID)
+
+	// Validate the token against the control server. This returns
+	// the session metadata (device_id, tty_user, cols, rows, user_id)
+	// or an error if the token is invalid/expired.
+	validated, err := h.controlProxy.ValidateTerminalToken(r.Context(), sessionID, token)
+	if err != nil {
+		logger.Warn("terminal token validation failed", "error", err)
+		http.Error(w, "invalid or expired session token", http.StatusUnauthorized)
+		return
+	}
+	logger = logger.With("device_id", validated.DeviceId, "user_id", validated.UserId)
+
+	// Verify the agent is connected to THIS gateway.
+	if !h.manager.IsConnected(validated.DeviceId) {
+		logger.Warn("device not connected to this gateway")
+		http.Error(w, "device not connected to this gateway", http.StatusServiceUnavailable)
+		return
+	}
+
+	// Upgrade to WebSocket.
+	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		// The gateway sits behind a reverse proxy that may strip the
+		// Origin header. InsecureSkipVerify is safe here because the
+		// session token is the authentication mechanism, not CORS.
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		logger.Warn("websocket upgrade failed", "error", err)
+		return
+	}
+	defer ws.CloseNow()
+
+	// Register the session so agent messages get routed to us.
+	sess := connection.NewTerminalSession(
+		sessionID,
+		validated.DeviceId,
+		validated.UserId,
+		validated.TtyUser,
+		validated.Cols,
+		validated.Rows,
+	)
+	h.sessions.Register(sess)
+	defer h.sessions.Unregister(sessionID)
+
+	logger.Info("terminal bridge session started",
+		"tty_user", validated.TtyUser,
+		"cols", validated.Cols,
+		"rows", validated.Rows,
+	)
+
+	// Send TerminalStart to the agent.
+	startMsg := &pm.ServerMessage{
+		Id: ulid.Make().String(),
+		Payload: &pm.ServerMessage_TerminalStart{
+			TerminalStart: &pm.TerminalStart{
+				SessionId: sessionID,
+				TtyUser:   validated.TtyUser,
+				Cols:      validated.Cols,
+				Rows:      validated.Rows,
+			},
+		},
+	}
+	if err := h.manager.Send(validated.DeviceId, startMsg); err != nil {
+		logger.Error("failed to send TerminalStart to agent", "error", err)
+		ws.Close(websocket.StatusInternalError, "failed to start terminal on device")
+		return
+	}
+
+	// Wait for the agent to respond with STARTED or ERROR.
+	if err := h.waitForStarted(sess, ws, logger); err != nil {
+		// waitForStarted already closed the WebSocket with an
+		// appropriate status. Just return.
+		return
+	}
+
+	// Enter the bidirectional I/O bridge. Two goroutines: one reads
+	// from the WebSocket and forwards to the agent, the other reads
+	// from the agent (via the session's OutputCh) and forwards to
+	// the WebSocket. When either side ends, the other is cancelled.
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	// Track whether we've sent TerminalStop to avoid double-stop.
+	var stopSent atomic.Bool
+
+	sendStop := func(reason string) {
+		if !stopSent.CompareAndSwap(false, true) {
+			return
+		}
+		stopMsg := &pm.ServerMessage{
+			Id: ulid.Make().String(),
+			Payload: &pm.ServerMessage_TerminalStop{
+				TerminalStop: &pm.TerminalStop{
+					SessionId: sessionID,
+					Reason:    reason,
+				},
+			},
+		}
+		if err := h.manager.Send(validated.DeviceId, stopMsg); err != nil {
+			logger.Debug("failed to send TerminalStop (agent may have disconnected)",
+				"error", err)
+		}
+	}
+	defer sendStop("websocket closed")
+
+	// WS → agent goroutine.
+	wsErrCh := make(chan error, 1)
+	go func() {
+		wsErrCh <- h.bridgeWSToAgent(ctx, ws, sess, validated, logger)
+	}()
+
+	// Agent → WS goroutine.
+	agentErrCh := make(chan error, 1)
+	go func() {
+		agentErrCh <- h.bridgeAgentToWS(ctx, ws, sess, logger)
+	}()
+
+	// Wait for either side to finish. Cancel the other.
+	select {
+	case err := <-wsErrCh:
+		if err != nil {
+			logger.Debug("ws→agent bridge ended", "error", err)
+		}
+		cancel()
+		sendStop("client disconnected")
+	case err := <-agentErrCh:
+		if err != nil {
+			logger.Debug("agent→ws bridge ended", "error", err)
+		}
+		cancel()
+		// Don't send TerminalStop — the agent initiated the close.
+		stopSent.Store(true)
+	}
+
+	// Wait for the other goroutine to finish so we don't leak it.
+	select {
+	case <-wsErrCh:
+	case <-agentErrCh:
+	case <-time.After(5 * time.Second):
+	}
+
+	ws.Close(websocket.StatusNormalClosure, "session ended")
+	logger.Info("terminal bridge session ended")
+}
+
+// waitForStarted blocks until the agent sends a TerminalStateChange
+// with state STARTED, or returns an error (and closes the WebSocket)
+// if it sees ERROR or times out.
+func (h *TerminalBridgeHandler) waitForStarted(sess *connection.TerminalSession, ws *websocket.Conn, logger *slog.Logger) error {
+	timer := time.NewTimer(terminalStartTimeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case msg, ok := <-sess.OutputCh:
+			if !ok {
+				ws.Close(websocket.StatusInternalError, "session channel closed unexpectedly")
+				return fmt.Errorf("output channel closed before STARTED")
+			}
+			sc, ok := msg.Payload.(*pm.AgentMessage_TerminalStateChange)
+			if !ok {
+				// Unexpected message type before STARTED — could be
+				// output from a previous session's stale frame. Drop it.
+				continue
+			}
+			switch sc.TerminalStateChange.State {
+			case pm.TerminalSessionState_TERMINAL_SESSION_STATE_STARTED:
+				logger.Info("agent confirmed terminal session started")
+				return nil
+			case pm.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR:
+				errMsg := sc.TerminalStateChange.Error
+				logger.Warn("agent rejected terminal session", "error", errMsg)
+				ws.Close(websocket.StatusInternalError, "agent error: "+errMsg)
+				return fmt.Errorf("agent error: %s", errMsg)
+			case pm.TerminalSessionState_TERMINAL_SESSION_STATE_EXITED:
+				logger.Warn("agent session exited before STARTED",
+					"exit_code", sc.TerminalStateChange.ExitCode)
+				ws.Close(websocket.StatusInternalError, "session exited prematurely")
+				return fmt.Errorf("session exited before STARTED")
+			}
+		case <-timer.C:
+			logger.Warn("timed out waiting for agent STARTED")
+			ws.Close(websocket.StatusInternalError, "terminal start timed out")
+			return fmt.Errorf("terminal start timed out")
+		}
+	}
+}
+
+// resizeMessage is the JSON control message the web client sends in
+// a text WebSocket frame to request a terminal window resize.
+type resizeMessage struct {
+	Type string `json:"type"`
+	Cols uint32 `json:"cols"`
+	Rows uint32 `json:"rows"`
+}
+
+// bridgeWSToAgent reads frames from the WebSocket and forwards them
+// to the agent. Binary frames become TerminalInput; text frames are
+// parsed as JSON control messages (currently only "resize").
+// Also tees stdin to the audit queue.
+func (h *TerminalBridgeHandler) bridgeWSToAgent(
+	ctx context.Context,
+	ws *websocket.Conn,
+	sess *connection.TerminalSession,
+	validated *pm.InternalValidateTerminalTokenResponse,
+	logger *slog.Logger,
+) error {
+	var auditSeq int64
+
+	for {
+		msgType, data, err := ws.Read(ctx)
+		if err != nil {
+			return err
+		}
+		sess.Touch()
+
+		switch msgType {
+		case websocket.MessageBinary:
+			// Forward as TerminalInput.
+			inputMsg := &pm.ServerMessage{
+				Id: ulid.Make().String(),
+				Payload: &pm.ServerMessage_TerminalInput{
+					TerminalInput: &pm.TerminalInput{
+						SessionId: sess.SessionID,
+						Data:      data,
+					},
+				},
+			}
+			if err := h.manager.Send(validated.DeviceId, inputMsg); err != nil {
+				return fmt.Errorf("send terminal input: %w", err)
+			}
+
+			// Audit tee: enqueue stdin to control:inbox.
+			auditSeq++
+			h.enqueueAuditChunk(sess, validated, data, auditSeq)
+
+		case websocket.MessageText:
+			// JSON control message.
+			var ctrl resizeMessage
+			if err := json.Unmarshal(data, &ctrl); err != nil {
+				logger.Debug("invalid terminal control message", "error", err)
+				continue
+			}
+			if ctrl.Type == "resize" && ctrl.Cols > 0 && ctrl.Rows > 0 {
+				resizeMsg := &pm.ServerMessage{
+					Id: ulid.Make().String(),
+					Payload: &pm.ServerMessage_TerminalResize{
+						TerminalResize: &pm.TerminalResize{
+							SessionId: sess.SessionID,
+							Cols:      ctrl.Cols,
+							Rows:      ctrl.Rows,
+						},
+					},
+				}
+				if err := h.manager.Send(validated.DeviceId, resizeMsg); err != nil {
+					logger.Warn("failed to send resize", "error", err)
+				}
+			}
+		}
+	}
+}
+
+// bridgeAgentToWS reads messages from the session's OutputCh and
+// forwards them to the WebSocket. TerminalOutput becomes a binary
+// frame; TerminalStateChange with EXITED or ERROR ends the bridge.
+func (h *TerminalBridgeHandler) bridgeAgentToWS(
+	ctx context.Context,
+	ws *websocket.Conn,
+	sess *connection.TerminalSession,
+	logger *slog.Logger,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case msg, ok := <-sess.OutputCh:
+			if !ok {
+				return fmt.Errorf("output channel closed")
+			}
+			sess.Touch()
+
+			switch p := msg.Payload.(type) {
+			case *pm.AgentMessage_TerminalOutput:
+				if err := ws.Write(ctx, websocket.MessageBinary, p.TerminalOutput.Data); err != nil {
+					return fmt.Errorf("write terminal output: %w", err)
+				}
+			case *pm.AgentMessage_TerminalStateChange:
+				switch p.TerminalStateChange.State {
+				case pm.TerminalSessionState_TERMINAL_SESSION_STATE_EXITED:
+					logger.Info("agent session exited",
+						"exit_code", p.TerminalStateChange.ExitCode)
+					return nil
+				case pm.TerminalSessionState_TERMINAL_SESSION_STATE_ERROR:
+					logger.Warn("agent session error",
+						"error", p.TerminalStateChange.Error)
+					return fmt.Errorf("agent error: %s", p.TerminalStateChange.Error)
+				}
+			}
+		}
+	}
+}
+
+// enqueueAuditChunk sends a stdin chunk to the control:inbox queue
+// for audit persistence. Best-effort: a failure is logged but does
+// not break the session.
+func (h *TerminalBridgeHandler) enqueueAuditChunk(
+	sess *connection.TerminalSession,
+	validated *pm.InternalValidateTerminalTokenResponse,
+	data []byte,
+	seq int64,
+) {
+	if h.aqClient == nil {
+		return
+	}
+	payload := taskqueue.TerminalAuditChunkPayload{
+		SessionID: sess.SessionID,
+		DeviceID:  validated.DeviceId,
+		UserID:    validated.UserId,
+		Data:      data,
+		Sequence:  seq,
+	}
+	if err := h.aqClient.EnqueueToControl(taskqueue.TypeTerminalAuditChunk, payload); err != nil {
+		h.logger.Debug("failed to enqueue terminal audit chunk",
+			"session_id", sess.SessionID, "error", err)
+	}
+}

--- a/internal/handler/terminal_bridge.go
+++ b/internal/handler/terminal_bridge.go
@@ -114,41 +114,11 @@ func (h *TerminalBridgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		"rows", validated.Rows,
 	)
 
-	// Send TerminalStart to the agent.
-	startMsg := &pm.ServerMessage{
-		Id: ulid.Make().String(),
-		Payload: &pm.ServerMessage_TerminalStart{
-			TerminalStart: &pm.TerminalStart{
-				SessionId: sessionID,
-				TtyUser:   validated.TtyUser,
-				Cols:      validated.Cols,
-				Rows:      validated.Rows,
-			},
-		},
-	}
-	if err := h.manager.Send(validated.DeviceId, startMsg); err != nil {
-		logger.Error("failed to send TerminalStart to agent", "error", err)
-		ws.Close(websocket.StatusInternalError, "failed to start terminal on device")
-		return
-	}
-
-	// Wait for the agent to respond with STARTED or ERROR.
-	if err := h.waitForStarted(sess, ws, logger); err != nil {
-		// waitForStarted already closed the WebSocket with an
-		// appropriate status. Just return.
-		return
-	}
-
-	// Enter the bidirectional I/O bridge. Two goroutines: one reads
-	// from the WebSocket and forwards to the agent, the other reads
-	// from the agent (via the session's OutputCh) and forwards to
-	// the WebSocket. When either side ends, the other is cancelled.
-	ctx, cancel := context.WithCancel(r.Context())
-	defer cancel()
-
-	// Track whether we've sent TerminalStop to avoid double-stop.
+	// Set up TerminalStop tracking early — before sending
+	// TerminalStart — so that if the handshake fails or times out,
+	// the deferred cleanup still sends TerminalStop to the agent
+	// and the orphaned PTY is cleaned up.
 	var stopSent atomic.Bool
-
 	sendStop := func(reason string) {
 		if !stopSent.CompareAndSwap(false, true) {
 			return
@@ -168,6 +138,36 @@ func (h *TerminalBridgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		}
 	}
 	defer sendStop("websocket closed")
+
+	// Send TerminalStart to the agent. If this fails, the deferred
+	// sendStop above still fires (cleaning up any agent-side state
+	// if the start was partially processed).
+	startMsg := &pm.ServerMessage{
+		Id: ulid.Make().String(),
+		Payload: &pm.ServerMessage_TerminalStart{
+			TerminalStart: &pm.TerminalStart{
+				SessionId: sessionID,
+				TtyUser:   validated.TtyUser,
+				Cols:      validated.Cols,
+				Rows:      validated.Rows,
+			},
+		},
+	}
+	if err := h.manager.Send(validated.DeviceId, startMsg); err != nil {
+		logger.Error("failed to send TerminalStart to agent", "error", err)
+		ws.Close(websocket.StatusInternalError, "failed to start terminal on device")
+		return
+	}
+
+	// Wait for the agent to respond with STARTED or ERROR. If this
+	// fails (timeout, agent error), the deferred sendStop fires.
+	if err := h.waitForStarted(sess, ws, logger); err != nil {
+		return
+	}
+
+	// Enter the bidirectional I/O bridge.
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
 
 	// WS → agent goroutine.
 	wsErrCh := make(chan error, 1)

--- a/internal/handler/terminal_bridge.go
+++ b/internal/handler/terminal_bridge.go
@@ -181,17 +181,31 @@ func (h *TerminalBridgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 		agentErrCh <- h.bridgeAgentToWS(ctx, ws, sess, logger)
 	}()
 
-	// Wait for either side to finish. Cancel the other.
+	// Wait for either side to finish. Cancel the other. Track the
+	// close reason so we can use an appropriate WebSocket close code.
+	var closeCode websocket.StatusCode
+	var closeReason string
+
 	select {
 	case err := <-wsErrCh:
 		if err != nil {
 			logger.Debug("ws→agent bridge ended", "error", err)
+			closeCode = websocket.StatusInternalError
+			closeReason = "client error"
+		} else {
+			closeCode = websocket.StatusNormalClosure
+			closeReason = "client disconnected"
 		}
 		cancel()
 		sendStop("client disconnected")
 	case err := <-agentErrCh:
 		if err != nil {
 			logger.Debug("agent→ws bridge ended", "error", err)
+			closeCode = websocket.StatusInternalError
+			closeReason = err.Error()
+		} else {
+			closeCode = websocket.StatusNormalClosure
+			closeReason = "session ended"
 		}
 		cancel()
 		// Don't send TerminalStop — the agent initiated the close.
@@ -205,8 +219,8 @@ func (h *TerminalBridgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	case <-time.After(5 * time.Second):
 	}
 
-	ws.Close(websocket.StatusNormalClosure, "session ended")
-	logger.Info("terminal bridge session ended")
+	ws.Close(closeCode, closeReason)
+	logger.Info("terminal bridge session ended", "close_code", closeCode, "reason", closeReason)
 }
 
 // waitForStarted blocks until the agent sends a TerminalStateChange

--- a/internal/taskqueue/payloads.go
+++ b/internal/taskqueue/payloads.go
@@ -127,6 +127,18 @@ type LogQueryResultPayload struct {
 	Logs     string `json:"logs"`
 }
 
+// TerminalAuditChunkPayload carries a stdin chunk from a terminal
+// session so the control server's inbox worker can persist it as an
+// audit event. Only stdin is audited — stdout is high-volume and
+// derivable from input replay.
+type TerminalAuditChunkPayload struct {
+	SessionID string `json:"session_id"`
+	DeviceID  string `json:"device_id"`
+	UserID    string `json:"user_id"`
+	Data      []byte `json:"data"`
+	Sequence  int64  `json:"sequence"`
+}
+
 // === Search index payloads (search queue) ===
 
 // SearchReindexPayload is the payload for TypeSearchReindex tasks.

--- a/internal/taskqueue/types.go
+++ b/internal/taskqueue/types.go
@@ -48,6 +48,12 @@ const (
 
 	// TypeLogQueryResult reports the result of a journalctl log query.
 	TypeLogQueryResult = "log:result"
+
+	// TypeTerminalAuditChunk carries a stdin chunk from a terminal
+	// session for audit persistence. Enqueued by the gateway's
+	// WebSocket bridge and consumed by the control's inbox worker.
+	// Only stdin is audited (stdout is high-volume and derivable).
+	TypeTerminalAuditChunk = "terminal:audit_chunk"
 )
 
 // ControlInboxQueue is the Asynq queue name for gateway → control messages.


### PR DESCRIPTION
> ⚠️ **Stacked on #37** (gateway routing). Merge #37 first.

## Summary

Implements step 4 of manchtools/power-manage-sdk#16 — the gateway-side WebSocket endpoint that bridges web client terminal connections to the agent's bidi stream. After this PR + its prerequisite stack land, the full data path works end-to-end:

\`\`\`
Web client (xterm.js) ↔ WebSocket ↔ Gateway bridge ↔ Agent bidi stream ↔ PTY
\`\`\`

## Architecture

The gateway now has **three listeners**:

| Listener | Port | TLS | Purpose |
|---|---|---|---|
| Agent (mTLS) | \`:8080\` | mTLS (RequireAndVerifyClientCert) | Agent bidi streams, GatewayService for admin fan-out |
| Web (TLS) | \`:8443\` (configurable) | Standard TLS (no client cert) | Terminal WebSocket for web clients |
| Ops | \`:9090\` | None | Health checks |

The web listener uses the same server cert as the mTLS listener but **no ClientAuth**, so web browsers can connect via \`wss://\`. Authentication is via the session token validated against the control server's \`ProxyValidateTerminalToken\` RPC.

## What's in this PR

See the commit message for the full file-by-file breakdown. Key pieces:

- **\`TerminalSessionRegistry\`** — routes agent TerminalOutput/TerminalStateChange messages to the matching WebSocket bridge goroutine via a buffered channel. Non-blocking: full channel drops frames (acceptable for terminal output).
- **\`TerminalBridgeHandler\`** — the \`/terminal\` WebSocket handler. Validates token, verifies agent is connected, upgrades WS, sends TerminalStart, waits for STARTED, then runs two goroutines (WS→agent for input + resize, agent→WS for output). Tees stdin to the audit queue.
- **\`GatewayServiceHandler\`** — admin List/Terminate RPCs on the mTLS listener.
- **Agent message routing** — the existing \`handleAgentMessage\` no longer drops terminal messages; it routes them through the registry.
- **Audit tee** — new \`TypeTerminalAuditChunk\` task type enqueued to \`control:inbox\` for every binary (stdin) frame.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/connection/ ./internal/handler/ ./internal/taskqueue/ ./internal/gateway/... -count=1 -race\` — all existing tests pass
- [ ] End-to-end integration test with a real agent + wscat (manual, deferred until the full stack lands on main)

## Refs

- manchtools/power-manage-sdk#16 — parent feature
- manchtools/power-manage-server#6 — server-side parent issue
- #37 — base branch (must merge first)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket terminal endpoint with token validation, bidirectional bridging, and session management for live terminal sessions
  * Gateway admin endpoints to list and remotely terminate active terminal sessions
  * Terminal input audit enqueueing for persistent recording

* **Configuration**
  * New environment variable to enable an optional HTTPS listener address for the WebSocket terminal endpoint and a health check

* **Stability**
  * Graceful startup/shutdown handling for the optional web listener
<!-- end of auto-generated comment: release notes by coderabbit.ai -->