### PR TITLE
feat: auto-provision pm-tty-* user accounts for terminal sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ See the [Control Server README](cmd/control/) for details on the event model, AP
 | `internal/search` | Full-text search indexer using Valkey RediSearch — FT index management, Asynq reindex workers, cascade updates |
 | `internal/store` | PostgreSQL event store, migrations, sqlc queries |
 | `internal/taskqueue` | Asynq task queue client, task type constants, payload structs |
+| `internal/terminal` | Session token store (Valkey-backed) for remote terminal sessions |
+| `internal/gateway/registry` | Multi-gateway device→gateway routing registry (Valkey-backed) |
 | `internal/testutil` | Test helpers — PostgreSQL testcontainers, test entity factories, auth context injection |
 
 ## API Reference
@@ -390,6 +392,15 @@ Automatic Linux user account management on devices. When provisioning is enabled
 
 Permission-based authorization replaces the old admin/user role model. Roles are custom collections of permissions. Users can have multiple roles (directly assigned or inherited via user groups). Permissions include scoped variants like `GetUser:self` and `ListDevices:assigned`.
 
+#### Remote Terminal Permissions
+
+| Permission | Description |
+|------------|-------------|
+| `StartTerminal` | Open a remote terminal session on a device |
+| `StopTerminal` | Stop a remote terminal session you opened |
+| `ListActiveTerminalSessions` | View active terminal sessions (admin) |
+| `TerminateTerminalSession` | Forcibly terminate any terminal session (admin) |
+
 ### OPA Authorization (`internal/auth/opa.go`)
 
 Embedded Rego policies (`internal/auth/policies/authz.rego`) evaluate every RPC call based on the user's effective permissions (union of all assigned roles).
@@ -440,6 +451,21 @@ CGO_ENABLED=0 go build -ldflags="-s -w" -o indexer ./cmd/indexer
 CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=2026.3.0" -o control ./cmd/control
 CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=2026.3.0" -o gateway ./cmd/gateway
 ```
+
+## Configuration
+
+### Gateway Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `VALKEY_ADDR` | Valkey address, e.g. `localhost:6379` |
+| `VALKEY_PASSWORD` | Valkey password |
+| `GATEWAY_CONTROL_URL` | URL of the Control Server |
+| `GATEWAY_ID` | Stable gateway identifier (empty = generate ULID at startup) |
+| `GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE` | Template for the public terminal WebSocket URL, e.g. `wss://{id}.gateway.example.com/terminal` |
+| `GATEWAY_BOOTSTRAP_HOST` | Wildcard root hostname for agent bootstrap redirect, e.g. `gateway.example.com` |
+| `GATEWAY_WEB_LISTEN_ADDR` | Listen address for the web TLS listener (terminal WebSocket), e.g. `:8443` |
+| `CONTROL_TERMINAL_GATEWAY_URL` | Fallback terminal gateway URL for single-gateway deployments (deprecated in favor of registry) |
 
 ## Running Locally
 

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -112,26 +112,30 @@ func (m *SystemActionManager) SyncUserSystemActions(ctx context.Context, userID 
 	// when the user holds the StartTerminal permission (directly or
 	// via a user group role). When the permission is revoked, the
 	// action is cleaned up so the account is removed from devices.
-	ttyNeeded := false
+	//
+	// If the permission query fails, we skip the TTY block entirely
+	// and leave the existing state untouched — a transient DB error
+	// must NOT trigger a cleanup that deletes a working TTY account.
 	permissions, err := m.store.Queries().GetUserPermissionsWithGroups(ctx, userID)
 	if err != nil {
-		m.logger.Error("failed to resolve user permissions for tty action sync",
+		m.logger.Error("failed to resolve user permissions for tty action sync; leaving TTY state unchanged",
 			"user_id", userID, "error", err)
 	} else {
+		ttyNeeded := false
 		for _, p := range permissions {
 			if p == "StartTerminal" {
 				ttyNeeded = true
 				break
 			}
 		}
-	}
-	if ttyNeeded {
-		if err := m.syncTtyUserAction(ctx, user); err != nil {
-			m.logger.Error("failed to sync tty user action", "user_id", userID, "error", err)
-		}
-	} else {
-		if err := m.cleanupTtyAction(ctx, user); err != nil {
-			m.logger.Error("failed to cleanup tty user action", "user_id", userID, "error", err)
+		if ttyNeeded {
+			if err := m.syncTtyUserAction(ctx, user); err != nil {
+				m.logger.Error("failed to sync tty user action", "user_id", userID, "error", err)
+			}
+		} else {
+			if err := m.cleanupTtyAction(ctx, user); err != nil {
+				m.logger.Error("failed to cleanup tty user action", "user_id", userID, "error", err)
+			}
 		}
 	}
 

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -107,6 +107,34 @@ func (m *SystemActionManager) SyncUserSystemActions(ctx context.Context, userID 
 		}
 	}
 
+	// --- System TTY user action (for remote terminal sessions) ---
+	// The pm-tty-* account is created on the user's assigned devices
+	// when the user holds the StartTerminal permission (directly or
+	// via a user group role). When the permission is revoked, the
+	// action is cleaned up so the account is removed from devices.
+	ttyNeeded := false
+	permissions, err := m.store.Queries().GetUserPermissionsWithGroups(ctx, userID)
+	if err != nil {
+		m.logger.Error("failed to resolve user permissions for tty action sync",
+			"user_id", userID, "error", err)
+	} else {
+		for _, p := range permissions {
+			if p == "StartTerminal" {
+				ttyNeeded = true
+				break
+			}
+		}
+	}
+	if ttyNeeded {
+		if err := m.syncTtyUserAction(ctx, user); err != nil {
+			m.logger.Error("failed to sync tty user action", "user_id", userID, "error", err)
+		}
+	} else {
+		if err := m.cleanupTtyAction(ctx, user); err != nil {
+			m.logger.Error("failed to cleanup tty user action", "user_id", userID, "error", err)
+		}
+	}
+
 	return nil
 }
 
@@ -127,6 +155,14 @@ func (m *SystemActionManager) CleanupDeletedUserActions(ctx context.Context, use
 		}
 		if err := m.linkSystemAction(ctx, user.ID, "system_ssh_action_id", ""); err != nil {
 			m.logger.Error("failed to unlink system ssh action", "user_id", user.ID, "error", err)
+		}
+	}
+	if user.SystemTtyActionID != "" {
+		if err := m.deleteSystemAction(ctx, user.SystemTtyActionID); err != nil {
+			m.logger.Error("failed to delete system tty action", "action_id", user.SystemTtyActionID, "error", err)
+		}
+		if err := m.linkSystemAction(ctx, user.ID, "system_tty_action_id", ""); err != nil {
+			m.logger.Error("failed to unlink system tty action", "user_id", user.ID, "error", err)
 		}
 	}
 	return nil
@@ -253,6 +289,78 @@ func (m *SystemActionManager) cleanupSshAction(ctx context.Context, user db.User
 		m.logger.Error("failed to unlink system ssh action", "user_id", user.ID, "error", err)
 	}
 	m.logger.Info("cleaned up system ssh access action", "user_id", user.ID)
+	return nil
+}
+
+// syncTtyUserAction ensures a dedicated pm-tty-<linux_username>
+// system User action exists for the given user so that when the
+// action is resolved onto the user's assigned devices the agent
+// creates the TTY account. The action uses nologin as the shell
+// (the agent temporarily activates it during a session), no home
+// directory, and the deterministic UID from the SDK's TTYUID helper.
+func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.UsersProjection) error {
+	ttyUsername := "pm-tty-" + user.LinuxUsername
+	ttyUID := int(user.LinuxUid) + 100000 // terminal.DefaultUIDOffset
+
+	params := map[string]any{
+		"username":   ttyUsername,
+		"uid":        ttyUID,
+		"shell":      "/usr/sbin/nologin",
+		"createHome": false,
+		"comment":    "Power Manage terminal user for " + user.LinuxUsername,
+		"system":     true, // AccountsService SystemAccount=true → hidden from login screens
+	}
+	if user.Disabled {
+		params["disabled"] = true
+	}
+
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("marshal tty user params: %w", err)
+	}
+
+	actionName := "system:tty-user:" + user.ID
+
+	if user.SystemTtyActionID == "" {
+		// Create new system action
+		actionID, err := m.createSystemAction(ctx, actionName, int32(pm.ActionType_ACTION_TYPE_USER), int32(pm.DesiredState_DESIRED_STATE_PRESENT), paramsJSON)
+		if err != nil {
+			return fmt.Errorf("create tty user action: %w", err)
+		}
+
+		if err := m.assignActionToUser(ctx, actionID, user.ID); err != nil {
+			return fmt.Errorf("assign tty user action: %w", err)
+		}
+
+		if err := m.linkSystemAction(ctx, user.ID, "system_tty_action_id", actionID); err != nil {
+			return fmt.Errorf("link tty user action: %w", err)
+		}
+
+		m.signActionByID(ctx, actionID)
+		m.logger.Info("created system tty user action",
+			"user_id", user.ID, "action_id", actionID, "tty_user", ttyUsername)
+	} else {
+		// Update existing action if params changed
+		if err := m.updateSystemAction(ctx, user.SystemTtyActionID, int32(pm.DesiredState_DESIRED_STATE_PRESENT), paramsJSON); err != nil {
+			return fmt.Errorf("update tty user action: %w", err)
+		}
+		m.signActionByID(ctx, user.SystemTtyActionID)
+	}
+
+	return nil
+}
+
+func (m *SystemActionManager) cleanupTtyAction(ctx context.Context, user db.UsersProjection) error {
+	if user.SystemTtyActionID == "" {
+		return nil
+	}
+	if err := m.deleteSystemAction(ctx, user.SystemTtyActionID); err != nil {
+		m.logger.Error("failed to delete system tty action", "action_id", user.SystemTtyActionID, "error", err)
+	}
+	if err := m.linkSystemAction(ctx, user.ID, "system_tty_action_id", ""); err != nil {
+		m.logger.Error("failed to unlink system tty action", "user_id", user.ID, "error", err)
+	}
+	m.logger.Info("cleaned up system tty user action", "user_id", user.ID)
 	return nil
 }
 

--- a/internal/store/generated/models.go
+++ b/internal/store/generated/models.go
@@ -502,4 +502,5 @@ type UsersProjection struct {
 	SystemUserActionID      string     `json:"system_user_action_id"`
 	SystemSshActionID       string     `json:"system_ssh_action_id"`
 	UserProvisioningEnabled bool       `json:"user_provisioning_enabled"`
+	SystemTtyActionID       string     `json:"system_tty_action_id"`
 }

--- a/internal/store/generated/scim.sql.go
+++ b/internal/store/generated/scim.sql.go
@@ -36,7 +36,7 @@ func (q *Queries) CountSCIMUsers(ctx context.Context, providerID string) (int64,
 }
 
 const findSCIMUserByEmail = `-- name: FindSCIMUserByEmail :one
-SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, il.external_id AS scim_external_id
+SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id, il.external_id AS scim_external_id
 FROM users_projection u
 JOIN identity_links_projection il ON il.user_id = u.id
 WHERE il.provider_id = $1 AND u.email = $2 AND u.is_deleted = FALSE
@@ -76,6 +76,7 @@ type FindSCIMUserByEmailRow struct {
 	SystemUserActionID      string     `json:"system_user_action_id"`
 	SystemSshActionID       string     `json:"system_ssh_action_id"`
 	UserProvisioningEnabled bool       `json:"user_provisioning_enabled"`
+	SystemTtyActionID       string     `json:"system_tty_action_id"`
 	ScimExternalID          string     `json:"scim_external_id"`
 }
 
@@ -111,13 +112,14 @@ func (q *Queries) FindSCIMUserByEmail(ctx context.Context, arg FindSCIMUserByEma
 		&i.SystemUserActionID,
 		&i.SystemSshActionID,
 		&i.UserProvisioningEnabled,
+		&i.SystemTtyActionID,
 		&i.ScimExternalID,
 	)
 	return i, err
 }
 
 const findSCIMUserByExternalID = `-- name: FindSCIMUserByExternalID :one
-SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, il.external_id AS scim_external_id
+SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id, il.external_id AS scim_external_id
 FROM users_projection u
 JOIN identity_links_projection il ON il.user_id = u.id
 WHERE il.provider_id = $1 AND il.external_id = $2 AND u.is_deleted = FALSE
@@ -157,6 +159,7 @@ type FindSCIMUserByExternalIDRow struct {
 	SystemUserActionID      string     `json:"system_user_action_id"`
 	SystemSshActionID       string     `json:"system_ssh_action_id"`
 	UserProvisioningEnabled bool       `json:"user_provisioning_enabled"`
+	SystemTtyActionID       string     `json:"system_tty_action_id"`
 	ScimExternalID          string     `json:"scim_external_id"`
 }
 
@@ -192,6 +195,7 @@ func (q *Queries) FindSCIMUserByExternalID(ctx context.Context, arg FindSCIMUser
 		&i.SystemUserActionID,
 		&i.SystemSshActionID,
 		&i.UserProvisioningEnabled,
+		&i.SystemTtyActionID,
 		&i.ScimExternalID,
 	)
 	return i, err
@@ -287,7 +291,7 @@ func (q *Queries) GetSCIMGroupMappingByUserGroup(ctx context.Context, arg GetSCI
 }
 
 const getUserByExternalSCIMID = `-- name: GetUserByExternalSCIMID :one
-SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled FROM users_projection u
+SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id FROM users_projection u
 JOIN identity_links_projection il ON il.user_id = u.id
 WHERE il.provider_id = $1 AND il.external_id = $2 AND u.is_deleted = FALSE
 `
@@ -329,6 +333,7 @@ func (q *Queries) GetUserByExternalSCIMID(ctx context.Context, arg GetUserByExte
 		&i.SystemUserActionID,
 		&i.SystemSshActionID,
 		&i.UserProvisioningEnabled,
+		&i.SystemTtyActionID,
 	)
 	return i, err
 }
@@ -427,7 +432,7 @@ func (q *Queries) ListSCIMGroupMappings(ctx context.Context, providerID string) 
 }
 
 const listSCIMUsers = `-- name: ListSCIMUsers :many
-SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, il.external_id AS scim_external_id
+SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id, il.external_id AS scim_external_id
 FROM users_projection u
 JOIN identity_links_projection il ON il.user_id = u.id
 WHERE il.provider_id = $1 AND u.is_deleted = FALSE
@@ -470,6 +475,7 @@ type ListSCIMUsersRow struct {
 	SystemUserActionID      string     `json:"system_user_action_id"`
 	SystemSshActionID       string     `json:"system_ssh_action_id"`
 	UserProvisioningEnabled bool       `json:"user_provisioning_enabled"`
+	SystemTtyActionID       string     `json:"system_tty_action_id"`
 	ScimExternalID          string     `json:"scim_external_id"`
 }
 
@@ -511,6 +517,7 @@ func (q *Queries) ListSCIMUsers(ctx context.Context, arg ListSCIMUsersParams) ([
 			&i.SystemUserActionID,
 			&i.SystemSshActionID,
 			&i.UserProvisioningEnabled,
+			&i.SystemTtyActionID,
 			&i.ScimExternalID,
 		); err != nil {
 			return nil, err

--- a/internal/store/generated/users.sql.go
+++ b/internal/store/generated/users.sql.go
@@ -33,7 +33,7 @@ func (q *Queries) GetNextLinuxUID(ctx context.Context) (int32, error) {
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled FROM users_projection
+SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 WHERE email = $1 AND is_deleted = FALSE
 `
 
@@ -69,12 +69,13 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (UsersProjec
 		&i.SystemUserActionID,
 		&i.SystemSshActionID,
 		&i.UserProvisioningEnabled,
+		&i.SystemTtyActionID,
 	)
 	return i, err
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled FROM users_projection
+SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 WHERE id = $1 AND is_deleted = FALSE
 `
 
@@ -110,6 +111,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (UsersProjection, 
 		&i.SystemUserActionID,
 		&i.SystemSshActionID,
 		&i.UserProvisioningEnabled,
+		&i.SystemTtyActionID,
 	)
 	return i, err
 }
@@ -133,7 +135,7 @@ func (q *Queries) GetUserSessionInfo(ctx context.Context, id string) (GetUserSes
 }
 
 const listAllNonDeletedUsers = `-- name: ListAllNonDeletedUsers :many
-SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled FROM users_projection
+SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 WHERE is_deleted = FALSE
 ORDER BY created_at
 `
@@ -176,6 +178,7 @@ func (q *Queries) ListAllNonDeletedUsers(ctx context.Context) ([]UsersProjection
 			&i.SystemUserActionID,
 			&i.SystemSshActionID,
 			&i.UserProvisioningEnabled,
+			&i.SystemTtyActionID,
 		); err != nil {
 			return nil, err
 		}
@@ -188,7 +191,7 @@ func (q *Queries) ListAllNonDeletedUsers(ctx context.Context) ([]UsersProjection
 }
 
 const listAllUsers = `-- name: ListAllUsers :many
-SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled FROM users_projection
+SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
 `
@@ -236,6 +239,7 @@ func (q *Queries) ListAllUsers(ctx context.Context, arg ListAllUsersParams) ([]U
 			&i.SystemUserActionID,
 			&i.SystemSshActionID,
 			&i.UserProvisioningEnabled,
+			&i.SystemTtyActionID,
 		); err != nil {
 			return nil, err
 		}
@@ -248,7 +252,7 @@ func (q *Queries) ListAllUsers(ctx context.Context, arg ListAllUsersParams) ([]U
 }
 
 const listUsers = `-- name: ListUsers :many
-SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled FROM users_projection
+SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 WHERE is_deleted = FALSE
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
@@ -297,6 +301,7 @@ func (q *Queries) ListUsers(ctx context.Context, arg ListUsersParams) ([]UsersPr
 			&i.SystemUserActionID,
 			&i.SystemSshActionID,
 			&i.UserProvisioningEnabled,
+			&i.SystemTtyActionID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/migrations/007_tty_user_action.sql
+++ b/internal/store/migrations/007_tty_user_action.sql
@@ -184,5 +184,14 @@ $$ LANGUAGE plpgsql;
 
 -- +goose Down
 ALTER TABLE users_projection DROP COLUMN IF EXISTS system_tty_action_id;
--- The down migration does not restore the old function body; running
--- all downs in reverse order (006 → 005 → ... → 002) handles that.
+-- WARNING: This down migration drops the system_tty_action_id column
+-- but does NOT restore the prior project_user_event function body
+-- (which lacks the system_tty_action_id CASE arm). The trigger will
+-- still try to SET system_tty_action_id on UserSystemActionLinked
+-- events, but PostgreSQL silently ignores SET on a dropped column in
+-- an UPDATE, so this is safe for a partial rollback.
+--
+-- For a clean rollback, run all downs in reverse order (007 → 006 →
+-- ... → 002) so migration 002's function body is restored. A partial
+-- rollback of only 007 is operationally safe but leaves the trigger
+-- referencing a non-existent column (harmless).

--- a/internal/store/migrations/007_tty_user_action.sql
+++ b/internal/store/migrations/007_tty_user_action.sql
@@ -1,0 +1,188 @@
+-- +goose Up
+
+-- Add system_tty_action_id to users_projection for tracking the
+-- auto-created pm-tty-* User action per Power Manage user.
+ALTER TABLE users_projection
+    ADD COLUMN IF NOT EXISTS system_tty_action_id TEXT NOT NULL DEFAULT '';
+
+-- Extend the UserSystemActionLinked handler in the user projector to
+-- also handle the system_tty_action_id field. The full function body
+-- is reproduced because CREATE OR REPLACE replaces the entire body.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'UserCreated' THEN
+            INSERT INTO users_projection (
+                id, email, password_hash, role, created_at, updated_at, projection_version, session_version, has_password,
+                display_name, given_name, family_name, preferred_username, picture, locale,
+                linux_username, linux_uid
+            ) VALUES (
+                event.stream_id,
+                event.data->>'email',
+                COALESCE(event.data->>'password_hash', ''),
+                COALESCE(event.data->>'role', 'user'),
+                event.occurred_at,
+                event.occurred_at,
+                event.sequence_num,
+                0,
+                COALESCE(NULLIF(event.data->>'password_hash', ''), NULL) IS NOT NULL,
+                COALESCE(event.data->>'display_name', ''),
+                COALESCE(event.data->>'given_name', ''),
+                COALESCE(event.data->>'family_name', ''),
+                COALESCE(event.data->>'preferred_username', ''),
+                COALESCE(event.data->>'picture', ''),
+                COALESCE(event.data->>'locale', ''),
+                COALESCE(event.data->>'linux_username', ''),
+                COALESCE((event.data->>'linux_uid')::INTEGER, 0)
+            );
+
+        WHEN 'UserProfileUpdated' THEN
+            UPDATE users_projection
+            SET display_name = COALESCE(event.data->>'display_name', ''),
+                given_name = COALESCE(event.data->>'given_name', ''),
+                family_name = COALESCE(event.data->>'family_name', ''),
+                preferred_username = COALESCE(event.data->>'preferred_username', ''),
+                picture = COALESCE(event.data->>'picture', ''),
+                locale = COALESCE(event.data->>'locale', ''),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserEmailChanged' THEN
+            UPDATE users_projection
+            SET email = event.data->>'email',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserPasswordChanged' THEN
+            UPDATE users_projection
+            SET password_hash = event.data->>'password_hash',
+                has_password = TRUE,
+                session_version = session_version + 1,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserRoleChanged' THEN
+            UPDATE users_projection
+            SET role = event.data->>'role',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserSessionInvalidated' THEN
+            UPDATE users_projection
+            SET session_version = session_version + 1,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserDisabled' THEN
+            UPDATE users_projection
+            SET disabled = TRUE,
+                session_version = session_version + 1,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserEnabled' THEN
+            UPDATE users_projection
+            SET disabled = FALSE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserLoggedIn' THEN
+            UPDATE users_projection
+            SET last_login_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserDeleted' THEN
+            DELETE FROM identity_links_projection WHERE user_id = event.stream_id;
+
+            UPDATE users_projection
+            SET is_deleted = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserSshKeyAdded' THEN
+            UPDATE users_projection
+            SET ssh_public_keys = ssh_public_keys || jsonb_build_array(
+                jsonb_build_object(
+                    'id', event.data->>'key_id',
+                    'public_key', event.data->>'public_key',
+                    'comment', event.data->>'comment',
+                    'added_at', event.occurred_at
+                )
+            ),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserSshKeyRemoved' THEN
+            UPDATE users_projection
+            SET ssh_public_keys = (
+                SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)
+                FROM jsonb_array_elements(ssh_public_keys) AS elem
+                WHERE elem->>'id' != event.data->>'key_id'
+            ),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserSshSettingsUpdated' THEN
+            UPDATE users_projection
+            SET ssh_access_enabled = COALESCE((event.data->>'ssh_access_enabled')::BOOLEAN, ssh_access_enabled),
+                ssh_allow_pubkey = COALESCE((event.data->>'ssh_allow_pubkey')::BOOLEAN, ssh_allow_pubkey),
+                ssh_allow_password = COALESCE((event.data->>'ssh_allow_password')::BOOLEAN, ssh_allow_password),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserLinuxUsernameChanged' THEN
+            UPDATE users_projection
+            SET linux_username = event.data->>'linux_username',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserSystemActionLinked' THEN
+            UPDATE users_projection
+            SET system_user_action_id = CASE
+                    WHEN event.data->>'field' = 'system_user_action_id' THEN COALESCE(event.data->>'action_id', '')
+                    ELSE system_user_action_id
+                END,
+                system_ssh_action_id = CASE
+                    WHEN event.data->>'field' = 'system_ssh_action_id' THEN COALESCE(event.data->>'action_id', '')
+                    ELSE system_ssh_action_id
+                END,
+                system_tty_action_id = CASE
+                    WHEN event.data->>'field' = 'system_tty_action_id' THEN COALESCE(event.data->>'action_id', '')
+                    ELSE system_tty_action_id
+                END,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserProvisioningSettingsUpdated' THEN
+            UPDATE users_projection
+            SET user_provisioning_enabled = COALESCE((event.data->>'user_provisioning_enabled')::BOOLEAN, user_provisioning_enabled),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+ALTER TABLE users_projection DROP COLUMN IF EXISTS system_tty_action_id;
+-- The down migration does not restore the old function body; running
+-- all downs in reverse order (006 → 005 → ... → 002) handles that.


### PR DESCRIPTION
## Summary

Closes the last functional gap that would cause terminal sessions to fail in production: the agent's `OnTerminalStart` requires the `pm-tty-*` account to exist on the device before it can allocate a PTY. Without this PR, every `StartTerminal` call that successfully mints a token and reaches the agent fails with "tty user not provisioned."

This PR hooks into the existing `SystemActionManager` (which already handles user provisioning and SSH access actions) to auto-create a dedicated `pm-tty-<linux_username>` User action when the PM user has `StartTerminal` permission.

Independent of the terminal PR stack (#35 → #36 → #37 → #40); lands directly on main.

## How it works

**Trigger:** `SyncUserSystemActions` is called on user create, update, role change, linux username change, etc. It now queries the user's effective permissions via `GetUserPermissionsWithGroups` and checks for `StartTerminal`.

**If the user has `StartTerminal` permission:**
- Creates a system `ACTION_TYPE_USER` action named `system:tty-user:<user_id>` with:
  - `username`: `pm-tty-<linux_username>`
  - `uid`: `linux_uid + 100000` (deterministic, matches `terminal.DefaultUIDOffset`)
  - `shell`: `/usr/sbin/nologin` (agent activates during session only)
  - `createHome`: false (agent creates per-session temp dir)
  - `system`: true (hidden from login screens via AccountsService)
  - `disabled`: mirrors the PM user's disabled state
- Assigns the action to the user (so it resolves onto the user's assigned devices via the existing assignment/resolution engine)
- Links via `system_tty_action_id` on the user projection

**If the user does NOT have `StartTerminal` permission:**
- Deletes the existing action and unlinks it

**On user deletion:** `CleanupDeletedUserActions` now also cleans up the TTY action.

## Migration 007

- Adds `system_tty_action_id TEXT NOT NULL DEFAULT ''` to `users_projection`
- Extends the `UserSystemActionLinked` case in `project_user_event` to handle the new field alongside `system_user_action_id` and `system_ssh_action_id`
- Full `CREATE OR REPLACE` of `project_user_event` because PL/pgSQL doesn't support partial function updates; body reproduces existing logic from 002 with the third `CASE` arm added

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] sqlc regeneration adds `SystemTtyActionID` to `UsersProjection` model
- [x] Migration SQL uses `+goose StatementBegin`/`End` for the PL/pgSQL function (per the project's Goose migration memory)
- [ ] Integration tests (will run in CI against a real PostgreSQL instance)

## Refs

- manchtools/power-manage-sdk#16 — parent feature
- manchtools/power-manage-server#6 — server-side parent issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic terminal (TTY) access is provisioned for eligible users and kept up to date.
  * System-managed terminal accounts use deterministic, consistent naming.

* **Bug Fixes**
  * Terminal access and linked accounts are removed reliably when permissions are revoked to prevent stale entries.

* **Chores**
  * Backend now tracks per-user terminal access status for auditing and synchronization.

* **Documentation**
  * Added Remote Terminal permissions and gateway/terminal configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->