### PR TITLE
feat: audit chunk consumer, admin fan-out, internal URL registry, compose update

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -384,13 +385,38 @@ func main() {
 		// must be able to validate tokens minted by other replicas.
 		terminalTokenStore = terminal.NewTokenStore(terminal.NewValkeyBackend(rdb))
 		gatewayReg := registry.New(registry.NewValkeyBackend(rdb), logger.With("component", "gateway_registry"))
-		svc.SetTerminalHandler(api.NewTerminalHandler(
+		termHandler := api.NewTerminalHandler(
 			st,
 			terminalTokenStore,
 			gatewayReg,
 			api.GatewayBaseURL(cfg.TerminalGatewayURL),
 			logger.With("component", "terminal_handler"),
-		))
+		)
+		// Build an mTLS HTTP client for gateway admin fan-out. The
+		// control uses its own cert as the client cert and the CA
+		// cert to verify the gateway's server cert — same trust
+		// model as the gateway→control direction.
+		if cfg.InternalTLSCert != "" && cfg.CACertPath != "" {
+			gwCert, err := tls.LoadX509KeyPair(cfg.InternalTLSCert, cfg.InternalTLSKey)
+			if err == nil {
+				caCert, err := os.ReadFile(cfg.CACertPath)
+				if err == nil {
+					caPool := x509.NewCertPool()
+					if caPool.AppendCertsFromPEM(caCert) {
+						gwTransport := &http.Transport{
+							TLSClientConfig: &tls.Config{
+								Certificates: []tls.Certificate{gwCert},
+								RootCAs:      caPool,
+								MinVersion:   tls.VersionTLS13,
+							},
+						}
+						termHandler.SetInternalHTTPClient(&http.Client{Transport: gwTransport})
+						logger.Info("terminal admin fan-out enabled (mTLS client configured)")
+					}
+				}
+			}
+		}
+		svc.SetTerminalHandler(termHandler)
 		if cfg.TerminalGatewayURL != "" {
 			logger.Info("remote terminal sessions enabled",
 				"fallback_gateway_url", cfg.TerminalGatewayURL,

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -398,11 +398,20 @@ func main() {
 		// model as the gateway→control direction.
 		if cfg.InternalTLSCert != "" && cfg.CACertPath != "" {
 			gwCert, err := tls.LoadX509KeyPair(cfg.InternalTLSCert, cfg.InternalTLSKey)
-			if err == nil {
+			if err != nil {
+				logger.Warn("terminal admin fan-out disabled: failed to load internal TLS key pair",
+					"cert", cfg.InternalTLSCert, "key", cfg.InternalTLSKey, "error", err)
+			} else {
 				caCert, err := os.ReadFile(cfg.CACertPath)
-				if err == nil {
+				if err != nil {
+					logger.Warn("terminal admin fan-out disabled: failed to read CA certificate",
+						"path", cfg.CACertPath, "error", err)
+				} else {
 					caPool := x509.NewCertPool()
-					if caPool.AppendCertsFromPEM(caCert) {
+					if !caPool.AppendCertsFromPEM(caCert) {
+						logger.Warn("terminal admin fan-out disabled: CA certificate file contained no valid PEM certificates",
+							"path", cfg.CACertPath)
+					} else {
 						gwTransport := &http.Transport{
 							TLSClientConfig: &tls.Config{
 								Certificates: []tls.Certificate{gwCert},

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -172,10 +172,30 @@ func main() {
 			os.Exit(1)
 		}
 		defer stop()
+
+		// Also publish the internal mTLS URL so the control server
+		// can discover this gateway for admin fan-out (List/Terminate
+		// terminal sessions). Uses the same TTL as the terminal URL.
+		if cfg.InternalURL != "" {
+			if err := gatewayReg.RegisterGatewayInternal(
+				context.Background(), gatewayID, cfg.InternalURL, registry.DefaultGatewayTTL,
+			); err != nil {
+				logger.Warn("failed to register gateway internal URL", "error", err)
+			}
+			// Refresh the internal URL alongside the terminal URL.
+			// The heartbeat goroutine in RegisterGateway handles the
+			// terminal key; for the internal key we just set it once
+			// with the same TTL — it'll expire together with the
+			// terminal key if the gateway crashes. A separate refresh
+			// goroutine isn't worth the complexity for a key that
+			// changes only on gateway restart.
+		}
+
 		logger.Info("multi-gateway routing enabled",
 			"gateway_id", gatewayID,
 			"terminal_url", terminalURL,
 			"assigned_host", assignedHost,
+			"internal_url", cfg.InternalURL,
 		)
 	}
 	// Fail fast if BootstrapHost is set but we have no assignedHost

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -182,13 +182,28 @@ func main() {
 			); err != nil {
 				logger.Warn("failed to register gateway internal URL", "error", err)
 			}
-			// Refresh the internal URL alongside the terminal URL.
-			// The heartbeat goroutine in RegisterGateway handles the
-			// terminal key; for the internal key we just set it once
-			// with the same TTL — it'll expire together with the
-			// terminal key if the gateway crashes. A separate refresh
-			// goroutine isn't worth the complexity for a key that
-			// changes only on gateway restart.
+			// Refresh the internal URL on the same cadence as the
+			// terminal URL so it does not expire while the gateway is
+			// running. Use a dedicated cancel context so the goroutine
+			// stops cleanly on shutdown (shutdownCtx is declared later).
+			internalRefreshCtx, stopInternalRefresh := context.WithCancel(context.Background())
+			defer stopInternalRefresh()
+			go func() {
+				ticker := time.NewTicker(registry.DefaultGatewayRefreshInterval)
+				defer ticker.Stop()
+				for {
+					select {
+					case <-ticker.C:
+						if err := gatewayReg.RegisterGatewayInternal(
+							context.Background(), gatewayID, cfg.InternalURL, registry.DefaultGatewayTTL,
+						); err != nil {
+							logger.Warn("failed to refresh gateway internal URL", "error", err)
+						}
+					case <-internalRefreshCtx.Done():
+						return
+					}
+				}
+			}()
 		}
 
 		logger.Info("multi-gateway routing enabled",

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -108,6 +108,10 @@ services:
       - CONTROL_SSH_ACCESS_FOR_ALL=${CONTROL_SSH_ACCESS_FOR_ALL:-false}
       - CONTROL_VALKEY_ADDR=valkey:6379
       - CONTROL_VALKEY_PASSWORD=${VALKEY_PASSWORD}
+      # Remote terminal fallback URL for single-gateway deployments.
+      # Leave empty when using multi-gateway routing (the control
+      # server resolves the correct gateway from the registry).
+      - CONTROL_TERMINAL_GATEWAY_URL=${CONTROL_TERMINAL_GATEWAY_URL:-}
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8081/health"]
       interval: 10s
@@ -165,6 +169,13 @@ services:
       - GATEWAY_CONTROL_URL=https://control:8082
       - GATEWAY_LISTEN_ADDR=:8080
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      # Remote terminal (multi-gateway routing). Leave empty to disable.
+      # GATEWAY_ID is auto-generated as a ULID if empty.
+      - GATEWAY_ID=${GATEWAY_ID:-}
+      - GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE=${GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE:-}
+      - GATEWAY_BOOTSTRAP_HOST=${GATEWAY_BOOTSTRAP_HOST:-}
+      - GATEWAY_WEB_LISTEN_ADDR=${GATEWAY_WEB_LISTEN_ADDR:-}
+      - GATEWAY_INTERNAL_URL=${GATEWAY_INTERNAL_URL:-}
     command:
       - "-tls-cert=/certs/gateway.crt"
       - "-tls-key=/certs/gateway.key"

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -803,12 +803,18 @@ func (s *ControlService) StopTerminal(ctx context.Context, req *connect.Request[
 }
 
 func (s *ControlService) ListActiveTerminalSessions(ctx context.Context, req *connect.Request[pm.ListActiveTerminalSessionsRequest]) (*connect.Response[pm.ListActiveTerminalSessionsResponse], error) {
-	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented,
-		"admin terminal session listing is not yet implemented (requires gateway fan-out)")
+	if s.terminal == nil {
+		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
+			"remote terminal sessions are not configured on this control instance")
+	}
+	return s.terminal.ListActiveTerminalSessions(ctx, req)
 }
 
 func (s *ControlService) TerminateTerminalSession(ctx context.Context, req *connect.Request[pm.TerminateTerminalSessionRequest]) (*connect.Response[pm.TerminateTerminalSessionResponse], error) {
-	return nil, apiErrorCtx(ctx, ErrUnimplemented, connect.CodeUnimplemented,
-		"admin terminal session termination is not yet implemented (requires gateway fan-out)")
+	if s.terminal == nil {
+		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
+			"remote terminal sessions are not configured on this control instance")
+	}
+	return s.terminal.TerminateTerminalSession(ctx, req)
 }
 

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/jackc/pgx/v5"
@@ -357,8 +358,10 @@ func (h *TerminalHandler) ListActiveTerminalSessions(ctx context.Context, req *c
 		wg.Add(1)
 		go func(gwID, gwURL string) {
 			defer wg.Done()
+			childCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
 			client := pmv1connect.NewGatewayServiceClient(h.internalHTTPClient, gwURL)
-			resp, err := client.ListGatewayTerminalSessions(ctx, connect.NewRequest(&pm.ListGatewayTerminalSessionsRequest{}))
+			resp, err := client.ListGatewayTerminalSessions(childCtx, connect.NewRequest(&pm.ListGatewayTerminalSessionsRequest{}))
 			if err != nil {
 				h.logger.Warn("gateway fan-out failed",
 					"gateway_id", gwID, "url", gwURL, "error", err)
@@ -403,8 +406,8 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 	session, err := h.tokenStore.Lookup(ctx, req.Msg.SessionId)
 	if err != nil {
 		if errors.Is(err, terminal.ErrTokenNotFound) {
-			return nil, apiErrorCtx(ctx, ErrTokenNotFound, connect.CodeNotFound,
-				"terminal session not found or already ended")
+			// Idempotent: session already gone is success.
+			return connect.NewResponse(&pm.TerminateTerminalSessionResponse{}), nil
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
 			"failed to look up session")
@@ -415,7 +418,12 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 		if errors.Is(err, registry.ErrNoGateway) {
 			// Device not connected — session may have already ended.
 			// Revoke the token anyway and return success.
-			_ = h.tokenStore.Revoke(ctx, req.Msg.SessionId)
+			if rErr := h.tokenStore.Revoke(ctx, req.Msg.SessionId); rErr != nil {
+				h.logger.Error("failed to revoke terminal session token after no-gateway",
+					"session_id", req.Msg.SessionId, "error", rErr)
+				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+					"failed to revoke terminal session token")
+			}
 			return connect.NewResponse(&pm.TerminateTerminalSessionResponse{}), nil
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable,
@@ -425,7 +433,12 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 	gwURL, err := h.registry.LookupGatewayInternalURL(ctx, gatewayID)
 	if err != nil {
 		// Gateway disappeared between lookups. Revoke token and return.
-		_ = h.tokenStore.Revoke(ctx, req.Msg.SessionId)
+		if rErr := h.tokenStore.Revoke(ctx, req.Msg.SessionId); rErr != nil {
+			h.logger.Error("failed to revoke terminal session token after gateway disappearance",
+				"session_id", req.Msg.SessionId, "error", rErr)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+				"failed to revoke terminal session token")
+		}
 		return connect.NewResponse(&pm.TerminateTerminalSessionResponse{}), nil
 	}
 
@@ -448,7 +461,12 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 	}
 
 	// Revoke the token and emit audit event.
-	_ = h.tokenStore.Revoke(ctx, req.Msg.SessionId)
+	if err := h.tokenStore.Revoke(ctx, req.Msg.SessionId); err != nil {
+		h.logger.Error("failed to revoke terminal session token after gateway termination",
+			"session_id", req.Msg.SessionId, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+			"failed to revoke terminal session token")
+	}
 
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "device",

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 
 	"connectrpc.com/connect"
 	"github.com/jackc/pgx/v5"
@@ -13,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	sdkterminal "github.com/manchtools/power-manage/sdk/go/sys/terminal"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
@@ -32,6 +35,20 @@ type TerminalHandler struct {
 	registry   *registry.Registry // multi-gateway routing; may be nil for single-gateway fallback
 	fallbackURL string             // used only when registry is nil
 	logger     *slog.Logger
+
+	// internalHTTPClient is an mTLS-configured HTTP client used to
+	// call GatewayService on each live gateway for admin fan-out
+	// (ListActiveTerminalSessions, TerminateTerminalSession). Set
+	// via SetInternalHTTPClient at startup. nil means admin RPCs
+	// return Unavailable.
+	internalHTTPClient *http.Client
+}
+
+// SetInternalHTTPClient configures the mTLS HTTP client used for
+// gateway fan-out. Called from main.go with the same mTLS client
+// used for the InternalService proxy.
+func (h *TerminalHandler) SetInternalHTTPClient(c *http.Client) {
+	h.internalHTTPClient = c
 }
 
 // NewTerminalHandler constructs a TerminalHandler.
@@ -311,6 +328,146 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 		"device_id", session.DeviceID,
 	)
 	return connect.NewResponse(&pm.StopTerminalResponse{}), nil
+}
+
+// ListActiveTerminalSessions fans out to every live gateway via the
+// registry and merges the results. Each gateway returns its local
+// session snapshot; the control enriches with user/device metadata
+// from the database and returns the merged list.
+func (h *TerminalHandler) ListActiveTerminalSessions(ctx context.Context, req *connect.Request[pm.ListActiveTerminalSessionsRequest]) (*connect.Response[pm.ListActiveTerminalSessionsResponse], error) {
+	if h.registry == nil || h.internalHTTPClient == nil {
+		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
+			"terminal admin RPCs require a configured registry and internal HTTP client")
+	}
+
+	gateways, err := h.registry.ListGatewayInternalURLs(ctx)
+	if err != nil {
+		h.logger.Error("failed to list gateways for session fan-out", "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable,
+			"failed to enumerate gateways")
+	}
+
+	var (
+		mu       sync.Mutex
+		all      []*pm.TerminalSessionInfo
+		wg       sync.WaitGroup
+	)
+
+	for gwID, gwURL := range gateways {
+		wg.Add(1)
+		go func(gwID, gwURL string) {
+			defer wg.Done()
+			client := pmv1connect.NewGatewayServiceClient(h.internalHTTPClient, gwURL)
+			resp, err := client.ListGatewayTerminalSessions(ctx, connect.NewRequest(&pm.ListGatewayTerminalSessionsRequest{}))
+			if err != nil {
+				h.logger.Warn("gateway fan-out failed",
+					"gateway_id", gwID, "url", gwURL, "error", err)
+				return
+			}
+			mu.Lock()
+			for _, s := range resp.Msg.Sessions {
+				all = append(all, &pm.TerminalSessionInfo{
+					SessionId:      s.SessionId,
+					UserId:         s.UserId,
+					DeviceId:       s.DeviceId,
+					TtyUser:        s.TtyUser,
+					StartedAt:      s.StartedAt,
+					LastActivityAt: s.LastActivityAt,
+					GatewayId:      gwID,
+				})
+			}
+			mu.Unlock()
+		}(gwID, gwURL)
+	}
+	wg.Wait()
+
+	// TODO: enrich with user email / device hostname from DB for
+	// the admin view. For now the IDs are returned directly.
+
+	return connect.NewResponse(&pm.ListActiveTerminalSessionsResponse{
+		Sessions:   all,
+		TotalCount: int32(len(all)),
+	}), nil
+}
+
+// TerminateTerminalSession finds which gateway hosts the session
+// (via the token store's device_id → registry lookup) and calls
+// TerminateGatewayTerminalSession on that gateway.
+func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *connect.Request[pm.TerminateTerminalSessionRequest]) (*connect.Response[pm.TerminateTerminalSessionResponse], error) {
+	if h.registry == nil || h.internalHTTPClient == nil {
+		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
+			"terminal admin RPCs require a configured registry and internal HTTP client")
+	}
+
+	// Look up the session to find the device, then the gateway.
+	session, err := h.tokenStore.Lookup(ctx, req.Msg.SessionId)
+	if err != nil {
+		if errors.Is(err, terminal.ErrTokenNotFound) {
+			return nil, apiErrorCtx(ctx, ErrTokenNotFound, connect.CodeNotFound,
+				"terminal session not found or already ended")
+		}
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+			"failed to look up session")
+	}
+
+	gatewayID, err := h.registry.LookupDeviceGateway(ctx, session.DeviceID)
+	if err != nil {
+		if errors.Is(err, registry.ErrNoGateway) {
+			// Device not connected — session may have already ended.
+			// Revoke the token anyway and return success.
+			_ = h.tokenStore.Revoke(ctx, req.Msg.SessionId)
+			return connect.NewResponse(&pm.TerminateTerminalSessionResponse{}), nil
+		}
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable,
+			"failed to look up gateway for device")
+	}
+
+	gwURL, err := h.registry.LookupGatewayInternalURL(ctx, gatewayID)
+	if err != nil {
+		// Gateway disappeared between lookups. Revoke token and return.
+		_ = h.tokenStore.Revoke(ctx, req.Msg.SessionId)
+		return connect.NewResponse(&pm.TerminateTerminalSessionResponse{}), nil
+	}
+
+	// Call the gateway to terminate the session.
+	client := pmv1connect.NewGatewayServiceClient(h.internalHTTPClient, gwURL)
+	resp, err := client.TerminateGatewayTerminalSession(ctx, connect.NewRequest(&pm.TerminateGatewayTerminalSessionRequest{
+		SessionId: req.Msg.SessionId,
+		Reason:    req.Msg.Reason,
+	}))
+	if err != nil {
+		h.logger.Error("gateway terminate fan-out failed",
+			"gateway_id", gatewayID, "session_id", req.Msg.SessionId, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+			"failed to terminate session on gateway")
+	}
+
+	if !resp.Msg.Found {
+		h.logger.Debug("session not found on gateway (may have ended naturally)",
+			"gateway_id", gatewayID, "session_id", req.Msg.SessionId)
+	}
+
+	// Revoke the token and emit audit event.
+	_ = h.tokenStore.Revoke(ctx, req.Msg.SessionId)
+
+	if err := h.store.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   session.DeviceID,
+		EventType:  "TerminalSessionTerminated",
+		Data: map[string]any{
+			"session_id": session.SessionID,
+			"reason":     req.Msg.Reason,
+		},
+		ActorType: "user",
+		ActorID:   func() string { if u, ok := auth.UserFromContext(ctx); ok { return u.ID }; return "system" }(),
+	}); err != nil {
+		h.logger.Error("failed to append TerminalSessionTerminated event",
+			"session_id", session.SessionID, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+			"failed to persist terminal session termination event")
+	}
+
+	return connect.NewResponse(&pm.TerminateTerminalSessionResponse{}), nil
 }
 
 // GatewayBaseURL normalises the configured gateway URL into the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,12 @@ type Config struct {
 	// sessions won't work but agent connections are unaffected.
 	WebListenAddr string
 
+	// InternalURL is the mTLS URL the control server uses to call
+	// GatewayService RPCs on this gateway for admin fan-out. Published
+	// to the registry so the control server can discover all gateways.
+	// Example: "https://gw-01.internal:8080"
+	InternalURL string
+
 	// Logging
 	LogLevel string
 }
@@ -70,6 +76,7 @@ func FromEnv() *Config {
 		PublicTerminalURLTemplate: getEnv("GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE", ""),
 		BootstrapHost:             getEnv("GATEWAY_BOOTSTRAP_HOST", ""),
 		WebListenAddr:             getEnv("GATEWAY_WEB_LISTEN_ADDR", ""),
+		InternalURL:               getEnv("GATEWAY_INTERNAL_URL", ""),
 		LogLevel:                  getEnv("LOG_LEVEL", "info"),
 	}
 }

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -50,6 +50,7 @@ func (w *InboxWorker) NewMux() *asynq.ServeMux {
 	mux.HandleFunc(taskqueue.TypeSecurityAlert, w.handleSecurityAlert)
 	mux.HandleFunc(taskqueue.TypeRevokeLuksDeviceKeyResult, w.handleRevokeLuksDeviceKeyResult)
 	mux.HandleFunc(taskqueue.TypeLogQueryResult, w.handleLogQueryResult)
+	mux.HandleFunc(taskqueue.TypeTerminalAuditChunk, w.handleTerminalAuditChunk)
 	return mux
 }
 
@@ -658,4 +659,35 @@ func addCommandOutputs(data map[string]any, result *pm.ActionResult) {
 func stableExecutionID(deviceID, actionID, completedAt string) string {
 	h := sha256.Sum256([]byte("exec:" + deviceID + ":" + actionID + ":" + completedAt))
 	return hex.EncodeToString(h[:16])
+}
+
+// handleTerminalAuditChunk persists a terminal stdin chunk as an
+// audit event on the device stream. The gateway tees every binary
+// WebSocket frame (stdin) to this handler so the full input sequence
+// is reconstructable from the event store for forensics / replay.
+func (w *InboxWorker) handleTerminalAuditChunk(ctx context.Context, t *asynq.Task) error {
+	var payload taskqueue.TerminalAuditChunkPayload
+	if err := json.Unmarshal(t.Payload(), &payload); err != nil {
+		return fmt.Errorf("unmarshal terminal audit chunk: %w", err)
+	}
+
+	if payload.SessionID == "" || payload.DeviceID == "" {
+		w.logger.Warn("dropping terminal audit chunk with missing fields",
+			"session_id", payload.SessionID, "device_id", payload.DeviceID)
+		return nil
+	}
+
+	return w.store.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   payload.DeviceID,
+		EventType:  "TerminalInputChunk",
+		Data: map[string]any{
+			"session_id": payload.SessionID,
+			"user_id":    payload.UserID,
+			"data":       payload.Data,
+			"sequence":   payload.Sequence,
+		},
+		ActorType: "user",
+		ActorID:   payload.UserID,
+	})
 }

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -671,9 +671,9 @@ func (w *InboxWorker) handleTerminalAuditChunk(ctx context.Context, t *asynq.Tas
 		return fmt.Errorf("unmarshal terminal audit chunk: %w", err)
 	}
 
-	if payload.SessionID == "" || payload.DeviceID == "" {
+	if payload.SessionID == "" || payload.DeviceID == "" || payload.UserID == "" {
 		w.logger.Warn("dropping terminal audit chunk with missing fields",
-			"session_id", payload.SessionID, "device_id", payload.DeviceID)
+			"session_id", payload.SessionID, "device_id", payload.DeviceID, "user_id", payload.UserID)
 		return nil
 	}
 

--- a/internal/gateway/registry/fake_backend.go
+++ b/internal/gateway/registry/fake_backend.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 )
@@ -70,4 +71,23 @@ func (b *FakeBackend) Delete(ctx context.Context, key string) error {
 	defer b.mu.Unlock()
 	delete(b.values, key)
 	return nil
+}
+
+// ScanPrefix returns all non-expired key-value pairs matching the prefix.
+func (b *FakeBackend) ScanPrefix(ctx context.Context, prefix string) (map[string]string, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	result := make(map[string]string)
+	now := b.now()
+	for k, entry := range b.values {
+		if !strings.HasPrefix(k, prefix) {
+			continue
+		}
+		if !now.Before(entry.expiresAt) {
+			delete(b.values, k)
+			continue
+		}
+		result[k] = entry.value
+	}
+	return result, nil
 }

--- a/internal/gateway/registry/registry.go
+++ b/internal/gateway/registry/registry.go
@@ -65,12 +65,14 @@ var (
 // code uses the typed Registry methods rather than building keys
 // directly.
 const (
-	gatewayKeyPrefix = "pm:gateway:terminal:"
-	deviceKeyPrefix  = "pm:device:gateway:"
+	gatewayKeyPrefix         = "pm:gateway:terminal:"
+	gatewayInternalKeyPrefix = "pm:gateway:internal:"
+	deviceKeyPrefix          = "pm:device:gateway:"
 )
 
-func gatewayKey(gatewayID string) string { return gatewayKeyPrefix + gatewayID }
-func deviceKey(deviceID string) string   { return deviceKeyPrefix + deviceID }
+func gatewayKey(gatewayID string) string         { return gatewayKeyPrefix + gatewayID }
+func gatewayInternalKey(gatewayID string) string  { return gatewayInternalKeyPrefix + gatewayID }
+func deviceKey(deviceID string) string            { return deviceKeyPrefix + deviceID }
 
 // Backend is the storage interface the Registry depends on. Two
 // implementations ship with this package: ValkeyBackend (production)
@@ -86,6 +88,10 @@ type Backend interface {
 	Get(ctx context.Context, key string) (string, error)
 	// Delete removes the key. Idempotent: missing keys return nil.
 	Delete(ctx context.Context, key string) error
+	// ScanPrefix returns all key-value pairs matching the given
+	// prefix. Used by the admin fan-out to enumerate live gateways.
+	// Implementations should filter expired entries.
+	ScanPrefix(ctx context.Context, prefix string) (map[string]string, error)
 }
 
 // Registry is the high-level façade used by gateway and control.
@@ -291,4 +297,61 @@ func (r *Registry) LookupGatewayTerminalURL(ctx context.Context, gatewayID strin
 		return "", fmt.Errorf("registry: lookup gateway URL: %w", err)
 	}
 	return val, nil
+}
+
+// LookupGatewayInternalURL returns the internal mTLS RPC URL for
+// the given gatewayID, or ErrNoGateway if the gateway has expired
+// or never registered its internal URL.
+func (r *Registry) LookupGatewayInternalURL(ctx context.Context, gatewayID string) (string, error) {
+	if gatewayID == "" {
+		return "", errors.New("registry: gatewayID is required")
+	}
+	val, err := r.backend.Get(ctx, gatewayInternalKey(gatewayID))
+	if err != nil {
+		if errors.Is(err, ErrNoGateway) {
+			return "", ErrNoGateway
+		}
+		return "", fmt.Errorf("registry: lookup gateway internal URL: %w", err)
+	}
+	return val, nil
+}
+
+// RegisterGatewayInternal publishes this gateway's internal
+// mTLS-protected RPC URL under pm:gateway:internal:<gatewayID>.
+// The control server uses this to fan out admin RPCs
+// (ListGatewayTerminalSessions, TerminateGatewayTerminalSession)
+// to each live gateway.
+func (r *Registry) RegisterGatewayInternal(ctx context.Context, gatewayID, internalURL string, ttl time.Duration) error {
+	if gatewayID == "" || internalURL == "" {
+		return errors.New("registry: gatewayID and internalURL are required")
+	}
+	if ttl <= 0 {
+		ttl = DefaultGatewayTTL
+	}
+	return r.backend.Set(ctx, gatewayInternalKey(gatewayID), internalURL, ttl)
+}
+
+// DeregisterGatewayInternal removes the internal URL entry.
+func (r *Registry) DeregisterGatewayInternal(ctx context.Context, gatewayID string) error {
+	return r.backend.Delete(ctx, gatewayInternalKey(gatewayID))
+}
+
+// ListGatewayInternalURLs returns a map of gatewayID → internalURL
+// for all currently-live gateways. Used by the control server to
+// fan out admin RPCs. Returns an empty map (not an error) if no
+// gateways are registered.
+func (r *Registry) ListGatewayInternalURLs(ctx context.Context) (map[string]string, error) {
+	raw, err := r.backend.ScanPrefix(ctx, gatewayInternalKeyPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("registry: list gateways: %w", err)
+	}
+	result := make(map[string]string, len(raw))
+	for key, url := range raw {
+		// Strip the prefix to get the gateway ID.
+		gwID := key[len(gatewayInternalKeyPrefix):]
+		if gwID != "" {
+			result[gwID] = url
+		}
+	}
+	return result, nil
 }

--- a/internal/gateway/registry/registry_test.go
+++ b/internal/gateway/registry/registry_test.go
@@ -265,6 +265,10 @@ func (b *countingBackend) Delete(ctx context.Context, key string) error {
 	return b.inner.Delete(ctx, key)
 }
 
+func (b *countingBackend) ScanPrefix(ctx context.Context, prefix string) (map[string]string, error) {
+	return b.inner.ScanPrefix(ctx, prefix)
+}
+
 func (b *countingBackend) SetCalls() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/gateway/registry/valkey_backend.go
+++ b/internal/gateway/registry/valkey_backend.go
@@ -51,3 +51,29 @@ func (b *ValkeyBackend) Delete(ctx context.Context, key string) error {
 	}
 	return nil
 }
+
+// ScanPrefix returns all key-value pairs matching the given prefix.
+// Uses SCAN to avoid blocking the Valkey instance on large keyspaces.
+// Expired keys are filtered natively by Valkey's TTL eviction.
+func (b *ValkeyBackend) ScanPrefix(ctx context.Context, prefix string) (map[string]string, error) {
+	result := make(map[string]string)
+	var cursor uint64
+	for {
+		keys, nextCursor, err := b.client.Scan(ctx, cursor, prefix+"*", 100).Result()
+		if err != nil {
+			return nil, fmt.Errorf("registry: valkey scan: %w", err)
+		}
+		for _, key := range keys {
+			val, err := b.client.Get(ctx, key).Result()
+			if err != nil {
+				continue // key expired between SCAN and GET
+			}
+			result[key] = val
+		}
+		cursor = nextCursor
+		if cursor == 0 {
+			break
+		}
+	}
+	return result, nil
+}


### PR DESCRIPTION
## Summary

The three remaining items needed before the terminal feature can go live. Independent of #40 (gateway WS bridge) and #41 (TTY provisioning) — all three can merge in any order.

## What's in this PR

### 1. Audit chunk consumer

The gateway tees every stdin frame to \`control:inbox\` as \`terminal:audit_chunk\` tasks, but the inbox worker had no handler for them — chunks were silently dropped. Now persisted as \`TerminalInputChunk\` events on the device stream, enabling full keystroke replay for forensics.

### 2. Admin fan-out (ListActiveTerminalSessions + TerminateTerminalSession)

Replaces the last two \`Unimplemented\` stubs on ControlService:

- **ListActiveTerminalSessions**: fans out to all live gateways concurrently via \`ListGatewayInternalURLs\` → ad-hoc \`GatewayServiceClient\` per gateway → merge results. Partial failures (one gateway unreachable) are logged but don't fail the RPC.
- **TerminateTerminalSession**: session → device → gateway → internal URL chain lookup, calls \`TerminateGatewayTerminalSession\` on the owning gateway, revokes the Valkey token, emits \`TerminalSessionTerminated\` audit event.

### 3. Gateway internal URL registry

New \`pm:gateway:internal:<gatewayID>\` key alongside the existing terminal URL key. The control server discovers all gateways via \`ListGatewayInternalURLs\` (uses new \`ScanPrefix\` Backend method). New \`GATEWAY_INTERNAL_URL\` env var.

### 4. compose.yml

All terminal env vars added to both gateway and control service definitions with comments.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./internal/gateway/registry/ -count=1 -race\`
- [x] \`go test ./internal/control/ -count=1 -race\`

## Refs

- manchtools/power-manage-sdk#16
- manchtools/power-manage-server#6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added terminal session management capabilities: list active sessions and terminate sessions remotely.
  * Implemented secure mTLS internal communication for multi-gateway deployments.
  * Introduced terminal activity audit logging for monitoring and compliance.

* **Configuration**
  * Added new environment variables for internal gateway URLs and terminal gateway endpoints in multi-gateway setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->