### PR TITLE
fix: generate valid ULIDs for agent-scheduled execution IDs

### DIFF
--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -3,7 +3,6 @@ package control
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -654,11 +653,15 @@ func addCommandOutputs(data map[string]any, result *pm.ActionResult) {
 // and completed-at timestamp. Including completedAt ensures separate scheduled
 // runs of the same action get unique IDs, while retries of the same result
 // (same completedAt) produce the same ID for deduplication.
-// Note: returns a 32-char hex string, not a ULID. This is intentional —
-// deterministic IDs cannot be ULIDs (which encode timestamps).
+//
+// Returns a valid ULID constructed from the first 16 bytes of a SHA-256 hash.
+// The timestamp portion is not meaningful, but the result is deterministic and
+// passes ULID validation everywhere IDs are checked.
 func stableExecutionID(deviceID, actionID, completedAt string) string {
 	h := sha256.Sum256([]byte("exec:" + deviceID + ":" + actionID + ":" + completedAt))
-	return hex.EncodeToString(h[:16])
+	var id ulid.ULID
+	copy(id[:], h[:16])
+	return id.String()
 }
 
 // handleTerminalAuditChunk persists a terminal stdin chunk as an


### PR DESCRIPTION
## Summary
- `stableExecutionID` was producing 32-char hex strings instead of valid ULIDs, causing `GetExecution` validation failures and action signature verification errors during dispatch
- Now constructs a valid ULID from the same SHA-256 hash bytes — still deterministic for Asynq retry deduplication

## Test plan
- [ ] Verify `go build ./cmd/control` succeeds
- [ ] Verify agent-scheduled executions get valid ULID IDs
- [ ] Verify `GetExecution` works for new executions
- [ ] Existing hex IDs fixed via manual SQL migration

Refs manchtools/power-manage-server#43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal execution identifier generation to use a standardized format, improving consistency and reliability of system operations and logging without affecting public APIs or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->