### PR TITLE
feat: separate agent and terminal hostname templates for multi-gateway

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -143,12 +143,27 @@ func main() {
 
 		// The bootstrap middleware needs the bare assigned hostname
 		// (no scheme, no path) so it can build a redirect Location.
-		// Derive it from the terminal URL.
-		assignedHost = hostFromURL(terminalURL)
-		if assignedHost == "" {
-			logger.Error("could not extract host from GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE",
-				"template", cfg.PublicTerminalURLTemplate, "resolved", terminalURL)
-			os.Exit(1)
+		// When PublicAgentURLTemplate is set, the agent redirect goes
+		// to a different hostname than the terminal WebSocket (needed
+		// when Traefik uses TCP passthrough for agent mTLS and HTTP
+		// termination for terminal WebSocket — they can't share a
+		// hostname). Otherwise fall back to deriving from the terminal
+		// URL (legacy single-hostname mode).
+		if cfg.PublicAgentURLTemplate != "" {
+			agentURL := strings.ReplaceAll(cfg.PublicAgentURLTemplate, "{id}", gatewayID)
+			assignedHost = hostFromURL(agentURL)
+			if assignedHost == "" {
+				logger.Error("could not extract host from GATEWAY_PUBLIC_AGENT_URL_TEMPLATE",
+					"template", cfg.PublicAgentURLTemplate, "resolved", agentURL)
+				os.Exit(1)
+			}
+		} else {
+			assignedHost = hostFromURL(terminalURL)
+			if assignedHost == "" {
+				logger.Error("could not extract host from GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE",
+					"template", cfg.PublicTerminalURLTemplate, "resolved", terminalURL)
+				os.Exit(1)
+			}
 		}
 
 		rdb := redis.NewClient(&redis.Options{
@@ -209,7 +224,7 @@ func main() {
 		logger.Info("multi-gateway routing enabled",
 			"gateway_id", gatewayID,
 			"terminal_url", terminalURL,
-			"assigned_host", assignedHost,
+			"agent_redirect_host", assignedHost,
 			"internal_url", cfg.InternalURL,
 		)
 	}
@@ -218,7 +233,7 @@ func main() {
 	// guard, BootstrapRedirectMiddleware would panic on an empty
 	// assignedHost further down.
 	if cfg.BootstrapHost != "" && assignedHost == "" {
-		logger.Error("GATEWAY_BOOTSTRAP_HOST is set but GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE is empty; cannot derive the per-gateway hostname for bootstrap redirects",
+		logger.Error("GATEWAY_BOOTSTRAP_HOST is set but neither GATEWAY_PUBLIC_AGENT_URL_TEMPLATE nor GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE is set; cannot derive the per-gateway hostname for bootstrap redirects",
 			"bootstrap_host", cfg.BootstrapHost)
 		os.Exit(1)
 	}
@@ -395,8 +410,8 @@ func main() {
 // hostFromURL extracts the host (including port if present) from a
 // URL like "wss://gw-01.example.com:8443/terminal" so the bootstrap
 // redirect middleware constructs a correct Location header that
-// preserves non-default ports. Only ws:// and wss:// schemes are
-// accepted. Returns "" on parse failure, unsupported scheme, or
+// preserves non-default ports. Accepts http, https, ws, and wss
+// schemes. Returns "" on parse failure, unsupported scheme, or
 // missing host component.
 func hostFromURL(raw string) string {
 	if raw == "" {
@@ -406,7 +421,10 @@ func hostFromURL(raw string) string {
 	if err != nil {
 		return ""
 	}
-	if u.Scheme != "ws" && u.Scheme != "wss" {
+	switch u.Scheme {
+	case "http", "https", "ws", "wss":
+		// OK
+	default:
 		return ""
 	}
 	// u.Host includes the port (e.g. "gw-01.example.com:8443").

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -135,29 +135,30 @@ func main() {
 		gatewayReg   *registry.Registry
 		assignedHost string
 	)
+
+	// Compute the agent redirect hostname independently of the terminal
+	// URL. This supports multi-gateway agent routing without requiring
+	// the terminal feature to be enabled.
+	if cfg.PublicAgentURLTemplate != "" {
+		agentURL := strings.ReplaceAll(cfg.PublicAgentURLTemplate, "{id}", gatewayID)
+		assignedHost = hostFromURL(agentURL)
+		if assignedHost == "" {
+			logger.Error("could not extract host from GATEWAY_PUBLIC_AGENT_URL_TEMPLATE",
+				"template", cfg.PublicAgentURLTemplate, "resolved", agentURL)
+			os.Exit(1)
+		}
+	}
+
 	if cfg.PublicTerminalURLTemplate != "" {
 		// Substitute {id} in the URL template. The template is the
 		// public WebSocket URL operators want clients to use; the
 		// gateway never constructs hostnames from the request side.
 		terminalURL := strings.ReplaceAll(cfg.PublicTerminalURLTemplate, "{id}", gatewayID)
 
-		// The bootstrap middleware needs the bare assigned hostname
-		// (no scheme, no path) so it can build a redirect Location.
-		// When PublicAgentURLTemplate is set, the agent redirect goes
-		// to a different hostname than the terminal WebSocket (needed
-		// when Traefik uses TCP passthrough for agent mTLS and HTTP
-		// termination for terminal WebSocket — they can't share a
-		// hostname). Otherwise fall back to deriving from the terminal
-		// URL (legacy single-hostname mode).
-		if cfg.PublicAgentURLTemplate != "" {
-			agentURL := strings.ReplaceAll(cfg.PublicAgentURLTemplate, "{id}", gatewayID)
-			assignedHost = hostFromURL(agentURL)
-			if assignedHost == "" {
-				logger.Error("could not extract host from GATEWAY_PUBLIC_AGENT_URL_TEMPLATE",
-					"template", cfg.PublicAgentURLTemplate, "resolved", agentURL)
-				os.Exit(1)
-			}
-		} else {
+		// If no agent URL template was set, fall back to deriving the
+		// agent redirect hostname from the terminal URL (legacy
+		// single-hostname mode).
+		if assignedHost == "" {
 			assignedHost = hostFromURL(terminalURL)
 			if assignedHost == "" {
 				logger.Error("could not extract host from GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,8 +35,20 @@ type Config struct {
 	// session registration on this gateway (the gateway still
 	// accepts agent connections normally).
 	//
-	// Example: "wss://{id}.gateway.example.com/terminal"
+	// Example: "wss://{id}.terminal.example.com/terminal"
 	PublicTerminalURLTemplate string
+
+	// PublicAgentURLTemplate is the template the gateway uses for
+	// agent mTLS bootstrap redirects. '{id}' is substituted with
+	// GatewayID. When an agent connects to BootstrapHost, the
+	// gateway redirects to this URL so subsequent reconnects go
+	// directly to this gateway instance. Empty means the redirect
+	// hostname is derived from PublicTerminalURLTemplate (legacy
+	// single-hostname mode — only valid when agent mTLS and
+	// terminal traffic can share a hostname).
+	//
+	// Example: "https://{id}.gw.example.com"
+	PublicAgentURLTemplate string
 
 	// BootstrapHost is the wildcard root hostname agents use for
 	// the initial connection before they have an assigned gateway.
@@ -74,6 +86,7 @@ func FromEnv() *Config {
 		ControlURL:                getEnv("GATEWAY_CONTROL_URL", "http://control:8081"),
 		GatewayID:                 getEnv("GATEWAY_ID", ""),
 		PublicTerminalURLTemplate: getEnv("GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE", ""),
+		PublicAgentURLTemplate:    getEnv("GATEWAY_PUBLIC_AGENT_URL_TEMPLATE", ""),
 		BootstrapHost:             getEnv("GATEWAY_BOOTSTRAP_HOST", ""),
 		WebListenAddr:             getEnv("GATEWAY_WEB_LISTEN_ADDR", ""),
 		InternalURL:               getEnv("GATEWAY_INTERNAL_URL", ""),


### PR DESCRIPTION
## Summary
- Add `GATEWAY_PUBLIC_AGENT_URL_TEMPLATE` env var so agent mTLS bootstrap redirects use a different hostname than terminal WebSocket connections
- Required because Traefik can't mix TCP passthrough (agent mTLS) and HTTP TLS termination (terminal WebSocket) on the same hostname
- Falls back to deriving from `GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE` when not set (backwards compatible)
- `hostFromURL` now accepts http/https schemes for agent URLs

## Example config
```
GATEWAY_PUBLIC_AGENT_URL_TEMPLATE=https://{id}.gw.example.com
GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE=wss://{id}.terminal.example.com/terminal
GATEWAY_BOOTSTRAP_HOST=gateway.example.com
```

## Test plan
- [ ] Verify `go build ./cmd/gateway` succeeds
- [ ] Single-gateway: leave agent template empty, terminal template set — assignedHost derived from terminal URL (legacy behavior)
- [ ] Multi-gateway: set both templates — agent redirects go to `*.gw.example.com`, terminal URLs go to `*.terminal.example.com`
- [ ] Verify bootstrap 307 redirect uses agent hostname, not terminal hostname

Refs manchtools/power-manage-server#6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable public agent URL template for bootstrap redirects with dynamic gateway ID substitution.

* **Chores**
  * Broadened URL acceptance to include HTTP and HTTPS in addition to WebSocket schemes.
  * Improved startup host-derivation with conditional fallback between agent and terminal templates.
  * Renamed startup log field for clearer host redirection information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->