### PR TITLE
fix: re-sign action payload with execution ID in dispatchPendingActions

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -457,7 +457,7 @@ func main() {
 		}
 
 		// Build Asynq mux with inbox worker only (search worker runs in indexer binary)
-		inboxWorker := control.NewInboxWorker(st, aqClient, logger.With("component", "inbox_worker"))
+		inboxWorker := control.NewInboxWorker(st, aqClient, actionSigner, logger.With("component", "inbox_worker"))
 		mux := inboxWorker.NewMux()
 
 		// Start Asynq server consuming control:inbox queue only

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/alicebob/miniredis/v2 v2.37.0 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -80,6 +81,7 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/alicebob/miniredis/v2 v2.37.0 h1:RheObYW32G1aiJIj81XVt78ZHJpHonHLHW7OLIshq68=
+github.com/alicebob/miniredis/v2 v2.37.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc h1:biVzkmvwrH8WK8raXaxBx6fRVTlJILwEwQGL1I/ByEI=
 github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
@@ -182,6 +184,8 @@ github.com/tklauser/go-sysconf v0.3.12 h1:0QaGUFOdQaIVdPgfITYzaTegZvdCjmYO52cSFA
 github.com/tklauser/go-sysconf v0.3.12/go.mod h1:Ho14jnntGE1fpdOqQEEaiKRpvIavV0hSfmBq8nJbHYI=
 github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+Fk=
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/yusufpapurcu/wmi v1.2.4 h1:zFUKzehAFReQwLys1b/iSMl+JQGSCSjtVqQn9bBrPo0=
 github.com/yusufpapurcu/wmi v1.2.4/go.mod h1:SBZ9tNy3G9/m5Oi98Zks0QjeHVDvuK0qfxQmPyzfmi0=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -571,20 +571,32 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 		// Action.Id = executionID, so the agent verifies the signature
 		// against the execution ID — not the original action ID the
 		// action was signed with. This mirrors the API dispatch handler.
+		// If signing fails, skip this execution entirely — never enqueue
+		// an unsigned payload that the agent will reject.
 		var signature, paramsCanonical []byte
-		if w.signer != nil && exec.ActionID != nil {
-			if action, err := w.store.Queries().GetActionByID(ctx, *exec.ActionID); err == nil {
-				paramsCanonical = action.ParamsCanonical
-				if paramsCanonical == nil {
-					paramsCanonical = exec.Params
-				}
-				if sig, err := w.signer.Sign(exec.ID, exec.ActionType, paramsCanonical); err == nil {
-					signature = sig
-				} else {
-					logger.Warn("failed to re-sign action for dispatch",
-						"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
-				}
+		if exec.ActionID != nil {
+			if w.signer == nil {
+				logger.Error("cannot dispatch execution without signer",
+					"execution_id", exec.ID, "action_id", *exec.ActionID)
+				continue
 			}
+			action, err := w.store.Queries().GetActionByID(ctx, *exec.ActionID)
+			if err != nil {
+				logger.Error("failed to look up action for re-signing, skipping dispatch",
+					"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
+				continue
+			}
+			paramsCanonical = action.ParamsCanonical
+			if paramsCanonical == nil {
+				paramsCanonical = exec.Params
+			}
+			sig, err := w.signer.Sign(exec.ID, exec.ActionType, paramsCanonical)
+			if err != nil {
+				logger.Error("failed to re-sign action for dispatch, skipping",
+					"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
+				continue
+			}
+			signature = sig
 		}
 
 		// Enqueue to device queue first — only record the event after the

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -22,7 +22,12 @@ import (
 
 // ActionSigner signs action payloads so agents can verify authenticity.
 // The Sign method returns the signature bytes for the given action ID,
-// type, and canonical params JSON. Nil means signing is disabled.
+// type, and canonical params JSON.
+//
+// A nil ActionSigner disables signing globally (development only).
+// Note that dispatchPendingActions requires a non-nil signer and will
+// skip dispatch for any execution that references an action when the
+// signer is nil, since the agent rejects unsigned payloads.
 type ActionSigner interface {
 	Sign(actionID string, actionType int32, paramsJSON []byte) ([]byte, error)
 }
@@ -576,12 +581,14 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 		var signature, paramsCanonical []byte
 		if exec.ActionID != nil {
 			if w.signer == nil {
+				enqueueErrs = append(enqueueErrs, fmt.Errorf("missing signer for execution %s (action %s)", exec.ID, *exec.ActionID))
 				logger.Error("cannot dispatch execution without signer",
 					"execution_id", exec.ID, "action_id", *exec.ActionID)
 				continue
 			}
 			action, err := w.store.Queries().GetActionByID(ctx, *exec.ActionID)
 			if err != nil {
+				enqueueErrs = append(enqueueErrs, fmt.Errorf("load action %s for execution %s: %w", *exec.ActionID, exec.ID, err))
 				logger.Error("failed to look up action for re-signing, skipping dispatch",
 					"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
 				continue
@@ -592,6 +599,7 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			}
 			sig, err := w.signer.Sign(exec.ID, exec.ActionType, paramsCanonical)
 			if err != nil {
+				enqueueErrs = append(enqueueErrs, fmt.Errorf("re-sign execution %s (action %s): %w", exec.ID, *exec.ActionID, err))
 				logger.Error("failed to re-sign action for dispatch, skipping",
 					"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
 				continue

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -20,19 +20,28 @@ import (
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
+// ActionSigner signs action payloads so agents can verify authenticity.
+// The Sign method returns the signature bytes for the given action ID,
+// type, and canonical params JSON. Nil means signing is disabled.
+type ActionSigner interface {
+	Sign(actionID string, actionType int32, paramsJSON []byte) ([]byte, error)
+}
+
 // InboxWorker processes tasks from the control:inbox queue.
 // It replaces the PostgreSQL LISTEN-based Handler for gateway → control messages.
 type InboxWorker struct {
 	store    *store.Store
 	aqClient *taskqueue.Client
+	signer   ActionSigner
 	logger   *slog.Logger
 }
 
 // NewInboxWorker creates a new inbox worker.
-func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, logger *slog.Logger) *InboxWorker {
+func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ActionSigner, logger *slog.Logger) *InboxWorker {
 	return &InboxWorker{
 		store:    st,
 		aqClient: aqClient,
+		signer:   signer,
 		logger:   logger,
 	}
 }
@@ -558,12 +567,23 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			params = exec.Params
 		}
 
-		// Look up the action's signature if this execution references one
+		// Re-sign the action with the execution ID. The gateway sets
+		// Action.Id = executionID, so the agent verifies the signature
+		// against the execution ID — not the original action ID the
+		// action was signed with. This mirrors the API dispatch handler.
 		var signature, paramsCanonical []byte
-		if exec.ActionID != nil {
+		if w.signer != nil && exec.ActionID != nil {
 			if action, err := w.store.Queries().GetActionByID(ctx, *exec.ActionID); err == nil {
-				signature = action.Signature
 				paramsCanonical = action.ParamsCanonical
+				if paramsCanonical == nil {
+					paramsCanonical = exec.Params
+				}
+				if sig, err := w.signer.Sign(exec.ID, exec.ActionType, paramsCanonical); err == nil {
+					signature = sig
+				} else {
+					logger.Warn("failed to re-sign action for dispatch",
+						"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
+				}
 			}
 		}
 

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -564,6 +564,10 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 
 	logger.Debug("found pending executions", "count", len(executions))
 
+	// Cache action lookups — multiple executions may reference the same
+	// action (e.g., system actions assigned to many devices).
+	actionCache := make(map[string][]byte) // actionID → paramsCanonical
+
 	var enqueueErrs []error
 	for _, exec := range executions {
 		// Parse params from []byte to avoid base64 encoding
@@ -576,30 +580,34 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 		// Action.Id = executionID, so the agent verifies the signature
 		// against the execution ID — not the original action ID the
 		// action was signed with. This mirrors the API dispatch handler.
-		// If signing fails, skip this execution entirely — never enqueue
-		// an unsigned payload that the agent will reject.
+		//
+		// Signing failures are permanent (missing signer, deleted action,
+		// broken key) — skip silently rather than returning an error that
+		// would cause Asynq to retry the entire hello handler.
 		var signature, paramsCanonical []byte
 		if exec.ActionID != nil {
 			if w.signer == nil {
-				enqueueErrs = append(enqueueErrs, fmt.Errorf("missing signer for execution %s (action %s)", exec.ID, *exec.ActionID))
 				logger.Error("cannot dispatch execution without signer",
 					"execution_id", exec.ID, "action_id", *exec.ActionID)
 				continue
 			}
-			action, err := w.store.Queries().GetActionByID(ctx, *exec.ActionID)
-			if err != nil {
-				enqueueErrs = append(enqueueErrs, fmt.Errorf("load action %s for execution %s: %w", *exec.ActionID, exec.ID, err))
-				logger.Error("failed to look up action for re-signing, skipping dispatch",
-					"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
-				continue
+			cached, ok := actionCache[*exec.ActionID]
+			if !ok {
+				action, err := w.store.Queries().GetActionByID(ctx, *exec.ActionID)
+				if err != nil {
+					logger.Error("failed to look up action for re-signing, skipping dispatch",
+						"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
+					continue
+				}
+				cached = action.ParamsCanonical
+				actionCache[*exec.ActionID] = cached
 			}
-			paramsCanonical = action.ParamsCanonical
+			paramsCanonical = cached
 			if paramsCanonical == nil {
 				paramsCanonical = exec.Params
 			}
 			sig, err := w.signer.Sign(exec.ID, exec.ActionType, paramsCanonical)
 			if err != nil {
-				enqueueErrs = append(enqueueErrs, fmt.Errorf("re-sign execution %s (action %s): %w", exec.ID, *exec.ActionID, err))
 				logger.Error("failed to re-sign action for dispatch, skipping",
 					"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
 				continue

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/alicebob/miniredis/v2"
 	"github.com/hibiken/asynq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -21,6 +23,36 @@ import (
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
+// fakeSigner records Sign calls so tests can verify the signer
+// was invoked with the correct arguments (execution ID, not action ID).
+type fakeSigner struct {
+	mu    sync.Mutex
+	calls []fakeSignCall
+}
+
+type fakeSignCall struct {
+	ActionID   string
+	ActionType int32
+	ParamsJSON []byte
+}
+
+func (s *fakeSigner) Sign(actionID string, actionType int32, paramsJSON []byte) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls = append(s.calls, fakeSignCall{
+		ActionID:   actionID,
+		ActionType: actionType,
+		ParamsJSON: append([]byte(nil), paramsJSON...),
+	})
+	return []byte("fake-sig-for-" + actionID), nil
+}
+
+func (s *fakeSigner) getCalls() []fakeSignCall {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]fakeSignCall(nil), s.calls...)
+}
+
 func newTask(t *testing.T, typeName string, payload any) *asynq.Task {
 	t.Helper()
 	data, err := json.Marshal(payload)
@@ -30,7 +62,7 @@ func newTask(t *testing.T, typeName string, payload any) *asynq.Task {
 
 func TestHandleDeviceHeartbeat(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "heartbeat-host")
@@ -55,7 +87,7 @@ func TestHandleDeviceHeartbeat(t *testing.T) {
 
 func TestHandleDeviceHeartbeat_DeletedDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "deleted-heartbeat-host")
@@ -83,7 +115,7 @@ func TestHandleDeviceHeartbeat_DeletedDevice(t *testing.T) {
 
 func TestHandleSecurityAlert(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "alert-host")
@@ -117,7 +149,7 @@ func TestHandleSecurityAlert(t *testing.T) {
 
 func TestHandleExecutionResult_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -176,7 +208,7 @@ func TestHandleExecutionResult_Success(t *testing.T) {
 
 func TestHandleExecutionResult_Failed(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -231,7 +263,7 @@ func TestHandleExecutionResult_Failed(t *testing.T) {
 
 func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -260,7 +292,7 @@ func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 
 func TestHandleExecutionOutputChunk(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "chunk-host")
@@ -300,7 +332,7 @@ func TestHandleExecutionOutputChunk(t *testing.T) {
 
 func TestHandleRevokeLuksDeviceKeyResult_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "luks-host")
@@ -318,7 +350,7 @@ func TestHandleRevokeLuksDeviceKeyResult_Success(t *testing.T) {
 
 func TestHandleRevokeLuksDeviceKeyResult_Failure(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "luks-fail-host")
@@ -339,7 +371,7 @@ func TestHandleDeviceHello(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	// handleDeviceHello calls dispatchPendingActions which needs aqClient.
 	// Passing nil is safe here because there are no pending executions to dispatch.
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "hello-host")
@@ -361,7 +393,7 @@ func TestHandleDeviceHello(t *testing.T) {
 
 func TestHandleDeviceHello_DeletedDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "hello-deleted-host")
@@ -386,4 +418,76 @@ func TestHandleDeviceHello_DeletedDevice(t *testing.T) {
 	// Should succeed silently (skip deleted device)
 	err = mux.ProcessTask(context.Background(), task)
 	require.NoError(t, err)
+}
+
+// TestDispatchPendingActions_ReSignsWithExecutionID verifies that when
+// dispatchPendingActions dispatches a pending execution, it re-signs
+// the action payload with the execution ID (not the original action ID).
+// This is critical because the gateway sets Action.Id = executionID,
+// so the agent verifies the signature against the execution ID.
+func TestDispatchPendingActions_ReSignsWithExecutionID(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	mr := miniredis.RunT(t)
+	aqClient := taskqueue.NewClient(mr.Addr(), "", 0)
+	defer aqClient.Close()
+
+	signer := &fakeSigner{}
+	worker := control.NewInboxWorker(st, aqClient, signer, slog.Default())
+	mux := worker.NewMux()
+
+	ctx := context.Background()
+
+	// Setup: create user, device, action, and a pending execution
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "resign-host")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Resign Test", int(pm.ActionType_ACTION_TYPE_USER))
+
+	// Sign the action with the action ID (as the real system does)
+	err := st.Queries().UpdateActionSignature(ctx, db.UpdateActionSignatureParams{
+		ID:              actionID,
+		Signature:       []byte("original-sig-for-action"),
+		ParamsCanonical: []byte(`{"username":"test"}`),
+	})
+	require.NoError(t, err)
+
+	// Create a pending execution for this device+action
+	executionID := testutil.NewID()
+	err = st.AppendEvent(ctx, store.Event{
+		StreamType: "execution",
+		StreamID:   executionID,
+		EventType:  "ExecutionCreated",
+		Data: map[string]any{
+			"device_id":       deviceID,
+			"action_id":       actionID,
+			"action_type":     int(pm.ActionType_ACTION_TYPE_USER),
+			"desired_state":   0,
+			"params":          map[string]any{"username": "test"},
+			"timeout_seconds": 300,
+			"executed_at":     time.Now().Format(time.RFC3339Nano),
+		},
+		ActorType: "user",
+		ActorID:   adminID,
+	})
+	require.NoError(t, err)
+
+	// Verify execution is pending
+	exec, err := st.Queries().GetExecutionByID(ctx, executionID)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", exec.Status)
+
+	// Trigger device hello — this calls dispatchPendingActions internally
+	task := newTask(t, taskqueue.TypeDeviceHello, taskqueue.DeviceHelloPayload{
+		DeviceID:     deviceID,
+		Hostname:     "resign-host",
+		AgentVersion: "1.0.0",
+	})
+	err = mux.ProcessTask(ctx, task)
+	require.NoError(t, err)
+
+	// Verify the signer was called with the EXECUTION ID, not the action ID
+	calls := signer.getCalls()
+	require.Len(t, calls, 1, "signer should be called exactly once for the pending execution")
+	assert.Equal(t, executionID, calls[0].ActionID,
+		"signer must be called with the execution ID (not action ID %s)", actionID)
+	assert.Equal(t, int32(pm.ActionType_ACTION_TYPE_USER), calls[0].ActionType)
 }

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -484,10 +484,13 @@ func TestDispatchPendingActions_ReSignsWithExecutionID(t *testing.T) {
 	err = mux.ProcessTask(ctx, task)
 	require.NoError(t, err)
 
-	// Verify the signer was called with the EXECUTION ID, not the action ID
+	// Verify the signer was called with the EXECUTION ID, not the action ID,
+	// and with the correct canonical params and action type.
 	calls := signer.getCalls()
 	require.Len(t, calls, 1, "signer should be called exactly once for the pending execution")
 	assert.Equal(t, executionID, calls[0].ActionID,
 		"signer must be called with the execution ID (not action ID %s)", actionID)
 	assert.Equal(t, int32(pm.ActionType_ACTION_TYPE_USER), calls[0].ActionType)
+	assert.JSONEq(t, `{"username":"test"}`, string(calls[0].ParamsJSON),
+		"signer must receive the canonical params from the action")
 }


### PR DESCRIPTION
## Summary
- `dispatchPendingActions` was sending the action's original signature (signed over the action ID), but the gateway sets `Action.Id = executionID` — causing agent signature verification failures on reconnect dispatch
- Now re-signs with the execution ID before enqueuing, mirroring the API dispatch handler
- Adds integration test with miniredis verifying the signer receives the execution ID, not the action ID

## Root cause
The gateway always sets `Action.Id = payload.ExecutionID` in `task_handlers.go:69`. The API dispatch path re-signs with the execution ID before enqueuing. But `dispatchPendingActions` (triggered on device hello for pending/dispatched executions) used the action's original signature — signed over the action ID. When the agent verified the signature against `Action.Id` (the execution ID), it failed.

This was a latent bug that became visible when:
1. The Asynq task from the original API dispatch was consumed but the agent disconnected before executing
2. On reconnect, `dispatchPendingActions` re-dispatched with the mismatched signature

## Test plan
- [x] `TestDispatchPendingActions_ReSignsWithExecutionID` — verifies signer is called with execution ID
- [x] All existing inbox worker tests pass
- [ ] Deploy and verify agents no longer get signature errors on reconnect dispatch

Refs manchtools/power-manage-server#43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Internal Improvements**
  - Pending actions are now re-signed at dispatch via an injected signer; executions that cannot be re-signed or resolved are skipped and emit structured logs.

* **Tests**
  - Added a concurrency-safe test double and an integration-style test that verifies re-signing is invoked with the expected identifiers and canonical parameters.

* **Chores**
  - Updated indirect module requirements to support the test infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->