### PR TITLE
fix: server audit Tier 1 — security, concurrency, shutdown correctness

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	urlpkg "net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -272,7 +273,17 @@ func main() {
 		os.Exit(1)
 	}
 	if encryptor == nil {
-		logger.Warn("PM_ENCRYPTION_KEY not set - secrets will be stored unencrypted")
+		// Fail closed: IdP client secrets, LUKS keys, and other
+		// secrets-at-rest rely on this encryptor. Running without a
+		// key would silently degrade security in production. Operators
+		// who truly want unencrypted storage can set
+		// PM_ENCRYPTION_KEY_REQUIRED=false to opt in explicitly.
+		if os.Getenv("PM_ENCRYPTION_KEY_REQUIRED") == "false" {
+			logger.Warn("PM_ENCRYPTION_KEY not set and PM_ENCRYPTION_KEY_REQUIRED=false - secrets will be stored unencrypted")
+		} else {
+			logger.Error("PM_ENCRYPTION_KEY is required (set PM_ENCRYPTION_KEY_REQUIRED=false to opt out)")
+			os.Exit(1)
+		}
 	}
 
 	// Initialize action signer (signs actions so agents can verify authenticity)
@@ -533,7 +544,7 @@ func main() {
 		}
 		server.TLSConfig = &tls.Config{
 			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS12,
+			MinVersion:   tls.VersionTLS13,
 		}
 		if err := http2.ConfigureServer(server, &http2.Server{}); err != nil {
 			logger.Error("failed to configure HTTP/2 for public server", "error", err)
@@ -869,17 +880,17 @@ func runPeriodic(ctx context.Context, interval time.Duration, fn func(), runImme
 }
 
 // maskDatabaseURL masks the password in a database URL for logging.
-func maskDatabaseURL(url string) string {
-	// Simple masking - replace password portion
-	// postgres://user:password@host:port/db -> postgres://user:***@host:port/db
-	for i := 0; i < len(url); i++ {
-		if url[i] == ':' && i > 10 { // Skip the postgres:// part
-			for j := i + 1; j < len(url); j++ {
-				if url[j] == '@' {
-					return url[:i+1] + "***" + url[j:]
-				}
-			}
-		}
+// Uses net/url parsing so URL-encoded credentials (e.g. passwords that
+// contain ':' or '@') are handled correctly; the hand-rolled scan we
+// had before could mangle those edge cases.
+func maskDatabaseURL(raw string) string {
+	u, err := urlpkg.Parse(raw)
+	if err != nil || u.User == nil {
+		return raw
 	}
-	return url
+	if _, hasPassword := u.User.Password(); !hasPassword {
+		return raw
+	}
+	u.User = urlpkg.UserPassword(u.User.Username(), "***")
+	return u.String()
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -125,6 +125,12 @@ func main() {
 		logger.Info("using configured gateway ID", "gateway_id", gatewayID)
 	}
 
+	// Declare the shutdown signal ctx up-front so downstream goroutines
+	// (registry refresh, internal-URL refresh) can derive from it and
+	// exit cleanly on SIGTERM/SIGINT rather than ticking past shutdown.
+	shutdownCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
 	// Wire the multi-gateway registry. Reuses the same Valkey
 	// instance the Asynq queue uses, no extra connection pool. The
 	// registry is enabled only when the operator has set the
@@ -200,9 +206,9 @@ func main() {
 			}
 			// Refresh the internal URL on the same cadence as the
 			// terminal URL so it does not expire while the gateway is
-			// running. Use a dedicated cancel context so the goroutine
-			// stops cleanly on shutdown (shutdownCtx is declared later).
-			internalRefreshCtx, stopInternalRefresh := context.WithCancel(context.Background())
+			// running. Derive from shutdownCtx so the goroutine exits
+			// as soon as a signal arrives.
+			internalRefreshCtx, stopInternalRefresh := context.WithCancel(shutdownCtx)
 			defer stopInternalRefresh()
 			go func() {
 				ticker := time.NewTicker(registry.DefaultGatewayRefreshInterval)
@@ -314,10 +320,6 @@ func main() {
 		logger.Error("failed to configure HTTP/2", "error", err)
 		os.Exit(1)
 	}
-
-	// Graceful shutdown
-	shutdownCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer stop()
 
 	// Start ops server (health checks, no TLS)
 	opsServer := &http.Server{

--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -71,6 +71,9 @@ func (h *DeviceGroupHandler) CreateDeviceGroup(ctx context.Context, req *connect
 
 	// Validate dynamic query if provided
 	if req.Msg.IsDynamic && req.Msg.DynamicQuery != "" {
+		if len(req.Msg.DynamicQuery) > maxDynamicQueryLength {
+			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "dynamic_query exceeds maximum length")
+		}
 		validationErr, err := h.store.Queries().ValidateDynamicQuery(ctx, req.Msg.DynamicQuery)
 		if err != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate query")
@@ -432,6 +435,9 @@ func (h *DeviceGroupHandler) UpdateDeviceGroupQuery(ctx context.Context, req *co
 
 	// Validate dynamic query if provided
 	if req.Msg.IsDynamic && req.Msg.DynamicQuery != "" {
+		if len(req.Msg.DynamicQuery) > maxDynamicQueryLength {
+			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "dynamic_query exceeds maximum length")
+		}
 		validationErr, err := h.store.Queries().ValidateDynamicQuery(ctx, req.Msg.DynamicQuery)
 		if err != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate query")

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -16,6 +16,12 @@ import (
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
+// maxDynamicQueryLength caps the size of user-supplied dynamic-group
+// queries (device groups, user groups). Keeps event-store payload
+// sizes bounded and stops pathological queries from stressing the
+// validator / projector.
+const maxDynamicQueryLength = 10_000
+
 // requireAuth extracts the authenticated user from context.
 // Returns the user context or a standardized unauthenticated error.
 func requireAuth(ctx context.Context) (*auth.UserContext, error) {

--- a/internal/api/registration_handler.go
+++ b/internal/api/registration_handler.go
@@ -77,6 +77,15 @@ func (h *RegistrationHandler) Register(ctx context.Context, req *connect.Request
 		logger.Warn("token max uses reached")
 		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "registration token has reached max uses")
 	}
+	// Defence-in-depth for one-time tokens. The `token.Disabled` check above
+	// already rejects consumed one-time tokens once their TokenDisabled event
+	// has projected, and the event-store optimistic lock at AppendEvent
+	// rejects concurrent consumptions. Rejecting on CurrentUses>0 here fails
+	// fast in the projection-lag window, before the (expensive) CSR signing.
+	if token.OneTime && token.CurrentUses > 0 {
+		logger.Warn("one-time token already used")
+		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "registration token has already been used")
+	}
 
 	// Generate device ID
 	deviceID := ulid.Make().String()

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -66,12 +66,17 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 		pageSize = 50
 	}
 
-	// Parse page token as offset.
+	// Parse page token as offset. Cap the offset to prevent an
+	// attacker or misbehaving client from walking arbitrarily deep
+	// into results (Atoi alone has no ceiling).
+	const maxSearchOffset = 100_000
 	offset := 0
 	if req.Msg.PageToken != "" {
-		if v, err := strconv.Atoi(req.Msg.PageToken); err == nil {
-			offset = v
+		v, err := strconv.Atoi(req.Msg.PageToken)
+		if err != nil || v < 0 || v > maxSearchOffset {
+			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid page token"))
 		}
+		offset = v
 	}
 
 	// Determine which scopes to search.

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -80,6 +80,9 @@ func (h *UserGroupHandler) CreateUserGroup(ctx context.Context, req *connect.Req
 
 	// Validate dynamic query if provided
 	if req.Msg.IsDynamic && req.Msg.DynamicQuery != "" {
+		if len(req.Msg.DynamicQuery) > maxDynamicQueryLength {
+			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "dynamic_query exceeds maximum length")
+		}
 		validationErr, err := h.store.Queries().ValidateUserGroupQuery(ctx, req.Msg.DynamicQuery)
 		if err != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate query")
@@ -590,6 +593,9 @@ func (h *UserGroupHandler) UpdateUserGroupQuery(ctx context.Context, req *connec
 
 	// Validate dynamic query if provided
 	if req.Msg.IsDynamic && req.Msg.DynamicQuery != "" {
+		if len(req.Msg.DynamicQuery) > maxDynamicQueryLength {
+			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "dynamic_query exceeds maximum length")
+		}
 		validationErr, err := h.store.Queries().ValidateUserGroupQuery(ctx, req.Msg.DynamicQuery)
 		if err != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate query")

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -98,6 +98,17 @@ func (ca *CA) IssueCertificateFromCSR(deviceID string, csrPEM []byte) (*Certific
 		return nil, fmt.Errorf("invalid CSR signature: %w", err)
 	}
 
+	// Reject CSRs that request Subject Alternative Names. Agent
+	// certificates are client certs identified by the deviceID in the
+	// Subject CN — DNSNames, IPAddresses, EmailAddresses, and URIs have
+	// no legitimate use here and would otherwise be copied into the
+	// issued cert, letting a malicious agent request SANs for internal
+	// hostnames (e.g. control-server.example.com) that downstream
+	// verifiers might then trust.
+	if len(csr.DNSNames) > 0 || len(csr.IPAddresses) > 0 || len(csr.EmailAddresses) > 0 || len(csr.URIs) > 0 {
+		return nil, fmt.Errorf("CSR must not request subject alternative names")
+	}
+
 	// Generate serial number
 	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	if err != nil {
@@ -118,7 +129,6 @@ func (ca *CA) IssueCertificateFromCSR(deviceID string, csrPEM []byte) (*Certific
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
-		DNSNames:              csr.DNSNames,
 	}
 
 	// Add device ID to the Subject's SerialNumber field

--- a/internal/connection/manager.go
+++ b/internal/connection/manager.go
@@ -26,15 +26,17 @@ type Agent struct {
 
 // Send sends a message to the agent.
 func (a *Agent) Send(msg *pm.ServerMessage) error {
-	// Check if the agent connection has been closed
+	// Acquire the send lock FIRST, then check the context. If we checked
+	// the context before locking, Close() could race in between — cancelling
+	// the ctx while our goroutine still holds a stale "not done" read — and
+	// we'd send on a stream the handler has already declared dead.
+	a.sendMu.Lock()
+	defer a.sendMu.Unlock()
 	select {
 	case <-a.ctx.Done():
 		return ErrAgentNotConnected
 	default:
 	}
-
-	a.sendMu.Lock()
-	defer a.sendMu.Unlock()
 	return a.Stream.Send(msg)
 }
 
@@ -56,9 +58,12 @@ func NewManager() *Manager {
 	}
 }
 
-// Register registers a new agent connection.
-func (m *Manager) Register(deviceID, hostname, version string, stream *connect.BidiStream[pm.AgentMessage, pm.ServerMessage]) *Agent {
-	ctx, cancel := context.WithCancel(context.Background())
+// Register registers a new agent connection. The parent ctx should be
+// the handler's request ctx so the agent's lifetime ends when the RPC
+// ends (graceful shutdown, client disconnect). Close() still cancels
+// independently for Unregister-driven teardown.
+func (m *Manager) Register(parentCtx context.Context, deviceID, hostname, version string, stream *connect.BidiStream[pm.AgentMessage, pm.ServerMessage]) *Agent {
+	ctx, cancel := context.WithCancel(parentCtx)
 
 	agent := &Agent{
 		DeviceID:    deviceID,

--- a/internal/connection/manager_test.go
+++ b/internal/connection/manager_test.go
@@ -1,6 +1,7 @@
 package connection
 
 import (
+	"context"
 	"sync"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 func TestManager_RegisterGet(t *testing.T) {
 	m := NewManager()
 
-	agent := m.Register("device-1", "host1", "1.0.0", nil)
+	agent := m.Register(context.Background(), "device-1", "host1", "1.0.0", nil)
 	assert.Equal(t, "device-1", agent.DeviceID)
 	assert.Equal(t, "host1", agent.Hostname)
 	assert.Equal(t, "1.0.0", agent.Version)
@@ -32,8 +33,8 @@ func TestManager_GetNotFound(t *testing.T) {
 func TestManager_ReplaceExisting(t *testing.T) {
 	m := NewManager()
 
-	agent1 := m.Register("device-1", "host1", "1.0.0", nil)
-	agent2 := m.Register("device-1", "host1", "2.0.0", nil)
+	agent1 := m.Register(context.Background(), "device-1", "host1", "1.0.0", nil)
+	agent2 := m.Register(context.Background(), "device-1", "host1", "2.0.0", nil)
 
 	assert.NotEqual(t, agent1, agent2)
 
@@ -53,7 +54,7 @@ func TestManager_ReplaceExisting(t *testing.T) {
 func TestManager_Unregister(t *testing.T) {
 	m := NewManager()
 
-	agent := m.Register("device-1", "host1", "1.0.0", nil)
+	agent := m.Register(context.Background(), "device-1", "host1", "1.0.0", nil)
 	m.Unregister("device-1")
 
 	_, ok := m.Get("device-1")
@@ -78,10 +79,10 @@ func TestManager_Count(t *testing.T) {
 
 	assert.Equal(t, 0, m.Count())
 
-	m.Register("device-1", "host1", "1.0.0", nil)
+	m.Register(context.Background(), "device-1", "host1", "1.0.0", nil)
 	assert.Equal(t, 1, m.Count())
 
-	m.Register("device-2", "host2", "1.0.0", nil)
+	m.Register(context.Background(), "device-2", "host2", "1.0.0", nil)
 	assert.Equal(t, 2, m.Count())
 
 	m.Unregister("device-1")
@@ -91,9 +92,9 @@ func TestManager_Count(t *testing.T) {
 func TestManager_List(t *testing.T) {
 	m := NewManager()
 
-	m.Register("device-1", "host1", "1.0.0", nil)
-	m.Register("device-2", "host2", "1.0.0", nil)
-	m.Register("device-3", "host3", "1.0.0", nil)
+	m.Register(context.Background(), "device-1", "host1", "1.0.0", nil)
+	m.Register(context.Background(), "device-2", "host2", "1.0.0", nil)
+	m.Register(context.Background(), "device-3", "host3", "1.0.0", nil)
 
 	ids := m.List()
 	assert.Len(t, ids, 3)
@@ -107,7 +108,7 @@ func TestManager_IsConnected(t *testing.T) {
 
 	assert.False(t, m.IsConnected("device-1"))
 
-	m.Register("device-1", "host1", "1.0.0", nil)
+	m.Register(context.Background(), "device-1", "host1", "1.0.0", nil)
 	assert.True(t, m.IsConnected("device-1"))
 
 	m.Unregister("device-1")
@@ -117,7 +118,7 @@ func TestManager_IsConnected(t *testing.T) {
 func TestManager_UpdateLastSeen(t *testing.T) {
 	m := NewManager()
 
-	agent := m.Register("device-1", "host1", "1.0.0", nil)
+	agent := m.Register(context.Background(), "device-1", "host1", "1.0.0", nil)
 	initial := agent.LastSeen
 
 	m.UpdateLastSeen("device-1")
@@ -140,7 +141,7 @@ func TestManager_SendNotConnected(t *testing.T) {
 func TestManager_Context(t *testing.T) {
 	m := NewManager()
 
-	m.Register("device-1", "host1", "1.0.0", nil)
+	m.Register(context.Background(), "device-1", "host1", "1.0.0", nil)
 
 	ctx, ok := m.Context("device-1")
 	require.True(t, ok)
@@ -162,7 +163,7 @@ func TestManager_ConcurrentAccess(t *testing.T) {
 		wg.Add(1)
 		go func(id string) {
 			defer wg.Done()
-			m.Register(id, "host", "1.0.0", nil)
+			m.Register(context.Background(), id, "host", "1.0.0", nil)
 		}(string(rune('a' + i)))
 	}
 

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -595,6 +595,30 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			if !ok {
 				action, err := w.store.Queries().GetActionByID(ctx, *exec.ActionID)
 				if err != nil {
+					if errors.Is(err, pgx.ErrNoRows) {
+						// Action was deleted after the execution was created.
+						// Mark the execution failed so it leaves the "pending"
+						// state — otherwise every reconnect retries dispatch
+						// and re-logs the same error forever.
+						logger.Warn("action for pending execution no longer exists; failing execution",
+							"execution_id", exec.ID, "action_id", *exec.ActionID)
+						if appendErr := w.store.AppendEvent(ctx, store.Event{
+							StreamType: "execution",
+							StreamID:   exec.ID,
+							EventType:  "ExecutionFailed",
+							Data: map[string]any{
+								"error":        "action was deleted before the device came online",
+								"duration_ms":  int64(0),
+								"completed_at": time.Now().UTC().Format(time.RFC3339Nano),
+							},
+							ActorType: "system",
+							ActorID:   "dispatcher",
+						}); appendErr != nil {
+							logger.Error("failed to mark orphaned execution as failed",
+								"execution_id", exec.ID, "error", appendErr)
+						}
+						continue
+					}
 					logger.Error("failed to look up action for re-signing, skipping dispatch",
 						"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
 					continue

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -273,7 +273,7 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 	)
 
 	// Register the agent connection
-	agent := h.manager.Register(deviceID, hello.Hostname, hello.AgentVersion, stream)
+	agent := h.manager.Register(ctx, deviceID, hello.Hostname, hello.AgentVersion, stream)
 
 	// Publish the device→gateway mapping in the multi-gateway
 	// registry so ControlService.StartTerminal can route the user's

--- a/internal/handler/terminal_bridge.go
+++ b/internal/handler/terminal_bridge.go
@@ -375,6 +375,13 @@ func (h *TerminalBridgeHandler) bridgeAgentToWS(
 						"error", p.TerminalStateChange.Error)
 					return fmt.Errorf("agent error: %s", p.TerminalStateChange.Error)
 				}
+			default:
+				// Agents are only supposed to route TerminalOutput and
+				// TerminalStateChange into a terminal session's channel.
+				// Anything else is a protocol violation and would
+				// otherwise vanish silently.
+				logger.Warn("unexpected message type in terminal output channel",
+					"type", fmt.Sprintf("%T", p))
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Tier 1 findings from the CodeRabbit-style server audit. Split into three themed commits for reviewability; every fix is independent and any one can revert cleanly.

Tier 2 validation notes and a follow-up hardening issue are tracked at #53.

## Commit 1 — security hardening (\`47ef1d1\`)

- **registration_handler**: reject one-time tokens with CurrentUses > 0 before CSR signing. Defence-in-depth; the existing \`token.Disabled\` + event-store optimistic lock already prevent real reuse, but this fails fast in the projection-lag window.
- **ca**: reject CSRs requesting Subject Alternative Names. Agent certs are CN-identified — copying \`csr.DNSNames\` verbatim into the issued cert let a malicious agent request SANs for internal hostnames that downstream verifiers might trust.
- **device_group / user_group handlers**: cap \`dynamic_query\` at 10 000 chars before validation. Untrusted input that ends up on the event stream is now length-bounded.
- **search_handler**: cap pagination offset at 100 000 instead of accepting any integer from \`strconv.Atoi\`.

## Commit 2 — concurrency and lifecycle (\`2e18f72\`)

- **connection.Agent.Send**: acquire \`sendMu\` before checking \`ctx.Done()\` — prior order had a TOCTOU window where \`Close()\` could cancel ctx between the check and the lock.
- **connection.Manager.Register**: derive agent ctx from a parent ctx argument (the handler's RPC ctx), not \`context.Background()\`. Agent lifetime now ends when the handler goroutine does. Signature change ripples to \`handler/agent.go\` and the unit tests.
- **handler/terminal_bridge.bridgeAgentToWS**: add a \`default\` branch to the type switch. Unknown agent message types are now logged rather than silently dropped.
- **control/inbox_worker.dispatchPendingActions**: mark execution failed via \`ExecutionFailed\` event when \`GetActionByID\` returns \`pgx.ErrNoRows\`. Fixes the "stuck pending forever" loop that re-ran the same orphaned execution on every reconnect.

## Commit 3 — startup and shutdown (\`15244c3\`)

- **cmd/control**: raise public-listener \`MinVersion\` from TLS 1.2 to 1.3, matching the internal mTLS listener.
- **cmd/control**: fail closed when \`PM_ENCRYPTION_KEY\` is unset. Operators who genuinely want plaintext secret storage can opt in with \`PM_ENCRYPTION_KEY_REQUIRED=false\`.
- **cmd/control**: rewrite \`maskDatabaseURL\` with \`net/url.Parse\` rather than a hand-rolled scan that mangled URL-encoded passwords.
- **cmd/gateway**: declare \`shutdownCtx\` early and derive the internal-URL refresh goroutine from it. Previously that goroutine ticked past SIGTERM until the function-exit defer ran.

## Audit findings ruled out

Several subagent-flagged items were verified as false positives against the current code:

- \`RebuildSearchIndex\` "missing auth": the \`AuthzInterceptor\` chain at \`cmd/control/main.go:505\` already gates every non-public RPC against \`HasPermission(procedureName)\`, and \`RebuildSearchIndex\` is a registered permission.
- OIDC \`redirect_uri\` whitelist: the \`auth_states\` row captures the exact URI at login time and the callback re-reads it; combined with IdP-side pre-registration this is already the standard mitigation.
- SCIM cross-provider authz bypass: \`bcrypt.CompareHashAndPassword\` at \`scim/auth.go:79\` binds the token to the slug's stored hash.
- SCIM slug enumeration via status codes: all failure paths return 401.
- TOTP / backup-code timing: \`pquerna/otp\` and \`bcrypt\` are constant-time; loop-index leak only reveals which of the attacker's own codes matched.
- Redis pipeline error silencing in search-index warm: intentional best-effort; reconciliation restores state.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -short ./internal/ca/ ./internal/connection/ ./internal/mtls/ ./internal/auth/totp/\`
- [ ] Integration: re-run testcontainers suite on CI
- [ ] Manual: start control with PM_ENCRYPTION_KEY unset — verify fail-closed behaviour
- [ ] Manual: verify \`GATEWAY_ID\`-enabled gateway shuts down cleanly on SIGTERM without ticking refresh logs

## Follow-up

- #53 — SCIM rate limiting per-token + bcrypt cost parity (backlog, not blocking)