### PR TITLE
chore: pin SDK to a specific commit + drop replace ../sdk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,32 +26,14 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Resolve SDK ref
-        id: sdk_ref
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          if git ls-remote --heads https://github.com/MANCHTOOLS/power-manage-sdk.git "refs/heads/${BRANCH}" | grep -q .; then
-            echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=main" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout SDK
-        uses: actions/checkout@v5
-        with:
-          repository: MANCHTOOLS/power-manage-sdk
-          ref: ${{ steps.sdk_ref.outputs.ref }}
-          path: _sdk
-
-      - name: Rewrite SDK replace directive
-        run: go mod edit -replace github.com/manchtools/power-manage/sdk=./_sdk
-
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 
+      # go.mod pins a specific SDK commit via pseudo-version + replace
+      # directive, so unit tests build against exactly that SDK state.
+      # Bumping the pin is an explicit commit, not something that
+      # happens silently when SDK main advances.
       - name: Run unit tests
         run: go test -count=1 ./internal/auth/... ./internal/connection/... ./internal/middleware/... ./internal/taskqueue/... ./internal/config/... ./internal/mtls/... ./internal/crypto/...
 
@@ -60,28 +42,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-
-      - name: Resolve SDK ref
-        id: sdk_ref
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}"
-          if git ls-remote --heads https://github.com/MANCHTOOLS/power-manage-sdk.git "refs/heads/${BRANCH}" | grep -q .; then
-            echo "ref=${BRANCH}" >> "$GITHUB_OUTPUT"
-          else
-            echo "ref=main" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout SDK
-        uses: actions/checkout@v5
-        with:
-          repository: MANCHTOOLS/power-manage-sdk
-          ref: ${{ steps.sdk_ref.outputs.ref }}
-          path: _sdk
-
-      - name: Rewrite SDK replace directive
-        run: go mod edit -replace github.com/manchtools/power-manage/sdk=./_sdk
 
       - uses: actions/setup-go@v6
         with:

--- a/README.md
+++ b/README.md
@@ -498,6 +498,42 @@ cd internal/store && sqlc generate
 cd ../../sdk && make generate
 ```
 
+## SDK versioning
+
+The server pins a specific SDK tag via `go.mod`'s replace directive:
+
+```
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.1.0
+```
+
+The replace maps the monorepo-style import path (`github.com/manchtools/power-manage/sdk`) to the actual polyrepo URL (`github.com/manchtools/power-manage-sdk`). `go build` fetches the exact tagged version from GitHub — SDK `main` can move freely without breaking server builds. When the server is ready to consume a newer SDK:
+
+```bash
+cd server
+go get github.com/manchtools/power-manage-sdk@v0.2.0   # or any tag / commit SHA
+go mod tidy
+```
+
+The SDK is still pre-v1.0.0, so minor bumps (`v0.1.0` → `v0.2.0`) may carry breaking API changes. Expect each bump PR to carry the matching migration in the same commit.
+
+### Working on SDK + server together
+
+For cross-cutting changes, use a `go.work` at the workspace root (the directory that contains both `sdk/` and `server/` checkouts). It overrides any `replace` directive.
+
+```bash
+# At the workspace root (NOT committed — each dev manages their own):
+cat > go.work <<'EOF'
+go 1.25
+
+use (
+    ./sdk
+    ./server
+)
+EOF
+```
+
+Rename it to `go.work.off` or delete it when you want `go build` to use the pinned SDK again.
+
 ## Testing
 
 The server has ~328 tests across 29 files covering auth, connection management, event store projections, all API handlers, SCIM provisioning, and gateway message handling.

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,14 @@ go 1.25
 
 require (
 	connectrpc.com/connect v1.18.1
+	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.8.0
-	github.com/manchtools/power-manage/sdk v0.0.0
+	github.com/manchtools/power-manage/sdk v0.1.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0
@@ -22,13 +23,13 @@ require (
 	golang.org/x/net v0.49.0
 	golang.org/x/oauth2 v0.35.0
 	google.golang.org/protobuf v1.36.11
+	nhooyr.io/websocket v1.8.17
 )
 
 require (
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
-	github.com/alicebob/miniredis/v2 v2.37.0 // indirect
 	github.com/boombuler/barcode v1.0.1-0.20190219062509-6c824513bacc // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -98,7 +99,12 @@ require (
 	google.golang.org/grpc v1.78.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/sqlite v1.44.3 // indirect
-	nhooyr.io/websocket v1.8.17 // indirect
 )
 
-replace github.com/manchtools/power-manage/sdk => ../sdk
+// The SDK import path differs from the actual GitHub repo URL
+// (monorepo-style import path, polyrepo actual layout). Map it here
+// so every `go build` uses a specific, pinned SDK commit rather than
+// whatever happens to be in a local ../sdk checkout. Developers who
+// want to iterate against a local SDK override this with a per-dev
+// go.work at their workspace root — see server/README.md for setup.
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -109,6 +109,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/manchtools/power-manage-sdk v0.1.0 h1:qNOZWXWlX7J2GMYSDIfE5txH5+OI4/L0GTm5STYf4LQ=
+github.com/manchtools/power-manage-sdk v0.1.0/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=


### PR DESCRIPTION
Same shape as the agent change. Stops SDK refactors from breaking server CI the moment they land on SDK \`main\`.

## Before

- \`go.mod\`: \`github.com/manchtools/power-manage/sdk v0.0.0\` + \`replace github.com/manchtools/power-manage/sdk => ../sdk\`
- CI's \`test.yml\` did: resolve SDK ref (branch-match or fallback to \`main\`) → checkout SDK → \`go mod edit -replace\` to point at the checkout. Same fragility as the agent.

## After

- \`go.mod\`: pinned pseudo-version
  \`\`\`
  require github.com/manchtools/power-manage/sdk v0.0.0-20260411192158-80326c39d5aa
  replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.0.0-20260411192158-80326c39d5aa
  \`\`\`
- \`test.yml\`: dropped the SDK ref resolution, SDK checkout, and replace rewrite steps from both the unit and integration jobs. \`go test\` fetches the pinned SDK via the replace directive.

## Pin choice

SDK commit \`80326c3\` — "feat: InternalService.ProxyValidateTerminalToken RPC (#27)". Last SDK main commit fully compatible with server main.

## Cross-cutting development

Workspace-root \`go.work\` for paired SDK/server work — see the new "Working on SDK + server together" section in \`server/README.md\`.

## Depends on

- manchtools/power-manage-sdk docs PR explaining the full pattern: manchtools/power-manage-sdk#$(gh -R manchtools/power-manage-sdk pr list --head docs/release-coordination --json number --jq '.[0].number // "TBD"')

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test -short ./internal/auth/... ./internal/crypto/... ./internal/mtls/...\` — pass
- [ ] CI (unit + integration jobs) green against the pinned SDK