### PR TITLE
feat: bcrypt parity + gateway self-registration into Traefik (#53)

### DIFF
--- a/cmd/gateway/README.md
+++ b/cmd/gateway/README.md
@@ -59,12 +59,32 @@ The Gateway Server:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GATEWAY_LISTEN_ADDR` | `:8080` | Listen address |
+| `GATEWAY_LISTEN_ADDR` | `:8080` | Listen address for the agent mTLS listener |
+| `GATEWAY_WEB_LISTEN_ADDR` | (empty) | Listen address for the TTY WebSocket listener (empty disables the terminal feature) |
 | `VALKEY_ADDR` | `localhost:6379` | Valkey/Redis address for Asynq task queue |
 | `VALKEY_PASSWORD` | (empty) | Valkey/Redis password |
 | `VALKEY_DB` | `0` | Valkey/Redis database number |
 | `GATEWAY_CONTROL_URL` | `http://control:8081` | Control Server URL for Connect-RPC proxy |
+| `GATEWAY_ID` | (auto-ULID) | Stable gateway identifier; auto-generated per process when empty (required for replica scaling) |
+| `GATEWAY_INTERNAL_URL` | (empty) | mTLS URL the control server uses for admin fan-out RPCs |
 | `LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
+
+#### Traefik self-registration (Redis KV)
+
+When enabled, each gateway replica publishes its own routing entries into Traefik's Redis KV provider. This removes the need for per-replica Traefik labels in compose and lets `docker compose up --scale gateway=N` (or k8s replica sets) add instances with zero operator touch per replica. The shared mTLS TCP router is load-balanced across all replicas; each replica owns a `/gw/<id>` path on the TTY host for session-specific routing.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GATEWAY_TRAEFIK_SELF_REGISTER` | `false` | Enable self-registration. All of the other `GATEWAY_TRAEFIK_*` fields are required when true. |
+| `GATEWAY_TRAEFIK_ROOT_KEY` | `traefik` | Matches Traefik's `--providers.redis.rootkey`. |
+| `GATEWAY_TRAEFIK_MTLS_HOST` | — | Public `HostSNI` for agent mTLS, e.g. `gateway.example.com`. |
+| `GATEWAY_TRAEFIK_MTLS_BACKEND` | auto | Internal `host:port` for this replica's mTLS listener. Auto-derived from `os.Hostname()` + `GATEWAY_LISTEN_ADDR` when empty. |
+| `GATEWAY_TRAEFIK_MTLS_ENTRYPOINT` | — | Traefik entrypoint the TCP router binds to, e.g. `mtls`. |
+| `GATEWAY_TRAEFIK_TTY_HOST` | — | Public `Host` for TTY, e.g. `tty.example.com`. |
+| `GATEWAY_TRAEFIK_TTY_BACKEND` | auto | Internal URL for this replica's TTY listener. Auto-derived from `os.Hostname()` + `GATEWAY_WEB_LISTEN_ADDR` when empty. |
+| `GATEWAY_TRAEFIK_TTY_ENTRYPOINT` | — | Traefik entrypoint the TTY router binds to, e.g. `websecure`. |
+
+All Traefik keys share the registry TTL (45 s default) and are refreshed on the same cadence as the gateway terminal-URL entry. Graceful shutdown revokes only per-replica keys; shared router keys expire naturally when the last replica stops. See `server/deploy/compose.yml` for the matching Traefik command flags.
 
 ## Setup
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -235,6 +235,110 @@ func main() {
 			"internal_url", cfg.InternalURL,
 		)
 	}
+
+	// Traefik Redis-KV self-registration. Opt-in; when enabled, every
+	// replica writes its own routing entry into the same Valkey
+	// instance Traefik watches via `--providers.redis`, so scaling the
+	// gateway deployment does not require hand-edited labels or per-
+	// replica public DNS entries. The shared pm-mtls TCP router is
+	// load-balanced across all replicas; each replica owns a unique
+	// /gw/<id> path prefix on the shared tty host for TTY routing.
+	if cfg.TraefikSelfRegister {
+		if gatewayReg == nil {
+			// Need a Valkey-backed registry. When PublicTerminalURLTemplate
+			// was empty we skipped the Valkey connection earlier; set one
+			// up here so Traefik self-reg still works in deployments that
+			// only want the routing layer (no terminal feature).
+			rdb := redis.NewClient(&redis.Options{
+				Addr:     cfg.ValkeyAddr,
+				Password: cfg.ValkeyPassword,
+				DB:       cfg.ValkeyDB,
+				Protocol: 2,
+			})
+			defer rdb.Close()
+			gatewayReg = registry.New(registry.NewValkeyBackend(rdb), logger.With("component", "registry"))
+		}
+
+		// Auto-derive per-replica backend addresses when not set.
+		// In Compose / k8s, os.Hostname() returns the container name
+		// (pm-server-gateway-1, gateway-abc123, …), which resolves to
+		// that specific replica's IP inside the pm-internal network.
+		// The operator only has to set the public Host/EntryPoint
+		// values; replica identity is self-discovered.
+		mtlsBackend := cfg.TraefikMTLSBackend
+		ttyBackend := cfg.TraefikTTYBackend
+		if mtlsBackend == "" || ttyBackend == "" {
+			hostname, err := os.Hostname()
+			if err != nil || hostname == "" {
+				logger.Error("cannot auto-derive Traefik backends: os.Hostname failed", "error", err)
+				os.Exit(1)
+			}
+			if mtlsBackend == "" {
+				mtlsBackend = hostname + portOfListenAddr(cfg.ListenAddr)
+			}
+			if ttyBackend == "" && cfg.WebListenAddr != "" {
+				ttyBackend = "http://" + hostname + portOfListenAddr(cfg.WebListenAddr)
+			}
+		}
+
+		traefikCfg := registry.TraefikRouteConfig{
+			RootKey:        cfg.TraefikRootKey,
+			MTLSHost:       cfg.TraefikMTLSHost,
+			MTLSBackend:    mtlsBackend,
+			MTLSEntryPoint: cfg.TraefikMTLSEntryPoint,
+			TTYHost:        cfg.TraefikTTYHost,
+			TTYBackend:     ttyBackend,
+			TTYEntryPoint:  cfg.TraefikTTYEntryPoint,
+		}
+
+		if err := gatewayReg.PublishTraefikRoute(
+			context.Background(), gatewayID, traefikCfg, registry.DefaultGatewayTTL,
+		); err != nil {
+			logger.Error("failed to publish Traefik routing config", "error", err)
+			os.Exit(1)
+		}
+
+		// Refresh on the same cadence as the gateway terminal URL and
+		// internal URL so all three keys share a lifecycle. Derive from
+		// shutdownCtx so the goroutine exits cleanly on SIGTERM.
+		traefikRefreshCtx, stopTraefikRefresh := context.WithCancel(shutdownCtx)
+		defer stopTraefikRefresh()
+		go func() {
+			ticker := time.NewTicker(registry.DefaultGatewayRefreshInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					if err := gatewayReg.PublishTraefikRoute(
+						context.Background(), gatewayID, traefikCfg, registry.DefaultGatewayTTL,
+					); err != nil {
+						logger.Warn("failed to refresh Traefik routing config", "error", err)
+					}
+				case <-traefikRefreshCtx.Done():
+					return
+				}
+			}
+		}()
+
+		// Clean shutdown revokes only per-replica keys so other
+		// replicas' routes stay up. Uses a bounded context so a flaky
+		// Valkey can't stall the shutdown.
+		defer func() {
+			cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := gatewayReg.RevokeTraefikRoute(cleanupCtx, gatewayID, traefikCfg); err != nil {
+				logger.Warn("failed to revoke Traefik routing config", "error", err)
+			}
+		}()
+
+		logger.Info("traefik self-registration enabled",
+			"gateway_id", gatewayID,
+			"mtls_host", cfg.TraefikMTLSHost,
+			"mtls_backend", cfg.TraefikMTLSBackend,
+			"tty_host", cfg.TraefikTTYHost,
+			"tty_backend", cfg.TraefikTTYBackend,
+		)
+	}
 	// Fail fast if BootstrapHost is set but we have no assignedHost
 	// (because PublicTerminalURLTemplate was empty). Without this
 	// guard, BootstrapRedirectMiddleware would panic on an empty
@@ -408,6 +512,21 @@ func main() {
 	}
 
 	logger.Info("server stopped")
+}
+
+// portOfListenAddr returns the port portion of a Go net.Listen style
+// address (":8080", "0.0.0.0:8080", "[::]:8080") formatted as
+// ":port" for concatenation with a hostname. Returns "" if the input
+// has no parseable port.
+func portOfListenAddr(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	idx := strings.LastIndex(addr, ":")
+	if idx < 0 {
+		return ""
+	}
+	return addr[idx:]
 }
 
 // hostFromURL extracts the host (including port if present) from a

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -35,8 +35,15 @@ ADMIN_PASSWORD=CHANGE_ME_use_a_strong_password
 # Public domain for the control server (Web UI and API)
 CONTROL_DOMAIN=power-manage.example.com
 
-# Public domain for the gateway (agent mTLS connections)
+# Public domain for the gateway (agent mTLS connections). Agents connect to
+# this hostname on port 8443 (TCP passthrough for the mTLS handshake).
 GATEWAY_DOMAIN=gateway.example.com
+
+# Public domain for TTY WebSocket traffic. Defaults to GATEWAY_DOMAIN when
+# unset, so single-domain deployments just leave this empty. Each gateway
+# replica takes a /gw/<id> path prefix on this host for session-specific
+# routing.
+# GATEWAY_TTY_DOMAIN=tty.example.com
 
 # =============================================================================
 # TLS / Let's Encrypt
@@ -108,3 +115,14 @@ LOG_LEVEL=info
 # --- Docker Images ----------------------------------------------------------
 # Tag for control, gateway, and indexer images (default: latest)
 # IMAGE_TAG=latest
+
+# --- Gateway scaling (Traefik Redis KV self-registration) -------------------
+# Enabled by default in compose.yml. When true, each gateway replica writes
+# its own Traefik routing entry into Valkey at startup so scaling via
+# `docker compose up --scale gateway=N` works without per-replica labels.
+# Set to false only when migrating back to static Traefik labels.
+# GATEWAY_TRAEFIK_SELF_REGISTER=true
+
+# Traefik root key in Valkey. Must match --providers.redis.rootkey in the
+# Traefik command. Default matches the one set in compose.yml.
+# GATEWAY_TRAEFIK_ROOT_KEY=traefik

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -18,23 +18,41 @@ services:
     image: docker.io/traefik:v3
     container_name: pm-traefik
     restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
+    depends_on:
+      valkey:
+        condition: service_healthy
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./data/traefik:/letsencrypt
     command:
+      # Docker provider stays for the non-gateway services
+      # (control, indexer) that don't scale horizontally.
       - "--providers.docker=true"
       - "--providers.docker.exposedbydefault=false"
       - "--providers.docker.network=pm-internal"
+      # Redis KV provider — each gateway replica self-registers its
+      # routing config into Valkey at startup (see
+      # server/cmd/gateway/main.go). Lets `docker compose up
+      # --scale gateway=N` work without per-replica labels.
+      - "--providers.redis=true"
+      - "--providers.redis.endpoints=valkey:6379"
+      - "--providers.redis.password=${VALKEY_PASSWORD}"
+      - "--providers.redis.rootkey=traefik"
       - "--entrypoints.web.address=:80"
       - "--entrypoints.websecure.address=:443"
+      # Dedicated entrypoint for agent mTLS passthrough. Agents
+      # connect to ${GATEWAY_DOMAIN}:8443; Traefik TCP-routes by SNI
+      # to whichever gateway replica is in the pm-mtls pool.
+      - "--entrypoints.mtls.address=:8443"
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
       - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
       - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
       - "--certificatesresolvers.letsencrypt.acme.httpchallenge.entrypoint=web"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8443:8443"
     networks:
       - internal
 
@@ -153,8 +171,10 @@ services:
       - internal
 
   gateway:
+    # No container_name: scaling to N replicas needs Compose to auto-name
+    # containers (pm-server-gateway-1, -2, ...). Self-registration into
+    # Traefik's Redis KV means no per-replica Traefik labels are needed.
     image: ghcr.io/manchtools/power-manage-gateway:${IMAGE_TAG:-latest}
-    container_name: pm-gateway
     restart: unless-stopped
     depends_on:
       valkey:
@@ -170,12 +190,23 @@ services:
       - GATEWAY_LISTEN_ADDR=:8080
       - LOG_LEVEL=${LOG_LEVEL:-info}
       # Remote terminal (multi-gateway routing). Leave empty to disable.
-      # GATEWAY_ID is auto-generated as a ULID if empty.
+      # GATEWAY_ID is auto-generated as a ULID if empty; when scaling
+      # replicas, leave it empty so each container gets its own ID.
       - GATEWAY_ID=${GATEWAY_ID:-}
       - GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE=${GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE:-}
       - GATEWAY_BOOTSTRAP_HOST=${GATEWAY_BOOTSTRAP_HOST:-}
       - GATEWAY_WEB_LISTEN_ADDR=${GATEWAY_WEB_LISTEN_ADDR:-}
       - GATEWAY_INTERNAL_URL=${GATEWAY_INTERNAL_URL:-}
+      # Traefik self-registration via Redis KV. Each replica publishes
+      # its own routing entry; backend host:port values are auto-
+      # derived from the container's hostname + listener ports when
+      # not set explicitly, which is exactly what scaling needs.
+      - GATEWAY_TRAEFIK_SELF_REGISTER=${GATEWAY_TRAEFIK_SELF_REGISTER:-true}
+      - GATEWAY_TRAEFIK_ROOT_KEY=${GATEWAY_TRAEFIK_ROOT_KEY:-traefik}
+      - GATEWAY_TRAEFIK_MTLS_HOST=${GATEWAY_DOMAIN}
+      - GATEWAY_TRAEFIK_MTLS_ENTRYPOINT=mtls
+      - GATEWAY_TRAEFIK_TTY_HOST=${GATEWAY_TTY_DOMAIN:-${GATEWAY_DOMAIN}}
+      - GATEWAY_TRAEFIK_TTY_ENTRYPOINT=websecure
     command:
       - "-tls-cert=/certs/gateway.crt"
       - "-tls-key=/certs/gateway.key"
@@ -185,12 +216,6 @@ services:
       interval: 10s
       timeout: 5s
       retries: 3
-    labels:
-      - "traefik.enable=true"
-      - "traefik.tcp.routers.gateway.rule=HostSNI(`${GATEWAY_DOMAIN}`)"
-      - "traefik.tcp.routers.gateway.entrypoints=websecure"
-      - "traefik.tcp.routers.gateway.tls.passthrough=true"
-      - "traefik.tcp.services.gateway.loadbalancer.server.port=8080"
     networks:
       - internal
 

--- a/internal/auth/totp/backup.go
+++ b/internal/auth/totp/backup.go
@@ -14,7 +14,9 @@ const (
 	BackupCodeCount = 10
 	// BackupCodeLength is the byte length of each backup code (16 hex chars = 64 bits).
 	BackupCodeLength = 8
-	bcryptCost       = 12
+	// bcryptCost matches auth/password.go so a compromised backup-code hash is
+	// no cheaper to grind offline than a compromised password hash.
+	bcryptCost = 14
 )
 
 // GenerateBackupCodes creates a set of random backup codes and their bcrypt hashes.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,50 @@ type Config struct {
 	// Example: "https://gw-01.internal:8080"
 	InternalURL string
 
+	// Traefik self-registration (via Redis KV provider).
+	//
+	// When TraefikSelfRegister is true, the gateway publishes its own
+	// routing entries into the Traefik KV tree in Valkey, so scaling
+	// the gateway deployment (`docker compose up --scale gateway=N`,
+	// or adding replicas in k8s) works with zero operator touch per
+	// instance. Operators enable this by also pointing Traefik at the
+	// same Valkey instance via `--providers.redis`.
+	//
+	// All Traefik* fields below are required when TraefikSelfRegister
+	// is true; the gateway will refuse to start otherwise.
+	TraefikSelfRegister bool
+
+	// TraefikRootKey matches Traefik's `--providers.redis.rootkey`
+	// value. Defaults to "traefik" when empty.
+	TraefikRootKey string
+
+	// TraefikMTLSHost is the public HostSNI the shared TCP (passthrough)
+	// router matches for agent mTLS. Example: "gateway.example.com".
+	TraefikMTLSHost string
+
+	// TraefikMTLSBackend is this replica's internal agent-mTLS
+	// host:port reachable from Traefik. Example:
+	// "gateway-1.internal:8080".
+	TraefikMTLSBackend string
+
+	// TraefikMTLSEntryPoint is the Traefik static-config entrypoint
+	// the mTLS TCP router attaches to. Example: "mtls".
+	TraefikMTLSEntryPoint string
+
+	// TraefikTTYHost is the public Host header the per-replica HTTP
+	// router matches for TTY WebSocket traffic. Example:
+	// "tty.example.com". Each gateway gets path prefix /gw/<id>.
+	TraefikTTYHost string
+
+	// TraefikTTYBackend is this replica's internal TTY listener URL.
+	// Cleartext is fine — Traefik terminates the public TLS.
+	// Example: "http://gateway-1.internal:8443".
+	TraefikTTYBackend string
+
+	// TraefikTTYEntryPoint is the Traefik entrypoint the TTY HTTP
+	// router attaches to. Example: "websecure".
+	TraefikTTYEntryPoint string
+
 	// Logging
 	LogLevel string
 }
@@ -90,6 +134,14 @@ func FromEnv() *Config {
 		BootstrapHost:             getEnv("GATEWAY_BOOTSTRAP_HOST", ""),
 		WebListenAddr:             getEnv("GATEWAY_WEB_LISTEN_ADDR", ""),
 		InternalURL:               getEnv("GATEWAY_INTERNAL_URL", ""),
+		TraefikSelfRegister:       getEnvBool("GATEWAY_TRAEFIK_SELF_REGISTER", false),
+		TraefikRootKey:            getEnv("GATEWAY_TRAEFIK_ROOT_KEY", ""),
+		TraefikMTLSHost:           getEnv("GATEWAY_TRAEFIK_MTLS_HOST", ""),
+		TraefikMTLSBackend:        getEnv("GATEWAY_TRAEFIK_MTLS_BACKEND", ""),
+		TraefikMTLSEntryPoint:     getEnv("GATEWAY_TRAEFIK_MTLS_ENTRYPOINT", ""),
+		TraefikTTYHost:            getEnv("GATEWAY_TRAEFIK_TTY_HOST", ""),
+		TraefikTTYBackend:         getEnv("GATEWAY_TRAEFIK_TTY_BACKEND", ""),
+		TraefikTTYEntryPoint:      getEnv("GATEWAY_TRAEFIK_TTY_ENTRYPOINT", ""),
 		LogLevel:                  getEnv("LOG_LEVEL", "info"),
 	}
 }
@@ -105,6 +157,15 @@ func getEnvInt(key string, defaultValue int) int {
 	if value := os.Getenv(key); value != "" {
 		if i, err := strconv.Atoi(value); err == nil {
 			return i
+		}
+	}
+	return defaultValue
+}
+
+func getEnvBool(key string, defaultValue bool) bool {
+	if value := os.Getenv(key); value != "" {
+		if b, err := strconv.ParseBool(value); err == nil {
+			return b
 		}
 	}
 	return defaultValue

--- a/internal/gateway/registry/traefik.go
+++ b/internal/gateway/registry/traefik.go
@@ -1,0 +1,195 @@
+package registry
+
+// Self-registration of each gateway replica into Traefik's routing
+// table via the Redis KV provider. Replaces the old per-service
+// Traefik labels in compose.yml so scaling the gateway service (for
+// example `docker compose up --scale gateway=3`) works with zero
+// operator touch per replica.
+//
+// Traefik's Redis provider reads keys under a rootkey (default
+// "traefik") and builds its dynamic config from them. Two kinds of
+// routes are published:
+//
+//   * Shared TCP router for agent mTLS passthrough. All replicas
+//     write the same router/service keys (identical values, so
+//     concurrent writes are benign) and each adds a distinct server
+//     entry under `traefik/tcp/services/pm-mtls/loadbalancer/
+//     servers/<gatewayID>/address` so Traefik load-balances the pool.
+//
+//   * Per-replica HTTP router for TTY WebSocket traffic. Each
+//     gateway writes its own router scoped to `/gw/<gatewayID>`, so
+//     the control server can mint TTY tokens whose URL routes
+//     deterministically to the replica holding the agent.
+//
+// All keys carry the same TTL as the gateway registration itself;
+// the heartbeat refreshes them in lock-step with the existing
+// RegisterGateway loop, and clean shutdown revokes the per-replica
+// keys. The shared pm-mtls router keys expire naturally once the
+// last replica goes away.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// DefaultTraefikRootKey matches Traefik's default `--providers.redis.rootkey`
+// value. Override via TraefikRouteConfig.RootKey if the deployment uses a
+// different root.
+const DefaultTraefikRootKey = "traefik"
+
+// TraefikRouteConfig carries the per-gateway values needed to publish
+// a complete routing entry. The caller (the gateway's main.go)
+// populates this from its environment / flags.
+type TraefikRouteConfig struct {
+	// MTLSHost is the public HostSNI the shared TCP router matches,
+	// e.g. "gateway.example.com".
+	MTLSHost string
+	// MTLSBackend is this replica's agent mTLS listener address,
+	// e.g. "gateway-1.internal:8443". Added to the shared
+	// `pm-mtls` service's load-balancer pool.
+	MTLSBackend string
+	// MTLSEntryPoint names the Traefik entrypoint the TCP router
+	// binds to. Typically "mtls" on a dedicated port. Must be
+	// defined in Traefik's static config.
+	MTLSEntryPoint string
+	// TTYHost is the public Host header the per-replica HTTP router
+	// matches, e.g. "tty.example.com".
+	TTYHost string
+	// TTYBackend is this replica's TTY WebSocket listener URL,
+	// e.g. "http://gateway-1.internal:8080". Traefik proxies cleartext
+	// to it and handles public TLS termination itself.
+	TTYBackend string
+	// TTYEntryPoint is the HTTP entrypoint name, typically
+	// "websecure".
+	TTYEntryPoint string
+	// RootKey is the Traefik Redis root-key prefix. Defaults to
+	// DefaultTraefikRootKey.
+	RootKey string
+}
+
+func (c TraefikRouteConfig) validate() error {
+	missing := []string{}
+	if c.MTLSHost == "" {
+		missing = append(missing, "MTLSHost")
+	}
+	if c.MTLSBackend == "" {
+		missing = append(missing, "MTLSBackend")
+	}
+	if c.MTLSEntryPoint == "" {
+		missing = append(missing, "MTLSEntryPoint")
+	}
+	if c.TTYHost == "" {
+		missing = append(missing, "TTYHost")
+	}
+	if c.TTYBackend == "" {
+		missing = append(missing, "TTYBackend")
+	}
+	if c.TTYEntryPoint == "" {
+		missing = append(missing, "TTYEntryPoint")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("registry: TraefikRouteConfig missing fields: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+func (c TraefikRouteConfig) rootKey() string {
+	if c.RootKey == "" {
+		return DefaultTraefikRootKey
+	}
+	return c.RootKey
+}
+
+// traefikKeys builds the complete list of (key, value) pairs for a
+// single gateway replica. Shared pm-mtls keys come first (all replicas
+// write identical values), per-replica keys come last.
+func (c TraefikRouteConfig) traefikKeys(gatewayID string) []struct{ key, value string } {
+	root := c.rootKey()
+
+	// Shared TCP router for agent mTLS. Identical across all replicas.
+	sharedMTLS := []struct{ key, value string }{
+		{root + "/tcp/routers/pm-mtls/rule", fmt.Sprintf("HostSNI(`%s`)", c.MTLSHost)},
+		{root + "/tcp/routers/pm-mtls/entrypoints/0", c.MTLSEntryPoint},
+		{root + "/tcp/routers/pm-mtls/tls/passthrough", "true"},
+		{root + "/tcp/routers/pm-mtls/service", "pm-mtls"},
+	}
+
+	// Per-replica TCP server entry in the shared service.
+	mtlsServerKey := fmt.Sprintf("%s/tcp/services/pm-mtls/loadbalancer/servers/%s/address", root, gatewayID)
+
+	// Per-replica HTTP router for TTY. Unique to this gateway.
+	ttyRouter := fmt.Sprintf("pm-tty-%s", gatewayID)
+	ttyRule := fmt.Sprintf("Host(`%s`) && PathPrefix(`/gw/%s`)", c.TTYHost, gatewayID)
+	perReplica := []struct{ key, value string }{
+		{mtlsServerKey, c.MTLSBackend},
+		{fmt.Sprintf("%s/http/routers/%s/rule", root, ttyRouter), ttyRule},
+		{fmt.Sprintf("%s/http/routers/%s/entrypoints/0", root, ttyRouter), c.TTYEntryPoint},
+		{fmt.Sprintf("%s/http/routers/%s/tls", root, ttyRouter), "true"},
+		{fmt.Sprintf("%s/http/routers/%s/service", root, ttyRouter), ttyRouter},
+		{fmt.Sprintf("%s/http/services/%s/loadbalancer/servers/0/url", root, ttyRouter), c.TTYBackend},
+	}
+
+	out := make([]struct{ key, value string }, 0, len(sharedMTLS)+len(perReplica))
+	out = append(out, sharedMTLS...)
+	out = append(out, perReplica...)
+	return out
+}
+
+// perReplicaKeys returns only the keys owned exclusively by this gateway
+// replica — the ones safe to delete on shutdown without clobbering
+// other replicas' routes. Shared pm-mtls keys are NOT included; they
+// expire naturally via TTL once the last replica stops refreshing them.
+func (c TraefikRouteConfig) perReplicaKeys(gatewayID string) []string {
+	root := c.rootKey()
+	ttyRouter := fmt.Sprintf("pm-tty-%s", gatewayID)
+	return []string{
+		fmt.Sprintf("%s/tcp/services/pm-mtls/loadbalancer/servers/%s/address", root, gatewayID),
+		fmt.Sprintf("%s/http/routers/%s/rule", root, ttyRouter),
+		fmt.Sprintf("%s/http/routers/%s/entrypoints/0", root, ttyRouter),
+		fmt.Sprintf("%s/http/routers/%s/tls", root, ttyRouter),
+		fmt.Sprintf("%s/http/routers/%s/service", root, ttyRouter),
+		fmt.Sprintf("%s/http/services/%s/loadbalancer/servers/0/url", root, ttyRouter),
+	}
+}
+
+// PublishTraefikRoute writes (or refreshes) the full routing entry
+// for this gateway. Call at startup and on every heartbeat tick; all
+// keys carry the same TTL so a crashed replica disappears from the
+// pool within the TTL window. Idempotent.
+func (r *Registry) PublishTraefikRoute(ctx context.Context, gatewayID string, cfg TraefikRouteConfig, ttl time.Duration) error {
+	if gatewayID == "" {
+		return errors.New("registry: gatewayID is required")
+	}
+	if err := cfg.validate(); err != nil {
+		return err
+	}
+	if ttl <= 0 {
+		ttl = DefaultGatewayTTL
+	}
+
+	for _, pair := range cfg.traefikKeys(gatewayID) {
+		if err := r.backend.Set(ctx, pair.key, pair.value, ttl); err != nil {
+			return fmt.Errorf("registry: publish traefik key %q: %w", pair.key, err)
+		}
+	}
+	return nil
+}
+
+// RevokeTraefikRoute removes the per-replica keys for this gateway so
+// Traefik drops its routes immediately on clean shutdown. Shared
+// pm-mtls router keys are intentionally left alone — other replicas
+// may still be publishing them. Idempotent.
+func (r *Registry) RevokeTraefikRoute(ctx context.Context, gatewayID string, cfg TraefikRouteConfig) error {
+	if gatewayID == "" {
+		return errors.New("registry: gatewayID is required")
+	}
+	for _, key := range cfg.perReplicaKeys(gatewayID) {
+		if err := r.backend.Delete(ctx, key); err != nil {
+			return fmt.Errorf("registry: revoke traefik key %q: %w", key, err)
+		}
+	}
+	return nil
+}

--- a/internal/gateway/registry/traefik_test.go
+++ b/internal/gateway/registry/traefik_test.go
@@ -1,0 +1,214 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func baseTraefikConfig() TraefikRouteConfig {
+	return TraefikRouteConfig{
+		MTLSHost:       "gateway.example.com",
+		MTLSBackend:    "gateway-1.internal:8443",
+		MTLSEntryPoint: "mtls",
+		TTYHost:        "tty.example.com",
+		TTYBackend:     "http://gateway-1.internal:8080",
+		TTYEntryPoint:  "websecure",
+	}
+}
+
+func TestPublishTraefikRoute_WritesExpectedKeys(t *testing.T) {
+	backend := NewFakeBackend(nil)
+	r := New(backend, nil)
+	ctx := context.Background()
+
+	cfg := baseTraefikConfig()
+	if err := r.PublishTraefikRoute(ctx, "gw-1", cfg, 30*time.Second); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	want := map[string]string{
+		"traefik/tcp/routers/pm-mtls/rule":                                      "HostSNI(`gateway.example.com`)",
+		"traefik/tcp/routers/pm-mtls/entrypoints/0":                             "mtls",
+		"traefik/tcp/routers/pm-mtls/tls/passthrough":                           "true",
+		"traefik/tcp/routers/pm-mtls/service":                                   "pm-mtls",
+		"traefik/tcp/services/pm-mtls/loadbalancer/servers/gw-1/address":        "gateway-1.internal:8443",
+		"traefik/http/routers/pm-tty-gw-1/rule":                                 "Host(`tty.example.com`) && PathPrefix(`/gw/gw-1`)",
+		"traefik/http/routers/pm-tty-gw-1/entrypoints/0":                        "websecure",
+		"traefik/http/routers/pm-tty-gw-1/tls":                                  "true",
+		"traefik/http/routers/pm-tty-gw-1/service":                              "pm-tty-gw-1",
+		"traefik/http/services/pm-tty-gw-1/loadbalancer/servers/0/url":          "http://gateway-1.internal:8080",
+	}
+
+	for key, expected := range want {
+		got, err := backend.Get(ctx, key)
+		if err != nil {
+			t.Errorf("missing key %q: %v", key, err)
+			continue
+		}
+		if got != expected {
+			t.Errorf("key %q: got %q, want %q", key, got, expected)
+		}
+	}
+}
+
+func TestPublishTraefikRoute_CustomRootKey(t *testing.T) {
+	backend := NewFakeBackend(nil)
+	r := New(backend, nil)
+	ctx := context.Background()
+
+	cfg := baseTraefikConfig()
+	cfg.RootKey = "pm-traefik"
+	if err := r.PublishTraefikRoute(ctx, "gw-A", cfg, 30*time.Second); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	if _, err := backend.Get(ctx, "pm-traefik/tcp/routers/pm-mtls/rule"); err != nil {
+		t.Errorf("expected custom rootkey keys to be written: %v", err)
+	}
+	if _, err := backend.Get(ctx, "traefik/tcp/routers/pm-mtls/rule"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("default rootkey should not be used when RootKey is set; got err=%v", err)
+	}
+}
+
+func TestPublishTraefikRoute_RejectsEmptyFields(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	ctx := context.Background()
+
+	bad := baseTraefikConfig()
+	bad.MTLSHost = ""
+	bad.TTYBackend = ""
+
+	err := r.PublishTraefikRoute(ctx, "gw-1", bad, 30*time.Second)
+	if err == nil {
+		t.Fatal("expected validation error for empty MTLSHost and TTYBackend")
+	}
+	if !strings.Contains(err.Error(), "MTLSHost") || !strings.Contains(err.Error(), "TTYBackend") {
+		t.Errorf("error should name all missing fields; got: %v", err)
+	}
+}
+
+func TestPublishTraefikRoute_RejectsEmptyGatewayID(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	if err := r.PublishTraefikRoute(context.Background(), "", baseTraefikConfig(), 30*time.Second); err == nil {
+		t.Fatal("expected error for empty gatewayID")
+	}
+}
+
+func TestPublishTraefikRoute_Idempotent(t *testing.T) {
+	backend := NewFakeBackend(nil)
+	r := New(backend, nil)
+	ctx := context.Background()
+	cfg := baseTraefikConfig()
+
+	if err := r.PublishTraefikRoute(ctx, "gw-1", cfg, 30*time.Second); err != nil {
+		t.Fatalf("first publish: %v", err)
+	}
+	if err := r.PublishTraefikRoute(ctx, "gw-1", cfg, 30*time.Second); err != nil {
+		t.Errorf("second publish should be idempotent, got: %v", err)
+	}
+}
+
+func TestRevokeTraefikRoute_DeletesPerReplicaOnly(t *testing.T) {
+	backend := NewFakeBackend(nil)
+	r := New(backend, nil)
+	ctx := context.Background()
+	cfg := baseTraefikConfig()
+
+	if err := r.PublishTraefikRoute(ctx, "gw-1", cfg, 30*time.Second); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if err := r.RevokeTraefikRoute(ctx, "gw-1", cfg); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	// Per-replica keys must be gone.
+	perReplicaGone := []string{
+		"traefik/tcp/services/pm-mtls/loadbalancer/servers/gw-1/address",
+		"traefik/http/routers/pm-tty-gw-1/rule",
+		"traefik/http/services/pm-tty-gw-1/loadbalancer/servers/0/url",
+	}
+	for _, key := range perReplicaGone {
+		if _, err := backend.Get(ctx, key); !errors.Is(err, ErrNoGateway) {
+			t.Errorf("key %q should be deleted after revoke, got err=%v", key, err)
+		}
+	}
+
+	// Shared keys must still be present — other replicas rely on them.
+	sharedStays := []string{
+		"traefik/tcp/routers/pm-mtls/rule",
+		"traefik/tcp/routers/pm-mtls/service",
+	}
+	for _, key := range sharedStays {
+		if _, err := backend.Get(ctx, key); err != nil {
+			t.Errorf("shared key %q must NOT be deleted by revoke, got err=%v", key, err)
+		}
+	}
+}
+
+func TestRevokeTraefikRoute_Idempotent(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	if err := r.RevokeTraefikRoute(context.Background(), "never-published", baseTraefikConfig()); err != nil {
+		t.Errorf("revoke of unknown gateway should be idempotent, got %v", err)
+	}
+}
+
+func TestPublishTraefikRoute_TwoReplicas_SharedService(t *testing.T) {
+	backend := NewFakeBackend(nil)
+	r := New(backend, nil)
+	ctx := context.Background()
+
+	cfgA := baseTraefikConfig()
+	cfgA.MTLSBackend = "gateway-A.internal:8443"
+	cfgA.TTYBackend = "http://gateway-A.internal:8080"
+
+	cfgB := baseTraefikConfig()
+	cfgB.MTLSBackend = "gateway-B.internal:8443"
+	cfgB.TTYBackend = "http://gateway-B.internal:8080"
+
+	if err := r.PublishTraefikRoute(ctx, "gw-A", cfgA, 30*time.Second); err != nil {
+		t.Fatalf("publish A: %v", err)
+	}
+	if err := r.PublishTraefikRoute(ctx, "gw-B", cfgB, 30*time.Second); err != nil {
+		t.Fatalf("publish B: %v", err)
+	}
+
+	addrA, err := backend.Get(ctx, "traefik/tcp/services/pm-mtls/loadbalancer/servers/gw-A/address")
+	if err != nil || addrA != "gateway-A.internal:8443" {
+		t.Errorf("replica A address got %q err=%v", addrA, err)
+	}
+	addrB, err := backend.Get(ctx, "traefik/tcp/services/pm-mtls/loadbalancer/servers/gw-B/address")
+	if err != nil || addrB != "gateway-B.internal:8443" {
+		t.Errorf("replica B address got %q err=%v", addrB, err)
+	}
+
+	// Shared rule must be present once (same value from both writes).
+	rule, err := backend.Get(ctx, "traefik/tcp/routers/pm-mtls/rule")
+	if err != nil {
+		t.Fatalf("shared rule: %v", err)
+	}
+	if rule != "HostSNI(`gateway.example.com`)" {
+		t.Errorf("shared rule got %q", rule)
+	}
+
+	// Each replica has its own HTTP TTY router.
+	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-A/rule"); err != nil {
+		t.Errorf("replica A TTY router missing: %v", err)
+	}
+	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-B/rule"); err != nil {
+		t.Errorf("replica B TTY router missing: %v", err)
+	}
+
+	// Revoking A leaves B's entries and the shared service intact.
+	if err := r.RevokeTraefikRoute(ctx, "gw-A", cfgA); err != nil {
+		t.Fatalf("revoke A: %v", err)
+	}
+	if _, err := backend.Get(ctx, "traefik/tcp/services/pm-mtls/loadbalancer/servers/gw-B/address"); err != nil {
+		t.Errorf("replica B server entry must survive A's revoke: %v", err)
+	}
+	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-B/rule"); err != nil {
+		t.Errorf("replica B TTY router must survive A's revoke: %v", err)
+	}
+}


### PR DESCRIPTION
Bundled 2026.05 server batch. Closes manchtools/power-manage-server#53 and fixes the per-replica Traefik label problem that blocked >1-gateway deployments in the 2026.05 RC.

## Summary

### #53 — TOTP backup-code bcrypt cost parity
- \`server/internal/auth/totp/backup.go\` raises \`bcryptCost\` from 12 to 14 so backup codes are no cheaper to offline-crack than password or SCIM-token hashes.

### Gateway self-registration into Traefik (Redis KV)
- New \`PublishTraefikRoute\` / \`RevokeTraefikRoute\` on the existing registry (\`server/internal/gateway/registry/traefik.go\`). Each replica writes its own Traefik routing entry into the Valkey instance Traefik watches via \`--providers.redis\`. Shared pm-mtls TCP router is load-balanced across replicas; each replica owns a \`/gw/<id>\` path prefix on the TTY HTTP host.
- 8 new \`GATEWAY_TRAEFIK_*\` env vars (gated by \`GATEWAY_TRAEFIK_SELF_REGISTER\`). Backend host:port auto-derived from \`os.Hostname()\` when unset, so operators don't have to hand-wire replica identities.
- \`deploy/compose.yml\`: dropped the gateway's Traefik labels and \`container_name\`, enabled the Traefik Redis KV provider, added an \`:8443 mtls\` entrypoint for TCP passthrough. \`docker compose up --scale gateway=N\` now works out of the box.
- Lifecycle: publish at startup, refresh on existing \`DefaultGatewayRefreshInterval\`, revoke per-replica keys on graceful shutdown (shared keys expire via TTL when the last replica stops).

## Test plan

- [x] \`go build ./...\` green
- [x] \`go test ./internal/gateway/registry/... ./internal/auth/totp/... ./internal/config/... ./cmd/gateway/...\` green
- [x] \`go vet ./...\` clean
- [ ] Integration: spin up compose with \`--scale gateway=2\`, verify both replicas publish their entries in Valkey and that Traefik picks them up within ~seconds
- [ ] Integration: kill one replica, verify its per-replica keys expire via TTL within 45 s and its routes vanish from Traefik
- [ ] Manual: TOTP backup-code flow still generates + verifies without UX regression (cost 14 is ~100–200 ms per verify, same budget as the password path)