### PR TITLE
fix: bound settings-update background goroutine with a timeout

### DIFF
--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"connectrpc.com/connect"
 
@@ -67,8 +68,15 @@ func (h *SettingsHandler) UpdateServerSettings(ctx context.Context, req *connect
 	// Propagate global flags to individual users when enabled.
 	// This makes the global toggle a "batch enable" — once set per user,
 	// turning off the global flag won't remove provisioning for existing users.
+	//
+	// The work runs in a detached goroutine because the response
+	// returns immediately; we don't want the admin's RPC to block on
+	// a potentially-slow fan-out. bgCtx is bounded by a hard timeout
+	// so a wedged downstream (DB outage, hanging action dispatch) can
+	// never leak the goroutine forever.
 	go func() {
-		bgCtx := context.Background()
+		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cancel()
 		if req.Msg.UserProvisioningEnabled {
 			if err := h.enableProvisioningForAllUsers(bgCtx); err != nil {
 				h.logger.Error("failed to propagate provisioning to users", "error", err)


### PR DESCRIPTION
Found during a systematic Go-footgun sweep across the server / agent / sdk repos.

UpdateServerSettings detaches its provisioning / SSH / system-action fan-out into a background goroutine using `context.Background()`. Without a timeout the goroutine can run forever if any downstream call hangs (DB outage, wedged action dispatch), leaking memory + file descriptors per request.

## Change

Wrap the background ctx with `context.WithTimeout(5 * time.Minute)` + deferred cancel. Settings updates are rare admin actions; 5 minutes is comfortably above the expected batch-enable time.

## Test plan

- [x] `go build ./...`
- [ ] Manual: trigger `UpdateServerSettings` and confirm the provisioning fan-out completes within the timeout.