### PR TITLE
feat: migrate server to SDK v0.2.0 proto surface (#52)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.8.0
-	github.com/manchtools/power-manage/sdk v0.1.0
+	github.com/manchtools/power-manage/sdk v0.2.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0
@@ -107,4 +107,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.1.0
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.1.0 h1:qNOZWXWlX7J2GMYSDIfE5txH5+OI4/L0GTm5STYf4LQ=
-github.com/manchtools/power-manage-sdk v0.1.0/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.2.0 h1:M28+5EmjAI33xmeLEAYkw2/9XAQT7t744iP76L+HC9c=
+github.com/manchtools/power-manage-sdk v0.2.0/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/actionparams/actionparams.go
+++ b/internal/actionparams/actionparams.go
@@ -33,10 +33,10 @@ func PopulateAction(action *pm.Action, actionType int32, paramsJSON []byte) {
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
 			action.Params = &pm.Action_Shell{Shell: &p}
 		}
-	case pm.ActionType_ACTION_TYPE_SYSTEMD:
-		var p pm.SystemdParams
+	case pm.ActionType_ACTION_TYPE_SERVICE:
+		var p pm.ServiceParams
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Systemd{Systemd: &p}
+			action.Params = &pm.Action_Service{Service: &p}
 		}
 	case pm.ActionType_ACTION_TYPE_FILE:
 		var p pm.FileParams
@@ -78,20 +78,20 @@ func PopulateAction(action *pm.Action, actionType int32, paramsJSON []byte) {
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
 			action.Params = &pm.Action_Sshd{Sshd: &p}
 		}
-	case pm.ActionType_ACTION_TYPE_SUDO:
-		var p pm.SudoParams
+	case pm.ActionType_ACTION_TYPE_ADMIN_POLICY:
+		var p pm.AdminPolicyParams
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Sudo{Sudo: &p}
+			action.Params = &pm.Action_AdminPolicy{AdminPolicy: &p}
 		}
 	case pm.ActionType_ACTION_TYPE_LPS:
 		var p pm.LpsParams
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
 			action.Params = &pm.Action_Lps{Lps: &p}
 		}
-	case pm.ActionType_ACTION_TYPE_LUKS:
-		var p pm.LuksParams
+	case pm.ActionType_ACTION_TYPE_ENCRYPTION:
+		var p pm.EncryptionParams
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Luks{Luks: &p}
+			action.Params = &pm.Action_Encryption{Encryption: &p}
 		}
 	case pm.ActionType_ACTION_TYPE_WIFI:
 		var p pm.WifiParams
@@ -130,10 +130,10 @@ func PopulateManagedAction(action *pm.ManagedAction, actionType pm.ActionType, p
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
 			action.Params = &pm.ManagedAction_Shell{Shell: &p}
 		}
-	case pm.ActionType_ACTION_TYPE_SYSTEMD:
-		var p pm.SystemdParams
+	case pm.ActionType_ACTION_TYPE_SERVICE:
+		var p pm.ServiceParams
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Systemd{Systemd: &p}
+			action.Params = &pm.ManagedAction_Service{Service: &p}
 		}
 	case pm.ActionType_ACTION_TYPE_FILE:
 		var p pm.FileParams
@@ -175,20 +175,20 @@ func PopulateManagedAction(action *pm.ManagedAction, actionType pm.ActionType, p
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
 			action.Params = &pm.ManagedAction_Sshd{Sshd: &p}
 		}
-	case pm.ActionType_ACTION_TYPE_SUDO:
-		var p pm.SudoParams
+	case pm.ActionType_ACTION_TYPE_ADMIN_POLICY:
+		var p pm.AdminPolicyParams
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Sudo{Sudo: &p}
+			action.Params = &pm.ManagedAction_AdminPolicy{AdminPolicy: &p}
 		}
 	case pm.ActionType_ACTION_TYPE_LPS:
 		var p pm.LpsParams
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
 			action.Params = &pm.ManagedAction_Lps{Lps: &p}
 		}
-	case pm.ActionType_ACTION_TYPE_LUKS:
-		var p pm.LuksParams
+	case pm.ActionType_ACTION_TYPE_ENCRYPTION:
+		var p pm.EncryptionParams
 		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Luks{Luks: &p}
+			action.Params = &pm.ManagedAction_Encryption{Encryption: &p}
 		}
 	case pm.ActionType_ACTION_TYPE_WIFI:
 		var p pm.WifiParams

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -64,9 +64,9 @@ func validateCreateActionParams(ctx context.Context, req *pm.CreateActionRequest
 			}
 			return nil
 		}
-	case *pm.CreateActionRequest_Systemd:
-		if p.Systemd != nil {
-			return Validate(ctx, p.Systemd)
+	case *pm.CreateActionRequest_Service:
+		if p.Service != nil {
+			return Validate(ctx, p.Service)
 		}
 	case *pm.CreateActionRequest_File:
 		if p.File != nil {
@@ -104,17 +104,17 @@ func validateCreateActionParams(ctx context.Context, req *pm.CreateActionRequest
 		if p.Sshd != nil {
 			return Validate(ctx, p.Sshd)
 		}
-	case *pm.CreateActionRequest_Sudo:
-		if p.Sudo != nil {
-			return Validate(ctx, p.Sudo)
+	case *pm.CreateActionRequest_AdminPolicy:
+		if p.AdminPolicy != nil {
+			return Validate(ctx, p.AdminPolicy)
 		}
 	case *pm.CreateActionRequest_Lps:
 		if p.Lps != nil {
 			return Validate(ctx, p.Lps)
 		}
-	case *pm.CreateActionRequest_Luks:
-		if p.Luks != nil {
-			return Validate(ctx, p.Luks)
+	case *pm.CreateActionRequest_Encryption:
+		if p.Encryption != nil {
+			return Validate(ctx, p.Encryption)
 		}
 	case *pm.CreateActionRequest_Group:
 		if p.Group != nil {
@@ -143,9 +143,9 @@ func validateUpdateActionParams(ctx context.Context, req *pm.UpdateActionParamsR
 		if p.Shell != nil {
 			return Validate(ctx, p.Shell)
 		}
-	case *pm.UpdateActionParamsRequest_Systemd:
-		if p.Systemd != nil {
-			return Validate(ctx, p.Systemd)
+	case *pm.UpdateActionParamsRequest_Service:
+		if p.Service != nil {
+			return Validate(ctx, p.Service)
 		}
 	case *pm.UpdateActionParamsRequest_File:
 		if p.File != nil {
@@ -183,17 +183,17 @@ func validateUpdateActionParams(ctx context.Context, req *pm.UpdateActionParamsR
 		if p.Sshd != nil {
 			return Validate(ctx, p.Sshd)
 		}
-	case *pm.UpdateActionParamsRequest_Sudo:
-		if p.Sudo != nil {
-			return Validate(ctx, p.Sudo)
+	case *pm.UpdateActionParamsRequest_AdminPolicy:
+		if p.AdminPolicy != nil {
+			return Validate(ctx, p.AdminPolicy)
 		}
 	case *pm.UpdateActionParamsRequest_Lps:
 		if p.Lps != nil {
 			return Validate(ctx, p.Lps)
 		}
-	case *pm.UpdateActionParamsRequest_Luks:
-		if p.Luks != nil {
-			return Validate(ctx, p.Luks)
+	case *pm.UpdateActionParamsRequest_Encryption:
+		if p.Encryption != nil {
+			return Validate(ctx, p.Encryption)
 		}
 	case *pm.UpdateActionParamsRequest_Group:
 		if p.Group != nil {
@@ -1172,8 +1172,8 @@ func extractCreateActionParamsMsg(req *pm.CreateActionRequest) proto.Message {
 		return p.Flatpak
 	case *pm.CreateActionRequest_Shell:
 		return p.Shell
-	case *pm.CreateActionRequest_Systemd:
-		return p.Systemd
+	case *pm.CreateActionRequest_Service:
+		return p.Service
 	case *pm.CreateActionRequest_File:
 		return p.File
 	case *pm.CreateActionRequest_Update:
@@ -1188,12 +1188,12 @@ func extractCreateActionParamsMsg(req *pm.CreateActionRequest) proto.Message {
 		return p.Ssh
 	case *pm.CreateActionRequest_Sshd:
 		return p.Sshd
-	case *pm.CreateActionRequest_Sudo:
-		return p.Sudo
+	case *pm.CreateActionRequest_AdminPolicy:
+		return p.AdminPolicy
 	case *pm.CreateActionRequest_Lps:
 		return p.Lps
-	case *pm.CreateActionRequest_Luks:
-		return p.Luks
+	case *pm.CreateActionRequest_Encryption:
+		return p.Encryption
 	case *pm.CreateActionRequest_Group:
 		return p.Group
 	case *pm.CreateActionRequest_Wifi:
@@ -1216,8 +1216,8 @@ func extractUpdateActionParamsMsg(req *pm.UpdateActionParamsRequest) proto.Messa
 		return p.Flatpak
 	case *pm.UpdateActionParamsRequest_Shell:
 		return p.Shell
-	case *pm.UpdateActionParamsRequest_Systemd:
-		return p.Systemd
+	case *pm.UpdateActionParamsRequest_Service:
+		return p.Service
 	case *pm.UpdateActionParamsRequest_File:
 		return p.File
 	case *pm.UpdateActionParamsRequest_Update:
@@ -1232,12 +1232,12 @@ func extractUpdateActionParamsMsg(req *pm.UpdateActionParamsRequest) proto.Messa
 		return p.Ssh
 	case *pm.UpdateActionParamsRequest_Sshd:
 		return p.Sshd
-	case *pm.UpdateActionParamsRequest_Sudo:
-		return p.Sudo
+	case *pm.UpdateActionParamsRequest_AdminPolicy:
+		return p.AdminPolicy
 	case *pm.UpdateActionParamsRequest_Lps:
 		return p.Lps
-	case *pm.UpdateActionParamsRequest_Luks:
-		return p.Luks
+	case *pm.UpdateActionParamsRequest_Encryption:
+		return p.Encryption
 	case *pm.UpdateActionParamsRequest_Group:
 		return p.Group
 	case *pm.UpdateActionParamsRequest_Wifi:
@@ -1260,8 +1260,8 @@ func extractActionParamsMsg(action *pm.Action) proto.Message {
 		return p.Flatpak
 	case *pm.Action_Shell:
 		return p.Shell
-	case *pm.Action_Systemd:
-		return p.Systemd
+	case *pm.Action_Service:
+		return p.Service
 	case *pm.Action_File:
 		return p.File
 	case *pm.Action_Update:
@@ -1276,12 +1276,12 @@ func extractActionParamsMsg(action *pm.Action) proto.Message {
 		return p.Ssh
 	case *pm.Action_Sshd:
 		return p.Sshd
-	case *pm.Action_Sudo:
-		return p.Sudo
+	case *pm.Action_AdminPolicy:
+		return p.AdminPolicy
 	case *pm.Action_Lps:
 		return p.Lps
-	case *pm.Action_Luks:
-		return p.Luks
+	case *pm.Action_Encryption:
+		return p.Encryption
 	case *pm.Action_Group:
 		return p.Group
 	case *pm.Action_Wifi:

--- a/internal/api/action_handler_test.go
+++ b/internal/api/action_handler_test.go
@@ -35,6 +35,60 @@ func TestCreateAction_Shell(t *testing.T) {
 	assert.Equal(t, pm.ActionType_ACTION_TYPE_SHELL, resp.Msg.Action.Type)
 }
 
+// AdminPolicy custom_config carries the raw sudoers / doas.conf
+// fragment the admin wants rendered on the device. The proto pins a
+// `validate:"required_if=AccessLevel 3"` rule that refuses
+// ADMIN_ACCESS_LEVEL_CUSTOM with an empty custom_config — otherwise
+// the agent would end up rendering an empty policy file, which on
+// sudoers means "no rules" and on doas means the rule set silently
+// disappears. Pin the rejection here so a future refactor of Validate()
+// can't silently drop the guard.
+//
+// Syntax validation of the policy content itself lives on the agent
+// side (visudo -c / doas -C) — the server has no business parsing
+// either grammar, especially since the target distro's version of
+// sudo or doas may accept syntax the server's vendored parser
+// wouldn't. This test deliberately only covers the "empty-config"
+// rejection, which is a pure proto-level constraint.
+func TestCreateAction_AdminPolicy_CustomRequiresConfig(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
+		Name: "Admin Policy CUSTOM with no config",
+		Type: pm.ActionType_ACTION_TYPE_ADMIN_POLICY,
+		Params: &pm.CreateActionRequest_AdminPolicy{
+			AdminPolicy: &pm.AdminPolicyParams{
+				AccessLevel:  pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_CUSTOM,
+				Users:        []string{"opsuser"},
+				CustomConfig: "", // intentionally empty — should be rejected
+			},
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	// Sanity check the complementary path: CUSTOM + non-empty config
+	// passes validation, so the rule really is firing on empty-string
+	// and not on some unrelated precondition.
+	resp, err := h.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
+		Name: "Admin Policy CUSTOM with config",
+		Type: pm.ActionType_ACTION_TYPE_ADMIN_POLICY,
+		Params: &pm.CreateActionRequest_AdminPolicy{
+			AdminPolicy: &pm.AdminPolicyParams{
+				AccessLevel:  pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_CUSTOM,
+				Users:        []string{"opsuser"},
+				CustomConfig: "{group} ALL=(ALL) NOPASSWD: /usr/bin/systemctl *",
+			},
+		},
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, pm.ActionType_ACTION_TYPE_ADMIN_POLICY, resp.Msg.Action.Type)
+}
+
 func TestCreateAction_DefaultTimeout(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewActionHandler(st, slog.Default(), nil)

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -822,7 +822,7 @@ func (h *DeviceHandler) CreateLuksToken(ctx context.Context, req *connect.Reques
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}
 	if pm.ActionType(action.ActionType) != pm.ActionType_ACTION_TYPE_ENCRYPTION {
-		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "action is not a LUKS action")
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "action is not an encryption action")
 	}
 
 	// Parse LUKS params to get complexity requirements

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -821,12 +821,12 @@ func (h *DeviceHandler) CreateLuksToken(ctx context.Context, req *connect.Reques
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}
-	if pm.ActionType(action.ActionType) != pm.ActionType_ACTION_TYPE_LUKS {
+	if pm.ActionType(action.ActionType) != pm.ActionType_ACTION_TYPE_ENCRYPTION {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "action is not a LUKS action")
 	}
 
 	// Parse LUKS params to get complexity requirements
-	var luksParams pm.LuksParams
+	var luksParams pm.EncryptionParams
 	if len(action.Params) > 0 {
 		protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(action.Params, &luksParams)
 	}

--- a/internal/api/luks_action_test.go
+++ b/internal/api/luks_action_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
-func TestCreateAction_Luks(t *testing.T) {
+func TestCreateAction_Encryption(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewActionHandler(st, slog.Default(), nil)
 
@@ -22,20 +22,20 @@ func TestCreateAction_Luks(t *testing.T) {
 
 	resp, err := h.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
 		Name: "Encrypt Disk",
-		Type: pm.ActionType_ACTION_TYPE_LUKS,
-		Params: &pm.CreateActionRequest_Luks{
-			Luks: &pm.LuksParams{
+		Type: pm.ActionType_ACTION_TYPE_ENCRYPTION,
+		Params: &pm.CreateActionRequest_Encryption{
+			Encryption: &pm.EncryptionParams{
 				PresharedKey:         "initial-psk-secret",
 				RotationIntervalDays: 30,
 				MinWords:             5,
-				DeviceBoundKeyType:   pm.LuksDeviceBoundKeyType_LUKS_DEVICE_BOUND_KEY_TYPE_NONE,
+				DeviceBoundKeyType:   pm.EncryptionDeviceBoundKeyType_ENCRYPTION_DEVICE_BOUND_KEY_TYPE_NONE,
 			},
 		},
 	}))
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp.Msg.Action.Id)
 	assert.Equal(t, "Encrypt Disk", resp.Msg.Action.Name)
-	assert.Equal(t, pm.ActionType_ACTION_TYPE_LUKS, resp.Msg.Action.Type)
+	assert.Equal(t, pm.ActionType_ACTION_TYPE_ENCRYPTION, resp.Msg.Action.Type)
 }
 
 func TestCreateAction_Luks_WithTPM(t *testing.T) {
@@ -47,26 +47,26 @@ func TestCreateAction_Luks_WithTPM(t *testing.T) {
 
 	resp, err := h.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
 		Name: "LUKS with TPM",
-		Type: pm.ActionType_ACTION_TYPE_LUKS,
-		Params: &pm.CreateActionRequest_Luks{
-			Luks: &pm.LuksParams{
+		Type: pm.ActionType_ACTION_TYPE_ENCRYPTION,
+		Params: &pm.CreateActionRequest_Encryption{
+			Encryption: &pm.EncryptionParams{
 				PresharedKey:         "tpm-psk",
 				RotationIntervalDays: 90,
 				MinWords:             7,
-				DeviceBoundKeyType:   pm.LuksDeviceBoundKeyType_LUKS_DEVICE_BOUND_KEY_TYPE_TPM,
+				DeviceBoundKeyType:   pm.EncryptionDeviceBoundKeyType_ENCRYPTION_DEVICE_BOUND_KEY_TYPE_TPM,
 			},
 		},
 	}))
 	require.NoError(t, err)
-	assert.Equal(t, pm.ActionType_ACTION_TYPE_LUKS, resp.Msg.Action.Type)
+	assert.Equal(t, pm.ActionType_ACTION_TYPE_ENCRYPTION, resp.Msg.Action.Type)
 
 	// Verify params round-trip
-	luks := resp.Msg.Action.GetLuks()
+	luks := resp.Msg.Action.GetEncryption()
 	require.NotNil(t, luks)
 	assert.Equal(t, "tpm-psk", luks.PresharedKey)
 	assert.Equal(t, int32(90), luks.RotationIntervalDays)
 	assert.Equal(t, int32(7), luks.MinWords)
-	assert.Equal(t, pm.LuksDeviceBoundKeyType_LUKS_DEVICE_BOUND_KEY_TYPE_TPM, luks.DeviceBoundKeyType)
+	assert.Equal(t, pm.EncryptionDeviceBoundKeyType_ENCRYPTION_DEVICE_BOUND_KEY_TYPE_TPM, luks.DeviceBoundKeyType)
 }
 
 func TestCreateAction_Luks_WithUserPassphrase(t *testing.T) {
@@ -78,13 +78,13 @@ func TestCreateAction_Luks_WithUserPassphrase(t *testing.T) {
 
 	resp, err := h.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
 		Name: "LUKS User Passphrase",
-		Type: pm.ActionType_ACTION_TYPE_LUKS,
-		Params: &pm.CreateActionRequest_Luks{
-			Luks: &pm.LuksParams{
+		Type: pm.ActionType_ACTION_TYPE_ENCRYPTION,
+		Params: &pm.CreateActionRequest_Encryption{
+			Encryption: &pm.EncryptionParams{
 				PresharedKey:             "user-psk",
 				RotationIntervalDays:     60,
 				MinWords:                 5,
-				DeviceBoundKeyType:       pm.LuksDeviceBoundKeyType_LUKS_DEVICE_BOUND_KEY_TYPE_USER_PASSPHRASE,
+				DeviceBoundKeyType:       pm.EncryptionDeviceBoundKeyType_ENCRYPTION_DEVICE_BOUND_KEY_TYPE_USER_PASSPHRASE,
 				UserPassphraseMinLength:  20,
 				UserPassphraseComplexity: pm.LpsPasswordComplexity_LPS_PASSWORD_COMPLEXITY_COMPLEX,
 			},
@@ -92,9 +92,9 @@ func TestCreateAction_Luks_WithUserPassphrase(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	luks := resp.Msg.Action.GetLuks()
+	luks := resp.Msg.Action.GetEncryption()
 	require.NotNil(t, luks)
-	assert.Equal(t, pm.LuksDeviceBoundKeyType_LUKS_DEVICE_BOUND_KEY_TYPE_USER_PASSPHRASE, luks.DeviceBoundKeyType)
+	assert.Equal(t, pm.EncryptionDeviceBoundKeyType_ENCRYPTION_DEVICE_BOUND_KEY_TYPE_USER_PASSPHRASE, luks.DeviceBoundKeyType)
 	assert.Equal(t, int32(20), luks.UserPassphraseMinLength)
 	assert.Equal(t, pm.LpsPasswordComplexity_LPS_PASSWORD_COMPLEXITY_COMPLEX, luks.UserPassphraseComplexity)
 }
@@ -108,9 +108,9 @@ func TestCreateAction_Luks_GetAfterCreate(t *testing.T) {
 
 	createResp, err := h.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
 		Name: "LUKS Get Test",
-		Type: pm.ActionType_ACTION_TYPE_LUKS,
-		Params: &pm.CreateActionRequest_Luks{
-			Luks: &pm.LuksParams{
+		Type: pm.ActionType_ACTION_TYPE_ENCRYPTION,
+		Params: &pm.CreateActionRequest_Encryption{
+			Encryption: &pm.EncryptionParams{
 				PresharedKey:         "get-test-psk",
 				RotationIntervalDays: 14,
 				MinWords:             4,
@@ -124,9 +124,9 @@ func TestCreateAction_Luks_GetAfterCreate(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	assert.Equal(t, createResp.Msg.Action.Id, getResp.Msg.Action.Id)
-	assert.Equal(t, pm.ActionType_ACTION_TYPE_LUKS, getResp.Msg.Action.Type)
+	assert.Equal(t, pm.ActionType_ACTION_TYPE_ENCRYPTION, getResp.Msg.Action.Type)
 
-	luks := getResp.Msg.Action.GetLuks()
+	luks := getResp.Msg.Action.GetEncryption()
 	require.NotNil(t, luks)
 	assert.Equal(t, "get-test-psk", luks.PresharedKey)
 	assert.Equal(t, int32(14), luks.RotationIntervalDays)
@@ -142,13 +142,13 @@ func TestCreateAction_Luks_UpdateParams(t *testing.T) {
 
 	createResp, err := h.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
 		Name: "LUKS Update Test",
-		Type: pm.ActionType_ACTION_TYPE_LUKS,
-		Params: &pm.CreateActionRequest_Luks{
-			Luks: &pm.LuksParams{
+		Type: pm.ActionType_ACTION_TYPE_ENCRYPTION,
+		Params: &pm.CreateActionRequest_Encryption{
+			Encryption: &pm.EncryptionParams{
 				PresharedKey:         "update-psk",
 				RotationIntervalDays: 30,
 				MinWords:             5,
-				DeviceBoundKeyType:   pm.LuksDeviceBoundKeyType_LUKS_DEVICE_BOUND_KEY_TYPE_NONE,
+				DeviceBoundKeyType:   pm.EncryptionDeviceBoundKeyType_ENCRYPTION_DEVICE_BOUND_KEY_TYPE_NONE,
 			},
 		},
 	}))
@@ -156,22 +156,22 @@ func TestCreateAction_Luks_UpdateParams(t *testing.T) {
 
 	updateResp, err := h.UpdateActionParams(ctx, connect.NewRequest(&pm.UpdateActionParamsRequest{
 		Id: createResp.Msg.Action.Id,
-		Params: &pm.UpdateActionParamsRequest_Luks{
-			Luks: &pm.LuksParams{
+		Params: &pm.UpdateActionParamsRequest_Encryption{
+			Encryption: &pm.EncryptionParams{
 				PresharedKey:         "update-psk",
 				RotationIntervalDays: 7,
 				MinWords:             8,
-				DeviceBoundKeyType:   pm.LuksDeviceBoundKeyType_LUKS_DEVICE_BOUND_KEY_TYPE_TPM,
+				DeviceBoundKeyType:   pm.EncryptionDeviceBoundKeyType_ENCRYPTION_DEVICE_BOUND_KEY_TYPE_TPM,
 			},
 		},
 	}))
 	require.NoError(t, err)
 
-	luks := updateResp.Msg.Action.GetLuks()
+	luks := updateResp.Msg.Action.GetEncryption()
 	require.NotNil(t, luks)
 	assert.Equal(t, int32(7), luks.RotationIntervalDays)
 	assert.Equal(t, int32(8), luks.MinWords)
-	assert.Equal(t, pm.LuksDeviceBoundKeyType_LUKS_DEVICE_BOUND_KEY_TYPE_TPM, luks.DeviceBoundKeyType)
+	assert.Equal(t, pm.EncryptionDeviceBoundKeyType_ENCRYPTION_DEVICE_BOUND_KEY_TYPE_TPM, luks.DeviceBoundKeyType)
 }
 
 func TestCreateAction_Luks_DeleteAction(t *testing.T) {
@@ -183,9 +183,9 @@ func TestCreateAction_Luks_DeleteAction(t *testing.T) {
 
 	createResp, err := h.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
 		Name: "LUKS Delete Test",
-		Type: pm.ActionType_ACTION_TYPE_LUKS,
-		Params: &pm.CreateActionRequest_Luks{
-			Luks: &pm.LuksParams{
+		Type: pm.ActionType_ACTION_TYPE_ENCRYPTION,
+		Params: &pm.CreateActionRequest_Encryption{
+			Encryption: &pm.EncryptionParams{
 				PresharedKey:         "delete-psk",
 				RotationIntervalDays: 30,
 				MinWords:             5,
@@ -215,9 +215,9 @@ func TestCreateAction_Luks_ListIncludesLuks(t *testing.T) {
 
 	_, err := h.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
 		Name: "LUKS List Test",
-		Type: pm.ActionType_ACTION_TYPE_LUKS,
-		Params: &pm.CreateActionRequest_Luks{
-			Luks: &pm.LuksParams{
+		Type: pm.ActionType_ACTION_TYPE_ENCRYPTION,
+		Params: &pm.CreateActionRequest_Encryption{
+			Encryption: &pm.EncryptionParams{
 				PresharedKey:         "list-psk",
 				RotationIntervalDays: 30,
 				MinWords:             5,
@@ -231,7 +231,7 @@ func TestCreateAction_Luks_ListIncludesLuks(t *testing.T) {
 
 	found := false
 	for _, a := range resp.Msg.Actions {
-		if a.Name == "LUKS List Test" && a.Type == pm.ActionType_ACTION_TYPE_LUKS {
+		if a.Name == "LUKS List Test" && a.Type == pm.ActionType_ACTION_TYPE_ENCRYPTION {
 			found = true
 			break
 		}

--- a/internal/gateway/task_handlers_test.go
+++ b/internal/gateway/task_handlers_test.go
@@ -44,11 +44,11 @@ func TestParseActionParams_ScriptRun(t *testing.T) {
 func TestParseActionParams_Systemd(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"unitName":"nginx.service","enable":true}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SYSTEMD), []byte(params))
+	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SERVICE), []byte(params))
 
-	require.NotNil(t, action.GetSystemd())
-	assert.Equal(t, "nginx.service", action.GetSystemd().UnitName)
-	assert.True(t, action.GetSystemd().Enable)
+	require.NotNil(t, action.GetService())
+	assert.Equal(t, "nginx.service", action.GetService().UnitName)
+	assert.True(t, action.GetService().Enable)
 }
 
 func TestParseActionParams_File(t *testing.T) {


### PR DESCRIPTION
Closes manchtools/power-manage-server#52.

## Summary

Bumps server to SDK v0.2.0 and renames every reference to the escalator-agnostic symbols shipped in SDK #32.

## Changes

Proto symbol renames across `internal/actionparams`, `internal/api`, `internal/handler`, `internal/gateway`:

| Area | Old | New |
|---|---|---|
| Action type enum | `ACTION_TYPE_SYSTEMD / SUDO / LUKS` | `ACTION_TYPE_SERVICE / ADMIN_POLICY / ENCRYPTION` |
| Params | `SystemdParams / SudoParams / LuksParams` | `ServiceParams / AdminPolicyParams / EncryptionParams` |
| Oneof cases (Action) | `Action_{Systemd, Sudo, Luks}` | `Action_{Service, AdminPolicy, Encryption}` |
| Oneof cases (ManagedAction) | same | same |
| Request oneofs | `{Create,UpdateActionParams}Request_{Systemd, Sudo, Luks}` | `..._{Service, AdminPolicy, Encryption}` |
| Enum values | `SudoAccessLevel_SUDO_*`, `SystemdUnitState_SYSTEMD_*`, `LuksDeviceBoundKeyType_LUKS_*` | `AdminAccessLevel_ADMIN_*`, `ServiceUnitState_SERVICE_*`, `EncryptionDeviceBoundKeyType_ENCRYPTION_*` |

## Non-goals

No rendering logic lives on the server side — admin-policy content is serialized on the control plane and rendered on the agent by `internal/executor/sudo.go` (already migrated in agent PR #46 / #41). The server's job here is purely the proto migration.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] `go test ./...` — full suite (testcontainer-based, run in CI)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK dependency to v0.2.0.
  * Renamed internal action types for clarity: "Systemd" actions now called "Service," "Sudo" actions now called "AdminPolicy," and "Luks" actions now called "Encryption."
  * Updated corresponding tests to reflect action type changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->