### PR TITLE
feat: configurable heartbeat interval via GATEWAY_HEARTBEAT_INTERVAL

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -362,7 +362,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	// Create agent handler (always mTLS)
-	agentHandler := handler.NewAgentHandlerWithTLS(manager, aqClient, controlProxy, workerMgr, version, logger)
+	agentHandler := handler.NewAgentHandlerWithTLS(manager, aqClient, controlProxy, workerMgr, version, cfg.HeartbeatInterval, logger)
 	if gatewayReg != nil {
 		agentHandler.SetGatewayRouting(gatewayReg, gatewayID)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,17 @@ package config
 import (
 	"os"
 	"strconv"
+	"time"
+)
+
+// Heartbeat interval bounds. Agents must heartbeat at least once every
+// 5 minutes so server-side liveness detection stays responsive, and no
+// more often than every 5 seconds so we don't hammer the stream with
+// keepalives that serve no purpose.
+const (
+	MinHeartbeatInterval     = 5 * time.Second
+	MaxHeartbeatInterval     = 5 * time.Minute
+	DefaultHeartbeatInterval = 30 * time.Second
 )
 
 // Config holds the gateway server configuration.
@@ -116,6 +127,11 @@ type Config struct {
 	// router attaches to. Example: "websecure".
 	TraefikTTYEntryPoint string
 
+	// HeartbeatInterval is the default heartbeat cadence sent to every
+	// agent in the Welcome message. Clamped to [MinHeartbeatInterval,
+	// MaxHeartbeatInterval] in FromEnv.
+	HeartbeatInterval time.Duration
+
 	// Logging
 	LogLevel string
 }
@@ -142,8 +158,32 @@ func FromEnv() *Config {
 		TraefikTTYHost:            getEnv("GATEWAY_TRAEFIK_TTY_HOST", ""),
 		TraefikTTYBackend:         getEnv("GATEWAY_TRAEFIK_TTY_BACKEND", ""),
 		TraefikTTYEntryPoint:      getEnv("GATEWAY_TRAEFIK_TTY_ENTRYPOINT", ""),
+		HeartbeatInterval:         getEnvHeartbeatInterval("GATEWAY_HEARTBEAT_INTERVAL"),
 		LogLevel:                  getEnv("LOG_LEVEL", "info"),
 	}
+}
+
+// getEnvHeartbeatInterval parses GATEWAY_HEARTBEAT_INTERVAL (a Go
+// duration string) and clamps it to [MinHeartbeatInterval,
+// MaxHeartbeatInterval]. An unset, empty, or unparseable value falls
+// back to DefaultHeartbeatInterval so the gateway always comes up with
+// a sensible cadence.
+func getEnvHeartbeatInterval(key string) time.Duration {
+	v := os.Getenv(key)
+	if v == "" {
+		return DefaultHeartbeatInterval
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return DefaultHeartbeatInterval
+	}
+	if d < MinHeartbeatInterval {
+		return MinHeartbeatInterval
+	}
+	if d > MaxHeartbeatInterval {
+		return MaxHeartbeatInterval
+	}
+	return d
 }
 
 func getEnv(key, defaultValue string) string {

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -8,9 +8,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
@@ -33,13 +35,14 @@ const (
 type AgentHandler struct {
 	pmv1connect.UnimplementedAgentServiceHandler
 
-	manager       *connection.Manager
-	aqClient      *taskqueue.Client
-	controlProxy  *ControlProxy
-	workerMgr     *gateway.DeviceWorkerManager
-	logger        *slog.Logger
-	serverVersion string
-	requireTLS    bool
+	manager           *connection.Manager
+	aqClient          *taskqueue.Client
+	controlProxy      *ControlProxy
+	workerMgr         *gateway.DeviceWorkerManager
+	logger            *slog.Logger
+	serverVersion     string
+	heartbeatInterval time.Duration
+	requireTLS        bool
 
 	// Multi-gateway routing. registry and gatewayID are set via
 	// SetGatewayRouting at startup. nil registry means single-
@@ -64,16 +67,18 @@ func NewAgentHandler(
 	controlProxy *ControlProxy,
 	workerMgr *gateway.DeviceWorkerManager,
 	serverVersion string,
+	heartbeatInterval time.Duration,
 	logger *slog.Logger,
 ) *AgentHandler {
 	return &AgentHandler{
-		manager:       manager,
-		aqClient:      aqClient,
-		controlProxy:  controlProxy,
-		workerMgr:     workerMgr,
-		serverVersion: serverVersion,
-		logger:        logger,
-		requireTLS:    false,
+		manager:           manager,
+		aqClient:          aqClient,
+		controlProxy:      controlProxy,
+		workerMgr:         workerMgr,
+		serverVersion:     serverVersion,
+		heartbeatInterval: heartbeatInterval,
+		logger:            logger,
+		requireTLS:        false,
 	}
 }
 
@@ -84,16 +89,18 @@ func NewAgentHandlerWithTLS(
 	controlProxy *ControlProxy,
 	workerMgr *gateway.DeviceWorkerManager,
 	serverVersion string,
+	heartbeatInterval time.Duration,
 	logger *slog.Logger,
 ) *AgentHandler {
 	return &AgentHandler{
-		manager:       manager,
-		aqClient:      aqClient,
-		controlProxy:  controlProxy,
-		workerMgr:     workerMgr,
-		serverVersion: serverVersion,
-		logger:        logger,
-		requireTLS:    true,
+		manager:           manager,
+		aqClient:          aqClient,
+		controlProxy:      controlProxy,
+		workerMgr:         workerMgr,
+		serverVersion:     serverVersion,
+		heartbeatInterval: heartbeatInterval,
+		logger:            logger,
+		requireTLS:        true,
 	}
 }
 
@@ -328,9 +335,15 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 		h.logger.Warn("failed to enqueue device hello", "error", err)
 	}
 
-	// Send Welcome message to agent with server version.
+	// Send Welcome message to agent with server version. Populate
+	// HeartbeatInterval only when configured — the agent SDK falls back
+	// to its built-in default if the field is zero / unset, so older
+	// agents that ignore the field keep working unchanged.
 	welcome := &pm.Welcome{
 		ServerVersion: h.serverVersion,
+	}
+	if h.heartbeatInterval > 0 {
+		welcome.HeartbeatInterval = durationpb.New(h.heartbeatInterval)
 	}
 
 	if err := h.manager.Send(deviceID, &pm.ServerMessage{


### PR DESCRIPTION
## Summary

- New `GATEWAY_HEARTBEAT_INTERVAL` env var (Go duration string) sets the default agent heartbeat cadence fleet-wide. Clamped to `[5s, 5min]`; default `30s`.
- Populates `Welcome.heartbeat_interval` on every agent connect — SDK v0.2.1+ agents reset their ticker to match on every connect and reconnect.
- Welcome field is only emitted when configured (> 0), so older SDKs that ignore it fall through to their built-in default unchanged.

Closes #27.

## Depends on

- `manchtools/power-manage-sdk#34` — SDK-side clamp + ticker reset logic
- `manchtools/power-manage-server#61` — base branch (rebased to main once that merges)

## Why env var, not DB setting

Heartbeat cadence rarely changes and the gateway has no DB — a DB-backed setting would require an extra RPC hop on every agent connect. Env var keeps the knob next to the other operational tuning (`VALKEY_ADDR`, `GATEWAY_CONTROL_URL`, …) and matches the ops reality that changing the cadence implies a gateway restart.

## Test plan

- [x] Unit tests pass (`internal/config`, `internal/handler`)
- [x] `go build ./...`
- [ ] Manual: set `GATEWAY_HEARTBEAT_INTERVAL=10s`, connect agent, observe ticker reset on reconnect