### PR TITLE
rc3: env-var namespace cleanup + Traefik KV TTY cert-resolver fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,14 +458,20 @@ CGO_ENABLED=0 go build -ldflags="-s -w -X main.version=2026.3.0" -o gateway ./cm
 
 | Variable | Description |
 |----------|-------------|
-| `VALKEY_ADDR` | Valkey address, e.g. `localhost:6379` |
-| `VALKEY_PASSWORD` | Valkey password |
+| `GATEWAY_VALKEY_ADDR` | Valkey address, e.g. `localhost:6379` |
+| `GATEWAY_VALKEY_PASSWORD` | Valkey password |
+| `GATEWAY_VALKEY_DB` | Valkey DB number (default `0`) |
 | `GATEWAY_CONTROL_URL` | URL of the Control Server |
 | `GATEWAY_ID` | Stable gateway identifier (empty = generate ULID at startup) |
 | `GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE` | Template for the public terminal WebSocket URL, e.g. `wss://{id}.gateway.example.com/terminal` |
 | `GATEWAY_BOOTSTRAP_HOST` | Wildcard root hostname for agent bootstrap redirect, e.g. `gateway.example.com` |
 | `GATEWAY_WEB_LISTEN_ADDR` | Listen address for the web TLS listener (terminal WebSocket), e.g. `:8443` |
+| `GATEWAY_LOG_LEVEL` | Log level: `debug`, `info`, `warn`, `error` (default `info`) |
+| `GATEWAY_HEARTBEAT_INTERVAL` | Heartbeat cadence sent to agents (Go duration, 5s..5m; default `30s`) |
+| `GATEWAY_TRAEFIK_TTY_CERT_RESOLVER` | Traefik cert resolver name for the per-replica TTY HTTP router (e.g. `letsencrypt`) |
 | `CONTROL_TERMINAL_GATEWAY_URL` | Fallback terminal gateway URL for single-gateway deployments (deprecated in favor of registry) |
+
+> **rc3 migration:** the previously unprefixed `VALKEY_ADDR` / `VALKEY_PASSWORD` / `VALKEY_DB` / `LOG_LEVEL` are now `GATEWAY_*`-prefixed. The old names are no longer read — rename them in your `.env` before upgrading.
 
 ## Running Locally
 
@@ -482,8 +488,8 @@ Requires a running PostgreSQL and Valkey instance. See the [self-hosting guide](
   -gateway-url=http://localhost:8080
 
 # Gateway server (no database required, connects to Valkey and Control)
-export VALKEY_ADDR=localhost:6379
-export VALKEY_PASSWORD=your-valkey-password
+export GATEWAY_VALKEY_ADDR=localhost:6379
+export GATEWAY_VALKEY_PASSWORD=your-valkey-password
 export GATEWAY_CONTROL_URL=http://localhost:8081
 ./gateway -tls -tls-cert=certs/gateway.crt -tls-key=certs/gateway.key -tls-ca=certs/ca.crt
 ```

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -267,7 +267,14 @@ func main() {
 	}, false)
 
 	// Initialize secret encryptor
-	encryptor, err := crypto.NewEncryptor(os.Getenv("PM_ENCRYPTION_KEY"))
+	//
+	// rc3 note: previously read unprefixed PM_ENCRYPTION_KEY /
+	// PM_ENCRYPTION_KEY_REQUIRED. Now namespaced as
+	// CONTROL_ENCRYPTION_KEY / CONTROL_ENCRYPTION_KEY_REQUIRED so all
+	// control-server knobs live under one prefix. Operators upgrading
+	// from rc2 must rename their .env entries — the old names are no
+	// longer read.
+	encryptor, err := crypto.NewEncryptor(os.Getenv("CONTROL_ENCRYPTION_KEY"))
 	if err != nil {
 		logger.Error("failed to initialize encryptor", "error", err)
 		os.Exit(1)
@@ -277,11 +284,11 @@ func main() {
 		// secrets-at-rest rely on this encryptor. Running without a
 		// key would silently degrade security in production. Operators
 		// who truly want unencrypted storage can set
-		// PM_ENCRYPTION_KEY_REQUIRED=false to opt in explicitly.
-		if os.Getenv("PM_ENCRYPTION_KEY_REQUIRED") == "false" {
-			logger.Warn("PM_ENCRYPTION_KEY not set and PM_ENCRYPTION_KEY_REQUIRED=false - secrets will be stored unencrypted")
+		// CONTROL_ENCRYPTION_KEY_REQUIRED=false to opt in explicitly.
+		if os.Getenv("CONTROL_ENCRYPTION_KEY_REQUIRED") == "false" {
+			logger.Warn("CONTROL_ENCRYPTION_KEY not set and CONTROL_ENCRYPTION_KEY_REQUIRED=false - secrets will be stored unencrypted")
 		} else {
-			logger.Error("PM_ENCRYPTION_KEY is required (set PM_ENCRYPTION_KEY_REQUIRED=false to opt out)")
+			logger.Error("CONTROL_ENCRYPTION_KEY is required (set CONTROL_ENCRYPTION_KEY_REQUIRED=false to opt out)")
 			os.Exit(1)
 		}
 	}

--- a/cmd/gateway/README.md
+++ b/cmd/gateway/README.md
@@ -61,13 +61,16 @@ The Gateway Server:
 |----------|---------|-------------|
 | `GATEWAY_LISTEN_ADDR` | `:8080` | Listen address for the agent mTLS listener |
 | `GATEWAY_WEB_LISTEN_ADDR` | (empty) | Listen address for the TTY WebSocket listener (empty disables the terminal feature) |
-| `VALKEY_ADDR` | `localhost:6379` | Valkey/Redis address for Asynq task queue |
-| `VALKEY_PASSWORD` | (empty) | Valkey/Redis password |
-| `VALKEY_DB` | `0` | Valkey/Redis database number |
+| `GATEWAY_VALKEY_ADDR` | `localhost:6379` | Valkey/Redis address for Asynq task queue |
+| `GATEWAY_VALKEY_PASSWORD` | (empty) | Valkey/Redis password |
+| `GATEWAY_VALKEY_DB` | `0` | Valkey/Redis database number |
 | `GATEWAY_CONTROL_URL` | `http://control:8081` | Control Server URL for Connect-RPC proxy |
 | `GATEWAY_ID` | (auto-ULID) | Stable gateway identifier; auto-generated per process when empty (required for replica scaling) |
 | `GATEWAY_INTERNAL_URL` | (empty) | mTLS URL the control server uses for admin fan-out RPCs |
-| `LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
+| `GATEWAY_HEARTBEAT_INTERVAL` | `30s` | Heartbeat cadence sent to every agent (Go duration, 5s..5m) |
+| `GATEWAY_LOG_LEVEL` | `info` | Log level (debug, info, warn, error) |
+
+> **rc3 migration:** the previously unprefixed `VALKEY_ADDR` / `VALKEY_PASSWORD` / `VALKEY_DB` / `LOG_LEVEL` knobs now live under the `GATEWAY_*` namespace. The old names are no longer read.
 
 #### Traefik self-registration (Redis KV)
 
@@ -83,6 +86,7 @@ When enabled, each gateway replica publishes its own routing entries into Traefi
 | `GATEWAY_TRAEFIK_TTY_HOST` | — | Public `Host` for TTY, e.g. `tty.example.com`. |
 | `GATEWAY_TRAEFIK_TTY_BACKEND` | auto | Internal URL for this replica's TTY listener. Auto-derived from `os.Hostname()` + `GATEWAY_WEB_LISTEN_ADDR` when empty. |
 | `GATEWAY_TRAEFIK_TTY_ENTRYPOINT` | — | Traefik entrypoint the TTY router binds to, e.g. `websecure`. |
+| `GATEWAY_TRAEFIK_TTY_CERT_RESOLVER` | (empty) | Cert resolver for the per-replica TTY HTTP router, e.g. `letsencrypt`. Must match a `--certificatesresolvers.<name>.*` entry in Traefik's static config. Leave empty only for bring-your-own-cert deployments that ship a default cert matching `GATEWAY_TRAEFIK_TTY_HOST` — otherwise browsers reject the default self-signed cert Traefik serves for Redis-KV routers. |
 
 All Traefik keys share the registry TTL (45 s default) and are refreshed on the same cadence as the gateway terminal-URL entry. Graceful shutdown revokes only per-replica keys; shared router keys expire naturally when the last replica stops. See `server/deploy/compose.yml` for the matching Traefik command flags.
 
@@ -119,8 +123,8 @@ openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key \
 For local development without TLS:
 
 ```bash
-export VALKEY_ADDR=localhost:6379
-export VALKEY_PASSWORD=your-password
+export GATEWAY_VALKEY_ADDR=localhost:6379
+export GATEWAY_VALKEY_PASSWORD=your-password
 export GATEWAY_CONTROL_URL=http://localhost:8081
 export LOG_LEVEL=debug
 
@@ -132,8 +136,8 @@ This runs in HTTP/2 cleartext (h2c) mode - **not suitable for production**.
 ### Running in Production Mode (mTLS)
 
 ```bash
-export VALKEY_ADDR=valkey:6379
-export VALKEY_PASSWORD=your-password
+export GATEWAY_VALKEY_ADDR=valkey:6379
+export GATEWAY_VALKEY_PASSWORD=your-password
 export GATEWAY_CONTROL_URL=http://control:8081
 
 go run ./server/cmd/gateway \
@@ -380,7 +384,7 @@ When running multiple Gateways behind a load balancer:
 ### Debug Logging
 
 ```bash
-LOG_LEVEL=debug ./gateway -tls -tls-cert=... -tls-key=... -tls-ca=...
+GATEWAY_LOG_LEVEL=debug ./gateway -tls -tls-cert=... -tls-key=... -tls-ca=...
 ```
 
 ### Common Issues
@@ -390,7 +394,7 @@ LOG_LEVEL=debug ./gateway -tls -tls-cert=... -tls-key=... -tls-ca=...
 | "TLS enabled but missing required flags" | Missing -tls-cert, -tls-key, or -tls-ca | Provide all three certificate paths |
 | Agent connection refused | mTLS cert validation failed | Verify agent certificate is signed by the same CA |
 | Actions not dispatched | Asynq worker not started for device | Check device ID matches between certificate and Hello |
-| "failed to connect to valkey" | Valkey not reachable | Check `VALKEY_ADDR` and `VALKEY_PASSWORD` |
+| "failed to connect to valkey" | Valkey not reachable | Check `GATEWAY_VALKEY_ADDR` and `GATEWAY_VALKEY_PASSWORD` |
 | Credential operations failing | Control Server not reachable | Check `GATEWAY_CONTROL_URL` |
 
 ## Development
@@ -415,8 +419,8 @@ go test ./server/internal/connection/...
 podman-compose up -d valkey control
 
 # Run gateway in dev mode
-export VALKEY_ADDR=localhost:6379
-export VALKEY_PASSWORD=your-password
+export GATEWAY_VALKEY_ADDR=localhost:6379
+export GATEWAY_VALKEY_PASSWORD=your-password
 export GATEWAY_CONTROL_URL=http://localhost:8081
 export LOG_LEVEL=debug
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -56,7 +56,7 @@ func main() {
 
 	// Validate required config
 	if cfg.ValkeyAddr == "" {
-		logger.Error("VALKEY_ADDR is required")
+		logger.Error("GATEWAY_VALKEY_ADDR is required")
 		os.Exit(1)
 	}
 	if cfg.ControlURL == "" {
@@ -282,13 +282,14 @@ func main() {
 		}
 
 		traefikCfg := registry.TraefikRouteConfig{
-			RootKey:        cfg.TraefikRootKey,
-			MTLSHost:       cfg.TraefikMTLSHost,
-			MTLSBackend:    mtlsBackend,
-			MTLSEntryPoint: cfg.TraefikMTLSEntryPoint,
-			TTYHost:        cfg.TraefikTTYHost,
-			TTYBackend:     ttyBackend,
-			TTYEntryPoint:  cfg.TraefikTTYEntryPoint,
+			RootKey:         cfg.TraefikRootKey,
+			MTLSHost:        cfg.TraefikMTLSHost,
+			MTLSBackend:     mtlsBackend,
+			MTLSEntryPoint:  cfg.TraefikMTLSEntryPoint,
+			TTYHost:         cfg.TraefikTTYHost,
+			TTYBackend:      ttyBackend,
+			TTYEntryPoint:   cfg.TraefikTTYEntryPoint,
+			TTYCertResolver: cfg.TraefikTTYCertResolver,
 		}
 
 		if err := gatewayReg.PublishTraefikRoute(
@@ -337,6 +338,7 @@ func main() {
 			"mtls_backend", cfg.TraefikMTLSBackend,
 			"tty_host", cfg.TraefikTTYHost,
 			"tty_backend", cfg.TraefikTTYBackend,
+			"tty_cert_resolver", cfg.TraefikTTYCertResolver,
 		)
 	}
 	// Fail fast if BootstrapHost is set but we have no assignedHost

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -58,15 +58,24 @@ ACME_EMAIL=admin@example.com
 # LPS passwords). Must be exactly 64 hex characters (32 bytes).
 # Generate with: openssl rand -hex 32
 # WARNING: Changing this key after data has been encrypted will make existing
-# encrypted secrets unrecoverable. If not set, secrets are stored unencrypted.
-PM_ENCRYPTION_KEY=
+# encrypted secrets unrecoverable. If not set (and CONTROL_ENCRYPTION_KEY_REQUIRED
+# is false), secrets are stored unencrypted.
+CONTROL_ENCRYPTION_KEY=
+
+# Set to "false" to opt out of the fail-closed check above. Default: unset,
+# which makes the control server refuse to start without CONTROL_ENCRYPTION_KEY.
+# CONTROL_ENCRYPTION_KEY_REQUIRED=false
 
 # =============================================================================
 # Optional — uncomment and set as needed
 # =============================================================================
 
 # --- Logging ----------------------------------------------------------------
-# Log level: debug, info, warn, error (default: info)
+# Log level: debug, info, warn, error (default: info).
+# The variable is read directly by each service via its prefixed name
+# (CONTROL_LOG_LEVEL, GATEWAY_LOG_LEVEL, INDEXER_LOG_LEVEL); compose.yml feeds
+# this single knob into each. Override per-service in compose.yml if you want
+# split log levels.
 LOG_LEVEL=info
 # Log format: text (human-readable) or json (structured, for log aggregators)
 # LOG_FORMAT=text
@@ -126,3 +135,14 @@ LOG_LEVEL=info
 # Traefik root key in Valkey. Must match --providers.redis.rootkey in the
 # Traefik command. Default matches the one set in compose.yml.
 # GATEWAY_TRAEFIK_ROOT_KEY=traefik
+
+# Traefik certificate resolver for the per-replica TTY HTTP router. Must match
+# a `--certificatesresolvers.<name>.*` entry in the Traefik static config. If
+# unset, Traefik serves its default self-signed cert for the TTY router —
+# browsers refuse that for WebSocket upgrades, so leave the default value in
+# place unless you ship your own pre-matched default cert.
+# GATEWAY_TRAEFIK_TTY_CERT_RESOLVER=letsencrypt
+
+# Heartbeat cadence sent to every connected agent (Go duration, 5s..5m).
+# Default: 30s.
+# GATEWAY_HEARTBEAT_INTERVAL=30s

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -117,7 +117,8 @@ services:
       - CONTROL_DYNAMIC_GROUP_EVAL_INTERVAL=${DYNAMIC_GROUP_EVAL_INTERVAL:-1h}
       - CONTROL_SSO_CALLBACK_BASE_URL=${CONTROL_SSO_CALLBACK_BASE_URL:-}
       - CONTROL_SCIM_BASE_URL=${CONTROL_SCIM_BASE_URL:-}
-      - PM_ENCRYPTION_KEY=${PM_ENCRYPTION_KEY:-}
+      - CONTROL_ENCRYPTION_KEY=${CONTROL_ENCRYPTION_KEY:-}
+      - CONTROL_ENCRYPTION_KEY_REQUIRED=${CONTROL_ENCRYPTION_KEY_REQUIRED:-}
       - CONTROL_INTERNAL_LISTEN_ADDR=:8082
       - CONTROL_INTERNAL_TLS_CERT=/certs/control.crt
       - CONTROL_INTERNAL_TLS_KEY=/certs/control.key
@@ -184,11 +185,13 @@ services:
     volumes:
       - ./certs:/certs:ro,z
     environment:
-      - VALKEY_ADDR=valkey:6379
-      - VALKEY_PASSWORD=${VALKEY_PASSWORD}
+      - GATEWAY_VALKEY_ADDR=valkey:6379
+      - GATEWAY_VALKEY_PASSWORD=${VALKEY_PASSWORD}
       - GATEWAY_CONTROL_URL=https://control:8082
       - GATEWAY_LISTEN_ADDR=:8080
-      - LOG_LEVEL=${LOG_LEVEL:-info}
+      - GATEWAY_LOG_LEVEL=${LOG_LEVEL:-info}
+      # rc3: configurable agent heartbeat cadence (Go duration, 5s..5m).
+      - GATEWAY_HEARTBEAT_INTERVAL=${GATEWAY_HEARTBEAT_INTERVAL:-30s}
       # Remote terminal (multi-gateway routing). Leave empty to disable.
       # GATEWAY_ID is auto-generated as a ULID if empty; when scaling
       # replicas, leave it empty so each container gets its own ID.
@@ -207,6 +210,12 @@ services:
       - GATEWAY_TRAEFIK_MTLS_ENTRYPOINT=mtls
       - GATEWAY_TRAEFIK_TTY_HOST=${GATEWAY_TTY_DOMAIN:-${GATEWAY_DOMAIN}}
       - GATEWAY_TRAEFIK_TTY_ENTRYPOINT=websecure
+      # rc3: explicitly name the cert resolver for the TTY router. The Redis
+      # KV provider does not inherit the entrypoint-level default cert
+      # resolver the way Docker-labelled routers do, so without this the
+      # TTY router falls back to Traefik's default self-signed cert and
+      # browsers refuse the WebSocket upgrade.
+      - GATEWAY_TRAEFIK_TTY_CERT_RESOLVER=${GATEWAY_TRAEFIK_TTY_CERT_RESOLVER:-letsencrypt}
     command:
       - "-tls-cert=/certs/gateway.crt"
       - "-tls-key=/certs/gateway.key"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -127,6 +127,16 @@ type Config struct {
 	// router attaches to. Example: "websecure".
 	TraefikTTYEntryPoint string
 
+	// TraefikTTYCertResolver is the Traefik certificate-resolver name
+	// the TTY HTTP router uses to obtain a TLS cert (typically
+	// "letsencrypt" matching --certificatesresolvers.letsencrypt.* on
+	// Traefik's static config). Empty leaves the router with just
+	// `tls = true`, which makes Traefik serve its default self-signed
+	// cert — browser WebSocket clients refuse that, so unset is only
+	// useful for bring-your-own-cert deployments that ship a
+	// pre-matched default certificate for the TTY host.
+	TraefikTTYCertResolver string
+
 	// HeartbeatInterval is the default heartbeat cadence sent to every
 	// agent in the Welcome message. Clamped to [MinHeartbeatInterval,
 	// MaxHeartbeatInterval] in FromEnv.
@@ -137,12 +147,19 @@ type Config struct {
 }
 
 // FromEnv loads configuration from environment variables.
+//
+// rc3 note: the gateway previously read VALKEY_ADDR / VALKEY_PASSWORD /
+// VALKEY_DB / LOG_LEVEL unprefixed. Those are now GATEWAY_VALKEY_ADDR
+// / GATEWAY_VALKEY_PASSWORD / GATEWAY_VALKEY_DB / GATEWAY_LOG_LEVEL so
+// every gateway knob shares one namespace and nothing silently aliases
+// a global the way the old names could. The old names no longer work;
+// operators upgrading from rc2 must rename their .env entries.
 func FromEnv() *Config {
 	return &Config{
 		ListenAddr:                getEnv("GATEWAY_LISTEN_ADDR", ":8080"),
-		ValkeyAddr:                getEnv("VALKEY_ADDR", "localhost:6379"),
-		ValkeyPassword:            getEnv("VALKEY_PASSWORD", ""),
-		ValkeyDB:                  getEnvInt("VALKEY_DB", 0),
+		ValkeyAddr:                getEnv("GATEWAY_VALKEY_ADDR", "localhost:6379"),
+		ValkeyPassword:            getEnv("GATEWAY_VALKEY_PASSWORD", ""),
+		ValkeyDB:                  getEnvInt("GATEWAY_VALKEY_DB", 0),
 		ControlURL:                getEnv("GATEWAY_CONTROL_URL", "http://control:8081"),
 		GatewayID:                 getEnv("GATEWAY_ID", ""),
 		PublicTerminalURLTemplate: getEnv("GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE", ""),
@@ -158,8 +175,9 @@ func FromEnv() *Config {
 		TraefikTTYHost:            getEnv("GATEWAY_TRAEFIK_TTY_HOST", ""),
 		TraefikTTYBackend:         getEnv("GATEWAY_TRAEFIK_TTY_BACKEND", ""),
 		TraefikTTYEntryPoint:      getEnv("GATEWAY_TRAEFIK_TTY_ENTRYPOINT", ""),
+		TraefikTTYCertResolver:    getEnv("GATEWAY_TRAEFIK_TTY_CERT_RESOLVER", ""),
 		HeartbeatInterval:         getEnvHeartbeatInterval("GATEWAY_HEARTBEAT_INTERVAL"),
-		LogLevel:                  getEnv("LOG_LEVEL", "info"),
+		LogLevel:                  getEnv("GATEWAY_LOG_LEVEL", "info"),
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,10 +5,12 @@ import (
 )
 
 func TestFromEnv_Defaults(t *testing.T) {
-	// Clear any env vars that might be set
+	// Clear any env vars that might be set. rc3 renamed the unprefixed
+	// VALKEY_* / LOG_LEVEL knobs into the GATEWAY_* namespace so every
+	// gateway config variable shares one prefix.
 	for _, key := range []string{
-		"GATEWAY_LISTEN_ADDR", "VALKEY_ADDR", "VALKEY_PASSWORD",
-		"VALKEY_DB", "GATEWAY_CONTROL_URL", "LOG_LEVEL",
+		"GATEWAY_LISTEN_ADDR", "GATEWAY_VALKEY_ADDR", "GATEWAY_VALKEY_PASSWORD",
+		"GATEWAY_VALKEY_DB", "GATEWAY_CONTROL_URL", "GATEWAY_LOG_LEVEL",
 	} {
 		t.Setenv(key, "")
 	}
@@ -37,11 +39,11 @@ func TestFromEnv_Defaults(t *testing.T) {
 
 func TestFromEnv_CustomValues(t *testing.T) {
 	t.Setenv("GATEWAY_LISTEN_ADDR", ":9090")
-	t.Setenv("VALKEY_ADDR", "valkey:6380")
-	t.Setenv("VALKEY_PASSWORD", "secret")
-	t.Setenv("VALKEY_DB", "3")
+	t.Setenv("GATEWAY_VALKEY_ADDR", "valkey:6380")
+	t.Setenv("GATEWAY_VALKEY_PASSWORD", "secret")
+	t.Setenv("GATEWAY_VALKEY_DB", "3")
 	t.Setenv("GATEWAY_CONTROL_URL", "http://localhost:8081")
-	t.Setenv("LOG_LEVEL", "debug")
+	t.Setenv("GATEWAY_LOG_LEVEL", "debug")
 
 	cfg := FromEnv()
 
@@ -66,12 +68,56 @@ func TestFromEnv_CustomValues(t *testing.T) {
 }
 
 func TestFromEnv_InvalidValkeyDB_UsesDefault(t *testing.T) {
-	t.Setenv("VALKEY_DB", "not-a-number")
+	t.Setenv("GATEWAY_VALKEY_DB", "not-a-number")
 
 	cfg := FromEnv()
 
 	if cfg.ValkeyDB != 0 {
 		t.Errorf("ValkeyDB = %d, want 0 (default on invalid input)", cfg.ValkeyDB)
+	}
+}
+
+// rc3: unprefixed VALKEY_* / LOG_LEVEL must not be read. Anyone upgrading
+// from rc2 who forgets to rename their env gets default values, not a
+// silent half-configured gateway.
+func TestFromEnv_IgnoresOldUnprefixedVars(t *testing.T) {
+	t.Setenv("VALKEY_ADDR", "old:6379")
+	t.Setenv("VALKEY_PASSWORD", "old-secret")
+	t.Setenv("VALKEY_DB", "9")
+	t.Setenv("LOG_LEVEL", "debug")
+	// Ensure nothing leaks in from the rc3 vars either.
+	t.Setenv("GATEWAY_VALKEY_ADDR", "")
+	t.Setenv("GATEWAY_VALKEY_PASSWORD", "")
+	t.Setenv("GATEWAY_VALKEY_DB", "")
+	t.Setenv("GATEWAY_LOG_LEVEL", "")
+
+	cfg := FromEnv()
+
+	if cfg.ValkeyAddr != "localhost:6379" {
+		t.Errorf("ValkeyAddr = %q, want default (unprefixed VALKEY_ADDR must not be read)", cfg.ValkeyAddr)
+	}
+	if cfg.ValkeyPassword != "" {
+		t.Errorf("ValkeyPassword = %q, want empty (unprefixed VALKEY_PASSWORD must not be read)", cfg.ValkeyPassword)
+	}
+	if cfg.ValkeyDB != 0 {
+		t.Errorf("ValkeyDB = %d, want 0 (unprefixed VALKEY_DB must not be read)", cfg.ValkeyDB)
+	}
+	if cfg.LogLevel != "info" {
+		t.Errorf("LogLevel = %q, want default (unprefixed LOG_LEVEL must not be read)", cfg.LogLevel)
+	}
+}
+
+func TestFromEnv_TraefikTTYCertResolver(t *testing.T) {
+	t.Setenv("GATEWAY_TRAEFIK_TTY_CERT_RESOLVER", "letsencrypt")
+	cfg := FromEnv()
+	if cfg.TraefikTTYCertResolver != "letsencrypt" {
+		t.Errorf("TraefikTTYCertResolver = %q, want %q", cfg.TraefikTTYCertResolver, "letsencrypt")
+	}
+
+	t.Setenv("GATEWAY_TRAEFIK_TTY_CERT_RESOLVER", "")
+	cfg = FromEnv()
+	if cfg.TraefikTTYCertResolver != "" {
+		t.Errorf("TraefikTTYCertResolver = %q, want empty by default", cfg.TraefikTTYCertResolver)
 	}
 }
 

--- a/internal/gateway/registry/traefik.go
+++ b/internal/gateway/registry/traefik.go
@@ -65,6 +65,17 @@ type TraefikRouteConfig struct {
 	// TTYEntryPoint is the HTTP entrypoint name, typically
 	// "websecure".
 	TTYEntryPoint string
+	// TTYCertResolver is the Traefik certificate resolver the per-
+	// replica TTY HTTP router should use to obtain its public TLS
+	// cert, e.g. "letsencrypt". Matches a resolver declared in
+	// Traefik's static config (`--certificatesresolvers.<name>.*`).
+	//
+	// Empty leaves the router with just `tls=true`, which makes
+	// Traefik serve its default self-signed certificate — browsers
+	// refuse that for WebSocket upgrades, so unset is only viable
+	// for bring-your-own-cert setups that ship a default cert
+	// pre-matched to TTYHost.
+	TTYCertResolver string
 	// RootKey is the Traefik Redis root-key prefix. Defaults to
 	// DefaultTraefikRootKey.
 	RootKey string
@@ -121,15 +132,29 @@ func (c TraefikRouteConfig) traefikKeys(gatewayID string) []struct{ key, value s
 	mtlsServerKey := fmt.Sprintf("%s/tcp/services/pm-mtls/loadbalancer/servers/%s/address", root, gatewayID)
 
 	// Per-replica HTTP router for TTY. Unique to this gateway.
+	//
+	// NB: for a Redis-KV-defined router, `tls` must be a nested map
+	// rather than the flat string "true". Writing both
+	// `<router>/tls` = "true" and `<router>/tls/certResolver` = "..."
+	// is invalid in Traefik's KV schema (the first key blocks the
+	// nested path). We therefore always publish nested TLS keys:
+	// `/tls/passthrough = false` stands in for the "TLS is on" bit,
+	// and `/tls/certResolver` is added when configured. This keeps
+	// browsers from seeing Traefik's default self-signed cert.
 	ttyRouter := fmt.Sprintf("pm-tty-%s", gatewayID)
 	ttyRule := fmt.Sprintf("Host(`%s`) && PathPrefix(`/gw/%s`)", c.TTYHost, gatewayID)
 	perReplica := []struct{ key, value string }{
 		{mtlsServerKey, c.MTLSBackend},
 		{fmt.Sprintf("%s/http/routers/%s/rule", root, ttyRouter), ttyRule},
 		{fmt.Sprintf("%s/http/routers/%s/entrypoints/0", root, ttyRouter), c.TTYEntryPoint},
-		{fmt.Sprintf("%s/http/routers/%s/tls", root, ttyRouter), "true"},
+		{fmt.Sprintf("%s/http/routers/%s/tls/passthrough", root, ttyRouter), "false"},
 		{fmt.Sprintf("%s/http/routers/%s/service", root, ttyRouter), ttyRouter},
 		{fmt.Sprintf("%s/http/services/%s/loadbalancer/servers/0/url", root, ttyRouter), c.TTYBackend},
+	}
+	if c.TTYCertResolver != "" {
+		perReplica = append(perReplica, struct{ key, value string }{
+			fmt.Sprintf("%s/http/routers/%s/tls/certResolver", root, ttyRouter), c.TTYCertResolver,
+		})
 	}
 
 	out := make([]struct{ key, value string }, 0, len(sharedMTLS)+len(perReplica))
@@ -142,6 +167,11 @@ func (c TraefikRouteConfig) traefikKeys(gatewayID string) []struct{ key, value s
 // replica — the ones safe to delete on shutdown without clobbering
 // other replicas' routes. Shared pm-mtls keys are NOT included; they
 // expire naturally via TTL once the last replica stops refreshing them.
+//
+// Always lists /tls/certResolver too, even when unset at publish time:
+// deleting a key that doesn't exist is a no-op, and listing it here
+// means an operator who re-launches without a resolver cleanly leaves
+// no orphaned key behind.
 func (c TraefikRouteConfig) perReplicaKeys(gatewayID string) []string {
 	root := c.rootKey()
 	ttyRouter := fmt.Sprintf("pm-tty-%s", gatewayID)
@@ -149,7 +179,8 @@ func (c TraefikRouteConfig) perReplicaKeys(gatewayID string) []string {
 		fmt.Sprintf("%s/tcp/services/pm-mtls/loadbalancer/servers/%s/address", root, gatewayID),
 		fmt.Sprintf("%s/http/routers/%s/rule", root, ttyRouter),
 		fmt.Sprintf("%s/http/routers/%s/entrypoints/0", root, ttyRouter),
-		fmt.Sprintf("%s/http/routers/%s/tls", root, ttyRouter),
+		fmt.Sprintf("%s/http/routers/%s/tls/passthrough", root, ttyRouter),
+		fmt.Sprintf("%s/http/routers/%s/tls/certResolver", root, ttyRouter),
 		fmt.Sprintf("%s/http/routers/%s/service", root, ttyRouter),
 		fmt.Sprintf("%s/http/services/%s/loadbalancer/servers/0/url", root, ttyRouter),
 	}

--- a/internal/gateway/registry/traefik.go
+++ b/internal/gateway/registry/traefik.go
@@ -133,27 +133,43 @@ func (c TraefikRouteConfig) traefikKeys(gatewayID string) []struct{ key, value s
 
 	// Per-replica HTTP router for TTY. Unique to this gateway.
 	//
-	// NB: for a Redis-KV-defined router, `tls` must be a nested map
-	// rather than the flat string "true". Writing both
-	// `<router>/tls` = "true" and `<router>/tls/certResolver` = "..."
-	// is invalid in Traefik's KV schema (the first key blocks the
-	// nested path). We therefore always publish nested TLS keys:
-	// `/tls/passthrough = false` stands in for the "TLS is on" bit,
-	// and `/tls/certResolver` is added when configured. This keeps
-	// browsers from seeing Traefik's default self-signed cert.
+	// Traefik's Redis-KV provider has two mutually exclusive ways to
+	// spell "this HTTP router has TLS on":
+	//
+	//   a) flat:   <root>/http/routers/<r>/tls = "true"
+	//   b) nested: <root>/http/routers/<r>/tls/certResolver = "<name>"
+	//              (any key under /tls/ makes Traefik infer TLS on)
+	//
+	// The two shapes cannot coexist — Traefik's KV walker treats the
+	// flat string as a scalar leaf that blocks every nested /tls/*
+	// subkey underneath it, so a config that publishes both is
+	// silently rejected and the router falls back to no-TLS (which
+	// then fails TLS handshake on the websecure entrypoint). We
+	// therefore branch on TTYCertResolver and publish one shape or
+	// the other, never both:
+	//
+	//   * TTYCertResolver set (the normal path): write only the
+	//     nested certResolver key. This is the canonical shape in
+	//     Traefik's own docs for Redis-KV HTTP routers.
+	//   * TTYCertResolver empty (bring-your-own-cert setups): write
+	//     only the flat /tls = "true" so Traefik serves its static-
+	//     config default certificate.
 	ttyRouter := fmt.Sprintf("pm-tty-%s", gatewayID)
 	ttyRule := fmt.Sprintf("Host(`%s`) && PathPrefix(`/gw/%s`)", c.TTYHost, gatewayID)
 	perReplica := []struct{ key, value string }{
 		{mtlsServerKey, c.MTLSBackend},
 		{fmt.Sprintf("%s/http/routers/%s/rule", root, ttyRouter), ttyRule},
 		{fmt.Sprintf("%s/http/routers/%s/entrypoints/0", root, ttyRouter), c.TTYEntryPoint},
-		{fmt.Sprintf("%s/http/routers/%s/tls/passthrough", root, ttyRouter), "false"},
 		{fmt.Sprintf("%s/http/routers/%s/service", root, ttyRouter), ttyRouter},
 		{fmt.Sprintf("%s/http/services/%s/loadbalancer/servers/0/url", root, ttyRouter), c.TTYBackend},
 	}
 	if c.TTYCertResolver != "" {
 		perReplica = append(perReplica, struct{ key, value string }{
 			fmt.Sprintf("%s/http/routers/%s/tls/certResolver", root, ttyRouter), c.TTYCertResolver,
+		})
+	} else {
+		perReplica = append(perReplica, struct{ key, value string }{
+			fmt.Sprintf("%s/http/routers/%s/tls", root, ttyRouter), "true",
 		})
 	}
 
@@ -168,10 +184,11 @@ func (c TraefikRouteConfig) traefikKeys(gatewayID string) []struct{ key, value s
 // other replicas' routes. Shared pm-mtls keys are NOT included; they
 // expire naturally via TTL once the last replica stops refreshing them.
 //
-// Always lists /tls/certResolver too, even when unset at publish time:
-// deleting a key that doesn't exist is a no-op, and listing it here
-// means an operator who re-launches without a resolver cleanly leaves
-// no orphaned key behind.
+// Both TLS shapes (flat `/tls` and nested `/tls/certResolver`) are
+// always listed, regardless of which one PublishTraefikRoute wrote
+// this cycle: deleting a key that doesn't exist is a no-op, and
+// listing both means a replica that flipped between BYO-cert and
+// letsencrypt across restarts cleans up the stale shape on exit.
 func (c TraefikRouteConfig) perReplicaKeys(gatewayID string) []string {
 	root := c.rootKey()
 	ttyRouter := fmt.Sprintf("pm-tty-%s", gatewayID)
@@ -179,7 +196,7 @@ func (c TraefikRouteConfig) perReplicaKeys(gatewayID string) []string {
 		fmt.Sprintf("%s/tcp/services/pm-mtls/loadbalancer/servers/%s/address", root, gatewayID),
 		fmt.Sprintf("%s/http/routers/%s/rule", root, ttyRouter),
 		fmt.Sprintf("%s/http/routers/%s/entrypoints/0", root, ttyRouter),
-		fmt.Sprintf("%s/http/routers/%s/tls/passthrough", root, ttyRouter),
+		fmt.Sprintf("%s/http/routers/%s/tls", root, ttyRouter),
 		fmt.Sprintf("%s/http/routers/%s/tls/certResolver", root, ttyRouter),
 		fmt.Sprintf("%s/http/routers/%s/service", root, ttyRouter),
 		fmt.Sprintf("%s/http/services/%s/loadbalancer/servers/0/url", root, ttyRouter),

--- a/internal/gateway/registry/traefik_test.go
+++ b/internal/gateway/registry/traefik_test.go
@@ -37,7 +37,7 @@ func TestPublishTraefikRoute_WritesExpectedKeys(t *testing.T) {
 		"traefik/tcp/services/pm-mtls/loadbalancer/servers/gw-1/address": "gateway-1.internal:8443",
 		"traefik/http/routers/pm-tty-gw-1/rule":                          "Host(`tty.example.com`) && PathPrefix(`/gw/gw-1`)",
 		"traefik/http/routers/pm-tty-gw-1/entrypoints/0":                 "websecure",
-		"traefik/http/routers/pm-tty-gw-1/tls/passthrough":               "false",
+		"traefik/http/routers/pm-tty-gw-1/tls":                           "true",
 		"traefik/http/routers/pm-tty-gw-1/service":                       "pm-tty-gw-1",
 		"traefik/http/services/pm-tty-gw-1/loadbalancer/servers/0/url":   "http://gateway-1.internal:8080",
 	}
@@ -53,18 +53,15 @@ func TestPublishTraefikRoute_WritesExpectedKeys(t *testing.T) {
 		}
 	}
 
-	// Without TTYCertResolver set, the nested certResolver key must NOT
-	// exist. The flat `/tls=true` string must also not exist — it would
-	// block the nested /tls/passthrough path in Traefik's KV schema.
+	// Without TTYCertResolver set, the BYO-cert path is active:
+	// only the flat /tls = "true" is written, never any nested
+	// /tls/* keys. Coexistence would break Traefik's KV parse.
 	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls/certResolver"); !errors.Is(err, ErrNoGateway) {
-		t.Errorf("tls/certResolver should not be written when TTYCertResolver empty; got err=%v", err)
-	}
-	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls"); !errors.Is(err, ErrNoGateway) {
-		t.Errorf("flat tls key must not be written (would block nested tls path); got err=%v", err)
+		t.Errorf("tls/certResolver must not coexist with flat /tls; got err=%v", err)
 	}
 }
 
-func TestPublishTraefikRoute_CertResolverWritten(t *testing.T) {
+func TestPublishTraefikRoute_CertResolver_NestedOnly(t *testing.T) {
 	backend := NewFakeBackend(nil)
 	r := New(backend, nil)
 	ctx := context.Background()
@@ -84,22 +81,33 @@ func TestPublishTraefikRoute_CertResolverWritten(t *testing.T) {
 		t.Errorf("tls/certResolver got %q, want %q", got, "letsencrypt")
 	}
 
-	// Confirmation: /tls/passthrough=false is still written even when a
-	// cert resolver is in play. Both keys coexist under the same /tls
-	// prefix — this is the correct KV shape.
-	if got, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls/passthrough"); err != nil || got != "false" {
-		t.Errorf("tls/passthrough got %q err=%v, want %q", got, err, "false")
+	// Critical invariant: the flat /tls string MUST NOT coexist with
+	// the nested certResolver key, because Traefik's KV walker treats
+	// the flat scalar as a leaf that blocks the nested subtree — the
+	// whole failure mode rc3 exists to fix.
+	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("flat /tls key must not be written when TTYCertResolver is set; got err=%v", err)
 	}
 }
 
-func TestRevokeTraefikRoute_CleansCertResolver(t *testing.T) {
+func TestRevokeTraefikRoute_CleansBothTLSShapes(t *testing.T) {
 	backend := NewFakeBackend(nil)
 	r := New(backend, nil)
 	ctx := context.Background()
 
+	// Seed both shapes directly — simulates a replica that flipped
+	// between BYO-cert and certResolver across restarts, leaving one
+	// stale key behind.
+	ctxBg := context.Background()
+	if err := backend.Set(ctxBg, "traefik/http/routers/pm-tty-gw-1/tls", "true", 30*time.Second); err != nil {
+		t.Fatalf("seed flat /tls: %v", err)
+	}
+	if err := backend.Set(ctxBg, "traefik/http/routers/pm-tty-gw-1/tls/certResolver", "letsencrypt", 30*time.Second); err != nil {
+		t.Fatalf("seed nested certResolver: %v", err)
+	}
+
 	cfg := baseTraefikConfig()
 	cfg.TTYCertResolver = "letsencrypt"
-
 	if err := r.PublishTraefikRoute(ctx, "gw-1", cfg, 30*time.Second); err != nil {
 		t.Fatalf("publish: %v", err)
 	}
@@ -107,11 +115,13 @@ func TestRevokeTraefikRoute_CleansCertResolver(t *testing.T) {
 		t.Fatalf("revoke: %v", err)
 	}
 
-	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls/certResolver"); !errors.Is(err, ErrNoGateway) {
-		t.Errorf("tls/certResolver should be deleted after revoke, got err=%v", err)
-	}
-	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls/passthrough"); !errors.Is(err, ErrNoGateway) {
-		t.Errorf("tls/passthrough should be deleted after revoke, got err=%v", err)
+	for _, key := range []string{
+		"traefik/http/routers/pm-tty-gw-1/tls",
+		"traefik/http/routers/pm-tty-gw-1/tls/certResolver",
+	} {
+		if _, err := backend.Get(ctx, key); !errors.Is(err, ErrNoGateway) {
+			t.Errorf("key %q should be deleted after revoke, got err=%v", key, err)
+		}
 	}
 }
 

--- a/internal/gateway/registry/traefik_test.go
+++ b/internal/gateway/registry/traefik_test.go
@@ -30,16 +30,16 @@ func TestPublishTraefikRoute_WritesExpectedKeys(t *testing.T) {
 	}
 
 	want := map[string]string{
-		"traefik/tcp/routers/pm-mtls/rule":                                      "HostSNI(`gateway.example.com`)",
-		"traefik/tcp/routers/pm-mtls/entrypoints/0":                             "mtls",
-		"traefik/tcp/routers/pm-mtls/tls/passthrough":                           "true",
-		"traefik/tcp/routers/pm-mtls/service":                                   "pm-mtls",
-		"traefik/tcp/services/pm-mtls/loadbalancer/servers/gw-1/address":        "gateway-1.internal:8443",
-		"traefik/http/routers/pm-tty-gw-1/rule":                                 "Host(`tty.example.com`) && PathPrefix(`/gw/gw-1`)",
-		"traefik/http/routers/pm-tty-gw-1/entrypoints/0":                        "websecure",
-		"traefik/http/routers/pm-tty-gw-1/tls":                                  "true",
-		"traefik/http/routers/pm-tty-gw-1/service":                              "pm-tty-gw-1",
-		"traefik/http/services/pm-tty-gw-1/loadbalancer/servers/0/url":          "http://gateway-1.internal:8080",
+		"traefik/tcp/routers/pm-mtls/rule":                               "HostSNI(`gateway.example.com`)",
+		"traefik/tcp/routers/pm-mtls/entrypoints/0":                      "mtls",
+		"traefik/tcp/routers/pm-mtls/tls/passthrough":                    "true",
+		"traefik/tcp/routers/pm-mtls/service":                            "pm-mtls",
+		"traefik/tcp/services/pm-mtls/loadbalancer/servers/gw-1/address": "gateway-1.internal:8443",
+		"traefik/http/routers/pm-tty-gw-1/rule":                          "Host(`tty.example.com`) && PathPrefix(`/gw/gw-1`)",
+		"traefik/http/routers/pm-tty-gw-1/entrypoints/0":                 "websecure",
+		"traefik/http/routers/pm-tty-gw-1/tls/passthrough":               "false",
+		"traefik/http/routers/pm-tty-gw-1/service":                       "pm-tty-gw-1",
+		"traefik/http/services/pm-tty-gw-1/loadbalancer/servers/0/url":   "http://gateway-1.internal:8080",
 	}
 
 	for key, expected := range want {
@@ -51,6 +51,67 @@ func TestPublishTraefikRoute_WritesExpectedKeys(t *testing.T) {
 		if got != expected {
 			t.Errorf("key %q: got %q, want %q", key, got, expected)
 		}
+	}
+
+	// Without TTYCertResolver set, the nested certResolver key must NOT
+	// exist. The flat `/tls=true` string must also not exist — it would
+	// block the nested /tls/passthrough path in Traefik's KV schema.
+	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls/certResolver"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("tls/certResolver should not be written when TTYCertResolver empty; got err=%v", err)
+	}
+	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("flat tls key must not be written (would block nested tls path); got err=%v", err)
+	}
+}
+
+func TestPublishTraefikRoute_CertResolverWritten(t *testing.T) {
+	backend := NewFakeBackend(nil)
+	r := New(backend, nil)
+	ctx := context.Background()
+
+	cfg := baseTraefikConfig()
+	cfg.TTYCertResolver = "letsencrypt"
+
+	if err := r.PublishTraefikRoute(ctx, "gw-1", cfg, 30*time.Second); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	got, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls/certResolver")
+	if err != nil {
+		t.Fatalf("tls/certResolver missing: %v", err)
+	}
+	if got != "letsencrypt" {
+		t.Errorf("tls/certResolver got %q, want %q", got, "letsencrypt")
+	}
+
+	// Confirmation: /tls/passthrough=false is still written even when a
+	// cert resolver is in play. Both keys coexist under the same /tls
+	// prefix — this is the correct KV shape.
+	if got, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls/passthrough"); err != nil || got != "false" {
+		t.Errorf("tls/passthrough got %q err=%v, want %q", got, err, "false")
+	}
+}
+
+func TestRevokeTraefikRoute_CleansCertResolver(t *testing.T) {
+	backend := NewFakeBackend(nil)
+	r := New(backend, nil)
+	ctx := context.Background()
+
+	cfg := baseTraefikConfig()
+	cfg.TTYCertResolver = "letsencrypt"
+
+	if err := r.PublishTraefikRoute(ctx, "gw-1", cfg, 30*time.Second); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if err := r.RevokeTraefikRoute(ctx, "gw-1", cfg); err != nil {
+		t.Fatalf("revoke: %v", err)
+	}
+
+	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls/certResolver"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("tls/certResolver should be deleted after revoke, got err=%v", err)
+	}
+	if _, err := backend.Get(ctx, "traefik/http/routers/pm-tty-gw-1/tls/passthrough"); !errors.Is(err, ErrNoGateway) {
+		t.Errorf("tls/passthrough should be deleted after revoke, got err=%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Env-var namespace cleanup.** The remaining unprefixed knobs are moved onto the per-service namespace so nothing silently aliases a host-wide global. Gateway: `VALKEY_ADDR` / `VALKEY_PASSWORD` / `VALKEY_DB` / `LOG_LEVEL` → `GATEWAY_VALKEY_ADDR` / `GATEWAY_VALKEY_PASSWORD` / `GATEWAY_VALKEY_DB` / `GATEWAY_LOG_LEVEL`. Control: `PM_ENCRYPTION_KEY` / `PM_ENCRYPTION_KEY_REQUIRED` → `CONTROL_ENCRYPTION_KEY` / `CONTROL_ENCRYPTION_KEY_REQUIRED`. Old names are no longer read — operators upgrading from rc2 must rename their `.env` entries.
- **Terminal WebSocket cert fix.** The per-replica TTY HTTP router was publishing `/tls = "true"` (a flat string) into Traefik's Redis KV tree. Redis-KV routers don't inherit the entrypoint's default cert resolver the way Docker-labelled routers do, so the TTY router fell back to Traefik's default self-signed cert — which browsers refuse for WebSocket upgrades. Worse, the flat `/tls` value blocks any nested `/tls/<subkey>` path in Traefik's KV schema, so the operator-side workaround (`redis-cli SET …/tls/certResolver letsencrypt`) was silently ignored and would have been clobbered 15 s later by the gateway's refresh anyway. The registry now publishes nested `/tls/passthrough=false` plus optional `/tls/certResolver`, threaded from the new `GATEWAY_TRAEFIK_TTY_CERT_RESOLVER` env (default `letsencrypt` in compose.yml). The revoke path also lists the certResolver key so nothing orphans on shutdown.

## Test plan

- [x] `go test ./...` (all green; registry + config packages updated)
- [x] `go vet ./...`
- [x] `go build ./cmd/control ./cmd/gateway`
- [x] New registry tests: flat `/tls` key no longer written, nested `/tls/passthrough=false` written, `/tls/certResolver` written iff set, revoke cleans both.
- [x] New config tests: the rc3 `GATEWAY_*` reads work, unprefixed `VALKEY_*` / `LOG_LEVEL` are NOT read (guards against rc2 `.env` accidentally still working), `GATEWAY_TRAEFIK_TTY_CERT_RESOLVER` round-trips.
- [ ] Operator deploy verification: `docker compose up -d` on a fresh machine, confirm the TTY WebSocket presents the Let's Encrypt cert and the browser terminal opens.

## Notes for operators

`.env` rename list:
- `VALKEY_ADDR` → `GATEWAY_VALKEY_ADDR`
- `VALKEY_PASSWORD` → `GATEWAY_VALKEY_PASSWORD`
- `VALKEY_DB` → `GATEWAY_VALKEY_DB`
- `LOG_LEVEL` → `GATEWAY_LOG_LEVEL` (control + indexer continue to read `LOG_LEVEL` via compose's `${LOG_LEVEL:-info}`; the gateway container gets its own `GATEWAY_LOG_LEVEL`, still defaulted from the same `.env` value)
- `PM_ENCRYPTION_KEY` → `CONTROL_ENCRYPTION_KEY`
- `PM_ENCRYPTION_KEY_REQUIRED` → `CONTROL_ENCRYPTION_KEY_REQUIRED`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `GATEWAY_TRAEFIK_TTY_CERT_RESOLVER` configuration option
  * Added `GATEWAY_HEARTBEAT_INTERVAL` configuration option (default: 30s)
  * Added `CONTROL_ENCRYPTION_KEY_REQUIRED` configuration option

* **Chores**
  * Environment variables renamed with service-specific prefixes
  * Control: `PM_ENCRYPTION_KEY` → `CONTROL_ENCRYPTION_KEY`
  * Gateway: `VALKEY_*` → `GATEWAY_VALKEY_*`; `LOG_LEVEL` → `GATEWAY_LOG_LEVEL`
  * Legacy unprefixed variable names no longer supported

* **Documentation**
  * Updated deployment configuration and README examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->