### PR TITLE
fix: gateway terminal listener cleartext behind Traefik (rc4)

### DIFF
--- a/cmd/gateway/README.md
+++ b/cmd/gateway/README.md
@@ -60,7 +60,7 @@ The Gateway Server:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GATEWAY_LISTEN_ADDR` | `:8080` | Listen address for the agent mTLS listener |
-| `GATEWAY_WEB_LISTEN_ADDR` | (empty) | Listen address for the TTY WebSocket listener (empty disables the terminal feature) |
+| `GATEWAY_WEB_LISTEN_ADDR` | (empty) | Listen address for the TTY WebSocket listener (cleartext HTTP — public TLS is terminated at Traefik; empty disables the terminal feature) |
 | `GATEWAY_VALKEY_ADDR` | `localhost:6379` | Valkey/Redis address for Asynq task queue |
 | `GATEWAY_VALKEY_PASSWORD` | (empty) | Valkey/Redis password |
 | `GATEWAY_VALKEY_DB` | `0` | Valkey/Redis database number |

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -449,10 +449,21 @@ func main() {
 		}
 	}()
 
-	// Start web TLS server for terminal WebSocket (standard TLS, no
-	// mTLS — web browsers cannot present client certificates in
-	// WebSocket upgrades). The terminal bridge authenticates via
-	// session tokens validated against the control server.
+	// Start cleartext HTTP server for terminal WebSocket traffic.
+	//
+	// Public TLS termination happens at Traefik (Let's Encrypt via the
+	// TTY router's certResolver); Traefik then forwards cleartext HTTP
+	// to this listener over the internal docker/k8s network. Running a
+	// second TLS handshake on the gateway side served no real purpose
+	// (the cert was internally-signed and no browser client ever saw
+	// it directly) and caused rc3 failures when Traefik's backend URL
+	// was http:// — the listener rejected the cleartext bytes with
+	// "Client sent an HTTP request to an HTTPS server". Standard
+	// Traefik-behind-service pattern: terminate TLS at the edge,
+	// cleartext inside the private network.
+	//
+	// The terminal bridge authenticates via session tokens validated
+	// against the control server; no TLS client cert is needed.
 	var webServer *http.Server
 	if cfg.WebListenAddr != "" {
 		bridgeHandler := handler.NewTerminalBridgeHandler(
@@ -466,27 +477,18 @@ func main() {
 			w.Write([]byte("ok"))
 		})
 
-		// Standard TLS: same cert/key as the mTLS server, but no
-		// client cert requirement. The cert must include the *.gateway
-		// wildcard SAN so both per-gateway hostnames and the bootstrap
-		// hostname resolve to a valid cert.
-		webTLS := &tls.Config{
-			Certificates: []tls.Certificate{controlCert},
-			MinVersion:   tls.VersionTLS13,
-		}
 		webServer = &http.Server{
 			Addr:              cfg.WebListenAddr,
 			Handler:           middleware.RequestID(middleware.SecurityHeaders(webMux)),
-			TLSConfig:         webTLS,
-			ReadTimeout:       0,    // long-lived WebSocket
-			WriteTimeout:      0,    // long-lived WebSocket
+			ReadTimeout:       0, // long-lived WebSocket
+			WriteTimeout:      0, // long-lived WebSocket
 			IdleTimeout:       120 * time.Second,
 			ReadHeaderTimeout: 10 * time.Second,
 		}
 		go func() {
-			logger.Info("web server listening (terminal WebSocket)",
+			logger.Info("web server listening (terminal WebSocket, cleartext HTTP behind Traefik)",
 				"address", cfg.WebListenAddr)
-			if err := webServer.ListenAndServeTLS("", ""); err != nil && err != http.ErrServerClosed {
+			if err := webServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 				logger.Error("web server error", "error", err)
 				stop()
 			}

--- a/internal/gateway/registry/traefik.go
+++ b/internal/gateway/registry/traefik.go
@@ -31,6 +31,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -103,6 +104,23 @@ func (c TraefikRouteConfig) validate() error {
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("registry: TraefikRouteConfig missing fields: %s", strings.Join(missing, ", "))
+	}
+	// TTYBackend must be an http:// URL with a non-empty host. The
+	// gateway's TTY listener accepts cleartext HTTP only (public TLS
+	// is terminated at Traefik); publishing an https:// backend would
+	// silently produce a non-functional router — Traefik opens a
+	// cleartext TCP conn to the backend, the backend expects TLS,
+	// handshake fails, every WebSocket upgrade 400s. Fail fast at
+	// config time instead.
+	u, err := url.Parse(c.TTYBackend)
+	if err != nil {
+		return fmt.Errorf("registry: TTYBackend %q is not a valid URL: %w", c.TTYBackend, err)
+	}
+	if u.Scheme != "http" {
+		return fmt.Errorf("registry: TTYBackend scheme must be \"http\" (got %q); the TTY listener is cleartext behind Traefik", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("registry: TTYBackend %q has no host", c.TTYBackend)
 	}
 	return nil
 }

--- a/internal/gateway/registry/traefik.go
+++ b/internal/gateway/registry/traefik.go
@@ -107,11 +107,11 @@ func (c TraefikRouteConfig) validate() error {
 	}
 	// TTYBackend must be an http:// URL with a non-empty host. The
 	// gateway's TTY listener accepts cleartext HTTP only (public TLS
-	// is terminated at Traefik); publishing an https:// backend would
-	// silently produce a non-functional router — Traefik opens a
-	// cleartext TCP conn to the backend, the backend expects TLS,
-	// handshake fails, every WebSocket upgrade 400s. Fail fast at
-	// config time instead.
+	// is terminated at Traefik); publishing an https:// backend URL
+	// would silently produce a non-functional router — Traefik would
+	// initiate TLS to the backend, but the TTY listener speaks only
+	// cleartext HTTP, so the backend handshake fails and every
+	// WebSocket upgrade 400s. Fail fast at config time instead.
 	u, err := url.Parse(c.TTYBackend)
 	if err != nil {
 		return fmt.Errorf("registry: TTYBackend %q is not a valid URL: %w", c.TTYBackend, err)

--- a/internal/gateway/registry/traefik_test.go
+++ b/internal/gateway/registry/traefik_test.go
@@ -144,6 +144,33 @@ func TestPublishTraefikRoute_CustomRootKey(t *testing.T) {
 	}
 }
 
+func TestPublishTraefikRoute_RejectsNonHTTPTTYBackend(t *testing.T) {
+	tests := []struct {
+		name    string
+		backend string
+		wantSub string
+	}{
+		{"https rejected", "https://gateway.internal:8443", `scheme must be "http"`},
+		{"ws rejected", "ws://gateway.internal:8443", `scheme must be "http"`},
+		{"bare host no scheme", "gateway.internal:8443", `scheme must be "http"`},
+		{"missing host", "http://", "has no host"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := New(NewFakeBackend(nil), nil)
+			cfg := baseTraefikConfig()
+			cfg.TTYBackend = tt.backend
+			err := r.PublishTraefikRoute(context.Background(), "gw-1", cfg, 30*time.Second)
+			if err == nil {
+				t.Fatalf("expected validation error for TTYBackend %q", tt.backend)
+			}
+			if !strings.Contains(err.Error(), tt.wantSub) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantSub)
+			}
+		})
+	}
+}
+
 func TestPublishTraefikRoute_RejectsEmptyFields(t *testing.T) {
 	r := New(NewFakeBackend(nil), nil)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Fixes the terminal WebSocket 400 exposed once rc3 got past the Let's Encrypt cert.

The gateway's `/terminal` listener was calling `ListenAndServeTLS` with the internally-signed control cert. Traefik's TTY router forwards **cleartext HTTP** to it (the `ttyBackend` auto-derives as `http://<hostname>:<port>` and that's the documented shape), so every browser upgrade round-tripped into Go's \`tls.Conn\`:

\`\`\`
HTTP/2 400
Client sent an HTTP request to an HTTPS server.
\`\`\`

This was a latent rc2 bug hidden by the `/tls=\"true\"` cert regression fixed in rc3 — once browsers stopped bouncing off the self-signed cert, the backend-protocol mismatch became the new failure.

## Change

Strip TLS from the gateway's web listener entirely. Public TLS termination stays at Traefik (Let's Encrypt via the per-replica certResolver); Traefik forwards cleartext to the gateway over the internal `pm-internal` docker/k8s network — the standard Traefik-behind-service pattern.

- Drops a crypto layer that served no real purpose (the cert was internally-signed and no browser client ever saw it directly).
- Fixes the WebSocket upgrade path.
- mTLS listener on `:8080` is **unchanged** — agents still get the full client-cert handshake there.
- Ops/health listener unchanged.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` clean
- [x] \`go test ./internal/gateway/... ./internal/handler/...\`
- [ ] Operator verification: after rc4 deploy, \`curl -i https://\${TTY_DOMAIN}/gw/\${GATEWAY_ID}/terminal\` should return \`400 session_id and token query parameters are required\` (Go handler reached, not TLS error), and the browser terminal should open.

## Notes

No env-var or compose changes needed. The existing reference `compose.yml` already ships `ttyBackend` as `http://`. Operators with custom `GATEWAY_TRAEFIK_TTY_BACKEND` values need to make sure theirs is `http://`, not `https://`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified gateway docs to state the TTY WebSocket listener is cleartext HTTP with TLS terminated upstream.

* **Configuration**
  * WebSocket listener now accepts cleartext HTTP while TLS is handled upstream.

* **Validation**
  * TTY backend addresses are now validated to require an http scheme and a non-empty host.

* **Tests**
  * Added tests covering rejection of invalid TTY backend URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->