### PR TITLE
fix: register terminal handler at /gw/<id>/terminal (rc5)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -470,12 +470,7 @@ func main() {
 			manager, terminalSessions, controlProxy, aqClient,
 			logger.With("component", "terminal_bridge"),
 		)
-		webMux := http.NewServeMux()
-		webMux.Handle("/terminal", bridgeHandler)
-		webMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("ok"))
-		})
+		webMux := buildWebMux(gatewayID, bridgeHandler)
 
 		webServer = &http.Server{
 			Addr:              cfg.WebListenAddr,

--- a/cmd/gateway/web_mux.go
+++ b/cmd/gateway/web_mux.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// buildWebMux wires the gateway's terminal-WebSocket HTTP handlers.
+//
+// Two paths route to the same bridge handler:
+//
+//   - /terminal               — used by single-gateway deployments
+//     where the public URL is wss://<host>/terminal (the Traefik
+//     router routes by Host only).
+//   - /gw/<gatewayID>/terminal — used by multi-gateway deployments
+//     where Traefik's per-replica router rule is
+//     `Host(<ttyHost>) && PathPrefix(/gw/<id>)`. Traefik does NOT
+//     strip the prefix when forwarding, so the gateway sees the
+//     full path. Registering the prefixed route here is what lets
+//     the same binary work under either routing scheme.
+//
+// When gatewayID is empty the prefixed route is omitted — there's
+// no stable ID to key it on, and single-gateway setups don't need it.
+func buildWebMux(gatewayID string, bridgeHandler http.Handler) *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/terminal", bridgeHandler)
+	if gatewayID != "" {
+		mux.Handle(fmt.Sprintf("/gw/%s/terminal", gatewayID), bridgeHandler)
+	}
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	return mux
+}

--- a/cmd/gateway/web_mux_test.go
+++ b/cmd/gateway/web_mux_test.go
@@ -33,7 +33,7 @@ func TestBuildWebMux_RegistersBothTerminalPaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, tt.path, nil)
 			rec := httptest.NewRecorder()
 			mux.ServeHTTP(rec, req)
 			if rec.Code != tt.wantCode {
@@ -50,7 +50,7 @@ func TestBuildWebMux_EmptyGatewayIDSkipsPrefixedRoute(t *testing.T) {
 	mux := buildWebMux("", stubHandler{})
 
 	// Unprefixed /terminal still works — single-gateway case.
-	req := httptest.NewRequest(http.MethodGet, "/terminal", nil)
+	req := httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/terminal", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -58,7 +58,7 @@ func TestBuildWebMux_EmptyGatewayIDSkipsPrefixedRoute(t *testing.T) {
 	}
 
 	// No prefixed route registered — any /gw/... 404s.
-	req = httptest.NewRequest(http.MethodGet, "/gw/01KOTHERID/terminal", nil)
+	req = httptest.NewRequestWithContext(t.Context(), http.MethodGet, "/gw/01KOTHERID/terminal", nil)
 	rec = httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 	if rec.Code != http.StatusNotFound {

--- a/cmd/gateway/web_mux_test.go
+++ b/cmd/gateway/web_mux_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// stubHandler writes a sentinel so the test can tell the bridge
+// handler apart from the ServeMux default NotFound.
+type stubHandler struct{}
+
+func (stubHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write([]byte("bridge"))
+}
+
+func TestBuildWebMux_RegistersBothTerminalPaths(t *testing.T) {
+	mux := buildWebMux("01KEXAMPLEGATEWAYID00000000", stubHandler{})
+
+	tests := []struct {
+		name     string
+		path     string
+		wantCode int
+		wantBody string
+	}{
+		{"prefixed path routes to bridge", "/gw/01KEXAMPLEGATEWAYID00000000/terminal", http.StatusOK, "bridge"},
+		{"unprefixed path still routes to bridge", "/terminal", http.StatusOK, "bridge"},
+		{"health is plain OK", "/health", http.StatusOK, "ok"},
+		{"unknown path is 404", "/nope", http.StatusNotFound, "404 page not found\n"},
+		{"wrong gateway id prefix is 404", "/gw/01KOTHERID/terminal", http.StatusNotFound, "404 page not found\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			mux.ServeHTTP(rec, req)
+			if rec.Code != tt.wantCode {
+				t.Errorf("%s: got status %d, want %d", tt.path, rec.Code, tt.wantCode)
+			}
+			if body := rec.Body.String(); body != tt.wantBody {
+				t.Errorf("%s: got body %q, want %q", tt.path, body, tt.wantBody)
+			}
+		})
+	}
+}
+
+func TestBuildWebMux_EmptyGatewayIDSkipsPrefixedRoute(t *testing.T) {
+	mux := buildWebMux("", stubHandler{})
+
+	// Unprefixed /terminal still works — single-gateway case.
+	req := httptest.NewRequest(http.MethodGet, "/terminal", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("/terminal should route to bridge even without gatewayID, got %d", rec.Code)
+	}
+
+	// No prefixed route registered — any /gw/... 404s.
+	req = httptest.NewRequest(http.MethodGet, "/gw/01KOTHERID/terminal", nil)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("/gw/... should 404 without gatewayID, got %d", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

Third regression stacked on the rc2 multi-gateway routing work. Traefik's per-replica KV router rule is:

\`\`\`
Host(<ttyHost>) && PathPrefix(/gw/<id>)
\`\`\`

Traefik does NOT strip the prefix when forwarding, so the gateway's web listener receives \`/gw/<id>/terminal\`. The mux previously registered only \`/terminal\` — so every browser WebSocket upgrade landed on Go's NotFound → 404 → connection closed → *"WebSocket connection failed"* in the browser console. rc4 fixed the cleartext-vs-TLS mismatch that was masking this one; cleartext now works, so the path mismatch becomes the last blocker on the happy path.

## Change

Extract the mux construction into a testable \`buildWebMux(gatewayID, h)\` and register **both** routes when a gatewayID is available:

- \`/terminal\` — single-gateway deployments (no path prefix)
- \`/gw/<gatewayID>/terminal\` — multi-gateway / Redis-KV routing

Empty \`gatewayID\` falls back to the single-path form, so the single-gateway config continues to work unchanged.

## Pre-commit audit

Walked the full terminal path end-to-end before committing to avoid another round:

| Surface | Risk | Status |
|---|---|---|
| Mux \`/gw/<id>/terminal\` route | Missing until this PR | ✅ Fixed + regression test |
| Bridge handler reads only query params | Path-blind | ✅ No change needed |
| Security-headers middleware | Path-blind | ✅ No change needed |
| Traefik HTTP/2 → HTTP/1.1 Upgrade downgrade | Automatic | ✅ Default |
| \`PublicTerminalURLTemplate\` vs mux pattern (trailing slash, exact match) | Exact-match, template has no trailing slash | ✅ Match |
| \`controlProxy.ValidateTerminalToken\` | Runtime prereq | ℹ️ Out of code scope |
| \`manager.IsConnected(deviceID)\` | Runtime prereq | ℹ️ Out of code scope |
| **Agent-side \`tty.enabled=1\`** | **Runtime prereq — likely culprit if rc5 still fails** | ℹ️ Requires \`sudo power-manage-agent tty enable\` on the device |

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\`
- [x] \`go test ./cmd/gateway/... ./internal/gateway/... ./internal/handler/...\`
- [x] New regression tests: prefixed path routes, unprefixed path routes, health is plain OK, unknown path is 404, wrong-gateway-ID prefix is 404, empty-gatewayID skips prefixed route.
- [ ] Operator verification: after rc5 deploy, \`curl -i https://\${TTY_DOMAIN}/gw/\${GATEWAY_ID}/terminal\` should return **\`400 session_id and token query parameters are required\`** (bridge reached, token missing) rather than \`404 page not found\` (mux miss).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized HTTP server route registration for improved code organization.
  * Added conditional endpoint routing based on gateway identifier configuration.

* **Tests**
  * Added comprehensive test coverage for route registration, path handling, and endpoint responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->