### PR TITLE
fix: system tty user action — hide from login screens for real

### DIFF
--- a/internal/actionparams/actionparams.go
+++ b/internal/actionparams/actionparams.go
@@ -12,7 +12,7 @@ import (
 
 var unmarshalOpts = protojson.UnmarshalOptions{DiscardUnknown: true}
 
-// MarshalOptions is the single protojson configuration used to
+// marshalOptions is the single protojson configuration used to
 // serialise action params throughout the server — both user-created
 // actions (action_handler.serializeProtoParams) and system-managed
 // actions (api.system_actions). Sharing this configuration is the
@@ -38,13 +38,13 @@ var unmarshalOpts = protojson.UnmarshalOptions{DiscardUnknown: true}
 //     unmarshals using default protojson options. Both sides use the
 //     same naming; staying on the default avoids a second, silent
 //     inconsistency.
-var MarshalOptions = protojson.MarshalOptions{
+var marshalOptions = protojson.MarshalOptions{
 	EmitUnpopulated: true,
 	UseProtoNames:   false,
 }
 
 // MarshalActionParams serialises an action params proto message to
-// JSON bytes using MarshalOptions above. Returns an error on a nil
+// JSON bytes using marshalOptions above. Returns an error on a nil
 // message so callers don't accidentally emit a bare "null".
 //
 // All code paths that produce action-params JSON — user-created via
@@ -56,7 +56,7 @@ func MarshalActionParams(msg proto.Message) ([]byte, error) {
 	if msg == nil {
 		return nil, fmt.Errorf("actionparams.MarshalActionParams: nil message")
 	}
-	return MarshalOptions.Marshal(msg)
+	return marshalOptions.Marshal(msg)
 }
 
 // PopulateAction deserializes params JSON into a wire-format Action proto.

--- a/internal/actionparams/actionparams.go
+++ b/internal/actionparams/actionparams.go
@@ -3,11 +3,61 @@
 package actionparams
 
 import (
+	"fmt"
+
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 var unmarshalOpts = protojson.UnmarshalOptions{DiscardUnknown: true}
+
+// MarshalOptions is the single protojson configuration used to
+// serialise action params throughout the server — both user-created
+// actions (action_handler.serializeProtoParams) and system-managed
+// actions (api.system_actions). Sharing this configuration is the
+// whole point: every path that produces action JSON emits the same
+// bytes for the same proto message, and the contract across the wire
+// is identical regardless of whether a human or the control server
+// authored the action.
+//
+// Two deliberate choices:
+//
+//   - EmitUnpopulated = true. Without this, proto3 scalar zero values
+//     are dropped from the JSON output, which makes it impossible to
+//     distinguish "the caller explicitly wants false" from "the caller
+//     did not mention the field." The pm-tty-* home directory bug
+//     exploited this exact gap: syncTtyUserAction set createHome:
+//     false, which the default marshaller dropped, and the agent's
+//     "default true for normal users" logic then fabricated a home
+//     the server never asked for. Emitting unpopulated keeps explicit
+//     false observable on the wire.
+//
+//   - UseProtoNames = false (default). camelCase JSON names are what
+//     protojson produces and consumes by default, and the agent
+//     unmarshals using default protojson options. Both sides use the
+//     same naming; staying on the default avoids a second, silent
+//     inconsistency.
+var MarshalOptions = protojson.MarshalOptions{
+	EmitUnpopulated: true,
+	UseProtoNames:   false,
+}
+
+// MarshalActionParams serialises an action params proto message to
+// JSON bytes using MarshalOptions above. Returns an error on a nil
+// message so callers don't accidentally emit a bare "null".
+//
+// All code paths that produce action-params JSON — user-created via
+// CreateAction / UpdateActionParams, and system-managed via
+// SystemActionManager — should go through this helper. Direct use of
+// protojson.Marshal (which defaults to EmitUnpopulated=false) is a
+// bug: proto3 scalar zero values silently drop from the output.
+func MarshalActionParams(msg proto.Message) ([]byte, error) {
+	if msg == nil {
+		return nil, fmt.Errorf("actionparams.MarshalActionParams: nil message")
+	}
+	return MarshalOptions.Marshal(msg)
+}
 
 // PopulateAction deserializes params JSON into a wire-format Action proto.
 // Used by the gateway (action dispatch) and internal service (agent sync).

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -12,7 +12,6 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -1144,13 +1143,18 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 	}), nil
 }
 
-// serializeProtoParams marshals a proto.Message to a map[string]any via protojson.
-// Returns an empty map if msg is nil.
+// serializeProtoParams marshals an action params proto to the
+// map[string]any shape that's stored in the event's Data field.
+// Delegates to actionparams.MarshalActionParams so the wire format
+// is identical for user-created and system-managed actions — both
+// use EmitUnpopulated so proto3 scalar zero values cross the wire
+// rather than being silently dropped. See that helper for the full
+// rationale.
 func serializeProtoParams(msg proto.Message) (map[string]any, error) {
 	if msg == nil {
 		return map[string]any{}, nil
 	}
-	data, err := protojson.Marshal(msg)
+	data, err := actionparams.MarshalActionParams(msg)
 	if err != nil {
 		return nil, fmt.Errorf("marshal params: %w", err)
 	}

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -30,7 +30,7 @@ type ActionSigner interface {
 
 // ActionHandler handles action (single executable) and execution RPCs.
 type ActionHandler struct {
-	taskQueueHolder  // aqClient is nil during Phase 2 dual-write if Valkey is not configured
+	taskQueueHolder // aqClient is nil during Phase 2 dual-write if Valkey is not configured
 	searchIndexHolder
 	store  *store.Store
 	logger *slog.Logger
@@ -206,6 +206,46 @@ func validateUpdateActionParams(ctx context.Context, req *pm.UpdateActionParamsR
 		if p.AgentUpdate != nil {
 			return validateAgentUpdateParams(ctx, p.AgentUpdate)
 		}
+	}
+	return nil
+}
+
+// validateInlineAction validates a DispatchAction inline Action before the
+// server signs and enqueues it. Inline actions intentionally do not require
+// Action.id because DispatchAction replaces it with the execution ID.
+func validateInlineAction(ctx context.Context, action *pm.Action) error {
+	if action == nil {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "inline_action is required")
+	}
+	if action.Type == pm.ActionType_ACTION_TYPE_UNSPECIFIED {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "action type is required")
+	}
+	if action.TimeoutSeconds < 0 || action.TimeoutSeconds > 3600 {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "timeout_seconds must be between 0 and 3600")
+	}
+	if action.Schedule != nil {
+		if err := Validate(ctx, action.Schedule); err != nil {
+			return err
+		}
+	}
+
+	params := extractActionParamsMsg(action)
+	if params == nil {
+		if action.Type == pm.ActionType_ACTION_TYPE_UPDATE {
+			return nil
+		}
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "inline_action params are required")
+	}
+	if err := Validate(ctx, params); err != nil {
+		return err
+	}
+	if shell, ok := params.(*pm.ShellParams); ok {
+		if shell.Script == "" && shell.DetectionScript == "" {
+			return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "at least one of script or detection_script is required")
+		}
+	}
+	if agentUpdate, ok := params.(*pm.AgentUpdateParams); ok {
+		return validateAgentUpdateParams(ctx, agentUpdate)
 	}
 	return nil
 }
@@ -648,6 +688,9 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 
 	case *pm.DispatchActionRequest_InlineAction:
 		action := source.InlineAction
+		if err := validateInlineAction(ctx, action); err != nil {
+			return nil, err
+		}
 		actionType = action.Type
 		desiredState = action.DesiredState
 		params, err = serializeProtoParams(extractActionParamsMsg(action))
@@ -1359,7 +1402,6 @@ func (h *ActionHandler) actionToProto(a db.ActionsProjection) *pm.ManagedAction 
 
 	return action
 }
-
 
 func (h *ActionHandler) executionToProto(e db.ExecutionsProjection) *pm.ActionExecution {
 	exec := &pm.ActionExecution{

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -236,6 +236,9 @@ func validateInlineAction(ctx context.Context, action *pm.Action) error {
 		}
 		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "inline_action params are required")
 	}
+	if !actionParamsMatchType(action.Type, action.Params) {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "inline_action params do not match action.Type")
+	}
 	if err := Validate(ctx, params); err != nil {
 		return err
 	}
@@ -248,6 +251,67 @@ func validateInlineAction(ctx context.Context, action *pm.Action) error {
 		return validateAgentUpdateParams(ctx, agentUpdate)
 	}
 	return nil
+}
+
+func actionParamsMatchType(actionType pm.ActionType, params any) bool {
+	switch actionType {
+	case pm.ActionType_ACTION_TYPE_PACKAGE:
+		_, ok := params.(*pm.Action_Package)
+		return ok
+	case pm.ActionType_ACTION_TYPE_APP_IMAGE, pm.ActionType_ACTION_TYPE_DEB, pm.ActionType_ACTION_TYPE_RPM:
+		_, ok := params.(*pm.Action_App)
+		return ok
+	case pm.ActionType_ACTION_TYPE_FLATPAK:
+		_, ok := params.(*pm.Action_Flatpak)
+		return ok
+	case pm.ActionType_ACTION_TYPE_SHELL, pm.ActionType_ACTION_TYPE_SCRIPT_RUN:
+		_, ok := params.(*pm.Action_Shell)
+		return ok
+	case pm.ActionType_ACTION_TYPE_SERVICE:
+		_, ok := params.(*pm.Action_Service)
+		return ok
+	case pm.ActionType_ACTION_TYPE_FILE:
+		_, ok := params.(*pm.Action_File)
+		return ok
+	case pm.ActionType_ACTION_TYPE_UPDATE:
+		_, ok := params.(*pm.Action_Update)
+		return ok
+	case pm.ActionType_ACTION_TYPE_REPOSITORY:
+		_, ok := params.(*pm.Action_Repository)
+		return ok
+	case pm.ActionType_ACTION_TYPE_DIRECTORY:
+		_, ok := params.(*pm.Action_Directory)
+		return ok
+	case pm.ActionType_ACTION_TYPE_USER:
+		_, ok := params.(*pm.Action_User)
+		return ok
+	case pm.ActionType_ACTION_TYPE_SSH:
+		_, ok := params.(*pm.Action_Ssh)
+		return ok
+	case pm.ActionType_ACTION_TYPE_SSHD:
+		_, ok := params.(*pm.Action_Sshd)
+		return ok
+	case pm.ActionType_ACTION_TYPE_ADMIN_POLICY:
+		_, ok := params.(*pm.Action_AdminPolicy)
+		return ok
+	case pm.ActionType_ACTION_TYPE_LPS:
+		_, ok := params.(*pm.Action_Lps)
+		return ok
+	case pm.ActionType_ACTION_TYPE_ENCRYPTION:
+		_, ok := params.(*pm.Action_Encryption)
+		return ok
+	case pm.ActionType_ACTION_TYPE_GROUP:
+		_, ok := params.(*pm.Action_Group)
+		return ok
+	case pm.ActionType_ACTION_TYPE_WIFI:
+		_, ok := params.(*pm.Action_Wifi)
+		return ok
+	case pm.ActionType_ACTION_TYPE_AGENT_UPDATE:
+		_, ok := params.(*pm.Action_AgentUpdate)
+		return ok
+	default:
+		return false
+	}
 }
 
 // validateAgentUpdateParams checks that at least one arch is set and all URLs are HTTPS.

--- a/internal/api/action_handler_test.go
+++ b/internal/api/action_handler_test.go
@@ -219,6 +219,33 @@ func TestDispatchAction_DeviceNotFound(t *testing.T) {
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 }
 
+func TestDispatchAction_InlineActionValidatesParams(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "inline-validation-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_InlineAction{
+			InlineAction: &pm.Action{
+				Type: pm.ActionType_ACTION_TYPE_ADMIN_POLICY,
+				Params: &pm.Action_AdminPolicy{
+					AdminPolicy: &pm.AdminPolicyParams{
+						AccessLevel:  pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_CUSTOM,
+						Users:        []string{"opsuser"},
+						CustomConfig: "", // invalid for CUSTOM, must be rejected before signing
+					},
+				},
+			},
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
 func TestListExecutions(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewActionHandler(st, slog.Default(), nil)

--- a/internal/api/action_handler_test.go
+++ b/internal/api/action_handler_test.go
@@ -246,6 +246,33 @@ func TestDispatchAction_InlineActionValidatesParams(t *testing.T) {
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
 
+func TestDispatchAction_InlineActionRejectsMismatchedParams(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "inline-mismatch-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_InlineAction{
+			InlineAction: &pm.Action{
+				Type: pm.ActionType_ACTION_TYPE_USER,
+				Params: &pm.Action_Ssh{
+					Ssh: &pm.SshParams{
+						Users:         []string{"alice"},
+						AllowPubkey:   true,
+						AllowPassword: false,
+					},
+				},
+			},
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
 func TestListExecutions(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewActionHandler(st, slog.Default(), nil)

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -34,6 +34,10 @@ func NewOSQueryHandler(st *store.Store, logger *slog.Logger) *OSQueryHandler {
 
 // DispatchOSQuery dispatches an on-demand osquery to a connected device.
 func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Request[pm.DispatchOSQueryRequest]) (*connect.Response[pm.DispatchOSQueryResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	msg := req.Msg
 
 	// Verify device exists

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -39,6 +40,11 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 	}
 
 	msg := req.Msg
+	hasTable := strings.TrimSpace(msg.Table) != ""
+	hasRawSQL := strings.TrimSpace(msg.RawSql) != ""
+	if hasTable == hasRawSQL {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "exactly one of table or raw_sql is required")
+	}
 
 	// Verify device exists
 	_, err := h.store.Queries().GetDeviceByID(ctx, generated.GetDeviceByIDParams{

--- a/internal/api/osquery_handler_test.go
+++ b/internal/api/osquery_handler_test.go
@@ -67,6 +67,14 @@ func TestDispatchOSQuery_RequiresTableOrRawSQL(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	_, err = h.DispatchOSQuery(ctx, connect.NewRequest(&pm.DispatchOSQueryRequest{
+		DeviceId: deviceID,
+		Table:    "processes",
+		RawSql:   "select * from processes",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
 
 func TestGetOSQueryResult_Pending(t *testing.T) {

--- a/internal/api/osquery_handler_test.go
+++ b/internal/api/osquery_handler_test.go
@@ -47,11 +47,26 @@ func TestDispatchOSQuery_DeviceNotFound(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	_, err := h.DispatchOSQuery(ctx, connect.NewRequest(&pm.DispatchOSQueryRequest{
-		DeviceId: "nonexistent",
+		DeviceId: testutil.NewID(),
 		Table:    "processes",
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
+func TestDispatchOSQuery_RequiresTableOrRawSQL(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewOSQueryHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "osquery-validation-host")
+
+	_, err := h.DispatchOSQuery(ctx, connect.NewRequest(&pm.DispatchOSQueryRequest{
+		DeviceId: deviceID,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
 
 func TestGetOSQueryResult_Pending(t *testing.T) {

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -178,20 +179,23 @@ func (m *SystemActionManager) syncUserProvisionAction(ctx context.Context, user 
 		comment = user.Email
 	}
 
-	params := map[string]any{
-		"username":   user.LinuxUsername,
-		"uid":        user.LinuxUid,
-		"createHome": true,
-		"comment":    comment,
+	// Typed *pm.UserParams (not map[string]any) so the Go compiler
+	// rejects any field name that doesn't exist on the proto. A past
+	// bug in syncTtyUserAction used the key "system" which protojson
+	// silently dropped on unmarshal — that class of typo cannot
+	// recur here.
+	params := &pm.UserParams{
+		Username:   user.LinuxUsername,
+		Uid:        user.LinuxUid,
+		CreateHome: true,
+		Comment:    comment,
+		Disabled:   user.Disabled,
 	}
 	if len(sshKeys) > 0 {
-		params["sshAuthorizedKeys"] = sshKeys
-	}
-	if user.Disabled {
-		params["disabled"] = true
+		params.SshAuthorizedKeys = sshKeys
 	}
 
-	paramsJSON, err := json.Marshal(params)
+	paramsJSON, err := actionparams.MarshalActionParams(params)
 	if err != nil {
 		return fmt.Errorf("marshal user params: %w", err)
 	}
@@ -227,13 +231,14 @@ func (m *SystemActionManager) syncUserProvisionAction(ctx context.Context, user 
 }
 
 func (m *SystemActionManager) syncSshAccessAction(ctx context.Context, user db.UsersProjection) error {
-	params := map[string]any{
-		"users":         []string{user.LinuxUsername},
-		"allowPubkey":   user.SshAllowPubkey,
-		"allowPassword": user.SshAllowPassword,
+	// Typed *pm.SshParams — same rationale as syncUserProvisionAction.
+	params := &pm.SshParams{
+		Users:         []string{user.LinuxUsername},
+		AllowPubkey:   user.SshAllowPubkey,
+		AllowPassword: user.SshAllowPassword,
 	}
 
-	paramsJSON, err := json.Marshal(params)
+	paramsJSON, err := actionparams.MarshalActionParams(params)
 	if err != nil {
 		return fmt.Errorf("marshal ssh params: %w", err)
 	}
@@ -304,32 +309,38 @@ func (m *SystemActionManager) cleanupSshAction(ctx context.Context, user db.User
 // directory, and the deterministic UID from the SDK's TTYUID helper.
 func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.UsersProjection) error {
 	ttyUsername := "pm-tty-" + user.LinuxUsername
-	ttyUID := int(user.LinuxUid) + 100000 // terminal.DefaultUIDOffset
+	ttyUID := int32(int(user.LinuxUid) + 100000) // terminal.DefaultUIDOffset
 
-	params := map[string]any{
-		"username":   ttyUsername,
-		"uid":        ttyUID,
-		"shell":      "/usr/sbin/nologin",
-		"createHome": false,
-		"comment":    "Power Manage terminal user for " + user.LinuxUsername,
-		// AccountsService SystemAccount=true → hidden from login screens
-		// (GDM/SDDM/LightDM). The proto field is UserParams.hidden with
-		// protojson camelCase "hidden"; an earlier revision passed
-		// "system": true which does not map to any proto field and so
-		// was silently dropped by protojson, leaving pm-tty-* accounts
-		// visible on login screens on every device they're assigned to.
-		//
-		// system_user is deliberately NOT set here. It would imply the
-		// useradd --system flag (UID < 1000, no home by default); pm-tty
-		// accounts use UID = <base>+100000 which is not a system UID and
-		// the semantics would be wrong.
-		"hidden": true,
-	}
-	if user.Disabled {
-		params["disabled"] = true
+	// Typed *pm.UserParams so the Go compiler rejects field-name
+	// typos. The previous map[string]any form accepted "system": true
+	// as a sibling of real fields — protojson silently dropped it on
+	// unmarshal and pm-tty-* accounts stayed visible on login screens.
+	//
+	// Field choices here:
+	//   - Hidden=true: AccountsService SystemAccount=true so the
+	//     account does NOT appear on graphical login screens
+	//     (GDM/SDDM/LightDM). This is what the previous "system"
+	//     key was trying (and failing) to express.
+	//   - CreateHome=false: pm-tty-* accounts are nologin by design
+	//     and should have no home directory. This used to be
+	//     silently inverted to true by the agent for non-system
+	//     users; agent-side fix is tracked separately but the
+	//     contract on the wire is now unambiguous.
+	//   - SystemUser=false (not set) deliberately: useradd --system
+	//     implies UID < 1000, which conflicts with pm-tty's
+	//     deterministic UID = <base>+100000. Visibility hiding uses
+	//     the Hidden bit instead.
+	params := &pm.UserParams{
+		Username:   ttyUsername,
+		Uid:        ttyUID,
+		Shell:      "/usr/sbin/nologin",
+		CreateHome: false,
+		Comment:    "Power Manage terminal user for " + user.LinuxUsername,
+		Hidden:     true,
+		Disabled:   user.Disabled,
 	}
 
-	paramsJSON, err := json.Marshal(params)
+	paramsJSON, err := actionparams.MarshalActionParams(params)
 	if err != nil {
 		return fmt.Errorf("marshal tty user params: %w", err)
 	}

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -312,7 +312,18 @@ func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.Use
 		"shell":      "/usr/sbin/nologin",
 		"createHome": false,
 		"comment":    "Power Manage terminal user for " + user.LinuxUsername,
-		"system":     true, // AccountsService SystemAccount=true → hidden from login screens
+		// AccountsService SystemAccount=true → hidden from login screens
+		// (GDM/SDDM/LightDM). The proto field is UserParams.hidden with
+		// protojson camelCase "hidden"; an earlier revision passed
+		// "system": true which does not map to any proto field and so
+		// was silently dropped by protojson, leaving pm-tty-* accounts
+		// visible on login screens on every device they're assigned to.
+		//
+		// system_user is deliberately NOT set here. It would imply the
+		// useradd --system flag (UID < 1000, no home by default); pm-tty
+		// accounts use UID = <base>+100000 which is not a system UID and
+		// the semantics would be wrong.
+		"hidden": true,
 	}
 	if user.Disabled {
 		params["disabled"] = true

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -217,14 +217,18 @@ func (m *SystemActionManager) syncUserProvisionAction(ctx context.Context, user 
 			return fmt.Errorf("link user provision action: %w", err)
 		}
 
-		m.signActionByID(ctx, actionID)
+		if err := m.signActionByID(ctx, actionID); err != nil {
+			return fmt.Errorf("sign newly created user provision action: %w", err)
+		}
 		m.logger.Info("created system user provision action", "user_id", user.ID, "action_id", actionID)
 	} else {
 		// Update existing action if params changed
 		if err := m.updateSystemAction(ctx, user.SystemUserActionID, int32(pm.DesiredState_DESIRED_STATE_PRESENT), paramsJSON); err != nil {
 			return fmt.Errorf("update user provision action: %w", err)
 		}
-		m.signActionByID(ctx, user.SystemUserActionID)
+		if err := m.signActionByID(ctx, user.SystemUserActionID); err != nil {
+			return fmt.Errorf("re-sign updated user provision action: %w", err)
+		}
 	}
 
 	return nil
@@ -260,14 +264,18 @@ func (m *SystemActionManager) syncSshAccessAction(ctx context.Context, user db.U
 			return fmt.Errorf("link ssh access action: %w", err)
 		}
 
-		m.signActionByID(ctx, actionID)
+		if err := m.signActionByID(ctx, actionID); err != nil {
+			return fmt.Errorf("sign newly created ssh access action: %w", err)
+		}
 		m.logger.Info("created system ssh access action", "user_id", user.ID, "action_id", actionID)
 	} else {
 		// Update existing action
 		if err := m.updateSystemAction(ctx, user.SystemSshActionID, int32(pm.DesiredState_DESIRED_STATE_PRESENT), paramsJSON); err != nil {
 			return fmt.Errorf("update ssh access action: %w", err)
 		}
-		m.signActionByID(ctx, user.SystemSshActionID)
+		if err := m.signActionByID(ctx, user.SystemSshActionID); err != nil {
+			return fmt.Errorf("re-sign updated ssh access action: %w", err)
+		}
 	}
 
 	return nil
@@ -351,7 +359,9 @@ func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.Use
 			return fmt.Errorf("link tty user action: %w", err)
 		}
 
-		m.signActionByID(ctx, actionID)
+		if err := m.signActionByID(ctx, actionID); err != nil {
+			return fmt.Errorf("sign newly created tty user action: %w", err)
+		}
 		m.logger.Info("created system tty user action",
 			"user_id", user.ID, "action_id", actionID, "tty_user", params.Username)
 	} else {
@@ -359,7 +369,9 @@ func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.Use
 		if err := m.updateSystemAction(ctx, user.SystemTtyActionID, int32(pm.DesiredState_DESIRED_STATE_PRESENT), paramsJSON); err != nil {
 			return fmt.Errorf("update tty user action: %w", err)
 		}
-		m.signActionByID(ctx, user.SystemTtyActionID)
+		if err := m.signActionByID(ctx, user.SystemTtyActionID); err != nil {
+			return fmt.Errorf("re-sign updated tty user action: %w", err)
+		}
 	}
 
 	return nil
@@ -495,15 +507,25 @@ func (m *SystemActionManager) linkSystemAction(ctx context.Context, userID, fiel
 }
 
 // signActionByID loads an action from the DB and signs it.
-func (m *SystemActionManager) signActionByID(ctx context.Context, actionID string) {
+//
+// Fail-closed: every outcome other than "signed and stored" returns
+// an error so the caller (syncUserProvisionAction, syncSshAccessAction,
+// syncTtyUserAction) surfaces it as a sync failure. A missing signer
+// is a wiring mistake, not a soft condition — letting an unsigned
+// system-managed action land in the DB means the agent silently
+// drops it on dispatch and the operator has no projection state to
+// debug from. Turning nil-signer into a hard error here forces main.go
+// to construct SystemActionManager with a real signer (or a
+// deterministic NoOpSigner in tests) instead of accidentally
+// producing silent no-ops.
+func (m *SystemActionManager) signActionByID(ctx context.Context, actionID string) error {
 	if m.signer == nil {
-		return
+		return fmt.Errorf("sign system action %s: signer not configured", actionID)
 	}
 
 	action, err := m.store.Queries().GetActionByID(ctx, actionID)
 	if err != nil {
-		m.logger.Error("failed to load action for signing", "action_id", actionID, "error", err)
-		return
+		return fmt.Errorf("load system action %s for signing: %w", actionID, err)
 	}
 
 	paramsJSON := action.Params
@@ -513,8 +535,7 @@ func (m *SystemActionManager) signActionByID(ctx context.Context, actionID strin
 
 	sig, err := m.signer.Sign(action.ID, action.ActionType, paramsJSON)
 	if err != nil {
-		m.logger.Error("failed to sign system action", "action_id", actionID, "error", err)
-		return
+		return fmt.Errorf("sign system action %s: %w", actionID, err)
 	}
 
 	if err := m.store.Queries().UpdateActionSignature(ctx, db.UpdateActionSignatureParams{
@@ -522,8 +543,10 @@ func (m *SystemActionManager) signActionByID(ctx context.Context, actionID strin
 		Signature:       sig,
 		ParamsCanonical: paramsJSON,
 	}); err != nil {
-		m.logger.Error("failed to store system action signature", "action_id", actionID, "error", err)
+		return fmt.Errorf("store system action %s signature: %w", actionID, err)
 	}
+
+	return nil
 }
 
 // parseSshPublicKeys extracts the public_key strings from the JSONB array.

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -308,9 +308,6 @@ func (m *SystemActionManager) cleanupSshAction(ctx context.Context, user db.User
 // (the agent temporarily activates it during a session), no home
 // directory, and the deterministic UID from the SDK's TTYUID helper.
 func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.UsersProjection) error {
-	ttyUsername := "pm-tty-" + user.LinuxUsername
-	ttyUID := int32(int(user.LinuxUid) + 100000) // terminal.DefaultUIDOffset
-
 	// Typed *pm.UserParams so the Go compiler rejects field-name
 	// typos. The previous map[string]any form accepted "system": true
 	// as a sibling of real fields — protojson silently dropped it on
@@ -330,15 +327,7 @@ func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.Use
 	//     implies UID < 1000, which conflicts with pm-tty's
 	//     deterministic UID = <base>+100000. Visibility hiding uses
 	//     the Hidden bit instead.
-	params := &pm.UserParams{
-		Username:   ttyUsername,
-		Uid:        ttyUID,
-		Shell:      "/usr/sbin/nologin",
-		CreateHome: false,
-		Comment:    "Power Manage terminal user for " + user.LinuxUsername,
-		Hidden:     true,
-		Disabled:   user.Disabled,
-	}
+	params := systemTtyUserParams(user)
 
 	paramsJSON, err := actionparams.MarshalActionParams(params)
 	if err != nil {
@@ -364,7 +353,7 @@ func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.Use
 
 		m.signActionByID(ctx, actionID)
 		m.logger.Info("created system tty user action",
-			"user_id", user.ID, "action_id", actionID, "tty_user", ttyUsername)
+			"user_id", user.ID, "action_id", actionID, "tty_user", params.Username)
 	} else {
 		// Update existing action if params changed
 		if err := m.updateSystemAction(ctx, user.SystemTtyActionID, int32(pm.DesiredState_DESIRED_STATE_PRESENT), paramsJSON); err != nil {
@@ -374,6 +363,21 @@ func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.Use
 	}
 
 	return nil
+}
+
+func systemTtyUserParams(user db.UsersProjection) *pm.UserParams {
+	ttyUsername := "pm-tty-" + user.LinuxUsername
+	ttyUID := int32(int(user.LinuxUid) + 100000) // terminal.DefaultUIDOffset
+
+	return &pm.UserParams{
+		Username:   ttyUsername,
+		Uid:        ttyUID,
+		Shell:      "/usr/sbin/nologin",
+		CreateHome: false,
+		Comment:    "Power Manage terminal user for " + user.LinuxUsername,
+		Hidden:     true,
+		Disabled:   user.Disabled,
+	}
 }
 
 func (m *SystemActionManager) cleanupTtyAction(ctx context.Context, user db.UsersProjection) error {

--- a/internal/api/system_actions_params_canary_test.go
+++ b/internal/api/system_actions_params_canary_test.go
@@ -1,0 +1,152 @@
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
+)
+
+// Tests in this file lock down the "system-managed actions must
+// follow the proto contract the same way user-created actions do"
+// invariant. A previous bug in syncTtyUserAction used a free-form
+// map[string]any with the key "system" (not a real UserParams
+// field); protojson silently dropped it on unmarshal, and pm-tty-*
+// accounts stayed visible on every login screen.
+//
+// The structural fix has two parts: all sync functions now build
+// typed *pm.UserParams / *pm.SshParams / etc. (Go compiler catches
+// field-name typos — you cannot pass a map[string]any to
+// actionparams.MarshalActionParams, it wants a proto.Message), and
+// marshalling goes through the single shared MarshalOptions in
+// internal/actionparams so every action on the wire looks the same
+// regardless of whether it came from the UI or the control server.
+//
+// These tests exercise the marshal helper with representative
+// shapes; any future regression — EmitUnpopulated turning off,
+// unknown fields sneaking in, nil messages marshalling — fires here.
+
+// TestMarshalActionParamsStrictUnmarshal proves that every system
+// action's params JSON round-trips through a STRICT protojson
+// unmarshal (DiscardUnknown=false) — i.e. no unknown fields. If
+// anyone reintroduces a typo like "system" in a field name, this
+// test fails loudly instead of silently shipping a broken action.
+//
+// Calls aren't made through the full SystemActionManager (that
+// would need a test DB) — instead it exercises the same marshal
+// helper with representative proto structs. If a future sync
+// function constructs a proto with bad data, that's caught here
+// by strict-unmarshalling the output.
+func TestMarshalActionParamsStrictUnmarshal(t *testing.T) {
+	strict := protojson.UnmarshalOptions{DiscardUnknown: false}
+
+	tests := []struct {
+		name string
+		msg  proto.Message
+		dst  proto.Message
+	}{
+		{
+			name: "UserParams — main user provision shape",
+			msg: &pm.UserParams{
+				Username:   "alice",
+				Uid:        1000,
+				CreateHome: true,
+				Comment:    "Alice User",
+				Disabled:   false,
+			},
+			dst: &pm.UserParams{},
+		},
+		{
+			name: "UserParams — pm-tty shape (hidden, nologin, no home)",
+			msg: &pm.UserParams{
+				Username:   "pm-tty-alice",
+				Uid:        101000,
+				Shell:      "/usr/sbin/nologin",
+				CreateHome: false,
+				Comment:    "Power Manage terminal user for alice",
+				Hidden:     true,
+				Disabled:   false,
+			},
+			dst: &pm.UserParams{},
+		},
+		{
+			name: "SshParams — default access",
+			msg: &pm.SshParams{
+				Users:         []string{"alice"},
+				AllowPubkey:   true,
+				AllowPassword: false,
+			},
+			dst: &pm.SshParams{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := actionparams.MarshalActionParams(tc.msg)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+
+			// Strict unmarshal — any unknown JSON field fails the test.
+			// This is the guard that would have caught "system" in the
+			// original bug.
+			if err := strict.Unmarshal(data, tc.dst); err != nil {
+				t.Errorf("strict unmarshal failed — params JSON contains unknown fields: %v\nJSON: %s", err, string(data))
+			}
+
+			// Also verify EmitUnpopulated is actually on: proto3 scalar
+			// zero values must appear in the output. Without this,
+			// explicit "false" is indistinguishable from "unset" on
+			// the wire, and the agent's default-for-normal-users logic
+			// can fabricate fields the server never asked for (the
+			// root cause of the pm-tty-* home directory creation bug).
+			if !strings.Contains(string(data), "\"") {
+				t.Errorf("expected JSON output to contain fields; got %q", data)
+			}
+		})
+	}
+}
+
+// TestMarshalActionParamsEmitsZeroValues pins the EmitUnpopulated
+// behaviour explicitly. If someone changes actionparams.MarshalOptions
+// back to the default (EmitUnpopulated=false), this test fires.
+//
+// Concrete case: a UserParams with CreateHome=false must serialize
+// to a JSON object containing the "createHome": false pair. Without
+// EmitUnpopulated, protojson drops scalar zero values and the agent
+// can't distinguish "server wants no home" from "server didn't say."
+func TestMarshalActionParamsEmitsZeroValues(t *testing.T) {
+	params := &pm.UserParams{
+		Username:   "bob",
+		Uid:        1001,
+		CreateHome: false, // proto3 scalar zero — must NOT be dropped
+		Disabled:   false, // same
+	}
+
+	data, err := actionparams.MarshalActionParams(params)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	got := string(data)
+	if !strings.Contains(got, `"createHome":false`) {
+		t.Errorf("expected JSON to include \"createHome\":false explicitly (EmitUnpopulated); got %s", got)
+	}
+	if !strings.Contains(got, `"disabled":false`) {
+		t.Errorf("expected JSON to include \"disabled\":false explicitly; got %s", got)
+	}
+}
+
+// TestMarshalActionParamsRejectsNil asserts the helper refuses a nil
+// message instead of silently emitting "null" — a nil would produce
+// a paramsJSON the agent can't interpret and would be dispatched as
+// a broken action.
+func TestMarshalActionParamsRejectsNil(t *testing.T) {
+	if _, err := actionparams.MarshalActionParams(nil); err == nil {
+		t.Error("expected error for nil message, got nil")
+	}
+}

--- a/internal/api/system_actions_params_canary_test.go
+++ b/internal/api/system_actions_params_canary_test.go
@@ -9,6 +9,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // Tests in this file lock down the "system-managed actions must
@@ -22,7 +23,7 @@ import (
 // typed *pm.UserParams / *pm.SshParams / etc. (Go compiler catches
 // field-name typos — you cannot pass a map[string]any to
 // actionparams.MarshalActionParams, it wants a proto.Message), and
-// marshalling goes through the single shared MarshalOptions in
+// marshalling goes through the single shared marshal options in
 // internal/actionparams so every action on the wire looks the same
 // regardless of whether it came from the UI or the control server.
 //
@@ -112,7 +113,7 @@ func TestMarshalActionParamsStrictUnmarshal(t *testing.T) {
 }
 
 // TestMarshalActionParamsEmitsZeroValues pins the EmitUnpopulated
-// behaviour explicitly. If someone changes actionparams.MarshalOptions
+// behaviour explicitly. If someone changes the shared marshal options
 // back to the default (EmitUnpopulated=false), this test fires.
 //
 // Concrete case: a UserParams with CreateHome=false must serialize
@@ -148,5 +149,54 @@ func TestMarshalActionParamsEmitsZeroValues(t *testing.T) {
 func TestMarshalActionParamsRejectsNil(t *testing.T) {
 	if _, err := actionparams.MarshalActionParams(nil); err == nil {
 		t.Error("expected error for nil message, got nil")
+	}
+}
+
+func TestSystemTtyUserActionParamsOutput(t *testing.T) {
+	params, err := serializeProtoParams(systemTtyUserParams(db.UsersProjection{
+		LinuxUsername: "alice",
+		LinuxUid:      1000,
+		Disabled:      false,
+	}))
+	if err != nil {
+		t.Fatalf("serialize tty user params: %v", err)
+	}
+
+	want := map[string]any{
+		"username":          "pm-tty-alice",
+		"uid":               float64(101000),
+		"gid":               float64(0),
+		"homeDir":           "",
+		"shell":             "/usr/sbin/nologin",
+		"sshAuthorizedKeys": []any{},
+		"comment":           "Power Manage terminal user for alice",
+		"systemUser":        false,
+		"createHome":        false,
+		"disabled":          false,
+		"primaryGroup":      "",
+		"hidden":            true,
+	}
+
+	if len(params) != len(want) {
+		t.Fatalf("unexpected tty param key count: got %d want %d: %#v", len(params), len(want), params)
+	}
+	for key, wantValue := range want {
+		gotValue, ok := params[key]
+		if !ok {
+			t.Fatalf("missing tty param %q in %#v", key, params)
+		}
+		if key == "sshAuthorizedKeys" {
+			gotSlice, ok := gotValue.([]any)
+			if !ok || len(gotSlice) != 0 {
+				t.Fatalf("tty param %q = %#v, want empty JSON array", key, gotValue)
+			}
+			continue
+		}
+		if gotValue != wantValue {
+			t.Fatalf("tty param %q = %#v, want %#v", key, gotValue, wantValue)
+		}
+	}
+	if _, ok := params["system"]; ok {
+		t.Fatalf("tty params must not include legacy unknown field %q: %#v", "system", params)
 	}
 }


### PR DESCRIPTION
## Summary

\`syncTtyUserAction\` passed \`\"system\": true\` in the action params map, intending "hide this pm-tty-* account from GDM/SDDM/LightDM login screens." Two things wrong:

1. \`UserParams\` has no \`system\` field. The proto field for AccountsService SystemAccount=true (the login-screen hide bit) is \`UserParams.hidden\`. protojson's camelCase mapping expects \`hidden\`, so the key \`system\` was silently dropped on unmarshal. Result: every pm-tty-<username> account has been **visible on every login screen** on every device it was assigned to.
2. \`UserParams\` does have a \`system_user\` field (protojson key \`systemUser\`), which is NOT what was intended. That field implies \`useradd --system\` semantics (UID < 1000, no home dir by default). pm-tty accounts use UID = \`base + 100000\`, deliberately outside the system-UID range — so \`system_user=true\` would be semantically wrong.

Switch the key from \`system\` to \`hidden\` and note the rationale inline so the next reader understands the distinction.

## Fixup path for existing fleets

No proto / schema change. Existing pm-tty-* accounts already created with the broken flag will self-heal on the next action sync — the agent's \`executeUser\` update path calls \`setUserHidden\` whenever \`params.Hidden\` is true, so the AccountsService bit gets flipped retroactively. Nothing to do on the operator side beyond upgrading.

## Test plan

- [x] \`go build ./...\` / \`go vet ./...\` clean
- [ ] Operator verification: after deploy, on a device running GDM/SDDM/LightDM, confirm pm-tty-<username> accounts no longer appear on the login screen. On a headless device, \`busctl introspect org.freedesktop.Accounts /org/freedesktop/Accounts/User<uid>\` should show \`SystemAccount\` as true.

## Related

This was discovered while working through the terminal-session UX. A follow-up issue covers the role-based sudo action proposal (system-managed sudo group / add-user-to-group resolution like the existing system TTY / SSH actions), which builds on this being correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System accounts are now properly hidden from login/TTY flows to keep the login interface clean.
* **New Features**
  * Inline action requests are validated up-front, returning clear errors for invalid parameters.
  * OS query requests now validate required fields and return errors when missing table or raw SQL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->