### PR TITLE
fix: TTY router optional + LPS persistence fails closed (audit)

### DIFF
--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -212,6 +212,23 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("device_id and action_id are required"))
 	}
 
+	// Persistence MUST fail-closed. LPS rotation is irreversible:
+	// the agent has already run chpasswd locally, so the old password
+	// is gone. If the server silently fails to persist the new one,
+	// the user loses the only copy that LPS was meant to retain —
+	// and the gateway's post-RPC cleanup in agent.go clears the
+	// lps.rotations metadata from the execution result the moment
+	// this RPC returns success, so there is no second chance. Return
+	// an error on any append failure so the gateway leaves the
+	// metadata in place and the next retry replays the rotation
+	// persistence without needing a second local rotation.
+	//
+	// Encryption failures are already fail-closed above. Append
+	// failures now join that policy.
+	var (
+		persisted int
+		firstErr  error
+	)
 	for _, r := range req.Msg.Rotations {
 		encPassword, err := h.encryptor.Encrypt(r.Password)
 		if err != nil {
@@ -239,9 +256,34 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 				"device_id", req.Msg.DeviceId,
 				"action_id", req.Msg.ActionId,
 				"username", r.Username,
+				"persisted_before_failure", persisted,
+				"total_rotations", len(req.Msg.Rotations),
 				"error", err,
 			)
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
 		}
+		persisted++
+	}
+	if firstErr != nil {
+		// Partial success is indistinguishable from full failure
+		// from the agent's perspective: the gateway will leave the
+		// execution-result metadata alone and the inbox task will
+		// retry. The retry will re-attempt the full rotation list.
+		// Already-persisted rotations will append a second event
+		// with the same (device_id, username, password) payload —
+		// not ideal, but harmless: the projection deduplicates by
+		// (device_id, username) and keeps the most recent, and the
+		// event stream is an append-only audit record where a
+		// duplicate tells the truth ("we saw this twice during a
+		// retry") rather than lying.
+		return nil, connect.NewError(
+			connect.CodeInternal,
+			fmt.Errorf("failed to persist %d of %d LPS rotations for device %s action %s: %w",
+				len(req.Msg.Rotations)-persisted, len(req.Msg.Rotations), req.Msg.DeviceId, req.Msg.ActionId, firstErr),
+		)
 	}
 
 	return connect.NewResponse(&pm.InternalStoreLpsPasswordsResponse{}), nil

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -279,11 +279,21 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 		// event stream is an append-only audit record where a
 		// duplicate tells the truth ("we saw this twice during a
 		// retry") rather than lying.
-		return nil, connect.NewError(
-			connect.CodeInternal,
-			fmt.Errorf("failed to persist %d of %d LPS rotations for device %s action %s: %w",
-				len(req.Msg.Rotations)-persisted, len(req.Msg.Rotations), req.Msg.DeviceId, req.Msg.ActionId, firstErr),
+		//
+		// Route through apiErrorCtx so the response carries the
+		// same `internal_error` ErrorDetail code the rest of the
+		// handlers emit — the agent's inbox retry loop keys off
+		// that code to decide whether to retry.
+		h.logger.Error("LPS rotation persistence failed, returning error to trigger inbox retry",
+			"device_id", req.Msg.DeviceId,
+			"action_id", req.Msg.ActionId,
+			"persisted", persisted,
+			"total_rotations", len(req.Msg.Rotations),
+			"first_error", firstErr,
 		)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+			fmt.Sprintf("failed to persist %d of %d LPS rotations",
+				len(req.Msg.Rotations)-persisted, len(req.Msg.Rotations)))
 	}
 
 	return connect.NewResponse(&pm.InternalStoreLpsPasswordsResponse{}), nil

--- a/internal/gateway/registry/traefik.go
+++ b/internal/gateway/registry/traefik.go
@@ -82,7 +82,22 @@ type TraefikRouteConfig struct {
 	RootKey string
 }
 
+// ttyEnabled returns true when this config should publish the TTY
+// HTTP router in addition to the mTLS TCP router. The presence of
+// TTYBackend is the trigger: without a backend to route to, there
+// is nothing sensible to publish. This lets operators who only
+// need the agent mTLS path (no remote terminal feature) leave
+// GATEWAY_WEB_LISTEN_ADDR empty and still start the gateway, while
+// operators who want terminals set the listen address and the
+// rest falls into place via the auto-derivation in main.go.
+func (c TraefikRouteConfig) ttyEnabled() bool {
+	return c.TTYBackend != ""
+}
+
 func (c TraefikRouteConfig) validate() error {
+	// mTLS fields are required unconditionally — that's the core
+	// gateway function. Publishing without mTLS would mean the
+	// replica can't route agent traffic at all.
 	missing := []string{}
 	if c.MTLSHost == "" {
 		missing = append(missing, "MTLSHost")
@@ -93,17 +108,29 @@ func (c TraefikRouteConfig) validate() error {
 	if c.MTLSEntryPoint == "" {
 		missing = append(missing, "MTLSEntryPoint")
 	}
-	if c.TTYHost == "" {
-		missing = append(missing, "TTYHost")
-	}
-	if c.TTYBackend == "" {
-		missing = append(missing, "TTYBackend")
-	}
-	if c.TTYEntryPoint == "" {
-		missing = append(missing, "TTYEntryPoint")
+	// TTY fields are optional as a group — all set or all empty.
+	// Partial configuration is almost always an operator mistake
+	// (e.g. setting TTYHost in compose but forgetting to set
+	// GATEWAY_WEB_LISTEN_ADDR), so refuse to start and surface
+	// the inconsistency rather than quietly skipping the TTY
+	// router or publishing a broken one.
+	if c.ttyEnabled() {
+		if c.TTYHost == "" {
+			missing = append(missing, "TTYHost")
+		}
+		if c.TTYEntryPoint == "" {
+			missing = append(missing, "TTYEntryPoint")
+		}
 	}
 	if len(missing) > 0 {
 		return fmt.Errorf("registry: TraefikRouteConfig missing fields: %s", strings.Join(missing, ", "))
+	}
+	if !c.ttyEnabled() {
+		// No TTY route to publish; URL-shape validation below is
+		// irrelevant. Reject any TTY-host / entrypoint set without
+		// a backend (above catches those paths implicitly since
+		// the caller would have had to pass them deliberately).
+		return nil
 	}
 	// TTYBackend must be an http:// URL with a non-empty host. The
 	// gateway's TTY listener accepts cleartext HTTP only (public TLS
@@ -146,10 +173,19 @@ func (c TraefikRouteConfig) traefikKeys(gatewayID string) []struct{ key, value s
 		{root + "/tcp/routers/pm-mtls/service", "pm-mtls"},
 	}
 
-	// Per-replica TCP server entry in the shared service.
+	// Per-replica TCP server entry in the shared service — always
+	// published, this is the core routing data for the replica.
 	mtlsServerKey := fmt.Sprintf("%s/tcp/services/pm-mtls/loadbalancer/servers/%s/address", root, gatewayID)
+	perReplica := []struct{ key, value string }{
+		{mtlsServerKey, c.MTLSBackend},
+	}
 
-	// Per-replica HTTP router for TTY. Unique to this gateway.
+	// Per-replica HTTP router for TTY, only when the operator has
+	// enabled the terminal feature (TTYBackend set). Keeping this
+	// conditional lets an agent-only deployment — one that leaves
+	// GATEWAY_WEB_LISTEN_ADDR empty in the reference compose — start
+	// cleanly without a half-empty HTTP router entry that Traefik
+	// would reject.
 	//
 	// Traefik's Redis-KV provider has two mutually exclusive ways to
 	// spell "this HTTP router has TLS on":
@@ -172,23 +208,24 @@ func (c TraefikRouteConfig) traefikKeys(gatewayID string) []struct{ key, value s
 	//   * TTYCertResolver empty (bring-your-own-cert setups): write
 	//     only the flat /tls = "true" so Traefik serves its static-
 	//     config default certificate.
-	ttyRouter := fmt.Sprintf("pm-tty-%s", gatewayID)
-	ttyRule := fmt.Sprintf("Host(`%s`) && PathPrefix(`/gw/%s`)", c.TTYHost, gatewayID)
-	perReplica := []struct{ key, value string }{
-		{mtlsServerKey, c.MTLSBackend},
-		{fmt.Sprintf("%s/http/routers/%s/rule", root, ttyRouter), ttyRule},
-		{fmt.Sprintf("%s/http/routers/%s/entrypoints/0", root, ttyRouter), c.TTYEntryPoint},
-		{fmt.Sprintf("%s/http/routers/%s/service", root, ttyRouter), ttyRouter},
-		{fmt.Sprintf("%s/http/services/%s/loadbalancer/servers/0/url", root, ttyRouter), c.TTYBackend},
-	}
-	if c.TTYCertResolver != "" {
-		perReplica = append(perReplica, struct{ key, value string }{
-			fmt.Sprintf("%s/http/routers/%s/tls/certResolver", root, ttyRouter), c.TTYCertResolver,
-		})
-	} else {
-		perReplica = append(perReplica, struct{ key, value string }{
-			fmt.Sprintf("%s/http/routers/%s/tls", root, ttyRouter), "true",
-		})
+	if c.ttyEnabled() {
+		ttyRouter := fmt.Sprintf("pm-tty-%s", gatewayID)
+		ttyRule := fmt.Sprintf("Host(`%s`) && PathPrefix(`/gw/%s`)", c.TTYHost, gatewayID)
+		perReplica = append(perReplica,
+			struct{ key, value string }{fmt.Sprintf("%s/http/routers/%s/rule", root, ttyRouter), ttyRule},
+			struct{ key, value string }{fmt.Sprintf("%s/http/routers/%s/entrypoints/0", root, ttyRouter), c.TTYEntryPoint},
+			struct{ key, value string }{fmt.Sprintf("%s/http/routers/%s/service", root, ttyRouter), ttyRouter},
+			struct{ key, value string }{fmt.Sprintf("%s/http/services/%s/loadbalancer/servers/0/url", root, ttyRouter), c.TTYBackend},
+		)
+		if c.TTYCertResolver != "" {
+			perReplica = append(perReplica, struct{ key, value string }{
+				fmt.Sprintf("%s/http/routers/%s/tls/certResolver", root, ttyRouter), c.TTYCertResolver,
+			})
+		} else {
+			perReplica = append(perReplica, struct{ key, value string }{
+				fmt.Sprintf("%s/http/routers/%s/tls", root, ttyRouter), "true",
+			})
+		}
 	}
 
 	out := make([]struct{ key, value string }, 0, len(sharedMTLS)+len(perReplica))
@@ -202,11 +239,16 @@ func (c TraefikRouteConfig) traefikKeys(gatewayID string) []struct{ key, value s
 // other replicas' routes. Shared pm-mtls keys are NOT included; they
 // expire naturally via TTL once the last replica stops refreshing them.
 //
-// Both TLS shapes (flat `/tls` and nested `/tls/certResolver`) are
-// always listed, regardless of which one PublishTraefikRoute wrote
-// this cycle: deleting a key that doesn't exist is a no-op, and
-// listing both means a replica that flipped between BYO-cert and
-// letsencrypt across restarts cleans up the stale shape on exit.
+// The TTY router keys are always included even if TTY was disabled
+// this cycle. A replica may have flipped between "terminal enabled"
+// and "terminal disabled" across restarts; listing the TTY keys
+// unconditionally means the stale ones get cleaned up on the
+// shutdown after the operator disables the feature, and the backend
+// treats deletion of a nonexistent key as a no-op. Both TLS shapes
+// (flat `/tls` and nested `/tls/certResolver`) are also always
+// listed for the same reason — a replica that flipped between
+// BYO-cert and letsencrypt across restarts cleans up the stale
+// shape on exit.
 func (c TraefikRouteConfig) perReplicaKeys(gatewayID string) []string {
 	root := c.rootKey()
 	ttyRouter := fmt.Sprintf("pm-tty-%s", gatewayID)

--- a/internal/gateway/registry/traefik.go
+++ b/internal/gateway/registry/traefik.go
@@ -108,12 +108,13 @@ func (c TraefikRouteConfig) validate() error {
 	if c.MTLSEntryPoint == "" {
 		missing = append(missing, "MTLSEntryPoint")
 	}
-	// TTY fields are optional as a group — all set or all empty.
-	// Partial configuration is almost always an operator mistake
-	// (e.g. setting TTYHost in compose but forgetting to set
-	// GATEWAY_WEB_LISTEN_ADDR), so refuse to start and surface
-	// the inconsistency rather than quietly skipping the TTY
-	// router or publishing a broken one.
+	// TTY publishing is gated on TTYBackend. The companion fields
+	// (TTYHost, TTYEntryPoint) may legitimately stay populated from
+	// deployment defaults even when the backend is empty, so they
+	// are only validated once a backend is actually present — with
+	// a backend set, a missing host or entrypoint is an operator
+	// mistake and we refuse to start instead of publishing a broken
+	// HTTP router.
 	if c.ttyEnabled() {
 		if c.TTYHost == "" {
 			missing = append(missing, "TTYHost")
@@ -126,10 +127,8 @@ func (c TraefikRouteConfig) validate() error {
 		return fmt.Errorf("registry: TraefikRouteConfig missing fields: %s", strings.Join(missing, ", "))
 	}
 	if !c.ttyEnabled() {
-		// No TTY route to publish; URL-shape validation below is
-		// irrelevant. Reject any TTY-host / entrypoint set without
-		// a backend (above catches those paths implicitly since
-		// the caller would have had to pass them deliberately).
+		// No TTY route to publish; the URL-shape validation below
+		// has nothing to run against because there is no backend URL.
 		return nil
 	}
 	// TTYBackend must be an http:// URL with a non-empty host. The

--- a/internal/gateway/registry/traefik_test.go
+++ b/internal/gateway/registry/traefik_test.go
@@ -218,9 +218,11 @@ func TestPublishTraefikRoute_TTYDisabled(t *testing.T) {
 		t.Errorf("per-replica mTLS backend should be published: %v", err)
 	}
 
-	// No TTY router keys at all.
+	// No TTY router keys at all — every key the enabled path
+	// publishes must be absent, including the entrypoint list.
 	for _, k := range []string{
 		"traefik/http/routers/pm-tty-gw-mtls-only/rule",
+		"traefik/http/routers/pm-tty-gw-mtls-only/entrypoints/0",
 		"traefik/http/routers/pm-tty-gw-mtls-only/service",
 		"traefik/http/routers/pm-tty-gw-mtls-only/tls",
 		"traefik/http/routers/pm-tty-gw-mtls-only/tls/certResolver",

--- a/internal/gateway/registry/traefik_test.go
+++ b/internal/gateway/registry/traefik_test.go
@@ -177,14 +177,78 @@ func TestPublishTraefikRoute_RejectsEmptyFields(t *testing.T) {
 
 	bad := baseTraefikConfig()
 	bad.MTLSHost = ""
-	bad.TTYBackend = ""
+	bad.MTLSBackend = ""
 
 	err := r.PublishTraefikRoute(ctx, "gw-1", bad, 30*time.Second)
 	if err == nil {
-		t.Fatal("expected validation error for empty MTLSHost and TTYBackend")
+		t.Fatal("expected validation error for empty mTLS fields")
 	}
-	if !strings.Contains(err.Error(), "MTLSHost") || !strings.Contains(err.Error(), "TTYBackend") {
-		t.Errorf("error should name all missing fields; got: %v", err)
+	if !strings.Contains(err.Error(), "MTLSHost") || !strings.Contains(err.Error(), "MTLSBackend") {
+		t.Errorf("error should name all missing mTLS fields; got: %v", err)
+	}
+}
+
+// TestPublishTraefikRoute_TTYDisabled exercises the agent-only
+// deployment shape: mTLS is configured, but no TTYBackend because
+// the operator hasn't enabled the remote-terminal feature
+// (GATEWAY_WEB_LISTEN_ADDR unset in the reference compose).
+// PublishTraefikRoute must succeed and write ONLY the mTLS keys —
+// the earlier "all TTY fields required" validation used to
+// crash-loop the gateway in this case.
+func TestPublishTraefikRoute_TTYDisabled(t *testing.T) {
+	backend := NewFakeBackend(nil)
+	r := New(backend, nil)
+	ctx := context.Background()
+
+	cfg := baseTraefikConfig()
+	cfg.TTYBackend = "" // disables TTY router publication
+	// TTYHost and TTYEntryPoint can be set (e.g. compose defaults
+	// them to the same GATEWAY_DOMAIN / "websecure" as mTLS) but
+	// without a backend the whole HTTP router block is skipped.
+
+	if err := r.PublishTraefikRoute(ctx, "gw-mtls-only", cfg, 30*time.Second); err != nil {
+		t.Fatalf("publish with TTY disabled: %v", err)
+	}
+
+	// mTLS keys present.
+	if _, err := backend.Get(ctx, "traefik/tcp/routers/pm-mtls/rule"); err != nil {
+		t.Errorf("shared mTLS rule should be published: %v", err)
+	}
+	if _, err := backend.Get(ctx, "traefik/tcp/services/pm-mtls/loadbalancer/servers/gw-mtls-only/address"); err != nil {
+		t.Errorf("per-replica mTLS backend should be published: %v", err)
+	}
+
+	// No TTY router keys at all.
+	for _, k := range []string{
+		"traefik/http/routers/pm-tty-gw-mtls-only/rule",
+		"traefik/http/routers/pm-tty-gw-mtls-only/service",
+		"traefik/http/routers/pm-tty-gw-mtls-only/tls",
+		"traefik/http/routers/pm-tty-gw-mtls-only/tls/certResolver",
+		"traefik/http/services/pm-tty-gw-mtls-only/loadbalancer/servers/0/url",
+	} {
+		if _, err := backend.Get(ctx, k); !errors.Is(err, ErrNoGateway) {
+			t.Errorf("TTY-disabled config should not publish %q; got err=%v", k, err)
+		}
+	}
+}
+
+// TestPublishTraefikRoute_TTYPartialRejected catches the operator
+// misconfiguration where TTYBackend is set but the companion fields
+// are forgotten. That's almost always a .env mistake; refusing to
+// start is preferable to publishing a half-built HTTP router.
+func TestPublishTraefikRoute_TTYPartialRejected(t *testing.T) {
+	r := New(NewFakeBackend(nil), nil)
+	ctx := context.Background()
+
+	partial := baseTraefikConfig()
+	partial.TTYHost = "" // keep TTYBackend + TTYEntryPoint set
+
+	err := r.PublishTraefikRoute(ctx, "gw-1", partial, 30*time.Second)
+	if err == nil {
+		t.Fatal("expected validation error for partial TTY config")
+	}
+	if !strings.Contains(err.Error(), "TTYHost") {
+		t.Errorf("error should name TTYHost; got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two independent findings from the post-merge audit pass, folded into one PR.

### Registry: TTY router is now optional

`TraefikRouteConfig.validate()` previously required every \`TTY*\` field even on mTLS-only deployments. An operator who leaves \`GATEWAY_WEB_LISTEN_ADDR\` unset (no remote-terminal feature) would crash-loop the gateway at startup with a \"TraefikRouteConfig missing fields: TTYHost…\" error.

- \`TTYBackend\` presence is the trigger for publishing the TTY HTTP router.
- Partial TTY config (e.g. \`TTYBackend\` set, \`TTYHost\` missing) is still rejected — that shape is almost always a .env mistake, and publishing half a router is worse than failing to start.
- \`perReplicaKeys()\` continues to list TTY router keys unconditionally so a replica that flipped terminal-on/off across restarts cleans up stale keys on revoke.

### Internal handler: ProxyStoreLpsPasswords fails closed

Previously a DB append failure was logged and the RPC still returned success. The gateway's post-RPC cleanup clears \`lps.rotations\` from the execution-result metadata on success, so the freshly rotated password — the only copy, since the agent already ran \`chpasswd\` locally — could be lost silently on any transient DB hiccup.

Now:
- Any append error causes the RPC to return \`CodeInternal\`.
- The gateway leaves the metadata intact and the inbox task retries.
- The retry re-attempts the full rotation list. Already-persisted rotations append a second event with the same payload — harmless; the projection deduplicates by \`(device_id, username)\`.
- Added \`persisted_before_failure\` / \`total_rotations\` context to the log line.

## Test plan

- [x] \`go test ./internal/gateway/registry/... ./internal/api/...\` — green
- New: \`TestPublishTraefikRoute_TTYDisabled\` (mTLS-only deployment)
- New: \`TestPublishTraefikRoute_TTYPartialRejected\` (operator error)
- Updated: \`TestPublishTraefikRoute_RejectsEmptyFields\` now covers the mTLS-required path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TTY routing can be disabled; mTLS configuration remains required and functions independently.

* **Bug Fixes**
  * Password rotation now accumulates persistence progress, logs failure context, and reports how many rotations failed while continuing attempts.

* **Tests**
  * Added tests covering TTY-disabled, TTY-misconfigured, and mTLS-only validation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->