### PR TITLE
fix: server audit pass (peer-class, inline validation, fail-closed signing, key perms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See the [Control Server README](cmd/control/) for details on the event model, AP
 | Package | Purpose |
 |---------|---------|
 | `internal/api` | Control Server RPC handlers (actions, devices, users, tokens, assignments, roles, user groups, identity providers, SCIM, TOTP, compliance, etc.) |
-| `internal/auth` | JWT authentication, OPA authorization, TOTP 2FA, rate limiting, cookie management, self-scope enforcement |
+| `internal/auth` | JWT bearer authentication, OPA authorization, TOTP 2FA, rate limiting, self-scope enforcement |
 | `internal/ca` | Internal CA for signing agent certificates, certificate renewal verification, action payloads, and CA rotation via trust bundles |
 | `internal/config` | Configuration loading (gateway) |
 | `internal/connection` | Gateway connection manager — tracks connected agents, routes messages |
@@ -66,7 +66,7 @@ See the [Control Server README](cmd/control/) for details on the event model, AP
 | `internal/handler` | Gateway RPC handlers (agent streaming, Connect-RPC proxy to control, auto-update info) |
 | `internal/idp` | OIDC identity provider SSO (authorization code flow, token exchange, user linking) |
 | `internal/middleware` | HTTP middleware (request ID injection, security headers, logging) |
-| `internal/mtls` | mTLS setup (`RequireAndVerifyClientCert`, TLS 1.3), extracts device identity from client certificates |
+| `internal/mtls` | mTLS setup (`RequireAndVerifyClientCert`, TLS 1.3), extracts device identity from client certs, enforces SPIFFE peer-class URI SANs (`agent` / `gateway` / `control`) on each listener |
 | `internal/resolution` | Assignment resolution engine (user/user_group/device/device_group targets) |
 | `internal/scim` | SCIM v2 provisioning server (REST endpoints for user/group sync from external IdPs) |
 | `internal/search` | Full-text search indexer using Valkey RediSearch — FT index management, Asynq reindex workers, cascade updates |
@@ -84,9 +84,9 @@ The Control Server exposes a Connect-RPC API (`pm.v1.ControlService`) with 136 R
 
 | Method | Description |
 |--------|-------------|
-| `Login` | Authenticate with email/password, returns JWT access + refresh tokens. Sets httpOnly cookies. |
-| `RefreshToken` | Exchange refresh token for new token pair (with rotation). Reads from cookie or request body. |
-| `Logout` | Revoke refresh token and clear cookies. |
+| `Login` | Authenticate with email/password, returns JWT access + refresh tokens in the response body. Clients pass tokens via the `Authorization: Bearer` header on subsequent requests. |
+| `RefreshToken` | Exchange refresh token (from request body) for a new token pair with rotation. |
+| `Logout` | Revoke the presented refresh token. |
 | `GetCurrentUser` | Return the authenticated user's profile from JWT claims. |
 
 ### Users (8 RPCs)
@@ -414,15 +414,17 @@ Sliding-window rate limiter keyed by IP address:
 
 Background goroutine cleans up stale entries every 5 minutes.
 
-### Cookies (`internal/auth/cookie.go`)
+### Bearer-only token transport
 
-JWT tokens stored in httpOnly cookies (`pm_access`, `pm_refresh`) as a fallback to Authorization headers. Automatic secure mode detection via `Origin` header or `X-Forwarded-Proto`. HTTPS uses `SameSite=None; Secure`; HTTP uses `SameSite=Lax`.
+JWTs travel exclusively in the `Authorization: Bearer <token>` header. Clients receive both access and refresh tokens in the `Login` / `RefreshToken` response bodies and store them themselves (typically in `localStorage` for the web client and in the `credentials.enc` store for the agent). The server issues no authentication cookies — there is no `pm_access` / `pm_refresh` cookie to steal via XSS and no `SameSite` negotiation to get wrong.
 
-### mTLS (`internal/ca/`)
+### mTLS (`internal/ca/`, `internal/mtls/`)
 
 Internal CA signs agent CSRs during registration. Certificates use CN={deviceID}, valid for 1 year (configurable). The Gateway validates client certificates using `RequireAndVerifyClientCert` (TLS 1.3 minimum) and extracts device identity. Actions are also signed by the CA so agents can verify authenticity.
 
-Certificate renewal is handled via the `RenewCertificate` RPC — agents present their current certificate and a new CSR. The server verifies the certificate was issued by a trusted CA (from the trust bundle if configured), checks the fingerprint matches the database record (preventing use of revoked certificates), signs the new CSR, and returns the active CA certificate so agents can update their trust store during CA rotation.
+**Peer-class enforcement.** Every non-CA certificate carries a SPIFFE URI SAN of the form `spiffe://power-manage/<class>`, where `<class>` is one of `agent`, `gateway`, or `control`. The internal CA stamps `agent` on every cert it issues via CSR; `setup.sh` stamps `gateway` / `control` on the out-of-band certs for gateway replicas and the control server's internal listener. Middleware on each mTLS listener accepts only the expected class: the control server's `InternalService` admits `gateway` peers, the gateway's `AgentService` admits `agent` peers, and the gateway's `GatewayService` admits `control` peers. A leaked cert of one class therefore cannot be replayed against a listener intended for another class.
+
+Certificate renewal is handled via the `RenewCertificate` RPC — agents present their current certificate and a new CSR. The server verifies the certificate was issued by a trusted CA (from the trust bundle if configured), checks the fingerprint matches the database record (preventing use of revoked certificates), signs the new CSR with the `agent` peer-class URI SAN, and returns the active CA certificate so agents can update their trust store during CA rotation.
 
 ### Self-Scope Enforcement (`internal/auth/context.go`)
 
@@ -609,7 +611,6 @@ No database required. Test pure Go logic.
 | `internal/auth/jwt_test.go` | 14 | Token generation, validation (valid/expired/wrong-type/wrong-secret), refresh with rotation, revocation, unique JTIs |
 | `internal/auth/password_test.go` | 6 | bcrypt hashing, verification (correct/wrong/empty), unique salts, dummy hash for timing attack prevention |
 | `internal/auth/ratelimit_test.go` | 5 | Allow within limit, block after limit, independent keys, window expiry, 200-goroutine concurrent access |
-| `internal/auth/cookie_test.go` | 10 | Set/clear cookies (secure/insecure), parse Cookie header, detect HTTPS via Origin and X-Forwarded-Proto |
 | `internal/auth/context_test.go` | 9 | User/device context storage and retrieval, SubjectFromContext precedence |
 | `internal/auth/opa_test.go` | 17 | Admin allows all 18 actions, user self-access vs. other-access, user denied admin actions, device own-resource vs. other |
 | `internal/auth/interceptor_test.go` | 8 | Public procedure list (Login, RefreshToken, Logout, Register), non-public procedures, interceptor creation, streaming passthrough |
@@ -633,7 +634,7 @@ Each test spins up a PostgreSQL container and tests handler methods directly.
 | File | Tests | What it covers |
 |------|-------|----------------|
 | `internal/api/validator_test.go` | 9 | Struct validation: required fields, email, ULID, min-length, optional fields, snake_case conversion |
-| `internal/api/auth_handler_test.go` | 15 | Login (success, wrong password, nonexistent user, disabled user, cookie setting, TOTP verification), GetCurrentUser, SSO callback |
+| `internal/api/auth_handler_test.go` | 15 | Login (success, wrong password, nonexistent user, disabled user, token pair in response body, TOTP verification), GetCurrentUser, SSO callback |
 | `internal/api/user_handler_test.go` | 11 | CreateUser, GetUser (found, not found), ListUsers pagination, UpdateEmail, UpdatePassword (self, wrong current, privileged), SetUserDisabled, DeleteUser |
 | `internal/api/device_handler_test.go` | 10 | ListDevices (empty, with devices), GetDevice (found, not found), SetDeviceLabel, RemoveDeviceLabel, DeleteDevice, AssignDevice, UnassignDevice, SetDeviceSyncInterval |
 | `internal/api/token_handler_test.go` | 7 | CreateToken (admin, user one-time), GetToken (value hidden), ListTokens, RenameToken, SetTokenDisabled, DeleteToken |

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/middleware"
+	"github.com/manchtools/power-manage/server/internal/mtls"
 	"github.com/manchtools/power-manage/server/internal/scim"
 	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -619,8 +620,13 @@ func main() {
 	}
 	internalPath, internalH := pmv1connect.NewInternalServiceHandler(internalHandler)
 
+	// Peer-class gate: InternalService handles credential-bearing
+	// proxy calls (LUKS keys, LPS passwords). A compromised agent
+	// cert must NOT be usable here — only gateway replicas, which
+	// present certs issued out of band by setup.sh with a spiffe://
+	// peer-class URI, are admitted.
 	internalMux := http.NewServeMux()
-	internalMux.Handle(internalPath, internalH)
+	internalMux.Handle(internalPath, mtls.RequirePeerClass(logger, mtls.PeerClassGateway)(internalH))
 	internalMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("ok"))

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -399,10 +399,14 @@ func main() {
 	mux.Handle(path, bootstrappedHandler)
 
 	// Mount GatewayService on the mTLS listener (internal-only,
-	// called by the control server for admin list/terminate fan-out).
+	// called by the control server for admin list/terminate fan-
+	// out). Peer-class gate: only the control server's cert (which
+	// setup.sh stamps with spiffe://power-manage/control) is
+	// admitted — an agent cert that happens to chain to the same
+	// internal CA cannot invoke admin fan-out RPCs.
 	gwSvcHandler := handler.NewGatewayServiceHandler(terminalSessions, manager, logger.With("component", "gateway_service"))
 	gwSvcPath, gwSvcH := pmv1connect.NewGatewayServiceHandler(gwSvcHandler)
-	mux.Handle(gwSvcPath, gwSvcH)
+	mux.Handle(gwSvcPath, mtls.RequirePeerClass(logger, mtls.PeerClassControl)(gwSvcH))
 
 	// Wrap with security headers
 	securedMux := middleware.RequestID(middleware.SecurityHeaders(mux))

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -14,6 +14,14 @@
 
 set -e
 
+# Refuse to create files readable by group/other. Private keys are
+# chmod'd to 600 explicitly after generation, but a wider default
+# umask would still let openssl briefly create the key with 644
+# permissions on disk — a window where a racing reader on a
+# multi-user host could grab it before the chmod fires. umask 077
+# closes that window across every write in this script.
+umask 077
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -123,7 +131,7 @@ generate_ca() {
         -addext "keyUsage=critical,keyCertSign,cRLSign" \
         -addext "subjectKeyIdentifier=hash"
 
-    chmod 644 "$CERTS_DIR/ca.key"
+    chmod 600 "$CERTS_DIR/ca.key"
     chmod 644 "$CERTS_DIR/ca.crt"
 
     log_info "CA generated successfully"
@@ -150,15 +158,19 @@ generate_gateway_cert() {
         -subj "/CN=${GATEWAY_DOMAIN}/O=Power Manage" \
         -out "$CERTS_DIR/gateway.csr"
 
-    # Sign with CA (extfile sets SAN + AKI for reliable Go x509 chain matching)
+    # Sign with CA (extfile sets SAN + AKI for reliable Go x509 chain
+    # matching, plus a spiffe:// URI SAN that identifies this cert as
+    # a "gateway" peer class — the control server's peer-class
+    # middleware requires that class on the InternalService listener
+    # so a leaked agent cert cannot impersonate a gateway).
     openssl x509 -req -in "$CERTS_DIR/gateway.csr" \
         -CA "$CERTS_DIR/ca.crt" -CAkey "$CERTS_DIR/ca.key" -CAcreateserial \
         -days 825 \
-        -extfile <(printf "subjectAltName=DNS:%s\nauthorityKeyIdentifier=keyid:always" "${GATEWAY_DOMAIN}") \
+        -extfile <(printf "subjectAltName=DNS:%s,URI:spiffe://power-manage/gateway\nauthorityKeyIdentifier=keyid:always" "${GATEWAY_DOMAIN}") \
         -out "$CERTS_DIR/gateway.crt"
 
     rm -f "$CERTS_DIR/gateway.csr"
-    chmod 644 "$CERTS_DIR/gateway.key"
+    chmod 600 "$CERTS_DIR/gateway.key"
     chmod 644 "$CERTS_DIR/gateway.crt"
 
     log_info "Gateway certificate generated (valid 825 days)"
@@ -185,15 +197,19 @@ generate_control_cert() {
         -subj "/CN=control/O=Power Manage" \
         -out "$CERTS_DIR/control.csr"
 
-    # Sign with CA (extfile sets SAN + AKI for reliable Go x509 chain matching)
+    # Sign with CA (extfile sets SAN + AKI for reliable Go x509 chain
+    # matching, plus a spiffe:// URI SAN marking this cert as the
+    # "control" peer class — the gateway's GatewayService listener
+    # requires that class so an agent cert cannot pose as the control
+    # plane and issue admin fan-out calls).
     openssl x509 -req -in "$CERTS_DIR/control.csr" \
         -CA "$CERTS_DIR/ca.crt" -CAkey "$CERTS_DIR/ca.key" -CAcreateserial \
         -days 825 \
-        -extfile <(printf "subjectAltName=DNS:control,DNS:localhost\nauthorityKeyIdentifier=keyid:always") \
+        -extfile <(printf "subjectAltName=DNS:control,DNS:localhost,URI:spiffe://power-manage/control\nauthorityKeyIdentifier=keyid:always") \
         -out "$CERTS_DIR/control.crt"
 
     rm -f "$CERTS_DIR/control.csr"
-    chmod 644 "$CERTS_DIR/control.key"
+    chmod 600 "$CERTS_DIR/control.key"
     chmod 644 "$CERTS_DIR/control.crt"
 
     log_info "Control certificate generated (valid 825 days)"
@@ -228,7 +244,7 @@ generate_control_public_cert() {
         -out "$CERTS_DIR/control-public.crt"
 
     rm -f "$CERTS_DIR/control-public.csr"
-    chmod 644 "$CERTS_DIR/control-public.key"
+    chmod 600 "$CERTS_DIR/control-public.key"
     chmod 644 "$CERTS_DIR/control-public.crt"
 
     log_info "Control public certificate generated (valid 825 days)"

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25
 require (
 	connectrpc.com/connect v1.18.1
 	github.com/alicebob/miniredis/v2 v2.37.0
+	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
@@ -23,7 +24,6 @@ require (
 	golang.org/x/net v0.49.0
 	golang.org/x/oauth2 v0.35.0
 	google.golang.org/protobuf v1.36.11
-	nhooyr.io/websocket v1.8.17
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1x
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
+github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=
@@ -262,5 +264,3 @@ modernc.org/memory v1.11.0 h1:o4QC8aMQzmcwCK3t3Ux/ZHmwFPzE6hf2Y5LbkRs+hbI=
 modernc.org/memory v1.11.0/go.mod h1:/JP4VbVC+K5sU2wZi9bHoq2MAkCnrt2r98UGeSK7Mjw=
 modernc.org/sqlite v1.44.3 h1:+39JvV/HWMcYslAwRxHb8067w+2zowvFOUrOWIy9PjY=
 modernc.org/sqlite v1.44.3/go.mod h1:CzbrU2lSB1DKUusvwGz7rqEKIq+NUd8GWuBBZDs9/nA=
-nhooyr.io/websocket v1.8.17 h1:KEVeLJkUywCKVsnLIDlD/5gtayKp8VoCkksHCGGfT9Y=
-nhooyr.io/websocket v1.8.17/go.mod h1:rN9OFWIUwuxg4fR5tELlYC04bXYowCP9GX47ivo2l+c=

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -59,10 +59,7 @@ func validateCreateActionParams(ctx context.Context, req *pm.CreateActionRequest
 			if err := Validate(ctx, p.Shell); err != nil {
 				return err
 			}
-			if p.Shell.Script == "" && p.Shell.DetectionScript == "" {
-				return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "at least one of script or detection_script is required")
-			}
-			return nil
+			return validateShellScriptChoice(ctx, p.Shell)
 		}
 	case *pm.CreateActionRequest_Service:
 		if p.Service != nil {
@@ -132,6 +129,83 @@ func validateCreateActionParams(ctx context.Context, req *pm.CreateActionRequest
 	return nil
 }
 
+// validateShellScriptChoice enforces the Create-time rule that a
+// shell action must specify at least one of `script` or
+// `detection_script` — otherwise the action is a no-op that signs
+// cleanly and turns into a mystery when operators can't figure out
+// why nothing ran. Applied anywhere a ShellParams is accepted
+// (Create, Update params, inline Dispatch).
+func validateShellScriptChoice(ctx context.Context, p *pm.ShellParams) error {
+	if p == nil {
+		return nil
+	}
+	if p.Script == "" && p.DetectionScript == "" {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "at least one of script or detection_script is required")
+	}
+	return nil
+}
+
+// validateInlineActionPayload validates an inline Action proto on a
+// DispatchAction request. The non-inline DispatchAction path pulls
+// the action by ID from the DB, which has already been validated at
+// Create/Update time; inline actions skip that lookup and would
+// otherwise reach the agent unvalidated, potentially signing a
+// malformed or oversized payload that the agent silently drops.
+//
+// Every oneof branch mirrors validateCreateActionParams — including
+// the shell "at least one of script or detection_script" rule —
+// so an inline dispatched action cannot do anything a Create-path
+// action cannot.
+func validateInlineActionPayload(ctx context.Context, action *pm.Action) error {
+	if action == nil {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "inline_action is required")
+	}
+	switch p := action.Params.(type) {
+	case *pm.Action_Package:
+		return Validate(ctx, p.Package)
+	case *pm.Action_Shell:
+		if err := Validate(ctx, p.Shell); err != nil {
+			return err
+		}
+		return validateShellScriptChoice(ctx, p.Shell)
+	case *pm.Action_Service:
+		return Validate(ctx, p.Service)
+	case *pm.Action_File:
+		return Validate(ctx, p.File)
+	case *pm.Action_App:
+		return Validate(ctx, p.App)
+	case *pm.Action_Flatpak:
+		return Validate(ctx, p.Flatpak)
+	case *pm.Action_Update:
+		return Validate(ctx, p.Update)
+	case *pm.Action_Repository:
+		return Validate(ctx, p.Repository)
+	case *pm.Action_Directory:
+		return Validate(ctx, p.Directory)
+	case *pm.Action_User:
+		return Validate(ctx, p.User)
+	case *pm.Action_Ssh:
+		return Validate(ctx, p.Ssh)
+	case *pm.Action_Sshd:
+		return Validate(ctx, p.Sshd)
+	case *pm.Action_AdminPolicy:
+		return Validate(ctx, p.AdminPolicy)
+	case *pm.Action_Lps:
+		return Validate(ctx, p.Lps)
+	case *pm.Action_Encryption:
+		return Validate(ctx, p.Encryption)
+	case *pm.Action_Group:
+		return Validate(ctx, p.Group)
+	case *pm.Action_Wifi:
+		return Validate(ctx, p.Wifi)
+	case *pm.Action_AgentUpdate:
+		if p.AgentUpdate != nil {
+			return validateAgentUpdateParams(ctx, p.AgentUpdate)
+		}
+	}
+	return nil
+}
+
 // validateUpdateActionParams validates params for UpdateActionParamsRequest using struct tags.
 func validateUpdateActionParams(ctx context.Context, req *pm.UpdateActionParamsRequest) error {
 	switch p := req.Params.(type) {
@@ -141,7 +215,10 @@ func validateUpdateActionParams(ctx context.Context, req *pm.UpdateActionParamsR
 		}
 	case *pm.UpdateActionParamsRequest_Shell:
 		if p.Shell != nil {
-			return Validate(ctx, p.Shell)
+			if err := Validate(ctx, p.Shell); err != nil {
+				return err
+			}
+			return validateShellScriptChoice(ctx, p.Shell)
 		}
 	case *pm.UpdateActionParamsRequest_Service:
 		if p.Service != nil {
@@ -300,8 +377,14 @@ func (h *ActionHandler) CreateAction(ctx context.Context, req *connect.Request[p
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
 	}
 
-	// Sign the action so agents can verify authenticity
-	h.signAction(ctx, &action)
+	// Sign the action so agents can verify authenticity. Fail-closed:
+	// an unsigned action in the DB is a contract violation — callers
+	// expect every row to carry a verifiable signature, and the agent
+	// rejects rows without one on dispatch. Returning success here
+	// would quietly produce rows that will never run.
+	if err := h.signAction(ctx, &action); err != nil {
+		return nil, err
+	}
 
 	h.enqueueActionReindex(ctx, action)
 
@@ -518,8 +601,15 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}
 
-	// Re-sign the action after params update
-	h.signAction(ctx, &action)
+	// Re-sign the action after params update. Fail-closed: the
+	// previous signature covers the old params and no longer
+	// matches, so accepting a signing failure here would leave the
+	// DB row with a stale signature that the agent will reject —
+	// silently bricking the updated action until the operator
+	// figures out what happened.
+	if err := h.signAction(ctx, &action); err != nil {
+		return nil, err
+	}
 
 	h.enqueueActionReindex(ctx, action)
 
@@ -528,12 +618,19 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 	}), nil
 }
 
-// signAction computes a signature over the action's canonical payload and
-// persists it in the projection. This is a best-effort operation; signing
-// failures are logged but do not fail the parent request.
-func (h *ActionHandler) signAction(ctx context.Context, action *db.ActionsProjection) {
+// signAction computes a signature over the action's canonical
+// payload and persists it in the projection. Fail-closed: if signing
+// or persistence fails, the caller must NOT return success to the
+// user, otherwise the action lives in the DB as unsigned and either
+// (a) the agent rejects it on dispatch, or (b) a later ring that
+// still trusts unsigned actions runs it silently. Either outcome
+// silently diverges the projection from the signed-action contract.
+//
+// The returned error is already wrapped as a Connect error so
+// handlers can `return nil, err` directly.
+func (h *ActionHandler) signAction(ctx context.Context, action *db.ActionsProjection) error {
 	if h.signer == nil {
-		return
+		return nil
 	}
 
 	paramsJSON := action.Params
@@ -544,7 +641,7 @@ func (h *ActionHandler) signAction(ctx context.Context, action *db.ActionsProjec
 	sig, err := h.signer.Sign(action.ID, action.ActionType, paramsJSON)
 	if err != nil {
 		h.logger.Error("failed to sign action", "action_id", action.ID, "error", err)
-		return
+		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign action")
 	}
 
 	if err := h.store.Queries().UpdateActionSignature(ctx, db.UpdateActionSignatureParams{
@@ -553,12 +650,13 @@ func (h *ActionHandler) signAction(ctx context.Context, action *db.ActionsProjec
 		ParamsCanonical: paramsJSON,
 	}); err != nil {
 		h.logger.Error("failed to store action signature", "action_id", action.ID, "error", err)
-		return
+		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to store action signature")
 	}
 
 	// Update the in-memory struct so the response includes the signature
 	action.Signature = sig
 	action.ParamsCanonical = paramsJSON
+	return nil
 }
 
 // DeleteAction deletes an action.
@@ -649,6 +747,14 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 
 	case *pm.DispatchActionRequest_InlineAction:
 		action := source.InlineAction
+		// Run the same per-oneof validation Create applies, so a
+		// caller cannot bypass Validate by routing their payload
+		// through Dispatch's inline branch. validateInlineActionPayload
+		// also rejects nil — important, otherwise extractActionParamsMsg
+		// below would panic on the typed-nil inner message.
+		if err := validateInlineActionPayload(ctx, action); err != nil {
+			return nil, err
+		}
 		actionType = action.Type
 		desiredState = action.DesiredState
 		params, err = serializeProtoParams(extractActionParamsMsg(action))
@@ -692,13 +798,21 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 	if h.aqClient != nil {
 		paramsJSON, _ := json.Marshal(params)
 
-		// Always re-sign with the execution ID — the agent verifies against
-		// the received action ID, which is the execution ID for dispatched actions.
+		// Always re-sign with the execution ID — the agent verifies
+		// against the received action ID, which is the execution ID
+		// for dispatched actions. Fail-closed: enqueuing an unsigned
+		// dispatch means the agent drops the task on arrival, so the
+		// execution-record we just wrote turns into an unreachable
+		// "pending forever" state until the user cancels it. Abort
+		// instead so the caller sees the failure up-front.
 		if h.signer != nil {
-			if sig, err := h.signer.Sign(id, int32(actionType), paramsJSON); err == nil {
-				signature = sig
-				paramsCanonical = paramsJSON
+			sig, signErr := h.signer.Sign(id, int32(actionType), paramsJSON)
+			if signErr != nil {
+				h.logger.Error("dispatch: failed to sign action", "execution_id", id, "error", signErr)
+				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign dispatched action")
 			}
+			signature = sig
+			paramsCanonical = paramsJSON
 		}
 
 		if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -145,7 +145,7 @@ func validateShellScriptChoice(ctx context.Context, p *pm.ShellParams) error {
 	return nil
 }
 
-// validateInlineActionPayload validates an inline Action proto on a
+// validateInlineAction validates an inline Action proto on a
 // DispatchAction request. The non-inline DispatchAction path pulls
 // the action by ID from the DB, which has already been validated at
 // Create/Update time; inline actions skip that lookup and would
@@ -156,54 +156,128 @@ func validateShellScriptChoice(ctx context.Context, p *pm.ShellParams) error {
 // the shell "at least one of script or detection_script" rule —
 // so an inline dispatched action cannot do anything a Create-path
 // action cannot.
-func validateInlineActionPayload(ctx context.Context, action *pm.Action) error {
+//
+// Beyond the per-oneof params validation, this function enforces the
+// outer Action invariants that the by-ID dispatch path gets for free
+// from the Create/Update gate:
+//
+//   - Type is non-unspecified.
+//   - TimeoutSeconds is in [0, 3600].
+//   - Schedule, if present, validates.
+//   - Type matches the populated params oneof — a caller cannot say
+//     `Type=USER` while sending an Ssh oneof and have the dispatch
+//     path treat it as a USER action with garbage params.
+func validateInlineAction(ctx context.Context, action *pm.Action) error {
 	if action == nil {
 		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "inline_action is required")
 	}
-	switch p := action.Params.(type) {
-	case *pm.Action_Package:
-		return Validate(ctx, p.Package)
-	case *pm.Action_Shell:
-		if err := Validate(ctx, p.Shell); err != nil {
+	if action.Type == pm.ActionType_ACTION_TYPE_UNSPECIFIED {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "action type is required")
+	}
+	if action.TimeoutSeconds < 0 || action.TimeoutSeconds > 3600 {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "timeout_seconds must be between 0 and 3600")
+	}
+	if action.Schedule != nil {
+		if err := Validate(ctx, action.Schedule); err != nil {
 			return err
 		}
-		return validateShellScriptChoice(ctx, p.Shell)
-	case *pm.Action_Service:
-		return Validate(ctx, p.Service)
-	case *pm.Action_File:
-		return Validate(ctx, p.File)
-	case *pm.Action_App:
-		return Validate(ctx, p.App)
-	case *pm.Action_Flatpak:
-		return Validate(ctx, p.Flatpak)
-	case *pm.Action_Update:
-		return Validate(ctx, p.Update)
-	case *pm.Action_Repository:
-		return Validate(ctx, p.Repository)
-	case *pm.Action_Directory:
-		return Validate(ctx, p.Directory)
-	case *pm.Action_User:
-		return Validate(ctx, p.User)
-	case *pm.Action_Ssh:
-		return Validate(ctx, p.Ssh)
-	case *pm.Action_Sshd:
-		return Validate(ctx, p.Sshd)
-	case *pm.Action_AdminPolicy:
-		return Validate(ctx, p.AdminPolicy)
-	case *pm.Action_Lps:
-		return Validate(ctx, p.Lps)
-	case *pm.Action_Encryption:
-		return Validate(ctx, p.Encryption)
-	case *pm.Action_Group:
-		return Validate(ctx, p.Group)
-	case *pm.Action_Wifi:
-		return Validate(ctx, p.Wifi)
-	case *pm.Action_AgentUpdate:
-		if p.AgentUpdate != nil {
-			return validateAgentUpdateParams(ctx, p.AgentUpdate)
+	}
+
+	params := extractActionParamsMsg(action)
+	if params == nil {
+		// ACTION_TYPE_UPDATE has no params payload — that one
+		// matches `nil` legitimately. Every other type must
+		// carry a populated oneof.
+		if action.Type == pm.ActionType_ACTION_TYPE_UPDATE {
+			return nil
 		}
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "inline_action params are required")
+	}
+	if !actionParamsMatchType(action.Type, action.Params) {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "inline_action params do not match action.Type")
+	}
+	if err := Validate(ctx, params); err != nil {
+		return err
+	}
+	if shell, ok := params.(*pm.ShellParams); ok {
+		return validateShellScriptChoice(ctx, shell)
+	}
+	if agentUpdate, ok := params.(*pm.AgentUpdateParams); ok {
+		return validateAgentUpdateParams(ctx, agentUpdate)
 	}
 	return nil
+}
+
+// actionParamsMatchType returns true when the populated params oneof
+// matches the declared action.Type. The dispatch path trusts both
+// fields independently — without this guard, a caller could route a
+// Type=USER action through the Action_Ssh oneof and the agent would
+// receive a USER action whose params bytes are an Ssh proto, leading
+// to silent param corruption.
+func actionParamsMatchType(t pm.ActionType, params interface{}) bool {
+	switch t {
+	case pm.ActionType_ACTION_TYPE_PACKAGE:
+		_, ok := params.(*pm.Action_Package)
+		return ok
+	case pm.ActionType_ACTION_TYPE_APP_IMAGE, pm.ActionType_ACTION_TYPE_DEB, pm.ActionType_ACTION_TYPE_RPM:
+		_, ok := params.(*pm.Action_App)
+		return ok
+	case pm.ActionType_ACTION_TYPE_FLATPAK:
+		_, ok := params.(*pm.Action_Flatpak)
+		return ok
+	case pm.ActionType_ACTION_TYPE_SHELL, pm.ActionType_ACTION_TYPE_SCRIPT_RUN:
+		_, ok := params.(*pm.Action_Shell)
+		return ok
+	case pm.ActionType_ACTION_TYPE_SERVICE:
+		_, ok := params.(*pm.Action_Service)
+		return ok
+	case pm.ActionType_ACTION_TYPE_FILE:
+		_, ok := params.(*pm.Action_File)
+		return ok
+	case pm.ActionType_ACTION_TYPE_UPDATE:
+		// ACTION_TYPE_UPDATE may carry either *pm.Action_Update or
+		// nil params (kicks off whatever the agent's package
+		// manager considers an update). Both shapes are valid.
+		if params == nil {
+			return true
+		}
+		_, ok := params.(*pm.Action_Update)
+		return ok
+	case pm.ActionType_ACTION_TYPE_REPOSITORY:
+		_, ok := params.(*pm.Action_Repository)
+		return ok
+	case pm.ActionType_ACTION_TYPE_DIRECTORY:
+		_, ok := params.(*pm.Action_Directory)
+		return ok
+	case pm.ActionType_ACTION_TYPE_USER:
+		_, ok := params.(*pm.Action_User)
+		return ok
+	case pm.ActionType_ACTION_TYPE_GROUP:
+		_, ok := params.(*pm.Action_Group)
+		return ok
+	case pm.ActionType_ACTION_TYPE_SSH:
+		_, ok := params.(*pm.Action_Ssh)
+		return ok
+	case pm.ActionType_ACTION_TYPE_SSHD:
+		_, ok := params.(*pm.Action_Sshd)
+		return ok
+	case pm.ActionType_ACTION_TYPE_ADMIN_POLICY:
+		_, ok := params.(*pm.Action_AdminPolicy)
+		return ok
+	case pm.ActionType_ACTION_TYPE_LPS:
+		_, ok := params.(*pm.Action_Lps)
+		return ok
+	case pm.ActionType_ACTION_TYPE_ENCRYPTION:
+		_, ok := params.(*pm.Action_Encryption)
+		return ok
+	case pm.ActionType_ACTION_TYPE_WIFI:
+		_, ok := params.(*pm.Action_Wifi)
+		return ok
+	case pm.ActionType_ACTION_TYPE_AGENT_UPDATE:
+		_, ok := params.(*pm.Action_AgentUpdate)
+		return ok
+	}
+	return false
 }
 
 // validateUpdateActionParams validates params for UpdateActionParamsRequest using struct tags.
@@ -619,18 +693,24 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 }
 
 // signAction computes a signature over the action's canonical
-// payload and persists it in the projection. Fail-closed: if signing
-// or persistence fails, the caller must NOT return success to the
-// user, otherwise the action lives in the DB as unsigned and either
-// (a) the agent rejects it on dispatch, or (b) a later ring that
-// still trusts unsigned actions runs it silently. Either outcome
-// silently diverges the projection from the signed-action contract.
+// payload and persists it in the projection. Fail-closed: every
+// non-success path returns an error, including a nil signer.
+//
+// A nil signer is a wiring mistake, not a soft condition — main.go
+// constructs ActionHandler with the real internal/ca signer; tests
+// that need to skip real cryptography pass NoOpSigner instead, so
+// the "no signer" path NEVER produces unsigned rows in the DB
+// silently. Without this guard, a misconfigured production deploy
+// would happily Create / Update / Dispatch unsigned actions that
+// the agent then drops on receipt, leaving execution rows in
+// "pending forever" with no operator-visible cause.
 //
 // The returned error is already wrapped as a Connect error so
 // handlers can `return nil, err` directly.
 func (h *ActionHandler) signAction(ctx context.Context, action *db.ActionsProjection) error {
 	if h.signer == nil {
-		return nil
+		h.logger.Error("signAction called with nil signer — wiring bug", "action_id", action.ID)
+		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
 	}
 
 	paramsJSON := action.Params
@@ -747,12 +827,12 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 
 	case *pm.DispatchActionRequest_InlineAction:
 		action := source.InlineAction
-		// Run the same per-oneof validation Create applies, so a
-		// caller cannot bypass Validate by routing their payload
-		// through Dispatch's inline branch. validateInlineActionPayload
+		// Run the same per-oneof validation Create applies, plus
+		// the outer Action invariants (Type non-unspecified, timeout
+		// bounds, schedule, params-match-type). validateInlineAction
 		// also rejects nil — important, otherwise extractActionParamsMsg
 		// below would panic on the typed-nil inner message.
-		if err := validateInlineActionPayload(ctx, action); err != nil {
+		if err := validateInlineAction(ctx, action); err != nil {
 			return nil, err
 		}
 		actionType = action.Type
@@ -803,17 +883,21 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		// for dispatched actions. Fail-closed: enqueuing an unsigned
 		// dispatch means the agent drops the task on arrival, so the
 		// execution-record we just wrote turns into an unreachable
-		// "pending forever" state until the user cancels it. Abort
-		// instead so the caller sees the failure up-front.
-		if h.signer != nil {
-			sig, signErr := h.signer.Sign(id, int32(actionType), paramsJSON)
-			if signErr != nil {
-				h.logger.Error("dispatch: failed to sign action", "execution_id", id, "error", signErr)
-				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign dispatched action")
-			}
-			signature = sig
-			paramsCanonical = paramsJSON
+		// "pending forever" state until the user cancels it. Nil
+		// signer is a wiring bug (production wires the real CA;
+		// tests pass NoOpSigner) — refuse the dispatch instead of
+		// silently emitting an unsigned task.
+		if h.signer == nil {
+			h.logger.Error("dispatch: nil signer — wiring bug", "execution_id", id)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
 		}
+		sig, signErr := h.signer.Sign(id, int32(actionType), paramsJSON)
+		if signErr != nil {
+			h.logger.Error("dispatch: failed to sign action", "execution_id", id, "error", signErr)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign dispatched action")
+		}
+		signature = sig
+		paramsCanonical = paramsJSON
 
 		if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
 			ExecutionID:     id,

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -863,6 +863,35 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		eventData["action_id"] = *actionID
 	}
 
+	// Sign the dispatch BEFORE writing the ExecutionCreated event.
+	//
+	// Previously the sequence was:  appendEvent → sign → enqueue.
+	// Any failure after the event-write (sign fail, enqueue fail)
+	// left an execution row in the DB that no agent task would ever
+	// deliver — a zombie "pending forever" the operator had to cancel
+	// by hand. Signing doesn't depend on the row existing (it hashes
+	// `id`, `actionType`, `paramsJSON`), so we can fail fast here
+	// before touching the DB.
+	//
+	// Nil signer is a wiring bug (main.go passes the real internal/ca
+	// signer; tests pass NoOpSigner). Fail-closed to avoid silently
+	// enqueueing unsigned tasks the agent would drop on receipt.
+	var paramsJSON []byte
+	if h.aqClient != nil {
+		if h.signer == nil {
+			h.logger.Error("dispatch: nil signer — wiring bug", "execution_id", id)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
+		}
+		paramsJSON, _ = json.Marshal(params)
+		sig, signErr := h.signer.Sign(id, int32(actionType), paramsJSON)
+		if signErr != nil {
+			h.logger.Error("dispatch: failed to sign action", "execution_id", id, "error", signErr)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign dispatched action")
+		}
+		signature = sig
+		paramsCanonical = paramsJSON
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "execution",
 		StreamID:   id,
@@ -874,31 +903,11 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		return nil, err
 	}
 
-	// Dispatch action to device via Asynq task queue
+	// Dispatch action to device via Asynq task queue. The row exists
+	// now; if the enqueue fails we MUST transition it to a terminal
+	// state so the projection reflects reality. Silently returning
+	// success used to leave the row as `pending` indefinitely.
 	if h.aqClient != nil {
-		paramsJSON, _ := json.Marshal(params)
-
-		// Always re-sign with the execution ID — the agent verifies
-		// against the received action ID, which is the execution ID
-		// for dispatched actions. Fail-closed: enqueuing an unsigned
-		// dispatch means the agent drops the task on arrival, so the
-		// execution-record we just wrote turns into an unreachable
-		// "pending forever" state until the user cancels it. Nil
-		// signer is a wiring bug (production wires the real CA;
-		// tests pass NoOpSigner) — refuse the dispatch instead of
-		// silently emitting an unsigned task.
-		if h.signer == nil {
-			h.logger.Error("dispatch: nil signer — wiring bug", "execution_id", id)
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
-		}
-		sig, signErr := h.signer.Sign(id, int32(actionType), paramsJSON)
-		if signErr != nil {
-			h.logger.Error("dispatch: failed to sign action", "execution_id", id, "error", signErr)
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign dispatched action")
-		}
-		signature = sig
-		paramsCanonical = paramsJSON
-
 		if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
 			ExecutionID:     id,
 			ActionType:      int32(actionType),
@@ -908,7 +917,28 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 			Signature:       signature,
 			ParamsCanonical: paramsCanonical,
 		}, asynq.MaxRetry(5)); err != nil {
-			h.logger.Warn("failed to enqueue action dispatch", "error", err, "execution_id", id)
+			h.logger.Error("failed to enqueue action dispatch; emitting ExecutionFailed",
+				"error", err, "execution_id", id)
+			// Append a compensating ExecutionFailed event so the row
+			// moves to a terminal state the operator can act on.
+			// Best-effort: a failure here is logged but we still return
+			// the enqueue error to the caller so they know the dispatch
+			// did not reach the device.
+			if failErr := appendEvent(ctx, h.store, h.logger, store.Event{
+				StreamType: "execution",
+				StreamID:   id,
+				EventType:  "ExecutionFailed",
+				Data: map[string]any{
+					"error":        fmt.Sprintf("dispatch enqueue failed: %v", err),
+					"completed_at": nil, // projector falls back to event.occurred_at
+				},
+				ActorType: "system",
+				ActorID:   "system",
+			}, "failed to append ExecutionFailed compensating event"); failErr != nil {
+				h.logger.Error("compensating ExecutionFailed event failed; execution row is stuck in pending",
+					"execution_id", id, "error", failErr)
+			}
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to enqueue action dispatch")
 		}
 	}
 

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -422,6 +422,22 @@ func (h *ActionHandler) CreateAction(ctx context.Context, req *connect.Request[p
 		timeoutSeconds = 300
 	}
 
+	// Compute the signature BEFORE writing the ActionCreated event.
+	// If signing fails, no projection row ever appears, and the
+	// caller sees a clean error. Previously the order was
+	// appendEvent → sign, which left an unsigned row in the DB on
+	// any signer failure — lower severity than the dispatch fake-
+	// send issue but still an operator-confusing state.
+	paramsJSON, marshalErr := json.Marshal(params)
+	if marshalErr != nil {
+		h.logger.Error("create: failed to marshal params for signing", "action_id", id, "error", marshalErr)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to marshal action params")
+	}
+	sig, paramsCanonical, err := h.computeActionSignature(ctx, id, int32(req.Msg.Type), paramsJSON)
+	if err != nil {
+		return nil, err
+	}
+
 	eventData := map[string]any{
 		"name":            req.Msg.Name,
 		"description":     req.Msg.Description,
@@ -448,15 +464,18 @@ func (h *ActionHandler) CreateAction(ctx context.Context, req *connect.Request[p
 	action, err := h.store.Queries().GetActionByID(ctx, id)
 	if err != nil {
 		h.logger.Error("failed to get action after create", "error", err, "id", id)
+		// Projection row may already exist without signature; roll
+		// it back so the operator doesn't see an unsigned row.
+		h.rollbackUnsignedCreate(ctx, userCtx.ID, id)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
 	}
 
-	// Sign the action so agents can verify authenticity. Fail-closed:
-	// an unsigned action in the DB is a contract violation — callers
-	// expect every row to carry a verifiable signature, and the agent
-	// rejects rows without one on dispatch. Returning success here
-	// would quietly produce rows that will never run.
-	if err := h.signAction(ctx, &action); err != nil {
+	// Persist the precomputed signature. Narrow failure window: if
+	// this UPDATE fails after the event+projection succeeded, emit
+	// a compensating ActionDeleted so the unsigned row does not
+	// linger. See rollbackUnsignedCreate for the best-effort notes.
+	if err := h.persistActionSignature(ctx, &action, sig, paramsCanonical); err != nil {
+		h.rollbackUnsignedCreate(ctx, userCtx.ID, id)
 		return nil, err
 	}
 
@@ -647,6 +666,23 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 		}
 	}
 
+	// Compute the re-signature BEFORE writing ActionParamsUpdated.
+	// If signing fails the old event is never written, so the
+	// projection still carries the old (valid) signature matching
+	// the old params — a consistent state. Computing after the
+	// event used to leave the row with NEW params but OLD
+	// signature, which the agent rejects on dispatch.
+	paramsJSON, marshalErr := json.Marshal(params)
+	if marshalErr != nil {
+		h.logger.Error("update: failed to marshal params for signing",
+			"action_id", req.Msg.Id, "error", marshalErr)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to marshal updated action params")
+	}
+	sig, paramsCanonical, err := h.computeActionSignature(ctx, req.Msg.Id, existing.ActionType, paramsJSON)
+	if err != nil {
+		return nil, err
+	}
+
 	eventData := map[string]any{
 		"params":        params,
 		"desired_state": int32(req.Msg.DesiredState),
@@ -675,13 +711,17 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}
 
-	// Re-sign the action after params update. Fail-closed: the
-	// previous signature covers the old params and no longer
-	// matches, so accepting a signing failure here would leave the
-	// DB row with a stale signature that the agent will reject —
-	// silently bricking the updated action until the operator
-	// figures out what happened.
-	if err := h.signAction(ctx, &action); err != nil {
+	// Persist the precomputed signature. Unlike Create, there is no
+	// clean compensating event for Update — emitting "revert to
+	// previous params" would need an ActionParamsReverted event type
+	// the projector doesn't model. On persist failure we log loudly;
+	// the row now has NEW params with the OLD signature, which the
+	// agent will reject on dispatch. The operator recovers by
+	// re-running Update with the same payload once the DB is
+	// healthy.
+	if err := h.persistActionSignature(ctx, &action, sig, paramsCanonical); err != nil {
+		h.logger.Error("update: signature persist failed; row carries NEW params with OLD signature — re-run UpdateActionParams to recover",
+			"action_id", req.Msg.Id)
 		return nil, err
 	}
 
@@ -692,51 +732,68 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 	}), nil
 }
 
-// signAction computes a signature over the action's canonical
-// payload and persists it in the projection. Fail-closed: every
-// non-success path returns an error, including a nil signer.
-//
-// A nil signer is a wiring mistake, not a soft condition — main.go
-// constructs ActionHandler with the real internal/ca signer; tests
-// that need to skip real cryptography pass NoOpSigner instead, so
-// the "no signer" path NEVER produces unsigned rows in the DB
-// silently. Without this guard, a misconfigured production deploy
-// would happily Create / Update / Dispatch unsigned actions that
-// the agent then drops on receipt, leaving execution rows in
-// "pending forever" with no operator-visible cause.
-//
-// The returned error is already wrapped as a Connect error so
-// handlers can `return nil, err` directly.
-func (h *ActionHandler) signAction(ctx context.Context, action *db.ActionsProjection) error {
+// computeActionSignature produces a signature over (id, actionType,
+// paramsJSON). Pure compute — no DB access. Fail-closed on nil
+// signer. Split out of the legacy signAction() so Create/Update
+// can compute the signature BEFORE writing the ActionCreated /
+// ActionParamsUpdated event, so a sign failure never produces an
+// unsigned row in the projection.
+func (h *ActionHandler) computeActionSignature(ctx context.Context, id string, actionType int32, paramsJSON []byte) ([]byte, []byte, error) {
 	if h.signer == nil {
-		h.logger.Error("signAction called with nil signer — wiring bug", "action_id", action.ID)
-		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
+		h.logger.Error("computeActionSignature called with nil signer — wiring bug", "action_id", id)
+		return nil, nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
 	}
-
-	paramsJSON := action.Params
 	if paramsJSON == nil {
 		paramsJSON = []byte("{}")
 	}
-
-	sig, err := h.signer.Sign(action.ID, action.ActionType, paramsJSON)
+	sig, err := h.signer.Sign(id, actionType, paramsJSON)
 	if err != nil {
-		h.logger.Error("failed to sign action", "action_id", action.ID, "error", err)
-		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign action")
+		h.logger.Error("failed to sign action", "action_id", id, "error", err)
+		return nil, nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign action")
 	}
+	return sig, paramsJSON, nil
+}
 
+// persistActionSignature writes a precomputed signature to the
+// existing projection row. Intended for Create/Update after the
+// event has been written: the row exists, we just backfill the
+// sig + canonical params columns the projector doesn't set.
+//
+// On failure the row stays unsigned — callers SHOULD emit a
+// compensating ActionDeleted so the operator doesn't see a broken
+// unsigned row. See rollbackUnsignedCreate.
+func (h *ActionHandler) persistActionSignature(ctx context.Context, action *db.ActionsProjection, sig, paramsCanonical []byte) error {
 	if err := h.store.Queries().UpdateActionSignature(ctx, db.UpdateActionSignatureParams{
 		ID:              action.ID,
 		Signature:       sig,
-		ParamsCanonical: paramsJSON,
+		ParamsCanonical: paramsCanonical,
 	}); err != nil {
 		h.logger.Error("failed to store action signature", "action_id", action.ID, "error", err)
 		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to store action signature")
 	}
-
-	// Update the in-memory struct so the response includes the signature
 	action.Signature = sig
-	action.ParamsCanonical = paramsJSON
+	action.ParamsCanonical = paramsCanonical
 	return nil
+}
+
+// rollbackUnsignedCreate emits a compensating ActionDeleted event
+// when persistActionSignature fails after appendEvent(ActionCreated)
+// has already landed. Best-effort: if the compensating append also
+// fails, the row lingers as unsigned — logged loudly so the
+// operator can clean it up manually. Either way the caller's RPC
+// returns the original persist error.
+func (h *ActionHandler) rollbackUnsignedCreate(ctx context.Context, userID, actionID string) {
+	if err := appendEvent(ctx, h.store, h.logger, store.Event{
+		StreamType: "action",
+		StreamID:   actionID,
+		EventType:  "ActionDeleted",
+		Data:       map[string]any{},
+		ActorType:  "user",
+		ActorID:    userID,
+	}, "failed to append compensating ActionDeleted after signature persist failure"); err != nil {
+		h.logger.Error("compensating ActionDeleted failed; action row is stuck unsigned and visible in projection",
+			"action_id", actionID, "error", err)
+	}
 }
 
 // DeleteAction deletes an action.
@@ -897,7 +954,18 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		h.logger.Error("dispatch: nil signer — wiring bug", "execution_id", id)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
 	}
-	paramsJSON, _ := json.Marshal(params)
+	paramsJSON, marshalErr := json.Marshal(params)
+	if marshalErr != nil {
+		// `params` is either a map[string]any from extractActionParamsMsg
+		// (proto → map via protojson) or a raw JSON string — both should
+		// be safe to remarshal, but a json.Marshal error here MUST fail
+		// closed. Silently enqueueing with nil paramsJSON would produce
+		// an unverifiable signature and an empty-params task the agent
+		// rejects on receipt.
+		h.logger.Error("dispatch: failed to marshal params for signing",
+			"execution_id", id, "error", marshalErr)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to marshal dispatch params")
+	}
 	sig, signErr := h.signer.Sign(id, int32(actionType), paramsJSON)
 	if signErr != nil {
 		h.logger.Error("dispatch: failed to sign action", "execution_id", id, "error", signErr)

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -863,6 +863,23 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		eventData["action_id"] = *actionID
 	}
 
+	// Fail fast when no task queue is configured. Without this
+	// guard the handler used to silently write an ExecutionCreated
+	// event, skip signing, and return success — leaving the row in
+	// `pending` forever because no agent task was ever delivered.
+	// Self-hosted deployments that forget to set CONTROL_VALKEY_ADDR
+	// would have looked like dispatch worked. CodeFailedPrecondition
+	// is the correct shape: it tells the client to fix their
+	// deployment configuration rather than retry the call.
+	//
+	// Positioned here (after Validate + auth + device lookup + inline
+	// validation) so body-level errors still surface with their own
+	// code — a malformed request should see InvalidArgument, not get
+	// shadowed by an infrastructure precondition.
+	if h.aqClient == nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeFailedPrecondition, "dispatch unavailable: task queue not configured")
+	}
+
 	// Sign the dispatch BEFORE writing the ExecutionCreated event.
 	//
 	// Previously the sequence was:  appendEvent → sign → enqueue.
@@ -876,21 +893,18 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 	// Nil signer is a wiring bug (main.go passes the real internal/ca
 	// signer; tests pass NoOpSigner). Fail-closed to avoid silently
 	// enqueueing unsigned tasks the agent would drop on receipt.
-	var paramsJSON []byte
-	if h.aqClient != nil {
-		if h.signer == nil {
-			h.logger.Error("dispatch: nil signer — wiring bug", "execution_id", id)
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
-		}
-		paramsJSON, _ = json.Marshal(params)
-		sig, signErr := h.signer.Sign(id, int32(actionType), paramsJSON)
-		if signErr != nil {
-			h.logger.Error("dispatch: failed to sign action", "execution_id", id, "error", signErr)
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign dispatched action")
-		}
-		signature = sig
-		paramsCanonical = paramsJSON
+	if h.signer == nil {
+		h.logger.Error("dispatch: nil signer — wiring bug", "execution_id", id)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
 	}
+	paramsJSON, _ := json.Marshal(params)
+	sig, signErr := h.signer.Sign(id, int32(actionType), paramsJSON)
+	if signErr != nil {
+		h.logger.Error("dispatch: failed to sign action", "execution_id", id, "error", signErr)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign dispatched action")
+	}
+	signature = sig
+	paramsCanonical = paramsJSON
 
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "execution",
@@ -907,39 +921,40 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 	// now; if the enqueue fails we MUST transition it to a terminal
 	// state so the projection reflects reality. Silently returning
 	// success used to leave the row as `pending` indefinitely.
-	if h.aqClient != nil {
-		if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
-			ExecutionID:     id,
-			ActionType:      int32(actionType),
-			DesiredState:    int32(desiredState),
-			Params:          paramsJSON,
-			TimeoutSeconds:  timeoutSeconds,
-			Signature:       signature,
-			ParamsCanonical: paramsCanonical,
-		}, asynq.MaxRetry(5)); err != nil {
-			h.logger.Error("failed to enqueue action dispatch; emitting ExecutionFailed",
-				"error", err, "execution_id", id)
-			// Append a compensating ExecutionFailed event so the row
-			// moves to a terminal state the operator can act on.
-			// Best-effort: a failure here is logged but we still return
-			// the enqueue error to the caller so they know the dispatch
-			// did not reach the device.
-			if failErr := appendEvent(ctx, h.store, h.logger, store.Event{
-				StreamType: "execution",
-				StreamID:   id,
-				EventType:  "ExecutionFailed",
-				Data: map[string]any{
-					"error":        fmt.Sprintf("dispatch enqueue failed: %v", err),
-					"completed_at": nil, // projector falls back to event.occurred_at
-				},
-				ActorType: "system",
-				ActorID:   "system",
-			}, "failed to append ExecutionFailed compensating event"); failErr != nil {
-				h.logger.Error("compensating ExecutionFailed event failed; execution row is stuck in pending",
-					"execution_id", id, "error", failErr)
-			}
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to enqueue action dispatch")
+	//
+	// h.aqClient is guaranteed non-nil here — the precondition check
+	// at the top of DispatchAction rejects the call otherwise.
+	if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
+		ExecutionID:     id,
+		ActionType:      int32(actionType),
+		DesiredState:    int32(desiredState),
+		Params:          paramsJSON,
+		TimeoutSeconds:  timeoutSeconds,
+		Signature:       signature,
+		ParamsCanonical: paramsCanonical,
+	}, asynq.MaxRetry(5)); err != nil {
+		h.logger.Error("failed to enqueue action dispatch; emitting ExecutionFailed",
+			"error", err, "execution_id", id)
+		// Append a compensating ExecutionFailed event so the row
+		// moves to a terminal state the operator can act on.
+		// Best-effort: a failure here is logged but we still return
+		// the enqueue error to the caller so they know the dispatch
+		// did not reach the device.
+		if failErr := appendEvent(ctx, h.store, h.logger, store.Event{
+			StreamType: "execution",
+			StreamID:   id,
+			EventType:  "ExecutionFailed",
+			Data: map[string]any{
+				"error":        fmt.Sprintf("dispatch enqueue failed: %v", err),
+				"completed_at": nil, // projector falls back to event.occurred_at
+			},
+			ActorType: "system",
+			ActorID:   "system",
+		}, "failed to append ExecutionFailed compensating event"); failErr != nil {
+			h.logger.Error("compensating ExecutionFailed event failed; execution row is stuck in pending",
+				"execution_id", id, "error", failErr)
 		}
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to enqueue action dispatch")
 	}
 
 	exec, err := h.store.Queries().GetExecutionByID(ctx, id)
@@ -1331,6 +1346,13 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 		"timeout_seconds": timeoutSeconds,
 	}
 
+	// Fail fast when no task queue is configured — same fail-closed
+	// contract as DispatchAction. Positioned after validation/auth/
+	// device-lookup so body-level errors surface with their own codes.
+	if h.aqClient == nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeFailedPrecondition, "instant dispatch unavailable: task queue not configured")
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "execution",
 		StreamID:   id,
@@ -1342,17 +1364,36 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 		return nil, err
 	}
 
-	// Dispatch instant action to device via Asynq task queue
-	if h.aqClient != nil {
-		if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
-			ExecutionID:    id,
-			ActionType:     int32(req.Msg.InstantAction),
-			DesiredState:   int32(pm.DesiredState_DESIRED_STATE_PRESENT),
-			Params:         json.RawMessage("{}"),
-			TimeoutSeconds: timeoutSeconds,
-		}, asynq.MaxRetry(3)); err != nil {
-			h.logger.Warn("failed to enqueue instant action dispatch", "error", err, "execution_id", id)
+	// Dispatch instant action. Same contract as DispatchAction: an
+	// enqueue failure after the ExecutionCreated write MUST emit a
+	// compensating ExecutionFailed event so the row moves to a
+	// terminal `failed` state — otherwise the projection sits in
+	// `pending` forever and the operator has no idea why the
+	// reboot/sync never happened.
+	if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
+		ExecutionID:    id,
+		ActionType:     int32(req.Msg.InstantAction),
+		DesiredState:   int32(pm.DesiredState_DESIRED_STATE_PRESENT),
+		Params:         json.RawMessage("{}"),
+		TimeoutSeconds: timeoutSeconds,
+	}, asynq.MaxRetry(3)); err != nil {
+		h.logger.Error("failed to enqueue instant action dispatch; emitting ExecutionFailed",
+			"error", err, "execution_id", id)
+		if failErr := appendEvent(ctx, h.store, h.logger, store.Event{
+			StreamType: "execution",
+			StreamID:   id,
+			EventType:  "ExecutionFailed",
+			Data: map[string]any{
+				"error":        fmt.Sprintf("instant dispatch enqueue failed: %v", err),
+				"completed_at": nil,
+			},
+			ActorType: "system",
+			ActorID:   "system",
+		}, "failed to append ExecutionFailed compensating event"); failErr != nil {
+			h.logger.Error("compensating ExecutionFailed event failed; execution row is stuck in pending",
+				"execution_id", id, "error", failErr)
 		}
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to enqueue instant action dispatch")
 	}
 
 	exec, err := h.store.Queries().GetExecutionByID(ctx, id)

--- a/internal/api/action_handler_test.go
+++ b/internal/api/action_handler_test.go
@@ -184,6 +184,7 @@ func TestDeleteAction(t *testing.T) {
 func TestDispatchAction_ByID(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	actionID := testutil.CreateTestAction(t, st, adminID, "Dispatch Test", int(pm.ActionType_ACTION_TYPE_SHELL))
@@ -222,6 +223,7 @@ func TestDispatchAction_DeviceNotFound(t *testing.T) {
 func TestListExecutions(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	actionID := testutil.CreateTestAction(t, st, adminID, "Exec Test", int(pm.ActionType_ACTION_TYPE_SHELL))
@@ -247,6 +249,7 @@ func TestListExecutions(t *testing.T) {
 func TestGetExecution(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	actionID := testutil.CreateTestAction(t, st, adminID, "Get Exec", int(pm.ActionType_ACTION_TYPE_SHELL))
@@ -272,6 +275,7 @@ func TestGetExecution(t *testing.T) {
 func TestDispatchInstantAction(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "instant-host")

--- a/internal/api/action_handler_test.go
+++ b/internal/api/action_handler_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCreateAction_Shell(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -52,7 +52,7 @@ func TestCreateAction_Shell(t *testing.T) {
 // rejection, which is a pure proto-level constraint.
 func TestCreateAction_AdminPolicy_CustomRequiresConfig(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -91,7 +91,7 @@ func TestCreateAction_AdminPolicy_CustomRequiresConfig(t *testing.T) {
 
 func TestCreateAction_DefaultTimeout(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -109,7 +109,7 @@ func TestCreateAction_DefaultTimeout(t *testing.T) {
 
 func TestGetAction(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	actionID := testutil.CreateTestAction(t, st, adminID, "Test Action", int(pm.ActionType_ACTION_TYPE_SHELL))
@@ -123,7 +123,7 @@ func TestGetAction(t *testing.T) {
 
 func TestGetAction_NotFound(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -135,7 +135,7 @@ func TestGetAction_NotFound(t *testing.T) {
 
 func TestListActions(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -151,7 +151,7 @@ func TestListActions(t *testing.T) {
 
 func TestRenameAction(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	actionID := testutil.CreateTestAction(t, st, adminID, "Old", int(pm.ActionType_ACTION_TYPE_SHELL))
@@ -167,7 +167,7 @@ func TestRenameAction(t *testing.T) {
 
 func TestDeleteAction(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	actionID := testutil.CreateTestAction(t, st, adminID, "To Delete", int(pm.ActionType_ACTION_TYPE_SHELL))
@@ -183,7 +183,7 @@ func TestDeleteAction(t *testing.T) {
 
 func TestDispatchAction_ByID(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	actionID := testutil.CreateTestAction(t, st, adminID, "Dispatch Test", int(pm.ActionType_ACTION_TYPE_SHELL))
@@ -203,7 +203,7 @@ func TestDispatchAction_ByID(t *testing.T) {
 
 func TestDispatchAction_DeviceNotFound(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	actionID := testutil.CreateTestAction(t, st, adminID, "Test", int(pm.ActionType_ACTION_TYPE_SHELL))
@@ -221,7 +221,7 @@ func TestDispatchAction_DeviceNotFound(t *testing.T) {
 
 func TestListExecutions(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	actionID := testutil.CreateTestAction(t, st, adminID, "Exec Test", int(pm.ActionType_ACTION_TYPE_SHELL))
@@ -246,7 +246,7 @@ func TestListExecutions(t *testing.T) {
 
 func TestGetExecution(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	actionID := testutil.CreateTestAction(t, st, adminID, "Get Exec", int(pm.ActionType_ACTION_TYPE_SHELL))
@@ -271,7 +271,7 @@ func TestGetExecution(t *testing.T) {
 
 func TestDispatchInstantAction(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "instant-host")

--- a/internal/api/assignment_handler_test.go
+++ b/internal/api/assignment_handler_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCreateAssignment_ActionToDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	actionHandler := api.NewActionHandler(st, slog.Default(), nil)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -39,7 +39,7 @@ func TestCreateAssignment_ActionToDevice(t *testing.T) {
 
 func TestCreateAssignment_SetToGroup(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	actionHandler := api.NewActionHandler(st, slog.Default(), nil)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -60,7 +60,7 @@ func TestCreateAssignment_SetToGroup(t *testing.T) {
 
 func TestCreateAssignment_Idempotent(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	actionHandler := api.NewActionHandler(st, slog.Default(), nil)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -87,7 +87,7 @@ func TestCreateAssignment_Idempotent(t *testing.T) {
 
 func TestDeleteAssignment(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	actionHandler := api.NewActionHandler(st, slog.Default(), nil)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -111,7 +111,7 @@ func TestDeleteAssignment(t *testing.T) {
 
 func TestListAssignments(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	actionHandler := api.NewActionHandler(st, slog.Default(), nil)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -136,7 +136,7 @@ func TestListAssignments(t *testing.T) {
 
 func TestCreateAssignment_ActionToUser(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	actionHandler := api.NewActionHandler(st, slog.Default(), nil)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -158,7 +158,7 @@ func TestCreateAssignment_ActionToUser(t *testing.T) {
 
 func TestCreateAssignment_ActionToUserGroup(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	actionHandler := api.NewActionHandler(st, slog.Default(), nil)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -180,7 +180,7 @@ func TestCreateAssignment_ActionToUserGroup(t *testing.T) {
 
 func TestCreateAssignment_UserNotFound(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	actionHandler := api.NewActionHandler(st, slog.Default(), nil)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -199,7 +199,7 @@ func TestCreateAssignment_UserNotFound(t *testing.T) {
 
 func TestGetUserAssignments(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	actionHandler := api.NewActionHandler(st, slog.Default(), nil)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -237,7 +237,7 @@ func TestGetUserAssignments(t *testing.T) {
 
 func TestGetDeviceAssignments(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	actionHandler := api.NewActionHandler(st, slog.Default(), nil)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -892,31 +892,82 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 	// handler used to append LuksDeviceKeyRevocationDispatched and
 	// return success — the UI would show "dispatched" but the agent
 	// would never get the revocation task, leaving the LUKS key
-	// live when the operator thinks they've revoked it. Matches
-	// the fail-closed contract DispatchAction / DispatchOSQuery /
-	// QueryDeviceLogs adopted in this PR.
+	// live when the operator thinks they've revoked it.
 	if h.aqClient == nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeFailedPrecondition, "LUKS key revocation unavailable: task queue not configured")
 	}
 
-	// Dispatch LUKS device key revocation to device via Asynq task
-	// queue. Enqueue BEFORE recording the dispatched event so the
-	// event stream does not advertise a dispatch that did not leave
-	// the building. If the enqueue fails we return an error and no
-	// event is written — cleaner than the dispatch-action path's
-	// compensating event because this is a small, single-purpose
-	// RPC and the UI polls the event stream for status.
-	if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeRevokeLuksDeviceKey, taskqueue.RevokeLuksDeviceKeyPayload{
-		ActionID: req.Msg.ActionId,
-	}, asynq.MaxRetry(5)); err != nil {
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch LUKS revocation")
-	}
-
-	// Record dispatched event so the UI can show "dispatched" status
+	// Three-phase audit model:
+	//
+	//   Phase 1: append LuksDeviceKeyRevocationRequested (durable
+	//            operator-intent record) BEFORE touching the queue.
+	//   Phase 2: enqueue to Asynq.
+	//   Phase 3: append Dispatched on enqueue success, or Failed on
+	//            enqueue error.
+	//
+	// This flips the previous enqueue-first shape (which could
+	// revoke the key while the audit stream was silent about the
+	// operator ever asking for it) into an outbox-ish model: the
+	// audit record always exists, regardless of enqueue outcome.
+	// If the phase-3 append fails, the projection lingers at
+	// 'requested' — still a meaningful audit state the operator
+	// can investigate, rather than a silent no-op.
 	luksStreamID := newULID()
+	reqAt := time.Now().Format(time.RFC3339)
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "luks_key",
 		StreamID:   luksStreamID,
+		EventType:  "LuksDeviceKeyRevocationRequested",
+		Data: map[string]any{
+			"device_id":    req.Msg.DeviceId,
+			"action_id":    req.Msg.ActionId,
+			"requested_at": reqAt,
+		},
+		ActorType: "user",
+		ActorID:   userCtx.ID,
+	}); err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to record revocation request")
+	}
+
+	// Phase 2: enqueue.
+	if enqErr := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeRevokeLuksDeviceKey, taskqueue.RevokeLuksDeviceKeyPayload{
+		ActionID: req.Msg.ActionId,
+	}, asynq.MaxRetry(5)); enqErr != nil {
+		// Phase 3b: append Failed so the projection transitions
+		// requested → failed. Best-effort; if this append also
+		// fails the projection stays at 'requested', which is
+		// still a truthful audit state (the revocation did NOT
+		// happen).
+		h.logger.Error("luks revocation enqueue failed; emitting LuksDeviceKeyRevocationFailed",
+			"device_id", req.Msg.DeviceId, "action_id", req.Msg.ActionId, "error", enqErr)
+		if failErr := h.store.AppendEvent(ctx, store.Event{
+			StreamType: "luks_key",
+			StreamID:   newULID(),
+			EventType:  "LuksDeviceKeyRevocationFailed",
+			Data: map[string]any{
+				"device_id": req.Msg.DeviceId,
+				"action_id": req.Msg.ActionId,
+				"error":     fmt.Sprintf("dispatch enqueue failed: %v", enqErr),
+				"failed_at": time.Now().Format(time.RFC3339),
+			},
+			ActorType: "system",
+			ActorID:   "system",
+		}); failErr != nil {
+			h.logger.Error("failed to append LuksDeviceKeyRevocationFailed; projection stays at 'requested'",
+				"device_id", req.Msg.DeviceId, "action_id", req.Msg.ActionId, "error", failErr)
+		}
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch LUKS revocation")
+	}
+
+	// Phase 3a: append Dispatched. Task is already in the queue; a
+	// failure here leaves the projection at 'requested' while the
+	// agent proceeds with revocation. Log loudly and return error
+	// so the caller knows the UI-visible state will lag. The agent
+	// will still emit LuksDeviceKeyRevoked on success, which fully
+	// transitions the row — so the lag is bounded, not permanent.
+	if err := h.store.AppendEvent(ctx, store.Event{
+		StreamType: "luks_key",
+		StreamID:   newULID(),
 		EventType:  "LuksDeviceKeyRevocationDispatched",
 		Data: map[string]any{
 			"device_id":     req.Msg.DeviceId,
@@ -926,19 +977,14 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 		ActorType: "user",
 		ActorID:   userCtx.ID,
 	}); err != nil {
-		// Task is already enqueued; the event append failure means
-		// the UI won't show "dispatched" but the agent will still
-		// receive and process the revocation. Log loudly but return
-		// error so the caller knows the UI state is stale.
-		h.logger.Error("luks revocation enqueued but event append failed; UI state may lag real revocation",
+		h.logger.Error("luks revocation dispatched but Dispatched event append failed; projection stays at 'requested' until agent emits LuksDeviceKeyRevoked",
 			"device_id", req.Msg.DeviceId, "action_id", req.Msg.ActionId, "error", err)
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to record revocation event")
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to record revocation dispatched event")
 	}
-	h.logger.Debug("event appended",
+	h.logger.Debug("luks revocation full flow appended",
 		"request_id", middleware.RequestIDFromContext(ctx),
 		"stream_type", "luks_key",
 		"stream_id", luksStreamID,
-		"event_type", "LuksDeviceKeyRevocationDispatched",
 	)
 
 	return connect.NewResponse(&pm.RevokeLuksDeviceKeyResponse{}), nil

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -905,13 +905,13 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 	//   Phase 3: append Dispatched on enqueue success, or Failed on
 	//            enqueue error.
 	//
-	// This flips the previous enqueue-first shape (which could
-	// revoke the key while the audit stream was silent about the
-	// operator ever asking for it) into an outbox-ish model: the
-	// audit record always exists, regardless of enqueue outcome.
-	// If the phase-3 append fails, the projection lingers at
-	// 'requested' — still a meaningful audit state the operator
-	// can investigate, rather than a silent no-op.
+	// All three events share the SAME stream_id so the event stream
+	// tells a single correlated story per revocation attempt:
+	// Requested → (Dispatched|Failed) → Revoked|Failed. Using fresh
+	// ULIDs per event would split the history and force downstream
+	// readers to correlate via (device_id, action_id) instead — the
+	// projector already does that, but the audit log loses the
+	// "these three rows are one revocation attempt" invariant.
 	luksStreamID := newULID()
 	reqAt := time.Now().Format(time.RFC3339)
 	if err := h.store.AppendEvent(ctx, store.Event{
@@ -942,7 +942,7 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 			"device_id", req.Msg.DeviceId, "action_id", req.Msg.ActionId, "error", enqErr)
 		if failErr := h.store.AppendEvent(ctx, store.Event{
 			StreamType: "luks_key",
-			StreamID:   newULID(),
+			StreamID:   luksStreamID,
 			EventType:  "LuksDeviceKeyRevocationFailed",
 			Data: map[string]any{
 				"device_id": req.Msg.DeviceId,
@@ -967,7 +967,7 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 	// transitions the row — so the lag is bounded, not permanent.
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "luks_key",
-		StreamID:   newULID(),
+		StreamID:   luksStreamID,
 		EventType:  "LuksDeviceKeyRevocationDispatched",
 		Data: map[string]any{
 			"device_id":     req.Msg.DeviceId,

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -888,6 +888,30 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 		return nil, handleGetError(ctx, err, ErrDeviceNotFound, "device not found")
 	}
 
+	// Fail fast when no task queue is configured. Without this the
+	// handler used to append LuksDeviceKeyRevocationDispatched and
+	// return success — the UI would show "dispatched" but the agent
+	// would never get the revocation task, leaving the LUKS key
+	// live when the operator thinks they've revoked it. Matches
+	// the fail-closed contract DispatchAction / DispatchOSQuery /
+	// QueryDeviceLogs adopted in this PR.
+	if h.aqClient == nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeFailedPrecondition, "LUKS key revocation unavailable: task queue not configured")
+	}
+
+	// Dispatch LUKS device key revocation to device via Asynq task
+	// queue. Enqueue BEFORE recording the dispatched event so the
+	// event stream does not advertise a dispatch that did not leave
+	// the building. If the enqueue fails we return an error and no
+	// event is written — cleaner than the dispatch-action path's
+	// compensating event because this is a small, single-purpose
+	// RPC and the UI polls the event stream for status.
+	if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeRevokeLuksDeviceKey, taskqueue.RevokeLuksDeviceKeyPayload{
+		ActionID: req.Msg.ActionId,
+	}, asynq.MaxRetry(5)); err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch LUKS revocation")
+	}
+
 	// Record dispatched event so the UI can show "dispatched" status
 	luksStreamID := newULID()
 	if err := h.store.AppendEvent(ctx, store.Event{
@@ -902,6 +926,12 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 		ActorType: "user",
 		ActorID:   userCtx.ID,
 	}); err != nil {
+		// Task is already enqueued; the event append failure means
+		// the UI won't show "dispatched" but the agent will still
+		// receive and process the revocation. Log loudly but return
+		// error so the caller knows the UI state is stale.
+		h.logger.Error("luks revocation enqueued but event append failed; UI state may lag real revocation",
+			"device_id", req.Msg.DeviceId, "action_id", req.Msg.ActionId, "error", err)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to record revocation event")
 	}
 	h.logger.Debug("event appended",
@@ -910,15 +940,6 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 		"stream_id", luksStreamID,
 		"event_type", "LuksDeviceKeyRevocationDispatched",
 	)
-
-	// Dispatch LUKS device key revocation to device via Asynq task queue
-	if h.aqClient != nil {
-		if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeRevokeLuksDeviceKey, taskqueue.RevokeLuksDeviceKeyPayload{
-			ActionID: req.Msg.ActionId,
-		}, asynq.MaxRetry(5)); err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch LUKS revocation")
-		}
-	}
 
 	return connect.NewResponse(&pm.RevokeLuksDeviceKeyResponse{}), nil
 }

--- a/internal/api/dispatch_validation_test.go
+++ b/internal/api/dispatch_validation_test.go
@@ -1,0 +1,103 @@
+package api_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestDispatchAction_InlineNilRejected is the panic-guard the audit
+// called out: the inline branch dereferenced source.InlineAction
+// without a nil check, so a caller sending an empty InlineAction
+// oneof would crash the handler. The new validateInlineActionPayload
+// must reject nil before extractActionParamsMsg runs.
+func TestDispatchAction_InlineNilRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "dispatch-inline-nil-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_InlineAction{
+			InlineAction: nil,
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// TestDispatchAction_InlineShellMissingScriptRejected pins the
+// parity fix: DispatchAction's inline branch must run the same
+// shell "at least one of script or detection_script" rule that
+// Create applies, otherwise an inline dispatch can smuggle an
+// empty-script shell action that would never run.
+func TestDispatchAction_InlineShellMissingScriptRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "dispatch-inline-shell-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_InlineAction{
+			InlineAction: &pm.Action{
+				Type:         pm.ActionType_ACTION_TYPE_SHELL,
+				DesiredState: pm.DesiredState_DESIRED_STATE_PRESENT,
+				Params: &pm.Action_Shell{
+					Shell: &pm.ShellParams{
+						// Neither Script nor DetectionScript set.
+					},
+				},
+			},
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// TestUpdateActionParams_ShellMissingScriptRejected pins the
+// Update-path parity fix: the original Update handler only ran
+// struct-tag Validate, skipping the "script OR detection_script
+// required" rule that Create applies. An operator editing a valid
+// shell action to wipe both scripts would otherwise silently turn
+// it into a no-op signed action that does nothing on dispatch.
+func TestUpdateActionParams_ShellMissingScriptRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	// Seed a valid shell action first.
+	created, err := h.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
+		Name: "Shell-that-will-be-broken",
+		Type: pm.ActionType_ACTION_TYPE_SHELL,
+		Params: &pm.CreateActionRequest_Shell{
+			Shell: &pm.ShellParams{Script: "echo ok"},
+		},
+	}))
+	require.NoError(t, err)
+
+	_, err = h.UpdateActionParams(ctx, connect.NewRequest(&pm.UpdateActionParamsRequest{
+		Id: created.Msg.Action.Id,
+		Params: &pm.UpdateActionParamsRequest_Shell{
+			Shell: &pm.ShellParams{
+				// Both scripts blanked — must be rejected.
+			},
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}

--- a/internal/api/dispatch_validation_test.go
+++ b/internal/api/dispatch_validation_test.go
@@ -149,6 +149,53 @@ func TestDispatchAction_InlineTimeoutOutOfBoundsRejected(t *testing.T) {
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
 
+// TestDispatchAction_PreconditionNoTaskQueue pins the fail-closed
+// behaviour the reviewer flagged: if the server starts without a
+// Valkey / task-queue client (CONTROL_VALKEY_ADDR unset, etc.),
+// DispatchAction must refuse the RPC instead of silently writing
+// an ExecutionCreated event, skipping signing, and returning
+// success. The expected code is FailedPrecondition — a deployment-
+// configuration error, not a retryable transient fault.
+func TestDispatchAction_PreconditionNoTaskQueue(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	// Deliberately do NOT call h.SetTaskQueueClient — the handler
+	// has no enqueuer, which mimics a production deploy with no
+	// Valkey configured.
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, adminID, "No-queue dispatch", int(pm.ActionType_ACTION_TYPE_SHELL))
+	deviceID := testutil.CreateTestDevice(t, st, "no-queue-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_ActionId{
+			ActionId: actionID,
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+// TestDispatchInstantAction_PreconditionNoTaskQueue pins the
+// matching fail-closed behaviour for the instant-action path.
+func TestDispatchInstantAction_PreconditionNoTaskQueue(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "no-queue-instant-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchInstantAction(ctx, connect.NewRequest(&pm.DispatchInstantActionRequest{
+		DeviceId:      deviceID,
+		InstantAction: pm.ActionType_ACTION_TYPE_REBOOT,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
 // TestUpdateActionParams_ShellMissingScriptRejected pins the
 // Update-path parity fix: the original Update handler only ran
 // struct-tag Validate, skipping the "script OR detection_script

--- a/internal/api/dispatch_validation_test.go
+++ b/internal/api/dispatch_validation_test.go
@@ -16,11 +16,11 @@ import (
 // TestDispatchAction_InlineNilRejected is the panic-guard the audit
 // called out: the inline branch dereferenced source.InlineAction
 // without a nil check, so a caller sending an empty InlineAction
-// oneof would crash the handler. The new validateInlineActionPayload
+// oneof would crash the handler. The new validateInlineAction
 // must reject nil before extractActionParamsMsg runs.
 func TestDispatchAction_InlineNilRejected(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "dispatch-inline-nil-host")
@@ -43,7 +43,7 @@ func TestDispatchAction_InlineNilRejected(t *testing.T) {
 // empty-script shell action that would never run.
 func TestDispatchAction_InlineShellMissingScriptRejected(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "dispatch-inline-shell-host")
@@ -67,6 +67,88 @@ func TestDispatchAction_InlineShellMissingScriptRejected(t *testing.T) {
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
 
+// TestDispatchAction_InlineUnspecifiedTypeRejected pins one of the
+// invariants validateInlineAction enforces beyond the per-oneof
+// validation: ACTION_TYPE_UNSPECIFIED must be refused. Without the
+// guard, an inline dispatch with no Type set would reach the
+// agent and confuse the dispatch path.
+func TestDispatchAction_InlineUnspecifiedTypeRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "dispatch-inline-unspec-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_InlineAction{
+			InlineAction: &pm.Action{
+				// Type intentionally omitted.
+				Params: &pm.Action_Shell{Shell: &pm.ShellParams{Script: "echo x"}},
+			},
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// TestDispatchAction_InlineParamsMismatchTypeRejected pins the
+// strictest of the invariants: action.Type and action.Params oneof
+// must agree. A caller routing Type=USER through an Action_Ssh oneof
+// would otherwise have the dispatch path treat it as a USER action
+// while the agent receives Ssh-shaped params bytes — silent param
+// corruption. The guard refuses the request server-side.
+func TestDispatchAction_InlineParamsMismatchTypeRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "dispatch-inline-mismatch-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_InlineAction{
+			InlineAction: &pm.Action{
+				Type: pm.ActionType_ACTION_TYPE_USER,
+				Params: &pm.Action_Ssh{ // mismatched oneof
+					Ssh: &pm.SshParams{Users: []string{"alice"}},
+				},
+			},
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// TestDispatchAction_InlineTimeoutOutOfBoundsRejected pins the
+// timeout-bounds invariant. validateInlineAction enforces
+// 0 <= TimeoutSeconds <= 3600.
+func TestDispatchAction_InlineTimeoutOutOfBoundsRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "dispatch-inline-timeout-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_InlineAction{
+			InlineAction: &pm.Action{
+				Type:           pm.ActionType_ACTION_TYPE_SHELL,
+				TimeoutSeconds: 99999, // way over the 3600 cap
+				Params: &pm.Action_Shell{
+					Shell: &pm.ShellParams{Script: "echo x"},
+				},
+			},
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
 // TestUpdateActionParams_ShellMissingScriptRejected pins the
 // Update-path parity fix: the original Update handler only ran
 // struct-tag Validate, skipping the "script OR detection_script
@@ -75,7 +157,7 @@ func TestDispatchAction_InlineShellMissingScriptRejected(t *testing.T) {
 // it into a no-op signed action that does nothing on dispatch.
 func TestUpdateActionParams_ShellMissingScriptRejected(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)

--- a/internal/api/handler_base.go
+++ b/internal/api/handler_base.go
@@ -16,12 +16,24 @@ func (h *searchIndexHolder) SetSearchIndex(idx *search.Index) {
 	h.searchIdx = idx
 }
 
-// taskQueueHolder is a mixin for handlers that enqueue Asynq tasks. Same
-// promotion trick — h.aqClient remains accessible in handler methods.
+// taskQueueHolder is a mixin for handlers that enqueue Asynq tasks.
+// Same promotion trick — h.aqClient remains accessible in handler
+// methods. The field is an interface (taskqueue.Enqueuer) so tests
+// can inject a no-op / recording double without a real Valkey, and
+// production dispatch paths can refuse requests when the enqueuer
+// is nil instead of silently swallowing them.
 type taskQueueHolder struct {
-	aqClient *taskqueue.Client
+	aqClient taskqueue.Enqueuer
 }
 
-func (h *taskQueueHolder) SetTaskQueueClient(c *taskqueue.Client) {
+// SetTaskQueueClient accepts the interface so production (wiring
+// *taskqueue.Client from main.go) and tests (wiring
+// api.NoOpEnqueuer{}) share one setter. A nil argument keeps the
+// holder's current value — callers that want to explicitly clear
+// the enqueuer should reconstruct the handler.
+func (h *taskQueueHolder) SetTaskQueueClient(c taskqueue.Enqueuer) {
+	if c == nil {
+		return
+	}
 	h.aqClient = c
 }

--- a/internal/api/logs_handler.go
+++ b/internal/api/logs_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -42,6 +43,15 @@ func (h *LogsHandler) QueryDeviceLogs(ctx context.Context, req *connect.Request[
 		return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
 	}
 
+	// Fail fast when no task queue is configured. Same fail-closed
+	// contract as DispatchAction / DispatchOSQuery: silently
+	// returning a queryID the caller can poll until the 5-minute
+	// timeout was actively misleading — no agent task was ever
+	// enqueued.
+	if h.aqClient == nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeFailedPrecondition, "log query dispatch unavailable: task queue not configured")
+	}
+
 	// Generate query ID
 	queryID := ulid.Make().String()
 
@@ -53,28 +63,39 @@ func (h *LogsHandler) QueryDeviceLogs(ctx context.Context, req *connect.Request[
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create log query result")
 	}
 
-	// Dispatch log query to device via Asynq task queue
-	if h.aqClient != nil {
-		if err := h.aqClient.EnqueueToDevice(msg.DeviceId, taskqueue.TypeLogQueryDispatch, taskqueue.LogQueryDispatchPayload{
-			QueryID:  queryID,
-			Lines:    msg.Lines,
-			Unit:     msg.Unit,
-			Since:    msg.Since,
-			Until:    msg.Until,
-			Priority: msg.Priority,
-			Grep:     msg.Grep,
-			Kernel:   msg.Kernel,
-		},
-			asynq.MaxRetry(3),
-			asynq.Deadline(time.Now().Add(2*time.Minute)),
-		); err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch log query")
+	// Dispatch log query to device via Asynq task queue.
+	// Enqueue failure: the pending result row already exists. Mark
+	// it expired so callers polling GetDeviceLogResult see a
+	// terminal failure rather than waiting the full 5-minute
+	// timeout on a task that never shipped.
+	if err := h.aqClient.EnqueueToDevice(msg.DeviceId, taskqueue.TypeLogQueryDispatch, taskqueue.LogQueryDispatchPayload{
+		QueryID:  queryID,
+		Lines:    msg.Lines,
+		Unit:     msg.Unit,
+		Since:    msg.Since,
+		Until:    msg.Until,
+		Priority: msg.Priority,
+		Grep:     msg.Grep,
+		Kernel:   msg.Kernel,
+	},
+		asynq.MaxRetry(3),
+		asynq.Deadline(time.Now().Add(2*time.Minute)),
+	); err != nil {
+		h.logger.Error("log query enqueue failed; marking result expired",
+			"query_id", queryID, "device_id", msg.DeviceId, "error", err)
+		if expireErr := h.store.Queries().ExpirePendingLogQueryResult(ctx, generated.ExpirePendingLogQueryResultParams{
+			QueryID: queryID,
+			Error:   fmt.Sprintf("dispatch enqueue failed: %v", err),
+		}); expireErr != nil {
+			h.logger.Error("failed to mark enqueue-failed log query result as expired",
+				"query_id", queryID, "error", expireErr)
 		}
-		h.logger.Info("log query dispatched to device",
-			"query_id", queryID,
-			"device_id", msg.DeviceId,
-		)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch log query")
 	}
+	h.logger.Info("log query dispatched to device",
+		"query_id", queryID,
+		"device_id", msg.DeviceId,
+	)
 
 	return connect.NewResponse(&pm.QueryDeviceLogsResponse{
 		QueryId: queryID,

--- a/internal/api/logs_handler_test.go
+++ b/internal/api/logs_handler_test.go
@@ -28,22 +28,29 @@ func TestQueryDeviceLogs_DeviceNotFound(t *testing.T) {
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 }
 
-func TestQueryDeviceLogs_ValidDevice_NoTaskQueue(t *testing.T) {
+// TestQueryDeviceLogs_NoTaskQueue_RefusesWithPrecondition pins the
+// fail-closed contract introduced when we tightened the dispatch
+// paths against silent no-ops. Previously a handler with no aqClient
+// would still create a pending query row and return 200 OK — the
+// caller saw a queryID to poll that the agent would never receive.
+// Now the handler refuses the RPC with FailedPrecondition so the
+// operator knows the deployment is misconfigured.
+func TestQueryDeviceLogs_NoTaskQueue_RefusesWithPrecondition(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewLogsHandler(st, slog.Default())
-	// No task queue client set — tests that it still creates the query result row
+	// Intentionally do NOT call h.SetTaskQueueClient.
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
 
 	deviceID := testutil.CreateTestDevice(t, st, "test-device")
 
-	resp, err := h.QueryDeviceLogs(ctx, connect.NewRequest(&pm.QueryDeviceLogsRequest{
+	_, err := h.QueryDeviceLogs(ctx, connect.NewRequest(&pm.QueryDeviceLogsRequest{
 		DeviceId: deviceID,
 		Lines:    50,
 	}))
-	require.NoError(t, err)
-	assert.NotEmpty(t, resp.Msg.QueryId)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
 }
 
 func TestGetDeviceLogResult_NotFound(t *testing.T) {
@@ -63,6 +70,10 @@ func TestGetDeviceLogResult_NotFound(t *testing.T) {
 func TestGetDeviceLogResult_PendingResult(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewLogsHandler(st, slog.Default())
+	// Wire a no-op enqueuer so QueryDeviceLogs actually dispatches
+	// and creates the pending row this test reads back. Without it
+	// the new FailedPrecondition gate rejects the dispatch.
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)

--- a/internal/api/luks_action_test.go
+++ b/internal/api/luks_action_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestCreateAction_Encryption(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -40,7 +40,7 @@ func TestCreateAction_Encryption(t *testing.T) {
 
 func TestCreateAction_Luks_WithTPM(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -71,7 +71,7 @@ func TestCreateAction_Luks_WithTPM(t *testing.T) {
 
 func TestCreateAction_Luks_WithUserPassphrase(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -101,7 +101,7 @@ func TestCreateAction_Luks_WithUserPassphrase(t *testing.T) {
 
 func TestCreateAction_Luks_GetAfterCreate(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -135,7 +135,7 @@ func TestCreateAction_Luks_GetAfterCreate(t *testing.T) {
 
 func TestCreateAction_Luks_UpdateParams(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -176,7 +176,7 @@ func TestCreateAction_Luks_UpdateParams(t *testing.T) {
 
 func TestCreateAction_Luks_DeleteAction(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -208,7 +208,7 @@ func TestCreateAction_Luks_DeleteAction(t *testing.T) {
 
 func TestCreateAction_Luks_ListIncludesLuks(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewActionHandler(st, slog.Default(), nil)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)

--- a/internal/api/noop_enqueuer_test.go
+++ b/internal/api/noop_enqueuer_test.go
@@ -1,0 +1,53 @@
+package api
+
+import "github.com/hibiken/asynq"
+
+// This file's `_test.go` suffix means NoOpEnqueuer compiles ONLY
+// during `go test`. Production builds do not link it, so a handler
+// that accidentally reached for `api.NoOpEnqueuer{}` outside test
+// code would fail to build — the same footgun-closing trick as
+// NoOpSigner.
+//
+// Tests that exercise dispatch paths (DispatchAction,
+// DispatchInstantAction, device_handler revoke, osquery dispatch,
+// logs dispatch) construct their handler, then call
+// `h.SetTaskQueueClient(api.NoOpEnqueuer{})` before triggering the
+// RPC. Without this, the fail-closed precondition check now rejects
+// dispatches with CodeFailedPrecondition — the exact behaviour
+// production wants when Valkey is unconfigured, but not what the
+// tests are verifying.
+
+// NoOpEnqueuer is a recording no-op taskqueue.Enqueuer for tests.
+// Every method succeeds without enqueueing anything. Tests that
+// need to assert the dispatch was attempted inspect the recorded
+// calls directly.
+type NoOpEnqueuer struct {
+	// DeviceCalls records each EnqueueToDevice invocation so tests
+	// can assert the dispatch reached this boundary. Not protected
+	// by a mutex: tests do not run dispatch concurrently in the
+	// same handler under current fixtures.
+	DeviceCalls []NoOpEnqueuerCall
+}
+
+// NoOpEnqueuerCall captures the arguments of one EnqueueToDevice.
+type NoOpEnqueuerCall struct {
+	DeviceID string
+	TaskType string
+	Payload  any
+}
+
+// EnqueueToDevice records and succeeds.
+func (n *NoOpEnqueuer) EnqueueToDevice(deviceID, taskType string, payload any, _ ...asynq.Option) error {
+	n.DeviceCalls = append(n.DeviceCalls, NoOpEnqueuerCall{
+		DeviceID: deviceID,
+		TaskType: taskType,
+		Payload:  payload,
+	})
+	return nil
+}
+
+// EnqueueToControl is a no-op.
+func (*NoOpEnqueuer) EnqueueToControl(_ string, _ any) error { return nil }
+
+// EnqueueToSearch is a no-op.
+func (*NoOpEnqueuer) EnqueueToSearch(_ string, _ any) error { return nil }

--- a/internal/api/noop_signer.go
+++ b/internal/api/noop_signer.go
@@ -1,0 +1,24 @@
+package api
+
+// NoOpSigner is a deterministic test-only ActionSigner that returns
+// a fixed dummy signature. It exists so test fixtures can construct
+// ActionHandler / SystemActionManager without dragging in the real
+// CA, while still satisfying the production contract that the
+// signer field is non-nil.
+//
+// In production the wiring uses the real internal/ca signer; passing
+// a nil signer to NewActionHandler / NewSystemActionManager is now a
+// hard error (see signAction / signActionByID), which forces every
+// new test site to make a deliberate choice rather than silently
+// produce unsigned actions in the DB.
+type NoOpSigner struct{}
+
+// Sign returns a deterministic dummy signature. The bytes are
+// distinguishable from real signatures so an accidental escape into
+// production logs is greppable.
+func (NoOpSigner) Sign(actionID string, actionType int32, paramsJSON []byte) ([]byte, error) {
+	_ = actionID
+	_ = actionType
+	_ = paramsJSON
+	return []byte("noop-test-signature"), nil
+}

--- a/internal/api/noop_signer_test.go
+++ b/internal/api/noop_signer_test.go
@@ -1,5 +1,15 @@
 package api
 
+// This file's `_test.go` suffix means it compiles ONLY during
+// `go test`. Production builds do not link NoOpSigner at all — a
+// handler that tried to `api.NoOpSigner{}` in non-test code would
+// fail to build, closing the "footgun" a reviewer flagged when
+// NoOpSigner lived in a regular source file.
+//
+// NoOpSigner is still in `package api` (not `api_test`) so external
+// test files (`package api_test`) can reference `api.NoOpSigner{}`
+// the same way they reference any other exported type.
+
 // NoOpSigner is a deterministic test-only ActionSigner that returns
 // a fixed dummy signature. It exists so test fixtures can construct
 // ActionHandler / SystemActionManager without dragging in the real

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -44,6 +45,15 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 		return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
 	}
 
+	// Fail fast when no task queue is configured. Without this
+	// guard the handler used to write a pending osquery_result row
+	// and return a queryID the caller could poll forever — the
+	// agent never got the task. Same fail-closed contract as
+	// DispatchAction.
+	if h.aqClient == nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeFailedPrecondition, "osquery dispatch unavailable: task queue not configured")
+	}
+
 	// Generate query ID
 	queryID := ulid.Make().String()
 
@@ -65,25 +75,37 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 	// Dispatch osquery to device via Asynq task queue.
 	// Limit retries and set a deadline so queries to offline devices fail quickly
 	// rather than sitting in the queue indefinitely.
-	if h.aqClient != nil {
-		if err := h.aqClient.EnqueueToDevice(msg.DeviceId, taskqueue.TypeOSQueryDispatch, taskqueue.OSQueryDispatchPayload{
+	//
+	// Enqueue failure: the pending result row already exists. Mark
+	// it as expired with an explicit error so callers polling
+	// GetOSQueryResult see a terminal failure rather than waiting
+	// the full 5-minute timeout on a task that never shipped.
+	if err := h.aqClient.EnqueueToDevice(msg.DeviceId, taskqueue.TypeOSQueryDispatch, taskqueue.OSQueryDispatchPayload{
+		QueryID: queryID,
+		Table:   msg.Table,
+		Columns: msg.Columns,
+		Limit:   msg.Limit,
+		RawSQL:  msg.RawSql,
+	},
+		asynq.MaxRetry(3),
+		asynq.Deadline(time.Now().Add(2*time.Minute)),
+	); err != nil {
+		h.logger.Error("osquery enqueue failed; marking result expired",
+			"query_id", queryID, "device_id", msg.DeviceId, "error", err)
+		if expireErr := h.store.Queries().ExpirePendingOSQueryResult(ctx, generated.ExpirePendingOSQueryResultParams{
 			QueryID: queryID,
-			Table:   msg.Table,
-			Columns: msg.Columns,
-			Limit:   msg.Limit,
-			RawSQL:  msg.RawSql,
-		},
-			asynq.MaxRetry(3),
-			asynq.Deadline(time.Now().Add(2*time.Minute)),
-		); err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch osquery")
+			Error:   fmt.Sprintf("dispatch enqueue failed: %v", err),
+		}); expireErr != nil {
+			h.logger.Error("failed to mark enqueue-failed osquery result as expired",
+				"query_id", queryID, "error", expireErr)
 		}
-		h.logger.Info("osquery dispatched to device",
-			"query_id", queryID,
-			"device_id", msg.DeviceId,
-			"table", tableName,
-		)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch osquery")
 	}
+	h.logger.Info("osquery dispatched to device",
+		"query_id", queryID,
+		"device_id", msg.DeviceId,
+		"table", tableName,
+	)
 
 	return connect.NewResponse(&pm.DispatchOSQueryResponse{
 		QueryId: queryID,
@@ -183,18 +205,25 @@ func (h *OSQueryHandler) RefreshDeviceInventory(ctx context.Context, req *connec
 		return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
 	}
 
-	// Dispatch inventory request to device via Asynq task queue
-	if h.aqClient != nil {
-		if err := h.aqClient.EnqueueToDevice(msg.DeviceId, taskqueue.TypeInventoryRequest, taskqueue.InventoryRequestPayload{},
-			asynq.MaxRetry(3),
-			asynq.Deadline(time.Now().Add(2*time.Minute)),
-		); err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch inventory request")
-		}
-		h.logger.Info("inventory refresh dispatched to device",
-			"device_id", msg.DeviceId,
-		)
+	// Fail fast when no task queue is configured. RefreshDeviceInventory
+	// is fire-and-forget (no result row), so a silent-success when
+	// aqClient is nil was less misleading than the DispatchOSQuery
+	// case — but still returned 200 OK for a request that didn't
+	// reach the device. Match the fail-closed contract.
+	if h.aqClient == nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeFailedPrecondition, "inventory refresh unavailable: task queue not configured")
 	}
+
+	// Dispatch inventory request to device via Asynq task queue
+	if err := h.aqClient.EnqueueToDevice(msg.DeviceId, taskqueue.TypeInventoryRequest, taskqueue.InventoryRequestPayload{},
+		asynq.MaxRetry(3),
+		asynq.Deadline(time.Now().Add(2*time.Minute)),
+	); err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch inventory request")
+	}
+	h.logger.Info("inventory refresh dispatched to device",
+		"device_id", msg.DeviceId,
+	)
 
 	return connect.NewResponse(&pm.RefreshDeviceInventoryResponse{}), nil
 }

--- a/internal/api/osquery_handler_test.go
+++ b/internal/api/osquery_handler_test.go
@@ -18,6 +18,7 @@ import (
 func TestDispatchOSQuery(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewOSQueryHandler(st, slog.Default())
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -57,6 +58,7 @@ func TestDispatchOSQuery_DeviceNotFound(t *testing.T) {
 func TestGetOSQueryResult_Pending(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewOSQueryHandler(st, slog.Default())
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -81,6 +83,7 @@ func TestGetOSQueryResult_Pending(t *testing.T) {
 func TestGetOSQueryResult_Completed(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewOSQueryHandler(st, slog.Default())
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -125,6 +128,7 @@ func TestGetOSQueryResult_Completed(t *testing.T) {
 func TestGetOSQueryResult_CompletedWithError(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewOSQueryHandler(st, slog.Default())
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
@@ -272,6 +276,7 @@ func TestGetDeviceInventory_Empty(t *testing.T) {
 func TestRefreshDeviceInventory(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewOSQueryHandler(st, slog.Default())
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -213,14 +213,18 @@ func (m *SystemActionManager) syncUserProvisionAction(ctx context.Context, user 
 			return fmt.Errorf("link user provision action: %w", err)
 		}
 
-		m.signActionByID(ctx, actionID)
+		if err := m.signActionByID(ctx, actionID); err != nil {
+			return fmt.Errorf("sign newly created user provision action: %w", err)
+		}
 		m.logger.Info("created system user provision action", "user_id", user.ID, "action_id", actionID)
 	} else {
 		// Update existing action if params changed
 		if err := m.updateSystemAction(ctx, user.SystemUserActionID, int32(pm.DesiredState_DESIRED_STATE_PRESENT), paramsJSON); err != nil {
 			return fmt.Errorf("update user provision action: %w", err)
 		}
-		m.signActionByID(ctx, user.SystemUserActionID)
+		if err := m.signActionByID(ctx, user.SystemUserActionID); err != nil {
+			return fmt.Errorf("re-sign updated user provision action: %w", err)
+		}
 	}
 
 	return nil
@@ -255,14 +259,18 @@ func (m *SystemActionManager) syncSshAccessAction(ctx context.Context, user db.U
 			return fmt.Errorf("link ssh access action: %w", err)
 		}
 
-		m.signActionByID(ctx, actionID)
+		if err := m.signActionByID(ctx, actionID); err != nil {
+			return fmt.Errorf("sign newly created ssh access action: %w", err)
+		}
 		m.logger.Info("created system ssh access action", "user_id", user.ID, "action_id", actionID)
 	} else {
 		// Update existing action
 		if err := m.updateSystemAction(ctx, user.SystemSshActionID, int32(pm.DesiredState_DESIRED_STATE_PRESENT), paramsJSON); err != nil {
 			return fmt.Errorf("update ssh access action: %w", err)
 		}
-		m.signActionByID(ctx, user.SystemSshActionID)
+		if err := m.signActionByID(ctx, user.SystemSshActionID); err != nil {
+			return fmt.Errorf("re-sign updated ssh access action: %w", err)
+		}
 	}
 
 	return nil
@@ -340,7 +348,9 @@ func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.Use
 			return fmt.Errorf("link tty user action: %w", err)
 		}
 
-		m.signActionByID(ctx, actionID)
+		if err := m.signActionByID(ctx, actionID); err != nil {
+			return fmt.Errorf("sign newly created tty user action: %w", err)
+		}
 		m.logger.Info("created system tty user action",
 			"user_id", user.ID, "action_id", actionID, "tty_user", ttyUsername)
 	} else {
@@ -348,7 +358,9 @@ func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.Use
 		if err := m.updateSystemAction(ctx, user.SystemTtyActionID, int32(pm.DesiredState_DESIRED_STATE_PRESENT), paramsJSON); err != nil {
 			return fmt.Errorf("update tty user action: %w", err)
 		}
-		m.signActionByID(ctx, user.SystemTtyActionID)
+		if err := m.signActionByID(ctx, user.SystemTtyActionID); err != nil {
+			return fmt.Errorf("re-sign updated tty user action: %w", err)
+		}
 	}
 
 	return nil
@@ -469,15 +481,26 @@ func (m *SystemActionManager) linkSystemAction(ctx context.Context, userID, fiel
 }
 
 // signActionByID loads an action from the DB and signs it.
-func (m *SystemActionManager) signActionByID(ctx context.Context, actionID string) {
+//
+// Fail-closed: every outcome other than "signed and stored" returns
+// an error so the caller (syncUserProvisionAction, syncSshAccessAction,
+// syncTtyUserAction) surfaces it as a sync failure. A missing signer
+// is a wiring mistake, not a soft condition — letting an unsigned
+// system-managed action land in the DB means the agent silently
+// drops it on dispatch and the operator has no projection state to
+// debug from. This matches the policy applied to user-Create/Update
+// action signing elsewhere in this package.
+//
+// Ported forward from #69 so #72 can merge independently without
+// relying on #69 landing first.
+func (m *SystemActionManager) signActionByID(ctx context.Context, actionID string) error {
 	if m.signer == nil {
-		return
+		return fmt.Errorf("sign system action %s: signer not configured", actionID)
 	}
 
 	action, err := m.store.Queries().GetActionByID(ctx, actionID)
 	if err != nil {
-		m.logger.Error("failed to load action for signing", "action_id", actionID, "error", err)
-		return
+		return fmt.Errorf("load system action %s for signing: %w", actionID, err)
 	}
 
 	paramsJSON := action.Params
@@ -487,8 +510,7 @@ func (m *SystemActionManager) signActionByID(ctx context.Context, actionID strin
 
 	sig, err := m.signer.Sign(action.ID, action.ActionType, paramsJSON)
 	if err != nil {
-		m.logger.Error("failed to sign system action", "action_id", actionID, "error", err)
-		return
+		return fmt.Errorf("sign system action %s: %w", actionID, err)
 	}
 
 	if err := m.store.Queries().UpdateActionSignature(ctx, db.UpdateActionSignatureParams{
@@ -496,8 +518,10 @@ func (m *SystemActionManager) signActionByID(ctx context.Context, actionID strin
 		Signature:       sig,
 		ParamsCanonical: paramsJSON,
 	}); err != nil {
-		m.logger.Error("failed to store system action signature", "action_id", actionID, "error", err)
+		return fmt.Errorf("store system action %s signature: %w", actionID, err)
 	}
+
+	return nil
 }
 
 // parseSshPublicKeys extracts the public_key strings from the JSONB array.

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -11,8 +11,11 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
+	"net/url"
 	"os"
 	"time"
+
+	"github.com/manchtools/power-manage/server/internal/mtls"
 )
 
 // CA is a certificate authority that issues device certificates.
@@ -118,6 +121,17 @@ func (ca *CA) IssueCertificateFromCSR(deviceID string, csrPEM []byte) (*Certific
 	now := time.Now()
 	notAfter := now.Add(ca.validity)
 
+	// Stamp the SPIFFE URI SAN that marks this as an "agent" peer
+	// class. The gateway's mTLS middleware requires this class on
+	// its agent-facing listener, and the control server's internal
+	// listener refuses agents — so even if an agent cert leaks, the
+	// attacker cannot use it to reach the internal listener and
+	// read other devices' LUKS keys or LPS passwords.
+	peerURI, err := mtls.PeerClassURI(mtls.PeerClassAgent)
+	if err != nil {
+		return nil, fmt.Errorf("build peer-class URI: %w", err)
+	}
+
 	template := &x509.Certificate{
 		SerialNumber: serialNumber,
 		Subject: pkix.Name{
@@ -129,6 +143,7 @@ func (ca *CA) IssueCertificateFromCSR(deviceID string, csrPEM []byte) (*Certific
 		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 		BasicConstraintsValid: true,
+		URIs:                  []*url.URL{peerURI},
 	}
 
 	// Add device ID to the Subject's SerialNumber field

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -122,7 +122,11 @@ func (h *AgentHandler) SetTerminalSessions(reg *connection.TerminalSessionRegist
 	h.terminalSessions = reg
 }
 
-// MTLSMiddleware extracts the device ID from the client certificate and adds it to the context.
+// MTLSMiddleware extracts the device ID from the client certificate
+// and adds it to the context. It also refuses any peer whose cert
+// does not carry the "agent" peer-class URI SAN — the AgentService
+// listener is for managed devices only, and a leaked gateway or
+// control cert must not be usable here.
 func MTLSMiddleware(next http.Handler, logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip TLS check for health endpoints
@@ -140,6 +144,32 @@ func MTLSMiddleware(next http.Handler, logger *slog.Logger) http.Handler {
 			)
 			http.Error(w, "client certificate required", http.StatusUnauthorized)
 			return
+		}
+
+		// Enforce peer class. Agent certs issued by the internal CA
+		// carry a spiffe://power-manage/agent URI SAN; gateway /
+		// control certs carry a different class and must be
+		// rejected before reaching AgentService.
+		if r.TLS != nil {
+			class, err := mtls.PeerClassFromTLS(r.TLS)
+			if err != nil {
+				logger.Warn("mTLS peer-class missing",
+					"error", err,
+					"device_id", deviceID,
+					"remote_addr", r.RemoteAddr,
+				)
+				http.Error(w, "peer class required", http.StatusForbidden)
+				return
+			}
+			if class != mtls.PeerClassAgent {
+				logger.Warn("mTLS peer-class mismatch on AgentService",
+					"device_id", deviceID,
+					"remote_addr", r.RemoteAddr,
+					"presented", class,
+				)
+				http.Error(w, "peer class not allowed", http.StatusForbidden)
+				return
+			}
 		}
 
 		// Add device ID to context

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -150,26 +150,32 @@ func MTLSMiddleware(next http.Handler, logger *slog.Logger) http.Handler {
 		// carry a spiffe://power-manage/agent URI SAN; gateway /
 		// control certs carry a different class and must be
 		// rejected before reaching AgentService.
-		if r.TLS != nil {
-			class, err := mtls.PeerClassFromTLS(r.TLS)
-			if err != nil {
-				logger.Warn("mTLS peer-class missing",
-					"error", err,
-					"device_id", deviceID,
-					"remote_addr", r.RemoteAddr,
-				)
-				http.Error(w, "peer class required", http.StatusForbidden)
-				return
-			}
-			if class != mtls.PeerClassAgent {
-				logger.Warn("mTLS peer-class mismatch on AgentService",
-					"device_id", deviceID,
-					"remote_addr", r.RemoteAddr,
-					"presented", class,
-				)
-				http.Error(w, "peer class not allowed", http.StatusForbidden)
-				return
-			}
+		//
+		// No r.TLS nil-guard: DeviceIDFromRequest above already
+		// rejects requests with no TLS state (returns "no TLS
+		// connection"), so r.TLS is guaranteed non-nil here. A
+		// defensive `if r.TLS != nil` would let a future reorder
+		// of this middleware silently bypass the peer-class check;
+		// better to rely on the invariant and fail loudly than
+		// fail-open.
+		class, err := mtls.PeerClassFromTLS(r.TLS)
+		if err != nil {
+			logger.Warn("mTLS peer-class missing",
+				"error", err,
+				"device_id", deviceID,
+				"remote_addr", r.RemoteAddr,
+			)
+			http.Error(w, "peer class required", http.StatusForbidden)
+			return
+		}
+		if class != mtls.PeerClassAgent {
+			logger.Warn("mTLS peer-class mismatch on AgentService",
+				"device_id", deviceID,
+				"remote_addr", r.RemoteAddr,
+				"presented", class,
+			)
+			http.Error(w, "peer class not allowed", http.StatusForbidden)
+			return
 		}
 
 		// Add device ID to context

--- a/internal/handler/terminal_bridge.go
+++ b/internal/handler/terminal_bridge.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"nhooyr.io/websocket"
+	"github.com/coder/websocket"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/connection"
@@ -55,13 +55,61 @@ func NewTerminalBridgeHandler(
 	}
 }
 
+// terminalSubprotocolPrefix is the Sec-WebSocket-Protocol value
+// prefix the gateway accepts in place of a `?token=` query
+// parameter. Clients send `bearer.<token>`; the gateway echoes the
+// same string in its response so the handshake completes. This
+// moves the token off the URL — where reverse-proxy access logs,
+// browser referrer headers, and devtools network panels all tend
+// to capture query strings verbatim — into a header that is far
+// less likely to leak.
+const terminalSubprotocolPrefix = "bearer."
+
+// extractTerminalToken returns the session token from (a) the
+// Sec-WebSocket-Protocol header with the `bearer.<token>` shape,
+// preferred; or (b) the legacy `?token=` query parameter. When the
+// subprotocol form is used, the chosen subprotocol is returned so
+// the Accept call can echo it back — browsers reject a handshake
+// response that does not echo one of the client's offered
+// protocols.
+func extractTerminalToken(r *http.Request) (token, chosenSubprotocol string) {
+	// Sec-WebSocket-Protocol can be comma-separated with multiple
+	// offers. We scan for any entry starting with `bearer.` and
+	// use the first one. The header may also be repeated; Values
+	// flattens both shapes.
+	for _, raw := range r.Header.Values("Sec-WebSocket-Protocol") {
+		for _, offer := range strings.Split(raw, ",") {
+			offer = strings.TrimSpace(offer)
+			if strings.HasPrefix(offer, terminalSubprotocolPrefix) {
+				t := strings.TrimPrefix(offer, terminalSubprotocolPrefix)
+				if t != "" {
+					return t, offer
+				}
+			}
+		}
+	}
+	// Fallback: legacy `?token=...`. The handler logs a warning when
+	// this path is taken so operators can track clients still using
+	// the old shape.
+	return r.URL.Query().Get("token"), ""
+}
+
 // ServeHTTP handles the /terminal WebSocket endpoint.
 func (h *TerminalBridgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sessionID := r.URL.Query().Get("session_id")
-	token := r.URL.Query().Get("token")
+	token, chosenSubprotocol := extractTerminalToken(r)
 	if sessionID == "" || token == "" {
-		http.Error(w, "session_id and token query parameters are required", http.StatusBadRequest)
+		http.Error(w, "session_id and token are required (use Sec-WebSocket-Protocol: bearer.<token> or ?token=...)", http.StatusBadRequest)
 		return
+	}
+	if chosenSubprotocol == "" {
+		// Legacy path — token travelled in the URL. Warn so the
+		// operator can trace old clients. Once all clients have
+		// migrated, we can turn this into a hard reject.
+		h.logger.Warn("terminal token received via query parameter; switch client to Sec-WebSocket-Protocol: bearer.<token>",
+			"session_id", sessionID,
+			"remote_addr", r.RemoteAddr,
+		)
 	}
 
 	logger := h.logger.With("session_id", sessionID)
@@ -85,12 +133,21 @@ func (h *TerminalBridgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	// Upgrade to WebSocket.
-	ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		// The gateway sits behind a reverse proxy that may strip the
-		// Origin header. InsecureSkipVerify is safe here because the
-		// session token is the authentication mechanism, not CORS.
+	acceptOpts := &websocket.AcceptOptions{
+		// The gateway sits behind a reverse proxy that may strip
+		// the Origin header. The authentication mechanism is the
+		// session token (validated above), not CORS.
 		InsecureSkipVerify: true,
-	})
+	}
+	if chosenSubprotocol != "" {
+		// Echo the bearer.<token> subprotocol back to the client so
+		// the handshake succeeds. The token value itself is not
+		// sensitive in the response — the client already sent it —
+		// and we MUST echo one of the client's offers or browsers
+		// reject the handshake.
+		acceptOpts.Subprotocols = []string{chosenSubprotocol}
+	}
+	ws, err := websocket.Accept(w, r, acceptOpts)
 	if err != nil {
 		logger.Warn("websocket upgrade failed", "error", err)
 		return

--- a/internal/mtls/peer_class.go
+++ b/internal/mtls/peer_class.go
@@ -1,0 +1,184 @@
+package mtls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// PeerClass identifies the role of a mTLS peer. The internal CA
+// issues every non-CA certificate with exactly one URI SAN of the
+// form `spiffe://power-manage/<class>`, where `<class>` is one of
+// the constants below. Middleware on each listener requires a
+// specific class so a leaked cert of one class (e.g. an agent
+// cert pulled from a compromised host) cannot be used to reach
+// a listener intended for another class (e.g. the control
+// server's InternalService, which accepts only gateway peers).
+//
+// The SPIFFE URI shape is standard, machine-readable, and puts the
+// class in a field (SAN URI) that X.509 parsers treat as structured
+// data — unlike the CN, which is a free-form string reused for
+// device IDs on agent certs.
+type PeerClass string
+
+const (
+	// PeerClassAgent identifies a managed-device cert issued by the
+	// control server's Register / RenewCertificate RPC. Agents
+	// present this on the gateway's public mTLS listener.
+	PeerClassAgent PeerClass = "agent"
+	// PeerClassGateway identifies a gateway replica cert issued out
+	// of band by setup.sh. Gateways present this when calling the
+	// control server's InternalService (ProxyGetLuksKey, etc.).
+	PeerClassGateway PeerClass = "gateway"
+	// PeerClassControl identifies the control server's internal
+	// cert issued out of band by setup.sh. The control server
+	// presents this when calling the gateway's GatewayService
+	// (admin list/terminate fan-out).
+	PeerClassControl PeerClass = "control"
+)
+
+// peerClassURIScheme and peerClassURIHost match the URI SAN layout
+// that ca.IssueCertificateFromCSR emits for agent certs and that
+// setup.sh emits for gateway/control certs. Keeping them in one
+// place makes it obvious where to add a new class.
+const (
+	peerClassURIScheme = "spiffe"
+	peerClassURIHost   = "power-manage"
+)
+
+// peerClassURI builds the canonical SPIFFE URI for a class. Kept in
+// one place so emitters (CA + setup.sh) and verifiers agree.
+func peerClassURI(class PeerClass) string {
+	return fmt.Sprintf("%s://%s/%s", peerClassURIScheme, peerClassURIHost, class)
+}
+
+// PeerClassFromCert inspects the URI SANs on a peer certificate and
+// returns the identified class, or an error if the cert carries no
+// `spiffe://power-manage/<class>` URI or carries more than one such
+// URI (ambiguous class is a hard error — the CA MUST emit exactly
+// one).
+func PeerClassFromCert(cert *x509.Certificate) (PeerClass, error) {
+	if cert == nil {
+		return "", errors.New("nil certificate")
+	}
+	var found PeerClass
+	for _, u := range cert.URIs {
+		if u == nil {
+			continue
+		}
+		if u.Scheme != peerClassURIScheme || u.Host != peerClassURIHost {
+			continue
+		}
+		class := PeerClass(strings.TrimPrefix(u.Path, "/"))
+		if class == "" {
+			continue
+		}
+		if found != "" && found != class {
+			return "", fmt.Errorf("certificate carries multiple peer-class URIs (%q and %q)", found, class)
+		}
+		found = class
+	}
+	if found == "" {
+		return "", errors.New("certificate has no peer-class URI SAN")
+	}
+	switch found {
+	case PeerClassAgent, PeerClassGateway, PeerClassControl:
+		return found, nil
+	default:
+		return "", fmt.Errorf("unknown peer class %q", found)
+	}
+}
+
+// PeerClassFromTLS extracts the peer class from the first peer
+// certificate of a TLS connection state. Callers that already have
+// an *x509.Certificate should use PeerClassFromCert directly.
+func PeerClassFromTLS(state *tls.ConnectionState) (PeerClass, error) {
+	if state == nil {
+		return "", errors.New("no TLS connection state")
+	}
+	if len(state.PeerCertificates) == 0 {
+		return "", errors.New("no peer certificate")
+	}
+	return PeerClassFromCert(state.PeerCertificates[0])
+}
+
+// RequirePeerClass returns middleware that extracts the peer class
+// from the client certificate and rejects requests whose peer does
+// not match one of allowed. Health endpoints (/health, /ready) are
+// passed through untouched so they work without mTLS on the ops
+// listener.
+//
+// The classes are allowed as a set (variadic) rather than a single
+// class so a listener that serves multiple peer populations (not
+// currently needed, but possible — e.g. a GatewayService endpoint
+// reachable by both control and admin CLI peers) does not need to
+// be wrapped twice.
+func RequirePeerClass(logger *slog.Logger, allowed ...PeerClass) func(http.Handler) http.Handler {
+	allowSet := make(map[PeerClass]struct{}, len(allowed))
+	for _, c := range allowed {
+		allowSet[c] = struct{}{}
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/health" || r.URL.Path == "/ready" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			if r.TLS == nil {
+				http.Error(w, "mTLS required", http.StatusUnauthorized)
+				return
+			}
+			class, err := PeerClassFromTLS(r.TLS)
+			if err != nil {
+				if logger != nil {
+					logger.Warn("peer-class check failed: cert missing class",
+						"remote_addr", r.RemoteAddr,
+						"path", r.URL.Path,
+						"error", err,
+					)
+				}
+				http.Error(w, "peer class required", http.StatusForbidden)
+				return
+			}
+			if _, ok := allowSet[class]; !ok {
+				if logger != nil {
+					logger.Warn("peer-class check failed: wrong class",
+						"remote_addr", r.RemoteAddr,
+						"path", r.URL.Path,
+						"presented", class,
+						"allowed", allowedClassString(allowed),
+					)
+				}
+				http.Error(w, "peer class not allowed", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+func allowedClassString(classes []PeerClass) string {
+	out := make([]string, 0, len(classes))
+	for _, c := range classes {
+		out = append(out, string(c))
+	}
+	return strings.Join(out, ",")
+}
+
+// PeerClassURI returns the SPIFFE URI shape a CA emitter should
+// stamp onto a newly-issued certificate for the given class. Kept
+// exported so ca.IssueCertificateFromCSR can use it without
+// duplicating the format literal.
+func PeerClassURI(class PeerClass) (*url.URL, error) {
+	switch class {
+	case PeerClassAgent, PeerClassGateway, PeerClassControl:
+	default:
+		return nil, fmt.Errorf("unknown peer class %q", class)
+	}
+	return url.Parse(peerClassURI(class))
+}

--- a/internal/mtls/peer_class_test.go
+++ b/internal/mtls/peer_class_test.go
@@ -1,0 +1,140 @@
+package mtls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func mustURL(t *testing.T, s string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return u
+}
+
+// TestPeerClassFromCert_Roundtrip asserts that every well-known
+// class encodes to a SPIFFE URI and decodes back to the same class.
+func TestPeerClassFromCert_Roundtrip(t *testing.T) {
+	for _, class := range []PeerClass{PeerClassAgent, PeerClassGateway, PeerClassControl} {
+		t.Run(string(class), func(t *testing.T) {
+			u, err := PeerClassURI(class)
+			if err != nil {
+				t.Fatalf("PeerClassURI(%q): %v", class, err)
+			}
+			cert := &x509.Certificate{URIs: []*url.URL{u}}
+			got, err := PeerClassFromCert(cert)
+			if err != nil {
+				t.Fatalf("PeerClassFromCert: %v", err)
+			}
+			if got != class {
+				t.Errorf("got %q, want %q", got, class)
+			}
+		})
+	}
+}
+
+// TestPeerClassFromCert_Errors covers the rejection surface:
+// missing URI, non-spiffe scheme, wrong host, unknown class, and
+// ambiguous multi-class certs.
+func TestPeerClassFromCert_Errors(t *testing.T) {
+	cases := map[string]*x509.Certificate{
+		"nil cert":        nil,
+		"no URI SAN":      {},
+		"wrong scheme":    {URIs: []*url.URL{mustURL(t, "https://power-manage/agent")}},
+		"wrong host":      {URIs: []*url.URL{mustURL(t, "spiffe://other/agent")}},
+		"unknown class":   {URIs: []*url.URL{mustURL(t, "spiffe://power-manage/admin")}},
+		"empty class":     {URIs: []*url.URL{mustURL(t, "spiffe://power-manage/")}},
+		"multi-class": {URIs: []*url.URL{
+			mustURL(t, "spiffe://power-manage/agent"),
+			mustURL(t, "spiffe://power-manage/gateway"),
+		}},
+	}
+	for name, cert := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := PeerClassFromCert(cert); err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+// TestRequirePeerClass_AllowsAllowedRejectsOthers spins up a mTLS
+// test server with the middleware installed and asserts it
+// accepts an allowed class and rejects every other.
+func TestRequirePeerClass_AllowsAllowedRejectsOthers(t *testing.T) {
+	discardLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := RequirePeerClass(discardLogger, PeerClassGateway)(next)
+
+	// Simulate a TLS connection state carrying a peer cert with a
+	// given class. httptest.Server with a real TLS handshake would
+	// be overkill for unit coverage; the middleware only reads
+	// r.TLS.PeerCertificates, so we inject that directly.
+	call := func(class PeerClass) int {
+		req := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader(""))
+		u, _ := PeerClassURI(class)
+		req.TLS = &tls.ConnectionState{
+			PeerCertificates: []*x509.Certificate{{URIs: []*url.URL{u}}},
+		}
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+		return rr.Code
+	}
+
+	if code := call(PeerClassGateway); code != http.StatusOK {
+		t.Errorf("allowed class got %d, want 200", code)
+	}
+	if code := call(PeerClassAgent); code != http.StatusForbidden {
+		t.Errorf("disallowed agent class got %d, want 403", code)
+	}
+	if code := call(PeerClassControl); code != http.StatusForbidden {
+		t.Errorf("disallowed control class got %d, want 403", code)
+	}
+}
+
+// TestRequirePeerClass_HealthBypass asserts /health and /ready skip
+// the peer-class check so external load-balancer probes work
+// without a client cert.
+func TestRequirePeerClass_HealthBypass(t *testing.T) {
+	discardLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := RequirePeerClass(discardLogger, PeerClassGateway)(next)
+
+	for _, path := range []string{"/health", "/ready"} {
+		t.Run(path, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, path, nil)
+			// No TLS state at all — still should pass.
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, req)
+			if rr.Code != http.StatusOK {
+				t.Errorf("health bypass: got %d", rr.Code)
+			}
+		})
+	}
+}
+
+// TestRequirePeerClass_RejectsMissingTLS asserts a request without
+// any TLS state is rejected before a nil dereference can happen.
+func TestRequirePeerClass_RejectsMissingTLS(t *testing.T) {
+	discardLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	handler := RequirePeerClass(discardLogger, PeerClassGateway)(http.NotFoundHandler())
+	req := httptest.NewRequest(http.MethodGet, "/x", nil)
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("missing TLS: got %d, want 401", rr.Code)
+	}
+}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -56,10 +56,6 @@ const (
 	idxUserGroups         = "idx:user_groups"
 	idxExecutions         = "idx:executions"
 	idxAuditEvents        = "idx:audit_events"
-
-	// Warm window for high-volume data.
-	executionWarmDays = 90
-	auditWarmDays     = 90
 )
 
 // Scope constants used in task payloads and RPC requests.

--- a/internal/store/migrations/009_luks_revocation_requested.sql
+++ b/internal/store/migrations/009_luks_revocation_requested.sql
@@ -1,0 +1,153 @@
+-- Add LuksDeviceKeyRevocationRequested event to the luks_key projector.
+--
+-- Rationale: previously the revocation flow enqueued the Asynq task first
+-- and only appended a LuksDeviceKeyRevocationDispatched event afterwards.
+-- If the enqueue succeeded but the follow-up event append failed, the
+-- agent would revoke the key while the audit stream had no record of the
+-- operator ever asking for it — awkward for compliance, worse for incident
+-- response.
+--
+-- The revised flow in RevokeLuksDeviceKey emits this Requested event
+-- BEFORE attempting the enqueue, so operator intent is captured durably
+-- regardless of enqueue outcome. On enqueue success the handler follows
+-- up with the existing Dispatched event; on failure it emits the existing
+-- Failed event.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_luks_key_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'LuksKeyRotated' THEN
+            -- Mark all prior keys for this (device, device_path) as non-current.
+            UPDATE luks_keys_projection
+            SET is_current = FALSE
+            WHERE device_id = event.data->>'device_id'
+              AND device_path = event.data->>'device_path'
+              AND is_current = TRUE;
+
+            INSERT INTO luks_keys_projection (
+                id, device_id, action_id, device_path, passphrase_encrypted,
+                rotated_at, rotation_reason, is_current
+            ) VALUES (
+                event.stream_id,
+                event.data->>'device_id',
+                event.data->>'action_id',
+                event.data->>'device_path',
+                (event.data->>'passphrase')::BYTEA,
+                COALESCE((event.data->>'rotated_at')::TIMESTAMPTZ, event.occurred_at),
+                event.data->>'rotation_reason',
+                TRUE
+            );
+
+        WHEN 'LuksDeviceKeyRevocationRequested' THEN
+            -- Durable operator-intent record emitted BEFORE the Asynq
+            -- enqueue. Sets revocation_status = 'requested'; the follow-up
+            -- Dispatched / Failed event overwrites to 'dispatched' or
+            -- 'failed'. If the follow-up append itself fails, the
+            -- projection lingers at 'requested' — still a meaningful
+            -- audit state, not a silent no-op.
+            UPDATE luks_keys_projection
+            SET revocation_status = 'requested',
+                revocation_error = NULL,
+                revocation_at = (event.data->>'requested_at')::TIMESTAMPTZ
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND is_current = TRUE;
+
+        WHEN 'LuksDeviceKeyRevocationDispatched' THEN
+            UPDATE luks_keys_projection
+            SET revocation_status = 'dispatched',
+                revocation_error = NULL,
+                revocation_at = (event.data->>'dispatched_at')::TIMESTAMPTZ
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND is_current = TRUE;
+
+        WHEN 'LuksDeviceKeyRevoked' THEN
+            UPDATE luks_keys_projection
+            SET revocation_status = 'success',
+                revocation_error = NULL,
+                revocation_at = (event.data->>'revoked_at')::TIMESTAMPTZ
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND is_current = TRUE;
+
+        WHEN 'LuksDeviceKeyRevocationFailed' THEN
+            UPDATE luks_keys_projection
+            SET revocation_status = 'failed',
+                revocation_error = event.data->>'error',
+                revocation_at = (event.data->>'failed_at')::TIMESTAMPTZ
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND is_current = TRUE;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+-- Revert to the pre-requested projector (no 'requested' case).
+CREATE OR REPLACE FUNCTION project_luks_key_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'LuksKeyRotated' THEN
+            UPDATE luks_keys_projection
+            SET is_current = FALSE
+            WHERE device_id = event.data->>'device_id'
+              AND device_path = event.data->>'device_path'
+              AND is_current = TRUE;
+
+            INSERT INTO luks_keys_projection (
+                id, device_id, action_id, device_path, passphrase_encrypted,
+                rotated_at, rotation_reason, is_current
+            ) VALUES (
+                event.stream_id,
+                event.data->>'device_id',
+                event.data->>'action_id',
+                event.data->>'device_path',
+                (event.data->>'passphrase')::BYTEA,
+                COALESCE((event.data->>'rotated_at')::TIMESTAMPTZ, event.occurred_at),
+                event.data->>'rotation_reason',
+                TRUE
+            );
+
+        WHEN 'LuksDeviceKeyRevocationDispatched' THEN
+            UPDATE luks_keys_projection
+            SET revocation_status = 'dispatched',
+                revocation_error = NULL,
+                revocation_at = (event.data->>'dispatched_at')::TIMESTAMPTZ
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND is_current = TRUE;
+
+        WHEN 'LuksDeviceKeyRevoked' THEN
+            UPDATE luks_keys_projection
+            SET revocation_status = 'success',
+                revocation_error = NULL,
+                revocation_at = (event.data->>'revoked_at')::TIMESTAMPTZ
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND is_current = TRUE;
+
+        WHEN 'LuksDeviceKeyRevocationFailed' THEN
+            UPDATE luks_keys_projection
+            SET revocation_status = 'failed',
+                revocation_error = event.data->>'error',
+                revocation_at = (event.data->>'failed_at')::TIMESTAMPTZ
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND is_current = TRUE;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/taskqueue/client.go
+++ b/internal/taskqueue/client.go
@@ -7,10 +7,27 @@ import (
 	"github.com/hibiken/asynq"
 )
 
+// Enqueuer is the subset of Client that handlers need for
+// enqueueing tasks. Making the API-handler fields depend on the
+// interface rather than *Client lets tests inject a no-op or
+// recording double (see api.NoOpEnqueuer, api_test scope) without
+// spinning up a real Valkey — and lets production paths like
+// DispatchAction refuse a request when the enqueuer is nil,
+// instead of silently swallowing dispatches.
+type Enqueuer interface {
+	EnqueueToDevice(deviceID, taskType string, payload any, opts ...asynq.Option) error
+	EnqueueToControl(taskType string, payload any) error
+	EnqueueToSearch(taskType string, payload any) error
+}
+
 // Client wraps asynq.Client for enqueuing tasks to device and control queues.
 type Client struct {
 	client *asynq.Client
 }
+
+// Compile-time check that *Client satisfies Enqueuer. A drift here
+// means production code stopped matching the handler contract.
+var _ Enqueuer = (*Client)(nil)
 
 // NewClient creates a new task queue client connected to Valkey.
 func NewClient(addr, password string, db int) *Client {


### PR DESCRIPTION
## Summary

Addresses the server-sweep audit findings plus related code smells. All changes are within the no-backwards-compat window.

### High severity

**Private key permissions (setup.sh)**. Every private key is now chmod 0600 and the script runs under `umask 077` so openssl never briefly writes the key wider. The CA key particularly was world-readable before.

**Peer-class mTLS**. New \`internal/mtls/peer_class.go\` defines a SPIFFE URI SAN (\`spiffe://power-manage/<class>\`) stamped onto every cert. CA now emits \"agent\" on issued certs; setup.sh stamps \"gateway\" / \"control\" on its out-of-band certs. \`RequirePeerClass\` middleware enforces the expected class on each listener:

- control \`InternalService\` admits only \`gateway\`
- gateway \`AgentService\` admits only \`agent\`
- gateway \`GatewayService\` admits only \`control\`

A leaked agent cert can no longer be replayed against the internal listener to read other devices' LUKS/LPS secrets; a leaked agent cert can no longer pose as the control plane to issue admin fan-out RPCs.

### Medium severity

**Inline dispatch validation**. \`DispatchAction\`'s inline branch now runs the same per-oneof validation Create applies, including the shell \"at least one of script or detection_script\" rule. Previously an inline dispatch could smuggle a malformed or nil payload past Create's gate; nil \`inline_action\` even panicked \`extractActionParamsMsg\`. \`validateInlineActionPayload\` rejects nil before downstream serialization runs.

**\`signAction\` fail-closed**. Signing or persistence failure now aborts the Create / Update / Dispatch request with \`CodeInternal\` instead of being logged-and-swallowed. Previously the server could record an unsigned action that the agent silently drops on dispatch, leaving the execution in \"pending forever\" state with no clue to the operator. The Dispatch re-sign path also joins this policy.

**Update shell parity**. \`UpdateActionParams\` with a Shell payload now runs the \`Script | DetectionScript\` required-oneof check that Create has always done. Editing a valid shell action to blank both scripts is now rejected instead of signing a no-op.

### Low/medium — terminal bearer

Accept session token via \`Sec-WebSocket-Protocol: bearer.<token>\` as the preferred transport. Query-param \`?token=\` still works for legacy clients but logs a WARN naming the remote address so operators can trace the stragglers. Moving the token off the URL reduces exposure via proxy access logs, referrer headers, and browser devtools.

### Code smells

- Migrate from the deprecated \`nhooyr.io/websocket\` to its active successor \`github.com/coder/websocket\`. Drop-in rename; no API differences in what we use.
- Drop unused \`executionWarmDays\` / \`auditWarmDays\` constants in \`internal/search/index.go\`.
- README cookie-auth drift: bearer-only is the actual transport; the README's cookie section described a path that no longer exists in code. Also documents peer-class enforcement in the mTLS section.

## Migration

Operators upgrading need to:
1. Re-run \`server/deploy/setup.sh\` with \`--force\` to regenerate gateway + control certs with the new URI SANs.
2. Agents with pre-upgrade certs (no URI SAN) cannot reach the gateway until they renew. They CAN reach \`ControlService.RenewCertificate\` (which is on the public, LE-fronted listener — no peer-class enforcement there). CA-rotation trust-bundle mechanism triggers fleet-wide renewal.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./internal/auth/... ./internal/ca/... ./internal/handler/... ./internal/gateway/... ./internal/connection/... ./internal/terminal/... ./internal/taskqueue/... ./internal/config/... ./internal/mtls/... ./internal/search/... ./internal/middleware/...\` — all green
- [ ] \`go test ./internal/api/...\` — the long integration suite hit the local 900s timeout; CI should complete it
- New: \`internal/mtls/peer_class_test.go\` — roundtrip, rejection surface, middleware allow/deny, health bypass, missing-TLS 401
- New: \`internal/api/dispatch_validation_test.go\` — inline nil rejection, inline shell-missing-script rejection, update shell-missing-script rejection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * mTLS now enforces peer-class roles (agent, gateway, control) across listeners and rejects mismatched peers.
  * Device certificates and server certificates include SPIFFE peer-class URI SANs.

* **Bug Fixes**
  * Dispatch and signing paths are fail-closed; compensating events recorded on enqueue/sign failures.
  * Handlers return errors when no task-queue is configured to avoid dangling pending state.

* **Security Improvements**
  * JWTs moved to bearer-only transport; server-issued auth cookies removed.

* **Tests**
  * Added and updated tests and test helpers for peer-class, validation, enqueue, and signing behaviors.

* **Chores**
  * WebSocket library updated; script/file permissions tightened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->