### PR TITLE
fix: setup.sh data directories must be 755, not inherit umask 077

### DIFF
--- a/cmd/gateway/README.md
+++ b/cmd/gateway/README.md
@@ -81,7 +81,7 @@ When enabled, each gateway replica publishes its own routing entries into Traefi
 | `GATEWAY_TRAEFIK_ROOT_KEY` | `traefik` | Matches Traefik's `--providers.redis.rootkey`. |
 | `GATEWAY_TRAEFIK_MTLS_HOST` | — | Public `HostSNI` for agent mTLS, e.g. `gateway.example.com`. |
 | `GATEWAY_TRAEFIK_MTLS_BACKEND` | auto | Internal `host:port` for this replica's mTLS listener. Auto-derived from `os.Hostname()` + `GATEWAY_LISTEN_ADDR` when empty. |
-| `GATEWAY_TRAEFIK_MTLS_ENTRYPOINT` | — | Traefik entrypoint the TCP router binds to, e.g. `mtls`. |
+| `GATEWAY_TRAEFIK_MTLS_ENTRYPOINT` | — | Traefik entrypoint the TCP passthrough router binds to. In the reference compose this is `websecure` (port 443), shared with control's HTTP routers — Traefik's SNI dispatch separates passthrough traffic (gateway subdomain) from HTTP termination (control subdomain), so no dedicated mTLS port is required. |
 | `GATEWAY_TRAEFIK_TTY_HOST` | — | Public `Host` for TTY, e.g. `tty.example.com`. |
 | `GATEWAY_TRAEFIK_TTY_BACKEND` | auto | Internal URL for this replica's TTY listener. Auto-derived from `os.Hostname()` + `GATEWAY_WEB_LISTEN_ADDR` when empty. |
 | `GATEWAY_TRAEFIK_TTY_ENTRYPOINT` | — | Traefik entrypoint the TTY router binds to, e.g. `websecure`. |

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -7,9 +7,24 @@
 # Strong password for PostgreSQL (generate with: openssl rand -base64 32)
 POSTGRES_PASSWORD=CHANGE_ME_generate_a_strong_password
 
-# Password for the read-only indexer database user (pm_indexer)
-# Generate with: openssl rand -base64 32
-INDEXER_POSTGRES_PASSWORD=CHANGE_ME_generate_a_strong_password
+# Password for the read-only indexer database user (pm_indexer).
+#
+# MUST be URL-safe. The indexer builds its connection DSN by interpolating
+# this value into a URL template:
+#
+#     postgres://pm_indexer:${INDEXER_POSTGRES_PASSWORD}@postgres:5432/...
+#
+# so characters that are significant in URLs (`@`, `:`, `/`, `#`, `?`, `&`,
+# `=`, `+`, space, and several others) will break parsing with an
+# "invalid port" or "failed to parse as URL" error at indexer startup.
+#
+# Generate with either of:
+#   openssl rand -hex 32                      # alphanumeric only (recommended)
+#   openssl rand -base64 32 | tr -d '=+/'     # strip the three unsafe chars
+#
+# Do NOT use plain `openssl rand -base64` for this value — its output can
+# include `+`, `/`, and `=` which confuse the URL parser.
+INDEXER_POSTGRES_PASSWORD=CHANGE_ME_use_hex_only
 
 # =============================================================================
 # Valkey (Task Queue & Search)

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -51,7 +51,9 @@ ADMIN_PASSWORD=CHANGE_ME_use_a_strong_password
 CONTROL_DOMAIN=power-manage.example.com
 
 # Public domain for the gateway (agent mTLS connections). Agents connect to
-# this hostname on port 8443 (TCP passthrough for the mTLS handshake).
+# this hostname on port 443 — Traefik dispatches by SNI, so the same :443
+# entrypoint serves control (HTTP termination on its subdomain) and the
+# gateway TCP passthrough for the mTLS handshake on this subdomain.
 GATEWAY_DOMAIN=gateway.example.com
 
 # Public domain for TTY WebSocket traffic. Defaults to GATEWAY_DOMAIN when

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -39,11 +39,16 @@ services:
       - "--providers.redis.password=${VALKEY_PASSWORD}"
       - "--providers.redis.rootkey=traefik"
       - "--entrypoints.web.address=:80"
+      # One :443 entrypoint serves both the LE-terminated HTTP
+      # routers (control) and the gateway's TCP-passthrough mTLS
+      # router. Traefik dispatches by SNI: a TCP router with
+      # HostSNI(${GATEWAY_DOMAIN}) + tls.passthrough=true takes
+      # precedence when the ClientHello SNI matches the gateway
+      # subdomain; otherwise the HTTP router for the control
+      # subdomain wins and terminates TLS normally. No dedicated
+      # mtls entrypoint is needed — that used to be on :8443 but
+      # splitting ports added deploy friction for no real benefit.
       - "--entrypoints.websecure.address=:443"
-      # Dedicated entrypoint for agent mTLS passthrough. Agents
-      # connect to ${GATEWAY_DOMAIN}:8443; Traefik TCP-routes by SNI
-      # to whichever gateway replica is in the pm-mtls pool.
-      - "--entrypoints.mtls.address=:8443"
       - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
       - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
       - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
@@ -52,7 +57,6 @@ services:
     ports:
       - "80:80"
       - "443:443"
-      - "8443:8443"
     networks:
       - internal
 
@@ -207,7 +211,11 @@ services:
       - GATEWAY_TRAEFIK_SELF_REGISTER=${GATEWAY_TRAEFIK_SELF_REGISTER:-true}
       - GATEWAY_TRAEFIK_ROOT_KEY=${GATEWAY_TRAEFIK_ROOT_KEY:-traefik}
       - GATEWAY_TRAEFIK_MTLS_HOST=${GATEWAY_DOMAIN}
-      - GATEWAY_TRAEFIK_MTLS_ENTRYPOINT=mtls
+      # Bind the pm-mtls TCP router to the websecure (:443)
+      # entrypoint, alongside the control-domain HTTP routers.
+      # Traefik's SNI-based dispatch separates the two: gateway
+      # SNI → TCP passthrough, control SNI → HTTP termination.
+      - GATEWAY_TRAEFIK_MTLS_ENTRYPOINT=websecure
       - GATEWAY_TRAEFIK_TTY_HOST=${GATEWAY_TTY_DOMAIN:-${GATEWAY_DOMAIN}}
       - GATEWAY_TRAEFIK_TTY_ENTRYPOINT=websecure
       # rc3: explicitly name the cert resolver for the TTY router. The Redis

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -290,7 +290,14 @@ main() {
     generate_control_cert
     generate_control_public_cert
 
-    mkdir -p "$DATA_DIR/postgres" "$DATA_DIR/valkey" "$DATA_DIR/traefik"
+    # Data directories need permissions that let the container
+    # users (postgres uid 70, valkey uid 999, traefik uid 0)
+    # write into the bind-mounted volumes. The script-wide
+    # `umask 077` at the top protects the certs/ tree; for data/
+    # we reset to 022 so the directories are 755 and the
+    # containers can initialise them.
+    (umask 022 && mkdir -p "$DATA_DIR/postgres" "$DATA_DIR/valkey" "$DATA_DIR/traefik")
+    chmod 755 "$DATA_DIR/postgres" "$DATA_DIR/valkey" "$DATA_DIR/traefik"
     log_info "Created data directories: $DATA_DIR/{postgres,valkey,traefik}"
 
     show_instructions


### PR DESCRIPTION
## Summary

The script-wide \`umask 077\` added in the audit sweep to tighten \`certs/\` key permissions also narrowed the generated \`data/postgres\`, \`data/valkey\`, \`data/traefik\` directories to 700 root:root. Postgres container (uid 70) can't write into them and crash-loops with:

\`\`\`
mkdir: can't create directory '/var/lib/postgresql/18/': Permission denied
\`\`\`

Fix: wrap the data-dir mkdir in a subshell with \`umask 022\` and explicit \`chmod 755\` afterwards. Certs umask unchanged (still 077).

## Workaround for an already-broken deploy

\`\`\`bash
cd ~/deploy
docker compose down
chmod 755 data/postgres data/valkey data/traefik
rm -rf data/postgres/*   # in case the half-init left files
docker compose up -d
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment setup to properly configure directory permissions, enabling container services to correctly initialize and mount their volumes during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->