### PR TITLE
fix: gateway auto-derives Traefik backend from routable IP, not container ID

### DIFF
--- a/cmd/gateway/README.md
+++ b/cmd/gateway/README.md
@@ -77,15 +77,17 @@ When enabled, each gateway replica publishes its own routing entries into Traefi
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `GATEWAY_TRAEFIK_SELF_REGISTER` | `false` | Enable self-registration. All of the other `GATEWAY_TRAEFIK_*` fields are required when true. |
+| `GATEWAY_TRAEFIK_SELF_REGISTER` | `true` | Enable self-registration. Set to `false` to migrate back to static Traefik labels. |
 | `GATEWAY_TRAEFIK_ROOT_KEY` | `traefik` | Matches Traefik's `--providers.redis.rootkey`. |
-| `GATEWAY_TRAEFIK_MTLS_HOST` | — | Public `HostSNI` for agent mTLS, e.g. `gateway.example.com`. |
-| `GATEWAY_TRAEFIK_MTLS_BACKEND` | auto | Internal `host:port` for this replica's mTLS listener. Auto-derived from `os.Hostname()` + `GATEWAY_LISTEN_ADDR` when empty. |
-| `GATEWAY_TRAEFIK_MTLS_ENTRYPOINT` | — | Traefik entrypoint the TCP passthrough router binds to. In the reference compose this is `websecure` (port 443), shared with control's HTTP routers — Traefik's SNI dispatch separates passthrough traffic (gateway subdomain) from HTTP termination (control subdomain), so no dedicated mTLS port is required. |
-| `GATEWAY_TRAEFIK_TTY_HOST` | — | Public `Host` for TTY, e.g. `tty.example.com`. |
-| `GATEWAY_TRAEFIK_TTY_BACKEND` | auto | Internal URL for this replica's TTY listener. Auto-derived from `os.Hostname()` + `GATEWAY_WEB_LISTEN_ADDR` when empty. |
-| `GATEWAY_TRAEFIK_TTY_ENTRYPOINT` | — | Traefik entrypoint the TTY router binds to, e.g. `websecure`. |
-| `GATEWAY_TRAEFIK_TTY_CERT_RESOLVER` | (empty) | Cert resolver for the per-replica TTY HTTP router, e.g. `letsencrypt`. Must match a `--certificatesresolvers.<name>.*` entry in Traefik's static config. Leave empty only for bring-your-own-cert deployments that ship a default cert matching `GATEWAY_TRAEFIK_TTY_HOST` — otherwise browsers reject the default self-signed cert Traefik serves for Redis-KV routers. |
+| `GATEWAY_TRAEFIK_MTLS_HOST` | `$GATEWAY_DOMAIN` | Public `HostSNI` for agent mTLS, e.g. `gateway.example.com`. Falls back to `GATEWAY_DOMAIN` — most deployments only set that one env var. |
+| `GATEWAY_TRAEFIK_MTLS_BACKEND` | auto | Internal `host:port` for this replica's mTLS listener. Auto-derived from the replica's routable IPv4 on the shared Docker/k8s network + `GATEWAY_LISTEN_ADDR` when empty. |
+| `GATEWAY_TRAEFIK_MTLS_ENTRYPOINT` | `websecure` | Traefik entrypoint the TCP passthrough router binds to. Shared with control's HTTP routers — Traefik's SNI dispatch separates passthrough traffic (gateway subdomain) from HTTP termination (control subdomain), so no dedicated mTLS port is required. |
+| `GATEWAY_TRAEFIK_TTY_HOST` | `$GATEWAY_TTY_DOMAIN` | Public `Host` for TTY, e.g. `tty.example.com`. Falls back to `GATEWAY_TTY_DOMAIN`. Empty means the TTY router is not registered (single-domain deployments use `GATEWAY_DOMAIN` for both). |
+| `GATEWAY_TRAEFIK_TTY_BACKEND` | auto | Internal URL for this replica's TTY listener. Auto-derived from the replica's routable IPv4 + `GATEWAY_WEB_LISTEN_ADDR` when empty. |
+| `GATEWAY_TRAEFIK_TTY_ENTRYPOINT` | `websecure` | Traefik entrypoint the TTY router binds to. |
+| `GATEWAY_TRAEFIK_TTY_CERT_RESOLVER` | `letsencrypt` | Cert resolver for the per-replica TTY HTTP router. Must match a `--certificatesresolvers.<name>.*` entry in Traefik's static config. Set empty only for bring-your-own-cert deployments that ship a default cert matching `GATEWAY_TRAEFIK_TTY_HOST` — otherwise browsers reject the default self-signed cert Traefik serves for Redis-KV routers. |
+
+The backend auto-derivation uses the gateway replica's own IPv4 address on the shared container network (via `net.InterfaceAddrs()`), **not** `os.Hostname()` — a container's default hostname is its 12-char ID, which is not registered in Docker's embedded DNS, so publishing it as a Traefik backend leaves Traefik unable to resolve the replica and quietly falls back to the HTTP router (which serves the wrong cert).
 
 All Traefik keys share the registry TTL (45 s default) and are refreshed on the same cadence as the gateway terminal-URL entry. Graceful shutdown revokes only per-replica keys; shared router keys expire naturally when the last replica stops. See `server/deploy/compose.yml` for the matching Traefik command flags.
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -213,12 +214,12 @@ func main() {
 		// (Terminal Sessions page shows empty).
 		internalURL := cfg.InternalURL
 		if internalURL == "" {
-			hostname, err := os.Hostname()
-			if err != nil || hostname == "" {
-				logger.Error("cannot auto-derive GATEWAY_INTERNAL_URL: os.Hostname failed", "error", err)
+			ip, err := routableIP()
+			if err != nil {
+				logger.Error("cannot auto-derive GATEWAY_INTERNAL_URL", "error", err)
 				os.Exit(1)
 			}
-			internalURL = "https://" + hostname + portOfListenAddr(cfg.ListenAddr)
+			internalURL = "https://" + ip + portOfListenAddr(cfg.ListenAddr)
 			logger.Info("auto-derived GATEWAY_INTERNAL_URL", "internal_url", internalURL)
 		}
 		if internalURL != "" {
@@ -282,25 +283,26 @@ func main() {
 			gatewayReg = registry.New(registry.NewValkeyBackend(rdb), logger.With("component", "registry"))
 		}
 
-		// Auto-derive per-replica backend addresses when not set.
-		// In Compose / k8s, os.Hostname() returns the container name
-		// (pm-server-gateway-1, gateway-abc123, …), which resolves to
-		// that specific replica's IP inside the pm-internal network.
-		// The operator only has to set the public Host/EntryPoint
-		// values; replica identity is self-discovered.
+		// Auto-derive per-replica backend addresses when not set. We use
+		// the replica's own routable IP on the shared Docker/k8s network
+		// rather than os.Hostname(): the container's default hostname is
+		// its 12-char container ID, which is NOT registered in Docker's
+		// embedded DNS, so Traefik can't resolve it. The IP works on the
+		// pm-internal network Traefik shares with us, and the operator
+		// only has to set the public Host/EntryPoint values.
 		mtlsBackend := cfg.TraefikMTLSBackend
 		ttyBackend := cfg.TraefikTTYBackend
 		if mtlsBackend == "" || ttyBackend == "" {
-			hostname, err := os.Hostname()
-			if err != nil || hostname == "" {
-				logger.Error("cannot auto-derive Traefik backends: os.Hostname failed", "error", err)
+			ip, err := routableIP()
+			if err != nil {
+				logger.Error("cannot auto-derive Traefik backends", "error", err)
 				os.Exit(1)
 			}
 			if mtlsBackend == "" {
-				mtlsBackend = hostname + portOfListenAddr(cfg.ListenAddr)
+				mtlsBackend = ip + portOfListenAddr(cfg.ListenAddr)
 			}
 			if ttyBackend == "" && cfg.WebListenAddr != "" {
-				ttyBackend = "http://" + hostname + portOfListenAddr(cfg.WebListenAddr)
+				ttyBackend = "http://" + ip + portOfListenAddr(cfg.WebListenAddr)
 			}
 		}
 
@@ -551,6 +553,51 @@ func main() {
 	}
 
 	logger.Info("server stopped")
+}
+
+// routableIP returns the first non-loopback IPv4 address bound to an
+// up-and-running network interface. In Docker Compose / k8s deployments
+// this is the replica's address on the user-defined network Traefik
+// shares with us — Traefik can reach it directly.
+//
+// We deliberately do NOT use os.Hostname() here: inside a container the
+// hostname defaults to the 12-char container ID, which is not registered
+// in Docker's embedded DNS. Publishing that as a Traefik backend (or as
+// an internal URL for control-plane RPC) leaves Traefik unable to resolve
+// it, so the service falls back to the HTTP router and serves the wrong
+// cert — which is exactly how agent mTLS started failing in rc7/rc8.
+func routableIP() (string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return "", err
+	}
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, a := range addrs {
+			var ip net.IP
+			switch v := a.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() || ip.IsLinkLocalUnicast() {
+				continue
+			}
+			ip = ip.To4()
+			if ip == nil {
+				continue
+			}
+			return ip.String(), nil
+		}
+	}
+	return "", fmt.Errorf("no non-loopback IPv4 address found on any interface")
 }
 
 // portOfListenAddr returns the port portion of a Go net.Listen style

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -143,21 +143,28 @@ LOG_LEVEL=info
 # IMAGE_TAG=latest
 
 # --- Gateway scaling (Traefik Redis KV self-registration) -------------------
-# Enabled by default in compose.yml. When true, each gateway replica writes
-# its own Traefik routing entry into Valkey at startup so scaling via
-# `docker compose up --scale gateway=N` works without per-replica labels.
-# Set to false only when migrating back to static Traefik labels.
+# The reference compose stack auto-configures Traefik self-registration with
+# sensible defaults baked into the gateway binary:
+#
+#   GATEWAY_TRAEFIK_SELF_REGISTER=true       # publish routes into Valkey at startup
+#   GATEWAY_TRAEFIK_ROOT_KEY=traefik         # matches --providers.redis.rootkey
+#   GATEWAY_TRAEFIK_MTLS_HOST=$GATEWAY_DOMAIN
+#   GATEWAY_TRAEFIK_MTLS_ENTRYPOINT=websecure
+#   GATEWAY_TRAEFIK_TTY_HOST=$GATEWAY_TTY_DOMAIN (or $GATEWAY_DOMAIN)
+#   GATEWAY_TRAEFIK_TTY_ENTRYPOINT=websecure
+#   GATEWAY_TRAEFIK_TTY_CERT_RESOLVER=letsencrypt
+#   MTLS / TTY backends auto-derived from the replica's IP on pm-internal
+#
+# That covers every deployment that looks like the reference compose. Only
+# uncomment and override below when your Traefik topology differs (bring-
+# your-own-Traefik, static-label migration, split entrypoints, alternative
+# cert resolver, etc.).
 # GATEWAY_TRAEFIK_SELF_REGISTER=true
-
-# Traefik root key in Valkey. Must match --providers.redis.rootkey in the
-# Traefik command. Default matches the one set in compose.yml.
 # GATEWAY_TRAEFIK_ROOT_KEY=traefik
-
-# Traefik certificate resolver for the per-replica TTY HTTP router. Must match
-# a `--certificatesresolvers.<name>.*` entry in the Traefik static config. If
-# unset, Traefik serves its default self-signed cert for the TTY router —
-# browsers refuse that for WebSocket upgrades, so leave the default value in
-# place unless you ship your own pre-matched default cert.
+# GATEWAY_TRAEFIK_MTLS_HOST=gateway.example.com
+# GATEWAY_TRAEFIK_MTLS_ENTRYPOINT=websecure
+# GATEWAY_TRAEFIK_TTY_HOST=tty.example.com
+# GATEWAY_TRAEFIK_TTY_ENTRYPOINT=websecure
 # GATEWAY_TRAEFIK_TTY_CERT_RESOLVER=letsencrypt
 
 # Heartbeat cadence sent to every connected agent (Go duration, 5s..5m).

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -204,26 +204,19 @@ services:
       - GATEWAY_BOOTSTRAP_HOST=${GATEWAY_BOOTSTRAP_HOST:-}
       - GATEWAY_WEB_LISTEN_ADDR=${GATEWAY_WEB_LISTEN_ADDR:-}
       - GATEWAY_INTERNAL_URL=${GATEWAY_INTERNAL_URL:-}
-      # Traefik self-registration via Redis KV. Each replica publishes
-      # its own routing entry; backend host:port values are auto-
-      # derived from the container's hostname + listener ports when
-      # not set explicitly, which is exactly what scaling needs.
-      - GATEWAY_TRAEFIK_SELF_REGISTER=${GATEWAY_TRAEFIK_SELF_REGISTER:-true}
-      - GATEWAY_TRAEFIK_ROOT_KEY=${GATEWAY_TRAEFIK_ROOT_KEY:-traefik}
-      - GATEWAY_TRAEFIK_MTLS_HOST=${GATEWAY_DOMAIN}
-      # Bind the pm-mtls TCP router to the websecure (:443)
-      # entrypoint, alongside the control-domain HTTP routers.
-      # Traefik's SNI-based dispatch separates the two: gateway
-      # SNI → TCP passthrough, control SNI → HTTP termination.
-      - GATEWAY_TRAEFIK_MTLS_ENTRYPOINT=websecure
-      - GATEWAY_TRAEFIK_TTY_HOST=${GATEWAY_TTY_DOMAIN:-${GATEWAY_DOMAIN}}
-      - GATEWAY_TRAEFIK_TTY_ENTRYPOINT=websecure
-      # rc3: explicitly name the cert resolver for the TTY router. The Redis
-      # KV provider does not inherit the entrypoint-level default cert
-      # resolver the way Docker-labelled routers do, so without this the
-      # TTY router falls back to Traefik's default self-signed cert and
-      # browsers refuse the WebSocket upgrade.
-      - GATEWAY_TRAEFIK_TTY_CERT_RESOLVER=${GATEWAY_TRAEFIK_TTY_CERT_RESOLVER:-letsencrypt}
+      # Traefik self-registration via Redis KV. The gateway publishes
+      # its own routing entry into Valkey at startup; each replica's
+      # backend host:port is auto-derived from the container's IP on
+      # the pm-internal network plus the listener ports below.
+      #
+      # Everything else has a sensible default inside the binary
+      # (SelfRegister=true, RootKey=traefik, entrypoints=websecure,
+      # TTY cert resolver=letsencrypt, MTLS host=GATEWAY_DOMAIN,
+      # TTY host=GATEWAY_TTY_DOMAIN). Only override via
+      # GATEWAY_TRAEFIK_* in .env when your Traefik topology diverges
+      # from the reference stack.
+      - GATEWAY_DOMAIN=${GATEWAY_DOMAIN}
+      - GATEWAY_TTY_DOMAIN=${GATEWAY_TTY_DOMAIN:-}
     command:
       - "-tls-cert=/certs/gateway.crt"
       - "-tls-key=/certs/gateway.key"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -155,6 +155,24 @@ type Config struct {
 // a global the way the old names could. The old names no longer work;
 // operators upgrading from rc2 must rename their .env entries.
 func FromEnv() *Config {
+	// Traefik self-registration defaults: the previous shape forced
+	// operators to set seven GATEWAY_TRAEFIK_* env vars by hand, and
+	// every real deployment set them to the same values. The defaults
+	// here match the reference compose:
+	//
+	//   * SelfRegister = true   — scaling-ready out of the box
+	//   * RootKey      = traefik — matches Traefik default --providers.redis.rootkey
+	//   * MTLSHost     = GATEWAY_DOMAIN   (not Traefik-prefixed — one name per thing)
+	//   * MTLSEntryPoint    = websecure   (same :443 as control, SNI-separated)
+	//   * TTYHost      = GATEWAY_TTY_DOMAIN (falls back to empty → TTY router disabled)
+	//   * TTYEntryPoint     = websecure
+	//   * TTYCertResolver   = letsencrypt
+	//
+	// Backends (MTLSBackend / TTYBackend) are auto-derived from the
+	// gateway's own routable IP address in cmd/gateway/main.go, so
+	// operators normally never set them either. Explicit values
+	// override the defaults in each case — useful for bring-your-own-
+	// Traefik topologies that differ from the reference stack.
 	return &Config{
 		ListenAddr:                getEnv("GATEWAY_LISTEN_ADDR", ":8080"),
 		ValkeyAddr:                getEnv("GATEWAY_VALKEY_ADDR", "localhost:6379"),
@@ -167,18 +185,32 @@ func FromEnv() *Config {
 		BootstrapHost:             getEnv("GATEWAY_BOOTSTRAP_HOST", ""),
 		WebListenAddr:             getEnv("GATEWAY_WEB_LISTEN_ADDR", ""),
 		InternalURL:               getEnv("GATEWAY_INTERNAL_URL", ""),
-		TraefikSelfRegister:       getEnvBool("GATEWAY_TRAEFIK_SELF_REGISTER", false),
-		TraefikRootKey:            getEnv("GATEWAY_TRAEFIK_ROOT_KEY", ""),
-		TraefikMTLSHost:           getEnv("GATEWAY_TRAEFIK_MTLS_HOST", ""),
-		TraefikMTLSBackend:        getEnv("GATEWAY_TRAEFIK_MTLS_BACKEND", ""),
-		TraefikMTLSEntryPoint:     getEnv("GATEWAY_TRAEFIK_MTLS_ENTRYPOINT", ""),
-		TraefikTTYHost:            getEnv("GATEWAY_TRAEFIK_TTY_HOST", ""),
-		TraefikTTYBackend:         getEnv("GATEWAY_TRAEFIK_TTY_BACKEND", ""),
-		TraefikTTYEntryPoint:      getEnv("GATEWAY_TRAEFIK_TTY_ENTRYPOINT", ""),
-		TraefikTTYCertResolver:    getEnv("GATEWAY_TRAEFIK_TTY_CERT_RESOLVER", ""),
-		HeartbeatInterval:         getEnvHeartbeatInterval("GATEWAY_HEARTBEAT_INTERVAL"),
-		LogLevel:                  getEnv("GATEWAY_LOG_LEVEL", "info"),
+		TraefikSelfRegister:       getEnvBool("GATEWAY_TRAEFIK_SELF_REGISTER", true),
+		TraefikRootKey:            getEnv("GATEWAY_TRAEFIK_ROOT_KEY", "traefik"),
+		// MTLSHost reads GATEWAY_DOMAIN directly — same env var the
+		// rest of the stack uses, no separate GATEWAY_TRAEFIK_MTLS_HOST.
+		TraefikMTLSHost:        firstNonEmpty(os.Getenv("GATEWAY_TRAEFIK_MTLS_HOST"), os.Getenv("GATEWAY_DOMAIN")),
+		TraefikMTLSBackend:     getEnv("GATEWAY_TRAEFIK_MTLS_BACKEND", ""),
+		TraefikMTLSEntryPoint:  getEnv("GATEWAY_TRAEFIK_MTLS_ENTRYPOINT", "websecure"),
+		TraefikTTYHost:         firstNonEmpty(os.Getenv("GATEWAY_TRAEFIK_TTY_HOST"), os.Getenv("GATEWAY_TTY_DOMAIN")),
+		TraefikTTYBackend:      getEnv("GATEWAY_TRAEFIK_TTY_BACKEND", ""),
+		TraefikTTYEntryPoint:   getEnv("GATEWAY_TRAEFIK_TTY_ENTRYPOINT", "websecure"),
+		TraefikTTYCertResolver: getEnv("GATEWAY_TRAEFIK_TTY_CERT_RESOLVER", "letsencrypt"),
+		HeartbeatInterval:      getEnvHeartbeatInterval("GATEWAY_HEARTBEAT_INTERVAL"),
+		LogLevel:               getEnv("GATEWAY_LOG_LEVEL", "info"),
 	}
+}
+
+// firstNonEmpty returns the first argument that isn't the empty
+// string. Used to resolve an env-var name (the legacy one) with a
+// more-preferred name as the primary source.
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
 }
 
 // getEnvHeartbeatInterval parses GATEWAY_HEARTBEAT_INTERVAL (a Go

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -108,16 +108,16 @@ func TestFromEnv_IgnoresOldUnprefixedVars(t *testing.T) {
 }
 
 func TestFromEnv_TraefikTTYCertResolver(t *testing.T) {
-	t.Setenv("GATEWAY_TRAEFIK_TTY_CERT_RESOLVER", "letsencrypt")
+	t.Setenv("GATEWAY_TRAEFIK_TTY_CERT_RESOLVER", "custom-resolver")
 	cfg := FromEnv()
-	if cfg.TraefikTTYCertResolver != "letsencrypt" {
-		t.Errorf("TraefikTTYCertResolver = %q, want %q", cfg.TraefikTTYCertResolver, "letsencrypt")
+	if cfg.TraefikTTYCertResolver != "custom-resolver" {
+		t.Errorf("TraefikTTYCertResolver = %q, want %q", cfg.TraefikTTYCertResolver, "custom-resolver")
 	}
 
 	t.Setenv("GATEWAY_TRAEFIK_TTY_CERT_RESOLVER", "")
 	cfg = FromEnv()
-	if cfg.TraefikTTYCertResolver != "" {
-		t.Errorf("TraefikTTYCertResolver = %q, want empty by default", cfg.TraefikTTYCertResolver)
+	if cfg.TraefikTTYCertResolver != "letsencrypt" {
+		t.Errorf("TraefikTTYCertResolver = %q, want %q (default)", cfg.TraefikTTYCertResolver, "letsencrypt")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace `os.Hostname()` with a `routableIP()` helper when auto-deriving Traefik backends and `GATEWAY_INTERNAL_URL`. Inside a container the default hostname is the 12-char container ID, which is not registered in Docker's embedded DNS — publishing it to Traefik's Redis KV provider left the pm-mtls TCP router with an unresolvable backend, fell through to the control HTTP router on the shared `:443` entrypoint, and served the Let's Encrypt cert. That is the `x509: certificate signed by unknown authority` every agent has been hitting since rc7.
- Move the seven `GATEWAY_TRAEFIK_*` defaults into the gateway binary (`SelfRegister=true`, `RootKey=traefik`, `MTLSEntryPoint=websecure`, `TTYEntryPoint=websecure`, `TTYCertResolver=letsencrypt`, `MTLSHost` falls back to `GATEWAY_DOMAIN`, `TTYHost` falls back to `GATEWAY_TTY_DOMAIN`). Strip the matching env lines from `deploy/compose.yml` — operators now only need `GATEWAY_DOMAIN` plus optional `GATEWAY_TTY_DOMAIN`. Every knob remains overridable for bring-your-own-Traefik topologies.
- Update `.env.example` and `cmd/gateway/README.md` to document the new default set and the IP-based backend derivation.

Fixes manchtools/power-manage-server#74. Ships in `v2026.05-rc9`.

## Test plan

- [x] `go test ./internal/config/...` (updated `TestFromEnv_TraefikTTYCertResolver` for the new default)
- [x] `go build ./cmd/gateway ./cmd/control` compiles clean
- [ ] Redeploy staging with rc9 image; `agent install.sh` on a device and verify the agent connects without `x509: certificate signed by unknown authority`
- [ ] `docker exec pm-valkey valkey-cli -a \"\$VALKEY_PASSWORD\" --scan --pattern 'traefik/*' | xargs -I {} valkey-cli -a \"\$VALKEY_PASSWORD\" get {}` shows backends like `10.0.x.y:8080`, not `bb3ac39ada41:8080`
- [ ] Terminal session opens end-to-end through the TTY router

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Gateway now resolves internal addresses using routable IPv4 addresses instead of container hostnames, improving compatibility with Docker and Kubernetes deployments.
  * Traefik self-registration is now enabled by default for simplified setup.

* **Documentation**
  * Updated configuration documentation to reflect new defaults and simplified deployment requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->