### PR TITLE
feat: tokenless registration tokens for bulk enrollment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.2.0
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.2.0 h1:M28+5EmjAI33xmeLEAYkw2/9XAQT7t744iP76L+HC9c=
-github.com/manchtools/power-manage-sdk v0.2.0/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.0 h1:GkNucThsX9yOOvHE2tVzuiFLpbHoyUczyktzwevLj2s=
+github.com/manchtools/power-manage-sdk v0.4.0/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/token_handler.go
+++ b/internal/api/token_handler.go
@@ -65,14 +65,27 @@ func (h *TokenHandler) CreateToken(ctx context.Context, req *connect.Request[pm.
 	}
 
 	if auth.HasPermission(ctx, "CreateToken") {
-		// Unrestricted: can set any token configuration
+		// Unrestricted: can set any token configuration, including
+		// choosing who owns the resulting token. owner_id is honored
+		// literally — empty means ownerless (devices enrolled via the
+		// token are not auto-assigned to anyone, useful for bulk /
+		// imaging workflows). When non-empty, it must reference an
+		// existing user.
 		eventData["one_time"] = req.Msg.OneTime
 		eventData["max_uses"] = req.Msg.MaxUses
 		if req.Msg.ExpiresAt != nil && req.Msg.ExpiresAt.IsValid() {
 			eventData["expires_at"] = req.Msg.ExpiresAt.AsTime().Format(time.RFC3339)
 		}
+		if req.Msg.OwnerId != "" {
+			if _, err := h.store.Queries().GetUserByID(ctx, req.Msg.OwnerId); err != nil {
+				return nil, handleGetError(ctx, err, ErrUserNotFound, "owner user not found")
+			}
+			eventData["owner_id"] = req.Msg.OwnerId
+		}
 	} else {
-		// Self-scoped: one-time use, 7-day validity, owned by creator
+		// Self-scoped: one-time use, 7-day validity, owned by creator.
+		// Any owner_id supplied by the caller is ignored — the :self
+		// scope is for users minting tokens for their own devices.
 		eventData["one_time"] = true
 		eventData["max_uses"] = int32(1)
 		eventData["expires_at"] = time.Now().Add(7 * 24 * time.Hour).Format(time.RFC3339)

--- a/internal/api/token_handler_test.go
+++ b/internal/api/token_handler_test.go
@@ -27,6 +27,55 @@ func TestCreateToken_Admin(t *testing.T) {
 	assert.NotEmpty(t, resp.Msg.Token.Id)
 	assert.Equal(t, "Test Token", resp.Msg.Token.Name)
 	assert.NotEmpty(t, resp.Msg.Token.Value) // Value only returned on creation
+	// Admin omitted owner_id → ownerless token. Devices enrolled via
+	// this token won't be auto-assigned to the admin who created it.
+	assert.Empty(t, resp.Msg.Token.OwnerId)
+}
+
+func TestCreateToken_Admin_OwnerSelf(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewTokenHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.CreateToken(ctx, connect.NewRequest(&pm.CreateTokenRequest{
+		Name:    "Self-owned",
+		OwnerId: adminID,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, adminID, resp.Msg.Token.OwnerId)
+}
+
+func TestCreateToken_Admin_OwnerOtherUser(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewTokenHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	otherID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.CreateToken(ctx, connect.NewRequest(&pm.CreateTokenRequest{
+		Name:    "Owned by other",
+		OwnerId: otherID,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, otherID, resp.Msg.Token.OwnerId)
+}
+
+func TestCreateToken_Admin_OwnerNotFound(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewTokenHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.CreateToken(ctx, connect.NewRequest(&pm.CreateTokenRequest{
+		Name:    "Bad Owner",
+		OwnerId: "01ARZ3NDEKTSV4RRFFQ69G5FAV", // valid ULID, no such user
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 }
 
 func TestCreateToken_User(t *testing.T) {
@@ -34,13 +83,19 @@ func TestCreateToken_User(t *testing.T) {
 	h := api.NewTokenHandler(st, slog.Default())
 
 	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	otherID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
 	ctx := testutil.UserContext(userID)
 
+	// :self scope ignores any owner_id the caller passes — the token
+	// is always owned by the creator. Pass another user's ID to prove
+	// the server-side override holds.
 	resp, err := h.CreateToken(ctx, connect.NewRequest(&pm.CreateTokenRequest{
-		Name: "User Token",
+		Name:    "User Token",
+		OwnerId: otherID,
 	}))
 	require.NoError(t, err)
 	assert.True(t, resp.Msg.Token.OneTime) // Non-admin tokens are always one-time
+	assert.Equal(t, userID, resp.Msg.Token.OwnerId)
 }
 
 func TestGetToken(t *testing.T) {

--- a/internal/store/migrations/011_token_owner_no_actor_fallback.sql
+++ b/internal/store/migrations/011_token_owner_no_actor_fallback.sql
@@ -1,0 +1,141 @@
+-- Drop the actor fallback in the TokenCreated projector.
+--
+-- Today the projector backfills `tokens_projection.owner_id` with
+-- `event.actor_id` when the event itself omits `owner_id`, which made
+-- it impossible to mint a token without a user owner. The unrestricted
+-- CreateToken handler omits `owner_id` deliberately when the admin
+-- doesn't want one, but that intent was being silently overwritten —
+-- every device enrolled through such a token ended up auto-assigned
+-- to the admin who created the token.
+--
+-- After this migration the projector preserves NULL when the event
+-- omits the field. The :self-scoped CreateToken still emits
+-- `owner_id = creator` explicitly, so single-user enrollment is
+-- unchanged. Existing rows are not touched; only new TokenCreated
+-- events get the new behaviour.
+--
+-- See manchtools/power-manage-server#85.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_token_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'TokenCreated' THEN
+            INSERT INTO tokens_projection (
+                id, value_hash, name, one_time, max_uses, expires_at,
+                created_at, created_by, owner_id, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'value_hash',
+                COALESCE(event.data->>'name', ''),
+                COALESCE((event.data->>'one_time')::BOOLEAN, FALSE),
+                COALESCE((event.data->>'max_uses')::INTEGER, 0),
+                CASE WHEN event.data->>'expires_at' IS NOT NULL
+                     THEN (event.data->>'expires_at')::TIMESTAMPTZ
+                     ELSE NULL END,
+                event.occurred_at,
+                event.actor_id,
+                event.data->>'owner_id',
+                event.sequence_num
+            );
+
+        WHEN 'TokenRenamed' THEN
+            UPDATE tokens_projection
+            SET name = event.data->>'name',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenUsed' THEN
+            UPDATE tokens_projection
+            SET current_uses = current_uses + 1,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenDisabled' THEN
+            UPDATE tokens_projection
+            SET disabled = TRUE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenEnabled' THEN
+            UPDATE tokens_projection
+            SET disabled = FALSE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenDeleted' THEN
+            UPDATE tokens_projection
+            SET is_deleted = TRUE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_token_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'TokenCreated' THEN
+            INSERT INTO tokens_projection (
+                id, value_hash, name, one_time, max_uses, expires_at,
+                created_at, created_by, owner_id, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'value_hash',
+                COALESCE(event.data->>'name', ''),
+                COALESCE((event.data->>'one_time')::BOOLEAN, FALSE),
+                COALESCE((event.data->>'max_uses')::INTEGER, 0),
+                CASE WHEN event.data->>'expires_at' IS NOT NULL
+                     THEN (event.data->>'expires_at')::TIMESTAMPTZ
+                     ELSE NULL END,
+                event.occurred_at,
+                event.actor_id,
+                COALESCE(event.data->>'owner_id', event.actor_id),
+                event.sequence_num
+            );
+
+        WHEN 'TokenRenamed' THEN
+            UPDATE tokens_projection
+            SET name = event.data->>'name',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenUsed' THEN
+            UPDATE tokens_projection
+            SET current_uses = current_uses + 1,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenDisabled' THEN
+            UPDATE tokens_projection
+            SET disabled = TRUE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenEnabled' THEN
+            UPDATE tokens_projection
+            SET disabled = FALSE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenDeleted' THEN
+            UPDATE tokens_projection
+            SET is_deleted = TRUE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd


### PR DESCRIPTION
Closes #85.

## What ships

- **Migration 011** — drops the `COALESCE(event.data->>'owner_id', event.actor_id)` fallback in the `TokenCreated` projector. New `TokenCreated` events without an `owner_id` now produce `NULL` in the projection. Existing rows are untouched.
- **`token_handler.go`** — the unrestricted `CreateToken` branch honours the new `CreateTokenRequest.owner_id` field literally. Non-empty ⇒ validated via `GetUserByID` (returns `user_not_found` if missing). Empty/omitted ⇒ ownerless token, no auto-assignment when devices enrol through it. The `:self` branch continues to force the creator as owner, ignoring any value the caller passes.
- **Tests** — `TestCreateToken_Admin` now asserts the omitted-owner case is ownerless. New tests cover `OwnerSelf`, `OwnerOtherUser`, `OwnerNotFound`, and the `:self`-scope override.

## Order of operations for rc12

1. Merge SDK PR manchtools/power-manage-sdk#38 (adds the `owner_id` field to the proto).
2. Tag a new SDK release (the change is additive — bump minor: `v0.4.0`).
3. Bump this PR's `go.mod` replace to that SDK tag, repush, CI green, merge.
4. Tag server `v2026.05-rc12`.
5. Web `tokens/create-token-dialog.svelte` gets a \"Bulk enrollment (no owner)\" Switch shipped direct-to-main alongside the rc12 image rebuild.

## Test plan

- [x] Unit: token-handler tests (5 covering all owner-resolution branches) pass against testcontainers Postgres.
- [x] Unit: existing registration tests still pass (devices enrolled via ownerless tokens are not auto-assigned, since `registration_handler.go:207` already null-guards `OwnerID`).
- [ ] Manual: web-side dialog produces ownerless tokens when the bulk-enrollment switch is on; the device list view confirms no auto-assignment.