### PR TITLE
fix: terminal access for unassigned devices via permission-derived TTY resolution

### DIFF
--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -410,14 +410,17 @@ func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.Use
 	actionName := "system:tty-user:" + user.ID
 
 	if user.SystemTtyActionID == "" {
-		// Create new system action
+		// Create new system action. We deliberately do NOT emit an
+		// AssignmentCreated event for the TTY action — delivery is
+		// driven by the permission-derived path in resolution.go,
+		// which materializes the pm-tty-<username> account on every
+		// device whenever the user holds the StartTerminal permission.
+		// Coupling delivery to a per-user assignment was the original
+		// bug: admins manage the fleet without being assigned to any
+		// individual device, so their TTY accounts never landed.
 		actionID, err := m.createSystemAction(ctx, actionName, int32(pm.ActionType_ACTION_TYPE_USER), int32(pm.DesiredState_DESIRED_STATE_PRESENT), paramsJSON)
 		if err != nil {
 			return fmt.Errorf("create tty user action: %w", err)
-		}
-
-		if err := m.assignActionToUser(ctx, actionID, user.ID); err != nil {
-			return fmt.Errorf("assign tty user action: %w", err)
 		}
 
 		if err := m.linkSystemAction(ctx, user.ID, "system_tty_action_id", actionID); err != nil {

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -15,10 +15,24 @@ import (
 )
 
 // SystemActionManager creates and maintains system-managed actions
-// (user provisioning and SSH access) for PM users. These actions are
-// stored in actions_projection and assigned to users via
-// assignments_projection, so the resolution engine picks them up
-// automatically for devices with assigned users.
+// (user provisioning, SSH access, TTY user) for PM users. The actions
+// are stored in actions_projection. Delivery to devices splits into
+// two paths:
+//
+//   - User-account and SSH-access actions are routed through
+//     assignments_projection, so the resolution engine picks them
+//     up automatically for devices with assigned users.
+//   - The TTY user action is the exception: it is linked to the
+//     owning user via users_projection.system_tty_action_id but is
+//     NOT routed through assignments_projection. Delivery is
+//     permission-derived in resolution.ResolveActionsForDevice —
+//     every device receives the TTY action of every user holding
+//     StartTerminal, regardless of assignment. See
+//     syncTtyUserAction below.
+//
+// Future system actions added here should follow the user-account /
+// SSH pattern and ride assignments unless they share TTY's "must
+// land on every device for permission holders" property.
 type SystemActionManager struct {
 	store  *store.Store
 	signer ActionSigner
@@ -375,11 +389,16 @@ func (m *SystemActionManager) cleanupSshAction(ctx context.Context, user db.User
 }
 
 // syncTtyUserAction ensures a dedicated pm-tty-<linux_username>
-// system User action exists for the given user so that when the
-// action is resolved onto the user's assigned devices the agent
-// creates the TTY account. The action uses nologin as the shell
-// (the agent temporarily activates it during a session), no home
-// directory, and the deterministic UID from the SDK's TTYUID helper.
+// system User action exists for the given user. Delivery is NOT
+// driven by an assignment — the action is linked to the user via
+// users_projection.system_tty_action_id and surfaced to devices by
+// resolution.ResolveActionsForDevice's permission-derived layer
+// (every device gets the TTY action of every user holding
+// StartTerminal). See the package-level comment on
+// SystemActionManager for the split rationale.
+// The action uses nologin as the shell (the agent temporarily
+// activates it during a session), no home directory, and the
+// deterministic UID from the SDK's TTYUID helper.
 func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.UsersProjection) error {
 	// Typed *pm.UserParams so the Go compiler rejects field-name
 	// typos. The previous map[string]any form accepted "system": true

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -102,18 +102,21 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 	}
 	ttyUser := sdkterminal.TTYUsername(linuxUsername)
 
-	// Filter by the authenticated user's ID so users can only open
-	// terminal sessions on devices assigned to them (directly or via
-	// user groups). The SQL query's FilterUserID clause handles the
-	// assignment check — a non-assigned device looks like ErrNoRows,
-	// same as a genuinely missing device.
-	filterUserID := userCtx.ID
+	// Filter by the authenticated user's ID when the caller only has
+	// scoped (:assigned) access — they can only open sessions on
+	// devices assigned to them. Users with the unrestricted
+	// StartTerminal permission see all devices, matching the
+	// userFilterID(...) pattern used by every other handler that
+	// reads from the device projection. Pre-fix this was hardcoded
+	// to userCtx.ID, which masked admin access to bulk-enrolled
+	// (unassigned) devices.
+	filterUserID := userFilterID(ctx, "StartTerminal")
 	if _, err := h.store.Queries().GetDeviceByID(ctx, generated.GetDeviceByIDParams{
 		ID:           req.Msg.DeviceId,
-		FilterUserID: &filterUserID,
+		FilterUserID: filterUserID,
 	}); err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
-			return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found or not assigned to you")
+			return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up device")
 	}

--- a/internal/api/terminal_handler_test.go
+++ b/internal/api/terminal_handler_test.go
@@ -157,6 +157,32 @@ func TestStartTerminal_DeviceNotFound(t *testing.T) {
 	assert.Equal(t, connect.CodeNotFound, connectErr.Code())
 }
 
+// TestStartTerminal_AdminUnassigned covers the bulk-enrollment case
+// surfaced by manchtools/power-manage-server#85: a device that no
+// user is assigned to (no direct assignment, no group membership)
+// must still be reachable by an admin who holds the unrestricted
+// StartTerminal permission. The previous hardcoded
+// `filterUserID := userCtx.ID` collapsed admin and :assigned users
+// into the same scope and surfaced as "device not found" for any
+// device the admin hadn't explicitly assigned to themselves.
+func TestStartTerminal_AdminUnassigned(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _ := newTerminalHandler(t, st)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, adminID, "alice")
+	deviceID := testutil.CreateTestDevice(t, st, "unassigned-host")
+	// Deliberately no AssignDeviceToUser call — the device is
+	// ownerless / unassigned, the bulk-enrollment scenario.
+
+	resp, err := h.StartTerminal(testutil.AdminContext(adminID), connect.NewRequest(&pm.StartTerminalRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Msg.SessionId)
+	assert.Equal(t, "pm-tty-alice", resp.Msg.TtyUser)
+}
+
 func TestStartTerminal_NotAuthenticated(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h, _ := newTerminalHandler(t, st)

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -2,7 +2,6 @@ package resolution
 
 import (
 	"context"
-	"log/slog"
 
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -64,19 +63,20 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 	// handler, where each call is already a one-off — no in-process
 	// cache needed at current scale.
 	//
-	// Failure mode: this layer is purely additive — it only appends
-	// rows, never removes them. A transient DB hiccup on this single
-	// query path should not be allowed to abort the whole resolve and
-	// break ProxySyncActions for every device, including devices with
-	// no TTY-related state. Log and continue with an empty TTY slice;
-	// the next agent sync after the DB recovers reconciles things,
-	// and pm-tty accounts that already exist on devices stay put in
-	// the meantime.
+	// Failure mode: a previous revision of this code "gracefully
+	// degraded" the TTY query by logging and continuing with an
+	// empty slice. That was actively destructive: agent SyncActions
+	// (agent/internal/scheduler/scheduler.go) treats the server's
+	// returned action list as authoritative, and USER actions hit
+	// shouldRevertOnUnassign — so any TTY action missing from a
+	// successful sync response triggers DESIRED_STATE_ABSENT on the
+	// device, deleting the pm-tty-<username> account. Returning the
+	// error here makes ProxySyncActions fail fast; the agent retries
+	// on its sync interval and nothing on disk changes in the
+	// meantime.
 	ttyActions, err := q.ListSystemTtyActionsForPermissionHolders(ctx)
 	if err != nil {
-		slog.WarnContext(ctx, "permission-derived TTY action source failed; continuing without it",
-			"device_id", deviceID, "error", err)
-		ttyActions = nil
+		return nil, err
 	}
 
 	// 4. Device-layer excluded action IDs are needed only to filter the

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -11,15 +11,24 @@ type Querier interface {
 	ListResolvedActionsForDevice(ctx context.Context, targetID string) ([]db.ListResolvedActionsForDeviceRow, error)
 	ListDeviceLayerExcludedActionIDs(ctx context.Context, targetID string) ([]string, error)
 	ListUserLayerResolvedActionsForDevice(ctx context.Context, id string) ([]db.ListUserLayerResolvedActionsForDeviceRow, error)
+	ListSystemTtyActionsForPermissionHolders(ctx context.Context) ([]db.ListSystemTtyActionsForPermissionHoldersRow, error)
 }
 
-// ResolveActionsForDevice queries both device-layer and user-layer assignments,
-// merges them with cross-layer exclusion rules, and returns the final action list.
+// ResolveActionsForDevice queries device-layer assignments, user-layer
+// assignments, and the permission-derived TTY action source, merges them
+// with cross-layer exclusion rules, and returns the final action list.
 //
 // Cross-layer exclusion rules:
-//   - Device EXCLUDED → blocks action entirely (not returned from either layer)
+//   - Device EXCLUDED → blocks the action for assignment-derived layers
 //   - User EXCLUDED → only removes from user layer, device layer unaffected
 //   - Same action in both layers → device layer wins (no duplicates)
+//
+// The permission-derived TTY layer (every user with StartTerminal needs
+// their pm-tty-<username> account on every device) deliberately bypasses
+// device-layer EXCLUDED — terminal access is the system's escape hatch
+// and must never be turned off by an operator-side exclusion. User
+// deletion drives cleanup through a different path (the system action
+// itself is removed, agents drop the account on the next sync).
 func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([]db.ListResolvedActionsForDeviceRow, error) {
 	// 1. Get device-layer resolved actions (existing query, unchanged)
 	deviceActions, err := q.ListResolvedActionsForDevice(ctx, deviceID)
@@ -33,21 +42,24 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 		return nil, err
 	}
 
-	// If no user-layer actions, return device layer only (fast path)
-	if len(userActions) == 0 {
-		return deviceActions, nil
-	}
-
-	// 3. Get device-layer excluded action IDs
-	excludedIDs, err := q.ListDeviceLayerExcludedActionIDs(ctx, deviceID)
+	// 3. Permission-derived TTY actions — independent of device assignment.
+	ttyActions, err := q.ListSystemTtyActionsForPermissionHolders(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Build lookup sets
-	excludedSet := make(map[string]bool, len(excludedIDs))
-	for _, id := range excludedIDs {
-		excludedSet[id] = true
+	// 4. Device-layer excluded action IDs are needed only to filter the
+	//    user-layer; the TTY layer is exclusion-exempt by design.
+	var excludedSet map[string]bool
+	if len(userActions) > 0 {
+		excludedIDs, err := q.ListDeviceLayerExcludedActionIDs(ctx, deviceID)
+		if err != nil {
+			return nil, err
+		}
+		excludedSet = make(map[string]bool, len(excludedIDs))
+		for _, id := range excludedIDs {
+			excludedSet[id] = true
+		}
 	}
 
 	deviceActionSet := make(map[string]bool, len(deviceActions))
@@ -55,7 +67,8 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 		deviceActionSet[a.ID] = true
 	}
 
-	// 4. Merge: add user-layer actions that aren't device-excluded or duplicates
+	// 5. Merge user-layer actions: drop device-excluded and dedupe
+	//    against the device layer.
 	for _, ua := range userActions {
 		if excludedSet[ua.ID] || deviceActionSet[ua.ID] {
 			continue
@@ -76,6 +89,30 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 			ParamsCanonical:   ua.ParamsCanonical,
 		})
 		deviceActionSet[ua.ID] = true
+	}
+
+	// 6. Merge permission-derived TTY actions: dedupe against everything
+	//    already in the result, but never honor device-layer exclusion.
+	for _, ta := range ttyActions {
+		if deviceActionSet[ta.ID] {
+			continue
+		}
+		deviceActions = append(deviceActions, db.ListResolvedActionsForDeviceRow{
+			ID:                ta.ID,
+			Name:              ta.Name,
+			Description:       ta.Description,
+			ActionType:        ta.ActionType,
+			DesiredState:      ta.DesiredState,
+			Params:            ta.Params,
+			TimeoutSeconds:    ta.TimeoutSeconds,
+			CreatedAt:         ta.CreatedAt,
+			CreatedBy:         ta.CreatedBy,
+			IsDeleted:         ta.IsDeleted,
+			ProjectionVersion: ta.ProjectionVersion,
+			Signature:         ta.Signature,
+			ParamsCanonical:   ta.ParamsCanonical,
+		})
+		deviceActionSet[ta.ID] = true
 	}
 
 	return deviceActions, nil

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -43,6 +43,14 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 	}
 
 	// 3. Permission-derived TTY actions — independent of device assignment.
+	//
+	// Operational note: the query takes no deviceID and returns the
+	// same global set on every call, so a future bulk caller that
+	// resolves many devices in one pass should hoist this fetch out
+	// of the per-device loop and pass the slice down (e.g. add a
+	// ResolveActionsForDevices helper). The single live caller today
+	// is the per-agent ProxySyncActions handler, where each call is
+	// already a one-off — no in-process cache needed at current scale.
 	ttyActions, err := q.ListSystemTtyActionsForPermissionHolders(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -45,6 +45,16 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 
 	// 3. Permission-derived TTY actions — independent of device assignment.
 	//
+	// Scale note: this query returns one row per (user with
+	// StartTerminal × linked TTY action), and every device receives
+	// every row, so the per-device payload grows linearly with the
+	// terminal-capable operator population. That's the documented
+	// contract — every such user needs their pm-tty-<username>
+	// account on every device — but worth keeping in mind once the
+	// StartTerminal cohort gets large enough that ProxySyncActions
+	// starts feeling the extra rows. Mitigation rides on the bulk
+	// hoist below.
+	//
 	// TODO(bulk-resolve): the query takes no deviceID and returns the
 	// same global set on every call, so a future bulk caller that
 	// resolves many devices in one pass should hoist this fetch out
@@ -90,26 +100,17 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 
 	// 5. Merge user-layer actions: drop device-excluded and dedupe
 	//    against the device layer.
+	//
+	// The direct struct conversion is sound because the sqlc-generated
+	// row types share the same field layout (currently 14 fields). It
+	// also makes the previous Schedule-drop bug structurally impossible
+	// to repeat — if the layouts ever diverge, the conversion fails to
+	// compile and forces the merge to be re-evaluated explicitly.
 	for _, ua := range userActions {
 		if excludedSet[ua.ID] || deviceActionSet[ua.ID] {
 			continue
 		}
-		deviceActions = append(deviceActions, db.ListResolvedActionsForDeviceRow{
-			ID:                ua.ID,
-			Name:              ua.Name,
-			Description:       ua.Description,
-			ActionType:        ua.ActionType,
-			DesiredState:      ua.DesiredState,
-			Params:            ua.Params,
-			TimeoutSeconds:    ua.TimeoutSeconds,
-			CreatedAt:         ua.CreatedAt,
-			CreatedBy:         ua.CreatedBy,
-			IsDeleted:         ua.IsDeleted,
-			ProjectionVersion: ua.ProjectionVersion,
-			Signature:         ua.Signature,
-			ParamsCanonical:   ua.ParamsCanonical,
-			Schedule:          ua.Schedule,
-		})
+		deviceActions = append(deviceActions, db.ListResolvedActionsForDeviceRow(ua))
 		deviceActionSet[ua.ID] = true
 	}
 
@@ -119,22 +120,7 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 		if deviceActionSet[ta.ID] {
 			continue
 		}
-		deviceActions = append(deviceActions, db.ListResolvedActionsForDeviceRow{
-			ID:                ta.ID,
-			Name:              ta.Name,
-			Description:       ta.Description,
-			ActionType:        ta.ActionType,
-			DesiredState:      ta.DesiredState,
-			Params:            ta.Params,
-			TimeoutSeconds:    ta.TimeoutSeconds,
-			CreatedAt:         ta.CreatedAt,
-			CreatedBy:         ta.CreatedBy,
-			IsDeleted:         ta.IsDeleted,
-			ProjectionVersion: ta.ProjectionVersion,
-			Signature:         ta.Signature,
-			ParamsCanonical:   ta.ParamsCanonical,
-			Schedule:          ta.Schedule,
-		})
+		deviceActions = append(deviceActions, db.ListResolvedActionsForDeviceRow(ta))
 		deviceActionSet[ta.ID] = true
 	}
 

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -2,6 +2,7 @@ package resolution
 
 import (
 	"context"
+	"log/slog"
 
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -44,16 +45,28 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 
 	// 3. Permission-derived TTY actions — independent of device assignment.
 	//
-	// Operational note: the query takes no deviceID and returns the
+	// TODO(bulk-resolve): the query takes no deviceID and returns the
 	// same global set on every call, so a future bulk caller that
 	// resolves many devices in one pass should hoist this fetch out
 	// of the per-device loop and pass the slice down (e.g. add a
-	// ResolveActionsForDevices helper). The single live caller today
-	// is the per-agent ProxySyncActions handler, where each call is
-	// already a one-off — no in-process cache needed at current scale.
+	// ResolveActionsForDevices helper used by ProxySyncActions). The
+	// single live caller today is the per-agent ProxySyncActions
+	// handler, where each call is already a one-off — no in-process
+	// cache needed at current scale.
+	//
+	// Failure mode: this layer is purely additive — it only appends
+	// rows, never removes them. A transient DB hiccup on this single
+	// query path should not be allowed to abort the whole resolve and
+	// break ProxySyncActions for every device, including devices with
+	// no TTY-related state. Log and continue with an empty TTY slice;
+	// the next agent sync after the DB recovers reconciles things,
+	// and pm-tty accounts that already exist on devices stay put in
+	// the meantime.
 	ttyActions, err := q.ListSystemTtyActionsForPermissionHolders(ctx)
 	if err != nil {
-		return nil, err
+		slog.WarnContext(ctx, "permission-derived TTY action source failed; continuing without it",
+			"device_id", deviceID, "error", err)
+		ttyActions = nil
 	}
 
 	// 4. Device-layer excluded action IDs are needed only to filter the
@@ -95,6 +108,7 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 			ProjectionVersion: ua.ProjectionVersion,
 			Signature:         ua.Signature,
 			ParamsCanonical:   ua.ParamsCanonical,
+			Schedule:          ua.Schedule,
 		})
 		deviceActionSet[ua.ID] = true
 	}
@@ -119,6 +133,7 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 			ProjectionVersion: ta.ProjectionVersion,
 			Signature:         ta.Signature,
 			ParamsCanonical:   ta.ParamsCanonical,
+			Schedule:          ta.Schedule,
 		})
 		deviceActionSet[ta.ID] = true
 	}

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -289,6 +289,40 @@ func TestResolveActions_TTYPermissionSource_NoPermissionExcluded(t *testing.T) {
 	assert.Empty(t, actions, "user without StartTerminal must not have TTY action shipped")
 }
 
+// TestResolveActions_TTYPermissionSource_BypassesDeviceExcluded locks
+// in the rc13 contract: the permission-derived TTY layer is exempt
+// from device-layer EXCLUDED. An operator who attaches an EXCLUDED
+// assignment for a TTY action to a device must NOT be able to lock
+// terminal access out — terminal access is the system's escape
+// hatch, and cleanup of TTY accounts is driven by the user-deletion
+// path, never by an operator's per-device exclusion. The contrast
+// with TestResolveActions_DeviceExcludedBlocksUserRequired (which
+// honors EXCLUDED for assignment-derived rows) is the point of this
+// test: same exclusion event, different outcome by layer.
+func TestResolveActions_TTYPermissionSource_BypassesDeviceExcluded(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	operatorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	roleID := testutil.CreateTestRole(t, st, adminID, "tty-bypass", []string{"StartTerminal"})
+	testutil.AssignRoleToTestUser(t, st, adminID, operatorID, roleID)
+
+	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+operatorID, int(pm.ActionType_ACTION_TYPE_USER))
+	linkSystemTtyAction(t, st, adminID, operatorID, ttyActionID)
+
+	deviceID := testutil.CreateTestDevice(t, st, "exclusion-attempt-host")
+
+	// Operator-style attempt to lock the TTY action out via a
+	// device-layer EXCLUDED assignment (mode=2). The permission-
+	// derived layer must ignore it.
+	testutil.CreateTestAssignment(t, st, adminID, "action", ttyActionID, "device", deviceID, 2)
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, actions, 1, "device-layer EXCLUDED must NOT block permission-derived TTY actions")
+	assert.Equal(t, ttyActionID, actions[0].ID)
+}
+
 // A user with StartTerminal granted twice — direct role plus the same
 // permission inherited via a group — must produce exactly one row. The
 // DISTINCT ON in the query collapses the duplicate join paths.

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -330,9 +330,22 @@ func TestResolveActions_TTYPermissionSource_BypassesDeviceExcluded(t *testing.T)
 }
 
 // A user with StartTerminal granted twice — direct role plus the same
-// permission inherited via a group — must produce exactly one row. The
-// DISTINCT ON in the query collapses the duplicate join paths.
-func TestResolveActions_TTYPermissionSource_DedupesAcrossRoles(t *testing.T) {
+// permission inherited via a group — must produce exactly one TTY
+// action row in the resolved set.
+//
+// What this test actually exercises: the JOIN keys on
+// users_projection.system_tty_action_id, and each user has at most
+// one such ID, so the SQL never produces duplicate candidate rows
+// for one user regardless of how many permission paths grant the
+// permission (the role check is an EXISTS filter, not a row
+// multiplier). The user-visible "one row per action" property is
+// therefore upheld by the SQL shape on its own; the resolver's
+// deviceActionSet dedupe and the SQL's DISTINCT ON (a.id) are both
+// defensive belt-and-braces against future query/schema changes
+// that could expose row multiplication, and this test guards the
+// observable end-state rather than the exact mechanism that
+// guarantees it.
+func TestResolveActions_TTYPermissionSource_DedupesOverlappingRoleGrants(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	operatorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -203,7 +203,11 @@ func TestCreateAssignment_UserTargetViaHandler(t *testing.T) {
 // linkSystemTtyAction stamps users_projection.system_tty_action_id by
 // emitting the projector-recognised UserSystemActionLinked event. The
 // resolver's permission-derived TTY query joins on this column.
-func linkSystemTtyAction(t *testing.T, st *store.Store, actorID, userID, actionID string) {
+//
+// Mirrors production actor identity (ActorType "system", ActorID
+// "system") used by SystemActionManager.linkSystemAction so the tests
+// exercise the same audit/projection code path that ships.
+func linkSystemTtyAction(t *testing.T, st *store.Store, userID, actionID string) {
 	t.Helper()
 	err := st.AppendEvent(context.Background(), store.Event{
 		StreamType: "user",
@@ -213,8 +217,8 @@ func linkSystemTtyAction(t *testing.T, st *store.Store, actorID, userID, actionI
 			"field":     "system_tty_action_id",
 			"action_id": actionID,
 		},
-		ActorType: "user",
-		ActorID:   actorID,
+		ActorType: "system",
+		ActorID:   "system",
 	})
 	if err != nil {
 		t.Fatalf("link tty action: %v", err)
@@ -238,7 +242,7 @@ func TestResolveActions_TTYPermissionSource_DirectRole(t *testing.T) {
 
 	// Operator's TTY action; no assignment to anything.
 	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+operatorID, int(pm.ActionType_ACTION_TYPE_USER))
-	linkSystemTtyAction(t, st, adminID, operatorID, ttyActionID)
+	linkSystemTtyAction(t, st, operatorID, ttyActionID)
 
 	// Brand-new, totally unassigned device — the bulk-enrollment shape.
 	deviceID := testutil.CreateTestDevice(t, st, "bulk-enrolled")
@@ -261,7 +265,7 @@ func TestResolveActions_TTYPermissionSource_ViaUserGroup(t *testing.T) {
 	testutil.AssignRoleToTestGroup(t, st, adminID, groupID, roleID)
 
 	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+operatorID, int(pm.ActionType_ACTION_TYPE_USER))
-	linkSystemTtyAction(t, st, adminID, operatorID, ttyActionID)
+	linkSystemTtyAction(t, st, operatorID, ttyActionID)
 
 	deviceID := testutil.CreateTestDevice(t, st, "bulk-enrolled-2")
 
@@ -282,7 +286,7 @@ func TestResolveActions_TTYPermissionSource_NoPermissionExcluded(t *testing.T) {
 	noPermID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
 
 	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+noPermID, int(pm.ActionType_ACTION_TYPE_USER))
-	linkSystemTtyAction(t, st, adminID, noPermID, ttyActionID)
+	linkSystemTtyAction(t, st, noPermID, ttyActionID)
 
 	deviceID := testutil.CreateTestDevice(t, st, "no-perm-device")
 
@@ -310,7 +314,7 @@ func TestResolveActions_TTYPermissionSource_BypassesDeviceExcluded(t *testing.T)
 	testutil.AssignRoleToTestUser(t, st, adminID, operatorID, roleID)
 
 	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+operatorID, int(pm.ActionType_ACTION_TYPE_USER))
-	linkSystemTtyAction(t, st, adminID, operatorID, ttyActionID)
+	linkSystemTtyAction(t, st, operatorID, ttyActionID)
 
 	deviceID := testutil.CreateTestDevice(t, st, "exclusion-attempt-host")
 
@@ -344,7 +348,7 @@ func TestResolveActions_TTYPermissionSource_DedupesAcrossRoles(t *testing.T) {
 	testutil.AssignRoleToTestGroup(t, st, adminID, groupID, groupRoleID)
 
 	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+operatorID, int(pm.ActionType_ACTION_TYPE_USER))
-	linkSystemTtyAction(t, st, adminID, operatorID, ttyActionID)
+	linkSystemTtyAction(t, st, operatorID, ttyActionID)
 
 	deviceID := testutil.CreateTestDevice(t, st, "dedupe-host")
 

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -1,6 +1,7 @@
 package resolution_test
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 
@@ -11,6 +12,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/api"
 	"github.com/manchtools/power-manage/server/internal/resolution"
+	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
@@ -194,4 +196,124 @@ func TestCreateAssignment_UserTargetViaHandler(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, resp.Msg.Assignments, 1)
 	assert.Equal(t, "user", resp.Msg.Assignments[0].TargetType)
+}
+
+// linkSystemTtyAction stamps users_projection.system_tty_action_id by
+// emitting the projector-recognised UserSystemActionLinked event. The
+// resolver's permission-derived TTY query joins on this column.
+func linkSystemTtyAction(t *testing.T, st *store.Store, actorID, userID, actionID string) {
+	t.Helper()
+	err := st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user",
+		StreamID:   userID,
+		EventType:  "UserSystemActionLinked",
+		Data: map[string]any{
+			"field":     "system_tty_action_id",
+			"action_id": actionID,
+		},
+		ActorType: "user",
+		ActorID:   actorID,
+	})
+	if err != nil {
+		t.Fatalf("link tty action: %v", err)
+	}
+}
+
+// TestResolveActions_TTYPermissionSource is the rc13 contract:
+// when a user holds StartTerminal (directly or via group) and has
+// system_tty_action_id linked, the resolver returns that TTY action
+// for any device — including a freshly enrolled, unassigned device.
+// Pre-fix this hung off ordinary user assignment, so bulk-enrolled
+// devices never received the pm-tty-<username> account.
+func TestResolveActions_TTYPermissionSource_DirectRole(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	// Operator user with StartTerminal via a directly-granted role.
+	operatorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	roleID := testutil.CreateTestRole(t, st, adminID, "tty-operator", []string{"StartTerminal"})
+	testutil.AssignRoleToTestUser(t, st, adminID, operatorID, roleID)
+
+	// Operator's TTY action; no assignment to anything.
+	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+operatorID, int(pm.ActionType_ACTION_TYPE_USER))
+	linkSystemTtyAction(t, st, adminID, operatorID, ttyActionID)
+
+	// Brand-new, totally unassigned device — the bulk-enrollment shape.
+	deviceID := testutil.CreateTestDevice(t, st, "bulk-enrolled")
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, actions, 1, "TTY action must reach unassigned devices for permission holders")
+	assert.Equal(t, ttyActionID, actions[0].ID)
+}
+
+func TestResolveActions_TTYPermissionSource_ViaUserGroup(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	operatorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+
+	// Permission flows: user → group → role → permission.
+	groupID := testutil.CreateTestUserGroup(t, st, adminID, "tty-team")
+	roleID := testutil.CreateTestRole(t, st, adminID, "tty-via-group", []string{"StartTerminal"})
+	testutil.AddUserToTestGroup(t, st, adminID, groupID, operatorID)
+	testutil.AssignRoleToTestGroup(t, st, adminID, groupID, roleID)
+
+	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+operatorID, int(pm.ActionType_ACTION_TYPE_USER))
+	linkSystemTtyAction(t, st, adminID, operatorID, ttyActionID)
+
+	deviceID := testutil.CreateTestDevice(t, st, "bulk-enrolled-2")
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, actions, 1)
+	assert.Equal(t, ttyActionID, actions[0].ID)
+}
+
+// Linked-but-unprivileged users must NOT have their TTY action shipped
+// to devices — the system-action linkage alone is not authority. This
+// is the cleanup-safety property that the user-deletion path relies on:
+// revoking StartTerminal must drop the TTY account from the device's
+// resolved action set on the next sync.
+func TestResolveActions_TTYPermissionSource_NoPermissionExcluded(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	noPermID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+
+	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+noPermID, int(pm.ActionType_ACTION_TYPE_USER))
+	linkSystemTtyAction(t, st, adminID, noPermID, ttyActionID)
+
+	deviceID := testutil.CreateTestDevice(t, st, "no-perm-device")
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	assert.Empty(t, actions, "user without StartTerminal must not have TTY action shipped")
+}
+
+// A user with StartTerminal granted twice — direct role plus the same
+// permission inherited via a group — must produce exactly one row. The
+// DISTINCT ON in the query collapses the duplicate join paths.
+func TestResolveActions_TTYPermissionSource_DedupesAcrossRoles(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	operatorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+
+	// Direct role grant
+	directRoleID := testutil.CreateTestRole(t, st, adminID, "tty-direct", []string{"StartTerminal"})
+	testutil.AssignRoleToTestUser(t, st, adminID, operatorID, directRoleID)
+
+	// Plus the same permission via a group role
+	groupID := testutil.CreateTestUserGroup(t, st, adminID, "tty-dedupe-team")
+	groupRoleID := testutil.CreateTestRole(t, st, adminID, "tty-via-group", []string{"StartTerminal"})
+	testutil.AddUserToTestGroup(t, st, adminID, groupID, operatorID)
+	testutil.AssignRoleToTestGroup(t, st, adminID, groupID, groupRoleID)
+
+	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+operatorID, int(pm.ActionType_ACTION_TYPE_USER))
+	linkSystemTtyAction(t, st, adminID, operatorID, ttyActionID)
+
+	deviceID := testutil.CreateTestDevice(t, st, "dedupe-host")
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, actions, 1, "duplicate permission grants must collapse to one TTY action")
+	assert.Equal(t, ttyActionID, actions[0].ID)
 }

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -2,6 +2,7 @@ package resolution_test
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/api"
 	"github.com/manchtools/power-manage/server/internal/resolution"
 	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
@@ -350,4 +352,43 @@ func TestResolveActions_TTYPermissionSource_DedupesAcrossRoles(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, actions, 1, "duplicate permission grants must collapse to one TTY action")
 	assert.Equal(t, ttyActionID, actions[0].ID)
+}
+
+// ttyFailingQuerier wraps a real Querier and forces the TTY query to
+// fail, leaving every other call delegated. Used to verify the
+// graceful-degradation contract on the permission-derived TTY layer.
+type ttyFailingQuerier struct {
+	resolution.Querier
+	err error
+}
+
+func (q ttyFailingQuerier) ListSystemTtyActionsForPermissionHolders(ctx context.Context) ([]db.ListSystemTtyActionsForPermissionHoldersRow, error) {
+	return nil, q.err
+}
+
+// TestResolveActions_TTYPermissionSource_DegradesGracefully locks in
+// the contract that a transient failure on the (purely additive)
+// permission-derived TTY layer must NOT abort the whole resolve.
+// ProxySyncActions stays available for every device — including
+// those with no TTY-related state — and the next sync after recovery
+// reconciles. Without this guarantee, a single DB hiccup on the new
+// query path would silently break agent syncs fleet-wide.
+func TestResolveActions_TTYPermissionSource_DegradesGracefully(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	// Plain device-layer assignment so we can prove the rest of the
+	// resolve pipeline still produces output.
+	actionID := testutil.CreateTestAction(t, st, adminID, "Survives TTY Failure", int(pm.ActionType_ACTION_TYPE_SHELL))
+	deviceID := testutil.CreateTestDevice(t, st, "tty-failure-host")
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID, 0)
+
+	q := ttyFailingQuerier{
+		Querier: st.Queries(),
+		err:     errors.New("simulated DB hiccup"),
+	}
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), q, deviceID)
+	require.NoError(t, err, "TTY layer failure must not abort the resolve")
+	require.Len(t, actions, 1)
+	assert.Equal(t, actionID, actions[0].ID)
 }

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -356,7 +356,12 @@ func TestResolveActions_TTYPermissionSource_DedupesAcrossRoles(t *testing.T) {
 
 // ttyFailingQuerier wraps a real Querier and forces the TTY query to
 // fail, leaving every other call delegated. Used to verify the
-// graceful-degradation contract on the permission-derived TTY layer.
+// fail-fast contract: a TTY query error must propagate up, NOT
+// degrade to an empty slice. The agent's SyncActions treats the
+// server's action list as authoritative and reverts USER actions
+// that disappear from a successful sync response — so silently
+// dropping the TTY rows would tear down every pm-tty-<username>
+// account across the fleet on the next sync.
 type ttyFailingQuerier struct {
 	resolution.Querier
 	err error
@@ -366,29 +371,26 @@ func (q ttyFailingQuerier) ListSystemTtyActionsForPermissionHolders(ctx context.
 	return nil, q.err
 }
 
-// TestResolveActions_TTYPermissionSource_DegradesGracefully locks in
-// the contract that a transient failure on the (purely additive)
-// permission-derived TTY layer must NOT abort the whole resolve.
-// ProxySyncActions stays available for every device — including
-// those with no TTY-related state — and the next sync after recovery
-// reconciles. Without this guarantee, a single DB hiccup on the new
-// query path would silently break agent syncs fleet-wide.
-func TestResolveActions_TTYPermissionSource_DegradesGracefully(t *testing.T) {
+// TestResolveActions_TTYPermissionSource_FailsFastOnTtyError locks in
+// the rc13 safety contract: when ListSystemTtyActionsForPermissionHolders
+// fails, ResolveActionsForDevice MUST surface the error rather than
+// quietly continuing without TTY rows. ProxySyncActions then fails
+// the sync, the agent retries on its interval, and nothing on disk
+// changes in the meantime. The previous "graceful degradation" path
+// was actively destructive — see the failure-mode note in resolve.go.
+func TestResolveActions_TTYPermissionSource_FailsFastOnTtyError(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 
-	// Plain device-layer assignment so we can prove the rest of the
-	// resolve pipeline still produces output.
 	actionID := testutil.CreateTestAction(t, st, adminID, "Survives TTY Failure", int(pm.ActionType_ACTION_TYPE_SHELL))
 	deviceID := testutil.CreateTestDevice(t, st, "tty-failure-host")
 	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID, 0)
 
+	sentinel := errors.New("simulated DB hiccup")
 	q := ttyFailingQuerier{
 		Querier: st.Queries(),
-		err:     errors.New("simulated DB hiccup"),
+		err:     sentinel,
 	}
-	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), q, deviceID)
-	require.NoError(t, err, "TTY layer failure must not abort the resolve")
-	require.Len(t, actions, 1)
-	assert.Equal(t, actionID, actions[0].ID)
+	_, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), q, deviceID)
+	require.ErrorIs(t, err, sentinel, "TTY layer failure must propagate up, not degrade silently")
 }

--- a/internal/store/generated/assignments.sql.go
+++ b/internal/store/generated/assignments.sql.go
@@ -999,6 +999,105 @@ func (q *Queries) ListResolvedActionsForDevice(ctx context.Context, targetID str
 	return items, nil
 }
 
+const listSystemTtyActionsForPermissionHolders = `-- name: ListSystemTtyActionsForPermissionHolders :many
+SELECT DISTINCT ON (a.id)
+       a.id, a.name, a.description, a.action_type, a.desired_state,
+       a.params, a.timeout_seconds, a.created_at, a.created_by,
+       a.is_deleted, a.projection_version,
+       a.signature, a.params_canonical, a.schedule
+FROM users_projection u
+JOIN actions_projection a
+  ON a.id = u.system_tty_action_id AND a.is_deleted = FALSE
+WHERE u.is_deleted = FALSE
+  AND u.system_tty_action_id <> ''
+  AND EXISTS (
+    SELECT 1 FROM roles_projection r
+    WHERE r.is_deleted = FALSE
+      AND 'StartTerminal' = ANY(r.permissions)
+      AND (
+        r.id IN (
+          SELECT ur.role_id FROM user_roles_projection ur
+          WHERE ur.user_id = u.id
+        )
+        OR r.id IN (
+          SELECT ugr.role_id FROM user_group_roles_projection ugr
+          JOIN user_group_members_projection ugm ON ugm.group_id = ugr.group_id
+          JOIN user_groups_projection ug ON ug.id = ugm.group_id AND ug.is_deleted = FALSE
+          WHERE ugm.user_id = u.id
+        )
+      )
+  )
+`
+
+type ListSystemTtyActionsForPermissionHoldersRow struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	Description       *string    `json:"description"`
+	ActionType        int32      `json:"action_type"`
+	DesiredState      int32      `json:"desired_state"`
+	Params            []byte     `json:"params"`
+	TimeoutSeconds    int32      `json:"timeout_seconds"`
+	CreatedAt         *time.Time `json:"created_at"`
+	CreatedBy         string     `json:"created_by"`
+	IsDeleted         bool       `json:"is_deleted"`
+	ProjectionVersion int64      `json:"projection_version"`
+	Signature         []byte     `json:"signature"`
+	ParamsCanonical   []byte     `json:"params_canonical"`
+	Schedule          []byte     `json:"schedule"`
+}
+
+// Permission-derived TTY user actions.
+//
+// Every user that holds the StartTerminal permission (directly or via
+// a user-group role) and has a linked system_tty_action_id should
+// have their pm-tty-<username> account materialized on every device,
+// regardless of any assignment. The action-resolution layer queries
+// this and merges the rows into the per-device action list, so a
+// bulk-enrolled (unassigned) device still gets the TTY accounts it
+// needs for terminal sessions to succeed.
+//
+// DISTINCT ON (a.id) collapses the row when a user receives the
+// StartTerminal permission via multiple roles or via direct + group
+// grants — the resolver only wants each TTY action once.
+//
+// Filtering rules: skip soft-deleted users, actions, roles, and
+// groups so stale projection rows can't leak through and surface a
+// TTY account that should have been cleaned up.
+func (q *Queries) ListSystemTtyActionsForPermissionHolders(ctx context.Context) ([]ListSystemTtyActionsForPermissionHoldersRow, error) {
+	rows, err := q.db.Query(ctx, listSystemTtyActionsForPermissionHolders)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListSystemTtyActionsForPermissionHoldersRow{}
+	for rows.Next() {
+		var i ListSystemTtyActionsForPermissionHoldersRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Description,
+			&i.ActionType,
+			&i.DesiredState,
+			&i.Params,
+			&i.TimeoutSeconds,
+			&i.CreatedAt,
+			&i.CreatedBy,
+			&i.IsDeleted,
+			&i.ProjectionVersion,
+			&i.Signature,
+			&i.ParamsCanonical,
+			&i.Schedule,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUserLayerResolvedActionsForDevice = `-- name: ListUserLayerResolvedActionsForDevice :many
 WITH device_owners AS (
   SELECT dau.user_id FROM device_assigned_users_projection dau WHERE dau.device_id = $1

--- a/internal/store/queries/assignments.sql
+++ b/internal/store/queries/assignments.sql
@@ -733,3 +733,49 @@ WHERE is_deleted = FALSE AND (
   ))
 )
 ORDER BY created_at DESC;
+
+-- Permission-derived TTY user actions.
+--
+-- Every user that holds the StartTerminal permission (directly or via
+-- a user-group role) and has a linked system_tty_action_id should
+-- have their pm-tty-<username> account materialized on every device,
+-- regardless of any assignment. The action-resolution layer queries
+-- this and merges the rows into the per-device action list, so a
+-- bulk-enrolled (unassigned) device still gets the TTY accounts it
+-- needs for terminal sessions to succeed.
+--
+-- DISTINCT ON (a.id) collapses the row when a user receives the
+-- StartTerminal permission via multiple roles or via direct + group
+-- grants — the resolver only wants each TTY action once.
+--
+-- Filtering rules: skip soft-deleted users, actions, roles, and
+-- groups so stale projection rows can't leak through and surface a
+-- TTY account that should have been cleaned up.
+-- name: ListSystemTtyActionsForPermissionHolders :many
+SELECT DISTINCT ON (a.id)
+       a.id, a.name, a.description, a.action_type, a.desired_state,
+       a.params, a.timeout_seconds, a.created_at, a.created_by,
+       a.is_deleted, a.projection_version,
+       a.signature, a.params_canonical, a.schedule
+FROM users_projection u
+JOIN actions_projection a
+  ON a.id = u.system_tty_action_id AND a.is_deleted = FALSE
+WHERE u.is_deleted = FALSE
+  AND u.system_tty_action_id <> ''
+  AND EXISTS (
+    SELECT 1 FROM roles_projection r
+    WHERE r.is_deleted = FALSE
+      AND 'StartTerminal' = ANY(r.permissions)
+      AND (
+        r.id IN (
+          SELECT ur.role_id FROM user_roles_projection ur
+          WHERE ur.user_id = u.id
+        )
+        OR r.id IN (
+          SELECT ugr.role_id FROM user_group_roles_projection ugr
+          JOIN user_group_members_projection ugm ON ugm.group_id = ugr.group_id
+          JOIN user_groups_projection ug ON ug.id = ugm.group_id AND ug.is_deleted = FALSE
+          WHERE ugm.user_id = u.id
+        )
+      )
+  );


### PR DESCRIPTION
## Two coupled bugs blocking rc12's bulk-enrollment story

### 1. `StartTerminal` ignored permission scope

[`terminal_handler.go:110`](https://github.com/manchtools/power-manage-server/blob/main/internal/api/terminal_handler.go#L110) hardcoded `filterUserID := userCtx.ID`, so even an admin with the unrestricted `StartTerminal` permission saw \"device not found\" on any device they hadn't directly assigned to themselves. Every other handler that reads from `devices_projection` uses the canonical `userFilterID(ctx, \"StartTerminal\")` pattern (cf. `device_handler.go:182`); this PR fixes the inconsistency.

### 2. TTY accounts only landed on user-assigned devices

`syncTtyUserAction` shipped the `pm-tty-<username>` action through an ordinary `AssignmentCreated` event targeting the user themselves ([`system_actions.go:419`](https://github.com/manchtools/power-manage-server/blob/main/internal/api/system_actions.go#L419)). Delivery therefore depended on the user holding device assignments — exactly backwards for admins who manage the fleet without being individually assigned to each device. Bulk-enrolled (unassigned) devices never received the TTY account, so even with the handler fix above, `StartTerminal` minted a token but the agent had nobody to log in as.

## Approach — resolve TTY actions from permissions, not assignments

New sqlc query `ListSystemTtyActionsForPermissionHolders` joins `users_projection.system_tty_action_id` against role/group permissions, returning every TTY action whose owner holds `StartTerminal` (directly or via group role). `DISTINCT ON (a.id)` collapses overlapping grants. Filtering hides soft-deleted users, actions, roles, and groups so stale projections can't leak.

`ResolveActionsForDevice` adds this as a fourth layer, merged after the device- and user-layer assignment sources:

- Deduped against everything already in the result.
- **Ignores device-layer `EXCLUDED`** — terminal access is the system's escape hatch and must not be turn-off-able from an operator-side exclusion. User deletion drives cleanup through the existing path (the system action itself is removed, agents drop the account on next sync), which is the safety property we rely on instead.

`syncTtyUserAction` no longer emits `AssignmentCreated` — delivery is purely permission-derived. Existing TTY actions keep their stale assignments harmlessly; the new resolver source covers them.

## Tests

- `TestStartTerminal_AdminUnassigned` — handler fix; admin can start a session on an unassigned device.
- `TestResolveActions_TTYPermissionSource_DirectRole` — TTY ships when `StartTerminal` is directly granted.
- `TestResolveActions_TTYPermissionSource_ViaUserGroup` — same, via group → role → permission chain.
- `TestResolveActions_TTYPermissionSource_NoPermissionExcluded` — linked-but-unprivileged user does NOT ship a TTY action (the cleanup-safety property).
- `TestResolveActions_TTYPermissionSource_DedupesAcrossRoles` — direct + group grants of the same permission collapse to one row.

All pass against testcontainers Postgres locally; existing resolution / terminal / registration suites unchanged.

## Audit/history note

New TTY actions stop emitting `AssignmentCreated`. That's an intentional semantic change in line with the design (delivery is permission-derived, not assignment-derived); the link to the user via `system_tty_action_id` and the action-creation event itself remain auditable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Permission-derived TTY actions added so authorized users can start terminals on unassigned devices.

* **Bug Fixes**
  * TTY linking no longer emits assignment events.
  * Device-not-found messaging simplified.
  * Device-level exclusions no longer block permission-derived TTY actions.
  * StartTerminal authorization now respects unified user filtering.

* **Tests**
  * Added coverage for permission-sourced TTY resolution, deduplication, failure propagation, and terminal starts for unassigned devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->