### PR TITLE
feat: resolve uninstall assignment mode

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -27,4 +27,7 @@ knowledge_base:
     scope: auto
   linked_repositories:
     - repository: manchtools/power-manage-sdk
-    - repository: manchtools/power-manage-agent
+      instructions: >
+        Primary upstream dependency for server wire contracts. Use this
+        repository to validate proto compatibility, enum semantics, and shared
+        SDK API expectations when reviewing server changes.

--- a/internal/api/assignment_handler_test.go
+++ b/internal/api/assignment_handler_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
+const uninstallAssignmentMode = 3
+
 func TestCreateAssignment_ActionToDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
@@ -56,6 +58,27 @@ func TestCreateAssignment_SetToGroup(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "action_set", resp.Msg.Assignment.SourceType)
 	assert.Equal(t, "device_group", resp.Msg.Assignment.TargetType)
+}
+
+func TestCreateAssignment_UninstallMode(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Uninstall Assign Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+	deviceID := testutil.CreateTestDevice(t, st, "assign-uninstall-host")
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
+		SourceType: "action",
+		SourceId:   actionID,
+		TargetType: "device",
+		TargetId:   deviceID,
+		Mode:       pm.AssignmentMode(uninstallAssignmentMode),
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, pm.AssignmentMode(uninstallAssignmentMode), resp.Msg.Assignment.Mode)
 }
 
 func TestCreateAssignment_Idempotent(t *testing.T) {

--- a/internal/api/internal_handler_test.go
+++ b/internal/api/internal_handler_test.go
@@ -104,6 +104,25 @@ func TestProxySyncActions_WithAssignment(t *testing.T) {
 	assert.Equal(t, actionID, resp.Msg.Actions[0].Id.Value)
 }
 
+func TestProxySyncActions_UninstallAssignmentForcesAbsent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "sync-uninstall-host")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Sync Uninstall Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID, uninstallAssignmentMode)
+
+	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Actions, 1)
+	assert.Equal(t, actionID, resp.Msg.Actions[0].Id.Value)
+	assert.Equal(t, pm.DesiredState_DESIRED_STATE_ABSENT, resp.Msg.Actions[0].DesiredState)
+}
+
 func TestProxyStoreLuksKey(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	enc := testutil.NewEncryptor(t)

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
+const uninstallAssignmentMode = 3
+
 func TestResolveActions_DeviceLayerOnly(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -170,6 +172,133 @@ func TestResolveActions_MergeDeviceAndUserActions(t *testing.T) {
 	}
 	assert.True(t, ids[actionDev])
 	assert.True(t, ids[actionUser])
+}
+
+func TestResolveActions_DeviceUninstallForcesAbsent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Uninstall Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+	deviceID := testutil.CreateTestDevice(t, st, "resolve-uninstall")
+
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID, uninstallAssignmentMode)
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, actions, 1)
+	assert.Equal(t, actionID, actions[0].ID)
+	assert.Equal(t, int32(pm.DesiredState_DESIRED_STATE_ABSENT), actions[0].DesiredState)
+}
+
+func TestResolveActions_UserUninstallForcesAbsent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ownerID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	actionID := testutil.CreateTestAction(t, st, adminID, "User Uninstall Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+	deviceID := testutil.CreateTestDevice(t, st, "resolve-user-uninstall")
+
+	testutil.AssignDeviceToUser(t, st, adminID, deviceID, ownerID)
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "user", ownerID, uninstallAssignmentMode)
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, actions, 1)
+	assert.Equal(t, actionID, actions[0].ID)
+	assert.Equal(t, int32(pm.DesiredState_DESIRED_STATE_ABSENT), actions[0].DesiredState)
+}
+
+func TestResolveActions_ActionSetUninstallForcesAllMembersAbsent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "resolve-set-uninstall")
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Uninstall Set")
+	presentActionID := testutil.CreateTestActionWithDesiredState(t, st, adminID, "Present Member", int(pm.ActionType_ACTION_TYPE_SHELL), int(pm.DesiredState_DESIRED_STATE_PRESENT))
+	absentActionID := testutil.CreateTestActionWithDesiredState(t, st, adminID, "Absent Member", int(pm.ActionType_ACTION_TYPE_SHELL), int(pm.DesiredState_DESIRED_STATE_ABSENT))
+
+	testutil.AddActionToTestSet(t, st, adminID, setID, presentActionID, 0)
+	testutil.AddActionToTestSet(t, st, adminID, setID, absentActionID, 1)
+	testutil.CreateTestAssignment(t, st, adminID, "action_set", setID, "device", deviceID, uninstallAssignmentMode)
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, actions, 2)
+	for _, action := range actions {
+		assert.Equal(t, int32(pm.DesiredState_DESIRED_STATE_ABSENT), action.DesiredState)
+	}
+}
+
+func TestResolveActions_DefinitionUninstallForcesAllMembersAbsent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "resolve-definition-uninstall")
+	definitionID := testutil.CreateTestDefinition(t, st, adminID, "Uninstall Definition")
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Definition Set")
+	presentActionID := testutil.CreateTestActionWithDesiredState(t, st, adminID, "Definition Present Member", int(pm.ActionType_ACTION_TYPE_SHELL), int(pm.DesiredState_DESIRED_STATE_PRESENT))
+	absentActionID := testutil.CreateTestActionWithDesiredState(t, st, adminID, "Definition Absent Member", int(pm.ActionType_ACTION_TYPE_SHELL), int(pm.DesiredState_DESIRED_STATE_ABSENT))
+
+	testutil.AddActionToTestSet(t, st, adminID, setID, presentActionID, 0)
+	testutil.AddActionToTestSet(t, st, adminID, setID, absentActionID, 1)
+	testutil.AddActionSetToTestDefinition(t, st, adminID, definitionID, setID, 0)
+	testutil.CreateTestAssignment(t, st, adminID, "definition", definitionID, "device", deviceID, uninstallAssignmentMode)
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, actions, 2)
+	for _, action := range actions {
+		assert.Equal(t, int32(pm.DesiredState_DESIRED_STATE_ABSENT), action.DesiredState)
+	}
+}
+
+func TestResolveActions_ExcludedBeatsUninstallAtSamePriority(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Excluded Beats Uninstall", int(pm.ActionType_ACTION_TYPE_SHELL))
+	deviceID := testutil.CreateTestDevice(t, st, "resolve-excluded-beats-uninstall")
+	groupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Uninstall Conflict Group")
+	testutil.AddDeviceToTestGroup(t, st, adminID, groupID, deviceID)
+
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID, uninstallAssignmentMode)
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device_group", groupID, int(pm.AssignmentMode_ASSIGNMENT_MODE_EXCLUDED))
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	assert.Len(t, actions, 0)
+}
+
+func TestResolveActions_UninstallBeatsRequiredAtSamePriority(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Uninstall Beats Required", int(pm.ActionType_ACTION_TYPE_SHELL))
+	deviceID := testutil.CreateTestDevice(t, st, "resolve-uninstall-beats-required")
+	groupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Required Conflict Group")
+	testutil.AddDeviceToTestGroup(t, st, adminID, groupID, deviceID)
+
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID, int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device_group", groupID, uninstallAssignmentMode)
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, actions, 1)
+	assert.Equal(t, int32(pm.DesiredState_DESIRED_STATE_ABSENT), actions[0].DesiredState)
+}
+
+func TestResolveActions_HigherPriorityRequiredBeatsLowerPriorityUninstall(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestActionWithDesiredState(t, st, adminID, "Priority Winner", int(pm.ActionType_ACTION_TYPE_SHELL), int(pm.DesiredState_DESIRED_STATE_PRESENT))
+	deviceID := testutil.CreateTestDevice(t, st, "resolve-priority-wins")
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Lower Priority Set")
+	definitionID := testutil.CreateTestDefinition(t, st, adminID, "Lower Priority Definition")
+
+	testutil.AddActionToTestSet(t, st, adminID, setID, actionID, 0)
+	testutil.AddActionSetToTestDefinition(t, st, adminID, definitionID, setID, 0)
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID, int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
+	testutil.CreateTestAssignment(t, st, adminID, "definition", definitionID, "device", deviceID, uninstallAssignmentMode)
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, actions, 1)
+	assert.Equal(t, actionID, actions[0].ID)
+	assert.Equal(t, int32(pm.DesiredState_DESIRED_STATE_PRESENT), actions[0].DesiredState)
 }
 
 // Test that user assignment works via the handler (CreateAssignment + GetUserAssignments)

--- a/internal/store/generated/assignments.sql.go
+++ b/internal/store/generated/assignments.sql.go
@@ -914,12 +914,13 @@ effective AS (
     created_at, created_by, is_deleted, projection_version,
     signature, params_canonical, schedule,
     CASE
-      WHEN bool_or(mode = 2) THEN -1                           -- excluded: don't apply this action
-      WHEN bool_or(mode = 0) THEN 0                            -- required: apply
-      WHEN bool_or(mode = 1 AND user_selected = TRUE) THEN 0   -- available+selected �� apply
-      WHEN bool_or(mode = 1 AND user_selected = FALSE) THEN -1 -- available+rejected → skip
-      ELSE -1                                                    -- unselected available → skip
-    END AS effective_mode,
+      WHEN bool_or(mode = 2) THEN FALSE
+      WHEN bool_or(mode = 3) THEN TRUE
+      WHEN bool_or(mode = 0) THEN TRUE
+      WHEN bool_or(mode = 1 AND user_selected = TRUE) THEN TRUE
+      ELSE FALSE
+    END AS should_apply,
+    bool_or(mode = 3) AS force_absent,
     MIN(assignment_sort) AS assignment_sort,
     MIN(definition_sort) AS definition_sort,
     MIN(action_set_sort) AS action_set_sort,
@@ -929,11 +930,12 @@ effective AS (
            created_at, created_by, is_deleted, projection_version,
            signature, params_canonical, schedule
 )
-SELECT id, name, description, action_type, desired_state,
+SELECT id, name, description, action_type,
+  (CASE WHEN force_absent THEN 1 ELSE desired_state END)::INTEGER AS desired_state,
   params, timeout_seconds, created_at, created_by, is_deleted,
   projection_version, signature, params_canonical, schedule
 FROM effective
-WHERE effective_mode >= 0
+WHERE should_apply
 ORDER BY assignment_sort, definition_sort, action_set_sort, action_sort, id
 `
 
@@ -956,14 +958,16 @@ type ListResolvedActionsForDeviceRow struct {
 
 // Get all resolved actions for a device with conflict resolution.
 // This is used by the agent sync to determine what actions to apply.
-// Conflict resolution: excluded (2) > required (0) > available+selected > available+rejected > unselected (skip)
+// Conflict resolution: excluded (2) > uninstall (3) > required (0) >
+// available+selected > available+rejected > unselected (skip)
 // Resolution priority: action > action_set > definition
-// Within each level: excluded > required > available
+// Within each level: excluded > uninstall > required > available
 // Join with user selections for available assignments
 // Find the highest priority source level for each action
 // Filter to only keep assignments at the highest priority level for each action
-// Resolve conflicts per action at the winning priority level: excluded > required > available
-// Return actions that should be applied, using action's stored desired_state
+// Resolve conflicts per action at the winning priority level:
+// excluded > uninstall > required > available
+// Return actions that should be applied, forcing ABSENT for UNINSTALL.
 func (q *Queries) ListResolvedActionsForDevice(ctx context.Context, targetID string) ([]ListResolvedActionsForDeviceRow, error) {
 	rows, err := q.db.Query(ctx, listResolvedActionsForDevice, targetID)
 	if err != nil {
@@ -1261,12 +1265,13 @@ effective AS (
     created_at, created_by, is_deleted, projection_version,
     signature, params_canonical, schedule,
     CASE
-      WHEN bool_or(mode = 2) THEN -1
-      WHEN bool_or(mode = 0) THEN 0
-      WHEN bool_or(mode = 1 AND user_selected = TRUE) THEN 0
-      WHEN bool_or(mode = 1 AND user_selected = FALSE) THEN -1
-      ELSE -1
-    END AS effective_mode,
+      WHEN bool_or(mode = 2) THEN FALSE
+      WHEN bool_or(mode = 3) THEN TRUE
+      WHEN bool_or(mode = 0) THEN TRUE
+      WHEN bool_or(mode = 1 AND user_selected = TRUE) THEN TRUE
+      ELSE FALSE
+    END AS should_apply,
+    bool_or(mode = 3) AS force_absent,
     MIN(assignment_sort) AS assignment_sort,
     MIN(definition_sort) AS definition_sort,
     MIN(action_set_sort) AS action_set_sort,
@@ -1276,11 +1281,12 @@ effective AS (
            created_at, created_by, is_deleted, projection_version,
            signature, params_canonical, schedule
 )
-SELECT id, name, description, action_type, desired_state,
+SELECT id, name, description, action_type,
+  (CASE WHEN force_absent THEN 1 ELSE desired_state END)::INTEGER AS desired_state,
   params, timeout_seconds, created_at, created_by, is_deleted,
   projection_version, signature, params_canonical, schedule
 FROM effective
-WHERE effective_mode >= 0
+WHERE should_apply
 ORDER BY assignment_sort, definition_sort, action_set_sort, action_sort, id
 `
 

--- a/internal/store/queries/assignments.sql
+++ b/internal/store/queries/assignments.sql
@@ -212,10 +212,11 @@ ORDER BY assignment_sort, definition_sort, action_set_sort, action_sort, id;
 
 -- Get all resolved actions for a device with conflict resolution.
 -- This is used by the agent sync to determine what actions to apply.
--- Conflict resolution: excluded (2) > required (0) > available+selected > available+rejected > unselected (skip)
+-- Conflict resolution: excluded (2) > uninstall (3) > required (0) >
+-- available+selected > available+rejected > unselected (skip)
 -- name: ListResolvedActionsForDevice :many
 -- Resolution priority: action > action_set > definition
--- Within each level: excluded > required > available
+-- Within each level: excluded > uninstall > required > available
 WITH all_assignments AS (
   -- Direct action assignments (source_priority = 1, highest)
   SELECT
@@ -411,19 +412,21 @@ filtered AS (
   FROM with_selections ws
   JOIN priority_per_action ppa ON ws.id = ppa.id AND ws.source_priority = ppa.min_priority
 ),
--- Resolve conflicts per action at the winning priority level: excluded > required > available
+-- Resolve conflicts per action at the winning priority level:
+-- excluded > uninstall > required > available
 effective AS (
   SELECT
     id, name, description, action_type, desired_state, params, timeout_seconds,
     created_at, created_by, is_deleted, projection_version,
     signature, params_canonical, schedule,
     CASE
-      WHEN bool_or(mode = 2) THEN -1                           -- excluded: don't apply this action
-      WHEN bool_or(mode = 0) THEN 0                            -- required: apply
-      WHEN bool_or(mode = 1 AND user_selected = TRUE) THEN 0   -- available+selected �� apply
-      WHEN bool_or(mode = 1 AND user_selected = FALSE) THEN -1 -- available+rejected → skip
-      ELSE -1                                                    -- unselected available → skip
-    END AS effective_mode,
+      WHEN bool_or(mode = 2) THEN FALSE
+      WHEN bool_or(mode = 3) THEN TRUE
+      WHEN bool_or(mode = 0) THEN TRUE
+      WHEN bool_or(mode = 1 AND user_selected = TRUE) THEN TRUE
+      ELSE FALSE
+    END AS should_apply,
+    bool_or(mode = 3) AS force_absent,
     MIN(assignment_sort) AS assignment_sort,
     MIN(definition_sort) AS definition_sort,
     MIN(action_set_sort) AS action_set_sort,
@@ -433,12 +436,13 @@ effective AS (
            created_at, created_by, is_deleted, projection_version,
            signature, params_canonical, schedule
 )
--- Return actions that should be applied, using action's stored desired_state
-SELECT id, name, description, action_type, desired_state,
+-- Return actions that should be applied, forcing ABSENT for UNINSTALL.
+SELECT id, name, description, action_type,
+  (CASE WHEN force_absent THEN 1 ELSE desired_state END)::INTEGER AS desired_state,
   params, timeout_seconds, created_at, created_by, is_deleted,
   projection_version, signature, params_canonical, schedule
 FROM effective
-WHERE effective_mode >= 0
+WHERE should_apply
 ORDER BY assignment_sort, definition_sort, action_set_sort, action_sort, id;
 
 -- Get action IDs that are EXCLUDED at the device/device_group layer.
@@ -701,12 +705,13 @@ effective AS (
     created_at, created_by, is_deleted, projection_version,
     signature, params_canonical, schedule,
     CASE
-      WHEN bool_or(mode = 2) THEN -1
-      WHEN bool_or(mode = 0) THEN 0
-      WHEN bool_or(mode = 1 AND user_selected = TRUE) THEN 0
-      WHEN bool_or(mode = 1 AND user_selected = FALSE) THEN -1
-      ELSE -1
-    END AS effective_mode,
+      WHEN bool_or(mode = 2) THEN FALSE
+      WHEN bool_or(mode = 3) THEN TRUE
+      WHEN bool_or(mode = 0) THEN TRUE
+      WHEN bool_or(mode = 1 AND user_selected = TRUE) THEN TRUE
+      ELSE FALSE
+    END AS should_apply,
+    bool_or(mode = 3) AS force_absent,
     MIN(assignment_sort) AS assignment_sort,
     MIN(definition_sort) AS definition_sort,
     MIN(action_set_sort) AS action_set_sort,
@@ -716,11 +721,12 @@ effective AS (
            created_at, created_by, is_deleted, projection_version,
            signature, params_canonical, schedule
 )
-SELECT id, name, description, action_type, desired_state,
+SELECT id, name, description, action_type,
+  (CASE WHEN force_absent THEN 1 ELSE desired_state END)::INTEGER AS desired_state,
   params, timeout_seconds, created_at, created_by, is_deleted,
   projection_version, signature, params_canonical, schedule
 FROM effective
-WHERE effective_mode >= 0
+WHERE should_apply
 ORDER BY assignment_sort, definition_sort, action_set_sort, action_sort, id;
 
 -- Get all assignments targeting a user directly or via their user groups.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -136,6 +136,12 @@ func CreateTestDevice(t *testing.T, st *store.Store, hostname string) string {
 // CreateTestAction creates an action via events and returns the action ID.
 func CreateTestAction(t *testing.T, st *store.Store, actorID, name string, actionType int) string {
 	t.Helper()
+	return CreateTestActionWithDesiredState(t, st, actorID, name, actionType, 0)
+}
+
+// CreateTestActionWithDesiredState creates an action via events with an explicit desired_state.
+func CreateTestActionWithDesiredState(t *testing.T, st *store.Store, actorID, name string, actionType, desiredState int) string {
+	t.Helper()
 	ctx := context.Background()
 	id := NewID()
 
@@ -146,6 +152,7 @@ func CreateTestAction(t *testing.T, st *store.Store, actorID, name string, actio
 		Data: map[string]any{
 			"name":            name,
 			"action_type":     actionType,
+			"desired_state":   desiredState,
 			"params":          map[string]any{},
 			"timeout_seconds": 300,
 		},
@@ -448,6 +455,26 @@ func AssignDeviceToUser(t *testing.T, st *store.Store, actorID, deviceID, userID
 	}
 }
 
+// AddDeviceToTestGroup adds a device to a device group via events.
+func AddDeviceToTestGroup(t *testing.T, st *store.Store, actorID, groupID, deviceID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	err := st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group",
+		StreamID:   groupID,
+		EventType:  "DeviceGroupMemberAdded",
+		Data: map[string]any{
+			"device_id": deviceID,
+		},
+		ActorType: "user",
+		ActorID:   actorID,
+	})
+	if err != nil {
+		t.Fatalf("add device to test group: %v", err)
+	}
+}
+
 // CreateTestAssignment creates an assignment via events and returns its ID.
 func CreateTestAssignment(t *testing.T, st *store.Store, actorID, sourceType, sourceID, targetType, targetID string, mode int) string {
 	t.Helper()
@@ -473,6 +500,48 @@ func CreateTestAssignment(t *testing.T, st *store.Store, actorID, sourceType, so
 	}
 
 	return id
+}
+
+// AddActionToTestSet adds an action to an action set via events.
+func AddActionToTestSet(t *testing.T, st *store.Store, actorID, setID, actionID string, sortOrder int) {
+	t.Helper()
+	ctx := context.Background()
+
+	err := st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set",
+		StreamID:   setID,
+		EventType:  "ActionSetMemberAdded",
+		Data: map[string]any{
+			"action_id":  actionID,
+			"sort_order": sortOrder,
+		},
+		ActorType: "user",
+		ActorID:   actorID,
+	})
+	if err != nil {
+		t.Fatalf("add action to test set: %v", err)
+	}
+}
+
+// AddActionSetToTestDefinition adds an action set to a definition via events.
+func AddActionSetToTestDefinition(t *testing.T, st *store.Store, actorID, definitionID, actionSetID string, sortOrder int) {
+	t.Helper()
+	ctx := context.Background()
+
+	err := st.AppendEvent(ctx, store.Event{
+		StreamType: "definition",
+		StreamID:   definitionID,
+		EventType:  "DefinitionMemberAdded",
+		Data: map[string]any{
+			"action_set_id": actionSetID,
+			"sort_order":    sortOrder,
+		},
+		ActorType: "user",
+		ActorID:   actorID,
+	})
+	if err != nil {
+		t.Fatalf("add action set to test definition: %v", err)
+	}
 }
 
 // NewEncryptor creates an Encryptor with a test key.
@@ -555,12 +624,12 @@ func CreateTestIdentityProvider(t *testing.T, st *store.Store, enc *crypto.Encry
 			"name":                    name,
 			"slug":                    slug,
 			"provider_type":           "oidc",
-			"client_id":              "test-client-id",
+			"client_id":               "test-client-id",
 			"client_secret_encrypted": encSecret,
-			"issuer_url":             "https://idp.example.com",
-			"scopes":                 []string{"openid", "profile", "email"},
-			"auto_create_users":      false,
-			"auto_link_by_email":     false,
+			"issuer_url":              "https://idp.example.com",
+			"scopes":                  []string{"openid", "profile", "email"},
+			"auto_create_users":       false,
+			"auto_link_by_email":      false,
 		},
 		ActorType: "user",
 		ActorID:   actorID,


### PR DESCRIPTION
## Summary
Add support for assignment mode `3` in action resolution so uninstall assignments stay on the normal assignment path but force resolved actions to `DESIRED_STATE_ABSENT`.

This keeps the existing precedence rules intact:
- `EXCLUDED` wins over `UNINSTALL`
- `UNINSTALL` wins over `REQUIRED`
- higher source priority still wins over lower source priority

## Dependency
Blocked on companion SDK PR manchtools/power-manage-sdk#39 merging first.

## Testing
- `go test ./internal/resolution ./internal/api -run 'TestResolveActions_(DeviceUninstallForcesAbsent|UserUninstallForcesAbsent|ActionSetUninstallForcesAllMembersAbsent|DefinitionUninstallForcesAllMembersAbsent|ExcludedBeatsUninstallAtSamePriority|UninstallBeatsRequiredAtSamePriority|HigherPriorityRequiredBeatsLowerPriorityUninstall)$|TestProxySyncActions_UninstallAssignmentForcesAbsent$|TestCreateAssignment_UninstallMode$' -count=1`

## Related
- Implements #26
- Companion SDK PR: manchtools/power-manage-sdk#39
- Companion web PR: manchtools/power-manage-web#8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for uninstall assignments with comprehensive conflict-resolution semantics.
  * Uninstall assignments force targeted actions to an absent/disabled state.
  * Priority-aware conflict resolution: REQUIRED, EXCLUDED and uninstall interact predictably so higher-priority rules prevail.

* **Tests**
  * Expanded test coverage verifying uninstall behavior across assignment sources, layers, and precedence scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->