### PR TITLE
feat: UNINSTALL assignment mode

### DIFF
--- a/internal/api/assignment_handler_test.go
+++ b/internal/api/assignment_handler_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
-const uninstallAssignmentMode = 3
+const uninstallAssignmentMode = int(pm.AssignmentMode_ASSIGNMENT_MODE_UNINSTALL)
 
 func TestCreateAssignment_ActionToDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
-const uninstallAssignmentMode = 3
+const uninstallAssignmentMode = int(pm.AssignmentMode_ASSIGNMENT_MODE_UNINSTALL)
 
 func TestResolveActions_DeviceLayerOnly(t *testing.T) {
 	st := testutil.SetupPostgres(t)

--- a/internal/store/generated/assignments.sql.go
+++ b/internal/store/generated/assignments.sql.go
@@ -614,6 +614,11 @@ HAVING bool_or(mode = 2)
 
 // Get action IDs that are EXCLUDED at the device/device_group layer.
 // Used by the resolution merge to block these actions from the user layer.
+// Only EXCLUDED (mode = 2) blocks the action from the user layer.
+// UNINSTALL (mode = 3) is deliberately NOT included here: an UNINSTALL assignment
+// must still resolve at the device layer (with desired_state forced to ABSENT)
+// so the action runs and removes managed state. Treating UNINSTALL as exclusion
+// would suppress the removal entirely.
 func (q *Queries) ListDeviceLayerExcludedActionIDs(ctx context.Context, targetID string) ([]string, error) {
 	rows, err := q.db.Query(ctx, listDeviceLayerExcludedActionIDs, targetID)
 	if err != nil {
@@ -846,7 +851,10 @@ WITH all_assignments AS (
 
   UNION ALL
 
-  -- Actions via compliance policy assignments (direct to device, source_priority = 4)
+  -- Actions via compliance policy assignments (direct to device, source_priority = 4).
+  -- Compliance policies do not support assignment modes; mode is always REQUIRED (0).
+  -- UNINSTALL (3) is intentionally not applicable here — compliance rules express
+  -- "this state must hold", which has no removal semantics.
   SELECT
     a.id, a.name, a.description, a.action_type, a.desired_state, a.params, a.timeout_seconds,
     a.created_at, a.created_by, a.is_deleted, a.projection_version,
@@ -868,7 +876,8 @@ WITH all_assignments AS (
 
   UNION ALL
 
-  -- Actions via compliance policy assignments (via device group, source_priority = 4)
+  -- Actions via compliance policy assignments (via device group, source_priority = 4).
+  -- See note above: compliance policies have no UNINSTALL semantics; mode is always 0.
   SELECT
     a.id, a.name, a.description, a.action_type, a.desired_state, a.params, a.timeout_seconds,
     a.created_at, a.created_by, a.is_deleted, a.projection_version,

--- a/internal/store/queries/assignments.sql
+++ b/internal/store/queries/assignments.sql
@@ -347,7 +347,10 @@ WITH all_assignments AS (
 
   UNION ALL
 
-  -- Actions via compliance policy assignments (direct to device, source_priority = 4)
+  -- Actions via compliance policy assignments (direct to device, source_priority = 4).
+  -- Compliance policies do not support assignment modes; mode is always REQUIRED (0).
+  -- UNINSTALL (3) is intentionally not applicable here — compliance rules express
+  -- "this state must hold", which has no removal semantics.
   SELECT
     a.id, a.name, a.description, a.action_type, a.desired_state, a.params, a.timeout_seconds,
     a.created_at, a.created_by, a.is_deleted, a.projection_version,
@@ -369,7 +372,8 @@ WITH all_assignments AS (
 
   UNION ALL
 
-  -- Actions via compliance policy assignments (via device group, source_priority = 4)
+  -- Actions via compliance policy assignments (via device group, source_priority = 4).
+  -- See note above: compliance policies have no UNINSTALL semantics; mode is always 0.
   SELECT
     a.id, a.name, a.description, a.action_type, a.desired_state, a.params, a.timeout_seconds,
     a.created_at, a.created_by, a.is_deleted, a.projection_version,
@@ -535,6 +539,11 @@ dev_filtered AS (
   FROM dev_assignments da
   JOIN dev_priority dp ON da.action_id = dp.action_id AND da.source_priority = dp.min_priority
 )
+-- Only EXCLUDED (mode = 2) blocks the action from the user layer.
+-- UNINSTALL (mode = 3) is deliberately NOT included here: an UNINSTALL assignment
+-- must still resolve at the device layer (with desired_state forced to ABSENT)
+-- so the action runs and removes managed state. Treating UNINSTALL as exclusion
+-- would suppress the removal entirely.
 SELECT action_id AS id FROM dev_filtered
 GROUP BY action_id
 HAVING bool_or(mode = 2);


### PR DESCRIPTION
## Summary

Implements `ASSIGNMENT_MODE_UNINSTALL = 3` (manchtools/power-manage-server#26). When an assignment is in UNINSTALL mode, the resolution layer forces every action's `desired_state` to `ABSENT`, regardless of the per-action configured value. The agent receives flat resolved actions and needs no changes.

## Changes

- **Proto**: `ASSIGNMENT_MODE_UNINSTALL = 3` in `common.proto` + Go/TS codegen.
- **Resolution**: device-layer and user-layer queries honor the new mode via `bool_or(mode = 3) AS force_absent` and a `CASE WHEN force_absent THEN 1 ELSE desired_state END` override. Priority order: `EXCLUDED > UNINSTALL > REQUIRED > AVAILABLE`.
- **Tests**: device, user-layer, action-set cascade, definition cascade, and full priority truth table.
- **Web**: 4th option in the assignment-mode dropdown with destructive-style badge; en/de i18n keys.
- **SQL clarifications** (last commit): comments on the two spots that look like missing UNINSTALL coverage but are deliberate (compliance policies have no removal semantics; `ListDeviceLayerExcludedActionIDs` keeps mode = 3 out so it resolves with forced ABSENT instead of being suppressed). Tests now reference the proto enum instead of the magic number 3.

## Mutation model

Assignments are immutable after creation. To change mode (including REQUIRED → UNINSTALL), delete and recreate the assignment. No update RPC, no in-place edit, no mode-change audit UI by design.

## Test plan

- [x] `go test ./server/internal/resolution/...`
- [x] `go test ./server/internal/api/...`
- [x] `go vet ./server/...`
- [x] Manual: assign action set with mode=3 → web UI shows destructive badge → device receives action with `desired_state = ABSENT`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test cases to use generated enum values instead of hardcoded constants for improved reliability.

* **Chores**
  * Enhanced internal documentation to clarify assignment mode behavior and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->