### PR TITLE
chore: remove coderabbit linked_repositories

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -25,9 +25,3 @@ reviews:
 knowledge_base:
   learnings:
     scope: auto
-  linked_repositories:
-    - repository: manchtools/power-manage-sdk
-      instructions: >
-        Primary upstream dependency for server wire contracts. Use this
-        repository to validate proto compatibility, enum semantics, and shared
-        SDK API expectations when reviewing server changes.


### PR DESCRIPTION
CodeRabbit's current plan tier allows 0 linked repositories. The configured cross-repo reference to `power-manage-sdk` was being silently dropped on every review with a warning. Removing the block to stop the noise.

Same change going out on `power-manage-sdk` and `power-manage-agent`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

No user-visible changes. This release contains internal configuration updates only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->