### PR TITLE
feat: deferred dispatch + cancel execution (#57)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260503094624-92988e4a7115
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260503122520-778f885ac65e

--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260502221138-995a7814adeb
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260503094624-92988e4a7115

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260503094624-92988e4a7115 h1:u/TjulX16qeglbCD266E/JpCcbvqJNSi6oiPd8zvfX8=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260503094624-92988e4a7115/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260503122520-778f885ac65e h1:n9MGfcqLOsamGsG5dSsMiytSjywTJVBZXoRkqCT77TI=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260503122520-778f885ac65e/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260502221138-995a7814adeb h1:NxY+2F95GqfkUZiG8Bux5wR09wWmid+0tceOgEatgIw=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260502221138-995a7814adeb/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260503094624-92988e4a7115 h1:u/TjulX16qeglbCD266E/JpCcbvqJNSi6oiPd8zvfX8=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260503094624-92988e4a7115/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/hibiken/asynq"
@@ -908,6 +909,19 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 
 	id := ulid.Make().String()
 
+	// Compute the deferred-dispatch delay. RunAt is optional; when set
+	// it must be strictly in the future at scheduling time per the
+	// proto contract (a past timestamp would race the deferred-vs-
+	// immediate decision below).
+	var dispatchDelay time.Duration
+	if req.Msg.RunAt != nil {
+		dispatchAt := req.Msg.RunAt.AsTime()
+		dispatchDelay = time.Until(dispatchAt)
+		if dispatchDelay <= 0 {
+			return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "run_at must be in the future")
+		}
+	}
+
 	eventData := map[string]any{
 		"device_id":       req.Msg.DeviceId,
 		"action_type":     int32(actionType),
@@ -917,6 +931,16 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 	}
 	if actionID != nil {
 		eventData["action_id"] = *actionID
+	}
+	if dispatchDelay > 0 {
+		eventData["scheduled_for"] = req.Msg.RunAt.AsTime().UTC().Format(time.RFC3339Nano)
+	}
+	// respect_maintenance_window is reserved for #58; persist it so the
+	// dispatch path picks the right behaviour once the window
+	// enforcement layer ships, even on event replay of records written
+	// before #58 lands.
+	if req.Msg.RespectMaintenanceWindow {
+		eventData["respect_maintenance_window"] = true
 	}
 
 	// Fail fast when no task queue is configured. Without this
@@ -973,10 +997,18 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 	signature = sig
 	paramsCanonical = paramsJSON
 
+	// Choose ExecutionScheduled vs ExecutionCreated based on whether
+	// the caller asked for a deferred dispatch. The two events are
+	// projected to status='scheduled' / status='pending' respectively
+	// and the row only diverges from there on the dispatch's outcome.
+	initialEventType := "ExecutionCreated"
+	if dispatchDelay > 0 {
+		initialEventType = "ExecutionScheduled"
+	}
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "execution",
 		StreamID:   id,
-		EventType:  "ExecutionCreated",
+		EventType:  initialEventType,
 		Data:       eventData,
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -989,8 +1021,17 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 	// state so the projection reflects reality. Silently returning
 	// success used to leave the row as `pending` indefinitely.
 	//
+	// For deferred dispatches the asynq.TaskID is set to the execution
+	// id so CancelExecution can prune the scheduled task by that id.
+	// asynq.ProcessIn schedules the worker to pick the task up after
+	// dispatchDelay rather than immediately.
+	//
 	// h.aqClient is guaranteed non-nil here — the precondition check
 	// at the top of DispatchAction rejects the call otherwise.
+	enqueueOpts := []asynq.Option{asynq.MaxRetry(5)}
+	if dispatchDelay > 0 {
+		enqueueOpts = append(enqueueOpts, asynq.TaskID(id), asynq.ProcessIn(dispatchDelay))
+	}
 	if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
 		ExecutionID:     id,
 		ActionType:      int32(actionType),
@@ -999,7 +1040,7 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		TimeoutSeconds:  timeoutSeconds,
 		Signature:       signature,
 		ParamsCanonical: paramsCanonical,
-	}, asynq.MaxRetry(5)); err != nil {
+	}, enqueueOpts...); err != nil {
 		h.logger.Error("failed to enqueue action dispatch; emitting ExecutionFailed",
 			"error", err, "execution_id", id)
 		// Append a compensating ExecutionFailed event so the row
@@ -1405,12 +1446,28 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 
 	id := ulid.Make().String()
 
+	// Same deferred-dispatch handling as DispatchAction: optional
+	// future RunAt switches the path from immediate to scheduled.
+	var dispatchDelay time.Duration
+	if req.Msg.RunAt != nil {
+		dispatchDelay = time.Until(req.Msg.RunAt.AsTime())
+		if dispatchDelay <= 0 {
+			return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "run_at must be in the future")
+		}
+	}
+
 	eventData := map[string]any{
 		"device_id":       req.Msg.DeviceId,
 		"action_type":     int32(req.Msg.InstantAction),
 		"desired_state":   int32(pm.DesiredState_DESIRED_STATE_PRESENT),
 		"params":          map[string]any{},
 		"timeout_seconds": timeoutSeconds,
+	}
+	if dispatchDelay > 0 {
+		eventData["scheduled_for"] = req.Msg.RunAt.AsTime().UTC().Format(time.RFC3339Nano)
+	}
+	if req.Msg.RespectMaintenanceWindow {
+		eventData["respect_maintenance_window"] = true
 	}
 
 	// Fail fast when no task queue is configured — same fail-closed
@@ -1420,10 +1477,14 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeFailedPrecondition, "instant dispatch unavailable: task queue not configured")
 	}
 
+	initialEventType := "ExecutionCreated"
+	if dispatchDelay > 0 {
+		initialEventType = "ExecutionScheduled"
+	}
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "execution",
 		StreamID:   id,
-		EventType:  "ExecutionCreated",
+		EventType:  initialEventType,
 		Data:       eventData,
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -1437,13 +1498,17 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 	// terminal `failed` state — otherwise the projection sits in
 	// `pending` forever and the operator has no idea why the
 	// reboot/sync never happened.
+	enqueueOpts := []asynq.Option{asynq.MaxRetry(3)}
+	if dispatchDelay > 0 {
+		enqueueOpts = append(enqueueOpts, asynq.TaskID(id), asynq.ProcessIn(dispatchDelay))
+	}
 	if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
 		ExecutionID:    id,
 		ActionType:     int32(req.Msg.InstantAction),
 		DesiredState:   int32(pm.DesiredState_DESIRED_STATE_PRESENT),
 		Params:         json.RawMessage("{}"),
 		TimeoutSeconds: timeoutSeconds,
-	}, asynq.MaxRetry(3)); err != nil {
+	}, enqueueOpts...); err != nil {
 		h.logger.Error("failed to enqueue instant action dispatch; emitting ExecutionFailed",
 			"error", err, "execution_id", id)
 		if failErr := appendEvent(ctx, h.store, h.logger, store.Event{
@@ -1476,6 +1541,76 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 	)
 
 	return connect.NewResponse(&pm.DispatchInstantActionResponse{
+		Execution: h.executionToProto(exec),
+	}), nil
+}
+
+// CancelExecution prunes a scheduled or pending dispatch before it
+// fires. Idempotent: an execution that already left the SCHEDULED /
+// PENDING window is returned as-is (the projection's WHEN-clause on
+// ExecutionCancelled also guards against overwriting a real outcome
+// after the dispatch has run). See manchtools/power-manage-server#57.
+func (h *ActionHandler) CancelExecution(ctx context.Context, req *connect.Request[pm.CancelExecutionRequest]) (*connect.Response[pm.CancelExecutionResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
+	userCtx, err := requireAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	exec, err := h.store.Queries().GetExecutionByID(ctx, req.Msg.ExecutionId)
+	if err != nil {
+		return nil, handleGetError(ctx, err, ErrExecutionNotFound, "execution not found")
+	}
+
+	// Cancel only acts on rows that haven't dispatched yet. Past that
+	// point the execution either is running on the agent or has
+	// already reached a terminal state — both of which the cancel
+	// must NOT overwrite. Return the row as-is so the caller can
+	// observe the actual status and decide what to do.
+	if exec.Status != "scheduled" && exec.Status != "pending" {
+		return connect.NewResponse(&pm.CancelExecutionResponse{
+			Execution: h.executionToProto(exec),
+		}), nil
+	}
+
+	// Best-effort prune of the deferred Asynq task. A miss is fine —
+	// the projection's WHEN-clause guards the cancel event against
+	// double-application, so an in-flight dispatch that beat the
+	// inspector here will still surface its real outcome.
+	if h.aqClient != nil {
+		if delErr := h.aqClient.DeleteScheduledDeviceTask(exec.DeviceID, exec.ID); delErr != nil {
+			h.logger.Warn("CancelExecution: asynq prune failed; emitting ExecutionCancelled anyway",
+				"execution_id", exec.ID, "device_id", exec.DeviceID, "error", delErr)
+		}
+	}
+
+	if err := appendEvent(ctx, h.store, h.logger, store.Event{
+		StreamType: "execution",
+		StreamID:   exec.ID,
+		EventType:  "ExecutionCancelled",
+		Data:       map[string]any{},
+		ActorType:  "user",
+		ActorID:    userCtx.ID,
+	}, "failed to cancel execution"); err != nil {
+		return nil, err
+	}
+
+	exec, err = h.store.Queries().GetExecutionByID(ctx, req.Msg.ExecutionId)
+	if err != nil {
+		h.logger.Error("CancelExecution: failed to refetch execution after cancel", "execution_id", req.Msg.ExecutionId, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to read execution after cancel")
+	}
+
+	h.logger.Info("execution cancelled",
+		"execution_id", exec.ID,
+		"device_id", exec.DeviceID,
+		"actor_id", userCtx.ID,
+	)
+
+	return connect.NewResponse(&pm.CancelExecutionResponse{
 		Execution: h.executionToProto(exec),
 	}), nil
 }
@@ -1740,6 +1875,10 @@ func (h *ActionHandler) executionToProto(e db.ExecutionsProjection) *pm.ActionEx
 		exec.CompletedAt = timestamppb.New(*e.CompletedAt)
 	}
 
+	if e.ScheduledFor != nil {
+		exec.ScheduledFor = timestamppb.New(*e.ScheduledFor)
+	}
+
 	exec.Compliant = e.Compliant
 	if len(e.DetectionOutput) > 0 {
 		var detOutput pm.CommandOutput
@@ -1763,6 +1902,10 @@ func statusToString(s pm.ExecutionStatus) string {
 		return "failed"
 	case pm.ExecutionStatus_EXECUTION_STATUS_TIMEOUT:
 		return "timeout"
+	case pm.ExecutionStatus_EXECUTION_STATUS_SCHEDULED:
+		return "scheduled"
+	case pm.ExecutionStatus_EXECUTION_STATUS_CANCELLED:
+		return "cancelled"
 	default:
 		return ""
 	}
@@ -1782,6 +1925,10 @@ func stringToStatus(s string) pm.ExecutionStatus {
 		return pm.ExecutionStatus_EXECUTION_STATUS_FAILED
 	case "timeout":
 		return pm.ExecutionStatus_EXECUTION_STATUS_TIMEOUT
+	case "scheduled":
+		return pm.ExecutionStatus_EXECUTION_STATUS_SCHEDULED
+	case "cancelled":
+		return pm.ExecutionStatus_EXECUTION_STATUS_CANCELLED
 	default:
 		return pm.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED
 	}

--- a/internal/api/action_handler_test.go
+++ b/internal/api/action_handler_test.go
@@ -3,10 +3,12 @@ package api_test
 import (
 	"log/slog"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/api"
@@ -324,6 +326,88 @@ func TestGetExecution(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, dispatchResp.Msg.Execution.Id, resp.Msg.Execution.Id)
 	assert.Equal(t, deviceID, resp.Msg.Execution.DeviceId)
+}
+
+// TestDispatchAction_DeferredEmitsScheduled verifies that a future
+// run_at switches the dispatch path to ExecutionScheduled and
+// asynq.ProcessIn — execution surfaces with status=SCHEDULED and a
+// scheduled_for timestamp populated from the request.
+func TestDispatchAction_DeferredEmitsScheduled(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	queue := &api.NoOpEnqueuer{}
+	h.SetTaskQueueClient(queue)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Deferred", int(pm.ActionType_ACTION_TYPE_SHELL))
+	deviceID := testutil.CreateTestDevice(t, st, "deferred-host")
+	ctx := testutil.AdminContext(adminID)
+
+	runAt := time.Now().Add(2 * time.Hour).UTC()
+	resp, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId:     deviceID,
+		ActionSource: &pm.DispatchActionRequest_ActionId{ActionId: actionID},
+		RunAt:        timestamppb.New(runAt),
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, pm.ExecutionStatus_EXECUTION_STATUS_SCHEDULED, resp.Msg.Execution.Status)
+	require.NotNil(t, resp.Msg.Execution.ScheduledFor)
+	assert.WithinDuration(t, runAt, resp.Msg.Execution.ScheduledFor.AsTime(), time.Second)
+	require.Len(t, queue.DeviceCalls, 1)
+}
+
+// TestDispatchAction_DeferredPastRunAtRejected confirms validation
+// rejects a run_at in the past with InvalidArgument.
+func TestDispatchAction_DeferredPastRunAtRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Past", int(pm.ActionType_ACTION_TYPE_SHELL))
+	deviceID := testutil.CreateTestDevice(t, st, "past-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId:     deviceID,
+		ActionSource: &pm.DispatchActionRequest_ActionId{ActionId: actionID},
+		RunAt:        timestamppb.New(time.Now().Add(-1 * time.Hour).UTC()),
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// TestCancelExecution_CancelsScheduled verifies that cancelling a
+// SCHEDULED execution moves the projection to CANCELLED and prunes
+// the deferred Asynq task.
+func TestCancelExecution_CancelsScheduled(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	queue := &api.NoOpEnqueuer{}
+	h.SetTaskQueueClient(queue)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Cancel Me", int(pm.ActionType_ACTION_TYPE_SHELL))
+	deviceID := testutil.CreateTestDevice(t, st, "cancel-host")
+	ctx := testutil.AdminContext(adminID)
+
+	dispatch, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId:     deviceID,
+		ActionSource: &pm.DispatchActionRequest_ActionId{ActionId: actionID},
+		RunAt:        timestamppb.New(time.Now().Add(2 * time.Hour).UTC()),
+	}))
+	require.NoError(t, err)
+	require.Equal(t, pm.ExecutionStatus_EXECUTION_STATUS_SCHEDULED, dispatch.Msg.Execution.Status)
+
+	cancelResp, err := h.CancelExecution(ctx, connect.NewRequest(&pm.CancelExecutionRequest{
+		ExecutionId: dispatch.Msg.Execution.Id,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, pm.ExecutionStatus_EXECUTION_STATUS_CANCELLED, cancelResp.Msg.Execution.Status)
+
+	require.Len(t, queue.DeleteCalls, 1)
+	assert.Equal(t, deviceID, queue.DeleteCalls[0].DeviceID)
+	assert.Equal(t, dispatch.Msg.Execution.Id, queue.DeleteCalls[0].TaskID)
 }
 
 func TestDispatchInstantAction(t *testing.T) {

--- a/internal/api/noop_enqueuer_test.go
+++ b/internal/api/noop_enqueuer_test.go
@@ -27,6 +27,10 @@ type NoOpEnqueuer struct {
 	// by a mutex: tests do not run dispatch concurrently in the
 	// same handler under current fixtures.
 	DeviceCalls []NoOpEnqueuerCall
+	// DeleteCalls records each DeleteScheduledDeviceTask invocation.
+	// Tests for CancelExecution assert against this slice to verify
+	// the cancel path attempted the Asynq prune.
+	DeleteCalls []NoOpEnqueuerDelete
 }
 
 // NoOpEnqueuerCall captures the arguments of one EnqueueToDevice.
@@ -34,14 +38,22 @@ type NoOpEnqueuerCall struct {
 	DeviceID string
 	TaskType string
 	Payload  any
+	Opts     []asynq.Option
+}
+
+// NoOpEnqueuerDelete captures one DeleteScheduledDeviceTask invocation.
+type NoOpEnqueuerDelete struct {
+	DeviceID string
+	TaskID   string
 }
 
 // EnqueueToDevice records and succeeds.
-func (n *NoOpEnqueuer) EnqueueToDevice(deviceID, taskType string, payload any, _ ...asynq.Option) error {
+func (n *NoOpEnqueuer) EnqueueToDevice(deviceID, taskType string, payload any, opts ...asynq.Option) error {
 	n.DeviceCalls = append(n.DeviceCalls, NoOpEnqueuerCall{
 		DeviceID: deviceID,
 		TaskType: taskType,
 		Payload:  payload,
+		Opts:     opts,
 	})
 	return nil
 }
@@ -51,3 +63,13 @@ func (*NoOpEnqueuer) EnqueueToControl(_ string, _ any) error { return nil }
 
 // EnqueueToSearch is a no-op.
 func (*NoOpEnqueuer) EnqueueToSearch(_ string, _ any) error { return nil }
+
+// DeleteScheduledDeviceTask records the call and succeeds, mirroring
+// production's idempotent best-effort contract.
+func (n *NoOpEnqueuer) DeleteScheduledDeviceTask(deviceID, taskID string) error {
+	n.DeleteCalls = append(n.DeleteCalls, NoOpEnqueuerDelete{
+		DeviceID: deviceID,
+		TaskID:   taskID,
+	})
+	return nil
+}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -509,6 +509,10 @@ func (s *ControlService) DispatchInstantAction(ctx context.Context, req *connect
 	return s.action.DispatchInstantAction(ctx, req)
 }
 
+func (s *ControlService) CancelExecution(ctx context.Context, req *connect.Request[pm.CancelExecutionRequest]) (*connect.Response[pm.CancelExecutionResponse], error) {
+	return s.action.CancelExecution(ctx, req)
+}
+
 func (s *ControlService) GetExecution(ctx context.Context, req *connect.Request[pm.GetExecutionRequest]) (*connect.Response[pm.GetExecutionResponse], error) {
 	return s.action.GetExecution(ctx, req)
 }

--- a/internal/store/generated/actions.sql.go
+++ b/internal/store/generated/actions.sql.go
@@ -166,7 +166,7 @@ func (q *Queries) GetActionNamesByIDs(ctx context.Context, dollar_1 []string) ([
 
 const getExecutionByID = `-- name: GetExecutionByID :one
 
-SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output FROM executions_projection
+SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output, scheduled_for FROM executions_projection
 WHERE id = $1
 `
 
@@ -196,6 +196,7 @@ func (q *Queries) GetExecutionByID(ctx context.Context, id string) (ExecutionsPr
 		&i.Changed,
 		&i.Compliant,
 		&i.DetectionOutput,
+		&i.ScheduledFor,
 	)
 	return i, err
 }
@@ -261,7 +262,7 @@ func (q *Queries) ListActions(ctx context.Context, arg ListActionsParams) ([]Act
 }
 
 const listExecutions = `-- name: ListExecutions :many
-SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output FROM executions_projection
+SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output, scheduled_for FROM executions_projection
 WHERE ($1::TEXT = '' OR device_id = $1)
   AND ($2::TEXT = '' OR status = $2)
   AND ($3::INTEGER = 0 OR action_type = $3)
@@ -321,6 +322,7 @@ func (q *Queries) ListExecutions(ctx context.Context, arg ListExecutionsParams) 
 			&i.Changed,
 			&i.Compliant,
 			&i.DetectionOutput,
+			&i.ScheduledFor,
 		); err != nil {
 			return nil, err
 		}
@@ -333,7 +335,7 @@ func (q *Queries) ListExecutions(ctx context.Context, arg ListExecutionsParams) 
 }
 
 const listExecutionsForWarm = `-- name: ListExecutionsForWarm :many
-SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output FROM executions_projection
+SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output, scheduled_for FROM executions_projection
 WHERE created_at >= NOW() - INTERVAL '90 days'
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
@@ -375,6 +377,7 @@ func (q *Queries) ListExecutionsForWarm(ctx context.Context, arg ListExecutionsF
 			&i.Changed,
 			&i.Compliant,
 			&i.DetectionOutput,
+			&i.ScheduledFor,
 		); err != nil {
 			return nil, err
 		}
@@ -387,7 +390,7 @@ func (q *Queries) ListExecutionsForWarm(ctx context.Context, arg ListExecutionsF
 }
 
 const listPendingExecutionsForDevice = `-- name: ListPendingExecutionsForDevice :many
-SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output FROM executions_projection
+SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output, scheduled_for FROM executions_projection
 WHERE device_id = $1 AND status IN ('pending', 'dispatched')
 ORDER BY created_at ASC
 `
@@ -425,6 +428,7 @@ func (q *Queries) ListPendingExecutionsForDevice(ctx context.Context, deviceID s
 			&i.Changed,
 			&i.Compliant,
 			&i.DetectionOutput,
+			&i.ScheduledFor,
 		); err != nil {
 			return nil, err
 		}
@@ -437,7 +441,7 @@ func (q *Queries) ListPendingExecutionsForDevice(ctx context.Context, deviceID s
 }
 
 const listRecentExecutionsForDevice = `-- name: ListRecentExecutionsForDevice :many
-SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output FROM executions_projection
+SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output, scheduled_for FROM executions_projection
 WHERE device_id = $1
 ORDER BY created_at DESC
 LIMIT $2
@@ -479,6 +483,7 @@ func (q *Queries) ListRecentExecutionsForDevice(ctx context.Context, arg ListRec
 			&i.Changed,
 			&i.Compliant,
 			&i.DetectionOutput,
+			&i.ScheduledFor,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/generated/models.go
+++ b/internal/store/generated/models.go
@@ -247,6 +247,7 @@ type ExecutionsProjection struct {
 	Changed           bool       `json:"changed"`
 	Compliant         bool       `json:"compliant"`
 	DetectionOutput   []byte     `json:"detection_output"`
+	ScheduledFor      *time.Time `json:"scheduled_for"`
 }
 
 type IdentityLinksProjection struct {

--- a/internal/store/migrations/013_execution_scheduled_cancelled.sql
+++ b/internal/store/migrations/013_execution_scheduled_cancelled.sql
@@ -1,0 +1,236 @@
+-- One-shot scheduled dispatch + cancel
+--
+-- Adds the projection plumbing for the new executions states introduced
+-- by the deferred-dispatch feature (manchtools/power-manage-server#57):
+--
+--   * scheduled — execution row exists, deferred Asynq task is queued
+--     to fire at scheduled_for. Created by DispatchAction /
+--     DispatchInstantAction when their RunAt option is set.
+--   * cancelled — operator pruned a SCHEDULED or PENDING dispatch via
+--     CancelExecution before it fired.
+--
+-- A new `scheduled_for TIMESTAMPTZ NULL` column on executions_projection
+-- carries the scheduled timestamp so the UI can show "fires in N hours"
+-- on the execution-history list.
+--
+-- Two new event types are projected:
+--   * ExecutionScheduled — sets status='scheduled', scheduled_for=run_at.
+--   * ExecutionCancelled — sets status='cancelled', completed_at=event.occurred_at.
+
+-- +goose Up
+
+ALTER TABLE executions_projection
+    ADD COLUMN scheduled_for TIMESTAMPTZ NULL;
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_execution_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'ExecutionCreated' THEN
+            INSERT INTO executions_projection (
+                id, device_id, action_id, action_type, desired_state,
+                params, timeout_seconds, status, created_at,
+                created_by_type, created_by_id, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'device_id',
+                COALESCE(event.data->>'action_id', event.data->>'definition_id'),
+                (event.data->>'action_type')::INTEGER,
+                COALESCE((event.data->>'desired_state')::INTEGER, 0),
+                COALESCE(event.data->'params', '{}'),
+                COALESCE((event.data->>'timeout_seconds')::INTEGER, 300),
+                'pending',
+                COALESCE((event.data->>'executed_at')::TIMESTAMPTZ, event.occurred_at),
+                event.actor_type,
+                event.actor_id,
+                event.sequence_num
+            );
+
+        WHEN 'ExecutionScheduled' THEN
+            INSERT INTO executions_projection (
+                id, device_id, action_id, action_type, desired_state,
+                params, timeout_seconds, status, scheduled_for, created_at,
+                created_by_type, created_by_id, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'device_id',
+                COALESCE(event.data->>'action_id', event.data->>'definition_id'),
+                (event.data->>'action_type')::INTEGER,
+                COALESCE((event.data->>'desired_state')::INTEGER, 0),
+                COALESCE(event.data->'params', '{}'),
+                COALESCE((event.data->>'timeout_seconds')::INTEGER, 300),
+                'scheduled',
+                (event.data->>'scheduled_for')::TIMESTAMPTZ,
+                event.occurred_at,
+                event.actor_type,
+                event.actor_id,
+                event.sequence_num
+            );
+
+        WHEN 'ExecutionDispatched' THEN
+            UPDATE executions_projection
+            SET status = 'dispatched',
+                dispatched_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionStarted' THEN
+            UPDATE executions_projection
+            SET status = 'running',
+                started_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionCompleted' THEN
+            UPDATE executions_projection
+            SET status = 'success',
+                completed_at = COALESCE((event.data->>'completed_at')::TIMESTAMPTZ, event.occurred_at),
+                output = event.data->'output',
+                duration_ms = (event.data->>'duration_ms')::BIGINT,
+                changed = COALESCE((event.data->>'changed')::BOOLEAN, TRUE),
+                compliant = COALESCE((event.data->>'compliant')::BOOLEAN, FALSE),
+                detection_output = event.data->'detection_output',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionFailed' THEN
+            UPDATE executions_projection
+            SET status = 'failed',
+                completed_at = COALESCE((event.data->>'completed_at')::TIMESTAMPTZ, event.occurred_at),
+                error = event.data->>'error',
+                output = event.data->'output',
+                duration_ms = (event.data->>'duration_ms')::BIGINT,
+                changed = COALESCE((event.data->>'changed')::BOOLEAN, TRUE),
+                compliant = COALESCE((event.data->>'compliant')::BOOLEAN, FALSE),
+                detection_output = event.data->'detection_output',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionTimedOut' THEN
+            UPDATE executions_projection
+            SET status = 'timeout',
+                completed_at = COALESCE((event.data->>'completed_at')::TIMESTAMPTZ, event.occurred_at),
+                error = event.data->>'error',
+                output = event.data->'output',
+                duration_ms = (event.data->>'duration_ms')::BIGINT,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionSkipped' THEN
+            UPDATE executions_projection
+            SET status = 'skipped',
+                completed_at = event.occurred_at,
+                error = event.data->>'reason',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionCancelled' THEN
+            -- Cancel only moves a row that's still SCHEDULED or PENDING.
+            -- A cancel arriving after the dispatch has fired (RUNNING /
+            -- terminal status) is a documented no-op so the projection
+            -- doesn't overwrite a real outcome with the cancellation.
+            UPDATE executions_projection
+            SET status = 'cancelled',
+                completed_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id
+              AND status IN ('scheduled', 'pending');
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_execution_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'ExecutionCreated' THEN
+            INSERT INTO executions_projection (
+                id, device_id, action_id, action_type, desired_state,
+                params, timeout_seconds, status, created_at,
+                created_by_type, created_by_id, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'device_id',
+                COALESCE(event.data->>'action_id', event.data->>'definition_id'),
+                (event.data->>'action_type')::INTEGER,
+                COALESCE((event.data->>'desired_state')::INTEGER, 0),
+                COALESCE(event.data->'params', '{}'),
+                COALESCE((event.data->>'timeout_seconds')::INTEGER, 300),
+                'pending',
+                COALESCE((event.data->>'executed_at')::TIMESTAMPTZ, event.occurred_at),
+                event.actor_type,
+                event.actor_id,
+                event.sequence_num
+            );
+
+        WHEN 'ExecutionDispatched' THEN
+            UPDATE executions_projection
+            SET status = 'dispatched',
+                dispatched_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionStarted' THEN
+            UPDATE executions_projection
+            SET status = 'running',
+                started_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionCompleted' THEN
+            UPDATE executions_projection
+            SET status = 'success',
+                completed_at = COALESCE((event.data->>'completed_at')::TIMESTAMPTZ, event.occurred_at),
+                output = event.data->'output',
+                duration_ms = (event.data->>'duration_ms')::BIGINT,
+                changed = COALESCE((event.data->>'changed')::BOOLEAN, TRUE),
+                compliant = COALESCE((event.data->>'compliant')::BOOLEAN, FALSE),
+                detection_output = event.data->'detection_output',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionFailed' THEN
+            UPDATE executions_projection
+            SET status = 'failed',
+                completed_at = COALESCE((event.data->>'completed_at')::TIMESTAMPTZ, event.occurred_at),
+                error = event.data->>'error',
+                output = event.data->'output',
+                duration_ms = (event.data->>'duration_ms')::BIGINT,
+                changed = COALESCE((event.data->>'changed')::BOOLEAN, TRUE),
+                compliant = COALESCE((event.data->>'compliant')::BOOLEAN, FALSE),
+                detection_output = event.data->'detection_output',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionTimedOut' THEN
+            UPDATE executions_projection
+            SET status = 'timeout',
+                completed_at = COALESCE((event.data->>'completed_at')::TIMESTAMPTZ, event.occurred_at),
+                error = event.data->>'error',
+                output = event.data->'output',
+                duration_ms = (event.data->>'duration_ms')::BIGINT,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ExecutionSkipped' THEN
+            UPDATE executions_projection
+            SET status = 'skipped',
+                completed_at = event.occurred_at,
+                error = event.data->>'reason',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+ALTER TABLE executions_projection DROP COLUMN scheduled_for;

--- a/internal/taskqueue/client.go
+++ b/internal/taskqueue/client.go
@@ -2,6 +2,7 @@ package taskqueue
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/hibiken/asynq"
@@ -18,11 +19,19 @@ type Enqueuer interface {
 	EnqueueToDevice(deviceID, taskType string, payload any, opts ...asynq.Option) error
 	EnqueueToControl(taskType string, payload any) error
 	EnqueueToSearch(taskType string, payload any) error
+	// DeleteScheduledDeviceTask removes a scheduled or pending task
+	// from a device's queue by its asynq TaskID. Used by
+	// CancelExecution to prune deferred dispatches before they fire.
+	// Best-effort: returns nil if the task is not found (already
+	// fired, already cancelled, or never existed) so the cancel path
+	// stays idempotent.
+	DeleteScheduledDeviceTask(deviceID, taskID string) error
 }
 
 // Client wraps asynq.Client for enqueuing tasks to device and control queues.
 type Client struct {
-	client *asynq.Client
+	client    *asynq.Client
+	inspector *asynq.Inspector
 }
 
 // Compile-time check that *Client satisfies Enqueuer. A drift here
@@ -31,12 +40,15 @@ var _ Enqueuer = (*Client)(nil)
 
 // NewClient creates a new task queue client connected to Valkey.
 func NewClient(addr, password string, db int) *Client {
-	client := asynq.NewClient(asynq.RedisClientOpt{
+	opts := asynq.RedisClientOpt{
 		Addr:     addr,
 		Password: password,
 		DB:       db,
-	})
-	return &Client{client: client}
+	}
+	return &Client{
+		client:    asynq.NewClient(opts),
+		inspector: asynq.NewInspector(opts),
+	}
 }
 
 // EnqueueToDevice enqueues a task to a device-specific queue.
@@ -100,7 +112,37 @@ func (c *Client) EnqueueToSearch(taskType string, payload any) error {
 	return nil
 }
 
+// DeleteScheduledDeviceTask removes a scheduled or pending task from
+// a device's queue by its asynq TaskID. Used by CancelExecution to
+// prune deferred dispatches before they fire. Best-effort: returns
+// nil if the task is not found in either the scheduled or pending
+// list (already fired, already cancelled, never existed) so the
+// cancel path stays idempotent.
+//
+// asynq.Inspector.DeleteTask returns asynq.ErrTaskNotFound when the
+// task isn't in the specified queue+state; we swallow that and let
+// the caller observe the projection's actual status to decide what
+// happened.
+func (c *Client) DeleteScheduledDeviceTask(deviceID, taskID string) error {
+	queue := DeviceQueue(deviceID)
+	err := c.inspector.DeleteTask(queue, taskID)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, asynq.ErrTaskNotFound) || errors.Is(err, asynq.ErrQueueNotFound) {
+		return nil
+	}
+	return fmt.Errorf("delete task %s in %s: %w", taskID, queue, err)
+}
+
 // Close closes the underlying Asynq client connection.
 func (c *Client) Close() error {
+	if err := c.inspector.Close(); err != nil {
+		// Inspector close errors are non-fatal — the underlying
+		// connection is shared with the client which we still close
+		// below. Log via the returned error from client.Close so the
+		// caller sees the more authoritative failure.
+		_ = err
+	}
 	return c.client.Close()
 }


### PR DESCRIPTION
## Summary

Server half of [manchtools/power-manage-server#57](https://github.com/manchtools/power-manage-server/issues/57) — one-shot scheduled dispatch. Built on the SDK contract from [sdk #42](https://github.com/manchtools/power-manage-sdk/pull/42) (run_at + respect_maintenance_window on dispatch RPCs, CancelExecution RPC, SCHEDULED + CANCELLED execution statuses) and [sdk #43](https://github.com/manchtools/power-manage-sdk/pull/43) (scheduled_for on ActionExecution).

## Changes

### Migration `013_execution_scheduled_cancelled.sql`

- Adds `scheduled_for TIMESTAMPTZ NULL` to `executions_projection`.
- Two new event arms in `project_execution_event`:
  - **`ExecutionScheduled`** inserts a row with `status='scheduled'` and `scheduled_for` set from the event payload.
  - **`ExecutionCancelled`** moves a row from `status='scheduled'`/`'pending'` to `'cancelled'` with `completed_at=event.occurred_at`. The `WHEN` clause guards against overwriting a row that already reached a terminal state (the cancel arrived after the dispatch fired).

### `taskqueue.Enqueuer` extended

- New `DeleteScheduledDeviceTask(deviceID, taskID)` method. `Client` gains an `asynq.Inspector` alongside the existing `asynq.Client`; the delete is best-effort (`ErrTaskNotFound` / `ErrQueueNotFound` swallowed so the cancel path stays idempotent).

### Dispatch handlers extended

`DispatchAction` and `DispatchInstantAction` gain the deferred path. When `req.Msg.RunAt` is set:
- Validates run_at is strictly in the future (`InvalidArgument` otherwise).
- Switches the initial event from `ExecutionCreated` to `ExecutionScheduled` (with `scheduled_for` in the payload).
- Adds `asynq.TaskID(executionID)` + `asynq.ProcessIn(delay)` to the enqueue options. `TaskID` enables `CancelExecution` to prune by id.
- Persists `respect_maintenance_window` on the event payload for replay correctness even though the maintenance-window enforcement layer doesn't ship until #58.

### New `CancelExecution` handler

- Idempotent: returns the execution as-is when status is anything other than `scheduled`/`pending`. The projection's `WHEN` clause is the second line of defense.
- Best-effort Asynq prune via `DeleteScheduledDeviceTask`, then emits `ExecutionCancelled`.

### Other plumbing

- `statusToString` / `stringToStatus` extended for the new `SCHEDULED` + `CANCELLED` enum values.
- `ControlService` delegates the new `CancelExecution` RPC to `ActionHandler`.
- `executionToProto` surfaces the `scheduled_for` column.
- `NoOpEnqueuer` test helper gains `DeleteScheduledDeviceTask` + records `Opts` on `EnqueueToDevice` so the new tests can assert `ProcessIn` was applied and the delete reached the right `(deviceID, taskID)`.

## Test plan

- [x] `go build ./server/...` clean
- [x] `go vet ./server/...` clean
- [x] `TestDispatchAction_DeferredEmitsScheduled` — future `run_at` → SCHEDULED + `scheduled_for` populated, single enqueue call.
- [x] `TestDispatchAction_DeferredPastRunAtRejected` — past `run_at` → InvalidArgument.
- [x] `TestCancelExecution_CancelsScheduled` — schedule then cancel → status=CANCELLED, `DeleteScheduledDeviceTask` called with the right identifiers.
- [x] All existing dispatch + execution tests still pass.

Refs manchtools/power-manage-server#57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for scheduling actions to execute at a future time using a `RunAt` parameter.
  * Added ability to cancel scheduled or pending executions.
  * Scheduled executions now display their scheduled timestamp.

* **Chores**
  * Updated dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->