### PR TITLE
feat: per-group maintenance windows (#58)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260503122520-778f885ac65e
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-a3dd8bc45112

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260503122520-778f885ac65e h1:n9MGfcqLOsamGsG5dSsMiytSjywTJVBZXoRkqCT77TI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260503122520-778f885ac65e/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-a3dd8bc45112 h1:PMlIH3nqUmyQ+1aa8odJuBZDgtkB1QUd/ZDB+OMiRhI=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-a3dd8bc45112/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/maintenance"
 	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -594,6 +595,52 @@ func (h *DeviceGroupHandler) SetDeviceGroupSyncInterval(ctx context.Context, req
 	}), nil
 }
 
+// SetDeviceGroupMaintenanceWindow replaces the device group's
+// maintenance window. The agent ORs each reaching group's window
+// into a device-side union and gates non-instant action dispatch by
+// the result; passing an empty MaintenanceWindow clears the group's
+// contribution. See manchtools/power-manage-server#58.
+func (h *DeviceGroupHandler) SetDeviceGroupMaintenanceWindow(ctx context.Context, req *connect.Request[pm.SetDeviceGroupMaintenanceWindowRequest]) (*connect.Response[pm.UpdateDeviceGroupResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
+	userCtx, err := requireAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := maintenance.Validate(req.Msg.MaintenanceWindow); err != nil {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, err.Error())
+	}
+
+	if _, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id); err != nil {
+		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
+	}
+
+	if err := appendEvent(ctx, h.store, h.logger, store.Event{
+		StreamType: "device_group",
+		StreamID:   req.Msg.Id,
+		EventType:  "DeviceGroupMaintenanceWindowSet",
+		Data: map[string]any{
+			"maintenance_window": maintenanceWindowToMap(req.Msg.MaintenanceWindow),
+		},
+		ActorType: "user",
+		ActorID:   userCtx.ID,
+	}, "failed to set maintenance window"); err != nil {
+		return nil, err
+	}
+
+	group, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group")
+	}
+
+	return connect.NewResponse(&pm.UpdateDeviceGroupResponse{
+		Group: h.deviceGroupToProto(group),
+	}), nil
+}
+
 func (h *DeviceGroupHandler) deviceGroupToProto(g db.DeviceGroupsProjection) *pm.DeviceGroup {
 	group := &pm.DeviceGroup{
 		Id:                  g.ID,
@@ -603,6 +650,7 @@ func (h *DeviceGroupHandler) deviceGroupToProto(g db.DeviceGroupsProjection) *pm
 		CreatedBy:           g.CreatedBy,
 		IsDynamic:           g.IsDynamic,
 		SyncIntervalMinutes: g.SyncIntervalMinutes,
+		MaintenanceWindow:   maintenanceWindowFromJSON(g.MaintenanceWindow),
 	}
 
 	if g.DynamicQuery != nil {

--- a/internal/api/device_group_handler_test.go
+++ b/internal/api/device_group_handler_test.go
@@ -181,8 +181,11 @@ func TestSetDeviceGroupMaintenanceWindow(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	require.NotNil(t, resp.Msg.Group.MaintenanceWindow)
-	assert.Len(t, resp.Msg.Group.MaintenanceWindow.Schedule, 2)
+	require.Len(t, resp.Msg.Group.MaintenanceWindow.Schedule, 2)
+	assert.Equal(t, []string{"mon", "tue", "wed", "thu", "fri"}, resp.Msg.Group.MaintenanceWindow.Schedule[0].Days)
 	assert.Equal(t, "22:00-06:00", resp.Msg.Group.MaintenanceWindow.Schedule[0].Allow)
+	assert.Equal(t, []string{"sat", "sun"}, resp.Msg.Group.MaintenanceWindow.Schedule[1].Days)
+	assert.Equal(t, "00:00-23:59", resp.Msg.Group.MaintenanceWindow.Schedule[1].Allow)
 
 	// Clear the window — passing nil drops the schedule and the
 	// projection's COALESCE should restore the empty default.

--- a/internal/api/device_group_handler_test.go
+++ b/internal/api/device_group_handler_test.go
@@ -161,6 +161,59 @@ func TestSetDeviceGroupSyncInterval(t *testing.T) {
 	assert.Equal(t, int32(60), resp.Msg.Group.SyncIntervalMinutes)
 }
 
+func TestSetDeviceGroupMaintenanceWindow(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	groupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Window Group")
+	ctx := testutil.AdminContext(adminID)
+
+	// Set a window with two entries; the response carries the
+	// projected schedule as proto so we can assert round-trip
+	// fidelity end-to-end (handler → event → projector → query).
+	resp, err := h.SetDeviceGroupMaintenanceWindow(ctx, connect.NewRequest(&pm.SetDeviceGroupMaintenanceWindowRequest{
+		Id: groupID,
+		MaintenanceWindow: &pm.MaintenanceWindow{Schedule: []*pm.MaintenanceWindowEntry{
+			{Days: []string{"mon", "tue", "wed", "thu", "fri"}, Allow: "22:00-06:00"},
+			{Days: []string{"sat", "sun"}, Allow: "00:00-23:59"},
+		}},
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.Group.MaintenanceWindow)
+	assert.Len(t, resp.Msg.Group.MaintenanceWindow.Schedule, 2)
+	assert.Equal(t, "22:00-06:00", resp.Msg.Group.MaintenanceWindow.Schedule[0].Allow)
+
+	// Clear the window — passing nil drops the schedule and the
+	// projection's COALESCE should restore the empty default.
+	clearResp, err := h.SetDeviceGroupMaintenanceWindow(ctx, connect.NewRequest(&pm.SetDeviceGroupMaintenanceWindowRequest{
+		Id:                groupID,
+		MaintenanceWindow: nil,
+	}))
+	require.NoError(t, err)
+	assert.Nil(t, clearResp.Msg.Group.MaintenanceWindow,
+		"cleared window must surface as nil (no constraint)")
+}
+
+func TestSetDeviceGroupMaintenanceWindow_InvalidEntryRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	groupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Window Group Bad")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.SetDeviceGroupMaintenanceWindow(ctx, connect.NewRequest(&pm.SetDeviceGroupMaintenanceWindowRequest{
+		Id: groupID,
+		MaintenanceWindow: &pm.MaintenanceWindow{Schedule: []*pm.MaintenanceWindowEntry{
+			{Days: []string{"funday"}, Allow: "09:00-17:00"},
+		}},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
+		"validator should reject non-canonical weekday tokens at the boundary")
+}
+
 func TestValidateDynamicQuery(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewDeviceGroupHandler(st, slog.Default())

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -182,17 +182,37 @@ func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Req
 		})
 	}
 
+	// Resolved maintenance window across every group reaching the
+	// device. resolveMaintenanceWindowUnion returns nil when there is
+	// no constraint — the proto field stays unset so the agent skips
+	// the gate entirely. See manchtools/power-manage-server#58.
+	windowRows, err := h.store.Queries().ListMaintenanceWindowsForDevice(ctx, deviceID)
+	if err != nil {
+		h.logger.Warn("failed to load maintenance windows for sync; falling back to no constraint",
+			"device_id", deviceID, "error", err)
+	}
+	resolvedWindow := resolveMaintenanceWindowUnion(windowRows)
+
 	h.logger.Debug("proxy sync actions completed",
 		"device_id", deviceID,
 		"standalone_count", len(standalone),
 		"group_count", len(groups),
-		"sync_interval_minutes", syncInterval)
+		"sync_interval_minutes", syncInterval,
+		"window_entries", windowEntryCount(resolvedWindow))
 
 	return connect.NewResponse(&pm.SyncActionsResponse{
 		StandaloneActions:   standalone,
 		GroupedActions:      groups,
 		SyncIntervalMinutes: syncInterval,
+		MaintenanceWindow:   resolvedWindow,
 	}), nil
+}
+
+func windowEntryCount(w *pm.MaintenanceWindow) int {
+	if w == nil {
+		return 0
+	}
+	return len(w.GetSchedule())
 }
 
 // dbActionToWireAction converts a raw actions_projection row to wire

--- a/internal/api/maintenance_window.go
+++ b/internal/api/maintenance_window.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"encoding/json"
+
+	pmv1 "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/maintenance"
+)
+
+// maintenanceWindowToMap turns a proto MaintenanceWindow into the
+// JSONB shape stored on group projections. nil and empty windows
+// produce an empty map so the projector's COALESCE keeps the column
+// at its '{}' default — that way "clear the window" round-trips
+// through replay without leaving a residual schedule.
+func maintenanceWindowToMap(w *pmv1.MaintenanceWindow) map[string]any {
+	if w == nil || len(w.GetSchedule()) == 0 {
+		return map[string]any{}
+	}
+	entries := make([]map[string]any, 0, len(w.GetSchedule()))
+	for _, e := range w.GetSchedule() {
+		entries = append(entries, map[string]any{
+			"days":  e.GetDays(),
+			"allow": e.GetAllow(),
+		})
+	}
+	return map[string]any{"schedule": entries}
+}
+
+// maintenanceWindowFromJSON deserializes a JSONB column back into a
+// proto MaintenanceWindow. Empty/missing payloads return nil so the
+// caller can decide whether to surface "no window" vs. "empty
+// window" — both mean "no constraint" but the wire form prefers nil
+// to keep responses lean.
+func maintenanceWindowFromJSON(data []byte) *pmv1.MaintenanceWindow {
+	if len(data) == 0 {
+		return nil
+	}
+	var raw struct {
+		Schedule []struct {
+			Days  []string `json:"days"`
+			Allow string   `json:"allow"`
+		} `json:"schedule"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	if len(raw.Schedule) == 0 {
+		return nil
+	}
+	w := &pmv1.MaintenanceWindow{
+		Schedule: make([]*pmv1.MaintenanceWindowEntry, 0, len(raw.Schedule)),
+	}
+	for _, e := range raw.Schedule {
+		w.Schedule = append(w.Schedule, &pmv1.MaintenanceWindowEntry{
+			Days:  e.Days,
+			Allow: e.Allow,
+		})
+	}
+	return w
+}
+
+// resolveMaintenanceWindowUnion turns a slice of JSONB rows from
+// store.ListMaintenanceWindowsForDevice into the union the agent
+// will evaluate. Returns nil when the result is unconstrained — the
+// wire shape skips an empty MaintenanceWindow on the response.
+func resolveMaintenanceWindowUnion(rows [][]byte) *pmv1.MaintenanceWindow {
+	if len(rows) == 0 {
+		return nil
+	}
+	windows := make([]*pmv1.MaintenanceWindow, 0, len(rows))
+	for _, r := range rows {
+		w := maintenanceWindowFromJSON(r)
+		if w == nil {
+			// JSONB row with empty schedule contributes no constraint
+			// in the union; skip rather than collapsing to "always
+			// allowed" (the SQL pre-filter already drops empty rows).
+			continue
+		}
+		windows = append(windows, w)
+	}
+	if len(windows) == 0 {
+		return nil
+	}
+	out := maintenance.Union(windows...)
+	if out == nil || len(out.GetSchedule()) == 0 {
+		return nil
+	}
+	return out
+}

--- a/internal/api/maintenance_window_test.go
+++ b/internal/api/maintenance_window_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	pmv1 "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+func TestMaintenanceWindowToMap_NilOrEmpty(t *testing.T) {
+	if got := maintenanceWindowToMap(nil); len(got) != 0 {
+		t.Fatalf("nil window should produce empty map, got %v", got)
+	}
+	if got := maintenanceWindowToMap(&pmv1.MaintenanceWindow{}); len(got) != 0 {
+		t.Fatalf("empty window should produce empty map, got %v", got)
+	}
+}
+
+func TestMaintenanceWindowRoundTrip(t *testing.T) {
+	in := &pmv1.MaintenanceWindow{Schedule: []*pmv1.MaintenanceWindowEntry{
+		{Days: []string{"mon", "tue"}, Allow: "22:00-06:00"},
+		{Days: []string{"sat", "sun"}, Allow: "00:00-23:59"},
+	}}
+	asMap := maintenanceWindowToMap(in)
+	raw, err := json.Marshal(asMap)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	out := maintenanceWindowFromJSON(raw)
+	if out == nil {
+		t.Fatalf("expected non-nil round-trip, got nil")
+	}
+	if len(out.Schedule) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(out.Schedule))
+	}
+	if out.Schedule[0].Allow != "22:00-06:00" || out.Schedule[1].Allow != "00:00-23:59" {
+		t.Fatalf("ranges round-tripped wrong: %+v", out.Schedule)
+	}
+	if len(out.Schedule[0].Days) != 2 || out.Schedule[0].Days[0] != "mon" {
+		t.Fatalf("days round-tripped wrong: %+v", out.Schedule[0].Days)
+	}
+}
+
+func TestMaintenanceWindowFromJSON_EmptyAndMalformed(t *testing.T) {
+	if got := maintenanceWindowFromJSON(nil); got != nil {
+		t.Fatalf("nil bytes should yield nil, got %v", got)
+	}
+	if got := maintenanceWindowFromJSON([]byte("{}")); got != nil {
+		t.Fatalf("empty object should yield nil, got %v", got)
+	}
+	if got := maintenanceWindowFromJSON([]byte(`{"schedule":[]}`)); got != nil {
+		t.Fatalf("empty schedule should yield nil, got %v", got)
+	}
+	if got := maintenanceWindowFromJSON([]byte("not json")); got != nil {
+		t.Fatalf("malformed json should yield nil, got %v", got)
+	}
+}
+
+func TestResolveMaintenanceWindowUnion(t *testing.T) {
+	// Empty input → nil (no constraint).
+	if got := resolveMaintenanceWindowUnion(nil); got != nil {
+		t.Fatalf("nil rows should resolve to nil window, got %v", got)
+	}
+
+	// Two non-empty windows merge by concatenation.
+	w1 := []byte(`{"schedule":[{"days":["mon"],"allow":"22:00-06:00"}]}`)
+	w2 := []byte(`{"schedule":[{"days":["sat"],"allow":"00:00-23:59"}]}`)
+	got := resolveMaintenanceWindowUnion([][]byte{w1, w2})
+	if got == nil {
+		t.Fatalf("expected non-nil union, got nil")
+	}
+	if len(got.Schedule) != 2 {
+		t.Fatalf("expected 2 union entries, got %d", len(got.Schedule))
+	}
+
+	// One row is empty schedule — should be skipped, not collapse the
+	// union to "always allowed". The SQL pre-filter normally keeps
+	// these out, but Resolve must be defensive in case a future
+	// caller bypasses the filter.
+	wEmpty := []byte(`{}`)
+	got = resolveMaintenanceWindowUnion([][]byte{w1, wEmpty})
+	if got == nil {
+		t.Fatalf("non-empty + empty must keep the constraint, got nil")
+	}
+	if len(got.Schedule) != 1 {
+		t.Fatalf("empty row should be skipped, expected 1 entry, got %d", len(got.Schedule))
+	}
+
+	// All rows empty → nil.
+	if got := resolveMaintenanceWindowUnion([][]byte{wEmpty, wEmpty}); got != nil {
+		t.Fatalf("all-empty rows should resolve to nil, got %v", got)
+	}
+}

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -459,6 +459,10 @@ func (s *ControlService) SetDeviceGroupSyncInterval(ctx context.Context, req *co
 	return s.deviceGroup.SetDeviceGroupSyncInterval(ctx, req)
 }
 
+func (s *ControlService) SetDeviceGroupMaintenanceWindow(ctx context.Context, req *connect.Request[pm.SetDeviceGroupMaintenanceWindowRequest]) (*connect.Response[pm.UpdateDeviceGroupResponse], error) {
+	return s.deviceGroup.SetDeviceGroupMaintenanceWindow(ctx, req)
+}
+
 // Assignments
 func (s *ControlService) CreateAssignment(ctx context.Context, req *connect.Request[pm.CreateAssignmentRequest]) (*connect.Response[pm.CreateAssignmentResponse], error) {
 	return s.assignment.CreateAssignment(ctx, req)
@@ -663,6 +667,10 @@ func (s *ControlService) ValidateUserGroupQuery(ctx context.Context, req *connec
 
 func (s *ControlService) EvaluateDynamicUserGroup(ctx context.Context, req *connect.Request[pm.EvaluateDynamicUserGroupRequest]) (*connect.Response[pm.EvaluateDynamicUserGroupResponse], error) {
 	return s.userGroup.EvaluateDynamicUserGroup(ctx, req)
+}
+
+func (s *ControlService) SetUserGroupMaintenanceWindow(ctx context.Context, req *connect.Request[pm.SetUserGroupMaintenanceWindowRequest]) (*connect.Response[pm.UpdateUserGroupResponse], error) {
+	return s.userGroup.SetUserGroupMaintenanceWindow(ctx, req)
 }
 
 // Identity Providers

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/maintenance"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/search"
@@ -229,6 +230,54 @@ func (h *UserGroupHandler) UpdateUserGroup(ctx context.Context, req *connect.Req
 	roles, _ := h.store.Queries().GetUserGroupRoles(ctx, req.Msg.GroupId)
 
 	isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, req.Msg.GroupId)
+
+	return connect.NewResponse(&pm.UpdateUserGroupResponse{
+		Group: userGroupToProto(updated, roles, isScimManaged),
+	}), nil
+}
+
+// SetUserGroupMaintenanceWindow replaces the user group's
+// maintenance window. The agent unions every reaching group's window
+// (device groups + user groups assigned to the device) and gates
+// non-instant action dispatch by the result. Empty window clears the
+// group's contribution. See manchtools/power-manage-server#58.
+func (h *UserGroupHandler) SetUserGroupMaintenanceWindow(ctx context.Context, req *connect.Request[pm.SetUserGroupMaintenanceWindowRequest]) (*connect.Response[pm.UpdateUserGroupResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
+	userCtx, err := requireAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := maintenance.Validate(req.Msg.MaintenanceWindow); err != nil {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, err.Error())
+	}
+
+	if _, err := h.store.Queries().GetUserGroupByID(ctx, req.Msg.Id); err != nil {
+		return nil, handleGetError(ctx, err, ErrUserGroupNotFound, "user group not found")
+	}
+
+	if err := appendEvent(ctx, h.store, h.logger, store.Event{
+		StreamType: "user_group",
+		StreamID:   req.Msg.Id,
+		EventType:  "UserGroupMaintenanceWindowSet",
+		Data: map[string]any{
+			"maintenance_window": maintenanceWindowToMap(req.Msg.MaintenanceWindow),
+		},
+		ActorType: "user",
+		ActorID:   userCtx.ID,
+	}, "failed to set maintenance window"); err != nil {
+		return nil, err
+	}
+
+	updated, err := h.store.Queries().GetUserGroupByID(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to read user group")
+	}
+	roles, _ := h.store.Queries().GetUserGroupRoles(ctx, req.Msg.Id)
+	isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, req.Msg.Id)
 
 	return connect.NewResponse(&pm.UpdateUserGroupResponse{
 		Group: userGroupToProto(updated, roles, isScimManaged),
@@ -783,12 +832,13 @@ func (h *UserGroupHandler) bumpSessionVersionForGroupMembers(ctx context.Context
 // userGroupToProto converts a database user group projection to a protobuf UserGroup.
 func userGroupToProto(g db.UserGroupsProjection, roles []db.RolesProjection, isScimManaged bool) *pm.UserGroup {
 	group := &pm.UserGroup{
-		Id:            g.ID,
-		Name:          g.Name,
-		Description:   g.Description,
-		MemberCount:   g.MemberCount,
-		IsDynamic:     g.IsDynamic,
-		IsScimManaged: isScimManaged,
+		Id:                g.ID,
+		Name:              g.Name,
+		Description:       g.Description,
+		MemberCount:       g.MemberCount,
+		IsDynamic:         g.IsDynamic,
+		IsScimManaged:     isScimManaged,
+		MaintenanceWindow: maintenanceWindowFromJSON(g.MaintenanceWindow),
 	}
 
 	if g.DynamicQuery != nil {

--- a/internal/api/user_group_handler_test.go
+++ b/internal/api/user_group_handler_test.go
@@ -112,6 +112,50 @@ func TestUpdateUserGroup(t *testing.T) {
 	assert.Equal(t, "Updated description", resp.Msg.Group.Description)
 }
 
+func TestSetUserGroupMaintenanceWindow(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	groupID := testutil.CreateTestUserGroup(t, st, adminID, "Window UG")
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.SetUserGroupMaintenanceWindow(ctx, connect.NewRequest(&pm.SetUserGroupMaintenanceWindowRequest{
+		Id: groupID,
+		MaintenanceWindow: &pm.MaintenanceWindow{Schedule: []*pm.MaintenanceWindowEntry{
+			{Days: []string{"mon", "tue"}, Allow: "09:00-17:00"},
+		}},
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.Group.MaintenanceWindow)
+	assert.Len(t, resp.Msg.Group.MaintenanceWindow.Schedule, 1)
+	assert.Equal(t, "09:00-17:00", resp.Msg.Group.MaintenanceWindow.Schedule[0].Allow)
+
+	clearResp, err := h.SetUserGroupMaintenanceWindow(ctx, connect.NewRequest(&pm.SetUserGroupMaintenanceWindowRequest{
+		Id: groupID,
+	}))
+	require.NoError(t, err)
+	assert.Nil(t, clearResp.Msg.Group.MaintenanceWindow)
+}
+
+func TestSetUserGroupMaintenanceWindow_InvalidEntryRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	groupID := testutil.CreateTestUserGroup(t, st, adminID, "Bad Window UG")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.SetUserGroupMaintenanceWindow(ctx, connect.NewRequest(&pm.SetUserGroupMaintenanceWindowRequest{
+		Id: groupID,
+		MaintenanceWindow: &pm.MaintenanceWindow{Schedule: []*pm.MaintenanceWindowEntry{
+			{Days: []string{"mon"}, Allow: "09:00-09:00"},
+		}},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
 func TestDeleteUserGroup(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewUserGroupHandler(st, slog.Default())

--- a/internal/store/generated/device_groups.sql.go
+++ b/internal/store/generated/device_groups.sql.go
@@ -57,7 +57,7 @@ func (q *Queries) EvaluateQueuedDynamicGroups(ctx context.Context) (int32, error
 
 const getDeviceGroupByID = `-- name: GetDeviceGroupByID :one
 
-SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, is_dynamic, dynamic_query, sync_interval_minutes FROM device_groups_projection
+SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, is_dynamic, dynamic_query, sync_interval_minutes, maintenance_window FROM device_groups_projection
 WHERE id = $1 AND is_deleted = FALSE
 `
 
@@ -77,12 +77,13 @@ func (q *Queries) GetDeviceGroupByID(ctx context.Context, id string) (DeviceGrou
 		&i.IsDynamic,
 		&i.DynamicQuery,
 		&i.SyncIntervalMinutes,
+		&i.MaintenanceWindow,
 	)
 	return i, err
 }
 
 const getDeviceGroupByName = `-- name: GetDeviceGroupByName :one
-SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, is_dynamic, dynamic_query, sync_interval_minutes FROM device_groups_projection
+SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, is_dynamic, dynamic_query, sync_interval_minutes, maintenance_window FROM device_groups_projection
 WHERE name = $1 AND is_deleted = FALSE
 `
 
@@ -101,6 +102,7 @@ func (q *Queries) GetDeviceGroupByName(ctx context.Context, name string) (Device
 		&i.IsDynamic,
 		&i.DynamicQuery,
 		&i.SyncIntervalMinutes,
+		&i.MaintenanceWindow,
 	)
 	return i, err
 }
@@ -128,7 +130,7 @@ func (q *Queries) GetDeviceGroupMember(ctx context.Context, arg GetDeviceGroupMe
 }
 
 const getDynamicGroupsNeedingEvaluation = `-- name: GetDynamicGroupsNeedingEvaluation :many
-SELECT g.id, g.name, g.description, g.member_count, g.created_at, g.created_by, g.is_deleted, g.projection_version, g.is_dynamic, g.dynamic_query, g.sync_interval_minutes FROM device_groups_projection g
+SELECT g.id, g.name, g.description, g.member_count, g.created_at, g.created_by, g.is_deleted, g.projection_version, g.is_dynamic, g.dynamic_query, g.sync_interval_minutes, g.maintenance_window FROM device_groups_projection g
 JOIN dynamic_group_evaluation_queue q ON g.id = q.group_id
 WHERE g.is_deleted = FALSE
 ORDER BY q.queued_at ASC
@@ -156,6 +158,7 @@ func (q *Queries) GetDynamicGroupsNeedingEvaluation(ctx context.Context, limit i
 			&i.IsDynamic,
 			&i.DynamicQuery,
 			&i.SyncIntervalMinutes,
+			&i.MaintenanceWindow,
 		); err != nil {
 			return nil, err
 		}
@@ -217,7 +220,7 @@ func (q *Queries) ListDeviceGroupMembers(ctx context.Context, groupID string) ([
 }
 
 const listDeviceGroups = `-- name: ListDeviceGroups :many
-SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, is_dynamic, dynamic_query, sync_interval_minutes FROM device_groups_projection
+SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, is_dynamic, dynamic_query, sync_interval_minutes, maintenance_window FROM device_groups_projection
 WHERE is_deleted = FALSE
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
@@ -249,6 +252,7 @@ func (q *Queries) ListDeviceGroups(ctx context.Context, arg ListDeviceGroupsPara
 			&i.IsDynamic,
 			&i.DynamicQuery,
 			&i.SyncIntervalMinutes,
+			&i.MaintenanceWindow,
 		); err != nil {
 			return nil, err
 		}
@@ -306,7 +310,7 @@ func (q *Queries) ListDevicesInGroup(ctx context.Context, groupID string) ([]Dev
 
 const listDynamicDeviceGroups = `-- name: ListDynamicDeviceGroups :many
 
-SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, is_dynamic, dynamic_query, sync_interval_minutes FROM device_groups_projection
+SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, is_dynamic, dynamic_query, sync_interval_minutes, maintenance_window FROM device_groups_projection
 WHERE is_dynamic = TRUE AND is_deleted = FALSE
 ORDER BY created_at DESC
 `
@@ -333,6 +337,7 @@ func (q *Queries) ListDynamicDeviceGroups(ctx context.Context) ([]DeviceGroupsPr
 			&i.IsDynamic,
 			&i.DynamicQuery,
 			&i.SyncIntervalMinutes,
+			&i.MaintenanceWindow,
 		); err != nil {
 			return nil, err
 		}
@@ -345,7 +350,7 @@ func (q *Queries) ListDynamicDeviceGroups(ctx context.Context) ([]DeviceGroupsPr
 }
 
 const listGroupsForDevice = `-- name: ListGroupsForDevice :many
-SELECT g.id, g.name, g.description, g.member_count, g.created_at, g.created_by, g.is_deleted, g.projection_version, g.is_dynamic, g.dynamic_query, g.sync_interval_minutes FROM device_groups_projection g
+SELECT g.id, g.name, g.description, g.member_count, g.created_at, g.created_by, g.is_deleted, g.projection_version, g.is_dynamic, g.dynamic_query, g.sync_interval_minutes, g.maintenance_window FROM device_groups_projection g
 JOIN device_group_members_projection m ON g.id = m.group_id
 WHERE m.device_id = $1 AND g.is_deleted = FALSE
 ORDER BY g.name ASC
@@ -372,6 +377,7 @@ func (q *Queries) ListGroupsForDevice(ctx context.Context, deviceID string) ([]D
 			&i.IsDynamic,
 			&i.DynamicQuery,
 			&i.SyncIntervalMinutes,
+			&i.MaintenanceWindow,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/generated/models.go
+++ b/internal/store/generated/models.go
@@ -171,6 +171,7 @@ type DeviceGroupsProjection struct {
 	IsDynamic           bool       `json:"is_dynamic"`
 	DynamicQuery        *string    `json:"dynamic_query"`
 	SyncIntervalMinutes int32      `json:"sync_interval_minutes"`
+	MaintenanceWindow   []byte     `json:"maintenance_window"`
 }
 
 type DeviceInventory struct {
@@ -486,6 +487,7 @@ type UserGroupsProjection struct {
 	ProjectionVersion int64     `json:"projection_version"`
 	IsDynamic         bool      `json:"is_dynamic"`
 	DynamicQuery      *string   `json:"dynamic_query"`
+	MaintenanceWindow []byte    `json:"maintenance_window"`
 }
 
 type UserRolesProjection struct {

--- a/internal/store/generated/reach.sql.go
+++ b/internal/store/generated/reach.sql.go
@@ -9,6 +9,56 @@ import (
 	"context"
 )
 
+const listMaintenanceWindowsForDevice = `-- name: ListMaintenanceWindowsForDevice :many
+SELECT g.maintenance_window
+FROM device_groups_projection g
+JOIN device_group_members_projection m ON m.group_id = g.id
+WHERE m.device_id = $1
+  AND g.is_deleted = FALSE
+  AND g.maintenance_window <> '{}'::JSONB
+  AND g.maintenance_window IS NOT NULL
+
+UNION ALL
+
+SELECT ug.maintenance_window
+FROM user_groups_projection ug
+JOIN device_assigned_groups_projection dag ON dag.group_id = ug.id
+WHERE dag.device_id = $1
+  AND ug.is_deleted = FALSE
+  AND ug.maintenance_window <> '{}'::JSONB
+  AND ug.maintenance_window IS NOT NULL
+`
+
+// All non-empty maintenance windows reaching the device. The agent
+// ORs entries within and across these (most-permissive union); the
+// server just returns the raw set so the resolution layer can compute
+// the union without committing to a single SQL aggregate.
+//
+// We include device groups the device is a member of (direct or via
+// dynamic-membership rebuilds) and user groups directly assigned to
+// the device. An empty schedule (the default) contributes nothing —
+// the union of "constraint + no-constraint" stays "constraint",
+// matching the per-group "empty = always allowed" semantics.
+func (q *Queries) ListMaintenanceWindowsForDevice(ctx context.Context, deviceID string) ([][]byte, error) {
+	rows, err := q.db.Query(ctx, listMaintenanceWindowsForDevice, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := [][]byte{}
+	for rows.Next() {
+		var maintenance_window []byte
+		if err := rows.Scan(&maintenance_window); err != nil {
+			return nil, err
+		}
+		items = append(items, maintenance_window)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listReachedActionAssignmentsForDevice = `-- name: ListReachedActionAssignmentsForDevice :many
 SELECT
   a.id,

--- a/internal/store/generated/scim.sql.go
+++ b/internal/store/generated/scim.sql.go
@@ -339,7 +339,7 @@ func (q *Queries) GetUserByExternalSCIMID(ctx context.Context, arg GetUserByExte
 }
 
 const getUserGroupWithMembers = `-- name: GetUserGroupWithMembers :one
-SELECT ug.id, ug.name, ug.description, ug.member_count, ug.created_at, ug.created_by, ug.updated_at, ug.is_deleted, ug.projection_version, ug.is_dynamic, ug.dynamic_query, (
+SELECT ug.id, ug.name, ug.description, ug.member_count, ug.created_at, ug.created_by, ug.updated_at, ug.is_deleted, ug.projection_version, ug.is_dynamic, ug.dynamic_query, ug.maintenance_window, (
     SELECT count(*) FROM user_group_members_projection ugm
     WHERE ugm.group_id = ug.id
 ) AS actual_member_count
@@ -359,6 +359,7 @@ type GetUserGroupWithMembersRow struct {
 	ProjectionVersion int64     `json:"projection_version"`
 	IsDynamic         bool      `json:"is_dynamic"`
 	DynamicQuery      *string   `json:"dynamic_query"`
+	MaintenanceWindow []byte    `json:"maintenance_window"`
 	ActualMemberCount int64     `json:"actual_member_count"`
 }
 
@@ -377,6 +378,7 @@ func (q *Queries) GetUserGroupWithMembers(ctx context.Context, id string) (GetUs
 		&i.ProjectionVersion,
 		&i.IsDynamic,
 		&i.DynamicQuery,
+		&i.MaintenanceWindow,
 		&i.ActualMemberCount,
 	)
 	return i, err

--- a/internal/store/generated/user_groups.sql.go
+++ b/internal/store/generated/user_groups.sql.go
@@ -66,7 +66,7 @@ func (q *Queries) EvaluateQueuedDynamicUserGroups(ctx context.Context) (int32, e
 }
 
 const getUserGroupByID = `-- name: GetUserGroupByID :one
-SELECT id, name, description, member_count, created_at, created_by, updated_at, is_deleted, projection_version, is_dynamic, dynamic_query FROM user_groups_projection WHERE id = $1 AND is_deleted = FALSE
+SELECT id, name, description, member_count, created_at, created_by, updated_at, is_deleted, projection_version, is_dynamic, dynamic_query, maintenance_window FROM user_groups_projection WHERE id = $1 AND is_deleted = FALSE
 `
 
 func (q *Queries) GetUserGroupByID(ctx context.Context, id string) (UserGroupsProjection, error) {
@@ -84,12 +84,13 @@ func (q *Queries) GetUserGroupByID(ctx context.Context, id string) (UserGroupsPr
 		&i.ProjectionVersion,
 		&i.IsDynamic,
 		&i.DynamicQuery,
+		&i.MaintenanceWindow,
 	)
 	return i, err
 }
 
 const getUserGroupByName = `-- name: GetUserGroupByName :one
-SELECT id, name, description, member_count, created_at, created_by, updated_at, is_deleted, projection_version, is_dynamic, dynamic_query FROM user_groups_projection WHERE name = $1 AND is_deleted = FALSE
+SELECT id, name, description, member_count, created_at, created_by, updated_at, is_deleted, projection_version, is_dynamic, dynamic_query, maintenance_window FROM user_groups_projection WHERE name = $1 AND is_deleted = FALSE
 `
 
 func (q *Queries) GetUserGroupByName(ctx context.Context, name string) (UserGroupsProjection, error) {
@@ -107,6 +108,7 @@ func (q *Queries) GetUserGroupByName(ctx context.Context, name string) (UserGrou
 		&i.ProjectionVersion,
 		&i.IsDynamic,
 		&i.DynamicQuery,
+		&i.MaintenanceWindow,
 	)
 	return i, err
 }
@@ -305,7 +307,7 @@ func (q *Queries) ListUserGroupMembers(ctx context.Context, groupID string) ([]L
 }
 
 const listUserGroups = `-- name: ListUserGroups :many
-SELECT id, name, description, member_count, created_at, created_by, updated_at, is_deleted, projection_version, is_dynamic, dynamic_query FROM user_groups_projection WHERE is_deleted = FALSE ORDER BY name LIMIT $1 OFFSET $2
+SELECT id, name, description, member_count, created_at, created_by, updated_at, is_deleted, projection_version, is_dynamic, dynamic_query, maintenance_window FROM user_groups_projection WHERE is_deleted = FALSE ORDER BY name LIMIT $1 OFFSET $2
 `
 
 type ListUserGroupsParams struct {
@@ -334,6 +336,7 @@ func (q *Queries) ListUserGroups(ctx context.Context, arg ListUserGroupsParams) 
 			&i.ProjectionVersion,
 			&i.IsDynamic,
 			&i.DynamicQuery,
+			&i.MaintenanceWindow,
 		); err != nil {
 			return nil, err
 		}
@@ -346,7 +349,7 @@ func (q *Queries) ListUserGroups(ctx context.Context, arg ListUserGroupsParams) 
 }
 
 const listUserGroupsForUser = `-- name: ListUserGroupsForUser :many
-SELECT ug.id, ug.name, ug.description, ug.member_count, ug.created_at, ug.created_by, ug.updated_at, ug.is_deleted, ug.projection_version, ug.is_dynamic, ug.dynamic_query FROM user_groups_projection ug
+SELECT ug.id, ug.name, ug.description, ug.member_count, ug.created_at, ug.created_by, ug.updated_at, ug.is_deleted, ug.projection_version, ug.is_dynamic, ug.dynamic_query, ug.maintenance_window FROM user_groups_projection ug
 JOIN user_group_members_projection ugm ON ugm.group_id = ug.id
 WHERE ugm.user_id = $1 AND ug.is_deleted = FALSE
 ORDER BY ug.name
@@ -373,6 +376,7 @@ func (q *Queries) ListUserGroupsForUser(ctx context.Context, userID string) ([]U
 			&i.ProjectionVersion,
 			&i.IsDynamic,
 			&i.DynamicQuery,
+			&i.MaintenanceWindow,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/migrations/014_group_maintenance_windows.sql
+++ b/internal/store/migrations/014_group_maintenance_windows.sql
@@ -1,0 +1,437 @@
+-- Per-group maintenance windows for action dispatch.
+--
+-- A maintenance_window column is added to device_groups_projection
+-- and user_groups_projection. The column holds a JSONB document with
+-- the same shape as pm.v1.MaintenanceWindow:
+--
+--     {"schedule": [{"days": ["mon","tue"], "allow": "22:00-06:00"}, ...]}
+--
+-- An empty schedule (or NULL column) means "no constraint" — the
+-- group does not contribute to the device-side gate. The feature is
+-- opt-in: existing rows default to {} and behave exactly as today.
+--
+-- New event types:
+--   - DeviceGroupMaintenanceWindowSet (data: {"maintenance_window": <JSON>})
+--   - UserGroupMaintenanceWindowSet   (data: {"maintenance_window": <JSON>})
+--
+-- The agent enforces the union of these windows in device-local time
+-- inside scheduler.runDueActions; the server's only responsibility is
+-- to (1) persist them and (2) emit the resolved union over
+-- SyncActionsResponse. See manchtools/power-manage-server#58.
+
+-- +goose Up
+
+ALTER TABLE device_groups_projection
+    ADD COLUMN maintenance_window JSONB NOT NULL DEFAULT '{}'::JSONB;
+
+ALTER TABLE user_groups_projection
+    ADD COLUMN maintenance_window JSONB NOT NULL DEFAULT '{}'::JSONB;
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_device_group_event(event events) RETURNS void AS $$
+DECLARE
+    is_dyn BOOLEAN;
+    dyn_query TEXT;
+BEGIN
+    CASE event.event_type
+        WHEN 'DeviceGroupCreated' THEN
+            is_dyn := COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE);
+            dyn_query := event.data->>'dynamic_query';
+
+            INSERT INTO device_groups_projection (
+                id, name, description, is_dynamic, dynamic_query,
+                created_at, created_by, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'name',
+                COALESCE(event.data->>'description', ''),
+                is_dyn,
+                dyn_query,
+                event.occurred_at,
+                event.actor_id,
+                event.sequence_num
+            );
+
+            IF is_dyn THEN
+                INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+                VALUES (event.stream_id, clock_timestamp(), 'group_created')
+                ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+            END IF;
+
+        WHEN 'DeviceGroupRenamed' THEN
+            UPDATE device_groups_projection
+            SET name = event.data->>'name',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceGroupDescriptionUpdated' THEN
+            UPDATE device_groups_projection
+            SET description = COALESCE(event.data->>'description', ''),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceGroupQueryUpdated' THEN
+            is_dyn := COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE);
+            dyn_query := event.data->>'dynamic_query';
+
+            UPDATE device_groups_projection
+            SET is_dynamic = is_dyn,
+                dynamic_query = dyn_query,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            IF is_dyn THEN
+                DELETE FROM device_group_members_projection WHERE group_id = event.stream_id;
+                UPDATE device_groups_projection SET member_count = 0 WHERE id = event.stream_id;
+
+                INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+                VALUES (event.stream_id, clock_timestamp(), 'query_updated')
+                ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+            END IF;
+
+        WHEN 'DeviceGroupSyncIntervalSet' THEN
+            UPDATE device_groups_projection
+            SET sync_interval_minutes = COALESCE((event.data->>'sync_interval_minutes')::INTEGER, 0),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceGroupMaintenanceWindowSet' THEN
+            UPDATE device_groups_projection
+            SET maintenance_window = COALESCE(event.data->'maintenance_window', '{}'::JSONB),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceGroupMemberAdded', 'DeviceAddedToGroup' THEN
+            IF NOT EXISTS (SELECT 1 FROM device_groups_projection WHERE id = event.stream_id AND is_dynamic = TRUE) THEN
+                INSERT INTO device_group_members_projection (
+                    group_id, device_id, added_at, projection_version
+                ) VALUES (
+                    event.stream_id,
+                    event.data->>'device_id',
+                    event.occurred_at,
+                    event.sequence_num
+                ) ON CONFLICT (group_id, device_id) DO NOTHING;
+
+                UPDATE device_groups_projection
+                SET member_count = (SELECT COUNT(*) FROM device_group_members_projection WHERE group_id = event.stream_id),
+                    projection_version = event.sequence_num
+                WHERE id = event.stream_id;
+            END IF;
+
+        WHEN 'DeviceGroupMemberRemoved', 'DeviceRemovedFromGroup' THEN
+            IF NOT EXISTS (SELECT 1 FROM device_groups_projection WHERE id = event.stream_id AND is_dynamic = TRUE) THEN
+                DELETE FROM device_group_members_projection
+                WHERE group_id = event.stream_id AND device_id = event.data->>'device_id';
+
+                UPDATE device_groups_projection
+                SET member_count = (SELECT COUNT(*) FROM device_group_members_projection WHERE group_id = event.stream_id),
+                    projection_version = event.sequence_num
+                WHERE id = event.stream_id;
+            END IF;
+
+        WHEN 'DeviceGroupDeleted' THEN
+            UPDATE device_groups_projection
+            SET is_deleted = TRUE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            DELETE FROM device_group_members_projection WHERE group_id = event.stream_id;
+            DELETE FROM dynamic_group_evaluation_queue WHERE group_id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_group_event(event events) RETURNS void AS $$
+DECLARE
+    is_dyn BOOLEAN;
+BEGIN
+    CASE event.event_type
+        WHEN 'UserGroupCreated' THEN
+            is_dyn := COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE);
+            INSERT INTO user_groups_projection (
+                id, name, description, member_count,
+                created_at, created_by, updated_at, projection_version,
+                is_dynamic, dynamic_query
+            ) VALUES (
+                event.stream_id,
+                event.data->>'name',
+                COALESCE(event.data->>'description', ''),
+                0,
+                event.occurred_at,
+                event.actor_id,
+                event.occurred_at,
+                event.sequence_num,
+                is_dyn,
+                event.data->>'dynamic_query'
+            );
+
+            IF is_dyn THEN
+                INSERT INTO dynamic_user_group_evaluation_queue (group_id, reason)
+                VALUES (event.stream_id, 'group_created')
+                ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+            END IF;
+
+        WHEN 'UserGroupUpdated' THEN
+            UPDATE user_groups_projection
+            SET name = event.data->>'name',
+                description = COALESCE(event.data->>'description', description),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserGroupQueryUpdated' THEN
+            is_dyn := COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE);
+            UPDATE user_groups_projection
+            SET is_dynamic = is_dyn,
+                dynamic_query = event.data->>'dynamic_query',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            IF is_dyn THEN
+                DELETE FROM user_group_members_projection WHERE group_id = event.stream_id;
+                UPDATE user_groups_projection SET member_count = 0 WHERE id = event.stream_id;
+                INSERT INTO dynamic_user_group_evaluation_queue (group_id, reason)
+                VALUES (event.stream_id, 'query_updated')
+                ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+            END IF;
+
+        WHEN 'UserGroupMaintenanceWindowSet' THEN
+            UPDATE user_groups_projection
+            SET maintenance_window = COALESCE(event.data->'maintenance_window', '{}'::JSONB),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserGroupDeleted' THEN
+            DELETE FROM scim_group_mapping_projection WHERE user_group_id = event.stream_id;
+
+            UPDATE user_groups_projection
+            SET is_deleted = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            DELETE FROM user_group_members_projection WHERE group_id = event.stream_id;
+            DELETE FROM user_group_roles_projection WHERE group_id = event.stream_id;
+            DELETE FROM dynamic_user_group_evaluation_queue WHERE group_id = event.stream_id;
+
+        WHEN 'UserGroupMemberAdded' THEN
+            IF NOT EXISTS (
+                SELECT 1 FROM user_groups_projection
+                WHERE id = event.data->>'group_id' AND is_dynamic = TRUE
+            ) THEN
+                INSERT INTO user_group_members_projection (
+                    group_id, user_id, added_at, added_by, projection_version
+                ) VALUES (
+                    event.data->>'group_id',
+                    event.data->>'user_id',
+                    event.occurred_at,
+                    event.actor_id,
+                    event.sequence_num
+                )
+                ON CONFLICT (group_id, user_id) DO NOTHING;
+
+                UPDATE user_groups_projection
+                SET member_count = member_count + 1,
+                    updated_at = event.occurred_at,
+                    projection_version = event.sequence_num
+                WHERE id = event.data->>'group_id';
+            END IF;
+
+        WHEN 'UserGroupMemberRemoved' THEN
+            IF NOT EXISTS (
+                SELECT 1 FROM user_groups_projection
+                WHERE id = event.data->>'group_id' AND is_dynamic = TRUE
+            ) THEN
+                DELETE FROM user_group_members_projection
+                WHERE group_id = event.data->>'group_id'
+                  AND user_id = event.data->>'user_id';
+
+                UPDATE user_groups_projection
+                SET member_count = GREATEST(member_count - 1, 0),
+                    updated_at = event.occurred_at,
+                    projection_version = event.sequence_num
+                WHERE id = event.data->>'group_id';
+            END IF;
+
+        WHEN 'UserGroupRoleAssigned' THEN
+            INSERT INTO user_group_roles_projection (
+                group_id, role_id, assigned_at, assigned_by, projection_version
+            ) VALUES (
+                event.data->>'group_id',
+                event.data->>'role_id',
+                event.occurred_at,
+                event.actor_id,
+                event.sequence_num
+            )
+            ON CONFLICT (group_id, role_id) DO NOTHING;
+
+        WHEN 'UserGroupRoleRevoked' THEN
+            DELETE FROM user_group_roles_projection
+            WHERE group_id = event.data->>'group_id'
+              AND role_id = event.data->>'role_id';
+
+        WHEN 'UserGroupMembersRebuilt' THEN
+            DELETE FROM user_group_members_projection WHERE group_id = event.stream_id;
+
+            INSERT INTO user_group_members_projection (group_id, user_id, added_at, added_by, projection_version)
+            SELECT event.stream_id, uid, event.occurred_at, 'system', event.sequence_num
+            FROM jsonb_array_elements_text(event.data->'user_ids') AS uid
+            ON CONFLICT (group_id, user_id) DO NOTHING;
+
+            UPDATE user_groups_projection
+            SET member_count = COALESCE(jsonb_array_length(event.data->'user_ids'), 0),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the previous projector bodies (no maintenance_window cases).
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_device_group_event(event events) RETURNS void AS $$
+DECLARE
+    is_dyn BOOLEAN;
+    dyn_query TEXT;
+BEGIN
+    CASE event.event_type
+        WHEN 'DeviceGroupCreated' THEN
+            is_dyn := COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE);
+            dyn_query := event.data->>'dynamic_query';
+
+            INSERT INTO device_groups_projection (
+                id, name, description, is_dynamic, dynamic_query,
+                created_at, created_by, projection_version
+            ) VALUES (
+                event.stream_id, event.data->>'name', COALESCE(event.data->>'description', ''),
+                is_dyn, dyn_query, event.occurred_at, event.actor_id, event.sequence_num
+            );
+            IF is_dyn THEN
+                INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+                VALUES (event.stream_id, clock_timestamp(), 'group_created')
+                ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+            END IF;
+        WHEN 'DeviceGroupRenamed' THEN
+            UPDATE device_groups_projection SET name = event.data->>'name', projection_version = event.sequence_num WHERE id = event.stream_id;
+        WHEN 'DeviceGroupDescriptionUpdated' THEN
+            UPDATE device_groups_projection SET description = COALESCE(event.data->>'description', ''), projection_version = event.sequence_num WHERE id = event.stream_id;
+        WHEN 'DeviceGroupQueryUpdated' THEN
+            is_dyn := COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE);
+            dyn_query := event.data->>'dynamic_query';
+            UPDATE device_groups_projection SET is_dynamic = is_dyn, dynamic_query = dyn_query, projection_version = event.sequence_num WHERE id = event.stream_id;
+            IF is_dyn THEN
+                DELETE FROM device_group_members_projection WHERE group_id = event.stream_id;
+                UPDATE device_groups_projection SET member_count = 0 WHERE id = event.stream_id;
+                INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+                VALUES (event.stream_id, clock_timestamp(), 'query_updated')
+                ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+            END IF;
+        WHEN 'DeviceGroupSyncIntervalSet' THEN
+            UPDATE device_groups_projection SET sync_interval_minutes = COALESCE((event.data->>'sync_interval_minutes')::INTEGER, 0), projection_version = event.sequence_num WHERE id = event.stream_id;
+        WHEN 'DeviceGroupMemberAdded', 'DeviceAddedToGroup' THEN
+            IF NOT EXISTS (SELECT 1 FROM device_groups_projection WHERE id = event.stream_id AND is_dynamic = TRUE) THEN
+                INSERT INTO device_group_members_projection (group_id, device_id, added_at, projection_version)
+                VALUES (event.stream_id, event.data->>'device_id', event.occurred_at, event.sequence_num)
+                ON CONFLICT (group_id, device_id) DO NOTHING;
+                UPDATE device_groups_projection
+                SET member_count = (SELECT COUNT(*) FROM device_group_members_projection WHERE group_id = event.stream_id), projection_version = event.sequence_num
+                WHERE id = event.stream_id;
+            END IF;
+        WHEN 'DeviceGroupMemberRemoved', 'DeviceRemovedFromGroup' THEN
+            IF NOT EXISTS (SELECT 1 FROM device_groups_projection WHERE id = event.stream_id AND is_dynamic = TRUE) THEN
+                DELETE FROM device_group_members_projection WHERE group_id = event.stream_id AND device_id = event.data->>'device_id';
+                UPDATE device_groups_projection
+                SET member_count = (SELECT COUNT(*) FROM device_group_members_projection WHERE group_id = event.stream_id), projection_version = event.sequence_num
+                WHERE id = event.stream_id;
+            END IF;
+        WHEN 'DeviceGroupDeleted' THEN
+            UPDATE device_groups_projection SET is_deleted = TRUE, projection_version = event.sequence_num WHERE id = event.stream_id;
+            DELETE FROM device_group_members_projection WHERE group_id = event.stream_id;
+            DELETE FROM dynamic_group_evaluation_queue WHERE group_id = event.stream_id;
+        ELSE NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_group_event(event events) RETURNS void AS $$
+DECLARE
+    is_dyn BOOLEAN;
+BEGIN
+    CASE event.event_type
+        WHEN 'UserGroupCreated' THEN
+            is_dyn := COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE);
+            INSERT INTO user_groups_projection (id, name, description, member_count, created_at, created_by, updated_at, projection_version, is_dynamic, dynamic_query)
+            VALUES (event.stream_id, event.data->>'name', COALESCE(event.data->>'description', ''), 0, event.occurred_at, event.actor_id, event.occurred_at, event.sequence_num, is_dyn, event.data->>'dynamic_query');
+            IF is_dyn THEN
+                INSERT INTO dynamic_user_group_evaluation_queue (group_id, reason) VALUES (event.stream_id, 'group_created')
+                ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+            END IF;
+        WHEN 'UserGroupUpdated' THEN
+            UPDATE user_groups_projection SET name = event.data->>'name', description = COALESCE(event.data->>'description', description), updated_at = event.occurred_at, projection_version = event.sequence_num WHERE id = event.stream_id;
+        WHEN 'UserGroupQueryUpdated' THEN
+            is_dyn := COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE);
+            UPDATE user_groups_projection SET is_dynamic = is_dyn, dynamic_query = event.data->>'dynamic_query', updated_at = event.occurred_at, projection_version = event.sequence_num WHERE id = event.stream_id;
+            IF is_dyn THEN
+                DELETE FROM user_group_members_projection WHERE group_id = event.stream_id;
+                UPDATE user_groups_projection SET member_count = 0 WHERE id = event.stream_id;
+                INSERT INTO dynamic_user_group_evaluation_queue (group_id, reason) VALUES (event.stream_id, 'query_updated')
+                ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+            END IF;
+        WHEN 'UserGroupDeleted' THEN
+            DELETE FROM scim_group_mapping_projection WHERE user_group_id = event.stream_id;
+            UPDATE user_groups_projection SET is_deleted = TRUE, updated_at = event.occurred_at, projection_version = event.sequence_num WHERE id = event.stream_id;
+            DELETE FROM user_group_members_projection WHERE group_id = event.stream_id;
+            DELETE FROM user_group_roles_projection WHERE group_id = event.stream_id;
+            DELETE FROM dynamic_user_group_evaluation_queue WHERE group_id = event.stream_id;
+        WHEN 'UserGroupMemberAdded' THEN
+            IF NOT EXISTS (SELECT 1 FROM user_groups_projection WHERE id = event.data->>'group_id' AND is_dynamic = TRUE) THEN
+                INSERT INTO user_group_members_projection (group_id, user_id, added_at, added_by, projection_version)
+                VALUES (event.data->>'group_id', event.data->>'user_id', event.occurred_at, event.actor_id, event.sequence_num)
+                ON CONFLICT (group_id, user_id) DO NOTHING;
+                UPDATE user_groups_projection SET member_count = member_count + 1, updated_at = event.occurred_at, projection_version = event.sequence_num WHERE id = event.data->>'group_id';
+            END IF;
+        WHEN 'UserGroupMemberRemoved' THEN
+            IF NOT EXISTS (SELECT 1 FROM user_groups_projection WHERE id = event.data->>'group_id' AND is_dynamic = TRUE) THEN
+                DELETE FROM user_group_members_projection WHERE group_id = event.data->>'group_id' AND user_id = event.data->>'user_id';
+                UPDATE user_groups_projection SET member_count = GREATEST(member_count - 1, 0), updated_at = event.occurred_at, projection_version = event.sequence_num WHERE id = event.data->>'group_id';
+            END IF;
+        WHEN 'UserGroupRoleAssigned' THEN
+            INSERT INTO user_group_roles_projection (group_id, role_id, assigned_at, assigned_by, projection_version)
+            VALUES (event.data->>'group_id', event.data->>'role_id', event.occurred_at, event.actor_id, event.sequence_num)
+            ON CONFLICT (group_id, role_id) DO NOTHING;
+        WHEN 'UserGroupRoleRevoked' THEN
+            DELETE FROM user_group_roles_projection WHERE group_id = event.data->>'group_id' AND role_id = event.data->>'role_id';
+        WHEN 'UserGroupMembersRebuilt' THEN
+            DELETE FROM user_group_members_projection WHERE group_id = event.stream_id;
+            INSERT INTO user_group_members_projection (group_id, user_id, added_at, added_by, projection_version)
+            SELECT event.stream_id, uid, event.occurred_at, 'system', event.sequence_num
+            FROM jsonb_array_elements_text(event.data->'user_ids') AS uid
+            ON CONFLICT (group_id, user_id) DO NOTHING;
+            UPDATE user_groups_projection
+            SET member_count = COALESCE(jsonb_array_length(event.data->'user_ids'), 0), updated_at = event.occurred_at, projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+        ELSE NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+ALTER TABLE user_groups_projection DROP COLUMN maintenance_window;
+ALTER TABLE device_groups_projection DROP COLUMN maintenance_window;

--- a/internal/store/queries/reach.sql
+++ b/internal/store/queries/reach.sql
@@ -90,6 +90,35 @@ WHERE s.is_deleted = FALSE
 GROUP BY s.id, s.name, s.schedule
 ORDER BY s.name, s.id;
 
+-- name: ListMaintenanceWindowsForDevice :many
+-- All non-empty maintenance windows reaching the device. The agent
+-- ORs entries within and across these (most-permissive union); the
+-- server just returns the raw set so the resolution layer can compute
+-- the union without committing to a single SQL aggregate.
+--
+-- We include device groups the device is a member of (direct or via
+-- dynamic-membership rebuilds) and user groups directly assigned to
+-- the device. An empty schedule (the default) contributes nothing —
+-- the union of "constraint + no-constraint" stays "constraint",
+-- matching the per-group "empty = always allowed" semantics.
+SELECT g.maintenance_window
+FROM device_groups_projection g
+JOIN device_group_members_projection m ON m.group_id = g.id
+WHERE m.device_id = $1
+  AND g.is_deleted = FALSE
+  AND g.maintenance_window <> '{}'::JSONB
+  AND g.maintenance_window IS NOT NULL
+
+UNION ALL
+
+SELECT ug.maintenance_window
+FROM user_groups_projection ug
+JOIN device_assigned_groups_projection dag ON dag.group_id = ug.id
+WHERE dag.device_id = $1
+  AND ug.is_deleted = FALSE
+  AND ug.maintenance_window <> '{}'::JSONB
+  AND ug.maintenance_window IS NOT NULL;
+
 -- name: ListReachedActionAssignmentsForDevice :many
 SELECT
   a.id,


### PR DESCRIPTION
## Summary

- Persist `maintenance_window` JSONB on `device_groups_projection` and `user_groups_projection` via two new event types
- New RPCs `SetDeviceGroupMaintenanceWindow` + `SetUserGroupMaintenanceWindow`
- `ProxySyncActions` emits the resolved union of every reaching group's window (device groups + user groups assigned to the device) so the agent can gate `runDueActions` in device-local time
- Validation + union resolution share `sdk/go/maintenance` with the agent so semantics stay bit-for-bit identical
- Empty window = "no constraint"; the migration is opt-in (existing rows default to `'{}'`) and replays produce identical state
- Defensive: `resolveMaintenanceWindowUnion` skips empty rows instead of collapsing the union to "always allowed", so a stale projection or future bypass of the SQL pre-filter cannot accidentally unlock a constrained device

Closes #58

## Test plan

- [x] `go build ./...`
- [x] `go test -run "TestSetDeviceGroupMaintenanceWindow|TestSetUserGroupMaintenanceWindow|TestMaintenance" ./internal/api/`
- [x] Round-trip handler → event → projector → query asserts the window comes back identical
- [x] Negative cases assert validator runs at the handler boundary (bad weekday / zero-length range hit `CodeInvalidArgument`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API endpoints to set and manage maintenance windows for device groups, including support for multiple schedule entries and clearing windows
  * Added API endpoints to set and manage maintenance windows for user groups
  * Device sync responses now include computed maintenance window information reflecting all applicable constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->