### PR TITLE
refactor: drop get_stream_at + port get_device_sync_interval to sqlc (#95)

### DIFF
--- a/internal/store/generated/devices.sql.go
+++ b/internal/store/generated/devices.sql.go
@@ -129,12 +129,12 @@ func (q *Queries) GetDeviceByID(ctx context.Context, arg GetDeviceByIDParams) (D
 
 const getDeviceSyncInterval = `-- name: GetDeviceSyncInterval :one
 WITH device_override AS (
-    SELECT NULLIF(sync_interval_minutes, 0) AS interval
+    SELECT CASE WHEN sync_interval_minutes > 0 THEN sync_interval_minutes END AS interval
     FROM devices_projection
     WHERE id = $1::TEXT AND is_deleted = FALSE
 ),
 group_min AS (
-    SELECT MIN(NULLIF(dg.sync_interval_minutes, 0)) AS interval
+    SELECT MIN(CASE WHEN dg.sync_interval_minutes > 0 THEN dg.sync_interval_minutes END) AS interval
     FROM device_groups_projection dg
     JOIN device_group_members_projection dgm ON dgm.group_id = dg.id
     WHERE dgm.device_id = $1::TEXT

--- a/internal/store/generated/devices.sql.go
+++ b/internal/store/generated/devices.sql.go
@@ -128,9 +128,41 @@ func (q *Queries) GetDeviceByID(ctx context.Context, arg GetDeviceByIDParams) (D
 }
 
 const getDeviceSyncInterval = `-- name: GetDeviceSyncInterval :one
-SELECT get_device_sync_interval($1::TEXT) AS sync_interval_minutes
+WITH device_override AS (
+    SELECT NULLIF(sync_interval_minutes, 0) AS interval
+    FROM devices_projection
+    WHERE id = $1::TEXT AND is_deleted = FALSE
+),
+group_min AS (
+    SELECT MIN(NULLIF(dg.sync_interval_minutes, 0)) AS interval
+    FROM device_groups_projection dg
+    JOIN device_group_members_projection dgm ON dgm.group_id = dg.id
+    WHERE dgm.device_id = $1::TEXT
+      AND dg.is_deleted = FALSE
+)
+SELECT COALESCE(
+    (SELECT interval FROM device_override),
+    (SELECT interval FROM group_min),
+    0
+)::INTEGER AS sync_interval_minutes
 `
 
+// Effective sync interval for a device, in minutes.
+//
+// Resolution order matches the previous PL/pgSQL implementation
+// (#95):
+//  1. Device-level override (devices_projection.sync_interval_minutes
+//     > 0) takes precedence.
+//  2. Otherwise, the smallest non-zero sync_interval_minutes across
+//     every device-group the device belongs to. The MIN selects the
+//     tightest group cadence — operators expect "join two groups,
+//     get the more frequent sync".
+//  3. If neither sets a value, returns 0 so callers fall back to
+//     their default cadence.
+//
+// COALESCE chain instead of CASE because both sides can be NULL when
+// a device has no override and is in no group with a sync setting,
+// and the original PL/pgSQL function returned 0 in that case.
 func (q *Queries) GetDeviceSyncInterval(ctx context.Context, dollar_1 string) (int32, error) {
 	row := q.db.QueryRow(ctx, getDeviceSyncInterval, dollar_1)
 	var sync_interval_minutes int32

--- a/internal/store/migrations/016_drop_helper_functions.sql
+++ b/internal/store/migrations/016_drop_helper_functions.sql
@@ -1,0 +1,103 @@
+-- Drop two PL/pgSQL helper functions that no longer need to live in
+-- the database:
+--
+--   - get_stream_at()              — point-in-time stream replay
+--                                    helper. Zero callers in code or
+--                                    tests; only referenced in
+--                                    cmd/control/README.md as a
+--                                    "you can run this in psql"
+--                                    suggestion. Operators that need
+--                                    point-in-time replay can write
+--                                    the inline SELECT directly or
+--                                    add a sqlc query later if it
+--                                    becomes a hot operation.
+--
+--   - get_device_sync_interval()   — moved into a sqlc query in
+--                                    queries/devices.sql with the
+--                                    same resolution semantics
+--                                    (device override > group MIN >
+--                                    0). The Go-side query is now
+--                                    the single source of truth and
+--                                    is easier to read, debug, and
+--                                    extend than the PL/pgSQL
+--                                    function it replaces.
+--
+-- Two helpers explicitly NOT dropped in this migration:
+--
+--   - generate_ulid()             — still called by
+--                                    evaluate_dynamic_group() in
+--                                    migration 004 to synthesise
+--                                    group_id values during dynamic
+--                                    group rebuilds. Will be removed
+--                                    when the dynamic-query
+--                                    interpreter is ported to Go
+--                                    (Group 2, planned for
+--                                    2026.07).
+--
+--   - resolve_inventory_field()    — still called by
+--                                    evaluate_condition_v2() and
+--                                    evaluate_user_condition() in
+--                                    migrations 004/006. Same
+--                                    deferral as generate_ulid().
+--
+-- See manchtools/power-manage-server#95, tracker #107.
+
+-- +goose Up
+
+DROP FUNCTION IF EXISTS get_stream_at(TEXT, TEXT, TIMESTAMPTZ);
+DROP FUNCTION IF EXISTS get_device_sync_interval(TEXT);
+
+
+-- +goose Down
+
+-- Restore get_stream_at verbatim from migration 004 so a Down + Up
+-- cycle leaves the database in pre-#95 state.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION get_stream_at(
+    p_stream_type TEXT,
+    p_stream_id TEXT,
+    p_at TIMESTAMPTZ
+) RETURNS SETOF events AS $$
+BEGIN
+    RETURN QUERY
+    SELECT * FROM events
+    WHERE stream_type = p_stream_type
+      AND stream_id = p_stream_id
+      AND occurred_at <= p_at
+    ORDER BY stream_version;
+END;
+$$ LANGUAGE plpgsql STABLE;
+-- +goose StatementEnd
+
+-- Restore get_device_sync_interval verbatim from migration 004.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION get_device_sync_interval(p_device_id TEXT) RETURNS INTEGER AS $$
+DECLARE
+    device_interval INTEGER;
+    group_interval INTEGER;
+BEGIN
+    SELECT sync_interval_minutes INTO device_interval
+    FROM devices_projection
+    WHERE id = p_device_id AND is_deleted = FALSE;
+
+    IF device_interval IS NOT NULL AND device_interval > 0 THEN
+        RETURN device_interval;
+    END IF;
+
+    SELECT MIN(dg.sync_interval_minutes) INTO group_interval
+    FROM device_groups_projection dg
+    JOIN device_group_members_projection dgm ON dgm.group_id = dg.id
+    WHERE dgm.device_id = p_device_id
+      AND dg.is_deleted = FALSE
+      AND dg.sync_interval_minutes > 0;
+
+    IF group_interval IS NOT NULL AND group_interval > 0 THEN
+        RETURN group_interval;
+    END IF;
+
+    RETURN 0;
+END;
+$$ LANGUAGE plpgsql STABLE;
+-- +goose StatementEnd

--- a/internal/store/queries/devices.sql
+++ b/internal/store/queries/devices.sql
@@ -85,7 +85,39 @@ ORDER BY last_seen_at DESC
 LIMIT $3 OFFSET $4;
 
 -- name: GetDeviceSyncInterval :one
-SELECT get_device_sync_interval($1::TEXT) AS sync_interval_minutes;
+-- Effective sync interval for a device, in minutes.
+--
+-- Resolution order matches the previous PL/pgSQL implementation
+-- (#95):
+--   1. Device-level override (devices_projection.sync_interval_minutes
+--      > 0) takes precedence.
+--   2. Otherwise, the smallest non-zero sync_interval_minutes across
+--      every device-group the device belongs to. The MIN selects the
+--      tightest group cadence — operators expect "join two groups,
+--      get the more frequent sync".
+--   3. If neither sets a value, returns 0 so callers fall back to
+--      their default cadence.
+--
+-- COALESCE chain instead of CASE because both sides can be NULL when
+-- a device has no override and is in no group with a sync setting,
+-- and the original PL/pgSQL function returned 0 in that case.
+WITH device_override AS (
+    SELECT NULLIF(sync_interval_minutes, 0) AS interval
+    FROM devices_projection
+    WHERE id = $1::TEXT AND is_deleted = FALSE
+),
+group_min AS (
+    SELECT MIN(NULLIF(dg.sync_interval_minutes, 0)) AS interval
+    FROM device_groups_projection dg
+    JOIN device_group_members_projection dgm ON dgm.group_id = dg.id
+    WHERE dgm.device_id = $1::TEXT
+      AND dg.is_deleted = FALSE
+)
+SELECT COALESCE(
+    (SELECT interval FROM device_override),
+    (SELECT interval FROM group_min),
+    0
+)::INTEGER AS sync_interval_minutes;
 
 -- name: ListDeviceAssignedUsers :many
 SELECT dau.user_id, u.email AS user_email, dau.assigned_at

--- a/internal/store/queries/devices.sql
+++ b/internal/store/queries/devices.sql
@@ -102,12 +102,12 @@ LIMIT $3 OFFSET $4;
 -- a device has no override and is in no group with a sync setting,
 -- and the original PL/pgSQL function returned 0 in that case.
 WITH device_override AS (
-    SELECT NULLIF(sync_interval_minutes, 0) AS interval
+    SELECT CASE WHEN sync_interval_minutes > 0 THEN sync_interval_minutes END AS interval
     FROM devices_projection
     WHERE id = $1::TEXT AND is_deleted = FALSE
 ),
 group_min AS (
-    SELECT MIN(NULLIF(dg.sync_interval_minutes, 0)) AS interval
+    SELECT MIN(CASE WHEN dg.sync_interval_minutes > 0 THEN dg.sync_interval_minutes END) AS interval
     FROM device_groups_projection dg
     JOIN device_group_members_projection dgm ON dgm.group_id = dg.id
     WHERE dgm.device_id = $1::TEXT


### PR DESCRIPTION
## Summary

Second PR of the Phase 1 PL/pgSQL → Go listener migration (tracker #107). Narrows the original #95 scope from "drop four helpers" to "drop two": `get_stream_at` (no callers) and `get_device_sync_interval` (ported to a sqlc query inlining the same semantics).

The other two (`generate_ulid`, `resolve_inventory_field`) stay because they're called from PL/pgSQL functions inside the dynamic-query interpreter (Group 2, deferred to 2026.07). Removing them without first porting their callers would break dynamic-group evaluation. Migration 016's body documents the deferral so the intent isn't lost.

Closes #95 (with documented deferred follow-up for the remaining two helpers).

## Key design decisions

- **CTE + COALESCE chain** in the new `GetDeviceSyncInterval` query mirrors the PL/pgSQL resolution order exactly: device-level override (non-zero) > smallest non-zero group setting > 0. Behaviour is bit-identical.
- **`NULLIF(x, 0)`** treats 0 as "unset" so the COALESCE chain skips it cleanly. Original PL/pgSQL did the same with `IF NOT NULL AND > 0` chains.
- **MIN of group intervals** matches the original — operator expectation is "join two groups, get the more frequent sync".
- **No public Go API change** — `Queries.GetDeviceSyncInterval` keeps the same `(ctx, deviceID) → int32` signature.

## Test plan

- [x] `go test -run "TestSyncInterval|TestSetDeviceGroupSyncInterval|TestRebuildAll|TestProxySync" ./internal/api/ ./internal/store/` — all pass
- [x] `sqlc generate` produces a clean diff (only the inlined SQL changes)
- [x] `go build ./...` clean
- [x] Down migration restores both functions verbatim — round-trip safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated device synchronization interval logic in the database layer to compute intervals inline instead of relying on internal helper routines.
* **Chores**
  * Added a migration that removes the now-unused helper routines while providing a rollback path to restore them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->