### PR TITLE
feat: search-index listener covers user_group (#81 Phase 2b)

### DIFF
--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -126,6 +126,27 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// the membership-count refresh.
 
 	// ---------------------------------------------------------
+	// UserGroup scope
+	// ---------------------------------------------------------
+	// Name, description, dynamic_query, maintenance window, and
+	// member_count are denormalised in the search row. Member-add /
+	// member-remove + role-assign / role-revoke also touch the
+	// projection's updated_at and (transitively, via the role list)
+	// the searchable surface, so they reindex too.
+	case "UserGroupCreated",
+		"UserGroupUpdated",
+		"UserGroupQueryUpdated",
+		"UserGroupMaintenanceWindowSet",
+		"UserGroupMemberAdded",
+		"UserGroupMemberRemoved",
+		"UserGroupRoleAssigned",
+		"UserGroupRoleRevoked":
+		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeUserGroup, ID: e.StreamID}}
+
+	case "UserGroupDeleted":
+		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeUserGroup, ID: e.StreamID}}
+
+	// ---------------------------------------------------------
 	// Execution scope
 	// ---------------------------------------------------------
 	// Status, duration, action linkage, and the changed/compliant
@@ -286,6 +307,27 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, scope, id string
 		}
 		var createdAt int64
 		if g.CreatedAt != nil {
+			createdAt = g.CreatedAt.Unix()
+		}
+		return &taskqueue.SearchEntityData{
+			Name:        g.Name,
+			Description: g.Description,
+			IsDynamic:   isDynamic,
+			MemberCount: g.MemberCount,
+			CreatedAt:   createdAt,
+		}, nil
+
+	case search.ScopeUserGroup:
+		g, err := q.GetUserGroupByID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		isDynamic := "false"
+		if g.IsDynamic {
+			isDynamic = "true"
+		}
+		var createdAt int64
+		if !g.CreatedAt.IsZero() {
 			createdAt = g.CreatedAt.Unix()
 		}
 		return &taskqueue.SearchEntityData{

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 
@@ -128,23 +129,35 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// ---------------------------------------------------------
 	// UserGroup scope
 	// ---------------------------------------------------------
-	// Name, description, dynamic_query, maintenance window, and
-	// member_count are denormalised in the search row. Member-add /
-	// member-remove + role-assign / role-revoke also touch the
-	// projection's updated_at and (transitively, via the role list)
-	// the searchable surface, so they reindex too.
+	// Group-stream events (Created, Updated, QueryUpdated,
+	// MaintenanceWindowSet) carry the group ID directly in StreamID
+	// — these reindex against e.StreamID.
 	case "UserGroupCreated",
 		"UserGroupUpdated",
 		"UserGroupQueryUpdated",
-		"UserGroupMaintenanceWindowSet",
-		"UserGroupMemberAdded",
-		"UserGroupMemberRemoved",
-		"UserGroupRoleAssigned",
-		"UserGroupRoleRevoked":
+		"UserGroupMaintenanceWindowSet":
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeUserGroup, ID: e.StreamID}}
 
 	case "UserGroupDeleted":
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeUserGroup, ID: e.StreamID}}
+
+	// Member / role events use a COMPOSITE StreamID:
+	//   - Members: "<group_id>:<user_id>"
+	//   - Roles:   "<group_id>:role:<role_id>"
+	// We need the group_id prefix to load the user_groups_projection
+	// row. Same defensive prefix-split pattern as the system-action
+	// listener (#77) — the user_id / role_id suffixes are irrelevant
+	// to the search payload (member_count + role list are already
+	// denormalised on the projection row by the projector).
+	case "UserGroupMemberAdded",
+		"UserGroupMemberRemoved",
+		"UserGroupRoleAssigned",
+		"UserGroupRoleRevoked":
+		groupID, _, _ := strings.Cut(e.StreamID, ":")
+		if groupID == "" {
+			return nil
+		}
+		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeUserGroup, ID: groupID}}
 
 	// ---------------------------------------------------------
 	// Execution scope

--- a/internal/api/search_listener_test.go
+++ b/internal/api/search_listener_test.go
@@ -191,6 +191,38 @@ func TestAffectedSearchOps(t *testing.T) {
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeExecution, ID: "EXEC1"}},
 		},
 
+		// UserGroup scope (added in Phase 2b).
+		{
+			"UserGroupCreated reindexes user group",
+			store.PersistedEvent{EventType: "UserGroupCreated", StreamID: "UGRP1", StreamType: "user_group"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+		{
+			"UserGroupUpdated reindexes user group",
+			store.PersistedEvent{EventType: "UserGroupUpdated", StreamID: "UGRP1", StreamType: "user_group"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+		{
+			"UserGroupMemberAdded reindexes user group (member_count changed)",
+			store.PersistedEvent{EventType: "UserGroupMemberAdded", StreamID: "UGRP1", StreamType: "user_group"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+		{
+			"UserGroupRoleAssigned reindexes user group (roles list changed)",
+			store.PersistedEvent{EventType: "UserGroupRoleAssigned", StreamID: "UGRP1", StreamType: "user_group"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+		{
+			"UserGroupMaintenanceWindowSet reindexes user group",
+			store.PersistedEvent{EventType: "UserGroupMaintenanceWindowSet", StreamID: "UGRP1", StreamType: "user_group"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+		{
+			"UserGroupDeleted removes user group",
+			store.PersistedEvent{EventType: "UserGroupDeleted", StreamID: "UGRP1", StreamType: "user_group"},
+			[]api.SearchAffected{{Op: api.SearchOpRemove, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+
 		// Out-of-scope: event types from handlers not yet ported
 		// classify as nil today. When subsequent Phase 2 PRs add a
 		// scope they MUST move from nil to a populated slice in the

--- a/internal/api/search_listener_test.go
+++ b/internal/api/search_listener_test.go
@@ -192,6 +192,7 @@ func TestAffectedSearchOps(t *testing.T) {
 		},
 
 		// UserGroup scope (added in Phase 2b).
+		// Group-stream events use the group ID directly as StreamID.
 		{
 			"UserGroupCreated reindexes user group",
 			store.PersistedEvent{EventType: "UserGroupCreated", StreamID: "UGRP1", StreamType: "user_group"},
@@ -203,13 +204,8 @@ func TestAffectedSearchOps(t *testing.T) {
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
 		},
 		{
-			"UserGroupMemberAdded reindexes user group (member_count changed)",
-			store.PersistedEvent{EventType: "UserGroupMemberAdded", StreamID: "UGRP1", StreamType: "user_group"},
-			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
-		},
-		{
-			"UserGroupRoleAssigned reindexes user group (roles list changed)",
-			store.PersistedEvent{EventType: "UserGroupRoleAssigned", StreamID: "UGRP1", StreamType: "user_group"},
+			"UserGroupQueryUpdated reindexes user group",
+			store.PersistedEvent{EventType: "UserGroupQueryUpdated", StreamID: "UGRP1", StreamType: "user_group"},
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
 		},
 		{
@@ -221,6 +217,38 @@ func TestAffectedSearchOps(t *testing.T) {
 			"UserGroupDeleted removes user group",
 			store.PersistedEvent{EventType: "UserGroupDeleted", StreamID: "UGRP1", StreamType: "user_group"},
 			[]api.SearchAffected{{Op: api.SearchOpRemove, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+
+		// Member + role events use a COMPOSITE StreamID
+		// "<group_id>:<user_id>" (members) or
+		// "<group_id>:role:<role_id>" (roles). The classifier MUST
+		// extract the group_id prefix — passing the composite would
+		// make loadSearchEntityData fail to find the row and the
+		// reindex would silently drop. CodeRabbit catch on PR #112.
+		{
+			"UserGroupMemberAdded extracts group_id from composite StreamID",
+			store.PersistedEvent{EventType: "UserGroupMemberAdded", StreamID: "UGRP1:USR42", StreamType: "user_group"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+		{
+			"UserGroupMemberRemoved extracts group_id",
+			store.PersistedEvent{EventType: "UserGroupMemberRemoved", StreamID: "UGRP1:USR42", StreamType: "user_group"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+		{
+			"UserGroupRoleAssigned extracts group_id from <group>:role:<role> composite",
+			store.PersistedEvent{EventType: "UserGroupRoleAssigned", StreamID: "UGRP1:role:ROLE42", StreamType: "user_group"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+		{
+			"UserGroupRoleRevoked extracts group_id",
+			store.PersistedEvent{EventType: "UserGroupRoleRevoked", StreamID: "UGRP1:role:ROLE42", StreamType: "user_group"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+		},
+		{
+			"UserGroupMemberAdded with empty StreamID returns no-op (defensive)",
+			store.PersistedEvent{EventType: "UserGroupMemberAdded", StreamID: "", StreamType: "user_group"},
+			nil,
 		},
 
 		// Out-of-scope: event types from handlers not yet ported

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -15,10 +15,8 @@ import (
 	"github.com/manchtools/power-manage/sdk/go/maintenance"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/middleware"
-	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
-	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
 // UserGroupHandler handles user group management RPCs.
@@ -34,25 +32,6 @@ func NewUserGroupHandler(st *store.Store, logger *slog.Logger) *UserGroupHandler
 		store:  st,
 		logger: logger,
 	}
-}
-
-// enqueueUserGroupReindex enqueues a search index update for a user group.
-func (h *UserGroupHandler) enqueueUserGroupReindex(ctx context.Context, g db.UserGroupsProjection) {
-	isDynamic := "false"
-	if g.IsDynamic {
-		isDynamic = "true"
-	}
-	var createdAt int64
-	if !g.CreatedAt.IsZero() {
-		createdAt = g.CreatedAt.Unix()
-	}
-	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeUserGroup, g.ID, &taskqueue.SearchEntityData{
-		Name:        g.Name,
-		Description: g.Description,
-		IsDynamic:   isDynamic,
-		MemberCount: g.MemberCount,
-		CreatedAt:   createdAt,
-	})
 }
 
 // CreateUserGroup creates a new user group.
@@ -109,7 +88,6 @@ func (h *UserGroupHandler) CreateUserGroup(ctx context.Context, req *connect.Req
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to read user group")
 	}
 
-	h.enqueueUserGroupReindex(ctx, group)
 
 	return connect.NewResponse(&pm.CreateUserGroupResponse{
 		Group: userGroupToProto(group, nil, false),
@@ -225,7 +203,6 @@ func (h *UserGroupHandler) UpdateUserGroup(ctx context.Context, req *connect.Req
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to read user group")
 	}
 
-	h.enqueueUserGroupReindex(ctx, updated)
 
 	roles, _ := h.store.Queries().GetUserGroupRoles(ctx, req.Msg.GroupId)
 
@@ -322,11 +299,9 @@ func (h *UserGroupHandler) DeleteUserGroup(ctx context.Context, req *connect.Req
 		h.logger.Warn("partial session invalidation", "error", err)
 	}
 
-	if h.searchIdx != nil {
-		if err := h.searchIdx.EnqueueRemove(ctx, search.ScopeUserGroup, req.Msg.Id, nil); err != nil {
-			h.logger.Warn("failed to enqueue search remove", "scope", "user_group", "error", err)
-		}
-	}
+	// Search index removal is handled by api.SearchListener (Phase 2b
+	// of #81): the listener fires on UserGroupDeleted and emits the
+	// search:remove task.
 
 	return connect.NewResponse(&pm.DeleteUserGroupResponse{}), nil
 }
@@ -407,10 +382,9 @@ func (h *UserGroupHandler) AddUserToGroup(ctx context.Context, req *connect.Requ
 		}
 	}
 
-	// Re-read group for updated member_count and enqueue reindex
-	if updatedGroup, err := q.GetUserGroupByID(ctx, req.Msg.GroupId); err == nil {
-		h.enqueueUserGroupReindex(ctx, updatedGroup)
-	}
+	// Member-count reindex is handled by api.SearchListener (Phase 2b
+	// of #81): the listener fires on UserGroupMemberAdded /
+	// UserGroupMemberRemoved and reloads the projection.
 
 	return connect.NewResponse(&pm.AddUserToGroupResponse{}), nil
 }
@@ -469,10 +443,9 @@ func (h *UserGroupHandler) RemoveUserFromGroup(ctx context.Context, req *connect
 		h.logger.Warn("partial session invalidation after group member remove", "user_id", req.Msg.UserId, "error", err)
 	}
 
-	// Re-read group for updated member_count and enqueue reindex
-	if updatedGroup, err := h.store.Queries().GetUserGroupByID(ctx, req.Msg.GroupId); err == nil {
-		h.enqueueUserGroupReindex(ctx, updatedGroup)
-	}
+	// Member-count reindex is handled by api.SearchListener (Phase 2b
+	// of #81): the listener fires on UserGroupMemberRemoved and
+	// reloads the projection.
 
 	return connect.NewResponse(&pm.RemoveUserFromGroupResponse{}), nil
 }
@@ -668,7 +641,6 @@ func (h *UserGroupHandler) UpdateUserGroupQuery(ctx context.Context, req *connec
 		return nil, handleGetError(ctx, err, ErrUserGroupNotFound, "user group not found")
 	}
 
-	h.enqueueUserGroupReindex(ctx, group)
 
 	roles, _ := h.store.Queries().GetUserGroupRoles(ctx, req.Msg.Id)
 	isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, req.Msg.Id)
@@ -759,7 +731,6 @@ func (h *UserGroupHandler) EvaluateDynamicUserGroup(ctx context.Context, req *co
 		usersRemoved = membersBefore - group.MemberCount
 	}
 
-	h.enqueueUserGroupReindex(ctx, group)
 
 	roles, _ := h.store.Queries().GetUserGroupRoles(ctx, req.Msg.Id)
 	isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, req.Msg.Id)


### PR DESCRIPTION
## Summary

Phase 2b of #81. Extends `api.AffectedSearchOps` to classify every UserGroup* event and removes the now-redundant handler-side enqueues from `user_group_handler.go` (helper + 6 call sites + 1 EnqueueRemove + 2 now-empty 'Re-read group for member_count' blocks + 2 unused imports).

After this lands, the search-index listener is the sole source of truth for user_group reindex.

## Cleanup details

- Drops `enqueueUserGroupReindex` helper
- Drops 6 helper-call sites
- Drops the inline `EnqueueRemove` block in `DeleteUserGroup`
- Drops two now-empty `Re-read group for member_count` blocks in `AddUserToGroup` / `RemoveUserFromGroup` — the listener does the reload on `UserGroupMemberAdded`/`Removed`
- Drops now-unused `search` and `taskqueue` imports

## Test plan

- [x] `TestAffectedSearchOps` extended with explicit cases for Created, Updated, MemberAdded, RoleAssigned, MaintenanceWindowSet, Deleted
- [x] No regressions on `TestCreateUserGroup`, `TestUpdateUserGroup`, `TestDeleteUserGroup`, `TestAddUserToGroup`, `TestSetUserGroupMaintenanceWindow`
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive search indexing support for user groups with real-time updates for creation, modification, deletion, and membership changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->