### PR TITLE
feat: search-index listener covers action_set + definition (#81 Phase 2c)

### DIFF
--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -9,10 +9,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
-	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
-	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
 // ActionSetHandler handles action set RPCs.
@@ -72,7 +70,6 @@ func (h *ActionSetHandler) CreateActionSet(ctx context.Context, req *connect.Req
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action set")
 	}
 
-	h.enqueueSetReindex(ctx, set)
 
 	return connect.NewResponse(&pm.CreateActionSetResponse{
 		Set: h.actionSetToProto(set),
@@ -175,7 +172,6 @@ func (h *ActionSetHandler) RenameActionSet(ctx context.Context, req *connect.Req
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
 
-	h.enqueueSetReindex(ctx, set)
 
 	return connect.NewResponse(&pm.UpdateActionSetResponse{
 		Set: h.actionSetToProto(set),
@@ -217,7 +213,6 @@ func (h *ActionSetHandler) UpdateActionSetSchedule(ctx context.Context, req *con
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
 
-	h.enqueueSetReindex(ctx, set)
 
 	return connect.NewResponse(&pm.UpdateActionSetResponse{
 		Set: h.actionSetToProto(set),
@@ -253,7 +248,6 @@ func (h *ActionSetHandler) UpdateActionSetDescription(ctx context.Context, req *
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
 
-	h.enqueueSetReindex(ctx, set)
 
 	return connect.NewResponse(&pm.UpdateActionSetResponse{
 		Set: h.actionSetToProto(set),
@@ -271,11 +265,6 @@ func (h *ActionSetHandler) DeleteActionSet(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	var cascadeIDs []string
-	if h.searchIdx != nil {
-		cascadeIDs = h.searchIdx.GetReverseMembers(ctx, "action_set", req.Msg.Id)
-	}
-
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.Id,
@@ -287,11 +276,10 @@ func (h *ActionSetHandler) DeleteActionSet(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	if h.searchIdx != nil {
-		if err := h.searchIdx.EnqueueRemove(ctx, "action_set", req.Msg.Id, cascadeIDs); err != nil {
-			h.logger.Warn("failed to enqueue search index remove", "scope", "action_set", "error", err)
-		}
-	}
+	// Search index removal + cascade-rebuild of parent definitions
+	// is handled by api.SearchListener (Phase 2c of #81): the
+	// listener calls GetReverseMembers + EnqueueRemove on
+	// ActionSetDeleted.
 
 	return connect.NewResponse(&pm.DeleteActionSetResponse{}), nil
 }
@@ -422,24 +410,6 @@ func (h *ActionSetHandler) ReorderActionInSet(ctx context.Context, req *connect.
 	return connect.NewResponse(&pm.ReorderActionInSetResponse{
 		Set: h.actionSetToProto(set),
 	}), nil
-}
-
-// enqueueSetReindex enqueues a search index update for an action set.
-func (h *ActionSetHandler) enqueueSetReindex(ctx context.Context, s db.ActionSetsProjection) {
-	var createdAt, updatedAt int64
-	if s.CreatedAt != nil {
-		createdAt = s.CreatedAt.Unix()
-	}
-	if s.UpdatedAt != nil {
-		updatedAt = s.UpdatedAt.Unix()
-	}
-	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeActionSet, s.ID, &taskqueue.SearchEntityData{
-		Name:        s.Name,
-		Description: s.Description,
-		MemberCount: s.MemberCount,
-		CreatedAt:   createdAt,
-		UpdatedAt:   updatedAt,
-	})
 }
 
 func (h *ActionSetHandler) actionSetToProto(s db.ActionSetsProjection) *pm.ActionSet {

--- a/internal/api/definition_handler.go
+++ b/internal/api/definition_handler.go
@@ -9,10 +9,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
-	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
-	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
 // DefinitionHandler handles definition (collection of action sets) RPCs.
@@ -71,7 +69,6 @@ func (h *DefinitionHandler) CreateDefinition(ctx context.Context, req *connect.R
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get definition")
 	}
 
-	h.enqueueDefinitionReindex(ctx, def)
 
 	return connect.NewResponse(&pm.CreateDefinitionResponse{
 		Definition: h.definitionToProto(def),
@@ -172,7 +169,6 @@ func (h *DefinitionHandler) RenameDefinition(ctx context.Context, req *connect.R
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
 
-	h.enqueueDefinitionReindex(ctx, def)
 
 	return connect.NewResponse(&pm.UpdateDefinitionResponse{
 		Definition: h.definitionToProto(def),
@@ -215,7 +211,6 @@ func (h *DefinitionHandler) UpdateDefinitionSchedule(ctx context.Context, req *c
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
 
-	h.enqueueDefinitionReindex(ctx, def)
 
 	return connect.NewResponse(&pm.UpdateDefinitionResponse{
 		Definition: h.definitionToProto(def),
@@ -251,7 +246,6 @@ func (h *DefinitionHandler) UpdateDefinitionDescription(ctx context.Context, req
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
 
-	h.enqueueDefinitionReindex(ctx, def)
 
 	return connect.NewResponse(&pm.UpdateDefinitionResponse{
 		Definition: h.definitionToProto(def),
@@ -269,11 +263,6 @@ func (h *DefinitionHandler) DeleteDefinition(ctx context.Context, req *connect.R
 		return nil, err
 	}
 
-	var cascadeIDs []string
-	if h.searchIdx != nil {
-		cascadeIDs = h.searchIdx.GetReverseMembers(ctx, "definition", req.Msg.Id)
-	}
-
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.Id,
@@ -285,11 +274,10 @@ func (h *DefinitionHandler) DeleteDefinition(ctx context.Context, req *connect.R
 		return nil, err
 	}
 
-	if h.searchIdx != nil {
-		if err := h.searchIdx.EnqueueRemove(ctx, "definition", req.Msg.Id, cascadeIDs); err != nil {
-			h.logger.Warn("failed to enqueue search index remove", "scope", "definition", "error", err)
-		}
-	}
+	// Search index removal + cascade-rebuild of parent action_sets
+	// is handled by api.SearchListener (Phase 2c of #81): the
+	// listener calls GetReverseMembers + EnqueueRemove on
+	// DefinitionDeleted.
 
 	return connect.NewResponse(&pm.DeleteDefinitionResponse{}), nil
 }
@@ -422,23 +410,6 @@ func (h *DefinitionHandler) ReorderActionSetInDefinition(ctx context.Context, re
 	}), nil
 }
 
-// enqueueDefinitionReindex enqueues a search index update for a definition.
-func (h *DefinitionHandler) enqueueDefinitionReindex(ctx context.Context, d db.DefinitionsProjection) {
-	var createdAt, updatedAt int64
-	if d.CreatedAt != nil {
-		createdAt = d.CreatedAt.Unix()
-	}
-	if d.UpdatedAt != nil {
-		updatedAt = d.UpdatedAt.Unix()
-	}
-	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeDefinition, d.ID, &taskqueue.SearchEntityData{
-		Name:        d.Name,
-		Description: d.Description,
-		MemberCount: d.MemberCount,
-		CreatedAt:   createdAt,
-		UpdatedAt:   updatedAt,
-	})
-}
 
 func (h *DefinitionHandler) definitionToProto(d db.DefinitionsProjection) *pm.Definition {
 	def := &pm.Definition{

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -175,6 +175,47 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 		"ExecutionCancelled",
 		"ExecutionTimedOut":
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeExecution, ID: e.StreamID}}
+
+	// ---------------------------------------------------------
+	// ActionSet scope
+	// ---------------------------------------------------------
+	// Name, description, schedule, and member_count live on the
+	// search row. Member-add / member-remove / member-reorder all
+	// touch member_count or the displayed member list, so they
+	// reindex too.
+	//
+	// The action↔set membership EDGE (handler's
+	// EnqueueMemberAdded/Removed calls) is intentionally NOT covered
+	// here yet — those still fire from the handler. Phase 2c.2 (a
+	// follow-up PR) extends SearchAffected with member-edge variants
+	// and removes those calls. Splitting keeps this PR's diff small
+	// and CR-reviewable.
+	case "ActionSetCreated",
+		"ActionSetRenamed",
+		"ActionSetDescriptionUpdated",
+		"ActionSetScheduleUpdated",
+		"ActionSetMemberAdded",
+		"ActionSetMemberRemoved",
+		"ActionSetMemberReordered":
+		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeActionSet, ID: e.StreamID}}
+
+	case "ActionSetDeleted":
+		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeActionSet, ID: e.StreamID}}
+
+	// ---------------------------------------------------------
+	// Definition scope (same shape as ActionSet)
+	// ---------------------------------------------------------
+	case "DefinitionCreated",
+		"DefinitionRenamed",
+		"DefinitionDescriptionUpdated",
+		"DefinitionScheduleUpdated",
+		"DefinitionMemberAdded",
+		"DefinitionMemberRemoved",
+		"DefinitionMemberReordered":
+		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeDefinition, ID: e.StreamID}}
+
+	case "DefinitionDeleted":
+		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeDefinition, ID: e.StreamID}}
 	}
 
 	return nil
@@ -228,7 +269,17 @@ func SearchListener(st *store.Store, idx *search.Index, logger *slog.Logger) sto
 						"scope", op.Scope, "id", op.ID, "event_type", e.EventType, "error", err)
 				}
 			case SearchOpRemove:
-				if err := idx.EnqueueRemove(ctx, op.Scope, op.ID, nil); err != nil {
+				// For scopes with reverse-member relationships
+				// (action_set, definition), pull cascade IDs from
+				// the search index BEFORE enqueueing the remove —
+				// those parent rows need to rebuild their
+				// denormalised member lists once the child is gone.
+				// The reverse-member entries persist in Redis until
+				// the indexer worker actually processes the
+				// EnqueueRemove task, so the lookup still finds them
+				// when the listener fires.
+				cascadeIDs := cascadeIDsForRemove(ctx, idx, op.Scope, op.ID)
+				if err := idx.EnqueueRemove(ctx, op.Scope, op.ID, cascadeIDs); err != nil {
 					logger.Warn("search listener: failed to enqueue remove",
 						"scope", op.Scope, "id", op.ID, "event_type", e.EventType, "error", err)
 				}
@@ -330,6 +381,46 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, scope, id string
 			CreatedAt:   createdAt,
 		}, nil
 
+	case search.ScopeActionSet:
+		s, err := q.GetActionSetByID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		var createdAt, updatedAt int64
+		if s.CreatedAt != nil {
+			createdAt = s.CreatedAt.Unix()
+		}
+		if s.UpdatedAt != nil {
+			updatedAt = s.UpdatedAt.Unix()
+		}
+		return &taskqueue.SearchEntityData{
+			Name:        s.Name,
+			Description: s.Description,
+			MemberCount: s.MemberCount,
+			CreatedAt:   createdAt,
+			UpdatedAt:   updatedAt,
+		}, nil
+
+	case search.ScopeDefinition:
+		d, err := q.GetDefinitionByID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		var createdAt, updatedAt int64
+		if d.CreatedAt != nil {
+			createdAt = d.CreatedAt.Unix()
+		}
+		if d.UpdatedAt != nil {
+			updatedAt = d.UpdatedAt.Unix()
+		}
+		return &taskqueue.SearchEntityData{
+			Name:        d.Name,
+			Description: d.Description,
+			MemberCount: d.MemberCount,
+			CreatedAt:   createdAt,
+			UpdatedAt:   updatedAt,
+		}, nil
+
 	case search.ScopeUserGroup:
 		g, err := q.GetUserGroupByID(ctx, id)
 		if err != nil {
@@ -400,4 +491,26 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, scope, id string
 	// silently enqueueing an empty SearchEntityData payload that would
 	// blank out the indexed entity.
 	return nil, fmt.Errorf("loadSearchEntityData: unknown scope %q", scope)
+}
+
+// cascadeIDsForRemove looks up the parent IDs that need their
+// denormalised member-list rebuilt after a child entity is removed
+// from the search index. Only ActionSet and Definition support
+// reverse-member tracking today (other scopes return nil for "no
+// cascade needed"). Mirrors the GetReverseMembers + EnqueueRemove
+// dance the action_set / definition handlers used to do inline
+// before #81 Phase 2c moved the responsibility to the listener.
+//
+// Race window: if multiple removes for the same parent fire rapidly,
+// the indexer worker may have already processed one and cleared the
+// reverse-member set in Redis, so subsequent listener invocations
+// will see an empty cascade list. The periodic indexer reconciler
+// catches the resulting drift within ~1h. Single-remove flows have
+// no race.
+func cascadeIDsForRemove(ctx context.Context, idx *search.Index, scope, id string) []string {
+	switch scope {
+	case search.ScopeActionSet, search.ScopeDefinition:
+		return idx.GetReverseMembers(ctx, scope, id)
+	}
+	return nil
 }

--- a/internal/api/search_listener_test.go
+++ b/internal/api/search_listener_test.go
@@ -251,13 +251,62 @@ func TestAffectedSearchOps(t *testing.T) {
 			nil,
 		},
 
+		// ActionSet scope (added in Phase 2c).
+		{
+			"ActionSetCreated reindexes set",
+			store.PersistedEvent{EventType: "ActionSetCreated", StreamID: "AS1", StreamType: "action_set"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "AS1"}},
+		},
+		{
+			"ActionSetRenamed reindexes set",
+			store.PersistedEvent{EventType: "ActionSetRenamed", StreamID: "AS1", StreamType: "action_set"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "AS1"}},
+		},
+		{
+			"ActionSetScheduleUpdated reindexes set",
+			store.PersistedEvent{EventType: "ActionSetScheduleUpdated", StreamID: "AS1", StreamType: "action_set"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "AS1"}},
+		},
+		{
+			"ActionSetMemberAdded reindexes set (member_count changed)",
+			store.PersistedEvent{EventType: "ActionSetMemberAdded", StreamID: "AS1", StreamType: "action_set"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "AS1"}},
+		},
+		{
+			"ActionSetMemberReordered reindexes set (member-list ordering visible in search)",
+			store.PersistedEvent{EventType: "ActionSetMemberReordered", StreamID: "AS1", StreamType: "action_set"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "AS1"}},
+		},
+		{
+			"ActionSetDeleted removes set (cascade IDs resolved at dispatch time)",
+			store.PersistedEvent{EventType: "ActionSetDeleted", StreamID: "AS1", StreamType: "action_set"},
+			[]api.SearchAffected{{Op: api.SearchOpRemove, Scope: search.ScopeActionSet, ID: "AS1"}},
+		},
+
+		// Definition scope (added in Phase 2c — same shape as ActionSet).
+		{
+			"DefinitionCreated reindexes definition",
+			store.PersistedEvent{EventType: "DefinitionCreated", StreamID: "DEF1", StreamType: "definition"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDefinition, ID: "DEF1"}},
+		},
+		{
+			"DefinitionMemberAdded reindexes definition",
+			store.PersistedEvent{EventType: "DefinitionMemberAdded", StreamID: "DEF1", StreamType: "definition"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDefinition, ID: "DEF1"}},
+		},
+		{
+			"DefinitionDeleted removes definition",
+			store.PersistedEvent{EventType: "DefinitionDeleted", StreamID: "DEF1", StreamType: "definition"},
+			[]api.SearchAffected{{Op: api.SearchOpRemove, Scope: search.ScopeDefinition, ID: "DEF1"}},
+		},
+
 		// Out-of-scope: event types from handlers not yet ported
 		// classify as nil today. When subsequent Phase 2 PRs add a
 		// scope they MUST move from nil to a populated slice in the
 		// same PR that removes the handler-side enqueue.
 		{
-			"ActionSetCreated is Phase-2 scope (returns nil today)",
-			store.PersistedEvent{EventType: "ActionSetCreated", StreamID: "AS1", StreamType: "action_set"},
+			"ActionCreated is Phase-2d scope (returns nil today)",
+			store.PersistedEvent{EventType: "ActionCreated", StreamID: "ACT1", StreamType: "action"},
 			nil,
 		},
 

--- a/internal/api/search_listener_test.go
+++ b/internal/api/search_listener_test.go
@@ -251,7 +251,9 @@ func TestAffectedSearchOps(t *testing.T) {
 			nil,
 		},
 
-		// ActionSet scope (added in Phase 2c).
+		// ActionSet scope (added in Phase 2c). Every classified
+		// event has a row — the "every event gets an explicit case"
+		// contract documented at the top of the table.
 		{
 			"ActionSetCreated reindexes set",
 			store.PersistedEvent{EventType: "ActionSetCreated", StreamID: "AS1", StreamType: "action_set"},
@@ -263,6 +265,11 @@ func TestAffectedSearchOps(t *testing.T) {
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "AS1"}},
 		},
 		{
+			"ActionSetDescriptionUpdated reindexes set",
+			store.PersistedEvent{EventType: "ActionSetDescriptionUpdated", StreamID: "AS1", StreamType: "action_set"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "AS1"}},
+		},
+		{
 			"ActionSetScheduleUpdated reindexes set",
 			store.PersistedEvent{EventType: "ActionSetScheduleUpdated", StreamID: "AS1", StreamType: "action_set"},
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "AS1"}},
@@ -270,6 +277,11 @@ func TestAffectedSearchOps(t *testing.T) {
 		{
 			"ActionSetMemberAdded reindexes set (member_count changed)",
 			store.PersistedEvent{EventType: "ActionSetMemberAdded", StreamID: "AS1", StreamType: "action_set"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "AS1"}},
+		},
+		{
+			"ActionSetMemberRemoved reindexes set",
+			store.PersistedEvent{EventType: "ActionSetMemberRemoved", StreamID: "AS1", StreamType: "action_set"},
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "AS1"}},
 		},
 		{
@@ -290,8 +302,33 @@ func TestAffectedSearchOps(t *testing.T) {
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDefinition, ID: "DEF1"}},
 		},
 		{
+			"DefinitionRenamed reindexes definition",
+			store.PersistedEvent{EventType: "DefinitionRenamed", StreamID: "DEF1", StreamType: "definition"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDefinition, ID: "DEF1"}},
+		},
+		{
+			"DefinitionDescriptionUpdated reindexes definition",
+			store.PersistedEvent{EventType: "DefinitionDescriptionUpdated", StreamID: "DEF1", StreamType: "definition"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDefinition, ID: "DEF1"}},
+		},
+		{
+			"DefinitionScheduleUpdated reindexes definition",
+			store.PersistedEvent{EventType: "DefinitionScheduleUpdated", StreamID: "DEF1", StreamType: "definition"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDefinition, ID: "DEF1"}},
+		},
+		{
 			"DefinitionMemberAdded reindexes definition",
 			store.PersistedEvent{EventType: "DefinitionMemberAdded", StreamID: "DEF1", StreamType: "definition"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDefinition, ID: "DEF1"}},
+		},
+		{
+			"DefinitionMemberRemoved reindexes definition",
+			store.PersistedEvent{EventType: "DefinitionMemberRemoved", StreamID: "DEF1", StreamType: "definition"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDefinition, ID: "DEF1"}},
+		},
+		{
+			"DefinitionMemberReordered reindexes definition",
+			store.PersistedEvent{EventType: "DefinitionMemberReordered", StreamID: "DEF1", StreamType: "definition"},
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDefinition, ID: "DEF1"}},
 		},
 		{


### PR DESCRIPTION
## Summary

Phase 2c of #81. Extends `api.AffectedSearchOps` to classify every ActionSet* + Definition* stream event and removes the matching handler-side enqueues. Introduces `cascadeIDsForRemove()` helper so the listener can pull parent IDs from `search.Index.GetReverseMembers` before enqueueing the remove, replacing the inline lookup the delete handlers used to do.

After this lands, the search-index listener owns the lifecycle of action_set + definition reindex/remove. The action↔set and set↔definition membership EDGE updates (`EnqueueMemberAdded`/`EnqueueMemberRemoved`) still fire from handlers — Phase 2c.2 (a follow-up PR) will extend `SearchAffected` with member-edge variants and remove those calls.

## Cleanup details

- **action_set_handler.go**: drops `enqueueSetReindex` helper, 4 call sites, the `GetReverseMembers` + `EnqueueRemove` block in `DeleteActionSet`, and now-unused `search` / `taskqueue` imports.
- **definition_handler.go**: same treatment.

## Race-window note (cascade lookup)

`cascadeIDsForRemove` reads from Redis. The reverse-member entries for a deleted parent persist in Redis until the indexer worker actually processes the `EnqueueRemove` task — so the listener's lookup still finds them in the single-remove flow. For rapid-burst deletes there's a window where the indexer worker has already cleared one parent's reverse set when the listener for the next delete fires. Drift is bounded by the periodic indexer reconciler (~1h), so the worst case is "a parent's denormalised member list is briefly stale."

## Test plan

- [x] `TestAffectedSearchOps` extended with explicit cases for every newly-covered event type
- [x] No regressions on `TestCreateActionSet`, `TestDeleteActionSet`, `TestRenameActionSet`, `TestCreateDefinition`, `TestDeleteDefinition`, `TestRenameDefinition`
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Streamlined search index operations for action sets and definitions through updated event handling.

* **Tests**
  * Extended test coverage for search event classifications and operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->