### PR TITLE
feat: search-index listener covers action (#81 Phase 2d)

### DIFF
--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -18,7 +18,6 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
-	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
@@ -479,7 +478,6 @@ func (h *ActionHandler) CreateAction(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
-	h.enqueueActionReindex(ctx, action)
 
 	return connect.NewResponse(&pm.CreateActionResponse{
 		Action: h.actionToProto(action),
@@ -580,7 +578,6 @@ func (h *ActionHandler) RenameAction(ctx context.Context, req *connect.Request[p
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
 	}
 
-	h.enqueueActionReindex(ctx, action)
 
 	return connect.NewResponse(&pm.UpdateActionResponse{
 		Action: h.actionToProto(action),
@@ -624,7 +621,6 @@ func (h *ActionHandler) UpdateActionDescription(ctx context.Context, req *connec
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
 	}
 
-	h.enqueueActionReindex(ctx, action)
 
 	return connect.NewResponse(&pm.UpdateActionResponse{
 		Action: h.actionToProto(action),
@@ -725,7 +721,6 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	h.enqueueActionReindex(ctx, action)
 
 	return connect.NewResponse(&pm.UpdateActionResponse{
 		Action: h.actionToProto(action),
@@ -807,12 +802,6 @@ func (h *ActionHandler) DeleteAction(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
-	// Capture cascade IDs from Valkey before deleting.
-	var cascadeIDs []string
-	if h.searchIdx != nil {
-		cascadeIDs = h.searchIdx.GetReverseMembers(ctx, "action", req.Msg.Id)
-	}
-
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action",
 		StreamID:   req.Msg.Id,
@@ -824,11 +813,10 @@ func (h *ActionHandler) DeleteAction(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
-	if h.searchIdx != nil {
-		if err := h.searchIdx.EnqueueRemove(ctx, "action", req.Msg.Id, cascadeIDs); err != nil {
-			h.logger.Warn("failed to enqueue search index remove", "scope", "action", "error", err)
-		}
-	}
+	// Search index removal + cascade-rebuild of parent action_sets
+	// is handled by api.SearchListener (Phase 2d of #81): the
+	// listener calls GetReverseMembers + EnqueueRemove on
+	// ActionDeleted.
 
 	return connect.NewResponse(&pm.DeleteActionResponse{}), nil
 }
@@ -1743,36 +1731,6 @@ func extractActionParamsMsg(action *pm.Action) proto.Message {
 	default:
 		return nil
 	}
-}
-
-// enqueueActionReindex enqueues a search index update for an action.
-func (h *ActionHandler) enqueueActionReindex(ctx context.Context, a db.ActionsProjection) {
-	desc := ""
-	if a.Description != nil {
-		desc = *a.Description
-	}
-	isCompliance := false
-	var params map[string]any
-	if json.Unmarshal(a.Params, &params) == nil {
-		if v, ok := params["isCompliance"].(bool); ok {
-			isCompliance = v
-		}
-	}
-	var createdAt, updatedAt int64
-	if a.CreatedAt != nil {
-		createdAt = a.CreatedAt.Unix()
-	}
-	if a.UpdatedAt != nil {
-		updatedAt = a.UpdatedAt.Unix()
-	}
-	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeAction, a.ID, &taskqueue.SearchEntityData{
-		Name:         a.Name,
-		Description:  desc,
-		Type:         a.ActionType,
-		IsCompliance: isCompliance,
-		CreatedAt:    createdAt,
-		UpdatedAt:    updatedAt,
-	})
 }
 
 func (h *ActionHandler) actionToProto(a db.ActionsProjection) *pm.ManagedAction {

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -216,6 +217,22 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 
 	case "DefinitionDeleted":
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeDefinition, ID: e.StreamID}}
+
+	// ---------------------------------------------------------
+	// Action scope
+	// ---------------------------------------------------------
+	// Name, description, type, and the isCompliance flag (parsed
+	// from action.params) all live on the search row. ParamsUpdated
+	// triggers a reindex because the isCompliance derivation can
+	// flip when params change.
+	case "ActionCreated",
+		"ActionRenamed",
+		"ActionDescriptionUpdated",
+		"ActionParamsUpdated":
+		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeAction, ID: e.StreamID}}
+
+	case "ActionDeleted":
+		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeAction, ID: e.StreamID}}
 	}
 
 	return nil
@@ -401,6 +418,42 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, scope, id string
 			UpdatedAt:   updatedAt,
 		}, nil
 
+	case search.ScopeAction:
+		a, err := q.GetActionByID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		desc := ""
+		if a.Description != nil {
+			desc = *a.Description
+		}
+		// isCompliance lives in action.params as a boolean. The
+		// search row denormalises it so a search hit can render
+		// without parsing JSON. Mirrors the handler's old
+		// enqueueActionReindex shape.
+		isCompliance := false
+		var params map[string]any
+		if json.Unmarshal(a.Params, &params) == nil {
+			if v, ok := params["isCompliance"].(bool); ok {
+				isCompliance = v
+			}
+		}
+		var createdAt, updatedAt int64
+		if a.CreatedAt != nil {
+			createdAt = a.CreatedAt.Unix()
+		}
+		if a.UpdatedAt != nil {
+			updatedAt = a.UpdatedAt.Unix()
+		}
+		return &taskqueue.SearchEntityData{
+			Name:         a.Name,
+			Description:  desc,
+			Type:         a.ActionType,
+			IsCompliance: isCompliance,
+			CreatedAt:    createdAt,
+			UpdatedAt:    updatedAt,
+		}, nil
+
 	case search.ScopeDefinition:
 		d, err := q.GetDefinitionByID(ctx, id)
 		if err != nil {
@@ -509,7 +562,7 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, scope, id string
 // no race.
 func cascadeIDsForRemove(ctx context.Context, idx *search.Index, scope, id string) []string {
 	switch scope {
-	case search.ScopeActionSet, search.ScopeDefinition:
+	case search.ScopeAction, search.ScopeActionSet, search.ScopeDefinition:
 		return idx.GetReverseMembers(ctx, scope, id)
 	}
 	return nil

--- a/internal/api/search_listener_test.go
+++ b/internal/api/search_listener_test.go
@@ -337,13 +337,41 @@ func TestAffectedSearchOps(t *testing.T) {
 			[]api.SearchAffected{{Op: api.SearchOpRemove, Scope: search.ScopeDefinition, ID: "DEF1"}},
 		},
 
+		// Action scope (added in Phase 2d). Every classified event
+		// has an explicit row.
+		{
+			"ActionCreated reindexes action",
+			store.PersistedEvent{EventType: "ActionCreated", StreamID: "ACT1", StreamType: "action"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeAction, ID: "ACT1"}},
+		},
+		{
+			"ActionRenamed reindexes action",
+			store.PersistedEvent{EventType: "ActionRenamed", StreamID: "ACT1", StreamType: "action"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeAction, ID: "ACT1"}},
+		},
+		{
+			"ActionDescriptionUpdated reindexes action",
+			store.PersistedEvent{EventType: "ActionDescriptionUpdated", StreamID: "ACT1", StreamType: "action"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeAction, ID: "ACT1"}},
+		},
+		{
+			"ActionParamsUpdated reindexes action (isCompliance derived from params can flip)",
+			store.PersistedEvent{EventType: "ActionParamsUpdated", StreamID: "ACT1", StreamType: "action"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeAction, ID: "ACT1"}},
+		},
+		{
+			"ActionDeleted removes action (cascade IDs to parent action_sets resolved at dispatch time)",
+			store.PersistedEvent{EventType: "ActionDeleted", StreamID: "ACT1", StreamType: "action"},
+			[]api.SearchAffected{{Op: api.SearchOpRemove, Scope: search.ScopeAction, ID: "ACT1"}},
+		},
+
 		// Out-of-scope: event types from handlers not yet ported
 		// classify as nil today. When subsequent Phase 2 PRs add a
 		// scope they MUST move from nil to a populated slice in the
 		// same PR that removes the handler-side enqueue.
 		{
-			"ActionCreated is Phase-2d scope (returns nil today)",
-			store.PersistedEvent{EventType: "ActionCreated", StreamID: "ACT1", StreamType: "action"},
+			"CompliancePolicyCreated is Phase-2e scope (returns nil today)",
+			store.PersistedEvent{EventType: "CompliancePolicyCreated", StreamID: "CP1", StreamType: "compliance_policy"},
 			nil,
 		},
 


### PR DESCRIPTION
## Summary

Phase 2d of #81. Extends `api.AffectedSearchOps` to classify every Action* stream event and removes the handler-side enqueues from `action_handler.go` (helper + 4 call sites + the `GetReverseMembers` + `EnqueueRemove` block in `DeleteAction`).

`cascadeIDsForRemove` now covers `search.ScopeAction` too — actions have parent action_sets in the search-index reverse-member graph, and those parents need rebuild when an action is removed.

## Cleanup details

- Drops `enqueueActionReindex` helper
- Drops 4 helper call sites (`CreateAction`, `RenameAction`, `UpdateActionDescription`, `UpdateActionParams`)
- Drops the `GetReverseMembers` + `EnqueueRemove` block in `DeleteAction`
- Drops now-unused `search` import (taskqueue stays — it's used by the action-dispatch path)

## Test plan

- [x] `TestAffectedSearchOps` extended with cases for ActionCreated/Renamed/DescriptionUpdated/ParamsUpdated/Deleted
- [x] No regressions on `TestCreateAction`, `TestDeleteAction`, `TestRenameAction`, `TestUpdateActionDescription`
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal search index maintenance architecture for better code organization and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->