### PR TITLE
feat: search-index listener covers compliance_policy (#81 Phase 2e)

### DIFF
--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
-	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -12,10 +11,8 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
-	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
-	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
 // CompliancePolicyHandler handles compliance policy RPCs.
@@ -31,27 +28,6 @@ func NewCompliancePolicyHandler(st *store.Store, logger *slog.Logger) *Complianc
 		store:  st,
 		logger: logger,
 	}
-}
-
-// enqueueCompliancePolicyReindex enqueues a search index update for a compliance policy.
-// When rules is non-nil, action_names is included in the update. When nil, it is skipped
-// (HSET is additive, so existing action_names stays unchanged).
-func (h *CompliancePolicyHandler) enqueueCompliancePolicyReindex(ctx context.Context, p db.CompliancePoliciesProjection, rules []db.CompliancePolicyRulesProjection) {
-	data := &taskqueue.SearchEntityData{
-		Name:        p.Name,
-		Description: p.Description,
-	}
-	if rules != nil {
-		var actionNames []string
-		for _, r := range rules {
-			if r.ActionName != "" {
-				actionNames = append(actionNames, r.ActionName)
-			}
-		}
-		data.ActionNames = strings.Join(actionNames, " ")
-		data.HasActionNames = true
-	}
-	enqueueSearchReindex(ctx, h.searchIdx, h.logger, search.ScopeCompliancePolicy, p.ID, data)
 }
 
 // CreateCompliancePolicy creates a new compliance policy.
@@ -86,7 +62,6 @@ func (h *CompliancePolicyHandler) CreateCompliancePolicy(ctx context.Context, re
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy")
 	}
 
-	h.enqueueCompliancePolicyReindex(ctx, policy, []db.CompliancePolicyRulesProjection{})
 
 	return connect.NewResponse(&pm.CreateCompliancePolicyResponse{
 		Policy: h.policyToProto(policy, nil),
@@ -183,7 +158,6 @@ func (h *CompliancePolicyHandler) RenameCompliancePolicy(ctx context.Context, re
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy")
 	}
 
-	h.enqueueCompliancePolicyReindex(ctx, policy, nil)
 
 	return connect.NewResponse(&pm.UpdateCompliancePolicyResponse{
 		Policy: h.policyToProto(policy, nil),
@@ -225,7 +199,6 @@ func (h *CompliancePolicyHandler) UpdateCompliancePolicyDescription(ctx context.
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy")
 	}
 
-	h.enqueueCompliancePolicyReindex(ctx, policy, nil)
 
 	return connect.NewResponse(&pm.UpdateCompliancePolicyResponse{
 		Policy: h.policyToProto(policy, nil),
@@ -260,11 +233,8 @@ func (h *CompliancePolicyHandler) DeleteCompliancePolicy(ctx context.Context, re
 		return nil, err
 	}
 
-	if h.searchIdx != nil {
-		if err := h.searchIdx.EnqueueRemove(ctx, search.ScopeCompliancePolicy, req.Msg.Id, nil); err != nil {
-			h.logger.Warn("failed to enqueue compliance policy removal from search", "id", req.Msg.Id, "error", err)
-		}
-	}
+	// Search index removal is handled by api.SearchListener (Phase 2e
+	// of #81): the listener fires on CompliancePolicyDeleted.
 
 	return connect.NewResponse(&pm.DeleteCompliancePolicyResponse{}), nil
 }
@@ -332,7 +302,6 @@ func (h *CompliancePolicyHandler) AddCompliancePolicyRule(ctx context.Context, r
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy rules")
 	}
 
-	h.enqueueCompliancePolicyReindex(ctx, policy, rules)
 
 	return connect.NewResponse(&pm.AddCompliancePolicyRuleResponse{
 		Policy: h.policyToProto(policy, rules),
@@ -379,7 +348,6 @@ func (h *CompliancePolicyHandler) RemoveCompliancePolicyRule(ctx context.Context
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy rules")
 	}
 
-	h.enqueueCompliancePolicyReindex(ctx, policy, rules)
 
 	return connect.NewResponse(&pm.RemoveCompliancePolicyRuleResponse{
 		Policy: h.policyToProto(policy, rules),

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -288,7 +288,7 @@ func SearchListener(st *store.Store, idx *search.Index, logger *slog.Logger) sto
 		for _, op := range ops {
 			switch op.Op {
 			case SearchOpReindex:
-				data, err := loadSearchEntityData(ctx, st, op.Scope, op.ID)
+				data, err := loadSearchEntityData(ctx, st, logger, op.Scope, op.ID)
 				if err != nil {
 					if errors.Is(err, pgx.ErrNoRows) {
 						logger.Debug("search listener: entity gone before reindex (likely deleted in same tx batch); skipping",
@@ -336,7 +336,7 @@ func SearchListener(st *store.Store, idx *search.Index, logger *slog.Logger) sto
 // key but the LATEST payload wins. So listener payload divergence
 // would be silent until Phase 2 removes the handler-side path. The
 // Phase 1 tests assert end-to-end equivalence to catch this.
-func loadSearchEntityData(ctx context.Context, st *store.Store, scope, id string) (*taskqueue.SearchEntityData, error) {
+func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Logger, scope, id string) (*taskqueue.SearchEntityData, error) {
 	q := st.Queries()
 	switch scope {
 
@@ -448,10 +448,17 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, scope, id string
 		// Rule list is denormalised into ActionNames so a search
 		// hit can match against the action names referenced by the
 		// policy's rules. Best-effort: a rule-list query failure
-		// leaves ActionNames empty, which mirrors the handler's
-		// previous behaviour (caller passed nil rules in some
-		// paths).
-		if rules, rErr := q.ListCompliancePolicyRules(ctx, id); rErr == nil {
+		// is logged but doesn't fail the reindex — we'd rather
+		// publish a payload missing ActionNames than skip the
+		// reindex entirely. HasActionNames stays false so the
+		// indexer worker leaves any prior denormalised value alone
+		// (HSET-additive semantics) instead of clobbering it with
+		// an empty string we never confirmed was correct.
+		rules, rErr := q.ListCompliancePolicyRules(ctx, id)
+		if rErr != nil {
+			logger.Warn("search listener: failed to load compliance policy rules; reindex without action_names",
+				"policy_id", id, "error", rErr)
+		} else {
 			var actionNames []string
 			for _, r := range rules {
 				if r.ActionName != "" {

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -233,6 +233,24 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 
 	case "ActionDeleted":
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeAction, ID: e.StreamID}}
+
+	// ---------------------------------------------------------
+	// CompliancePolicy scope
+	// ---------------------------------------------------------
+	// Name + description live on the search row; the rule list
+	// contributes denormalised action names ("ActionNames" field) so
+	// a search hit ranks/highlights by the policy's referenced
+	// actions. Rule mutations therefore reindex the policy too.
+	case "CompliancePolicyCreated",
+		"CompliancePolicyRenamed",
+		"CompliancePolicyDescriptionUpdated",
+		"CompliancePolicyRuleAdded",
+		"CompliancePolicyRuleRemoved",
+		"CompliancePolicyRuleUpdated":
+		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeCompliancePolicy, ID: e.StreamID}}
+
+	case "CompliancePolicyDeleted":
+		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeCompliancePolicy, ID: e.StreamID}}
 	}
 
 	return nil
@@ -417,6 +435,33 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, scope, id string
 			CreatedAt:   createdAt,
 			UpdatedAt:   updatedAt,
 		}, nil
+
+	case search.ScopeCompliancePolicy:
+		p, err := q.GetCompliancePolicyByID(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		data := &taskqueue.SearchEntityData{
+			Name:        p.Name,
+			Description: p.Description,
+		}
+		// Rule list is denormalised into ActionNames so a search
+		// hit can match against the action names referenced by the
+		// policy's rules. Best-effort: a rule-list query failure
+		// leaves ActionNames empty, which mirrors the handler's
+		// previous behaviour (caller passed nil rules in some
+		// paths).
+		if rules, rErr := q.ListCompliancePolicyRules(ctx, id); rErr == nil {
+			var actionNames []string
+			for _, r := range rules {
+				if r.ActionName != "" {
+					actionNames = append(actionNames, r.ActionName)
+				}
+			}
+			data.ActionNames = strings.Join(actionNames, " ")
+			data.HasActionNames = true
+		}
+		return data, nil
 
 	case search.ScopeAction:
 		a, err := q.GetActionByID(ctx, id)

--- a/internal/api/search_listener_test.go
+++ b/internal/api/search_listener_test.go
@@ -365,14 +365,42 @@ func TestAffectedSearchOps(t *testing.T) {
 			[]api.SearchAffected{{Op: api.SearchOpRemove, Scope: search.ScopeAction, ID: "ACT1"}},
 		},
 
-		// Out-of-scope: event types from handlers not yet ported
-		// classify as nil today. When subsequent Phase 2 PRs add a
-		// scope they MUST move from nil to a populated slice in the
-		// same PR that removes the handler-side enqueue.
+		// CompliancePolicy scope (added in Phase 2e). Every classified
+		// event has an explicit row.
 		{
-			"CompliancePolicyCreated is Phase-2e scope (returns nil today)",
+			"CompliancePolicyCreated reindexes policy",
 			store.PersistedEvent{EventType: "CompliancePolicyCreated", StreamID: "CP1", StreamType: "compliance_policy"},
-			nil,
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeCompliancePolicy, ID: "CP1"}},
+		},
+		{
+			"CompliancePolicyRenamed reindexes policy",
+			store.PersistedEvent{EventType: "CompliancePolicyRenamed", StreamID: "CP1", StreamType: "compliance_policy"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeCompliancePolicy, ID: "CP1"}},
+		},
+		{
+			"CompliancePolicyDescriptionUpdated reindexes policy",
+			store.PersistedEvent{EventType: "CompliancePolicyDescriptionUpdated", StreamID: "CP1", StreamType: "compliance_policy"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeCompliancePolicy, ID: "CP1"}},
+		},
+		{
+			"CompliancePolicyRuleAdded reindexes policy (rules contribute denormalised action_names)",
+			store.PersistedEvent{EventType: "CompliancePolicyRuleAdded", StreamID: "CP1", StreamType: "compliance_policy"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeCompliancePolicy, ID: "CP1"}},
+		},
+		{
+			"CompliancePolicyRuleRemoved reindexes policy",
+			store.PersistedEvent{EventType: "CompliancePolicyRuleRemoved", StreamID: "CP1", StreamType: "compliance_policy"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeCompliancePolicy, ID: "CP1"}},
+		},
+		{
+			"CompliancePolicyRuleUpdated reindexes policy",
+			store.PersistedEvent{EventType: "CompliancePolicyRuleUpdated", StreamID: "CP1", StreamType: "compliance_policy"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeCompliancePolicy, ID: "CP1"}},
+		},
+		{
+			"CompliancePolicyDeleted removes policy",
+			store.PersistedEvent{EventType: "CompliancePolicyDeleted", StreamID: "CP1", StreamType: "compliance_policy"},
+			[]api.SearchAffected{{Op: api.SearchOpRemove, Scope: search.ScopeCompliancePolicy, ID: "CP1"}},
 		},
 
 		// Unknown event type


### PR DESCRIPTION
## Summary

Final scope-coverage PR for #81 Phase 2. Extends `api.AffectedSearchOps` to classify every CompliancePolicy* stream event and removes the handler-side enqueues from `compliance_policy_handler.go` (helper + 5 call sites + the inline `EnqueueRemove` in `DeleteCompliancePolicy` + 3 unused imports).

`loadSearchEntityData` for `ScopeCompliancePolicy` re-derives the same payload the handler used to build inline, including the denormalised `action_names` string built from the policy's rule list (best-effort: a rule-list query failure leaves `ActionNames` empty, mirroring the handler's previous nil-rules path).

## Status after this PR

The listener is the source of truth for **every reindex/remove path** on user, device, device_group, user_group, action_set, definition, action, execution, and compliance_policy.

The only remaining handler-side search calls are 4 `EnqueueMemberAdded`/`EnqueueMemberRemoved` sites in `action_set_handler.go` (`AddActionToSet`/`RemoveActionFromSet`) and `definition_handler.go` (`AddActionSetToDefinition`/`RemoveActionSetFromDefinition`). Those need a new `SearchOp` member-edge variant carrying parent-scope, child-scope, child-id, child-name. Tracked as Phase 2c.2 follow-up — not blocking the rest of #81 Phase 2 from landing.

## Test plan

- [x] `TestAffectedSearchOps` extended with cases for every CompliancePolicy* event
- [x] No regressions on `TestCreateCompliancePolicy`, `TestDeleteCompliancePolicy`, `TestRenameCompliancePolicy`, `TestAddCompliancePolicyRule`
- [x] `go build ./...` clean

## End-to-end test infrastructure

The classifier-table tests prove `AffectedSearchOps` for every covered event but don't exercise `loadSearchEntityData` / `cascadeIDsForRemove` end-to-end. CR raised this on PR #114; tracked as #115 for a dedicated follow-up that builds a fake `search.Index` recorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compliance policies are now included in search indexing. Search results will automatically update when compliance policies are created, modified, or deleted.

* **Bug Fixes**
  * Fixed search index handling for compliance policy operations to ensure consistent behavior across create, update, and delete actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->