### PR TITLE
feat: port project_security_alert_event to Go listener (#96)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -365,6 +365,26 @@ func main() {
 	// 3) Periodic reconciler — durability safety net for the listener,
 	//    catches any event whose effect on system actions the
 	//    listener doesn't yet know about. Default 1m.
+	// Phase 1 of the PL/pgSQL → Go projector migration (#96): the
+	// security_alert projector now lives in Go via a post-commit
+	// listener. The (now-deleted) PL/pgSQL function
+	// project_security_alert_event + its sidecar trigger ran inside
+	// the AppendEvent transaction. The Go listener fires post-commit,
+	// but no consumer of security_alerts_projection relies on
+	// read-your-writes after an alert append, so the async write is
+	// safe. ON CONFLICT (event_id) DO NOTHING in the insert keeps it
+	// idempotent against post-crash re-fires.
+	//
+	// Registered OUTSIDE the SystemActions guard below — the
+	// projector listener has no SystemActions dependency, and a
+	// deployment with SystemActions disabled must still update the
+	// security_alerts_projection (the PL/pgSQL trigger this replaces
+	// always fired regardless of subsystem availability).
+	st.RegisterEventListener(projectors.SecurityAlertListener(
+		st,
+		logger.With("component", "security_alert_projector"),
+	))
+
 	if svc.SystemActions() != nil {
 		// (1) Startup sweep — keeps the existing Info line so
 		// operators see the one-shot convergence in boot logs.
@@ -379,20 +399,6 @@ func main() {
 		// durability safety net. Reuse the same per-sweep timeout
 		// as the reconciler so a wedged DB / signer can't leak a
 		// goroutine indefinitely (#77 review round 2).
-		// Phase 1 of the PL/pgSQL → Go projector migration (#96):
-		// the security_alert projector now lives in Go via a
-		// post-commit listener. The (now-deleted) PL/pgSQL function
-		// project_security_alert_event + its sidecar trigger ran
-		// inside the AppendEvent transaction. The Go listener fires
-		// post-commit, but no consumer of security_alerts_projection
-		// relies on read-your-writes after an alert append, so the
-		// async write is safe. ON CONFLICT (event_id) DO NOTHING in
-		// the insert keeps it idempotent against post-crash re-fires.
-		st.RegisterEventListener(projectors.SecurityAlertListener(
-			st,
-			logger.With("component", "security_alert_projector"),
-		))
-
 		st.RegisterEventListener(api.SystemActionListener(
 			svc.SystemActions(),
 			logger.With("component", "system_action_listener"),

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/middleware"
+	"github.com/manchtools/power-manage/server/internal/projectors"
 	"github.com/manchtools/power-manage/server/internal/mtls"
 	"github.com/manchtools/power-manage/server/internal/scim"
 	"github.com/manchtools/power-manage/server/internal/search"
@@ -378,6 +379,20 @@ func main() {
 		// durability safety net. Reuse the same per-sweep timeout
 		// as the reconciler so a wedged DB / signer can't leak a
 		// goroutine indefinitely (#77 review round 2).
+		// Phase 1 of the PL/pgSQL → Go projector migration (#96):
+		// the security_alert projector now lives in Go via a
+		// post-commit listener. The (now-deleted) PL/pgSQL function
+		// project_security_alert_event + its sidecar trigger ran
+		// inside the AppendEvent transaction. The Go listener fires
+		// post-commit, but no consumer of security_alerts_projection
+		// relies on read-your-writes after an alert append, so the
+		// async write is safe. ON CONFLICT (event_id) DO NOTHING in
+		// the insert keeps it idempotent against post-crash re-fires.
+		st.RegisterEventListener(projectors.SecurityAlertListener(
+			st,
+			logger.With("component", "security_alert_projector"),
+		))
+
 		st.RegisterEventListener(api.SystemActionListener(
 			svc.SystemActions(),
 			logger.With("component", "system_action_listener"),

--- a/internal/projectors/security_alert.go
+++ b/internal/projectors/security_alert.go
@@ -1,0 +1,113 @@
+// Package projectors hosts pure functions that derive projection-row
+// shapes from PersistedEvents, plus the post-commit listeners that
+// apply those shapes to the database.
+//
+// The split between "pure derivation" and "DB-side application" is
+// deliberate: handlers building immediate API responses call the
+// pure function on the freshly-appended event to produce the
+// response in memory, while the post-commit listener calls the
+// SAME pure function and writes the result to the projection. By
+// construction the two cannot diverge — they're the same function
+// applied to the same event — so the read-back gap (post-commit
+// projection write hasn't landed yet) is invisible to the caller
+// that wrote the event.
+//
+// First scope ported under this pattern is `security_alert` (#96).
+// Subsequent ports (#97–#106) follow the same shape: one file per
+// stream type with pure derivation funcs + a Listener registration.
+//
+// Refs tracker #107.
+package projectors
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// ErrIgnoredEvent signals that the projector saw an event it does
+// not care about (wrong stream_type or wrong event_type combo). The
+// listener wrapper uses it to silently no-op on every other event
+// in the stream without polluting the warning log.
+var ErrIgnoredEvent = errors.New("projector: event ignored")
+
+// SecurityAlertProjectionFromEvent returns the projection row that
+// `SecurityAlert` event implies. Returns ErrIgnoredEvent for any
+// other event type so callers can use the same function for the
+// dispatcher's "should I do anything?" check.
+//
+// Pure: no I/O, deterministic, depends only on the event's fields.
+// Test it directly without a database. Reuse it from a handler that
+// wants to render the alert immediately while the listener writes
+// to the DB asynchronously.
+func SecurityAlertProjectionFromEvent(e store.PersistedEvent) (db.InsertSecurityAlertProjectionParams, error) {
+	if e.StreamType != "device" || e.EventType != "SecurityAlert" {
+		return db.InsertSecurityAlertProjectionParams{}, ErrIgnoredEvent
+	}
+
+	var data struct {
+		AlertType string          `json:"alert_type"`
+		Message   string          `json:"message"`
+		Details   json.RawMessage `json:"details"`
+	}
+	if err := json.Unmarshal(e.Data, &data); err != nil {
+		return db.InsertSecurityAlertProjectionParams{},
+			fmt.Errorf("projector: invalid SecurityAlert payload: %w", err)
+	}
+
+	// Details is a free-form JSONB blob; preserve whatever shape the
+	// emitter sent. The deleted PL/pgSQL projector stored
+	// `event.data->'details'` directly; json.RawMessage gives us the
+	// same byte-preservation contract on the Go side.
+	return db.InsertSecurityAlertProjectionParams{
+		EventID:   e.ID,
+		DeviceID:  e.StreamID,
+		AlertType: data.AlertType,
+		Message:   data.Message,
+		Details:   []byte(data.Details),
+		RaisedAt:  e.OccurredAt,
+	}, nil
+}
+
+// SecurityAlertAckParamsFromEvent returns the parameters needed to
+// apply a `SecurityAlertAcknowledged` event to the projection.
+// Same purity contract as SecurityAlertProjectionFromEvent.
+//
+// alert_id arrives as a string in the event data and must round-trip
+// to a UUID for the WHERE clause to hit the primary-key index. A
+// malformed UUID is propagated as a validation error rather than
+// silently full-scanning and matching nothing — matches the deleted
+// PL/pgSQL projector's `(event.data->>'alert_id')::uuid` behaviour.
+func SecurityAlertAckParamsFromEvent(e store.PersistedEvent) (db.AcknowledgeSecurityAlertProjectionParams, error) {
+	if e.StreamType != "device" || e.EventType != "SecurityAlertAcknowledged" {
+		return db.AcknowledgeSecurityAlertProjectionParams{}, ErrIgnoredEvent
+	}
+
+	var data struct {
+		AlertID        string `json:"alert_id"`
+		AcknowledgedBy string `json:"acknowledged_by"`
+	}
+	if err := json.Unmarshal(e.Data, &data); err != nil {
+		return db.AcknowledgeSecurityAlertProjectionParams{},
+			fmt.Errorf("projector: invalid SecurityAlertAcknowledged payload: %w", err)
+	}
+
+	alertID, err := uuid.Parse(data.AlertID)
+	if err != nil {
+		return db.AcknowledgeSecurityAlertProjectionParams{},
+			fmt.Errorf("projector: invalid alert_id %q in SecurityAlertAcknowledged: %w", data.AlertID, err)
+	}
+
+	occurredAt := e.OccurredAt
+	ackBy := data.AcknowledgedBy
+	return db.AcknowledgeSecurityAlertProjectionParams{
+		Column1:        alertID,
+		AcknowledgedAt: &occurredAt,
+		AcknowledgedBy: &ackBy,
+	}, nil
+}

--- a/internal/projectors/security_alert_listener.go
+++ b/internal/projectors/security_alert_listener.go
@@ -1,0 +1,99 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// SecurityAlertListener returns a store.EventListener that applies
+// SecurityAlert / SecurityAlertAcknowledged events to the
+// security_alerts_projection.
+//
+// Wired into the store at boot in cmd/control/main.go:
+//
+//	st.RegisterEventListener(projectors.SecurityAlertListener(st, logger))
+//
+// Replaces the (now-deleted) PL/pgSQL `project_security_alert_event`
+// function and its sidecar `project_security_alert_trigger`. The
+// trigger ran inside the AppendEvent transaction, so projection
+// writes were synchronous with the event commit. This listener is
+// post-commit, so the projection write is async — but no consumer
+// of security_alerts_projection relies on read-your-writes after a
+// SecurityAlert append. The original emitter (control InboxWorker
+// processing an Asynq task) doesn't return data to a synchronous
+// caller, and no API handler reads back the row immediately after
+// emitting the event.
+//
+// Errors are logged and swallowed (post-commit notification
+// contract). The 1h periodic indexer reconciler is the safety net
+// for any write that drops on the floor — bounded drift, not silent
+// data loss. The InsertSecurityAlertProjection query is idempotent
+// via ON CONFLICT (event_id) DO NOTHING, so a re-fire on crash
+// recovery is safe.
+//
+// Refs #96, tracker #107.
+func SecurityAlertListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		// Match the SearchListener factory contract: never return
+		// nil — handlers should not have to nil-guard registration.
+		return func(context.Context, store.PersistedEvent) {}
+	}
+
+	return func(ctx context.Context, e store.PersistedEvent) {
+		// Filter at the top so we don't pay the projector function
+		// call cost for every event flowing through the store.
+		if e.StreamType != "device" {
+			return
+		}
+		switch e.EventType {
+		case "SecurityAlert":
+			params, err := SecurityAlertProjectionFromEvent(e)
+			if err != nil {
+				if errors.Is(err, ErrIgnoredEvent) {
+					return
+				}
+				logger.Warn("security_alert projector: failed to derive insert params",
+					"event_id", e.ID, "error", err)
+				return
+			}
+			if err := st.Queries().InsertSecurityAlertProjection(ctx, params); err != nil {
+				logger.Warn("security_alert projector: failed to insert projection row",
+					"event_id", e.ID, "device_id", e.StreamID, "error", err)
+			}
+
+		case "SecurityAlertAcknowledged":
+			params, err := SecurityAlertAckParamsFromEvent(e)
+			if err != nil {
+				if errors.Is(err, ErrIgnoredEvent) {
+					return
+				}
+				// Malformed alert_id — log and skip. The deleted
+				// PL/pgSQL projector raised an EXCEPTION in this
+				// case so a sidecar trigger could catch it and
+				// write to projection_errors. Post-commit listener
+				// equivalent: log to stderr via slog.Warn so the
+				// operator sees it and can correlate with the event.
+				logger.Warn("security_alert projector: invalid SecurityAlertAcknowledged payload",
+					"event_id", e.ID, "error", err)
+				return
+			}
+			rows, err := st.Queries().AcknowledgeSecurityAlertProjection(ctx, params)
+			if err != nil {
+				logger.Warn("security_alert projector: failed to acknowledge alert",
+					"event_id", e.ID, "alert_id", params.Column1, "error", err)
+				return
+			}
+			if rows == 0 {
+				// Out-of-order replay (ack arrived before the
+				// alert insert reached the projection) or an alert
+				// that's been purged. Same warning the deleted
+				// PL/pgSQL projector raised.
+				logger.Warn("security_alert projector: SecurityAlertAcknowledged references unknown alert_id",
+					"event_id", e.ID, "alert_id", params.Column1)
+			}
+		}
+	}
+}

--- a/internal/projectors/security_alert_test.go
+++ b/internal/projectors/security_alert_test.go
@@ -175,4 +175,35 @@ func TestSecurityAlertListener_EndToEnd(t *testing.T) {
 	assert.Equal(t, "checksum mismatch", got.Message)
 	assert.JSONEq(t, `{"path":"/etc/shadow"}`, string(got.Details))
 	assert.False(t, got.Acknowledged, "newly-raised alert should not be acknowledged")
+
+	// Now exercise the SecurityAlertAcknowledged path end-to-end.
+	// Uses the alert's event_id as the alert_id payload — same
+	// shape the (deleted) PL/pgSQL projector matched on. CR catch
+	// on PR #117: this branch including the rows == 0 detection
+	// was previously not integration-tested.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   deviceID,
+		EventType:  "SecurityAlertAcknowledged",
+		Data: map[string]any{
+			"alert_id":        got.EventID.String(),
+			"acknowledged_by": "ops@example.com",
+		},
+		ActorType: "user",
+		ActorID:   "ops@example.com",
+	}))
+
+	for i := 0; i < 50; i++ {
+		alerts, err := st.Queries().ListSecurityAlertsForDevice(ctx, listParams)
+		require.NoError(t, err)
+		require.Len(t, alerts, 1)
+		if alerts[0].Acknowledged {
+			require.NotNil(t, alerts[0].AcknowledgedAt)
+			require.NotNil(t, alerts[0].AcknowledgedBy)
+			assert.Equal(t, "ops@example.com", *alerts[0].AcknowledgedBy)
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("listener did not apply SecurityAlertAcknowledged within polling window")
 }

--- a/internal/projectors/security_alert_test.go
+++ b/internal/projectors/security_alert_test.go
@@ -1,0 +1,178 @@
+package projectors_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestSecurityAlertProjectionFromEvent_Pure exercises the pure
+// derivation function without a database. Same input → same output;
+// the listener and any future handler-side immediate-render path
+// share this function so they cannot diverge.
+func TestSecurityAlertProjectionFromEvent_Pure(t *testing.T) {
+	occurredAt := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
+	eventID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+
+	t.Run("happy path with all fields", func(t *testing.T) {
+		payload, _ := json.Marshal(map[string]any{
+			"alert_type": "tamper",
+			"message":    "Filesystem checksum mismatch",
+			"details":    map[string]any{"path": "/etc/shadow"},
+		})
+		event := store.PersistedEvent{
+			ID:         eventID,
+			StreamType: "device",
+			StreamID:   "DEV1",
+			EventType:  "SecurityAlert",
+			Data:       payload,
+			OccurredAt: occurredAt,
+		}
+
+		got, err := projectors.SecurityAlertProjectionFromEvent(event)
+		require.NoError(t, err)
+		assert.Equal(t, eventID, got.EventID)
+		assert.Equal(t, "DEV1", got.DeviceID)
+		assert.Equal(t, "tamper", got.AlertType)
+		assert.Equal(t, "Filesystem checksum mismatch", got.Message)
+		assert.JSONEq(t, `{"path":"/etc/shadow"}`, string(got.Details))
+		assert.Equal(t, occurredAt, got.RaisedAt)
+	})
+
+	t.Run("missing details is empty bytes, not error", func(t *testing.T) {
+		payload, _ := json.Marshal(map[string]any{"alert_type": "x", "message": "y"})
+		got, err := projectors.SecurityAlertProjectionFromEvent(store.PersistedEvent{
+			ID: eventID, StreamType: "device", StreamID: "DEV1",
+			EventType: "SecurityAlert", Data: payload, OccurredAt: occurredAt,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, got.Details, "missing details ⇒ no bytes; matches the deleted PL/pgSQL projector's NULL semantics")
+	})
+
+	t.Run("wrong event type is silently ignored", func(t *testing.T) {
+		_, err := projectors.SecurityAlertProjectionFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceRegistered",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent),
+			"projector must signal ignore so the listener can no-op without logging")
+	})
+
+	t.Run("wrong stream type is silently ignored", func(t *testing.T) {
+		_, err := projectors.SecurityAlertProjectionFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "SecurityAlert",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed JSON returns a real error", func(t *testing.T) {
+		_, err := projectors.SecurityAlertProjectionFromEvent(store.PersistedEvent{
+			ID: eventID, StreamType: "device", StreamID: "DEV1",
+			EventType: "SecurityAlert", Data: []byte("not-json"), OccurredAt: occurredAt,
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent),
+			"a malformed payload is a real fault, not an ignore — operator must see it")
+	})
+}
+
+func TestSecurityAlertAckParamsFromEvent_Pure(t *testing.T) {
+	alertID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	occurredAt := time.Date(2026, 5, 4, 13, 0, 0, 0, time.UTC)
+
+	t.Run("happy path", func(t *testing.T) {
+		payload, _ := json.Marshal(map[string]any{
+			"alert_id":         alertID.String(),
+			"acknowledged_by":  "admin@example.com",
+		})
+		got, err := projectors.SecurityAlertAckParamsFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "SecurityAlertAcknowledged",
+			Data: payload, OccurredAt: occurredAt,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, alertID, got.Column1)
+		require.NotNil(t, got.AcknowledgedAt)
+		assert.Equal(t, occurredAt, *got.AcknowledgedAt)
+		require.NotNil(t, got.AcknowledgedBy)
+		assert.Equal(t, "admin@example.com", *got.AcknowledgedBy)
+	})
+
+	t.Run("malformed alert_id is a real error", func(t *testing.T) {
+		payload, _ := json.Marshal(map[string]any{"alert_id": "not-a-uuid"})
+		_, err := projectors.SecurityAlertAckParamsFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "SecurityAlertAcknowledged",
+			Data: payload, OccurredAt: occurredAt,
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent),
+			"a bad alert_id is a real fault — the deleted PL/pgSQL projector RAISE'd in this case")
+	})
+}
+
+// TestSecurityAlertListener_EndToEnd exercises the full pipeline:
+// register the listener → AppendEvent → poll for the projection
+// row to appear. Proves the listener writes correctly and that the
+// row's contents match what the pure derivation produced.
+//
+// Polling is required because the listener fires post-commit on a
+// separate goroutine — the AppendEvent call returns before the
+// projection insert lands. 1s budget at 20ms intervals is generous;
+// in practice the row appears within 1–2 polls on a warm container.
+func TestSecurityAlertListener_EndToEnd(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	logger := slog.Default()
+	st.RegisterEventListener(projectors.SecurityAlertListener(st, logger))
+
+	ctx := context.Background()
+	deviceID := testutil.CreateTestDevice(t, st, "alert-host-"+testutil.NewID())
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   deviceID,
+		EventType:  "SecurityAlert",
+		Data: map[string]any{
+			"alert_type": "tamper",
+			"message":    "checksum mismatch",
+			"details":    map[string]any{"path": "/etc/shadow"},
+		},
+		ActorType: "device",
+		ActorID:   deviceID,
+	}))
+
+	listParams := db.ListSecurityAlertsForDeviceParams{
+		DeviceID:            deviceID,
+		IncludeAcknowledged: true,
+		PageSize:            10,
+		PageOffset:          0,
+	}
+
+	var alerts []db.ListSecurityAlertsForDeviceRow
+	for i := 0; i < 50; i++ {
+		var err error
+		alerts, err = st.Queries().ListSecurityAlertsForDevice(ctx, listParams)
+		require.NoError(t, err)
+		if len(alerts) > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	require.Len(t, alerts, 1, "listener must have written the SecurityAlert projection within the polling window")
+
+	got := alerts[0]
+	assert.Equal(t, deviceID, got.DeviceID)
+	assert.Equal(t, "tamper", got.AlertType)
+	assert.Equal(t, "checksum mismatch", got.Message)
+	assert.JSONEq(t, `{"path":"/etc/shadow"}`, string(got.Details))
+	assert.False(t, got.Acknowledged, "newly-raised alert should not be acknowledged")
+}

--- a/internal/store/generated/security_alerts.sql.go
+++ b/internal/store/generated/security_alerts.sql.go
@@ -12,6 +12,33 @@ import (
 	"github.com/google/uuid"
 )
 
+const acknowledgeSecurityAlertProjection = `-- name: AcknowledgeSecurityAlertProjection :execrows
+UPDATE security_alerts_projection
+SET acknowledged = TRUE,
+    acknowledged_at = $2,
+    acknowledged_by = $3
+WHERE event_id = $1::uuid
+`
+
+type AcknowledgeSecurityAlertProjectionParams struct {
+	Column1        uuid.UUID  `json:"column_1"`
+	AcknowledgedAt *time.Time `json:"acknowledged_at"`
+	AcknowledgedBy *string    `json:"acknowledged_by"`
+}
+
+// AcknowledgeSecurityAlertProjection updates the ack columns. Returns
+// the affected row count so the projector listener can detect the
+// "acknowledged before alert exists" race (out-of-order replay) and
+// log it for operator visibility — matching the RAISE EXCEPTION
+// contract the deleted PL/pgSQL projector had.
+func (q *Queries) AcknowledgeSecurityAlertProjection(ctx context.Context, arg AcknowledgeSecurityAlertProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, acknowledgeSecurityAlertProjection, arg.Column1, arg.AcknowledgedAt, arg.AcknowledgedBy)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countSecurityAlertsForDevice = `-- name: CountSecurityAlertsForDevice :one
 SELECT COUNT(*)::bigint
 FROM security_alerts_projection
@@ -84,6 +111,39 @@ func (q *Queries) GetSecurityAlert(ctx context.Context, eventID uuid.UUID) (GetS
 		&i.AcknowledgedBy,
 	)
 	return i, err
+}
+
+const insertSecurityAlertProjection = `-- name: InsertSecurityAlertProjection :exec
+INSERT INTO security_alerts_projection (
+    event_id, device_id, alert_type, message, details, raised_at
+) VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (event_id) DO NOTHING
+`
+
+type InsertSecurityAlertProjectionParams struct {
+	EventID   uuid.UUID `json:"event_id"`
+	DeviceID  string    `json:"device_id"`
+	AlertType string    `json:"alert_type"`
+	Message   string    `json:"message"`
+	Details   []byte    `json:"details"`
+	RaisedAt  time.Time `json:"raised_at"`
+}
+
+// Write-side queries for the Go projector that replaced
+// project_security_alert_event() in #96. ON CONFLICT DO NOTHING on
+// insert keeps replay-from-events idempotent (the same event_id
+// inserted twice is a no-op); the projector listener can re-fire on
+// crash recovery without polluting the projection.
+func (q *Queries) InsertSecurityAlertProjection(ctx context.Context, arg InsertSecurityAlertProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertSecurityAlertProjection,
+		arg.EventID,
+		arg.DeviceID,
+		arg.AlertType,
+		arg.Message,
+		arg.Details,
+		arg.RaisedAt,
+	)
+	return err
 }
 
 const listSecurityAlertsForDevice = `-- name: ListSecurityAlertsForDevice :many

--- a/internal/store/migrations/017_drop_security_alert_projector.sql
+++ b/internal/store/migrations/017_drop_security_alert_projector.sql
@@ -1,0 +1,95 @@
+-- Drop the PL/pgSQL security_alert projector + its sidecar trigger.
+-- Replaced by a Go event listener (projectors.SecurityAlertListener)
+-- registered against the post-commit RegisterEventListener pipeline
+-- in cmd/control/main.go.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL trigger fired inside the AppendEvent
+--     transaction. Projection write was atomic with the event
+--     commit. Projector errors went into projection_errors via the
+--     sidecar trigger's EXCEPTION handler.
+--   - After: Go listener fires post-commit. Projection write is
+--     async (~ms after the event lands). Errors are logged via
+--     slog.Warn ("security_alert projector: ..."). The
+--     InsertSecurityAlertProjection sqlc query uses
+--     ON CONFLICT (event_id) DO NOTHING so a crash-recovered
+--     re-fire is idempotent.
+--
+-- Why this is safe for security_alert specifically:
+--   - The InboxWorker that emits SecurityAlert events is itself an
+--     async Asynq task — no synchronous caller waits on the
+--     projection write.
+--   - No API handler reads back a security_alert immediately after
+--     emitting one. The web UI's "ListSecurityAlertsForDevice"
+--     query naturally tolerates the small post-commit gap (refresh
+--     would catch up).
+--
+-- See manchtools/power-manage-server#96. First scope ported under
+-- the projector-migration pattern; subsequent stream types follow
+-- in #97–#106.
+
+-- +goose Up
+
+DROP TRIGGER IF EXISTS security_alert_projector ON events;
+DROP FUNCTION IF EXISTS project_security_alert_trigger();
+DROP FUNCTION IF EXISTS project_security_alert_event(events);
+
+
+-- +goose Down
+
+-- Restore both functions verbatim from migration 010 so a
+-- Down + Up cycle leaves the database in pre-#96 state.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_security_alert_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'SecurityAlert' THEN
+            INSERT INTO security_alerts_projection (
+                event_id, device_id, alert_type, message, details, raised_at
+            ) VALUES (
+                event.id,
+                event.stream_id,
+                event.data->>'alert_type',
+                event.data->>'message',
+                event.data->'details',
+                event.occurred_at
+            )
+            ON CONFLICT (event_id) DO NOTHING;
+        WHEN 'SecurityAlertAcknowledged' THEN
+            UPDATE security_alerts_projection
+            SET acknowledged = TRUE,
+                acknowledged_at = event.occurred_at,
+                acknowledged_by = event.data->>'acknowledged_by'
+            WHERE event_id = (event.data->>'alert_id')::uuid;
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'SecurityAlertAcknowledged references unknown alert_id=%', event.data->>'alert_id';
+            END IF;
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_security_alert_trigger() RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.stream_type = 'device'
+       AND NEW.event_type IN ('SecurityAlert', 'SecurityAlertAcknowledged') THEN
+        BEGIN
+            PERFORM project_security_alert_event(NEW);
+        EXCEPTION WHEN OTHERS THEN
+            INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+            VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+        END;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER security_alert_projector
+    AFTER INSERT ON events
+    FOR EACH ROW
+    EXECUTE FUNCTION project_security_alert_trigger();

--- a/internal/store/queries/security_alerts.sql
+++ b/internal/store/queries/security_alerts.sql
@@ -49,3 +49,28 @@ SELECT COUNT(*)::bigint
 FROM security_alerts_projection
 WHERE device_id = $1
   AND (sqlc.arg(include_acknowledged)::bool OR NOT acknowledged);
+
+-- Write-side queries for the Go projector that replaced
+-- project_security_alert_event() in #96. ON CONFLICT DO NOTHING on
+-- insert keeps replay-from-events idempotent (the same event_id
+-- inserted twice is a no-op); the projector listener can re-fire on
+-- crash recovery without polluting the projection.
+--
+-- name: InsertSecurityAlertProjection :exec
+INSERT INTO security_alerts_projection (
+    event_id, device_id, alert_type, message, details, raised_at
+) VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (event_id) DO NOTHING;
+
+-- AcknowledgeSecurityAlertProjection updates the ack columns. Returns
+-- the affected row count so the projector listener can detect the
+-- "acknowledged before alert exists" race (out-of-order replay) and
+-- log it for operator visibility — matching the RAISE EXCEPTION
+-- contract the deleted PL/pgSQL projector had.
+--
+-- name: AcknowledgeSecurityAlertProjection :execrows
+UPDATE security_alerts_projection
+SET acknowledged = TRUE,
+    acknowledged_at = $2,
+    acknowledged_by = $3
+WHERE event_id = $1::uuid;


### PR DESCRIPTION
## Summary

**Canary for the projector-migration pattern.** First scope ported under the agreed approach: a pure event→projection function lives in `internal/projectors/`, and a post-commit listener applies it to the database. The handler can call the same pure function on a freshly-appended event to render its API response immediately while the listener writes the row asynchronously — both produce identical state because they're the same function on the same event.

If this canary feels right, we apply the same shape to #97–#106 (totp, lps_password, luks_key, server_settings, role, user_role, token, identity_provider, scim_group_mapping, user_selection).

Closes #96. Unblocks #97–#106.

## Design summary

- **Pure function** (`SecurityAlertProjectionFromEvent`, `SecurityAlertAckParamsFromEvent`): no I/O, deterministic, fully unit-testable without a database. Returns `ErrIgnoredEvent` for events outside the scope so the listener wrapper can no-op silently.
- **Post-commit listener** (`SecurityAlertListener`): calls the pure functions, writes via two new sqlc queries (`InsertSecurityAlertProjection` / `AcknowledgeSecurityAlertProjection`). Errors logged + swallowed per the post-commit notification contract.
- **Idempotent insert** via `ON CONFLICT (event_id) DO NOTHING` so a crash-recovered re-fire is safe.
- **Out-of-order ack** (acknowledge arrives before the alert insert reaches the projection) is logged with the alert_id — same operator-visibility contract the deleted PL/pgSQL projector had via `RAISE EXCEPTION` + sidecar trigger's `EXCEPTION` handler.
- **Migration 017** drops `project_security_alert_event`, `project_security_alert_trigger`, and the `AFTER INSERT ON events` trigger. Down restores all three verbatim.

## Why async is safe for `security_alert` specifically

- The `InboxWorker` that emits `SecurityAlert` events is itself an async Asynq task — no synchronous caller waits on the projection write.
- No API handler reads back a security_alert immediately after emitting one; the web UI's list query naturally tolerates the small post-commit gap.

The handler-side immediate-render pattern (the killer feature of the pure-function split) isn't exercised by this scope, but it's available the moment a synchronous handler emits a `SecurityAlert` and wants to render the alert in its response. Subsequent ports (#97–#106) will exercise this path because their handlers are synchronous RPC paths.

## Test plan

- [x] `TestSecurityAlertProjectionFromEvent_Pure` — 5 cases (happy path, missing details, wrong event_type, wrong stream_type, malformed JSON)
- [x] `TestSecurityAlertAckParamsFromEvent_Pure` — happy + malformed UUID
- [x] `TestSecurityAlertListener_EndToEnd` — real Postgres via testcontainers, AppendEvent → poll for projection row → assert contents
- [x] `go build ./...` clean
- [x] No regressions on existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated security alert projection handling from database-level triggers to application-level event listeners, improving system performance and maintainability.

* **Tests**
  * Added comprehensive test coverage for security alert event projection and listener functionality, including edge cases and end-to-end scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->