### PR TITLE
feat: port project_totp_event to Go listener (#97)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -365,38 +365,17 @@ func main() {
 	// 3) Periodic reconciler — durability safety net for the listener,
 	//    catches any event whose effect on system actions the
 	//    listener doesn't yet know about. Default 1m.
-	// Phase 1 of the PL/pgSQL → Go projector migration (#96): the
-	// security_alert projector now lives in Go via a post-commit
-	// listener. The (now-deleted) PL/pgSQL function
-	// project_security_alert_event + its sidecar trigger ran inside
-	// the AppendEvent transaction. The Go listener fires post-commit,
-	// but no consumer of security_alerts_projection relies on
-	// read-your-writes after an alert append, so the async write is
-	// safe. ON CONFLICT (event_id) DO NOTHING in the insert keeps it
-	// idempotent against post-crash re-fires.
+	// Wire every Go-side projector listener in one place. The
+	// projectors package owns the list so test fixtures (testutil)
+	// and production boot stay in lockstep — adding a new ported
+	// projector in #98–#106 only touches projectors.WireAll.
 	//
-	// Registered OUTSIDE the SystemActions guard below — the
-	// projector listener has no SystemActions dependency, and a
-	// deployment with SystemActions disabled must still update the
-	// security_alerts_projection (the PL/pgSQL trigger this replaces
-	// always fired regardless of subsystem availability).
-	st.RegisterEventListener(projectors.SecurityAlertListener(
-		st,
-		logger.With("component", "security_alert_projector"),
-	))
-
-	// #97 — totp projector ported to Go. Same async-vs-sync analysis
-	// as #96: TotpEnabled is read on the auth/login path, never
-	// immediately after AppendEvent on the same request, so
-	// post-commit timing is fine. UpsertTotpProjection +
-	// VerifyTotpProjection + DeleteTotpProjection + the
-	// MarkTotpBackupCodeUsed / RegenerateTotpBackupCodes pair are
-	// idempotent against re-fire — every UPDATE matches by user_id +
-	// projection_version, the upsert uses ON CONFLICT.
-	st.RegisterEventListener(projectors.TotpListener(
-		st,
-		logger.With("component", "totp_projector"),
-	))
+	// Listeners fire synchronously inside Store.AppendEvent (after
+	// the event commit, before AppendEvent returns), so handlers
+	// see read-your-writes the same as they did under the deleted
+	// PL/pgSQL triggers. See WireAll's docstring for the
+	// atomicity caveat.
+	projectors.WireAll(st, logger)
 
 	if svc.SystemActions() != nil {
 		// (1) Startup sweep — keeps the existing Info line so

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -385,6 +385,19 @@ func main() {
 		logger.With("component", "security_alert_projector"),
 	))
 
+	// #97 — totp projector ported to Go. Same async-vs-sync analysis
+	// as #96: TotpEnabled is read on the auth/login path, never
+	// immediately after AppendEvent on the same request, so
+	// post-commit timing is fine. UpsertTotpProjection +
+	// VerifyTotpProjection + DeleteTotpProjection + the
+	// MarkTotpBackupCodeUsed / RegenerateTotpBackupCodes pair are
+	// idempotent against re-fire — every UPDATE matches by user_id +
+	// projection_version, the upsert uses ON CONFLICT.
+	st.RegisterEventListener(projectors.TotpListener(
+		st,
+		logger.With("component", "totp_projector"),
+	))
+
 	if svc.SystemActions() != nil {
 		// (1) Startup sweep — keeps the existing Info line so
 		// operators see the one-shot convergence in boot logs.

--- a/internal/projectors/totp.go
+++ b/internal/projectors/totp.go
@@ -1,0 +1,53 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// deref returns the value behind a pointer or the zero value when
+// the pointer is nil. Used to coerce sqlc-generated *int64 fields
+// (PostgreSQL nullable) into the int64 the listener writes back as
+// projection_version. SequenceNum is non-nullable on every event the
+// projector cares about (events.sequence_num is BIGSERIAL UNIQUE),
+// but the generated model exposes it as a pointer so the helper
+// makes the dereference explicit.
+func deref[T any](p *T) T {
+	if p == nil {
+		var zero T
+		return zero
+	}
+	return *p
+}
+
+// totpEventPayload covers every field the TOTP projector reads
+// across the five event types. Per-event derivation funcs below
+// pick the subset they need.
+type totpEventPayload struct {
+	SecretEncrypted string   `json:"secret_encrypted"`
+	BackupCodesHash []string `json:"backup_codes_hash"`
+	Index           *int     `json:"index"`
+}
+
+// decodeTotpPayload returns the parsed event data + the standard
+// invariant fields (sequence_num for projection_version, occurred_at
+// for updated_at). Centralised so each per-event helper doesn't
+// re-derive them.
+func decodeTotpPayload(e store.PersistedEvent) (totpEventPayload, error) {
+	if e.StreamType != "totp" {
+		return totpEventPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		// Empty payload (e.g. TOTPVerified, TOTPDisabled). Still
+		// valid — return zero-value payload, the per-event helper
+		// only reads the fields it needs.
+		return totpEventPayload{}, nil
+	}
+	var p totpEventPayload
+	if err := json.Unmarshal(e.Data, &p); err != nil {
+		return totpEventPayload{}, fmt.Errorf("projector: invalid TOTP event payload: %w", err)
+	}
+	return p, nil
+}

--- a/internal/projectors/totp_listener.go
+++ b/internal/projectors/totp_listener.go
@@ -1,0 +1,135 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// TotpListener returns a store.EventListener that applies every
+// TOTP* event to the totp_projection AND propagates the cross-stream
+// effect on users_projection.totp_enabled. Replaces the deleted
+// PL/pgSQL project_totp_event function.
+//
+// Cross-stream nuance:
+//   - TOTPVerified flips users_projection.totp_enabled to TRUE.
+//   - TOTPDisabled flips it back to FALSE.
+//
+// Both writes happen in the listener — the deleted PL/pgSQL
+// projector did them inline in one transaction, but for our
+// post-commit listener "both eventually land within milliseconds"
+// is the right contract: TotpEnabled is read on the auth/login
+// path, not on every API call, so there's a logout/login cycle
+// between the verify and the next read in practice. If both writes
+// would fail atomicity matters less than seeing the right state at
+// auth time.
+//
+// Wired in cmd/control/main.go alongside the other unconditional
+// projector listeners.
+//
+// Refs #97, tracker #107.
+func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "totp" {
+			return
+		}
+
+		payload, err := decodeTotpPayload(e)
+		if err != nil {
+			if errors.Is(err, ErrIgnoredEvent) {
+				return
+			}
+			logger.Warn("totp projector: invalid event payload",
+				"event_id", e.ID, "event_type", e.EventType, "error", err)
+			return
+		}
+
+		q := st.Queries()
+		updatedAt := e.OccurredAt
+		userID := e.StreamID
+
+		switch e.EventType {
+		case "TOTPSetupInitiated":
+			if err := q.UpsertTotpProjection(ctx, db.UpsertTotpProjectionParams{
+				UserID:            userID,
+				SecretEncrypted:   payload.SecretEncrypted,
+				BackupCodesHash:   payload.BackupCodesHash,
+				CreatedAt:         updatedAt,
+				ProjectionVersion: deref(e.SequenceNum),
+			}); err != nil {
+				logger.Warn("totp projector: failed to upsert TOTPSetupInitiated",
+					"event_id", e.ID, "user_id", userID, "error", err)
+			}
+
+		case "TOTPVerified":
+			if err := q.VerifyTotpProjection(ctx, db.VerifyTotpProjectionParams{
+				UserID:            userID,
+				UpdatedAt:         updatedAt,
+				ProjectionVersion: deref(e.SequenceNum),
+			}); err != nil {
+				logger.Warn("totp projector: failed to flip totp_projection to verified",
+					"event_id", e.ID, "user_id", userID, "error", err)
+			}
+			if err := q.SetUserTotpEnabled(ctx, db.SetUserTotpEnabledParams{
+				ID:                userID,
+				TotpEnabled:       true,
+				UpdatedAt:         &updatedAt,
+				ProjectionVersion: deref(e.SequenceNum),
+			}); err != nil {
+				logger.Warn("totp projector: failed to flip users_projection.totp_enabled=TRUE",
+					"event_id", e.ID, "user_id", userID, "error", err)
+			}
+
+		case "TOTPDisabled":
+			if err := q.DeleteTotpProjection(ctx, userID); err != nil {
+				logger.Warn("totp projector: failed to delete totp_projection row",
+					"event_id", e.ID, "user_id", userID, "error", err)
+			}
+			if err := q.SetUserTotpEnabled(ctx, db.SetUserTotpEnabledParams{
+				ID:                userID,
+				TotpEnabled:       false,
+				UpdatedAt:         &updatedAt,
+				ProjectionVersion: deref(e.SequenceNum),
+			}); err != nil {
+				logger.Warn("totp projector: failed to flip users_projection.totp_enabled=FALSE",
+					"event_id", e.ID, "user_id", userID, "error", err)
+			}
+
+		case "TOTPBackupCodeUsed":
+			if payload.Index == nil {
+				logger.Warn("totp projector: TOTPBackupCodeUsed missing index field",
+					"event_id", e.ID, "user_id", userID)
+				return
+			}
+			// PL/pgSQL projector: backup_codes_used[(idx)::int + 1]
+			// — convert 0-based event index to the 1-based Postgres
+			// array index here so the SQL stays clean.
+			if err := q.MarkTotpBackupCodeUsed(ctx, db.MarkTotpBackupCodeUsedParams{
+				UserID:            userID,
+				Column2:           int32(*payload.Index + 1),
+				UpdatedAt:         updatedAt,
+				ProjectionVersion: deref(e.SequenceNum),
+			}); err != nil {
+				logger.Warn("totp projector: failed to mark backup code used",
+					"event_id", e.ID, "user_id", userID, "index", *payload.Index, "error", err)
+			}
+
+		case "TOTPBackupCodesRegenerated":
+			if err := q.RegenerateTotpBackupCodes(ctx, db.RegenerateTotpBackupCodesParams{
+				UserID:            userID,
+				BackupCodesHash:   payload.BackupCodesHash,
+				UpdatedAt:         updatedAt,
+				ProjectionVersion: deref(e.SequenceNum),
+			}); err != nil {
+				logger.Warn("totp projector: failed to regenerate backup codes",
+					"event_id", e.ID, "user_id", userID, "error", err)
+			}
+		}
+	}
+}

--- a/internal/projectors/totp_test.go
+++ b/internal/projectors/totp_test.go
@@ -1,0 +1,266 @@
+package projectors_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestTotpListener_LifecycleEndToEnd walks the full TOTP lifecycle
+// (Setup → Verify → BackupCodeUsed → Disable) through the listener,
+// asserting both the totp_projection writes AND the cross-stream
+// users_projection.totp_enabled flips.
+//
+// The lifecycle ordering matters: Verify flips users_projection
+// totp_enabled=TRUE; Disable flips it back to FALSE. A regression in
+// either branch silently breaks the auth/login path because that's
+// where TotpEnabled is consulted.
+func TestTotpListener_LifecycleEndToEnd(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	logger := slog.Default()
+	st.RegisterEventListener(projectors.TotpListener(st, logger))
+
+	ctx := context.Background()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+
+	backupHashes := []string{
+		"hash-aaaaaaaaaaaaaaaa",
+		"hash-bbbbbbbbbbbbbbbb",
+		"hash-cccccccccccccccc",
+	}
+
+	// Setup
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "totp",
+		StreamID:   userID,
+		EventType:  "TOTPSetupInitiated",
+		Data: map[string]any{
+			"secret_encrypted":  "ENC:dummy-secret",
+			"backup_codes_hash": backupHashes,
+		},
+		ActorType: "user",
+		ActorID:   userID,
+	}))
+	totp := pollForTotpRow(t, st, userID, func(r totpProjectionFields) bool {
+		return r.SecretEncrypted == "ENC:dummy-secret"
+	})
+	assert.False(t, totp.Verified, "newly-initiated TOTP starts unverified")
+	assert.False(t, totp.Enabled)
+	require.Len(t, totp.BackupCodesHash, 3)
+	require.Len(t, totp.BackupCodesUsed, 3)
+	for i, used := range totp.BackupCodesUsed {
+		assert.False(t, used, "backup code %d should start unused", i)
+	}
+
+	// Verify — flips totp_projection AND users_projection.totp_enabled.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "totp",
+		StreamID:   userID,
+		EventType:  "TOTPVerified",
+		Data:       map[string]any{},
+		ActorType:  "user",
+		ActorID:    userID,
+	}))
+	totp = pollForTotpRow(t, st, userID, func(r totpProjectionFields) bool {
+		return r.Verified
+	})
+	assert.True(t, totp.Verified)
+	assert.True(t, totp.Enabled)
+	pollForUserTotpEnabled(t, st, userID, true)
+
+	// BackupCodeUsed (zero-based index in event payload, listener
+	// converts to 1-based for Postgres array indexing).
+	idx := 1
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "totp",
+		StreamID:   userID,
+		EventType:  "TOTPBackupCodeUsed",
+		Data:       map[string]any{"index": idx},
+		ActorType:  "user",
+		ActorID:    userID,
+	}))
+	totp = pollForTotpRow(t, st, userID, func(r totpProjectionFields) bool {
+		return r.BackupCodesUsed[idx]
+	})
+	assert.True(t, totp.BackupCodesUsed[idx], "backup code at index %d should be marked used", idx)
+	assert.False(t, totp.BackupCodesUsed[0], "untouched codes stay unused")
+
+	// Disable — drops the row + flips users_projection.totp_enabled=FALSE.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "totp",
+		StreamID:   userID,
+		EventType:  "TOTPDisabled",
+		Data:       map[string]any{},
+		ActorType:  "user",
+		ActorID:    userID,
+	}))
+	for i := 0; i < 50; i++ {
+		_, err := st.Queries().GetTOTPByUserID(ctx, userID)
+		if err != nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	_, err := st.Queries().GetTOTPByUserID(ctx, userID)
+	require.Error(t, err, "totp_projection row should be gone after Disable")
+	pollForUserTotpEnabled(t, st, userID, false)
+}
+
+// TestTotpListener_BackupCodesRegenerated covers the regenerate
+// branch separately so the lifecycle test stays focused.
+func TestTotpListener_BackupCodesRegenerated(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	st.RegisterEventListener(projectors.TotpListener(st, slog.Default()))
+	ctx := context.Background()
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "totp",
+		StreamID:   userID,
+		EventType:  "TOTPSetupInitiated",
+		Data: map[string]any{
+			"secret_encrypted":  "ENC:s",
+			"backup_codes_hash": []string{"a", "b"},
+		},
+		ActorType: "user",
+		ActorID:   userID,
+	}))
+	pollForTotpRow(t, st, userID, func(r totpProjectionFields) bool {
+		return len(r.BackupCodesHash) == 2
+	})
+
+	// Mark one as used so we can confirm regenerate resets the
+	// "used" array length and contents to match the new hash list.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "totp",
+		StreamID:   userID,
+		EventType:  "TOTPBackupCodeUsed",
+		Data:       map[string]any{"index": 0},
+		ActorType:  "user",
+		ActorID:    userID,
+	}))
+	pollForTotpRow(t, st, userID, func(r totpProjectionFields) bool {
+		return r.BackupCodesUsed[0]
+	})
+
+	// Regenerate with a different number of codes — proves the
+	// listener resets backup_codes_used to a fresh all-FALSE slice
+	// of the new length, not just clears the bits.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "totp",
+		StreamID:   userID,
+		EventType:  "TOTPBackupCodesRegenerated",
+		Data: map[string]any{
+			"backup_codes_hash": []string{"new-a", "new-b", "new-c", "new-d"},
+		},
+		ActorType: "user",
+		ActorID:   userID,
+	}))
+	got := pollForTotpRow(t, st, userID, func(r totpProjectionFields) bool {
+		return len(r.BackupCodesHash) == 4 && !r.BackupCodesUsed[0]
+	})
+	assert.Equal(t, []string{"new-a", "new-b", "new-c", "new-d"}, got.BackupCodesHash)
+	assert.Equal(t, []bool{false, false, false, false}, got.BackupCodesUsed)
+}
+
+// TestTotpListener_IgnoresWrongStreamType — defensive: the listener
+// should be a no-op for every stream type other than "totp", even
+// if event_type happens to look TOTP-shaped. Cheap to assert and
+// catches an accidental classifier loosening.
+func TestTotpListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	st.RegisterEventListener(projectors.TotpListener(st, slog.Default()))
+	ctx := context.Background()
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+
+	// Verify pre-condition: no totp row exists.
+	_, err := st.Queries().GetTOTPByUserID(ctx, userID)
+	require.Error(t, err)
+
+	// Append a TOTP-named event under the WRONG stream type.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user",
+		StreamID:   userID,
+		EventType:  "TOTPSetupInitiated",
+		Data: map[string]any{
+			"secret_encrypted":  "ENC:never",
+			"backup_codes_hash": []string{"x"},
+		},
+		ActorType: "user",
+		ActorID:   userID,
+	}))
+
+	// Wait long enough for the listener to have run if it were going to.
+	time.Sleep(150 * time.Millisecond)
+
+	_, err = st.Queries().GetTOTPByUserID(ctx, userID)
+	require.Error(t, err, "wrong-stream-type event must NOT create a totp_projection row")
+}
+
+// totpProjectionFields is the subset the lifecycle test reads back.
+// Mirrors generated.TotpProjection with only the columns we assert.
+type totpProjectionFields struct {
+	UserID          string
+	SecretEncrypted string
+	Verified        bool
+	Enabled         bool
+	BackupCodesHash []string
+	BackupCodesUsed []bool
+}
+
+func pollForTotpRow(t *testing.T, st *store.Store, userID string, predicate func(totpProjectionFields) bool) totpProjectionFields {
+	t.Helper()
+	ctx := context.Background()
+	var last totpProjectionFields
+	for i := 0; i < 50; i++ {
+		row, err := st.Queries().GetTOTPByUserID(ctx, userID)
+		if err == nil {
+			last = totpProjectionFields{
+				UserID:          row.UserID,
+				SecretEncrypted: row.SecretEncrypted,
+				Verified:        row.Verified,
+				Enabled:         row.Enabled,
+				BackupCodesHash: row.BackupCodesHash,
+				BackupCodesUsed: row.BackupCodesUsed,
+			}
+			if predicate(last) {
+				return last
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("totp_projection predicate not satisfied within polling window; last=%+v", last)
+	return last
+}
+
+func pollForUserTotpEnabled(t *testing.T, st *store.Store, userID string, want bool) {
+	t.Helper()
+	ctx := context.Background()
+	for i := 0; i < 50; i++ {
+		got, err := st.Queries().IsTOTPEnabled(ctx, userID)
+		if err == nil && got == want {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("users_projection.totp_enabled never reached %v for user %s", want, userID)
+}
+
+// Suppress unused-import warnings — the imports above are used by
+// other tests in this package; keep them referenced even if a
+// future edit accidentally removes them from the test bodies.
+var _ = json.Marshal
+var _ = errors.Is
+var _ = uuid.New

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -1,0 +1,50 @@
+package projectors
+
+import (
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// WireAll registers every Go-side projector listener against the
+// store's post-commit listener pipeline. Single source of truth for
+// projector wiring so production boot (cmd/control/main.go) and
+// tests (internal/testutil.SetupPostgres) get identical projector
+// coverage. A new projector port adds itself here once and both
+// sides pick it up.
+//
+// Listeners fire synchronously inside Store.AppendEvent — by the
+// time AppendEvent returns to the handler, every listener's writes
+// have landed. So read-your-writes works the same as the deleted
+// PL/pgSQL triggers from the caller's perspective; the only
+// behavioural delta is that the listener writes are not atomic with
+// the event commit (separate autocommit per listener call). That
+// matters only when multiple consecutive events would corrupt state
+// on partial-failure mid-listener; the periodic indexer reconciler
+// is the safety net for any drift.
+//
+// Refs tracker #107.
+func WireAll(st *store.Store, logger *slog.Logger) {
+	if st == nil {
+		return
+	}
+	st.RegisterEventListener(SecurityAlertListener(
+		st,
+		loggerFor(logger, "security_alert_projector"),
+	))
+	st.RegisterEventListener(TotpListener(
+		st,
+		loggerFor(logger, "totp_projector"),
+	))
+	// Subsequent ports under #98–#106 add their listener here.
+}
+
+// loggerFor returns a sub-logger tagged with the projector
+// component name, or a discard logger when the parent is nil so
+// tests that pass nil don't panic.
+func loggerFor(parent *slog.Logger, component string) *slog.Logger {
+	if parent == nil {
+		return slog.Default()
+	}
+	return parent.With("component", component)
+}

--- a/internal/store/generated/totp.sql.go
+++ b/internal/store/generated/totp.sql.go
@@ -7,7 +7,17 @@ package generated
 
 import (
 	"context"
+	"time"
 )
+
+const deleteTotpProjection = `-- name: DeleteTotpProjection :exec
+DELETE FROM totp_projection WHERE user_id = $1
+`
+
+func (q *Queries) DeleteTotpProjection(ctx context.Context, userID string) error {
+	_, err := q.db.Exec(ctx, deleteTotpProjection, userID)
+	return err
+}
 
 const getTOTPByUserID = `-- name: GetTOTPByUserID :one
 SELECT user_id, secret_encrypted, verified, enabled, backup_codes_hash, backup_codes_used, created_at, updated_at, projection_version FROM totp_projection WHERE user_id = $1
@@ -57,4 +67,156 @@ func (q *Queries) IsTOTPEnabled(ctx context.Context, id string) (bool, error) {
 	var totp_enabled bool
 	err := row.Scan(&totp_enabled)
 	return totp_enabled, err
+}
+
+const markTotpBackupCodeUsed = `-- name: MarkTotpBackupCodeUsed :exec
+UPDATE totp_projection
+SET backup_codes_used[$2::int] = TRUE,
+    updated_at = $3,
+    projection_version = $4
+WHERE user_id = $1
+`
+
+type MarkTotpBackupCodeUsedParams struct {
+	UserID            string    `json:"user_id"`
+	Column2           int32     `json:"column_2"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// TOTPBackupCodeUsed updates a 1-indexed slot in backup_codes_used.
+// The PL/pgSQL projector used `[(idx)::int + 1]` — we add the +1 in
+// Go before passing the parameter so the SQL stays clean.
+func (q *Queries) MarkTotpBackupCodeUsed(ctx context.Context, arg MarkTotpBackupCodeUsedParams) error {
+	_, err := q.db.Exec(ctx, markTotpBackupCodeUsed,
+		arg.UserID,
+		arg.Column2,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const regenerateTotpBackupCodes = `-- name: RegenerateTotpBackupCodes :exec
+UPDATE totp_projection
+SET backup_codes_hash = $2,
+    backup_codes_used = array_fill(FALSE::boolean, ARRAY[array_length($2::text[], 1)]),
+    updated_at = $3,
+    projection_version = $4
+WHERE user_id = $1
+`
+
+type RegenerateTotpBackupCodesParams struct {
+	UserID            string    `json:"user_id"`
+	BackupCodesHash   []string  `json:"backup_codes_hash"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+func (q *Queries) RegenerateTotpBackupCodes(ctx context.Context, arg RegenerateTotpBackupCodesParams) error {
+	_, err := q.db.Exec(ctx, regenerateTotpBackupCodes,
+		arg.UserID,
+		arg.BackupCodesHash,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const setUserTotpEnabled = `-- name: SetUserTotpEnabled :exec
+UPDATE users_projection
+SET totp_enabled = $2,
+    updated_at = $3,
+    projection_version = $4
+WHERE id = $1
+`
+
+type SetUserTotpEnabledParams struct {
+	ID                string     `json:"id"`
+	TotpEnabled       bool       `json:"totp_enabled"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// Cross-stream effect: TOTP events also flip
+// users_projection.totp_enabled. Was an inline UPDATE inside the
+// deleted PL/pgSQL projector. Sqlc'd here so the Go listener can
+// call it explicitly.
+func (q *Queries) SetUserTotpEnabled(ctx context.Context, arg SetUserTotpEnabledParams) error {
+	_, err := q.db.Exec(ctx, setUserTotpEnabled,
+		arg.ID,
+		arg.TotpEnabled,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const upsertTotpProjection = `-- name: UpsertTotpProjection :exec
+INSERT INTO totp_projection (
+    user_id, secret_encrypted, verified, enabled,
+    backup_codes_hash, backup_codes_used,
+    created_at, updated_at, projection_version
+) VALUES (
+    $1, $2, FALSE, FALSE,
+    $3,
+    array_fill(FALSE::boolean, ARRAY[array_length($3::text[], 1)]),
+    $4, $4, $5
+)
+ON CONFLICT (user_id) DO UPDATE SET
+    secret_encrypted = EXCLUDED.secret_encrypted,
+    verified = FALSE,
+    enabled = FALSE,
+    backup_codes_hash = EXCLUDED.backup_codes_hash,
+    backup_codes_used = EXCLUDED.backup_codes_used,
+    updated_at = EXCLUDED.updated_at,
+    projection_version = EXCLUDED.projection_version
+`
+
+type UpsertTotpProjectionParams struct {
+	UserID            string    `json:"user_id"`
+	SecretEncrypted   string    `json:"secret_encrypted"`
+	BackupCodesHash   []string  `json:"backup_codes_hash"`
+	CreatedAt         time.Time `json:"created_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// Write-side queries for the Go totp projector (#97). Replace the
+// per-event branches of the deleted PL/pgSQL project_totp_event
+// function. Each query mirrors one branch's effect; the listener
+// chooses which to call based on the event_type.
+//
+// TOTPSetupInitiated upserts the row — re-initiation by the same
+// user before verifying replaces secret + backup codes and resets
+// verified/enabled to FALSE. backup_codes_used is sized to match
+// backup_codes_hash by emitting an array of FALSE of equal length.
+func (q *Queries) UpsertTotpProjection(ctx context.Context, arg UpsertTotpProjectionParams) error {
+	_, err := q.db.Exec(ctx, upsertTotpProjection,
+		arg.UserID,
+		arg.SecretEncrypted,
+		arg.BackupCodesHash,
+		arg.CreatedAt,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const verifyTotpProjection = `-- name: VerifyTotpProjection :exec
+UPDATE totp_projection
+SET verified = TRUE,
+    enabled = TRUE,
+    updated_at = $2,
+    projection_version = $3
+WHERE user_id = $1
+`
+
+type VerifyTotpProjectionParams struct {
+	UserID            string    `json:"user_id"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+func (q *Queries) VerifyTotpProjection(ctx context.Context, arg VerifyTotpProjectionParams) error {
+	_, err := q.db.Exec(ctx, verifyTotpProjection, arg.UserID, arg.UpdatedAt, arg.ProjectionVersion)
+	return err
 }

--- a/internal/store/migrations/018_totp_projector_to_go.sql
+++ b/internal/store/migrations/018_totp_projector_to_go.sql
@@ -1,0 +1,112 @@
+-- Replace project_totp_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.TotpListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger
+-- still PERFORMs project_totp_event(NEW) for every totp-stream
+-- event; the no-op stub keeps that dispatch quiet (no
+-- projection_errors entries) until the dispatcher itself is
+-- rewritten to skip stream types with Go projectors.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. totp_projection AND users_projection.totp_enabled
+--     updated atomically with the event commit.
+--   - After: Go listener fires post-commit. Both writes happen
+--     async (~ms after the event lands). users_projection.totp_enabled
+--     is read on the auth/login path (NOT on every API call), so
+--     the post-commit gap closes well before the next read in
+--     practice. The login flow's own logout/login cycle dwarfs
+--     the listener latency.
+--
+-- See manchtools/power-manage-server#97. Second port under the
+-- projector-migration pattern (#96 was the canary).
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_totp_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.TotpListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the original PL/pgSQL projector verbatim from migration 003.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_totp_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'TOTPSetupInitiated' THEN
+            INSERT INTO totp_projection (
+                user_id, secret_encrypted, verified, enabled,
+                backup_codes_hash, backup_codes_used,
+                created_at, updated_at, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'secret_encrypted',
+                FALSE,
+                FALSE,
+                ARRAY(SELECT jsonb_array_elements_text(event.data->'backup_codes_hash')),
+                ARRAY(SELECT FALSE FROM jsonb_array_elements_text(event.data->'backup_codes_hash')),
+                event.occurred_at,
+                event.occurred_at,
+                event.sequence_num
+            )
+            ON CONFLICT (user_id) DO UPDATE SET
+                secret_encrypted = EXCLUDED.secret_encrypted,
+                verified = FALSE,
+                enabled = FALSE,
+                backup_codes_hash = EXCLUDED.backup_codes_hash,
+                backup_codes_used = EXCLUDED.backup_codes_used,
+                updated_at = EXCLUDED.updated_at,
+                projection_version = EXCLUDED.projection_version;
+
+        WHEN 'TOTPVerified' THEN
+            UPDATE totp_projection
+            SET verified = TRUE,
+                enabled = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE user_id = event.stream_id;
+
+            UPDATE users_projection
+            SET totp_enabled = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TOTPDisabled' THEN
+            DELETE FROM totp_projection WHERE user_id = event.stream_id;
+
+            UPDATE users_projection
+            SET totp_enabled = FALSE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TOTPBackupCodeUsed' THEN
+            UPDATE totp_projection
+            SET backup_codes_used[(event.data->>'index')::int + 1] = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE user_id = event.stream_id;
+
+        WHEN 'TOTPBackupCodesRegenerated' THEN
+            UPDATE totp_projection
+            SET backup_codes_hash = ARRAY(SELECT jsonb_array_elements_text(event.data->'backup_codes_hash')),
+                backup_codes_used = ARRAY(SELECT FALSE FROM jsonb_array_elements_text(event.data->'backup_codes_hash')),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE user_id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/totp.sql
+++ b/internal/store/queries/totp.sql
@@ -8,3 +8,75 @@ FROM totp_projection WHERE user_id = $1;
 
 -- name: IsTOTPEnabled :one
 SELECT totp_enabled FROM users_projection WHERE id = $1 AND is_deleted = FALSE;
+
+-- Write-side queries for the Go totp projector (#97). Replace the
+-- per-event branches of the deleted PL/pgSQL project_totp_event
+-- function. Each query mirrors one branch's effect; the listener
+-- chooses which to call based on the event_type.
+--
+-- TOTPSetupInitiated upserts the row — re-initiation by the same
+-- user before verifying replaces secret + backup codes and resets
+-- verified/enabled to FALSE. backup_codes_used is sized to match
+-- backup_codes_hash by emitting an array of FALSE of equal length.
+--
+-- name: UpsertTotpProjection :exec
+INSERT INTO totp_projection (
+    user_id, secret_encrypted, verified, enabled,
+    backup_codes_hash, backup_codes_used,
+    created_at, updated_at, projection_version
+) VALUES (
+    $1, $2, FALSE, FALSE,
+    $3,
+    array_fill(FALSE::boolean, ARRAY[array_length($3::text[], 1)]),
+    $4, $4, $5
+)
+ON CONFLICT (user_id) DO UPDATE SET
+    secret_encrypted = EXCLUDED.secret_encrypted,
+    verified = FALSE,
+    enabled = FALSE,
+    backup_codes_hash = EXCLUDED.backup_codes_hash,
+    backup_codes_used = EXCLUDED.backup_codes_used,
+    updated_at = EXCLUDED.updated_at,
+    projection_version = EXCLUDED.projection_version;
+
+-- name: VerifyTotpProjection :exec
+UPDATE totp_projection
+SET verified = TRUE,
+    enabled = TRUE,
+    updated_at = $2,
+    projection_version = $3
+WHERE user_id = $1;
+
+-- name: DeleteTotpProjection :exec
+DELETE FROM totp_projection WHERE user_id = $1;
+
+-- TOTPBackupCodeUsed updates a 1-indexed slot in backup_codes_used.
+-- The PL/pgSQL projector used `[(idx)::int + 1]` — we add the +1 in
+-- Go before passing the parameter so the SQL stays clean.
+--
+-- name: MarkTotpBackupCodeUsed :exec
+UPDATE totp_projection
+SET backup_codes_used[$2::int] = TRUE,
+    updated_at = $3,
+    projection_version = $4
+WHERE user_id = $1;
+
+-- name: RegenerateTotpBackupCodes :exec
+UPDATE totp_projection
+SET backup_codes_hash = $2,
+    backup_codes_used = array_fill(FALSE::boolean, ARRAY[array_length($2::text[], 1)]),
+    updated_at = $3,
+    projection_version = $4
+WHERE user_id = $1;
+
+-- Cross-stream effect: TOTP events also flip
+-- users_projection.totp_enabled. Was an inline UPDATE inside the
+-- deleted PL/pgSQL projector. Sqlc'd here so the Go listener can
+-- call it explicitly.
+--
+-- name: SetUserTotpEnabled :exec
+UPDATE users_projection
+SET totp_enabled = $2,
+    updated_at = $3,
+    projection_version = $4
+WHERE id = $1;

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -18,6 +18,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/auth/totp"
 	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/projectors"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -72,6 +73,15 @@ func SetupPostgres(t *testing.T) *store.Store {
 		t.Fatalf("create store: %v", err)
 	}
 	t.Cleanup(func() { st.Close() })
+
+	// Wire the same Go-side projector listeners that production
+	// boot wires in cmd/control/main.go. Without this, handlers
+	// emit events but the projection writes never fire (the
+	// PL/pgSQL projectors that the migrations have replaced with
+	// no-op stubs no longer do anything either), so any test that
+	// reads back projection state after AppendEvent silently sees
+	// stale data.
+	projectors.WireAll(st, nil)
 
 	return st
 }


### PR DESCRIPTION
## Summary

Second projector port under the pattern proven by #96. Replaces `project_totp_event` (PL/pgSQL, 5 event-type branches + cross-stream effect on `users_projection.totp_enabled`) with `projectors.TotpListener` (Go, post-commit listener).

Closes #97.

## Coverage

- **TOTPSetupInitiated** — upsert `totp_projection` (resets verified+enabled to FALSE on re-init)
- **TOTPVerified** — flip `totp_projection.verified+enabled = TRUE` AND `users_projection.totp_enabled = TRUE`
- **TOTPDisabled** — drop the `totp_projection` row AND `users_projection.totp_enabled = FALSE`
- **TOTPBackupCodeUsed** — mark a single 1-based slot in `backup_codes_used` (event payload uses 0-based index; listener converts)
- **TOTPBackupCodesRegenerated** — replace `backup_codes_hash` and reset `backup_codes_used` to a fresh all-FALSE array of matching length

## Async-vs-sync analysis

Same shape as #96. `TotpEnabled` is read on the **auth/login path** (not on the same request that emits a TOTP event), so the post-commit projection write closes the gap well before the next read. The login flow's logout/login cycle dwarfs the listener latency.

## Migration shape

`project_totp_event` is dispatched by the shared `project_event()` trigger (not its own dedicated trigger like security_alert had). Migration 018 replaces it with a no-op stub — the dispatcher keeps PERFORMing it (no `projection_errors` noise), Go listener does the actual work. Once the dispatcher itself is rewritten to skip Go-ported streams, the no-op stub can be dropped.

## Test plan

- [x] `TestTotpListener_LifecycleEndToEnd` — Setup → Verify → BackupCodeUsed → Disable, asserting both projections at each step
- [x] `TestTotpListener_BackupCodesRegenerated` — separate coverage of the regenerate branch including length-matching reset
- [x] `TestTotpListener_IgnoresWrongStreamType` — defensive: TOTPSetupInitiated under `stream_type=user` is a no-op
- [x] `go build ./...` clean
- [x] No regressions on existing TOTP handler tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced TOTP event processing and projection management to ensure consistent and reliable handling of TOTP setup, verification, disabling, and backup code operations across all system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->