### PR TITLE
feat: port project_lps_password_event to Go listener (#98)

### DIFF
--- a/internal/projectors/lps_password.go
+++ b/internal/projectors/lps_password.go
@@ -3,6 +3,7 @@ package projectors
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -25,6 +26,24 @@ type LpsPasswordRotatedPayload struct {
 	Password       string    `json:"password"`
 	RotatedAt      time.Time `json:"rotated_at"`
 	RotationReason string    `json:"rotation_reason"`
+}
+
+// LogValue implements slog.LogValuer so the encrypted Password is
+// never written verbatim by structured logs. The listener body
+// already logs only individual non-secret fields, but a future
+// `logger.Warn("…", "payload", payload)` or `fmt.Sprintf("%+v", p)`
+// routed through slog would otherwise leak the credential. Mask at
+// the type level so the safety holds regardless of caller
+// discipline.
+func (p LpsPasswordRotatedPayload) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("device_id", p.DeviceID),
+		slog.String("action_id", p.ActionID),
+		slog.String("username", p.Username),
+		slog.String("password", "[REDACTED]"),
+		slog.Time("rotated_at", p.RotatedAt),
+		slog.String("rotation_reason", p.RotationReason),
+	)
 }
 
 // LpsPasswordRotatedFromEvent decodes the event payload into the

--- a/internal/projectors/lps_password.go
+++ b/internal/projectors/lps_password.go
@@ -46,8 +46,24 @@ func LpsPasswordRotatedFromEvent(e store.PersistedEvent) (LpsPasswordRotatedPayl
 	if err := json.Unmarshal(e.Data, &p); err != nil {
 		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: invalid LpsPasswordRotated payload: %w", err)
 	}
-	if p.DeviceID == "" || p.Username == "" {
-		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: LpsPasswordRotated requires device_id + username")
+	// Every field below was implicitly required by the deleted
+	// PL/pgSQL projector — `(event.data->>'rotated_at')::TIMESTAMPTZ`
+	// would have raised on a missing value, and the inserted row is
+	// useless without the device/action/username/password tuple.
+	// Validating up front keeps the failure surface in the listener's
+	// log rather than producing silently-bad projection rows that
+	// outlast the event log.
+	switch {
+	case p.DeviceID == "":
+		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: LpsPasswordRotated requires device_id")
+	case p.ActionID == "":
+		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: LpsPasswordRotated requires action_id")
+	case p.Username == "":
+		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: LpsPasswordRotated requires username")
+	case p.Password == "":
+		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: LpsPasswordRotated requires password")
+	case p.RotatedAt.IsZero():
+		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: LpsPasswordRotated requires rotated_at")
 	}
 	if p.RotationReason == "" {
 		// Match the PL/pgSQL `COALESCE(... 'scheduled')` default so

--- a/internal/projectors/lps_password.go
+++ b/internal/projectors/lps_password.go
@@ -1,0 +1,59 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// LpsPasswordRotatedPayload covers every field the lps_password
+// projector reads from the LpsPasswordRotated event. The agent sends
+// rotated_at as an RFC 3339 string (see sdk/proto/pm/v1/internal.proto
+// LpsRotation.rotated_at), so json.Unmarshal into time.Time round-trips
+// natively.
+//
+// The deleted PL/pgSQL projector cast `(event.data->>'rotated_at')::TIMESTAMPTZ`
+// directly. Pre-parsing in Go preserves the same shape: a parse error
+// here is the analogue of a Postgres cast failure, which the PL/pgSQL
+// version would have surfaced via the projection_errors table.
+type LpsPasswordRotatedPayload struct {
+	DeviceID       string    `json:"device_id"`
+	ActionID       string    `json:"action_id"`
+	Username       string    `json:"username"`
+	Password       string    `json:"password"`
+	RotatedAt      time.Time `json:"rotated_at"`
+	RotationReason string    `json:"rotation_reason"`
+}
+
+// LpsPasswordRotatedFromEvent decodes the event payload into the
+// typed shape the listener writes. Returns ErrIgnoredEvent for any
+// event the lps_password projector does not act on so the listener
+// wrapper can silently no-op.
+//
+// Pure: no I/O, deterministic, depends only on the event's fields.
+// Reuse from a handler that wants to mirror the projection state in
+// memory while the listener writes to the DB.
+func LpsPasswordRotatedFromEvent(e store.PersistedEvent) (LpsPasswordRotatedPayload, error) {
+	if e.StreamType != "lps_password" || e.EventType != "LpsPasswordRotated" {
+		return LpsPasswordRotatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: empty LpsPasswordRotated payload")
+	}
+	var p LpsPasswordRotatedPayload
+	if err := json.Unmarshal(e.Data, &p); err != nil {
+		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: invalid LpsPasswordRotated payload: %w", err)
+	}
+	if p.DeviceID == "" || p.Username == "" {
+		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: LpsPasswordRotated requires device_id + username")
+	}
+	if p.RotationReason == "" {
+		// Match the PL/pgSQL `COALESCE(... 'scheduled')` default so
+		// rows inserted from older agents that omit the field stay
+		// indistinguishable from PL/pgSQL-projected rows.
+		p.RotationReason = "scheduled"
+	}
+	return p, nil
+}

--- a/internal/projectors/lps_password_listener.go
+++ b/internal/projectors/lps_password_listener.go
@@ -1,0 +1,80 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// LpsPasswordListener returns a store.EventListener that applies
+// LpsPasswordRotated events to lps_passwords_projection. Replaces the
+// deleted PL/pgSQL project_lps_password_event function.
+//
+// Three writes per event (mark previous not-current, insert new,
+// trim history to 3) wrapped in store.WithTx so the projection never
+// observes the intermediate "no current row" state mid-listener.
+// Atomicity-with-the-event-commit is sacrificed (the listener fires
+// post-commit), but atomicity-of-the-three-writes is preserved.
+//
+// LpsPasswordRotated is the only event the lps_password stream emits
+// today; the switch is intentionally a single case so a future event
+// type slots in next to it without touching the wiring.
+//
+// Wired in projectors.WireAll.
+//
+// Refs #98, tracker #107.
+func LpsPasswordListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "lps_password" {
+			return
+		}
+		if e.EventType != "LpsPasswordRotated" {
+			return
+		}
+
+		payload, err := LpsPasswordRotatedFromEvent(e)
+		if err != nil {
+			if errors.Is(err, ErrIgnoredEvent) {
+				return
+			}
+			logger.Warn("lps_password projector: invalid event payload",
+				"event_id", e.ID, "event_type", e.EventType, "error", err)
+			return
+		}
+
+		if err := st.WithTx(ctx, func(q *store.Queries) error {
+			if err := q.MarkLpsPasswordsNotCurrent(ctx, db.MarkLpsPasswordsNotCurrentParams{
+				DeviceID: payload.DeviceID,
+				Username: payload.Username,
+			}); err != nil {
+				return err
+			}
+			if err := q.InsertLpsPassword(ctx, db.InsertLpsPasswordParams{
+				DeviceID:       payload.DeviceID,
+				ActionID:       payload.ActionID,
+				Username:       payload.Username,
+				Password:       payload.Password,
+				RotatedAt:      payload.RotatedAt,
+				RotationReason: payload.RotationReason,
+			}); err != nil {
+				return err
+			}
+			return q.TrimLpsPasswordsToLast3(ctx, db.TrimLpsPasswordsToLast3Params{
+				DeviceID: payload.DeviceID,
+				Username: payload.Username,
+			})
+		}); err != nil {
+			logger.Warn("lps_password projector: failed to apply LpsPasswordRotated",
+				"event_id", e.ID,
+				"device_id", payload.DeviceID,
+				"username", payload.Username,
+				"error", err)
+		}
+	}
+}

--- a/internal/projectors/lps_password_test.go
+++ b/internal/projectors/lps_password_test.go
@@ -77,18 +77,49 @@ func TestLpsPasswordRotatedFromEvent_Pure(t *testing.T) {
 		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
 	})
 
-	t.Run("missing device_id is a validation error", func(t *testing.T) {
-		_, err := projectors.LpsPasswordRotatedFromEvent(store.PersistedEvent{
-			StreamType: "lps_password",
-			EventType:  "LpsPasswordRotated",
-			Data: jsonOrFail(t, map[string]any{
-				"username":   "alice",
-				"rotated_at": rotatedAt.Format(time.RFC3339),
-			}),
-		})
-		require.Error(t, err)
-		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent),
-			"validation failure must NOT be silently swallowed by the listener wrapper")
+	t.Run("required fields are validated individually", func(t *testing.T) {
+		// Each row drops ONE required field from the otherwise-valid
+		// payload below and asserts the listener rejects the event.
+		// CR caught this on PR #119: a payload that decodes to "" /
+		// zero values would otherwise silently produce a bad row.
+		base := map[string]any{
+			"device_id":  "dev-1",
+			"action_id":  "act-1",
+			"username":   "alice",
+			"password":   "ENC:s",
+			"rotated_at": rotatedAt.Format(time.RFC3339),
+		}
+		cases := []struct {
+			drop string
+			want string
+		}{
+			{"device_id", "device_id"},
+			{"action_id", "action_id"},
+			{"username", "username"},
+			{"password", "password"},
+			{"rotated_at", "rotated_at"},
+		}
+		for _, tc := range cases {
+			t.Run("missing "+tc.drop, func(t *testing.T) {
+				payload := map[string]any{}
+				for k, v := range base {
+					if k == tc.drop {
+						continue
+					}
+					payload[k] = v
+				}
+				_, err := projectors.LpsPasswordRotatedFromEvent(store.PersistedEvent{
+					StreamType: "lps_password",
+					EventType:  "LpsPasswordRotated",
+					Data:       jsonOrFail(t, payload),
+				})
+				require.Error(t, err)
+				assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent),
+					"validation failure must NOT be silently swallowed by the listener wrapper")
+				assert.Contains(t, err.Error(), tc.want,
+					"error message should name the missing field")
+			})
+		}
 	})
 
 	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {

--- a/internal/projectors/lps_password_test.go
+++ b/internal/projectors/lps_password_test.go
@@ -1,0 +1,247 @@
+package projectors_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestLpsPasswordRotatedFromEvent_Pure exercises the pure derivation
+// function without touching the database. Mirrors the security_alert
+// pure tests so a future change to the payload shape (added field,
+// renamed key) fails fast at unit-test time.
+func TestLpsPasswordRotatedFromEvent_Pure(t *testing.T) {
+	rotatedAt := time.Date(2026, 5, 4, 12, 30, 0, 0, time.UTC)
+
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.LpsPasswordRotatedFromEvent(store.PersistedEvent{
+			StreamType: "lps_password",
+			EventType:  "LpsPasswordRotated",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":       "dev-1",
+				"action_id":       "act-1",
+				"username":        "alice",
+				"password":        "ENC:secret",
+				"rotated_at":      rotatedAt.Format(time.RFC3339),
+				"rotation_reason": "scheduled",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.DeviceID)
+		assert.Equal(t, "act-1", got.ActionID)
+		assert.Equal(t, "alice", got.Username)
+		assert.Equal(t, "ENC:secret", got.Password)
+		assert.True(t, got.RotatedAt.Equal(rotatedAt))
+		assert.Equal(t, "scheduled", got.RotationReason)
+	})
+
+	t.Run("missing rotation_reason defaults to scheduled", func(t *testing.T) {
+		got, err := projectors.LpsPasswordRotatedFromEvent(store.PersistedEvent{
+			StreamType: "lps_password",
+			EventType:  "LpsPasswordRotated",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":  "dev-1",
+				"action_id":  "act-1",
+				"username":   "alice",
+				"password":   "ENC:s",
+				"rotated_at": rotatedAt.Format(time.RFC3339),
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "scheduled", got.RotationReason,
+			"matches PL/pgSQL COALESCE(... 'scheduled') default so older agents that omit the field stay backward-compatible")
+	})
+
+	t.Run("wrong stream_type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.LpsPasswordRotatedFromEvent(store.PersistedEvent{
+			StreamType: "totp",
+			EventType:  "LpsPasswordRotated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("wrong event_type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.LpsPasswordRotatedFromEvent(store.PersistedEvent{
+			StreamType: "lps_password",
+			EventType:  "SomethingElse",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("missing device_id is a validation error", func(t *testing.T) {
+		_, err := projectors.LpsPasswordRotatedFromEvent(store.PersistedEvent{
+			StreamType: "lps_password",
+			EventType:  "LpsPasswordRotated",
+			Data: jsonOrFail(t, map[string]any{
+				"username":   "alice",
+				"rotated_at": rotatedAt.Format(time.RFC3339),
+			}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent),
+			"validation failure must NOT be silently swallowed by the listener wrapper")
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.LpsPasswordRotatedFromEvent(store.PersistedEvent{
+			StreamType: "lps_password",
+			EventType:  "LpsPasswordRotated",
+			Data:       []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestLpsPasswordListener_RotationLifecycle drives four rotations
+// through the listener and asserts the projection ends in the right
+// state: only the most recent row is is_current=TRUE, history is
+// trimmed to 3 rows total. Mirrors the operational invariants the
+// PL/pgSQL projector enforced.
+func TestLpsPasswordListener_RotationLifecycle(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	deviceID := "device-" + testutil.NewID()
+	username := "alice"
+
+	rotations := []struct {
+		password  string
+		rotatedAt time.Time
+		reason    string
+	}{
+		{"ENC:p1", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), "scheduled"},
+		{"ENC:p2", time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), "scheduled"},
+		{"ENC:p3", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), "manual"},
+		{"ENC:p4", time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "scheduled"},
+	}
+
+	for i, r := range rotations {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "lps_password",
+			StreamID:   testutil.NewID(),
+			EventType:  "LpsPasswordRotated",
+			Data: map[string]any{
+				"device_id":       deviceID,
+				"action_id":       "action-" + deviceID,
+				"username":        username,
+				"password":        r.password,
+				"rotated_at":      r.rotatedAt.Format(time.RFC3339),
+				"rotation_reason": r.reason,
+			},
+			ActorType: "device",
+			ActorID:   deviceID,
+		}), "append rotation %d", i)
+	}
+
+	// Listener fires synchronously inside AppendEvent (see
+	// project_post_commit_listener_is_sync.md), so the assertions
+	// don't need to poll. A single read is enough.
+	current, err := st.Queries().GetCurrentLpsPasswords(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, current, 1, "exactly one is_current=TRUE row per (device,username) after the latest rotation")
+	assert.Equal(t, "ENC:p4", current[0].Password)
+	assert.Equal(t, "scheduled", current[0].RotationReason)
+
+	history, err := st.Queries().GetLpsPasswordHistory(ctx, deviceID)
+	require.NoError(t, err)
+	// 4 rotations → 4 rows minus trim-to-3 → 3 total → 1 current + 2 history.
+	assert.Len(t, history, 2, "TrimLpsPasswordsToLast3 keeps current + 2 prior; older rows are deleted")
+	gotPasswords := []string{history[0].Password, history[1].Password}
+	assert.ElementsMatch(t, []string{"ENC:p3", "ENC:p2"}, gotPasswords)
+}
+
+// TestLpsPasswordListener_PerUsernameScope confirms a rotation for
+// user A does NOT touch user B's projection, even on the same device.
+// The PL/pgSQL projector scoped its UPDATE / DELETE by
+// (device_id, username); a regression that drops the username
+// predicate would silently invalidate every other user's password on
+// the same device, so this is worth a dedicated test.
+func TestLpsPasswordListener_PerUsernameScope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	deviceID := "device-" + testutil.NewID()
+
+	rotate := func(username, password string, rotatedAt time.Time) {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "lps_password",
+			StreamID:   testutil.NewID(),
+			EventType:  "LpsPasswordRotated",
+			Data: map[string]any{
+				"device_id":       deviceID,
+				"action_id":       "act",
+				"username":        username,
+				"password":        password,
+				"rotated_at":      rotatedAt.Format(time.RFC3339),
+				"rotation_reason": "scheduled",
+			},
+			ActorType: "device",
+			ActorID:   deviceID,
+		}))
+	}
+
+	rotate("alice", "ENC:alice-1", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	rotate("bob", "ENC:bob-1", time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC))
+	rotate("alice", "ENC:alice-2", time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC))
+
+	current, err := st.Queries().GetCurrentLpsPasswords(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, current, 2, "one current row per user; rotating alice must not flip bob")
+	byUser := map[string]string{}
+	for _, p := range current {
+		byUser[p.Username] = p.Password
+	}
+	assert.Equal(t, "ENC:alice-2", byUser["alice"])
+	assert.Equal(t, "ENC:bob-1", byUser["bob"], "bob's row stays current despite alice's two rotations on the same device")
+}
+
+// TestLpsPasswordListener_IgnoresWrongStreamType is the cheap defence
+// against a future classifier loosening that would have the listener
+// react to LpsPasswordRotated under a different stream_type.
+func TestLpsPasswordListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	deviceID := "device-" + testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", // wrong
+		StreamID:   testutil.NewID(),
+		EventType:  "LpsPasswordRotated",
+		Data: map[string]any{
+			"device_id":  deviceID,
+			"action_id":  "act",
+			"username":   "alice",
+			"password":   "ENC:nope",
+			"rotated_at": time.Now().UTC().Format(time.RFC3339),
+		},
+		ActorType: "device",
+		ActorID:   deviceID,
+	}))
+
+	// Long enough for the listener to have fired if it were going to.
+	time.Sleep(150 * time.Millisecond)
+
+	current, err := st.Queries().GetCurrentLpsPasswords(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Empty(t, current, "wrong-stream-type event must NOT create an lps_passwords_projection row")
+}
+
+// jsonOrFail marshals the map for the pure-function tests. Inline
+// helper to avoid bringing in a json import at every callsite.
+func jsonOrFail(t *testing.T, v map[string]any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
+}

--- a/internal/projectors/lps_password_test.go
+++ b/internal/projectors/lps_password_test.go
@@ -260,9 +260,10 @@ func TestLpsPasswordListener_IgnoresWrongStreamType(t *testing.T) {
 		ActorID:   deviceID,
 	}))
 
-	// Long enough for the listener to have fired if it were going to.
-	time.Sleep(150 * time.Millisecond)
-
+	// fireListeners is synchronous (see project memory
+	// `feedback_post_commit_listener_is_sync.md`): if the listener
+	// were going to write, the row would already be there by the
+	// time AppendEvent returns. No sleep needed.
 	current, err := st.Queries().GetCurrentLpsPasswords(ctx, deviceID)
 	require.NoError(t, err)
 	assert.Empty(t, current, "wrong-stream-type event must NOT create an lps_passwords_projection row")

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -36,7 +36,11 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "totp_projector"),
 	))
-	// Subsequent ports under #98–#106 add their listener here.
+	st.RegisterEventListener(LpsPasswordListener(
+		st,
+		loggerFor(logger, "lps_password_projector"),
+	))
+	// Subsequent ports under #99–#106 add their listener here.
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/lps.sql.go
+++ b/internal/store/generated/lps.sql.go
@@ -7,6 +7,7 @@ package generated
 
 import (
 	"context"
+	"time"
 )
 
 const deleteLpsPasswordsByAction = `-- name: DeleteLpsPasswordsByAction :exec
@@ -89,4 +90,87 @@ func (q *Queries) GetLpsPasswordHistory(ctx context.Context, deviceID string) ([
 		return nil, err
 	}
 	return items, nil
+}
+
+const insertLpsPassword = `-- name: InsertLpsPassword :exec
+INSERT INTO lps_passwords_projection
+    (device_id, action_id, username, password, rotated_at, rotation_reason)
+VALUES ($1, $2, $3, $4, $5, $6)
+`
+
+type InsertLpsPasswordParams struct {
+	DeviceID       string    `json:"device_id"`
+	ActionID       string    `json:"action_id"`
+	Username       string    `json:"username"`
+	Password       string    `json:"password"`
+	RotatedAt      time.Time `json:"rotated_at"`
+	RotationReason string    `json:"rotation_reason"`
+}
+
+// Step 2 of LpsPasswordRotated projection. Always inserts a new row
+// — the PL/pgSQL projector did the same, and step 3's trim keeps
+// only the latest 3 by rotated_at so duplicates from a replay are
+// pruned automatically.
+func (q *Queries) InsertLpsPassword(ctx context.Context, arg InsertLpsPasswordParams) error {
+	_, err := q.db.Exec(ctx, insertLpsPassword,
+		arg.DeviceID,
+		arg.ActionID,
+		arg.Username,
+		arg.Password,
+		arg.RotatedAt,
+		arg.RotationReason,
+	)
+	return err
+}
+
+const markLpsPasswordsNotCurrent = `-- name: MarkLpsPasswordsNotCurrent :exec
+UPDATE lps_passwords_projection
+SET is_current = FALSE
+WHERE device_id = $1
+  AND username = $2
+`
+
+type MarkLpsPasswordsNotCurrentParams struct {
+	DeviceID string `json:"device_id"`
+	Username string `json:"username"`
+}
+
+// Step 1 of LpsPasswordRotated projection. Flip every prior row for
+// (device_id, username) so the new password (inserted by step 2) is
+// the only is_current=TRUE row. Idempotent: replaying the same event
+// after the new row already landed leaves the projection unchanged
+// because the new row matches WHERE and gets flipped to FALSE — but
+// the listener wraps both writes in a tx, so a replay of the full
+// listener body keeps the (mark-old-false, insert-new-true) pair
+// consistent.
+func (q *Queries) MarkLpsPasswordsNotCurrent(ctx context.Context, arg MarkLpsPasswordsNotCurrentParams) error {
+	_, err := q.db.Exec(ctx, markLpsPasswordsNotCurrent, arg.DeviceID, arg.Username)
+	return err
+}
+
+const trimLpsPasswordsToLast3 = `-- name: TrimLpsPasswordsToLast3 :exec
+DELETE FROM lps_passwords_projection AS p
+WHERE p.device_id = $1
+  AND p.username = $2
+  AND p.id NOT IN (
+      SELECT id FROM lps_passwords_projection
+      WHERE device_id = $1
+        AND username = $2
+      ORDER BY rotated_at DESC
+      LIMIT 3
+  )
+`
+
+type TrimLpsPasswordsToLast3Params struct {
+	DeviceID string `json:"device_id"`
+	Username string `json:"username"`
+}
+
+// Step 3 of LpsPasswordRotated projection. Keep only the latest 3
+// passwords per (device_id, username) — the operational requirement
+// is "the user has the previous password if the rotation was
+// mid-flight"; deeper history bloats the encrypted-password store.
+func (q *Queries) TrimLpsPasswordsToLast3(ctx context.Context, arg TrimLpsPasswordsToLast3Params) error {
+	_, err := q.db.Exec(ctx, trimLpsPasswordsToLast3, arg.DeviceID, arg.Username)
+	return err
 }

--- a/internal/store/migrations/019_lps_password_projector_to_go.sql
+++ b/internal/store/migrations/019_lps_password_projector_to_go.sql
@@ -1,0 +1,85 @@
+-- Replace project_lps_password_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.LpsPasswordListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger still
+-- PERFORMs project_lps_password_event(NEW) for every lps_password-
+-- stream event; the no-op stub keeps that dispatch quiet (no
+-- projection_errors entries) until the dispatcher itself is rewritten
+-- to skip stream types with Go projectors.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. The three writes (mark previous not-current,
+--     insert new, trim history to 3) and the event commit were
+--     atomic. A crash anywhere left no partial state.
+--   - After: Go listener fires post-commit. Its three writes are
+--     wrapped in store.WithTx so they remain atomic with EACH OTHER
+--     — the projection never observes the "no current row" gap
+--     between the UPDATE-to-FALSE and the INSERT. They are NOT
+--     atomic with the event commit; the event lands first, then the
+--     listener body runs (within ms). LPS reads are operator-driven
+--     ("show me the current password for user X on device Y"), not
+--     hot-path RPCs, so the post-commit gap closes before any
+--     human-driven query.
+--
+-- See manchtools/power-manage-server#98. Third port under the
+-- projector-migration pattern (#96 canary, #97 totp, #98 lps_password).
+--
+-- Refs tracker #107.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_lps_password_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.LpsPasswordListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the original PL/pgSQL projector verbatim from migration 003.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_lps_password_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'LpsPasswordRotated' THEN
+            -- Mark ALL previous passwords as not current for this device+username
+            UPDATE lps_passwords_projection
+            SET is_current = FALSE
+            WHERE device_id = event.data->>'device_id'
+              AND username = event.data->>'username';
+
+            -- Insert new password
+            INSERT INTO lps_passwords_projection
+                (device_id, action_id, username, password, rotated_at, rotation_reason)
+            VALUES (
+                event.data->>'device_id',
+                event.data->>'action_id',
+                event.data->>'username',
+                event.data->>'password',
+                (event.data->>'rotated_at')::TIMESTAMPTZ,
+                COALESCE(event.data->>'rotation_reason', 'scheduled')
+            );
+
+            -- Keep only last 3 passwords per device+username
+            DELETE FROM lps_passwords_projection
+            WHERE id NOT IN (
+                SELECT id FROM lps_passwords_projection
+                WHERE device_id = event.data->>'device_id'
+                  AND username = event.data->>'username'
+                ORDER BY rotated_at DESC LIMIT 3
+            )
+            AND device_id = event.data->>'device_id'
+            AND username = event.data->>'username';
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/lps.sql
+++ b/internal/store/queries/lps.sql
@@ -11,3 +11,42 @@ LIMIT 20;
 
 -- name: DeleteLpsPasswordsByAction :exec
 DELETE FROM lps_passwords_projection WHERE action_id = $1;
+
+-- name: MarkLpsPasswordsNotCurrent :exec
+-- Step 1 of LpsPasswordRotated projection. Flip every prior row for
+-- (device_id, username) so the new password (inserted by step 2) is
+-- the only is_current=TRUE row. Idempotent: replaying the same event
+-- after the new row already landed leaves the projection unchanged
+-- because the new row matches WHERE and gets flipped to FALSE — but
+-- the listener wraps both writes in a tx, so a replay of the full
+-- listener body keeps the (mark-old-false, insert-new-true) pair
+-- consistent.
+UPDATE lps_passwords_projection
+SET is_current = FALSE
+WHERE device_id = $1
+  AND username = $2;
+
+-- name: InsertLpsPassword :exec
+-- Step 2 of LpsPasswordRotated projection. Always inserts a new row
+-- — the PL/pgSQL projector did the same, and step 3's trim keeps
+-- only the latest 3 by rotated_at so duplicates from a replay are
+-- pruned automatically.
+INSERT INTO lps_passwords_projection
+    (device_id, action_id, username, password, rotated_at, rotation_reason)
+VALUES ($1, $2, $3, $4, $5, $6);
+
+-- name: TrimLpsPasswordsToLast3 :exec
+-- Step 3 of LpsPasswordRotated projection. Keep only the latest 3
+-- passwords per (device_id, username) — the operational requirement
+-- is "the user has the previous password if the rotation was
+-- mid-flight"; deeper history bloats the encrypted-password store.
+DELETE FROM lps_passwords_projection AS p
+WHERE p.device_id = $1
+  AND p.username = $2
+  AND p.id NOT IN (
+      SELECT id FROM lps_passwords_projection
+      WHERE device_id = $1
+        AND username = $2
+      ORDER BY rotated_at DESC
+      LIMIT 3
+  );


### PR DESCRIPTION
## Summary

Third port under the projector-migration pattern (after #96 security_alert canary and #97 totp). Replaces `project_lps_password_event` PL/pgSQL with `projectors.LpsPasswordListener`.

- Pure helper `LpsPasswordRotatedFromEvent` in `internal/projectors/lps_password.go` — payload decode + validation, returns `ErrIgnoredEvent` for non-matching events.
- Listener factory in `internal/projectors/lps_password_listener.go` — wraps the three writes (mark previous not-current, insert new, trim to last 3) in `store.WithTx` so the projection never observes the intermediate "no current row" state mid-listener.
- New sqlc queries `MarkLpsPasswordsNotCurrent`, `InsertLpsPassword`, `TrimLpsPasswordsToLast3` in `internal/store/queries/lps.sql`.
- Migration `019_lps_password_projector_to_go.sql` replaces the PL/pgSQL function with a no-op stub (the shared `project_event()` trigger still dispatches; final cleanup after #106 drops the dispatcher itself).
- Wired via `projectors.WireAll`.

## Behavioural delta

- **Before:** PL/pgSQL projector ran inside the AppendEvent transaction. Three writes + event commit atomic.
- **After:** Go listener fires post-commit. The three writes remain atomic with each other (`store.WithTx`) but not with the event commit. LPS reads are operator-driven ("show me the current password for user X on device Y"), not hot-path RPCs, so the post-commit gap closes before any human-driven query.

## Test plan

- [x] Pure-function tests cover happy path, default rotation_reason, wrong stream/event type → ErrIgnoredEvent, missing device_id, malformed payload bytes
- [x] Integration: 4-rotation lifecycle ends with exactly 1 current + 2 history rows (trim-to-3)
- [x] Integration: per-username scoping — alice's rotation must not flip bob's is_current=TRUE row on the same device
- [x] Integration: wrong stream_type is ignored
- [x] All tests pass locally (\`go test ./server/internal/projectors/...\`)

Refs tracker #107. Closes #98.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Internal Improvements**
  * Password rotation handling moved to a service-side listener for reliable async projection.
  * Payloads validated strictly; missing rotation reason defaults to "scheduled".
  * Structured logs redact password values for safer logging.
  * Rotation lifecycle ensures only the latest row is marked current and history is trimmed to the last 3 per device+user.
* **Tests**
  * Added unit and integration tests for parsing, lifecycle, scoping, and ignored-event cases.
* **Chores**
  * Migration updated to disable the old in-database projector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->