### PR TITLE
feat: port project_luks_key_event to Go listener (#99)

### DIFF
--- a/internal/projectors/luks_key.go
+++ b/internal/projectors/luks_key.go
@@ -1,0 +1,180 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// LuksKeyRotatedPayload covers every field the luks_key projector
+// reads from the LuksKeyRotated event. Same shape as
+// LpsPasswordRotatedPayload but with `device_path` in the partition
+// key — LUKS rotates per (device, action, device_path) where LPS
+// rotates per (device, username).
+type LuksKeyRotatedPayload struct {
+	DeviceID       string    `json:"device_id"`
+	ActionID       string    `json:"action_id"`
+	DevicePath     string    `json:"device_path"`
+	Passphrase     string    `json:"passphrase"`
+	RotatedAt      time.Time `json:"rotated_at"`
+	RotationReason string    `json:"rotation_reason"`
+}
+
+// LogValue implements slog.LogValuer so the encrypted Passphrase is
+// never written verbatim by structured logs. Mirrors the
+// LpsPasswordRotatedPayload masking — the listener body already logs
+// only individual non-secret fields, but a future
+// `logger.Warn("…", "payload", payload)` or `fmt.Sprintf("%+v", p)`
+// routed through slog would otherwise leak the credential. Mask at
+// the type level so the safety holds regardless of caller
+// discipline.
+func (p LuksKeyRotatedPayload) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("device_id", p.DeviceID),
+		slog.String("action_id", p.ActionID),
+		slog.String("device_path", p.DevicePath),
+		slog.String("passphrase", "[REDACTED]"),
+		slog.Time("rotated_at", p.RotatedAt),
+		slog.String("rotation_reason", p.RotationReason),
+	)
+}
+
+// LuksRevocationPayload is the union shape for the three revocation
+// event types (Dispatched, Revoked, Failed). They all UPDATE the
+// current row's revocation_status / revocation_at; only Failed sets
+// revocation_error. Status is the value the projector writes to the
+// row (`dispatched`, `success`, `failed`) — note that the event-type
+// suffix and the column value differ for the success case (event is
+// `LuksDeviceKeyRevoked`, status is `success`).
+type LuksRevocationPayload struct {
+	DeviceID string
+	ActionID string
+	Status   string
+	Error    *string
+	At       time.Time
+}
+
+// LuksKeyRotatedFromEvent decodes LuksKeyRotated. Returns
+// ErrIgnoredEvent for any other (stream, event_type) so the listener
+// wrapper can silently no-op.
+func LuksKeyRotatedFromEvent(e store.PersistedEvent) (LuksKeyRotatedPayload, error) {
+	if e.StreamType != "luks_key" || e.EventType != "LuksKeyRotated" {
+		return LuksKeyRotatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return LuksKeyRotatedPayload{}, fmt.Errorf("projector: empty LuksKeyRotated payload")
+	}
+	var p LuksKeyRotatedPayload
+	if err := json.Unmarshal(e.Data, &p); err != nil {
+		return LuksKeyRotatedPayload{}, fmt.Errorf("projector: invalid LuksKeyRotated payload: %w", err)
+	}
+	switch {
+	case p.DeviceID == "":
+		return LuksKeyRotatedPayload{}, fmt.Errorf("projector: LuksKeyRotated requires device_id")
+	case p.ActionID == "":
+		return LuksKeyRotatedPayload{}, fmt.Errorf("projector: LuksKeyRotated requires action_id")
+	case p.DevicePath == "":
+		return LuksKeyRotatedPayload{}, fmt.Errorf("projector: LuksKeyRotated requires device_path")
+	case p.Passphrase == "":
+		return LuksKeyRotatedPayload{}, fmt.Errorf("projector: LuksKeyRotated requires passphrase")
+	case p.RotatedAt.IsZero():
+		return LuksKeyRotatedPayload{}, fmt.Errorf("projector: LuksKeyRotated requires rotated_at")
+	}
+	if p.RotationReason == "" {
+		// Match the PL/pgSQL `COALESCE(... 'scheduled')` default.
+		p.RotationReason = "scheduled"
+	}
+	return p, nil
+}
+
+// LuksRevocationDispatchedFromEvent decodes
+// LuksDeviceKeyRevocationDispatched into the union revocation
+// payload. Status is hardcoded "dispatched" so the listener doesn't
+// need a per-event mapping table.
+func LuksRevocationDispatchedFromEvent(e store.PersistedEvent) (LuksRevocationPayload, error) {
+	if e.StreamType != "luks_key" || e.EventType != "LuksDeviceKeyRevocationDispatched" {
+		return LuksRevocationPayload{}, ErrIgnoredEvent
+	}
+	return decodeLuksRevocation(e, "dispatched", "dispatched_at", false)
+}
+
+// LuksRevokedFromEvent decodes LuksDeviceKeyRevoked. Status is
+// "success" — note the event type vs column-value mismatch is
+// intentional and matches the PL/pgSQL projector verbatim.
+func LuksRevokedFromEvent(e store.PersistedEvent) (LuksRevocationPayload, error) {
+	if e.StreamType != "luks_key" || e.EventType != "LuksDeviceKeyRevoked" {
+		return LuksRevocationPayload{}, ErrIgnoredEvent
+	}
+	return decodeLuksRevocation(e, "success", "revoked_at", false)
+}
+
+// LuksRevocationFailedFromEvent decodes LuksDeviceKeyRevocationFailed
+// — only this variant requires an error string in the payload.
+func LuksRevocationFailedFromEvent(e store.PersistedEvent) (LuksRevocationPayload, error) {
+	if e.StreamType != "luks_key" || e.EventType != "LuksDeviceKeyRevocationFailed" {
+		return LuksRevocationPayload{}, ErrIgnoredEvent
+	}
+	return decodeLuksRevocation(e, "failed", "failed_at", true)
+}
+
+// decodeLuksRevocation centralises the shared (device_id, action_id,
+// <its_at>, ?error) parsing for the three revocation variants.
+// `atKey` is the JSON key holding the timestamp (different per
+// variant — dispatched_at / revoked_at / failed_at). `requireError`
+// is true only for the Failed variant; the other two ignore any
+// error field that happens to be in the payload.
+func decodeLuksRevocation(e store.PersistedEvent, status, atKey string, requireError bool) (LuksRevocationPayload, error) {
+	if len(e.Data) == 0 {
+		return LuksRevocationPayload{}, fmt.Errorf("projector: empty %s payload", e.EventType)
+	}
+	// Decode dynamically because the timestamp key name varies per
+	// variant. A typed struct per variant would be three near-identical
+	// structs for one extra string conversion — not worth it.
+	var raw map[string]any
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return LuksRevocationPayload{}, fmt.Errorf("projector: invalid %s payload: %w", e.EventType, err)
+	}
+
+	deviceID, _ := raw["device_id"].(string)
+	actionID, _ := raw["action_id"].(string)
+	atRaw, _ := raw[atKey].(string)
+	errStr, _ := raw["error"].(string)
+
+	switch {
+	case deviceID == "":
+		return LuksRevocationPayload{}, fmt.Errorf("projector: %s requires device_id", e.EventType)
+	case actionID == "":
+		return LuksRevocationPayload{}, fmt.Errorf("projector: %s requires action_id", e.EventType)
+	case atRaw == "":
+		return LuksRevocationPayload{}, fmt.Errorf("projector: %s requires %s", e.EventType, atKey)
+	case requireError && errStr == "":
+		return LuksRevocationPayload{}, fmt.Errorf("projector: %s requires error", e.EventType)
+	}
+
+	at, err := time.Parse(time.RFC3339, atRaw)
+	if err != nil {
+		// Try RFC3339 with nanos as a fallback — agent code uses
+		// time.Now().Format(time.RFC3339) but a future emitter may
+		// switch to time.RFC3339Nano. Both are valid TIMESTAMPTZ
+		// inputs in the deleted PL/pgSQL projector.
+		at, err = time.Parse(time.RFC3339Nano, atRaw)
+		if err != nil {
+			return LuksRevocationPayload{}, fmt.Errorf("projector: %s has invalid %s %q: %w", e.EventType, atKey, atRaw, err)
+		}
+	}
+
+	out := LuksRevocationPayload{
+		DeviceID: deviceID,
+		ActionID: actionID,
+		Status:   status,
+		At:       at,
+	}
+	if requireError {
+		s := errStr
+		out.Error = &s
+	}
+	return out, nil
+}

--- a/internal/projectors/luks_key_listener.go
+++ b/internal/projectors/luks_key_listener.go
@@ -1,0 +1,138 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// LuksKeyListener returns a store.EventListener that applies every
+// LUKS-key event the deleted PL/pgSQL project_luks_key_event handled.
+// Replaces the four-case dispatcher with one switch in Go:
+//
+//   - LuksKeyRotated: 3 writes (mark previous not-current, insert
+//     new, trim to last 3) wrapped in store.WithTx so the projection
+//     never observes the intermediate "no current row" state.
+//   - LuksDeviceKeyRevocationDispatched: UPDATE current row's
+//     revocation_status='dispatched' + revocation_at, clear error.
+//   - LuksDeviceKeyRevoked: UPDATE current row's revocation_status='success'
+//     (note column-value vs event-name mismatch — matches PL/pgSQL).
+//   - LuksDeviceKeyRevocationFailed: UPDATE revocation_status='failed'
+//     + revocation_error captured.
+//
+// LuksDeviceKeyRevocationRequested is intentionally a no-op (the
+// PL/pgSQL projector also lacked a case for it). The Requested event
+// is a marker the dispatcher handler appends before enqueueing; the
+// projection only changes once Dispatched / Revoked / Failed lands.
+//
+// Wired in projectors.WireAll. Refs #99, tracker #107.
+func LuksKeyListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "luks_key" {
+			return
+		}
+
+		switch e.EventType {
+		case "LuksKeyRotated":
+			applyLuksKeyRotated(ctx, st, logger, e)
+		case "LuksDeviceKeyRevocationDispatched":
+			applyLuksRevocation(ctx, st, logger, e, LuksRevocationDispatchedFromEvent)
+		case "LuksDeviceKeyRevoked":
+			applyLuksRevocation(ctx, st, logger, e, LuksRevokedFromEvent)
+		case "LuksDeviceKeyRevocationFailed":
+			applyLuksRevocation(ctx, st, logger, e, LuksRevocationFailedFromEvent)
+		}
+		// Every other event_type (incl. LuksDeviceKeyRevocationRequested)
+		// is silently ignored — same behaviour as the deleted PL/pgSQL
+		// projector's CASE ... ELSE NULL.
+	}
+}
+
+func applyLuksKeyRotated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := LuksKeyRotatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("luks_key projector: invalid LuksKeyRotated payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.WithTx(ctx, func(q *store.Queries) error {
+		if err := q.MarkLuksKeysNotCurrent(ctx, db.MarkLuksKeysNotCurrentParams{
+			DeviceID:   payload.DeviceID,
+			ActionID:   payload.ActionID,
+			DevicePath: payload.DevicePath,
+		}); err != nil {
+			return err
+		}
+		if err := q.InsertLuksKey(ctx, db.InsertLuksKeyParams{
+			DeviceID:       payload.DeviceID,
+			ActionID:       payload.ActionID,
+			DevicePath:     payload.DevicePath,
+			Passphrase:     payload.Passphrase,
+			RotatedAt:      payload.RotatedAt,
+			RotationReason: payload.RotationReason,
+		}); err != nil {
+			return err
+		}
+		return q.TrimLuksKeysToLast3(ctx, db.TrimLuksKeysToLast3Params{
+			DeviceID:   payload.DeviceID,
+			ActionID:   payload.ActionID,
+			DevicePath: payload.DevicePath,
+		})
+	}); err != nil {
+		logger.Warn("luks_key projector: failed to apply LuksKeyRotated",
+			"event_id", e.ID,
+			"device_id", payload.DeviceID,
+			"action_id", payload.ActionID,
+			"device_path", payload.DevicePath,
+			"error", err)
+	}
+}
+
+// applyLuksRevocation is generic across the three revocation event
+// types — they all UPDATE the current row's (revocation_status,
+// revocation_error, revocation_at). The decoder picks the right
+// timestamp key + status value; the writer is identical.
+func applyLuksRevocation(
+	ctx context.Context,
+	st *store.Store,
+	logger *slog.Logger,
+	e store.PersistedEvent,
+	decode func(store.PersistedEvent) (LuksRevocationPayload, error),
+) {
+	payload, err := decode(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("luks_key projector: invalid revocation payload",
+			"event_id", e.ID, "event_type", e.EventType, "error", err)
+		return
+	}
+	at := payload.At
+	if err := st.Queries().UpdateLuksKeyRevocationStatus(ctx, db.UpdateLuksKeyRevocationStatusParams{
+		DeviceID:         payload.DeviceID,
+		ActionID:         payload.ActionID,
+		RevocationStatus: stringPtr(payload.Status),
+		RevocationError:  payload.Error,
+		RevocationAt:     &at,
+	}); err != nil {
+		logger.Warn("luks_key projector: failed to update revocation_status",
+			"event_id", e.ID,
+			"event_type", e.EventType,
+			"device_id", payload.DeviceID,
+			"action_id", payload.ActionID,
+			"status", payload.Status,
+			"error", err)
+	}
+}
+
+func stringPtr(s string) *string { return &s }

--- a/internal/projectors/luks_key_test.go
+++ b/internal/projectors/luks_key_test.go
@@ -1,0 +1,548 @@
+package projectors_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestLuksKeyRotatedFromEvent_Pure mirrors the lps_password pure
+// suite. The PL/pgSQL projector implicitly required every payload
+// field (any missing key would have raised on the TIMESTAMPTZ cast or
+// produced a row with NULL columns the table forbids); validating
+// here keeps the failure surface in the listener log instead of in
+// the projection.
+func TestLuksKeyRotatedFromEvent_Pure(t *testing.T) {
+	rotatedAt := time.Date(2026, 5, 4, 12, 30, 0, 0, time.UTC)
+
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.LuksKeyRotatedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key",
+			EventType:  "LuksKeyRotated",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":       "dev-1",
+				"action_id":       "act-1",
+				"device_path":     "/dev/sda3",
+				"passphrase":      "ENC:secret",
+				"rotated_at":      rotatedAt.Format(time.RFC3339),
+				"rotation_reason": "scheduled",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.DeviceID)
+		assert.Equal(t, "act-1", got.ActionID)
+		assert.Equal(t, "/dev/sda3", got.DevicePath)
+		assert.Equal(t, "ENC:secret", got.Passphrase)
+		assert.True(t, got.RotatedAt.Equal(rotatedAt))
+		assert.Equal(t, "scheduled", got.RotationReason)
+	})
+
+	t.Run("missing rotation_reason defaults to scheduled", func(t *testing.T) {
+		got, err := projectors.LuksKeyRotatedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key",
+			EventType:  "LuksKeyRotated",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":   "d", "action_id": "a", "device_path": "/dev/sda1",
+				"passphrase": "ENC:s", "rotated_at": rotatedAt.Format(time.RFC3339),
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "scheduled", got.RotationReason)
+	})
+
+	t.Run("wrong stream_type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.LuksKeyRotatedFromEvent(store.PersistedEvent{
+			StreamType: "lps_password",
+			EventType:  "LuksKeyRotated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("wrong event_type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.LuksKeyRotatedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key",
+			EventType:  "LuksDeviceKeyRevoked",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("required fields are validated individually", func(t *testing.T) {
+		base := map[string]any{
+			"device_id":   "dev-1",
+			"action_id":   "act-1",
+			"device_path": "/dev/sda1",
+			"passphrase":  "ENC:s",
+			"rotated_at":  rotatedAt.Format(time.RFC3339),
+		}
+		for _, drop := range []string{"device_id", "action_id", "device_path", "passphrase", "rotated_at"} {
+			t.Run("missing "+drop, func(t *testing.T) {
+				payload := map[string]any{}
+				for k, v := range base {
+					if k == drop {
+						continue
+					}
+					payload[k] = v
+				}
+				_, err := projectors.LuksKeyRotatedFromEvent(store.PersistedEvent{
+					StreamType: "luks_key",
+					EventType:  "LuksKeyRotated",
+					Data:       jsonOrFail(t, payload),
+				})
+				require.Error(t, err)
+				assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+				assert.Contains(t, err.Error(), drop)
+			})
+		}
+	})
+
+	t.Run("malformed payload → validation error", func(t *testing.T) {
+		_, err := projectors.LuksKeyRotatedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key",
+			EventType:  "LuksKeyRotated",
+			Data:       []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestLuksRevocationFromEvent_Pure covers the three revocation event
+// types that the PL/pgSQL projector treated as UPDATE-only operations
+// against the current row. Each one writes a different
+// (status, error, at) triple — the test enumerates them in one place
+// so a regression to any branch shows up as a focused failure.
+func TestLuksRevocationFromEvent_Pure(t *testing.T) {
+	at := time.Date(2026, 5, 4, 14, 0, 0, 0, time.UTC)
+
+	t.Run("dispatched", func(t *testing.T) {
+		got, err := projectors.LuksRevocationDispatchedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key",
+			EventType:  "LuksDeviceKeyRevocationDispatched",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":     "dev-1",
+				"action_id":     "act-1",
+				"dispatched_at": at.Format(time.RFC3339),
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.DeviceID)
+		assert.Equal(t, "act-1", got.ActionID)
+		assert.Equal(t, "dispatched", got.Status)
+		assert.Nil(t, got.Error)
+		assert.True(t, got.At.Equal(at))
+	})
+
+	t.Run("revoked", func(t *testing.T) {
+		got, err := projectors.LuksRevokedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key",
+			EventType:  "LuksDeviceKeyRevoked",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":  "dev-1",
+				"action_id":  "act-1",
+				"revoked_at": at.Format(time.RFC3339),
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "success", got.Status)
+		assert.Nil(t, got.Error)
+		assert.True(t, got.At.Equal(at))
+	})
+
+	t.Run("failed", func(t *testing.T) {
+		got, err := projectors.LuksRevocationFailedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key",
+			EventType:  "LuksDeviceKeyRevocationFailed",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id": "dev-1",
+				"action_id": "act-1",
+				"error":     "agent unreachable",
+				"failed_at": at.Format(time.RFC3339),
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "failed", got.Status)
+		require.NotNil(t, got.Error)
+		assert.Equal(t, "agent unreachable", *got.Error)
+		assert.True(t, got.At.Equal(at))
+	})
+
+	t.Run("wrong stream_type is ignored", func(t *testing.T) {
+		_, err := projectors.LuksRevocationDispatchedFromEvent(store.PersistedEvent{
+			StreamType: "lps_password",
+			EventType:  "LuksDeviceKeyRevocationDispatched",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("wrong event_type is ignored per-decoder", func(t *testing.T) {
+		// Each decoder is paired with one event_type; cross-pairs
+		// must return ErrIgnoredEvent so the listener wrapper can
+		// silently no-op without a warning log.
+		_, err := projectors.LuksRevocationDispatchedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key", EventType: "LuksDeviceKeyRevoked",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.LuksRevokedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key", EventType: "LuksDeviceKeyRevocationDispatched",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.LuksRevocationFailedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key", EventType: "LuksDeviceKeyRevoked",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("required fields validated for each variant", func(t *testing.T) {
+		// Each variant requires (device_id, action_id, <its_at>);
+		// failed additionally requires error. The decoder names the
+		// missing field in its error so listener logs are actionable.
+		_, err := projectors.LuksRevocationDispatchedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key", EventType: "LuksDeviceKeyRevocationDispatched",
+			Data: jsonOrFail(t, map[string]any{"action_id": "a", "dispatched_at": at.Format(time.RFC3339)}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "device_id")
+
+		_, err = projectors.LuksRevocationFailedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key", EventType: "LuksDeviceKeyRevocationFailed",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id": "d", "action_id": "a", "failed_at": at.Format(time.RFC3339),
+				// no error
+			}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "error")
+	})
+}
+
+// TestLuksKeyListener_RotationLifecycle walks 4 rotations through the
+// listener for the same (device, action, device_path) and asserts the
+// projection ends with exactly 1 current + 2 history rows (trim-to-3).
+func TestLuksKeyListener_RotationLifecycle(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	deviceID := "device-" + testutil.NewID()
+	actionID := "action-" + testutil.NewID()
+	devicePath := "/dev/sda1"
+
+	rotations := []struct {
+		passphrase string
+		rotatedAt  time.Time
+		reason     string
+	}{
+		{"ENC:p1", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC), "scheduled"},
+		{"ENC:p2", time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC), "scheduled"},
+		{"ENC:p3", time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), "manual"},
+		{"ENC:p4", time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC), "scheduled"},
+	}
+	for i, r := range rotations {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "luks_key",
+			StreamID:   testutil.NewID(),
+			EventType:  "LuksKeyRotated",
+			Data: map[string]any{
+				"device_id":       deviceID,
+				"action_id":       actionID,
+				"device_path":     devicePath,
+				"passphrase":      r.passphrase,
+				"rotated_at":      r.rotatedAt.Format(time.RFC3339),
+				"rotation_reason": r.reason,
+			},
+			ActorType: "device",
+			ActorID:   deviceID,
+		}), "rotation %d", i)
+	}
+
+	current, err := st.Queries().GetCurrentLuksKeyForAction(ctx, db.GetCurrentLuksKeyForActionParams{DeviceID: deviceID, ActionID: actionID})
+	require.NoError(t, err)
+	assert.Equal(t, "ENC:p4", current.Passphrase)
+	assert.Equal(t, "scheduled", current.RotationReason)
+
+	all := dumpLuksKeysForAction(t, st, deviceID, actionID, devicePath)
+	assert.Len(t, all, 3, "TrimLuksKeysToLast3 keeps current + 2 prior")
+	currentCount := 0
+	for _, k := range all {
+		if k.IsCurrent {
+			currentCount++
+		}
+	}
+	assert.Equal(t, 1, currentCount, "exactly one is_current=TRUE row per (device,action,device_path) after the latest rotation")
+}
+
+// TestLuksKeyListener_PerActionPathScope confirms a rotation for one
+// (action, device_path) does NOT touch another (action, device_path)
+// on the same device. The PL/pgSQL projector keyed its UPDATE / DELETE
+// on the full triple; a regression that drops device_path from the
+// WHERE clause would silently invalidate other partition keys.
+func TestLuksKeyListener_PerActionPathScope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	deviceID := "device-" + testutil.NewID()
+
+	rotate := func(actionID, devicePath, passphrase string, rotatedAt time.Time) {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "luks_key",
+			StreamID:   testutil.NewID(),
+			EventType:  "LuksKeyRotated",
+			Data: map[string]any{
+				"device_id":       deviceID,
+				"action_id":       actionID,
+				"device_path":     devicePath,
+				"passphrase":      passphrase,
+				"rotated_at":      rotatedAt.Format(time.RFC3339),
+				"rotation_reason": "scheduled",
+			},
+			ActorType: "device",
+			ActorID:   deviceID,
+		}))
+	}
+
+	rotate("act-A", "/dev/sda1", "ENC:A1", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	rotate("act-B", "/dev/sda2", "ENC:B1", time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC))
+	rotate("act-A", "/dev/sda1", "ENC:A2", time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC))
+
+	current, err := st.Queries().GetCurrentLuksKeys(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, current, 2, "one current row per (action, device_path)")
+	byKey := map[string]string{}
+	for _, k := range current {
+		byKey[k.ActionID+":"+k.DevicePath] = k.Passphrase
+	}
+	assert.Equal(t, "ENC:A2", byKey["act-A:/dev/sda1"])
+	assert.Equal(t, "ENC:B1", byKey["act-B:/dev/sda2"], "act-B's row stays current despite act-A's two rotations on the same device")
+}
+
+// TestLuksKeyListener_RevocationDispatched walks Rotate → Dispatched
+// and asserts the current row's revocation_status flips to 'dispatched'
+// without affecting the passphrase.
+func TestLuksKeyListener_RevocationDispatched(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID, actionID := "device-"+testutil.NewID(), "action-"+testutil.NewID()
+
+	rotateOnce(t, st, ctx, deviceID, actionID, "/dev/sda1", "ENC:k", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	dispatchedAt := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "luks_key",
+		StreamID:   testutil.NewID(),
+		EventType:  "LuksDeviceKeyRevocationDispatched",
+		Data: map[string]any{
+			"device_id":     deviceID,
+			"action_id":     actionID,
+			"dispatched_at": dispatchedAt.Format(time.RFC3339),
+		},
+		ActorType: "user", ActorID: "u-1",
+	}))
+
+	row, err := st.Queries().GetCurrentLuksKeyForAction(ctx, db.GetCurrentLuksKeyForActionParams{DeviceID: deviceID, ActionID: actionID})
+	require.NoError(t, err)
+	require.NotNil(t, row.RevocationStatus)
+	assert.Equal(t, "dispatched", *row.RevocationStatus)
+	assert.Nil(t, row.RevocationError)
+	require.NotNil(t, row.RevocationAt)
+	assert.True(t, row.RevocationAt.Equal(dispatchedAt))
+	assert.Equal(t, "ENC:k", row.Passphrase, "passphrase column is untouched by revocation events")
+}
+
+// TestLuksKeyListener_RevocationSuccessFlow walks
+// Rotate → Dispatched → Revoked. The Revoked event clears
+// revocation_error (PL/pgSQL set it to NULL) and stamps revocation_at
+// with revoked_at. The passphrase stays intact for audit history.
+func TestLuksKeyListener_RevocationSuccessFlow(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID, actionID := "device-"+testutil.NewID(), "action-"+testutil.NewID()
+
+	rotateOnce(t, st, ctx, deviceID, actionID, "/dev/sda1", "ENC:k", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	mustAppend(t, st, ctx, store.Event{
+		StreamType: "luks_key", StreamID: testutil.NewID(),
+		EventType: "LuksDeviceKeyRevocationDispatched",
+		Data: map[string]any{
+			"device_id": deviceID, "action_id": actionID,
+			"dispatched_at": time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		},
+		ActorType: "user", ActorID: "u-1",
+	})
+
+	revokedAt := time.Date(2026, 1, 3, 0, 0, 0, 0, time.UTC)
+	mustAppend(t, st, ctx, store.Event{
+		StreamType: "luks_key", StreamID: testutil.NewID(),
+		EventType: "LuksDeviceKeyRevoked",
+		Data: map[string]any{
+			"device_id": deviceID, "action_id": actionID,
+			"revoked_at": revokedAt.Format(time.RFC3339),
+		},
+		ActorType: "device", ActorID: deviceID,
+	})
+
+	row, err := st.Queries().GetCurrentLuksKeyForAction(ctx, db.GetCurrentLuksKeyForActionParams{DeviceID: deviceID, ActionID: actionID})
+	require.NoError(t, err)
+	require.NotNil(t, row.RevocationStatus)
+	assert.Equal(t, "success", *row.RevocationStatus)
+	assert.Nil(t, row.RevocationError)
+	require.NotNil(t, row.RevocationAt)
+	assert.True(t, row.RevocationAt.Equal(revokedAt))
+}
+
+// TestLuksKeyListener_RevocationFailedFlow walks Rotate → Failed and
+// asserts revocation_status='failed' + revocation_error captured. The
+// failure payload's error message must round-trip into the projection
+// so operators see WHY revocation failed without diving into the
+// event log.
+func TestLuksKeyListener_RevocationFailedFlow(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID, actionID := "device-"+testutil.NewID(), "action-"+testutil.NewID()
+
+	rotateOnce(t, st, ctx, deviceID, actionID, "/dev/sda1", "ENC:k", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	failedAt := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	mustAppend(t, st, ctx, store.Event{
+		StreamType: "luks_key", StreamID: testutil.NewID(),
+		EventType: "LuksDeviceKeyRevocationFailed",
+		Data: map[string]any{
+			"device_id": deviceID, "action_id": actionID,
+			"error":     "dispatch enqueue failed: connection refused",
+			"failed_at": failedAt.Format(time.RFC3339),
+		},
+		ActorType: "system", ActorID: "system",
+	})
+
+	row, err := st.Queries().GetCurrentLuksKeyForAction(ctx, db.GetCurrentLuksKeyForActionParams{DeviceID: deviceID, ActionID: actionID})
+	require.NoError(t, err)
+	require.NotNil(t, row.RevocationStatus)
+	assert.Equal(t, "failed", *row.RevocationStatus)
+	require.NotNil(t, row.RevocationError)
+	assert.Equal(t, "dispatch enqueue failed: connection refused", *row.RevocationError)
+	require.NotNil(t, row.RevocationAt)
+	assert.True(t, row.RevocationAt.Equal(failedAt))
+}
+
+// TestLuksKeyListener_RevocationRequestedIsIgnored — the deleted
+// PL/pgSQL projector did NOT have a case for LuksDeviceKeyRevocationRequested
+// (it's a marker event the dispatcher handler appends before enqueueing).
+// The Go listener must preserve that no-op behaviour or it will
+// double-write revocation_status before the dispatch even happens.
+func TestLuksKeyListener_RevocationRequestedIsIgnored(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID, actionID := "device-"+testutil.NewID(), "action-"+testutil.NewID()
+
+	rotateOnce(t, st, ctx, deviceID, actionID, "/dev/sda1", "ENC:k", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	mustAppend(t, st, ctx, store.Event{
+		StreamType: "luks_key", StreamID: testutil.NewID(),
+		EventType: "LuksDeviceKeyRevocationRequested",
+		Data: map[string]any{
+			"device_id": deviceID, "action_id": actionID,
+			"requested_at": time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC).Format(time.RFC3339),
+		},
+		ActorType: "user", ActorID: "u-1",
+	})
+
+	row, err := st.Queries().GetCurrentLuksKeyForAction(ctx, db.GetCurrentLuksKeyForActionParams{DeviceID: deviceID, ActionID: actionID})
+	require.NoError(t, err)
+	assert.Nil(t, row.RevocationStatus, "Requested must NOT update revocation_status — that's the Dispatched/Revoked/Failed responsibility")
+}
+
+// TestLuksKeyListener_IgnoresWrongStreamType — defensive: any
+// luks-shaped event under a different stream_type must be a no-op.
+func TestLuksKeyListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := "device-" + testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", // wrong
+		StreamID:   testutil.NewID(),
+		EventType:  "LuksKeyRotated",
+		Data: map[string]any{
+			"device_id":   deviceID,
+			"action_id":   "a",
+			"device_path": "/dev/sda1",
+			"passphrase":  "ENC:nope",
+			"rotated_at":  time.Now().UTC().Format(time.RFC3339),
+		},
+		ActorType: "device", ActorID: deviceID,
+	}))
+
+	// fireListeners is synchronous (see project memory
+	// `feedback_post_commit_listener_is_sync.md`): if the listener
+	// were going to write, the row would already be there by the
+	// time AppendEvent returns. No sleep needed.
+	current, err := st.Queries().GetCurrentLuksKeys(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Empty(t, current, "wrong-stream-type event must NOT create a luks_keys_projection row")
+}
+
+// rotateOnce is a one-event helper for tests that need a current row
+// in place before driving a revocation event through the listener.
+func rotateOnce(t *testing.T, st *store.Store, ctx context.Context, deviceID, actionID, devicePath, passphrase string, rotatedAt time.Time) {
+	t.Helper()
+	mustAppend(t, st, ctx, store.Event{
+		StreamType: "luks_key", StreamID: testutil.NewID(),
+		EventType: "LuksKeyRotated",
+		Data: map[string]any{
+			"device_id":       deviceID,
+			"action_id":       actionID,
+			"device_path":     devicePath,
+			"passphrase":      passphrase,
+			"rotated_at":      rotatedAt.Format(time.RFC3339),
+			"rotation_reason": "scheduled",
+		},
+		ActorType: "device", ActorID: deviceID,
+	})
+}
+
+func mustAppend(t *testing.T, st *store.Store, ctx context.Context, e store.Event) {
+	t.Helper()
+	require.NoError(t, st.AppendEvent(ctx, e))
+}
+
+// dumpLuksKeysForAction reads every row matching the partition key
+// (current + history) so the lifecycle test can assert the trim count.
+// Inline rather than a sqlc query because no production caller needs
+// it.
+func dumpLuksKeysForAction(t *testing.T, st *store.Store, deviceID, actionID, devicePath string) []luksKeyRow {
+	t.Helper()
+	rows, err := st.Pool().Query(context.Background(),
+		`SELECT id, passphrase, rotated_at, is_current, revocation_status FROM luks_keys_projection
+		 WHERE device_id = $1 AND action_id = $2 AND device_path = $3
+		 ORDER BY rotated_at DESC`,
+		deviceID, actionID, devicePath,
+	)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []luksKeyRow
+	for rows.Next() {
+		var r luksKeyRow
+		require.NoError(t, rows.Scan(&r.ID, &r.Passphrase, &r.RotatedAt, &r.IsCurrent, &r.RevocationStatus))
+		out = append(out, r)
+	}
+	require.NoError(t, rows.Err())
+	return out
+}
+
+type luksKeyRow struct {
+	ID               string
+	Passphrase       string
+	RotatedAt        time.Time
+	IsCurrent        bool
+	RevocationStatus *string
+}
+
+// jsonOrFail is defined in lps_password_test.go (same package); re-used here.
+var _ = json.Marshal

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -40,7 +40,11 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "lps_password_projector"),
 	))
-	// Subsequent ports under #99–#106 add their listener here.
+	st.RegisterEventListener(LuksKeyListener(
+		st,
+		loggerFor(logger, "luks_key_projector"),
+	))
+	// Subsequent ports under #100–#106 add their listener here.
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/luks.sql.go
+++ b/internal/store/generated/luks.sql.go
@@ -232,6 +232,7 @@ SET is_current = FALSE
 WHERE device_id = $1
   AND action_id = $2
   AND device_path = $3
+  AND is_current = TRUE
 `
 
 type MarkLuksKeysNotCurrentParams struct {
@@ -240,9 +241,12 @@ type MarkLuksKeysNotCurrentParams struct {
 	DevicePath string `json:"device_path"`
 }
 
-// Step 1 of LuksKeyRotated projection. Flip every prior row for the
+// Step 1 of LuksKeyRotated projection. Flip the current row for the
 // (device_id, action_id, device_path) triple so the new key
-// (inserted by step 2) is the only is_current=TRUE row.
+// (inserted by step 2) is the only is_current=TRUE row. The
+// `is_current = TRUE` predicate keeps the result identical (rows
+// already FALSE stay FALSE) but skips a write per historical row,
+// reducing write amplification on the hot path.
 func (q *Queries) MarkLuksKeysNotCurrent(ctx context.Context, arg MarkLuksKeysNotCurrentParams) error {
 	_, err := q.db.Exec(ctx, markLuksKeysNotCurrent, arg.DeviceID, arg.ActionID, arg.DevicePath)
 	return err

--- a/internal/store/generated/luks.sql.go
+++ b/internal/store/generated/luks.sql.go
@@ -7,6 +7,7 @@ package generated
 
 import (
 	"context"
+	"time"
 )
 
 const createLuksToken = `-- name: CreateLuksToken :one
@@ -194,6 +195,120 @@ func (q *Queries) GetLuksRevocationStreamID(ctx context.Context, arg GetLuksRevo
 	var stream_id string
 	err := row.Scan(&stream_id)
 	return stream_id, err
+}
+
+const insertLuksKey = `-- name: InsertLuksKey :exec
+INSERT INTO luks_keys_projection
+    (device_id, action_id, device_path, passphrase, rotated_at, rotation_reason)
+VALUES ($1, $2, $3, $4, $5, $6)
+`
+
+type InsertLuksKeyParams struct {
+	DeviceID       string    `json:"device_id"`
+	ActionID       string    `json:"action_id"`
+	DevicePath     string    `json:"device_path"`
+	Passphrase     string    `json:"passphrase"`
+	RotatedAt      time.Time `json:"rotated_at"`
+	RotationReason string    `json:"rotation_reason"`
+}
+
+// Step 2 of LuksKeyRotated projection. Always inserts a new row;
+// step 3's trim keeps only the latest 3 by rotated_at.
+func (q *Queries) InsertLuksKey(ctx context.Context, arg InsertLuksKeyParams) error {
+	_, err := q.db.Exec(ctx, insertLuksKey,
+		arg.DeviceID,
+		arg.ActionID,
+		arg.DevicePath,
+		arg.Passphrase,
+		arg.RotatedAt,
+		arg.RotationReason,
+	)
+	return err
+}
+
+const markLuksKeysNotCurrent = `-- name: MarkLuksKeysNotCurrent :exec
+UPDATE luks_keys_projection
+SET is_current = FALSE
+WHERE device_id = $1
+  AND action_id = $2
+  AND device_path = $3
+`
+
+type MarkLuksKeysNotCurrentParams struct {
+	DeviceID   string `json:"device_id"`
+	ActionID   string `json:"action_id"`
+	DevicePath string `json:"device_path"`
+}
+
+// Step 1 of LuksKeyRotated projection. Flip every prior row for the
+// (device_id, action_id, device_path) triple so the new key
+// (inserted by step 2) is the only is_current=TRUE row.
+func (q *Queries) MarkLuksKeysNotCurrent(ctx context.Context, arg MarkLuksKeysNotCurrentParams) error {
+	_, err := q.db.Exec(ctx, markLuksKeysNotCurrent, arg.DeviceID, arg.ActionID, arg.DevicePath)
+	return err
+}
+
+const trimLuksKeysToLast3 = `-- name: TrimLuksKeysToLast3 :exec
+DELETE FROM luks_keys_projection AS k
+WHERE k.device_id = $1
+  AND k.action_id = $2
+  AND k.device_path = $3
+  AND k.id NOT IN (
+      SELECT id FROM luks_keys_projection
+      WHERE device_id = $1
+        AND action_id = $2
+        AND device_path = $3
+      ORDER BY rotated_at DESC
+      LIMIT 3
+  )
+`
+
+type TrimLuksKeysToLast3Params struct {
+	DeviceID   string `json:"device_id"`
+	ActionID   string `json:"action_id"`
+	DevicePath string `json:"device_path"`
+}
+
+// Step 3 of LuksKeyRotated projection. Keep only the latest 3 keys
+// per (device_id, action_id, device_path) — operational requirement
+// mirrors the LPS trim policy (retain previous in case rotation was
+// mid-flight; deeper history bloats encrypted-passphrase storage).
+func (q *Queries) TrimLuksKeysToLast3(ctx context.Context, arg TrimLuksKeysToLast3Params) error {
+	_, err := q.db.Exec(ctx, trimLuksKeysToLast3, arg.DeviceID, arg.ActionID, arg.DevicePath)
+	return err
+}
+
+const updateLuksKeyRevocationStatus = `-- name: UpdateLuksKeyRevocationStatus :exec
+UPDATE luks_keys_projection
+SET revocation_status = $3,
+    revocation_error  = $4,
+    revocation_at     = $5
+WHERE device_id  = $1
+  AND action_id  = $2
+  AND is_current = TRUE
+`
+
+type UpdateLuksKeyRevocationStatusParams struct {
+	DeviceID         string     `json:"device_id"`
+	ActionID         string     `json:"action_id"`
+	RevocationStatus *string    `json:"revocation_status"`
+	RevocationError  *string    `json:"revocation_error"`
+	RevocationAt     *time.Time `json:"revocation_at"`
+}
+
+// Used by the three revocation events (Dispatched, Revoked, Failed).
+// Updates ONLY the current row for the (device_id, action_id) pair
+// — the PL/pgSQL projector keyed on `is_current = TRUE` so older
+// rotated-out rows keep their historical revocation_status.
+func (q *Queries) UpdateLuksKeyRevocationStatus(ctx context.Context, arg UpdateLuksKeyRevocationStatusParams) error {
+	_, err := q.db.Exec(ctx, updateLuksKeyRevocationStatus,
+		arg.DeviceID,
+		arg.ActionID,
+		arg.RevocationStatus,
+		arg.RevocationError,
+		arg.RevocationAt,
+	)
+	return err
 }
 
 const validateAndConsumeLuksToken = `-- name: ValidateAndConsumeLuksToken :one

--- a/internal/store/migrations/020_luks_key_projector_to_go.sql
+++ b/internal/store/migrations/020_luks_key_projector_to_go.sql
@@ -1,0 +1,120 @@
+-- Replace project_luks_key_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.LuksKeyListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger still
+-- PERFORMs project_luks_key_event(NEW) for every luks_key-stream
+-- event; the no-op stub keeps that dispatch quiet (no
+-- projection_errors entries) until the dispatcher itself is rewritten
+-- to skip stream types with Go projectors.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. The four event types (Rotated + three revocation
+--     variants) and the event commit were atomic.
+--   - After: Go listener fires post-commit. LuksKeyRotated's three
+--     writes (mark previous not-current, insert new, trim history to
+--     3) remain atomic with each other (store.WithTx) but not with
+--     the event commit. Revocation events are single UPDATEs and
+--     don't need a tx wrap. LUKS reads are operator-driven (recover
+--     a passphrase, audit revocation status) — not hot-path RPCs —
+--     so the post-commit gap closes before any human-driven query.
+--
+-- LuksDeviceKeyRevocationRequested stays a no-op in the Go listener
+-- (the deleted PL/pgSQL function also lacked a case for it). The
+-- Requested event is a marker the dispatcher handler appends before
+-- enqueueing; revocation_status only changes once Dispatched /
+-- Revoked / Failed lands.
+--
+-- See manchtools/power-manage-server#99. Fourth port under the
+-- projector-migration pattern (#96 canary, #97 totp, #98 lps_password,
+-- #99 luks_key).
+--
+-- Refs tracker #107.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_luks_key_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.LuksKeyListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the original PL/pgSQL projector verbatim from migration 003.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_luks_key_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'LuksKeyRotated' THEN
+            -- Mark previous keys as not current for this device+action+device_path
+            UPDATE luks_keys_projection
+            SET is_current = FALSE
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND device_path = event.data->>'device_path';
+
+            -- Insert new key (revocation resets on rotation)
+            INSERT INTO luks_keys_projection
+                (device_id, action_id, device_path, passphrase, rotated_at, rotation_reason)
+            VALUES (
+                event.data->>'device_id',
+                event.data->>'action_id',
+                event.data->>'device_path',
+                event.data->>'passphrase',
+                (event.data->>'rotated_at')::TIMESTAMPTZ,
+                COALESCE(event.data->>'rotation_reason', 'scheduled')
+            );
+
+            -- Keep only last 3 keys per device+action+device_path
+            DELETE FROM luks_keys_projection
+            WHERE id NOT IN (
+                SELECT id FROM luks_keys_projection
+                WHERE device_id = event.data->>'device_id'
+                  AND action_id = event.data->>'action_id'
+                  AND device_path = event.data->>'device_path'
+                ORDER BY rotated_at DESC LIMIT 3
+            )
+            AND device_id = event.data->>'device_id'
+            AND action_id = event.data->>'action_id'
+            AND device_path = event.data->>'device_path';
+
+        WHEN 'LuksDeviceKeyRevocationDispatched' THEN
+            UPDATE luks_keys_projection
+            SET revocation_status = 'dispatched',
+                revocation_error = NULL,
+                revocation_at = (event.data->>'dispatched_at')::TIMESTAMPTZ
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND is_current = TRUE;
+
+        WHEN 'LuksDeviceKeyRevoked' THEN
+            UPDATE luks_keys_projection
+            SET revocation_status = 'success',
+                revocation_error = NULL,
+                revocation_at = (event.data->>'revoked_at')::TIMESTAMPTZ
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND is_current = TRUE;
+
+        WHEN 'LuksDeviceKeyRevocationFailed' THEN
+            UPDATE luks_keys_projection
+            SET revocation_status = 'failed',
+                revocation_error = event.data->>'error',
+                revocation_at = (event.data->>'failed_at')::TIMESTAMPTZ
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id'
+              AND is_current = TRUE;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/luks.sql
+++ b/internal/store/queries/luks.sql
@@ -18,6 +18,54 @@ LIMIT 20;
 -- name: DeleteLuksKeysByAction :exec
 DELETE FROM luks_keys_projection WHERE action_id = $1;
 
+-- name: MarkLuksKeysNotCurrent :exec
+-- Step 1 of LuksKeyRotated projection. Flip every prior row for the
+-- (device_id, action_id, device_path) triple so the new key
+-- (inserted by step 2) is the only is_current=TRUE row.
+UPDATE luks_keys_projection
+SET is_current = FALSE
+WHERE device_id = $1
+  AND action_id = $2
+  AND device_path = $3;
+
+-- name: InsertLuksKey :exec
+-- Step 2 of LuksKeyRotated projection. Always inserts a new row;
+-- step 3's trim keeps only the latest 3 by rotated_at.
+INSERT INTO luks_keys_projection
+    (device_id, action_id, device_path, passphrase, rotated_at, rotation_reason)
+VALUES ($1, $2, $3, $4, $5, $6);
+
+-- name: TrimLuksKeysToLast3 :exec
+-- Step 3 of LuksKeyRotated projection. Keep only the latest 3 keys
+-- per (device_id, action_id, device_path) — operational requirement
+-- mirrors the LPS trim policy (retain previous in case rotation was
+-- mid-flight; deeper history bloats encrypted-passphrase storage).
+DELETE FROM luks_keys_projection AS k
+WHERE k.device_id = $1
+  AND k.action_id = $2
+  AND k.device_path = $3
+  AND k.id NOT IN (
+      SELECT id FROM luks_keys_projection
+      WHERE device_id = $1
+        AND action_id = $2
+        AND device_path = $3
+      ORDER BY rotated_at DESC
+      LIMIT 3
+  );
+
+-- name: UpdateLuksKeyRevocationStatus :exec
+-- Used by the three revocation events (Dispatched, Revoked, Failed).
+-- Updates ONLY the current row for the (device_id, action_id) pair
+-- — the PL/pgSQL projector keyed on `is_current = TRUE` so older
+-- rotated-out rows keep their historical revocation_status.
+UPDATE luks_keys_projection
+SET revocation_status = $3,
+    revocation_error  = $4,
+    revocation_at     = $5
+WHERE device_id  = $1
+  AND action_id  = $2
+  AND is_current = TRUE;
+
 -- name: CreateLuksToken :one
 INSERT INTO luks_tokens (device_id, action_id, token, min_length, complexity, expires_at)
 VALUES ($1, $2, $3, $4, $5, NOW() + INTERVAL '15 minutes')

--- a/internal/store/queries/luks.sql
+++ b/internal/store/queries/luks.sql
@@ -19,14 +19,18 @@ LIMIT 20;
 DELETE FROM luks_keys_projection WHERE action_id = $1;
 
 -- name: MarkLuksKeysNotCurrent :exec
--- Step 1 of LuksKeyRotated projection. Flip every prior row for the
+-- Step 1 of LuksKeyRotated projection. Flip the current row for the
 -- (device_id, action_id, device_path) triple so the new key
--- (inserted by step 2) is the only is_current=TRUE row.
+-- (inserted by step 2) is the only is_current=TRUE row. The
+-- `is_current = TRUE` predicate keeps the result identical (rows
+-- already FALSE stay FALSE) but skips a write per historical row,
+-- reducing write amplification on the hot path.
 UPDATE luks_keys_projection
 SET is_current = FALSE
 WHERE device_id = $1
   AND action_id = $2
-  AND device_path = $3;
+  AND device_path = $3
+  AND is_current = TRUE;
 
 -- name: InsertLuksKey :exec
 -- Step 2 of LuksKeyRotated projection. Always inserts a new row;


### PR DESCRIPTION
## Summary

Fourth port under the projector-migration pattern (#96 canary, #97 totp, #98 lps_password, #99 luks_key). Replaces `project_luks_key_event` PL/pgSQL with `projectors.LuksKeyListener`.

> Re-opened from closed PR #120 (originally stacked on #119; now rebased onto main after #119 merged). Includes sibling-sweep fixes carried over from #119's CR review: `slog.LogValuer` masking on `LuksKeyRotatedPayload.Passphrase` + dropped redundant `time.Sleep` in `IgnoresWrongStreamType`.

Four event types:
- `LuksKeyRotated` — 3 writes (mark prev not-current, insert new, trim to last 3) wrapped in `store.WithTx`
- `LuksDeviceKeyRevocationDispatched` — UPDATE `revocation_status='dispatched'`
- `LuksDeviceKeyRevoked` — UPDATE `revocation_status='success'` (event-name vs column-value mismatch matches PL/pgSQL verbatim)
- `LuksDeviceKeyRevocationFailed` — UPDATE `revocation_status='failed'` + `revocation_error` captured

`LuksDeviceKeyRevocationRequested` stays a no-op — the deleted PL/pgSQL projector also lacked a case for it.

## Behavioural delta

- **Before:** PL/pgSQL projector ran inside the AppendEvent transaction. Four event types + event commit atomic.
- **After:** Go listener fires post-commit. `LuksKeyRotated`'s 3 writes remain atomic with each other (`store.WithTx`); revocation events are single UPDATEs and don't need tx wrap. LUKS reads are operator-driven (recover passphrase, audit revocation status) — not hot-path RPCs — so the post-commit gap closes before any human-driven query.

## Test plan

Tests written FIRST per saved feedback (TDD).

- [x] Pure-function: happy paths, default `rotation_reason`, required-field validation per variant, wrong stream/event type → `ErrIgnoredEvent`, malformed payload bytes
- [x] Integration: 4-rotation lifecycle ends with exactly 1 current + 2 history rows (trim-to-3)
- [x] Integration: per-(action, device_path) scoping — act-A's rotation must not flip act-B's `is_current=TRUE` row on the same device
- [x] Integration: revocation flows — Dispatched / Revoked (success) / Failed (with error captured)
- [x] Integration: `LuksDeviceKeyRevocationRequested` is ignored (preserves PL/pgSQL no-op behaviour)
- [x] Integration: wrong-stream-type ignored
- [x] All tests pass locally (`go test ./server/internal/projectors/...`)

Refs tracker #107. Closes #99.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented LUKS key rotation and revocation handling with per-device/action scoping, history trimming to recent rotations, and revocation status lifecycle (dispatched, success, failed).
* **Tests**
  * Added unit and end-to-end tests covering decoding, rotation lifecycle, scoping, and revocation flows.
* **Chores**
  * Switched projection execution to the new Go-based listener and added a migration to delegate projector behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->