### PR TITLE
feat: port project_server_settings_event to Go listener (#100)

### DIFF
--- a/internal/projectors/server_settings.go
+++ b/internal/projectors/server_settings.go
@@ -54,11 +54,11 @@ func ServerSettingsUpdatedFromEvent(e store.PersistedEvent) (ServerSettingsUpdat
 	return p, nil
 }
 
-// ApplyServerSettingsUpdateForTest exposes the SQL UPDATE side of
-// the listener so tests can drive it with a synthetic
-// projection_version (e.g. an artificially-stale replay). Production
-// code goes through the listener; this is test-only seam.
-func ApplyServerSettingsUpdateForTest(ctx context.Context, st *store.Store, u ServerSettingsUpdate) error {
+// ApplyServerSettingsUpdate runs the COALESCE-based UPDATE behind
+// the listener. Shared between the production listener and the test
+// suite, which uses it to drive a synthetic projection_version (e.g.
+// an artificially-stale replay) without faking an event.
+func ApplyServerSettingsUpdate(ctx context.Context, st *store.Store, u ServerSettingsUpdate) error {
 	return st.Queries().UpdateServerSettings(ctx, db.UpdateServerSettingsParams{
 		UserProvisioningEnabled: u.UserProvisioningEnabled,
 		SshAccessForAll:         u.SshAccessForAll,

--- a/internal/projectors/server_settings.go
+++ b/internal/projectors/server_settings.go
@@ -1,0 +1,68 @@
+package projectors
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// ServerSettingsUpdatedPayload represents the decoded shape of a
+// ServerSettingUpdated event. Pointer fields distinguish "field
+// present in payload" from "field omitted" — the deleted PL/pgSQL
+// projector used `COALESCE((event.data->>'k')::BOOLEAN, existing)`
+// to preserve unset values, and the Go shape mirrors that contract
+// by passing nil through to the SQL UPDATE which uses COALESCE on
+// the receiving side.
+type ServerSettingsUpdatedPayload struct {
+	UserProvisioningEnabled *bool `json:"user_provisioning_enabled,omitempty"`
+	SshAccessForAll         *bool `json:"ssh_access_for_all,omitempty"`
+}
+
+// ServerSettingsUpdate carries the same payload shape plus the
+// per-event metadata the listener stamps onto the projection row.
+// Exposed so the test suite can drive the SQL UPDATE directly to
+// exercise the projection_version guard without faking an event.
+type ServerSettingsUpdate struct {
+	UserProvisioningEnabled *bool
+	SshAccessForAll         *bool
+	OccurredAt              time.Time
+	ProjectionVersion       int64
+}
+
+// ServerSettingsUpdatedFromEvent decodes ServerSettingUpdated.
+// Returns ErrIgnoredEvent for any other (stream, event_type) so the
+// listener wrapper can silently no-op.
+//
+// An empty payload is NOT an error — the deleted PL/pgSQL projector
+// would have applied `COALESCE(NULL, existing)` to every field,
+// which is a no-op UPDATE. We preserve that behavior.
+func ServerSettingsUpdatedFromEvent(e store.PersistedEvent) (ServerSettingsUpdatedPayload, error) {
+	if e.StreamType != "server_settings" || e.EventType != "ServerSettingUpdated" {
+		return ServerSettingsUpdatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return ServerSettingsUpdatedPayload{}, nil
+	}
+	var p ServerSettingsUpdatedPayload
+	if err := json.Unmarshal(e.Data, &p); err != nil {
+		return ServerSettingsUpdatedPayload{}, fmt.Errorf("projector: invalid ServerSettingUpdated payload: %w", err)
+	}
+	return p, nil
+}
+
+// ApplyServerSettingsUpdateForTest exposes the SQL UPDATE side of
+// the listener so tests can drive it with a synthetic
+// projection_version (e.g. an artificially-stale replay). Production
+// code goes through the listener; this is test-only seam.
+func ApplyServerSettingsUpdateForTest(ctx context.Context, st *store.Store, u ServerSettingsUpdate) error {
+	return st.Queries().UpdateServerSettings(ctx, db.UpdateServerSettingsParams{
+		UserProvisioningEnabled: u.UserProvisioningEnabled,
+		SshAccessForAll:         u.SshAccessForAll,
+		UpdatedAt:               u.OccurredAt,
+		ProjectionVersion:       u.ProjectionVersion,
+	})
+}

--- a/internal/projectors/server_settings_listener.go
+++ b/internal/projectors/server_settings_listener.go
@@ -41,7 +41,7 @@ func ServerSettingsListener(st *store.Store, logger *slog.Logger) store.EventLis
 			return
 		}
 
-		if err := ApplyServerSettingsUpdateForTest(ctx, st, ServerSettingsUpdate{
+		if err := ApplyServerSettingsUpdate(ctx, st, ServerSettingsUpdate{
 			UserProvisioningEnabled: payload.UserProvisioningEnabled,
 			SshAccessForAll:         payload.SshAccessForAll,
 			OccurredAt:              e.OccurredAt,

--- a/internal/projectors/server_settings_listener.go
+++ b/internal/projectors/server_settings_listener.go
@@ -1,0 +1,54 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// ServerSettingsListener returns a store.EventListener that applies
+// ServerSettingUpdated events to the singleton
+// server_settings_projection row. Replaces the deleted PL/pgSQL
+// project_server_settings_event function.
+//
+// Single event type, single UPDATE — no transaction wrap needed.
+// COALESCE preserves columns the payload omitted; the
+// `WHERE projection_version < $N` guard protects against stale
+// reconciler replays.
+//
+// Wired in projectors.WireAll. Refs #100, tracker #107.
+func ServerSettingsListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "server_settings" {
+			return
+		}
+		if e.EventType != "ServerSettingUpdated" {
+			return
+		}
+
+		payload, err := ServerSettingsUpdatedFromEvent(e)
+		if err != nil {
+			if errors.Is(err, ErrIgnoredEvent) {
+				return
+			}
+			logger.Warn("server_settings projector: invalid ServerSettingUpdated payload",
+				"event_id", e.ID, "error", err)
+			return
+		}
+
+		if err := ApplyServerSettingsUpdateForTest(ctx, st, ServerSettingsUpdate{
+			UserProvisioningEnabled: payload.UserProvisioningEnabled,
+			SshAccessForAll:         payload.SshAccessForAll,
+			OccurredAt:              e.OccurredAt,
+			ProjectionVersion:       deref(e.SequenceNum),
+		}); err != nil {
+			logger.Warn("server_settings projector: failed to apply ServerSettingUpdated",
+				"event_id", e.ID, "error", err)
+		}
+	}
+}

--- a/internal/projectors/server_settings_test.go
+++ b/internal/projectors/server_settings_test.go
@@ -194,7 +194,7 @@ func TestServerSettingsListener_StaleReplayRejected(t *testing.T) {
 	// projection_version directly via the sqlc query — the listener's
 	// SQL guard `WHERE projection_version < $N` should reject.
 	older := beforeReplay.ProjectionVersion - 5
-	require.NoError(t, projectors.ApplyServerSettingsUpdateForTest(ctx, st, projectors.ServerSettingsUpdate{
+	require.NoError(t, projectors.ApplyServerSettingsUpdate(ctx, st, projectors.ServerSettingsUpdate{
 		UserProvisioningEnabled: boolPtr(false),
 		SshAccessForAll:         boolPtr(false),
 		OccurredAt:              beforeReplay.UpdatedAt,

--- a/internal/projectors/server_settings_test.go
+++ b/internal/projectors/server_settings_test.go
@@ -1,0 +1,235 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestServerSettingsUpdatedFromEvent_Pure exercises the decoder.
+// The PL/pgSQL projector used `COALESCE((event.data->>'k')::BOOLEAN,
+// existing)` to preserve unset fields, so the Go shape must
+// distinguish "field present in payload" from "field omitted" — a
+// plain bool would conflate omitted with explicit false. The
+// decoder returns *bool fields so the listener can pass nil through
+// to the SQL UPDATE which uses COALESCE on the receiving side.
+func TestServerSettingsUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with both fields", func(t *testing.T) {
+		got, err := projectors.ServerSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "server_settings",
+			EventType:  "ServerSettingUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"user_provisioning_enabled": true,
+				"ssh_access_for_all":        false,
+			}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.UserProvisioningEnabled)
+		assert.True(t, *got.UserProvisioningEnabled)
+		require.NotNil(t, got.SshAccessForAll)
+		assert.False(t, *got.SshAccessForAll)
+	})
+
+	t.Run("partial update: only user_provisioning_enabled", func(t *testing.T) {
+		got, err := projectors.ServerSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "server_settings",
+			EventType:  "ServerSettingUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"user_provisioning_enabled": true,
+			}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.UserProvisioningEnabled)
+		assert.True(t, *got.UserProvisioningEnabled)
+		assert.Nil(t, got.SshAccessForAll, "omitted field stays nil so the SQL UPDATE preserves the existing column value via COALESCE")
+	})
+
+	t.Run("partial update: only ssh_access_for_all", func(t *testing.T) {
+		got, err := projectors.ServerSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "server_settings",
+			EventType:  "ServerSettingUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"ssh_access_for_all": true,
+			}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.UserProvisioningEnabled, "omitted field stays nil")
+		require.NotNil(t, got.SshAccessForAll)
+		assert.True(t, *got.SshAccessForAll)
+	})
+
+	t.Run("empty payload: both fields nil (caller decides whether that's an error)", func(t *testing.T) {
+		got, err := projectors.ServerSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "server_settings",
+			EventType:  "ServerSettingUpdated",
+			Data:       jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.UserProvisioningEnabled)
+		assert.Nil(t, got.SshAccessForAll)
+	})
+
+	t.Run("wrong stream_type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.ServerSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "luks_key",
+			EventType:  "ServerSettingUpdated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("wrong event_type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.ServerSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "server_settings",
+			EventType:  "Whatever",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.ServerSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "server_settings",
+			EventType:  "ServerSettingUpdated",
+			Data:       []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestServerSettingsListener_FullUpdate drives a both-fields update
+// through the listener and asserts the global row reflects them.
+// The seed row from migration starts with both flags false; flipping
+// to both-true is the canary case.
+func TestServerSettingsListener_FullUpdate(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "server_settings",
+		StreamID:   "global",
+		EventType:  "ServerSettingUpdated",
+		Data: map[string]any{
+			"user_provisioning_enabled": true,
+			"ssh_access_for_all":        true,
+		},
+		ActorType: "system", ActorID: "system",
+	}))
+
+	settings, err := st.Queries().GetServerSettings(ctx)
+	require.NoError(t, err)
+	assert.True(t, settings.UserProvisioningEnabled)
+	assert.True(t, settings.SshAccessForAll)
+	assert.Greater(t, settings.ProjectionVersion, int64(0), "projection_version stamps the event sequence_num")
+}
+
+// TestServerSettingsListener_PartialUpdate confirms COALESCE
+// semantics: omitting a field in the payload leaves the existing
+// column value alone. This is the contract the existing settings
+// handler depends on for partial UpdateServerSettings RPCs.
+func TestServerSettingsListener_PartialUpdate(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	// Step 1: set both to true
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "server_settings", StreamID: "global",
+		EventType: "ServerSettingUpdated",
+		Data: map[string]any{
+			"user_provisioning_enabled": true,
+			"ssh_access_for_all":        true,
+		},
+		ActorType: "system", ActorID: "system",
+	}))
+	v1, err := st.Queries().GetServerSettings(ctx)
+	require.NoError(t, err)
+	require.True(t, v1.UserProvisioningEnabled && v1.SshAccessForAll)
+
+	// Step 2: payload omits ssh_access_for_all entirely. The PL/pgSQL
+	// `COALESCE((event.data->>'ssh_access_for_all')::BOOLEAN, existing)`
+	// preserved the prior TRUE; the Go listener must do the same.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "server_settings", StreamID: "global",
+		EventType: "ServerSettingUpdated",
+		Data: map[string]any{
+			"user_provisioning_enabled": false,
+		},
+		ActorType: "system", ActorID: "system",
+	}))
+	v2, err := st.Queries().GetServerSettings(ctx)
+	require.NoError(t, err)
+	assert.False(t, v2.UserProvisioningEnabled, "user_provisioning_enabled flipped to false")
+	assert.True(t, v2.SshAccessForAll, "ssh_access_for_all preserved by COALESCE because the payload omitted it")
+	assert.Greater(t, v2.ProjectionVersion, v1.ProjectionVersion, "projection_version monotonically increases")
+}
+
+// TestServerSettingsListener_StaleReplayRejected confirms the
+// projection_version guard rejects an UPDATE whose
+// projection_version is older than the row's current value. The
+// reconciler safety net occasionally replays past events; without
+// the guard, an old "user_provisioning_enabled=false" event would
+// silently undo a later flip to true.
+func TestServerSettingsListener_StaleReplayRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	// Land a "true" event (gets the latest projection_version).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "server_settings", StreamID: "global",
+		EventType: "ServerSettingUpdated",
+		Data:      map[string]any{"user_provisioning_enabled": true, "ssh_access_for_all": true},
+		ActorType: "system", ActorID: "system",
+	}))
+	beforeReplay, err := st.Queries().GetServerSettings(ctx)
+	require.NoError(t, err)
+	require.True(t, beforeReplay.UserProvisioningEnabled)
+
+	// Replay the same event semantics with an artificially older
+	// projection_version directly via the sqlc query — the listener's
+	// SQL guard `WHERE projection_version < $N` should reject.
+	older := beforeReplay.ProjectionVersion - 5
+	require.NoError(t, projectors.ApplyServerSettingsUpdateForTest(ctx, st, projectors.ServerSettingsUpdate{
+		UserProvisioningEnabled: boolPtr(false),
+		SshAccessForAll:         boolPtr(false),
+		OccurredAt:              beforeReplay.UpdatedAt,
+		ProjectionVersion:       older,
+	}))
+
+	after, err := st.Queries().GetServerSettings(ctx)
+	require.NoError(t, err)
+	assert.True(t, after.UserProvisioningEnabled, "stale projection_version must NOT clobber the fresher TRUE state")
+	assert.True(t, after.SshAccessForAll)
+	assert.Equal(t, beforeReplay.ProjectionVersion, after.ProjectionVersion, "projection_version unchanged when guard rejects")
+}
+
+// TestServerSettingsListener_IgnoresWrongStreamType — defensive.
+// fireListeners is sync (project memory); a no-op listener must
+// leave the projection bytes untouched.
+func TestServerSettingsListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	pre, err := st.Queries().GetServerSettings(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", // wrong
+		StreamID:   "global",
+		EventType:  "ServerSettingUpdated",
+		Data:       map[string]any{"user_provisioning_enabled": true},
+		ActorType:  "system", ActorID: "system",
+	}))
+
+	post, err := st.Queries().GetServerSettings(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, pre.UserProvisioningEnabled, post.UserProvisioningEnabled)
+	assert.Equal(t, pre.ProjectionVersion, post.ProjectionVersion, "wrong-stream-type event must NOT advance projection_version")
+}
+
+func boolPtr(b bool) *bool { return &b }

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -44,7 +44,11 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "luks_key_projector"),
 	))
-	// Subsequent ports under #100–#106 add their listener here.
+	st.RegisterEventListener(ServerSettingsListener(
+		st,
+		loggerFor(logger, "server_settings_projector"),
+	))
+	// Subsequent ports under #101–#106 add their listener here.
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/settings.sql.go
+++ b/internal/store/generated/settings.sql.go
@@ -7,6 +7,7 @@ package generated
 
 import (
 	"context"
+	"time"
 )
 
 const getServerSettings = `-- name: GetServerSettings :one
@@ -24,4 +25,38 @@ func (q *Queries) GetServerSettings(ctx context.Context) (ServerSettingsProjecti
 		&i.ProjectionVersion,
 	)
 	return i, err
+}
+
+const updateServerSettings = `-- name: UpdateServerSettings :exec
+UPDATE server_settings_projection
+SET user_provisioning_enabled = COALESCE($1::BOOLEAN, user_provisioning_enabled),
+    ssh_access_for_all        = COALESCE($2::BOOLEAN, ssh_access_for_all),
+    updated_at                = $3,
+    projection_version        = $4
+WHERE id = 'global'
+  AND projection_version < $4
+`
+
+type UpdateServerSettingsParams struct {
+	UserProvisioningEnabled *bool     `json:"user_provisioning_enabled"`
+	SshAccessForAll         *bool     `json:"ssh_access_for_all"`
+	UpdatedAt               time.Time `json:"updated_at"`
+	ProjectionVersion       int64     `json:"projection_version"`
+}
+
+// Replaces the deleted PL/pgSQL project_server_settings_event
+// function. COALESCE preserves existing column values when the
+// event payload omits a field — sqlc.narg yields nullable *bool
+// params, and the listener passes nil for any field the event left
+// out, which COALESCE collapses to the existing value. The
+// `projection_version` guard protects against stale reconciler
+// replays clobbering a fresher state.
+func (q *Queries) UpdateServerSettings(ctx context.Context, arg UpdateServerSettingsParams) error {
+	_, err := q.db.Exec(ctx, updateServerSettings,
+		arg.UserProvisioningEnabled,
+		arg.SshAccessForAll,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	return err
 }

--- a/internal/store/migrations/021_server_settings_projector_to_go.sql
+++ b/internal/store/migrations/021_server_settings_projector_to_go.sql
@@ -1,0 +1,62 @@
+-- Replace project_server_settings_event() with a no-op stub. The
+-- actual projection logic now lives in
+-- projectors.ServerSettingsListener (Go, post-commit). The shared
+-- project_event() dispatcher trigger still PERFORMs
+-- project_server_settings_event(NEW) for every server_settings-stream
+-- event; the no-op stub keeps that dispatch quiet (no
+-- projection_errors entries) until the dispatcher itself is
+-- rewritten to skip stream types with Go projectors.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. The COALESCE-based UPDATE and the event commit
+--     were atomic.
+--   - After: Go listener fires post-commit (single UPDATE; no
+--     transaction wrap needed). COALESCE preserves columns the
+--     payload omitted; the new `WHERE projection_version < $N`
+--     guard rejects stale reconciler replays. The same handler
+--     (settings_handler.UpdateServerSettings) reads back from the
+--     projection AFTER AppendEvent returns — fireListeners is
+--     synchronous, so the read sees the listener's write
+--     (read-your-writes preserved).
+--
+-- See manchtools/power-manage-server#100. Fifth port under the
+-- projector-migration pattern (#96, #97, #98, #99, #100).
+--
+-- Refs tracker #107.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_server_settings_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.ServerSettingsListener. See
+    -- migration comment + the listener wiring in
+    -- cmd/control/main.go via projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the original PL/pgSQL projector verbatim from migration 003.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_server_settings_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'ServerSettingUpdated' THEN
+            UPDATE server_settings_projection
+            SET user_provisioning_enabled = COALESCE((event.data->>'user_provisioning_enabled')::BOOLEAN, user_provisioning_enabled),
+                ssh_access_for_all = COALESCE((event.data->>'ssh_access_for_all')::BOOLEAN, ssh_access_for_all),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = 'global';
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/settings.sql
+++ b/internal/store/queries/settings.sql
@@ -1,2 +1,18 @@
 -- name: GetServerSettings :one
 SELECT * FROM server_settings_projection WHERE id = 'global';
+
+-- name: UpdateServerSettings :exec
+-- Replaces the deleted PL/pgSQL project_server_settings_event
+-- function. COALESCE preserves existing column values when the
+-- event payload omits a field — sqlc.narg yields nullable *bool
+-- params, and the listener passes nil for any field the event left
+-- out, which COALESCE collapses to the existing value. The
+-- `projection_version` guard protects against stale reconciler
+-- replays clobbering a fresher state.
+UPDATE server_settings_projection
+SET user_provisioning_enabled = COALESCE(sqlc.narg('user_provisioning_enabled')::BOOLEAN, user_provisioning_enabled),
+    ssh_access_for_all        = COALESCE(sqlc.narg('ssh_access_for_all')::BOOLEAN, ssh_access_for_all),
+    updated_at                = sqlc.arg('updated_at'),
+    projection_version        = sqlc.arg('projection_version')
+WHERE id = 'global'
+  AND projection_version < sqlc.arg('projection_version');


### PR DESCRIPTION
## Summary

Fifth port under the projector-migration pattern. Replaces `project_server_settings_event` PL/pgSQL with `projectors.ServerSettingsListener`.

- Pure decoder `ServerSettingsUpdatedFromEvent` returns `*bool` fields so omitted-vs-explicit-false is distinguishable. Empty payload is NOT an error — mirrors the PL/pgSQL `COALESCE(NULL, existing)` no-op semantics.
- Listener factory wraps a single `UpdateServerSettings` call (no `store.WithTx` since it's one statement).
- New sqlc query uses `sqlc.narg()` to get nullable `*bool` params; COALESCE preserves columns when the listener passes nil.
- New `WHERE projection_version < $N` guard rejects stale reconciler replays — tightens the PL/pgSQL version which stamped `projection_version` without a guard.
- Migration replaces the PL/pgSQL function with a no-op stub (the shared `project_event()` trigger still dispatches; final cleanup after #106 drops the dispatcher itself).
- Wired via `projectors.WireAll`.

## Read-your-writes preserved

`settings_handler.UpdateServerSettings` reads back from the projection AFTER `AppendEvent` returns. `fireListeners` is synchronous (project memory `feedback_post_commit_listener_is_sync.md`), so the read sees the listener's write.

## Test plan

Tests written FIRST per saved TDD feedback.

- [x] Pure decoder: happy path with both fields, partial updates (each field omitted individually), empty payload returns nil-only struct, wrong stream/event type → `ErrIgnoredEvent`, malformed payload bytes
- [x] Integration: full update, partial update preserves omitted field via COALESCE, `projection_version` guard rejects stale replay, wrong-stream-type ignored
- [x] All tests pass locally (`go test ./server/internal/projectors/...`)

Refs tracker #107. Closes #100.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved server settings projection from a database stored procedure into the application to centralize update processing; user behavior unchanged.
* **Chores**
  * Added a safe migration to disable the old DB projector and new conditional update logic to the application flow.
* **Tests**
  * Added end-to-end and unit tests to validate full, partial, stale-replay, and wrong-stream handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->