### PR TITLE
feat: port project_role_event to Go listener (#101)

### DIFF
--- a/internal/projectors/role.go
+++ b/internal/projectors/role.go
@@ -1,0 +1,129 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// RoleCreatedPayload represents the decoded shape of a RoleCreated
+// event. The deleted PL/pgSQL projector applied COALESCE defaults
+// for description (''), permissions ('{}'), and is_system (FALSE);
+// the Go decoder mirrors via zero values + an explicit empty slice
+// so the listener can pass them through unchanged.
+type RoleCreatedPayload struct {
+	ID          string
+	Name        string
+	Description string
+	Permissions []string
+	IsSystem    bool
+	CreatedBy   string
+}
+
+// RoleUpdatedPayload distinguishes "field present" from "field
+// omitted" via pointers, mirroring the PL/pgSQL COALESCE/NULLIF
+// semantics:
+//
+//   - Name: present-with-value → update; missing OR empty-string →
+//     keep existing (PL/pgSQL `COALESCE(NULLIF(payload, ''), existing)`).
+//   - Description: present (incl. empty string) → update; missing →
+//     keep (PL/pgSQL `COALESCE(payload, existing)`).
+//   - Permissions: present (incl. empty array) → update; missing →
+//     keep (PL/pgSQL array COALESCE).
+//
+// The decoder collapses an empty Name to nil so the listener can
+// treat both "missing" and "explicit empty" as "no update" at the
+// SQL layer with a single `COALESCE($name, name)` call.
+type RoleUpdatedPayload struct {
+	ID          string
+	Name        *string
+	Description *string
+	Permissions *[]string
+}
+
+// roleCreatedRaw mirrors the JSON shape; conversion to the typed
+// payload below applies the COALESCE defaults so callers get a
+// fully-populated struct.
+type roleCreatedRaw struct {
+	Name        string    `json:"name"`
+	Description *string   `json:"description,omitempty"`
+	Permissions *[]string `json:"permissions,omitempty"`
+	IsSystem    *bool     `json:"is_system,omitempty"`
+}
+
+// RoleCreatedFromEvent decodes RoleCreated. Returns ErrIgnoredEvent
+// for any other (stream, event_type) so the listener wrapper can
+// silently no-op.
+//
+// Defaults match the PL/pgSQL projector: missing description → '';
+// missing permissions → empty slice; missing is_system → false.
+func RoleCreatedFromEvent(e store.PersistedEvent) (RoleCreatedPayload, error) {
+	if e.StreamType != "role" || e.EventType != "RoleCreated" {
+		return RoleCreatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return RoleCreatedPayload{}, fmt.Errorf("projector: empty RoleCreated payload")
+	}
+	var raw roleCreatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return RoleCreatedPayload{}, fmt.Errorf("projector: invalid RoleCreated payload: %w", err)
+	}
+	if raw.Name == "" {
+		return RoleCreatedPayload{}, fmt.Errorf("projector: RoleCreated requires name")
+	}
+	out := RoleCreatedPayload{
+		ID:          e.StreamID,
+		Name:        raw.Name,
+		Permissions: []string{},
+		CreatedBy:   e.ActorID,
+	}
+	if raw.Description != nil {
+		out.Description = *raw.Description
+	}
+	if raw.Permissions != nil {
+		out.Permissions = *raw.Permissions
+	}
+	if raw.IsSystem != nil {
+		out.IsSystem = *raw.IsSystem
+	}
+	return out, nil
+}
+
+// roleUpdatedRaw uses pointer fields so json.Unmarshal records
+// "field present" vs "field omitted" — the difference matters because
+// PL/pgSQL `COALESCE(payload, existing)` treats SQL NULL as missing
+// (preserve existing), but treats explicit empty-string / empty-array
+// as updates.
+type roleUpdatedRaw struct {
+	Name        *string   `json:"name,omitempty"`
+	Description *string   `json:"description,omitempty"`
+	Permissions *[]string `json:"permissions,omitempty"`
+}
+
+// RoleUpdatedFromEvent decodes RoleUpdated. The pointer fields on
+// the returned payload signal "update" vs "preserve":
+// non-nil = update; nil = preserve.
+//
+// Empty-string Name is collapsed to nil (preserve) to match the
+// PL/pgSQL `NULLIF(name, '')` semantics — a UI that sends "" for
+// the name field doesn't blank the role.
+func RoleUpdatedFromEvent(e store.PersistedEvent) (RoleUpdatedPayload, error) {
+	if e.StreamType != "role" || e.EventType != "RoleUpdated" {
+		return RoleUpdatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return RoleUpdatedPayload{ID: e.StreamID}, nil
+	}
+	var raw roleUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return RoleUpdatedPayload{}, fmt.Errorf("projector: invalid RoleUpdated payload: %w", err)
+	}
+	out := RoleUpdatedPayload{ID: e.StreamID}
+	if raw.Name != nil && *raw.Name != "" {
+		out.Name = raw.Name
+	}
+	out.Description = raw.Description
+	out.Permissions = raw.Permissions
+	return out, nil
+}

--- a/internal/projectors/role_listener.go
+++ b/internal/projectors/role_listener.go
@@ -93,12 +93,23 @@ func applyRoleUpdated(ctx context.Context, st *store.Store, logger *slog.Logger,
 func applyRoleDeleted(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
 	roleID := e.StreamID
 	if err := st.WithTx(ctx, func(q *store.Queries) error {
-		if err := q.SoftDeleteRoleProjection(ctx, db.SoftDeleteRoleProjectionParams{
+		// SoftDeleteRoleProjection returns rows-affected. If the
+		// projection_version guard rejected the UPDATE (stale
+		// reconciler replay, or row already at a newer version), we
+		// must NOT cascade the membership delete — otherwise an old
+		// RoleDeleted re-applied later would silently nuke a
+		// freshly-restored role's memberships. CR caught this on PR
+		// #123.
+		n, err := q.SoftDeleteRoleProjection(ctx, db.SoftDeleteRoleProjectionParams{
 			ID:                roleID,
 			UpdatedAt:         &e.OccurredAt,
 			ProjectionVersion: deref(e.SequenceNum),
-		}); err != nil {
+		})
+		if err != nil {
 			return err
+		}
+		if n == 0 {
+			return nil
 		}
 		return q.DeleteUserRolesByRole(ctx, roleID)
 	}); err != nil {

--- a/internal/projectors/role_listener.go
+++ b/internal/projectors/role_listener.go
@@ -1,0 +1,120 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// RoleListener returns a store.EventListener that applies every role
+// stream event the deleted PL/pgSQL project_role_event handled.
+// Replaces the three-case dispatcher with one switch in Go:
+//
+//   - RoleCreated:  INSERT … ON CONFLICT DO NOTHING (replay-safe)
+//   - RoleUpdated:  partial UPDATE (COALESCE preserves omitted fields;
+//     projection_version guard rejects stale reconciler replays)
+//   - RoleDeleted:  is_deleted=TRUE + cascade DELETE on
+//     user_roles_projection, wrapped in store.WithTx so the
+//     projection never observes "role marked deleted but
+//     memberships remain"
+//
+// Wired in projectors.WireAll. Refs #101, tracker #107.
+func RoleListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "role" {
+			return
+		}
+		switch e.EventType {
+		case "RoleCreated":
+			applyRoleCreated(ctx, st, logger, e)
+		case "RoleUpdated":
+			applyRoleUpdated(ctx, st, logger, e)
+		case "RoleDeleted":
+			applyRoleDeleted(ctx, st, logger, e)
+		}
+	}
+}
+
+func applyRoleCreated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := RoleCreatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("role projector: invalid RoleCreated payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().InsertRoleProjection(ctx, db.InsertRoleProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		Description:       payload.Description,
+		Permissions:       payload.Permissions,
+		IsSystem:          payload.IsSystem,
+		CreatedAt:         e.OccurredAt,
+		CreatedBy:         payload.CreatedBy,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("role projector: failed to insert RoleCreated",
+			"event_id", e.ID, "role_id", payload.ID, "error", err)
+	}
+}
+
+func applyRoleUpdated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := RoleUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("role projector: invalid RoleUpdated payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	updatedAt := e.OccurredAt
+	if err := st.Queries().UpdateRoleProjection(ctx, db.UpdateRoleProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		Description:       payload.Description,
+		Permissions:       derefSlice(payload.Permissions),
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("role projector: failed to apply RoleUpdated",
+			"event_id", e.ID, "role_id", payload.ID, "error", err)
+	}
+}
+
+func applyRoleDeleted(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	roleID := e.StreamID
+	if err := st.WithTx(ctx, func(q *store.Queries) error {
+		if err := q.SoftDeleteRoleProjection(ctx, db.SoftDeleteRoleProjectionParams{
+			ID:                roleID,
+			UpdatedAt:         &e.OccurredAt,
+			ProjectionVersion: deref(e.SequenceNum),
+		}); err != nil {
+			return err
+		}
+		return q.DeleteUserRolesByRole(ctx, roleID)
+	}); err != nil {
+		logger.Warn("role projector: failed to apply RoleDeleted",
+			"event_id", e.ID, "role_id", roleID, "error", err)
+	}
+}
+
+// derefSlice returns the value behind a pointer slice, or nil when
+// the pointer is nil. Distinguishes "nil pointer = no update" from
+// "non-nil pointer to empty slice = explicit empty array update".
+// sqlc's nullable []TEXT[] params accept []string nil for "preserve
+// existing" via COALESCE.
+func derefSlice[T any](p *[]T) []T {
+	if p == nil {
+		return nil
+	}
+	return *p
+}

--- a/internal/projectors/role_test.go
+++ b/internal/projectors/role_test.go
@@ -1,0 +1,326 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestRoleCreatedFromEvent_Pure exercises the decoder for RoleCreated.
+// The PL/pgSQL projector defaulted description to '', permissions to
+// '{}', is_system to FALSE — Go shape mirrors via zero values + an
+// explicit empty-slice for permissions when the payload omits the key.
+func TestRoleCreatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.RoleCreatedFromEvent(store.PersistedEvent{
+			StreamType: "role",
+			StreamID:   "role-1",
+			EventType:  "RoleCreated",
+			ActorID:    "user-1",
+			Data: jsonOrFail(t, map[string]any{
+				"name":        "admin",
+				"description": "Administrator role",
+				"permissions": []string{"users.read", "users.write"},
+				"is_system":   false,
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "role-1", got.ID)
+		assert.Equal(t, "admin", got.Name)
+		assert.Equal(t, "Administrator role", got.Description)
+		assert.Equal(t, []string{"users.read", "users.write"}, got.Permissions)
+		assert.False(t, got.IsSystem)
+		assert.Equal(t, "user-1", got.CreatedBy)
+	})
+
+	t.Run("defaults: description empty, permissions empty, is_system false", func(t *testing.T) {
+		got, err := projectors.RoleCreatedFromEvent(store.PersistedEvent{
+			StreamType: "role", StreamID: "role-2", EventType: "RoleCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"name": "viewer"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description)
+		assert.Equal(t, []string{}, got.Permissions, "missing permissions defaults to empty slice (matches PL/pgSQL '{}'::TEXT[])")
+		assert.False(t, got.IsSystem)
+	})
+
+	t.Run("name is required", func(t *testing.T) {
+		_, err := projectors.RoleCreatedFromEvent(store.PersistedEvent{
+			StreamType: "role", StreamID: "role-3", EventType: "RoleCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"description": "no name"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "name")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.RoleCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "RoleCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.RoleCreatedFromEvent(store.PersistedEvent{
+			StreamType: "role", EventType: "RoleUpdated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.RoleCreatedFromEvent(store.PersistedEvent{
+			StreamType: "role", EventType: "RoleCreated",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestRoleUpdatedFromEvent_Pure covers the partial-update decoder.
+// PL/pgSQL semantics:
+//   - name uses `COALESCE(NULLIF(payload, ''), existing)` — empty
+//     string is "no update"; missing field is also "no update".
+//   - description uses `COALESCE(payload, existing)` — empty string
+//     IS an update; missing field is "no update".
+//   - permissions uses array COALESCE — missing field is "no update";
+//     empty array IS an update.
+// Pointer fields distinguish "field present" from "field omitted".
+func TestRoleUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("all fields present", func(t *testing.T) {
+		got, err := projectors.RoleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "role", StreamID: "r-1", EventType: "RoleUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"name":        "admin-v2",
+				"description": "updated desc",
+				"permissions": []string{"perm.x"},
+			}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Name)
+		assert.Equal(t, "admin-v2", *got.Name)
+		require.NotNil(t, got.Description)
+		assert.Equal(t, "updated desc", *got.Description)
+		require.NotNil(t, got.Permissions)
+		assert.Equal(t, []string{"perm.x"}, *got.Permissions)
+	})
+
+	t.Run("only description present", func(t *testing.T) {
+		got, err := projectors.RoleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "role", StreamID: "r-1", EventType: "RoleUpdated",
+			Data: jsonOrFail(t, map[string]any{"description": "only desc changed"}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.Name, "missing name → omitted")
+		require.NotNil(t, got.Description)
+		assert.Equal(t, "only desc changed", *got.Description)
+		assert.Nil(t, got.Permissions)
+	})
+
+	t.Run("explicit empty description IS an update (vs missing-field)", func(t *testing.T) {
+		got, err := projectors.RoleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "role", StreamID: "r-1", EventType: "RoleUpdated",
+			Data: jsonOrFail(t, map[string]any{"description": ""}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Description, "explicit \"\" must be a present-with-empty-value, NOT omitted")
+		assert.Equal(t, "", *got.Description)
+	})
+
+	t.Run("explicit empty permissions IS an update", func(t *testing.T) {
+		got, err := projectors.RoleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "role", StreamID: "r-1", EventType: "RoleUpdated",
+			Data: jsonOrFail(t, map[string]any{"permissions": []string{}}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Permissions)
+		assert.Equal(t, []string{}, *got.Permissions, "explicit empty array clears permissions")
+	})
+
+	t.Run("name=\"\" → preserved-via-NULLIF (treated as missing)", func(t *testing.T) {
+		// PL/pgSQL: `NULLIF(event.data->>'name', '')` collapses
+		// empty-string to NULL, then COALESCE keeps existing.
+		got, err := projectors.RoleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "role", StreamID: "r-1", EventType: "RoleUpdated",
+			Data: jsonOrFail(t, map[string]any{"name": "", "description": "x"}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.Name, "empty-string name treated as missing per PL/pgSQL NULLIF semantics")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.RoleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "RoleUpdated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestRoleListener_CreateUpdateLifecycle drives Create → Update
+// through the listener and asserts the projection ends in the right
+// state. Confirms the partial-update semantics are wired correctly:
+// only the fields present in the Update payload should change.
+func TestRoleListener_CreateUpdateLifecycle(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	roleID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data: map[string]any{
+			"name":        "admin",
+			"description": "initial",
+			"permissions": []string{"a", "b"},
+		},
+		ActorType: "user", ActorID: "u-1",
+	}))
+
+	got, err := st.Queries().GetRoleByID(ctx, roleID)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", got.Name)
+	assert.Equal(t, "initial", got.Description)
+	assert.Equal(t, []string{"a", "b"}, got.Permissions)
+	assert.False(t, got.IsSystem)
+	assert.Greater(t, got.ProjectionVersion, int64(0))
+
+	// Partial update: only description.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleUpdated",
+		Data: map[string]any{"description": "updated"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetRoleByID(ctx, roleID)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", got.Name, "name preserved (omitted)")
+	assert.Equal(t, "updated", got.Description, "description updated")
+	assert.Equal(t, []string{"a", "b"}, got.Permissions, "permissions preserved (omitted)")
+
+	// Update permissions to an explicit empty array (clear).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleUpdated",
+		Data: map[string]any{"permissions": []string{}},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetRoleByID(ctx, roleID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{}, got.Permissions, "explicit empty permissions clears the column")
+	assert.Equal(t, "updated", got.Description, "description preserved across this update")
+}
+
+// TestRoleListener_DeleteCascadesUserRoles confirms RoleDeleted
+// flips is_deleted=TRUE AND removes every user_roles_projection
+// entry for the role. Both writes happen inside store.WithTx so the
+// projection never observes "role marked deleted but user-role
+// memberships still exist".
+func TestRoleListener_DeleteCascadesUserRoles(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	roleID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data: map[string]any{"name": "tmp", "permissions": []string{"x"}},
+		ActorType: "user", ActorID: "u-1",
+	}))
+
+	// Plant 2 user_roles_projection rows for this role via a direct
+	// insert (bypassing the user_role projector since #102 hasn't
+	// landed yet). The role projector only cares about cleanup, not
+	// who put them there.
+	_, err := st.Pool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by) VALUES ($1,$2,NOW(),''),($3,$2,NOW(),'')",
+		"user-A", roleID, "user-B",
+	)
+	require.NoError(t, err)
+
+	// Verify pre-delete state.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM user_roles_projection WHERE role_id = $1", roleID,
+	).Scan(&count))
+	require.Equal(t, 2, count)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleDeleted",
+		Data:       map[string]any{},
+		ActorType:  "user", ActorID: "u-1",
+	}))
+
+	// Role row marked deleted (won't show up via GetRoleByID which
+	// filters is_deleted=FALSE — query directly).
+	var isDeleted bool
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT is_deleted FROM roles_projection WHERE id = $1", roleID,
+	).Scan(&isDeleted))
+	assert.True(t, isDeleted, "RoleDeleted flips is_deleted=TRUE")
+
+	// Cascade cleared the user-role memberships.
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM user_roles_projection WHERE role_id = $1", roleID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "user_roles_projection rows for the deleted role are removed")
+}
+
+// TestRoleListener_StaleReplayRejected confirms the projection_version
+// guard on RoleUpdated rejects an UPDATE whose projection_version is
+// older than the row's current value. Without the guard, a reconciler
+// replay of an old event would overwrite a fresher state.
+func TestRoleListener_StaleReplayRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	roleID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data: map[string]any{"name": "first"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleUpdated",
+		Data: map[string]any{"description": "current state"},
+		ActorType: "user", ActorID: "u",
+	}))
+	current, err := st.Queries().GetRoleByID(ctx, roleID)
+	require.NoError(t, err)
+	currentVersion := current.ProjectionVersion
+
+	// Apply an UPDATE directly with an older projection_version.
+	desc := "stale replay would set this"
+	older := currentVersion - 5
+	updatedAt := current.CreatedAt
+	require.NoError(t, st.Queries().UpdateRoleProjection(ctx, db.UpdateRoleProjectionParams{
+		ID:                roleID,
+		Description:       &desc,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: older,
+	}))
+
+	after, err := st.Queries().GetRoleByID(ctx, roleID)
+	require.NoError(t, err)
+	assert.Equal(t, "current state", after.Description, "stale projection_version must NOT clobber fresher state")
+	assert.Equal(t, currentVersion, after.ProjectionVersion)
+}
+
+// TestRoleListener_IgnoresWrongStreamType — defensive.
+func TestRoleListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	roleID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", // wrong
+		StreamID:   roleID,
+		EventType:  "RoleCreated",
+		Data:       map[string]any{"name": "ghost"},
+		ActorType:  "user", ActorID: "u",
+	}))
+
+	_, err := st.Queries().GetRoleByID(ctx, roleID)
+	require.Error(t, err, "wrong-stream-type RoleCreated must NOT create a roles_projection row")
+}

--- a/internal/projectors/role_test.go
+++ b/internal/projectors/role_test.go
@@ -3,8 +3,10 @@ package projectors_test
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -340,27 +342,26 @@ func TestRoleListener_StaleDeleteReplayDoesNotNukeMemberships(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	// Simulate a stale RoleDeleted replay by calling the SAME
-	// listener helpers the post-commit hook would use, but with an
-	// artificially-stale projection_version. This exercises the
-	// transactional fix without faking an event.
+	// Drive the REAL listener with a synthetic PersistedEvent whose
+	// SequenceNum is older than the row's current projection_version.
+	// Calling the public projector entrypoint exercises the
+	// applyRoleDeleted bug-fix branch (rows-affected check skips the
+	// cascade) — duplicating the SQL inline would have left the
+	// branch untested even if it was deleted.
 	older := live.ProjectionVersion - 5
 	staleAt := live.CreatedAt
-	err = st.WithTx(ctx, func(q *store.Queries) error {
-		n, err := q.SoftDeleteRoleProjection(ctx, db.SoftDeleteRoleProjectionParams{
-			ID:                roleID,
-			UpdatedAt:         &staleAt,
-			ProjectionVersion: older,
-		})
-		if err != nil {
-			return err
-		}
-		if n == 0 {
-			return nil // listener's bug-fix branch: skip cascade
-		}
-		return q.DeleteUserRolesByRole(ctx, roleID)
+	listener := projectors.RoleListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "role",
+		StreamID:    roleID,
+		EventType:   "RoleDeleted",
+		Data:        []byte("{}"),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
 	})
-	require.NoError(t, err)
 
 	// Memberships still there.
 	count := 0

--- a/internal/projectors/role_test.go
+++ b/internal/projectors/role_test.go
@@ -307,6 +307,74 @@ func TestRoleListener_StaleReplayRejected(t *testing.T) {
 	assert.Equal(t, currentVersion, after.ProjectionVersion)
 }
 
+// TestRoleListener_StaleDeleteReplayDoesNotNukeMemberships is a
+// regression lock for a CR Major on PR #123: when the
+// projection_version guard rejects a stale RoleDeleted UPDATE, the
+// cascade DeleteUserRolesByRole MUST be skipped. Otherwise an old
+// RoleDeleted re-applied later (e.g. by the reconciler against a
+// freshly-restored or never-actually-deleted role) would silently
+// nuke live memberships.
+func TestRoleListener_StaleDeleteReplayDoesNotNukeMemberships(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	roleID := testutil.NewID()
+
+	// Land a role + an UPDATE so projection_version > 0.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data: map[string]any{"name": "live"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleUpdated",
+		Data: map[string]any{"description": "still alive"},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetRoleByID(ctx, roleID)
+	require.NoError(t, err)
+
+	// Plant 2 memberships.
+	_, err = st.Pool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by) VALUES ($1,$2,NOW(),''),($3,$2,NOW(),'')",
+		"user-A", roleID, "user-B",
+	)
+	require.NoError(t, err)
+
+	// Simulate a stale RoleDeleted replay by calling the SAME
+	// listener helpers the post-commit hook would use, but with an
+	// artificially-stale projection_version. This exercises the
+	// transactional fix without faking an event.
+	older := live.ProjectionVersion - 5
+	staleAt := live.CreatedAt
+	err = st.WithTx(ctx, func(q *store.Queries) error {
+		n, err := q.SoftDeleteRoleProjection(ctx, db.SoftDeleteRoleProjectionParams{
+			ID:                roleID,
+			UpdatedAt:         &staleAt,
+			ProjectionVersion: older,
+		})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return nil // listener's bug-fix branch: skip cascade
+		}
+		return q.DeleteUserRolesByRole(ctx, roleID)
+	})
+	require.NoError(t, err)
+
+	// Memberships still there.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM user_roles_projection WHERE role_id = $1", roleID,
+	).Scan(&count))
+	assert.Equal(t, 2, count, "stale RoleDeleted replay must NOT cascade-delete live memberships")
+
+	// And the role row is still alive.
+	stillAlive, err := st.Queries().GetRoleByID(ctx, roleID)
+	require.NoError(t, err)
+	assert.False(t, stillAlive.IsDeleted)
+}
+
 // TestRoleListener_IgnoresWrongStreamType — defensive.
 func TestRoleListener_IgnoresWrongStreamType(t *testing.T) {
 	st := testutil.SetupPostgres(t)

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -48,7 +48,11 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "server_settings_projector"),
 	))
-	// Subsequent ports under #101–#106 add their listener here.
+	st.RegisterEventListener(RoleListener(
+		st,
+		loggerFor(logger, "role_projector"),
+	))
+	// Subsequent ports under #102–#106 add their listener here.
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/roles.sql.go
+++ b/internal/store/generated/roles.sql.go
@@ -253,7 +253,7 @@ func (q *Queries) ListUserIDsWithRole(ctx context.Context, roleID string) ([]str
 	return items, nil
 }
 
-const softDeleteRoleProjection = `-- name: SoftDeleteRoleProjection :exec
+const softDeleteRoleProjection = `-- name: SoftDeleteRoleProjection :execrows
 UPDATE roles_projection
 SET is_deleted        = TRUE,
     updated_at        = $2,
@@ -272,9 +272,17 @@ type SoftDeleteRoleProjectionParams struct {
 // leaves the row so the audit log resolves role names. Listener
 // pairs this with DeleteUserRolesByRole inside store.WithTx so the
 // projection never observes "role deleted but memberships remain".
-func (q *Queries) SoftDeleteRoleProjection(ctx context.Context, arg SoftDeleteRoleProjectionParams) error {
-	_, err := q.db.Exec(ctx, softDeleteRoleProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
-	return err
+// Returns rows-affected so the listener can SKIP the cascade
+// DeleteUserRolesByRole when the projection_version guard rejects
+// a stale replay; otherwise an old RoleDeleted re-applied by the
+// reconciler would silently nuke a freshly-restored role's
+// memberships.
+func (q *Queries) SoftDeleteRoleProjection(ctx context.Context, arg SoftDeleteRoleProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteRoleProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const updateRoleProjection = `-- name: UpdateRoleProjection :exec

--- a/internal/store/generated/roles.sql.go
+++ b/internal/store/generated/roles.sql.go
@@ -7,6 +7,7 @@ package generated
 
 import (
 	"context"
+	"time"
 )
 
 const countRoles = `-- name: CountRoles :one
@@ -29,6 +30,19 @@ func (q *Queries) CountUsersWithRole(ctx context.Context, roleID string) (int64,
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const deleteUserRolesByRole = `-- name: DeleteUserRolesByRole :exec
+DELETE FROM user_roles_projection WHERE role_id = $1
+`
+
+// RoleDeleted handler — second half. Cascades the delete to
+// user_roles_projection so user-permission queries no longer surface
+// this role's permissions. Wrapped with SoftDeleteRoleProjection in
+// store.WithTx for inter-write atomicity.
+func (q *Queries) DeleteUserRolesByRole(ctx context.Context, roleID string) error {
+	_, err := q.db.Exec(ctx, deleteUserRolesByRole, roleID)
+	return err
 }
 
 const getRoleByID = `-- name: GetRoleByID :one
@@ -139,6 +153,42 @@ func (q *Queries) GetUserRoles(ctx context.Context, userID string) ([]RolesProje
 	return items, nil
 }
 
+const insertRoleProjection = `-- name: InsertRoleProjection :exec
+INSERT INTO roles_projection (
+    id, name, description, permissions, is_system,
+    created_at, created_by, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertRoleProjectionParams struct {
+	ID                string    `json:"id"`
+	Name              string    `json:"name"`
+	Description       string    `json:"description"`
+	Permissions       []string  `json:"permissions"`
+	IsSystem          bool      `json:"is_system"`
+	CreatedAt         time.Time `json:"created_at"`
+	CreatedBy         string    `json:"created_by"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// RoleCreated handler. ON CONFLICT DO NOTHING for replay safety —
+// the reconciler may re-deliver the event; if a row already exists
+// under the same id, leave it alone (RoleUpdated owns mutations).
+func (q *Queries) InsertRoleProjection(ctx context.Context, arg InsertRoleProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertRoleProjection,
+		arg.ID,
+		arg.Name,
+		arg.Description,
+		arg.Permissions,
+		arg.IsSystem,
+		arg.CreatedAt,
+		arg.CreatedBy,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
 const listRoles = `-- name: ListRoles :many
 SELECT id, name, description, permissions, is_system, created_at, created_by, updated_at, is_deleted, projection_version FROM roles_projection WHERE is_deleted = FALSE ORDER BY name LIMIT $1 OFFSET $2
 `
@@ -201,6 +251,68 @@ func (q *Queries) ListUserIDsWithRole(ctx context.Context, roleID string) ([]str
 		return nil, err
 	}
 	return items, nil
+}
+
+const softDeleteRoleProjection = `-- name: SoftDeleteRoleProjection :exec
+UPDATE roles_projection
+SET is_deleted        = TRUE,
+    updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type SoftDeleteRoleProjectionParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// RoleDeleted handler — first half. Marks the role as deleted but
+// leaves the row so the audit log resolves role names. Listener
+// pairs this with DeleteUserRolesByRole inside store.WithTx so the
+// projection never observes "role deleted but memberships remain".
+func (q *Queries) SoftDeleteRoleProjection(ctx context.Context, arg SoftDeleteRoleProjectionParams) error {
+	_, err := q.db.Exec(ctx, softDeleteRoleProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	return err
+}
+
+const updateRoleProjection = `-- name: UpdateRoleProjection :exec
+UPDATE roles_projection
+SET name              = COALESCE($1::TEXT, name),
+    description       = COALESCE($2::TEXT, description),
+    permissions       = COALESCE($3::TEXT[], permissions),
+    updated_at        = $4,
+    projection_version = $5
+WHERE id = $6
+  AND projection_version < $5
+`
+
+type UpdateRoleProjectionParams struct {
+	Name              *string    `json:"name"`
+	Description       *string    `json:"description"`
+	Permissions       []string   `json:"permissions"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+	ID                string     `json:"id"`
+}
+
+// RoleUpdated handler. nil pointers from the listener collapse to
+// SQL NULL, which COALESCE preserves the existing column. Empty-
+// string Name is converted to nil at the listener layer (NULLIF
+// equivalent), so this query treats both omitted and empty Name
+// identically. The `projection_version` guard rejects stale
+// reconciler replays.
+func (q *Queries) UpdateRoleProjection(ctx context.Context, arg UpdateRoleProjectionParams) error {
+	_, err := q.db.Exec(ctx, updateRoleProjection,
+		arg.Name,
+		arg.Description,
+		arg.Permissions,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+		arg.ID,
+	)
+	return err
 }
 
 const updateSystemRolePermissions = `-- name: UpdateSystemRolePermissions :execrows

--- a/internal/store/migrations/022_role_projector_to_go.sql
+++ b/internal/store/migrations/022_role_projector_to_go.sql
@@ -1,0 +1,101 @@
+-- Replace project_role_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.RoleListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger
+-- still PERFORMs project_role_event(NEW) for every role-stream
+-- event; the no-op stub keeps that dispatch quiet (no
+-- projection_errors entries) until the dispatcher itself is
+-- rewritten to skip stream types with Go projectors.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. The three event types (Created, Updated,
+--     Deleted) and the event commit were atomic. RoleDeleted's
+--     two writes (mark deleted + cascade-delete user_roles_projection)
+--     were both part of the same transaction.
+--   - After: Go listener fires post-commit. RoleDeleted's two
+--     writes remain atomic with each other (store.WithTx) but not
+--     with the event commit. The role-handler's read-after-write
+--     paths (CreateRole/UpdateRole reading back from
+--     roles_projection) still see the projection because
+--     fireListeners is synchronous — the listener has already run
+--     by the time AppendEvent returns.
+--
+-- Tightening: RoleUpdated and RoleDeleted now have explicit
+-- `WHERE projection_version < $N` guards, rejecting stale
+-- reconciler replays. The PL/pgSQL version stamped projection_version
+-- without a guard.
+--
+-- See manchtools/power-manage-server#101. Sixth port under the
+-- projector-migration pattern (#96 canary, then #97 totp, #98 lps,
+-- #99 luks, #100 server_settings, #101 role).
+--
+-- Refs tracker #107.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_role_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.RoleListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the original PL/pgSQL projector verbatim from migration 003.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_role_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'RoleCreated' THEN
+            INSERT INTO roles_projection (
+                id, name, description, permissions, is_system,
+                created_at, created_by, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'name',
+                COALESCE(event.data->>'description', ''),
+                COALESCE(
+                    ARRAY(SELECT jsonb_array_elements_text(event.data->'permissions')),
+                    '{}'::TEXT[]
+                ),
+                COALESCE((event.data->>'is_system')::BOOLEAN, FALSE),
+                event.occurred_at,
+                event.actor_id,
+                event.sequence_num
+            );
+
+        WHEN 'RoleUpdated' THEN
+            UPDATE roles_projection
+            SET name = COALESCE(NULLIF(event.data->>'name', ''), name),
+                description = COALESCE(event.data->>'description', description),
+                permissions = COALESCE(
+                    ARRAY(SELECT jsonb_array_elements_text(event.data->'permissions')),
+                    permissions
+                ),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'RoleDeleted' THEN
+            UPDATE roles_projection
+            SET is_deleted = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            -- Remove all user-role assignments for this role
+            DELETE FROM user_roles_projection WHERE role_id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/roles.sql
+++ b/internal/store/queries/roles.sql
@@ -59,11 +59,16 @@ SET name              = COALESCE(sqlc.narg('name')::TEXT, name),
 WHERE id = sqlc.arg('id')
   AND projection_version < sqlc.arg('projection_version');
 
--- name: SoftDeleteRoleProjection :exec
+-- name: SoftDeleteRoleProjection :execrows
 -- RoleDeleted handler — first half. Marks the role as deleted but
 -- leaves the row so the audit log resolves role names. Listener
 -- pairs this with DeleteUserRolesByRole inside store.WithTx so the
 -- projection never observes "role deleted but memberships remain".
+-- Returns rows-affected so the listener can SKIP the cascade
+-- DeleteUserRolesByRole when the projection_version guard rejects
+-- a stale replay; otherwise an old RoleDeleted re-applied by the
+-- reconciler would silently nuke a freshly-restored role's
+-- memberships.
 UPDATE roles_projection
 SET is_deleted        = TRUE,
     updated_at        = $2,

--- a/internal/store/queries/roles.sql
+++ b/internal/store/queries/roles.sql
@@ -32,3 +32,48 @@ SELECT EXISTS(SELECT 1 FROM user_roles_projection WHERE user_id = $1 AND role_id
 
 -- name: UpdateSystemRolePermissions :execrows
 UPDATE roles_projection SET permissions = $1, updated_at = NOW() WHERE id = $2 AND is_system = TRUE;
+
+-- name: InsertRoleProjection :exec
+-- RoleCreated handler. ON CONFLICT DO NOTHING for replay safety —
+-- the reconciler may re-deliver the event; if a row already exists
+-- under the same id, leave it alone (RoleUpdated owns mutations).
+INSERT INTO roles_projection (
+    id, name, description, permissions, is_system,
+    created_at, created_by, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: UpdateRoleProjection :exec
+-- RoleUpdated handler. nil pointers from the listener collapse to
+-- SQL NULL, which COALESCE preserves the existing column. Empty-
+-- string Name is converted to nil at the listener layer (NULLIF
+-- equivalent), so this query treats both omitted and empty Name
+-- identically. The `projection_version` guard rejects stale
+-- reconciler replays.
+UPDATE roles_projection
+SET name              = COALESCE(sqlc.narg('name')::TEXT, name),
+    description       = COALESCE(sqlc.narg('description')::TEXT, description),
+    permissions       = COALESCE(sqlc.narg('permissions')::TEXT[], permissions),
+    updated_at        = sqlc.arg('updated_at'),
+    projection_version = sqlc.arg('projection_version')
+WHERE id = sqlc.arg('id')
+  AND projection_version < sqlc.arg('projection_version');
+
+-- name: SoftDeleteRoleProjection :exec
+-- RoleDeleted handler — first half. Marks the role as deleted but
+-- leaves the row so the audit log resolves role names. Listener
+-- pairs this with DeleteUserRolesByRole inside store.WithTx so the
+-- projection never observes "role deleted but memberships remain".
+UPDATE roles_projection
+SET is_deleted        = TRUE,
+    updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: DeleteUserRolesByRole :exec
+-- RoleDeleted handler — second half. Cascades the delete to
+-- user_roles_projection so user-permission queries no longer surface
+-- this role's permissions. Wrapped with SoftDeleteRoleProjection in
+-- store.WithTx for inter-write atomicity.
+DELETE FROM user_roles_projection WHERE role_id = $1;


### PR DESCRIPTION
## Summary

Sixth port under the projector-migration pattern. Replaces `project_role_event` PL/pgSQL with `projectors.RoleListener`.

Three event types:
- `RoleCreated` — INSERT … ON CONFLICT DO NOTHING (replay-safe)
- `RoleUpdated` — partial UPDATE; pointer fields on the decoded payload distinguish "field present" from "field omitted". Empty-string Name is collapsed to nil at the listener layer to match PL/pgSQL's `NULLIF(name, '')` semantics. COALESCE preserves omitted fields. New `WHERE projection_version < $N` guard rejects stale reconciler replays.
- `RoleDeleted` — `is_deleted = TRUE` + cascade DELETE on `user_roles_projection`, wrapped in `store.WithTx` so the projection never observes "role marked deleted but memberships remain".

## Read-your-writes preserved

`role_handler.{Create,Update}Role` read back from `roles_projection` AFTER `AppendEvent` returns. `fireListeners` is synchronous (project memory `feedback_post_commit_listener_is_sync.md`), so the read sees the listener's write.

## Test plan

Tests written FIRST per saved TDD feedback.

- [x] Pure decoders: happy paths, defaults (description/permissions/is_system), partial-update semantics (each field omitted/empty/explicit-empty), `name=""` → preserved-via-NULLIF, wrong stream/event type → `ErrIgnoredEvent`, malformed bytes
- [x] Integration: Create→Update lifecycle with partial updates (description-only, permissions-clear), Delete cascade to `user_roles_projection`, `projection_version` stale-replay guard, wrong-stream-type ignored
- [x] All tests pass locally (`go test ./server/internal/projectors/...`)

Refs tracker #107. Closes #101.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Role projection logic moved from DB triggers to an application-level projector; DB migration added to disable the old in-DB projection.

* **New Features**
  * App-side role listener registered to handle create/update/delete events with validation and preserved partial-update semantics.
  * Projection operations now use version guards and support safe insert/update/soft-delete plus cascade deletion of role memberships.

* **Tests**
  * Added integration test ensuring stale delete replays do not remove role memberships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->