### PR TITLE
feat: port project_user_role_event to Go listener (#102)

### DIFF
--- a/internal/projectors/user_role.go
+++ b/internal/projectors/user_role.go
@@ -1,0 +1,70 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// UserRoleAssignedPayload is the decoded shape of a UserRoleAssigned
+// event. Both fields are required — they're the (composite-key)
+// columns of the row this projector inserts.
+type UserRoleAssignedPayload struct {
+	UserID     string `json:"user_id"`
+	RoleID     string `json:"role_id"`
+	AssignedBy string // populated from event.actor_id, not the JSON payload
+}
+
+// UserRoleRevokedPayload mirrors the assigned shape; same composite
+// key, same required-field semantics.
+type UserRoleRevokedPayload struct {
+	UserID string `json:"user_id"`
+	RoleID string `json:"role_id"`
+}
+
+// UserRoleAssignedFromEvent decodes UserRoleAssigned. Returns
+// ErrIgnoredEvent for any other (stream, event_type) so the listener
+// wrapper can silently no-op.
+func UserRoleAssignedFromEvent(e store.PersistedEvent) (UserRoleAssignedPayload, error) {
+	if e.StreamType != "user_role" || e.EventType != "UserRoleAssigned" {
+		return UserRoleAssignedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserRoleAssignedPayload{}, fmt.Errorf("projector: empty UserRoleAssigned payload")
+	}
+	var p UserRoleAssignedPayload
+	if err := json.Unmarshal(e.Data, &p); err != nil {
+		return UserRoleAssignedPayload{}, fmt.Errorf("projector: invalid UserRoleAssigned payload: %w", err)
+	}
+	switch {
+	case p.UserID == "":
+		return UserRoleAssignedPayload{}, fmt.Errorf("projector: UserRoleAssigned requires user_id")
+	case p.RoleID == "":
+		return UserRoleAssignedPayload{}, fmt.Errorf("projector: UserRoleAssigned requires role_id")
+	}
+	p.AssignedBy = e.ActorID
+	return p, nil
+}
+
+// UserRoleRevokedFromEvent decodes UserRoleRevoked. Same validation
+// shape as UserRoleAssigned — both composite-key fields required.
+func UserRoleRevokedFromEvent(e store.PersistedEvent) (UserRoleRevokedPayload, error) {
+	if e.StreamType != "user_role" || e.EventType != "UserRoleRevoked" {
+		return UserRoleRevokedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserRoleRevokedPayload{}, fmt.Errorf("projector: empty UserRoleRevoked payload")
+	}
+	var p UserRoleRevokedPayload
+	if err := json.Unmarshal(e.Data, &p); err != nil {
+		return UserRoleRevokedPayload{}, fmt.Errorf("projector: invalid UserRoleRevoked payload: %w", err)
+	}
+	switch {
+	case p.UserID == "":
+		return UserRoleRevokedPayload{}, fmt.Errorf("projector: UserRoleRevoked requires user_id")
+	case p.RoleID == "":
+		return UserRoleRevokedPayload{}, fmt.Errorf("projector: UserRoleRevoked requires role_id")
+	}
+	return p, nil
+}

--- a/internal/projectors/user_role_listener.go
+++ b/internal/projectors/user_role_listener.go
@@ -1,0 +1,83 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// UserRoleListener returns a store.EventListener that applies every
+// user_role stream event the deleted PL/pgSQL project_user_role_event
+// handled. Two event types, two single-statement writes — no
+// transaction wrap needed.
+//
+//   - UserRoleAssigned: INSERT … ON CONFLICT DO NOTHING (replay-safe)
+//   - UserRoleRevoked:  DELETE WHERE (user_id, role_id)
+//
+// Wired in projectors.WireAll. Refs #102, tracker #107.
+func UserRoleListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "user_role" {
+			return
+		}
+		switch e.EventType {
+		case "UserRoleAssigned":
+			applyUserRoleAssigned(ctx, st, logger, e)
+		case "UserRoleRevoked":
+			applyUserRoleRevoked(ctx, st, logger, e)
+		}
+	}
+}
+
+func applyUserRoleAssigned(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := UserRoleAssignedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("user_role projector: invalid UserRoleAssigned payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().InsertUserRoleProjection(ctx, db.InsertUserRoleProjectionParams{
+		UserID:            payload.UserID,
+		RoleID:            payload.RoleID,
+		AssignedAt:        e.OccurredAt,
+		AssignedBy:        payload.AssignedBy,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("user_role projector: failed to insert UserRoleAssigned",
+			"event_id", e.ID,
+			"user_id", payload.UserID,
+			"role_id", payload.RoleID,
+			"error", err)
+	}
+}
+
+func applyUserRoleRevoked(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := UserRoleRevokedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("user_role projector: invalid UserRoleRevoked payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().DeleteUserRoleProjection(ctx, db.DeleteUserRoleProjectionParams{
+		UserID: payload.UserID,
+		RoleID: payload.RoleID,
+	}); err != nil {
+		logger.Warn("user_role projector: failed to delete user_roles_projection row",
+			"event_id", e.ID,
+			"user_id", payload.UserID,
+			"role_id", payload.RoleID,
+			"error", err)
+	}
+}

--- a/internal/projectors/user_role_test.go
+++ b/internal/projectors/user_role_test.go
@@ -1,0 +1,253 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestUserRoleAssignedFromEvent_Pure exercises the decoder for
+// UserRoleAssigned. The PL/pgSQL projector required user_id and
+// role_id; the Go decoder mirrors that with explicit validation
+// instead of silently writing rows with empty composite-key columns.
+func TestUserRoleAssignedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+			StreamType: "user_role",
+			EventType:  "UserRoleAssigned",
+			ActorID:    "actor-1",
+			Data: jsonOrFail(t, map[string]any{
+				"user_id": "user-A",
+				"role_id": "role-X",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "user-A", got.UserID)
+		assert.Equal(t, "role-X", got.RoleID)
+		assert.Equal(t, "actor-1", got.AssignedBy)
+	})
+
+	t.Run("missing user_id", func(t *testing.T) {
+		_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+			StreamType: "user_role", EventType: "UserRoleAssigned",
+			Data: jsonOrFail(t, map[string]any{"role_id": "r"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "user_id")
+	})
+
+	t.Run("missing role_id", func(t *testing.T) {
+		_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+			StreamType: "user_role", EventType: "UserRoleAssigned",
+			Data: jsonOrFail(t, map[string]any{"user_id": "u"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "role_id")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+			StreamType: "role", EventType: "UserRoleAssigned",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+			StreamType: "user_role", EventType: "UserRoleRevoked",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+			StreamType: "user_role", EventType: "UserRoleAssigned",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestUserRoleRevokedFromEvent_Pure mirrors the assigned suite for
+// the revoke variant.
+func TestUserRoleRevokedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.UserRoleRevokedFromEvent(store.PersistedEvent{
+			StreamType: "user_role",
+			EventType:  "UserRoleRevoked",
+			Data: jsonOrFail(t, map[string]any{
+				"user_id": "user-A",
+				"role_id": "role-X",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "user-A", got.UserID)
+		assert.Equal(t, "role-X", got.RoleID)
+	})
+
+	t.Run("missing user_id or role_id is a validation error", func(t *testing.T) {
+		_, err := projectors.UserRoleRevokedFromEvent(store.PersistedEvent{
+			StreamType: "user_role", EventType: "UserRoleRevoked",
+			Data: jsonOrFail(t, map[string]any{"user_id": "u"}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "role_id")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.UserRoleRevokedFromEvent(store.PersistedEvent{
+			StreamType: "user_role", EventType: "UserRoleAssigned",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestUserRoleListener_AssignAndRevoke walks Assign → Revoke through
+// the listener and asserts the projection ends with no row for the
+// (user, role) pair.
+func TestUserRoleListener_AssignAndRevoke(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	roleID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+
+	// Plant a role row so the FK-less projection writes don't surprise us.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data: map[string]any{"name": "tmp", "permissions": []string{"x"}},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Assign the role.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID,
+		EventType:  "UserRoleAssigned",
+		Data: map[string]any{
+			"user_id": userID,
+			"role_id": roleID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	hasRole, err := st.Queries().UserHasRole(ctx, dbUserHasRoleParams(userID, roleID))
+	require.NoError(t, err)
+	assert.True(t, hasRole, "UserRoleAssigned must create a user_roles_projection row")
+
+	// Revoke it.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID,
+		EventType:  "UserRoleRevoked",
+		Data: map[string]any{
+			"user_id": userID,
+			"role_id": roleID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	hasRole, err = st.Queries().UserHasRole(ctx, dbUserHasRoleParams(userID, roleID))
+	require.NoError(t, err)
+	assert.False(t, hasRole, "UserRoleRevoked must remove the user_roles_projection row")
+}
+
+// TestUserRoleListener_AssignReplayIsIdempotent confirms that
+// re-applying the same UserRoleAssigned event (e.g. via the
+// reconciler) doesn't error or duplicate. The PL/pgSQL projector
+// used `ON CONFLICT (user_id, role_id) DO NOTHING`; the Go listener
+// must preserve that.
+func TestUserRoleListener_AssignReplayIsIdempotent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	roleID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data: map[string]any{"name": "tmp", "permissions": []string{"x"}},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	for i := 0; i < 3; i++ {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "user_role",
+			StreamID:   userID + ":" + roleID,
+			EventType:  "UserRoleAssigned",
+			Data: map[string]any{
+				"user_id": userID,
+				"role_id": roleID,
+			},
+			ActorType: "user", ActorID: "u",
+		}), "replay %d", i)
+	}
+
+	// Confirm exactly one row.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM user_roles_projection WHERE user_id=$1 AND role_id=$2",
+		userID, roleID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "ON CONFLICT DO NOTHING keeps assignment row unique despite replays")
+}
+
+// TestUserRoleListener_RevokeWhenAbsentIsNoop — defensive: a Revoke
+// event with no matching row must not error. The PL/pgSQL projector
+// used a plain DELETE which silently affects zero rows on a miss;
+// the Go listener must preserve that.
+func TestUserRoleListener_RevokeWhenAbsentIsNoop(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role",
+		StreamID:   "ghost:role",
+		EventType:  "UserRoleRevoked",
+		Data: map[string]any{
+			"user_id": "ghost-user",
+			"role_id": "ghost-role",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	// No assertion needed — the test passes as long as AppendEvent
+	// returns without error.
+}
+
+// TestUserRoleListener_IgnoresWrongStreamType — defensive.
+func TestUserRoleListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	roleID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", // wrong
+		StreamID:   userID + ":" + roleID,
+		EventType:  "UserRoleAssigned",
+		Data: map[string]any{
+			"user_id": userID,
+			"role_id": roleID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	hasRole, err := st.Queries().UserHasRole(ctx, dbUserHasRoleParams(userID, roleID))
+	require.NoError(t, err)
+	assert.False(t, hasRole, "wrong-stream-type UserRoleAssigned must NOT create a user_roles_projection row")
+}
+
+// dbUserHasRoleParams wraps the generated sqlc params struct so the
+// test bodies stay readable without repeating field names.
+func dbUserHasRoleParams(userID, roleID string) db.UserHasRoleParams {
+	return db.UserHasRoleParams{UserID: userID, RoleID: roleID}
+}

--- a/internal/projectors/user_role_test.go
+++ b/internal/projectors/user_role_test.go
@@ -93,7 +93,16 @@ func TestUserRoleRevokedFromEvent_Pure(t *testing.T) {
 		assert.Equal(t, "role-X", got.RoleID)
 	})
 
-	t.Run("missing user_id or role_id is a validation error", func(t *testing.T) {
+	t.Run("missing user_id is a validation error", func(t *testing.T) {
+		_, err := projectors.UserRoleRevokedFromEvent(store.PersistedEvent{
+			StreamType: "user_role", EventType: "UserRoleRevoked",
+			Data: jsonOrFail(t, map[string]any{"role_id": "r"}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user_id")
+	})
+
+	t.Run("missing role_id is a validation error", func(t *testing.T) {
 		_, err := projectors.UserRoleRevokedFromEvent(store.PersistedEvent{
 			StreamType: "user_role", EventType: "UserRoleRevoked",
 			Data: jsonOrFail(t, map[string]any{"user_id": "u"}),

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -52,7 +52,11 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "role_projector"),
 	))
-	// Subsequent ports under #102–#106 add their listener here.
+	st.RegisterEventListener(UserRoleListener(
+		st,
+		loggerFor(logger, "user_role_projector"),
+	))
+	// Subsequent ports under #103–#106 add their listener here.
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/roles.sql.go
+++ b/internal/store/generated/roles.sql.go
@@ -32,6 +32,25 @@ func (q *Queries) CountUsersWithRole(ctx context.Context, roleID string) (int64,
 	return count, err
 }
 
+const deleteUserRoleProjection = `-- name: DeleteUserRoleProjection :exec
+DELETE FROM user_roles_projection
+WHERE user_id = $1
+  AND role_id = $2
+`
+
+type DeleteUserRoleProjectionParams struct {
+	UserID string `json:"user_id"`
+	RoleID string `json:"role_id"`
+}
+
+// UserRoleRevoked handler. Plain DELETE — silently no-op on a miss
+// matches the PL/pgSQL projector's behaviour under repeated revoke
+// events.
+func (q *Queries) DeleteUserRoleProjection(ctx context.Context, arg DeleteUserRoleProjectionParams) error {
+	_, err := q.db.Exec(ctx, deleteUserRoleProjection, arg.UserID, arg.RoleID)
+	return err
+}
+
 const deleteUserRolesByRole = `-- name: DeleteUserRolesByRole :exec
 DELETE FROM user_roles_projection WHERE role_id = $1
 `
@@ -184,6 +203,35 @@ func (q *Queries) InsertRoleProjection(ctx context.Context, arg InsertRoleProjec
 		arg.IsSystem,
 		arg.CreatedAt,
 		arg.CreatedBy,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const insertUserRoleProjection = `-- name: InsertUserRoleProjection :exec
+INSERT INTO user_roles_projection (
+    user_id, role_id, assigned_at, assigned_by, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (user_id, role_id) DO NOTHING
+`
+
+type InsertUserRoleProjectionParams struct {
+	UserID            string    `json:"user_id"`
+	RoleID            string    `json:"role_id"`
+	AssignedAt        time.Time `json:"assigned_at"`
+	AssignedBy        string    `json:"assigned_by"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// UserRoleAssigned handler. ON CONFLICT (user_id, role_id) DO NOTHING
+// preserves the PL/pgSQL projector's idempotency under reconciler
+// replays.
+func (q *Queries) InsertUserRoleProjection(ctx context.Context, arg InsertUserRoleProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertUserRoleProjection,
+		arg.UserID,
+		arg.RoleID,
+		arg.AssignedAt,
+		arg.AssignedBy,
 		arg.ProjectionVersion,
 	)
 	return err

--- a/internal/store/migrations/023_user_role_projector_to_go.sql
+++ b/internal/store/migrations/023_user_role_projector_to_go.sql
@@ -1,0 +1,74 @@
+-- Replace project_user_role_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.UserRoleListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger
+-- still PERFORMs project_user_role_event(NEW) for every user_role-
+-- stream event; the no-op stub keeps that dispatch quiet (no
+-- projection_errors entries) until the dispatcher itself is
+-- rewritten to skip stream types with Go projectors.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. Both event types (Assigned, Revoked) atomic
+--     with the event commit.
+--   - After: Go listener fires post-commit. Each event type
+--     produces a single statement (INSERT or DELETE), so no tx
+--     wrap is needed. The role_handler's idempotency check
+--     (`UserHasRole` before emitting Assigned) still works because
+--     fireListeners is synchronous — the read sees the listener's
+--     write.
+--
+-- Idempotency under reconciler replays preserved via ON CONFLICT
+-- (user_id, role_id) DO NOTHING for Assigned and a plain DELETE for
+-- Revoked (silently no-op on a miss). Composite-key fields are
+-- explicitly validated at the listener layer so a malformed event
+-- can't write a row with empty user_id or role_id.
+--
+-- See manchtools/power-manage-server#102. Seventh port under the
+-- projector-migration pattern.
+--
+-- Refs tracker #107.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_role_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.UserRoleListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the original PL/pgSQL projector verbatim from migration 003.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_role_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'UserRoleAssigned' THEN
+            INSERT INTO user_roles_projection (
+                user_id, role_id, assigned_at, assigned_by, projection_version
+            ) VALUES (
+                event.data->>'user_id',
+                event.data->>'role_id',
+                event.occurred_at,
+                event.actor_id,
+                event.sequence_num
+            ) ON CONFLICT (user_id, role_id) DO NOTHING;
+
+        WHEN 'UserRoleRevoked' THEN
+            DELETE FROM user_roles_projection
+            WHERE user_id = event.data->>'user_id'
+              AND role_id = event.data->>'role_id';
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/roles.sql
+++ b/internal/store/queries/roles.sql
@@ -82,3 +82,20 @@ WHERE id = $1
 -- this role's permissions. Wrapped with SoftDeleteRoleProjection in
 -- store.WithTx for inter-write atomicity.
 DELETE FROM user_roles_projection WHERE role_id = $1;
+
+-- name: InsertUserRoleProjection :exec
+-- UserRoleAssigned handler. ON CONFLICT (user_id, role_id) DO NOTHING
+-- preserves the PL/pgSQL projector's idempotency under reconciler
+-- replays.
+INSERT INTO user_roles_projection (
+    user_id, role_id, assigned_at, assigned_by, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (user_id, role_id) DO NOTHING;
+
+-- name: DeleteUserRoleProjection :exec
+-- UserRoleRevoked handler. Plain DELETE — silently no-op on a miss
+-- matches the PL/pgSQL projector's behaviour under repeated revoke
+-- events.
+DELETE FROM user_roles_projection
+WHERE user_id = $1
+  AND role_id = $2;


### PR DESCRIPTION
## Summary

Seventh port under the projector-migration pattern. Replaces `project_user_role_event` PL/pgSQL with `projectors.UserRoleListener`.

Two event types, single statement each — no transaction wrap needed:
- `UserRoleAssigned` — INSERT … ON CONFLICT (user_id, role_id) DO NOTHING preserves the PL/pgSQL projector's idempotency under reconciler replays.
- `UserRoleRevoked` — DELETE WHERE composite key — silently no-op on a miss (matches PL/pgSQL behaviour for repeated revoke events).

Composite-key fields (user_id, role_id) are explicitly validated at the listener layer so a malformed event can't write a row with empty keys.

## Read-your-writes preserved

`role_handler.AssignRoleToUser` checks `UserHasRole` before emitting Assigned, and that read sees the prior listener's write because `fireListeners` is synchronous (project memory `feedback_post_commit_listener_is_sync.md`).

## Test plan

Tests written FIRST per saved TDD feedback.

- [x] Pure decoders: happy paths, missing user_id/role_id, wrong stream/event type → `ErrIgnoredEvent`, malformed payloads
- [x] Integration: Assign→Revoke lifecycle, replay idempotency (3x Assign produces 1 row), Revoke-when-absent is a no-op, wrong-stream-type ignored
- [x] All tests pass locally (`go test ./server/internal/projectors/...`)

Refs tracker #107. Closes #102.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved user-role event processing from database-side procedures into the application, centralizing projection handling and ensuring consistent role assignment/revocation behavior.

* **Tests**
  * Added end-to-end and unit tests for user role assign/revoke flows, covering idempotency, missing data, and edge cases to improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->