### PR TITLE
feat: port project_token_event to Go listener (#103)

### DIFF
--- a/internal/projectors/token.go
+++ b/internal/projectors/token.go
@@ -1,0 +1,107 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// TokenCreatedPayload covers the fields the token projector reads
+// from a TokenCreated event. Pointer fields for ExpiresAt and OwnerID
+// preserve "absent" vs "explicitly null" — the column accepts NULL
+// and the deleted PL/pgSQL projector relied on that.
+type TokenCreatedPayload struct {
+	ID        string
+	ValueHash string
+	Name      string
+	OneTime   bool
+	MaxUses   int32
+	ExpiresAt *time.Time
+	OwnerID   *string
+	CreatedBy string
+}
+
+// TokenRenamedPayload — sole field is the new name.
+type TokenRenamedPayload struct {
+	ID   string
+	Name string
+}
+
+type tokenCreatedRaw struct {
+	ValueHash string  `json:"value_hash"`
+	Name      *string `json:"name,omitempty"`
+	OneTime   *bool   `json:"one_time,omitempty"`
+	MaxUses   *int32  `json:"max_uses,omitempty"`
+	ExpiresAt *string `json:"expires_at,omitempty"`
+	OwnerID   *string `json:"owner_id,omitempty"`
+}
+
+// TokenCreatedFromEvent decodes TokenCreated. Defaults match the
+// PL/pgSQL projector: missing name → ''; missing one_time → false;
+// missing max_uses → 0; missing expires_at → nil (stays NULL); missing
+// owner_id → nil. value_hash is required (UNIQUE NOT NULL).
+func TokenCreatedFromEvent(e store.PersistedEvent) (TokenCreatedPayload, error) {
+	if e.StreamType != "token" || e.EventType != "TokenCreated" {
+		return TokenCreatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return TokenCreatedPayload{}, fmt.Errorf("projector: empty TokenCreated payload")
+	}
+	var raw tokenCreatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return TokenCreatedPayload{}, fmt.Errorf("projector: invalid TokenCreated payload: %w", err)
+	}
+	if raw.ValueHash == "" {
+		return TokenCreatedPayload{}, fmt.Errorf("projector: TokenCreated requires value_hash")
+	}
+	out := TokenCreatedPayload{
+		ID:        e.StreamID,
+		ValueHash: raw.ValueHash,
+		CreatedBy: e.ActorID,
+	}
+	if raw.Name != nil {
+		out.Name = *raw.Name
+	}
+	if raw.OneTime != nil {
+		out.OneTime = *raw.OneTime
+	}
+	if raw.MaxUses != nil {
+		out.MaxUses = *raw.MaxUses
+	}
+	if raw.ExpiresAt != nil && *raw.ExpiresAt != "" {
+		t, err := time.Parse(time.RFC3339, *raw.ExpiresAt)
+		if err != nil {
+			t, err = time.Parse(time.RFC3339Nano, *raw.ExpiresAt)
+			if err != nil {
+				return TokenCreatedPayload{}, fmt.Errorf("projector: TokenCreated has invalid expires_at %q: %w", *raw.ExpiresAt, err)
+			}
+		}
+		out.ExpiresAt = &t
+	}
+	out.OwnerID = raw.OwnerID
+	return out, nil
+}
+
+// TokenRenamedFromEvent decodes TokenRenamed. Name is required —
+// the rename handler always supplies it; an empty payload would be
+// a programmer error.
+func TokenRenamedFromEvent(e store.PersistedEvent) (TokenRenamedPayload, error) {
+	if e.StreamType != "token" || e.EventType != "TokenRenamed" {
+		return TokenRenamedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return TokenRenamedPayload{}, fmt.Errorf("projector: empty TokenRenamed payload")
+	}
+	var raw struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return TokenRenamedPayload{}, fmt.Errorf("projector: invalid TokenRenamed payload: %w", err)
+	}
+	if raw.Name == "" {
+		return TokenRenamedPayload{}, fmt.Errorf("projector: TokenRenamed requires name")
+	}
+	return TokenRenamedPayload{ID: e.StreamID, Name: raw.Name}, nil
+}

--- a/internal/projectors/token_listener.go
+++ b/internal/projectors/token_listener.go
@@ -1,0 +1,129 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// TokenListener returns a store.EventListener that applies every
+// token-stream event the deleted PL/pgSQL project_token_event
+// handled. Six event types, each a single statement:
+//
+//   - TokenCreated:  INSERT … ON CONFLICT DO NOTHING
+//   - TokenRenamed:  UPDATE name
+//   - TokenUsed:     UPDATE current_uses += 1
+//   - TokenDisabled: UPDATE disabled = TRUE
+//   - TokenEnabled:  UPDATE disabled = FALSE
+//   - TokenDeleted:  UPDATE is_deleted = TRUE
+//
+// Every UPDATE has a projection_version < $N guard rejecting stale
+// reconciler replays — load-bearing for TokenUsed since a duplicate
+// would erroneously bump current_uses twice.
+//
+// Wired in projectors.WireAll. Refs #103, tracker #107.
+func TokenListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "token" {
+			return
+		}
+		switch e.EventType {
+		case "TokenCreated":
+			applyTokenCreated(ctx, st, logger, e)
+		case "TokenRenamed":
+			applyTokenRenamed(ctx, st, logger, e)
+		case "TokenUsed":
+			applyTokenSimpleUpdate(ctx, st, logger, e, func(q *store.Queries, ver int64) error {
+				return q.IncrementTokenUseProjection(ctx, db.IncrementTokenUseProjectionParams{
+					ID: e.StreamID, ProjectionVersion: ver,
+				})
+			})
+		case "TokenDisabled":
+			applyTokenSimpleUpdate(ctx, st, logger, e, func(q *store.Queries, ver int64) error {
+				return q.SetTokenDisabledProjection(ctx, db.SetTokenDisabledProjectionParams{
+					ID: e.StreamID, Disabled: true, ProjectionVersion: ver,
+				})
+			})
+		case "TokenEnabled":
+			applyTokenSimpleUpdate(ctx, st, logger, e, func(q *store.Queries, ver int64) error {
+				return q.SetTokenDisabledProjection(ctx, db.SetTokenDisabledProjectionParams{
+					ID: e.StreamID, Disabled: false, ProjectionVersion: ver,
+				})
+			})
+		case "TokenDeleted":
+			applyTokenSimpleUpdate(ctx, st, logger, e, func(q *store.Queries, ver int64) error {
+				return q.SoftDeleteTokenProjection(ctx, db.SoftDeleteTokenProjectionParams{
+					ID: e.StreamID, ProjectionVersion: ver,
+				})
+			})
+		}
+	}
+}
+
+func applyTokenCreated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := TokenCreatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("token projector: invalid TokenCreated payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().InsertTokenProjection(ctx, db.InsertTokenProjectionParams{
+		ID:                payload.ID,
+		ValueHash:         payload.ValueHash,
+		Name:              payload.Name,
+		OneTime:           payload.OneTime,
+		MaxUses:           payload.MaxUses,
+		ExpiresAt:         payload.ExpiresAt,
+		CreatedAt:         &e.OccurredAt,
+		CreatedBy:         payload.CreatedBy,
+		OwnerID:           payload.OwnerID,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("token projector: failed to insert TokenCreated",
+			"event_id", e.ID, "token_id", payload.ID, "error", err)
+	}
+}
+
+func applyTokenRenamed(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := TokenRenamedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("token projector: invalid TokenRenamed payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().RenameTokenProjection(ctx, db.RenameTokenProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("token projector: failed to apply TokenRenamed",
+			"event_id", e.ID, "token_id", payload.ID, "error", err)
+	}
+}
+
+// applyTokenSimpleUpdate is the shared scaffold for the four
+// no-payload event types (Used, Disabled, Enabled, Deleted). They
+// all key off StreamID + the event sequence_num and differ only in
+// which sqlc query they call — the closure isolates that one
+// difference.
+func applyTokenSimpleUpdate(
+	ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent,
+	apply func(q *store.Queries, projectionVersion int64) error,
+) {
+	if err := apply(st.Queries(), deref(e.SequenceNum)); err != nil {
+		logger.Warn("token projector: failed to apply token update",
+			"event_id", e.ID, "event_type", e.EventType, "token_id", e.StreamID, "error", err)
+	}
+}

--- a/internal/projectors/token_test.go
+++ b/internal/projectors/token_test.go
@@ -225,6 +225,44 @@ func TestTokenListener_StaleReplayRejected(t *testing.T) {
 	assert.Equal(t, currentVer, after.ProjectionVersion)
 }
 
+// TestTokenListener_StaleReplayRejected_TokenUsed is the load-bearing
+// guard test for IncrementTokenUseProjection. Without the
+// projection_version guard, a duplicate reconciler replay of TokenUsed
+// would erroneously bump current_uses twice. The PR description
+// specifically called this out as the most critical guarded path; it
+// deserves a dedicated regression test rather than relying on the
+// SetTokenDisabledProjection coverage alone.
+func TestTokenListener_StaleReplayRejected_TokenUsed(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	tokenID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "token", StreamID: tokenID, EventType: "TokenCreated",
+		Data: map[string]any{"value_hash": "h-" + testutil.NewID(), "name": "n", "max_uses": 3},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "token", StreamID: tokenID, EventType: "TokenUsed",
+		Data: map[string]any{}, ActorType: "system", ActorID: "registration",
+	}))
+	current, err := st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err)
+	require.Equal(t, int32(1), current.CurrentUses)
+	currentVer := current.ProjectionVersion
+
+	// Stale replay of TokenUsed would re-bump current_uses to 2; the
+	// projection_version guard must reject it so the count stays at 1.
+	require.NoError(t, st.Queries().IncrementTokenUseProjection(ctx, db.IncrementTokenUseProjectionParams{
+		ID:                tokenID,
+		ProjectionVersion: currentVer - 5,
+	}))
+	after, err := st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), after.CurrentUses, "stale projection_version must NOT double-increment current_uses")
+	assert.Equal(t, currentVer, after.ProjectionVersion, "projection_version unchanged when guard rejects")
+}
+
 // TestTokenListener_IgnoresWrongStreamType — defensive.
 func TestTokenListener_IgnoresWrongStreamType(t *testing.T) {
 	st := testutil.SetupPostgres(t)

--- a/internal/projectors/token_test.go
+++ b/internal/projectors/token_test.go
@@ -1,0 +1,242 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestTokenCreatedFromEvent_Pure exercises the decoder. The PL/pgSQL
+// projector defaulted name='', one_time=FALSE, max_uses=0; the Go
+// shape mirrors via zero values.
+func TestTokenCreatedFromEvent_Pure(t *testing.T) {
+	expires := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.TokenCreatedFromEvent(store.PersistedEvent{
+			StreamType: "token", StreamID: "tok-1", EventType: "TokenCreated", ActorID: "actor-1",
+			Data: jsonOrFail(t, map[string]any{
+				"value_hash": "h1",
+				"name":       "agent-token",
+				"one_time":   true,
+				"max_uses":   5,
+				"expires_at": expires.Format(time.RFC3339),
+				"owner_id":   "user-1",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "tok-1", got.ID)
+		assert.Equal(t, "h1", got.ValueHash)
+		assert.Equal(t, "agent-token", got.Name)
+		assert.True(t, got.OneTime)
+		assert.Equal(t, int32(5), got.MaxUses)
+		require.NotNil(t, got.ExpiresAt)
+		assert.True(t, got.ExpiresAt.Equal(expires))
+		require.NotNil(t, got.OwnerID)
+		assert.Equal(t, "user-1", *got.OwnerID)
+		assert.Equal(t, "actor-1", got.CreatedBy)
+	})
+
+	t.Run("defaults: name='', one_time=false, max_uses=0, expires_at=nil, owner_id=nil", func(t *testing.T) {
+		got, err := projectors.TokenCreatedFromEvent(store.PersistedEvent{
+			StreamType: "token", StreamID: "tok-2", EventType: "TokenCreated", ActorID: "a",
+			Data: jsonOrFail(t, map[string]any{"value_hash": "h"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Name)
+		assert.False(t, got.OneTime)
+		assert.Equal(t, int32(0), got.MaxUses)
+		assert.Nil(t, got.ExpiresAt, "missing expires_at → nil (nullable column)")
+		assert.Nil(t, got.OwnerID, "missing owner_id → nil (nullable column; PL/pgSQL stored NULL)")
+	})
+
+	t.Run("value_hash is required", func(t *testing.T) {
+		_, err := projectors.TokenCreatedFromEvent(store.PersistedEvent{
+			StreamType: "token", StreamID: "tok-3", EventType: "TokenCreated", ActorID: "a",
+			Data: jsonOrFail(t, map[string]any{"name": "no hash"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "value_hash")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.TokenCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "TokenCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.TokenCreatedFromEvent(store.PersistedEvent{
+			StreamType: "token", EventType: "TokenRenamed",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestTokenRenamedFromEvent_Pure — minimal decoder.
+func TestTokenRenamedFromEvent_Pure(t *testing.T) {
+	got, err := projectors.TokenRenamedFromEvent(store.PersistedEvent{
+		StreamType: "token", StreamID: "tok-1", EventType: "TokenRenamed",
+		Data: jsonOrFail(t, map[string]any{"name": "renamed"}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "tok-1", got.ID)
+	assert.Equal(t, "renamed", got.Name)
+
+	_, err = projectors.TokenRenamedFromEvent(store.PersistedEvent{
+		StreamType: "user", EventType: "TokenRenamed",
+	})
+	assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+
+	_, err = projectors.TokenRenamedFromEvent(store.PersistedEvent{
+		StreamType: "token", StreamID: "tok-1", EventType: "TokenRenamed",
+		Data: jsonOrFail(t, map[string]any{}),
+	})
+	require.Error(t, err, "missing name is a validation error")
+}
+
+// TestTokenListener_CreateRenameUseDisableEnableDeleteLifecycle walks
+// every event type through the listener in sequence and asserts the
+// projection state at each step. Replaces 6 isolated tests with one
+// flow that enforces the cumulative invariants (current_uses
+// increments, disable/enable toggles, soft-delete preserves the row).
+func TestTokenListener_CreateRenameUseDisableEnableDeleteLifecycle(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	tokenID := testutil.NewID()
+	hash := "hash-" + testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "token", StreamID: tokenID, EventType: "TokenCreated",
+		Data: map[string]any{
+			"value_hash": hash,
+			"name":       "initial",
+			"one_time":   false,
+			"max_uses":   3,
+			"owner_id":   "user-A",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	tok, err := st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err)
+	assert.Equal(t, hash, tok.ValueHash)
+	assert.Equal(t, "initial", tok.Name)
+	assert.False(t, tok.OneTime)
+	assert.Equal(t, int32(3), tok.MaxUses)
+	assert.Equal(t, int32(0), tok.CurrentUses)
+	require.NotNil(t, tok.OwnerID)
+	assert.Equal(t, "user-A", *tok.OwnerID)
+	assert.False(t, tok.Disabled)
+	assert.False(t, tok.IsDeleted)
+
+	// Rename
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "token", StreamID: tokenID, EventType: "TokenRenamed",
+		Data: map[string]any{"name": "renamed"}, ActorType: "user", ActorID: "u",
+	}))
+	tok, err = st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", tok.Name)
+
+	// Use twice
+	for i := 0; i < 2; i++ {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "token", StreamID: tokenID, EventType: "TokenUsed",
+			Data: map[string]any{}, ActorType: "system", ActorID: "registration",
+		}))
+	}
+	tok, err = st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), tok.CurrentUses, "TokenUsed increments current_uses")
+
+	// Disable then enable
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "token", StreamID: tokenID, EventType: "TokenDisabled",
+		Data: map[string]any{}, ActorType: "user", ActorID: "u",
+	}))
+	tok, err = st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err)
+	assert.True(t, tok.Disabled)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "token", StreamID: tokenID, EventType: "TokenEnabled",
+		Data: map[string]any{}, ActorType: "user", ActorID: "u",
+	}))
+	tok, err = st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err)
+	assert.False(t, tok.Disabled)
+
+	// Delete (soft) — GetTokenByID filters is_deleted=FALSE so this
+	// makes the token disappear from that query.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "token", StreamID: tokenID, EventType: "TokenDeleted",
+		Data: map[string]any{}, ActorType: "user", ActorID: "u",
+	}))
+	_, err = st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.Error(t, err, "GetTokenByID excludes soft-deleted rows")
+	// Confirm row still exists with is_deleted=TRUE for audit.
+	var isDeleted bool
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT is_deleted FROM tokens_projection WHERE id = $1", tokenID,
+	).Scan(&isDeleted))
+	assert.True(t, isDeleted)
+}
+
+// TestTokenListener_StaleReplayRejected confirms the projection_version
+// guard rejects an UPDATE whose projection_version is older than the
+// row's current value. The PL/pgSQL projector lacked this guard; the
+// Go port tightens it.
+func TestTokenListener_StaleReplayRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	tokenID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "token", StreamID: tokenID, EventType: "TokenCreated",
+		Data: map[string]any{"value_hash": "h-" + testutil.NewID(), "name": "n"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "token", StreamID: tokenID, EventType: "TokenDisabled",
+		Data: map[string]any{}, ActorType: "user", ActorID: "u",
+	}))
+	current, err := st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err)
+	require.True(t, current.Disabled)
+	currentVer := current.ProjectionVersion
+
+	// Stale replay would re-enable; the guard must reject.
+	require.NoError(t, st.Queries().SetTokenDisabledProjection(ctx, db.SetTokenDisabledProjectionParams{
+		ID:                tokenID,
+		Disabled:          false,
+		ProjectionVersion: currentVer - 5,
+	}))
+	after, err := st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err)
+	assert.True(t, after.Disabled, "stale projection_version must NOT clobber fresher state")
+	assert.Equal(t, currentVer, after.ProjectionVersion)
+}
+
+// TestTokenListener_IgnoresWrongStreamType — defensive.
+func TestTokenListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	tokenID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", // wrong
+		StreamID:   tokenID, EventType: "TokenCreated",
+		Data: map[string]any{"value_hash": "h"}, ActorType: "user", ActorID: "u",
+	}))
+
+	_, err := st.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: tokenID})
+	require.Error(t, err, "wrong-stream-type TokenCreated must NOT create a tokens_projection row")
+}

--- a/internal/projectors/token_test.go
+++ b/internal/projectors/token_test.go
@@ -94,13 +94,20 @@ func TestTokenRenamedFromEvent_Pure(t *testing.T) {
 	_, err = projectors.TokenRenamedFromEvent(store.PersistedEvent{
 		StreamType: "user", EventType: "TokenRenamed",
 	})
-	assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent), "wrong stream_type → ErrIgnoredEvent")
+
+	_, err = projectors.TokenRenamedFromEvent(store.PersistedEvent{
+		StreamType: "token", EventType: "TokenCreated",
+	})
+	assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent), "wrong event_type → ErrIgnoredEvent")
 
 	_, err = projectors.TokenRenamedFromEvent(store.PersistedEvent{
 		StreamType: "token", StreamID: "tok-1", EventType: "TokenRenamed",
 		Data: jsonOrFail(t, map[string]any{}),
 	})
 	require.Error(t, err, "missing name is a validation error")
+	assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent),
+		"validation failure must NOT be silently swallowed by the listener wrapper")
 }
 
 // TestTokenListener_CreateRenameUseDisableEnableDeleteLifecycle walks

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -56,7 +56,11 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "user_role_projector"),
 	))
-	// Subsequent ports under #103–#106 add their listener here.
+	st.RegisterEventListener(TokenListener(
+		st,
+		loggerFor(logger, "token_projector"),
+	))
+	// Subsequent ports under #104–#106 add their listener here.
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/tokens.sql.go
+++ b/internal/store/generated/tokens.sql.go
@@ -7,6 +7,7 @@ package generated
 
 import (
 	"context"
+	"time"
 )
 
 const countTokens = `-- name: CountTokens :one
@@ -117,6 +118,69 @@ func (q *Queries) GetValidToken(ctx context.Context, valueHash string) (TokensPr
 	return i, err
 }
 
+const incrementTokenUseProjection = `-- name: IncrementTokenUseProjection :exec
+UPDATE tokens_projection
+SET current_uses      = current_uses + 1,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+`
+
+type IncrementTokenUseProjectionParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// TokenUsed handler. Uses current_uses + 1 (matches PL/pgSQL); a
+// duplicate event from the reconciler would erroneously bump the
+// counter twice without the projection_version guard, so the guard
+// is load-bearing here, not just defensive.
+func (q *Queries) IncrementTokenUseProjection(ctx context.Context, arg IncrementTokenUseProjectionParams) error {
+	_, err := q.db.Exec(ctx, incrementTokenUseProjection, arg.ID, arg.ProjectionVersion)
+	return err
+}
+
+const insertTokenProjection = `-- name: InsertTokenProjection :exec
+INSERT INTO tokens_projection (
+    id, value_hash, name, one_time, max_uses, expires_at,
+    created_at, created_by, owner_id, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertTokenProjectionParams struct {
+	ID                string     `json:"id"`
+	ValueHash         string     `json:"value_hash"`
+	Name              string     `json:"name"`
+	OneTime           bool       `json:"one_time"`
+	MaxUses           int32      `json:"max_uses"`
+	ExpiresAt         *time.Time `json:"expires_at"`
+	CreatedAt         *time.Time `json:"created_at"`
+	CreatedBy         string     `json:"created_by"`
+	OwnerID           *string    `json:"owner_id"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// TokenCreated handler. ON CONFLICT DO NOTHING for replay safety —
+// the reconciler may re-deliver the event; if a row already exists
+// under the same id, leave it alone. Composite-key partials
+// (TokenRenamed/Used/etc) own subsequent mutations.
+func (q *Queries) InsertTokenProjection(ctx context.Context, arg InsertTokenProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertTokenProjection,
+		arg.ID,
+		arg.ValueHash,
+		arg.Name,
+		arg.OneTime,
+		arg.MaxUses,
+		arg.ExpiresAt,
+		arg.CreatedAt,
+		arg.CreatedBy,
+		arg.OwnerID,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
 const listActiveTokens = `-- name: ListActiveTokens :many
 SELECT id, value_hash, name, one_time, max_uses, current_uses, expires_at, created_at, created_by, disabled, is_deleted, projection_version, owner_id FROM tokens_projection
 WHERE is_deleted = FALSE
@@ -212,4 +276,66 @@ func (q *Queries) ListTokens(ctx context.Context, arg ListTokensParams) ([]Token
 		return nil, err
 	}
 	return items, nil
+}
+
+const renameTokenProjection = `-- name: RenameTokenProjection :exec
+UPDATE tokens_projection
+SET name              = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type RenameTokenProjectionParams struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// TokenRenamed handler. projection_version guard rejects stale
+// reconciler replays.
+func (q *Queries) RenameTokenProjection(ctx context.Context, arg RenameTokenProjectionParams) error {
+	_, err := q.db.Exec(ctx, renameTokenProjection, arg.ID, arg.Name, arg.ProjectionVersion)
+	return err
+}
+
+const setTokenDisabledProjection = `-- name: SetTokenDisabledProjection :exec
+UPDATE tokens_projection
+SET disabled          = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type SetTokenDisabledProjectionParams struct {
+	ID                string `json:"id"`
+	Disabled          bool   `json:"disabled"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// TokenDisabled / TokenEnabled handler — same shape, parameterised
+// on the disabled bool. Listener picks the bool per event_type.
+func (q *Queries) SetTokenDisabledProjection(ctx context.Context, arg SetTokenDisabledProjectionParams) error {
+	_, err := q.db.Exec(ctx, setTokenDisabledProjection, arg.ID, arg.Disabled, arg.ProjectionVersion)
+	return err
+}
+
+const softDeleteTokenProjection = `-- name: SoftDeleteTokenProjection :exec
+UPDATE tokens_projection
+SET is_deleted        = TRUE,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+`
+
+type SoftDeleteTokenProjectionParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// TokenDeleted handler. Marks the row deleted; row stays so audit
+// queries can resolve token names by id.
+func (q *Queries) SoftDeleteTokenProjection(ctx context.Context, arg SoftDeleteTokenProjectionParams) error {
+	_, err := q.db.Exec(ctx, softDeleteTokenProjection, arg.ID, arg.ProjectionVersion)
+	return err
 }

--- a/internal/store/migrations/024_token_projector_to_go.sql
+++ b/internal/store/migrations/024_token_projector_to_go.sql
@@ -1,0 +1,106 @@
+-- Replace project_token_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.TokenListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger
+-- still PERFORMs project_token_event(NEW) for every token-stream
+-- event; the no-op stub keeps that dispatch quiet (no
+-- projection_errors entries) until the dispatcher itself is
+-- rewritten to skip stream types with Go projectors.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. All six event types (Created, Renamed, Used,
+--     Disabled, Enabled, Deleted) atomic with the event commit.
+--   - After: Go listener fires post-commit. Each event type
+--     produces a single statement, so no tx wrap is needed. The
+--     handler's read-after-write paths
+--     (token_handler.{Create,Rename,SetDisabled,Delete}Token reading
+--     back from tokens_projection) still see the projection because
+--     fireListeners is synchronous.
+--
+-- Tightening: every UPDATE now has a `WHERE projection_version < $N`
+-- guard, rejecting stale reconciler replays. This is load-bearing
+-- for TokenUsed in particular — without the guard, a duplicate
+-- replay would erroneously bump current_uses twice.
+--
+-- See manchtools/power-manage-server#103. Eighth port under the
+-- projector-migration pattern.
+--
+-- Refs tracker #107.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_token_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.TokenListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the original PL/pgSQL projector verbatim from migration 011.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_token_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'TokenCreated' THEN
+            INSERT INTO tokens_projection (
+                id, value_hash, name, one_time, max_uses, expires_at,
+                created_at, created_by, owner_id, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'value_hash',
+                COALESCE(event.data->>'name', ''),
+                COALESCE((event.data->>'one_time')::BOOLEAN, FALSE),
+                COALESCE((event.data->>'max_uses')::INTEGER, 0),
+                CASE WHEN event.data->>'expires_at' IS NOT NULL
+                     THEN (event.data->>'expires_at')::TIMESTAMPTZ
+                     ELSE NULL END,
+                event.occurred_at,
+                event.actor_id,
+                event.data->>'owner_id',
+                event.sequence_num
+            );
+
+        WHEN 'TokenRenamed' THEN
+            UPDATE tokens_projection
+            SET name = event.data->>'name',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenUsed' THEN
+            UPDATE tokens_projection
+            SET current_uses = current_uses + 1,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenDisabled' THEN
+            UPDATE tokens_projection
+            SET disabled = TRUE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenEnabled' THEN
+            UPDATE tokens_projection
+            SET disabled = FALSE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'TokenDeleted' THEN
+            UPDATE tokens_projection
+            SET is_deleted = TRUE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/tokens.sql
+++ b/internal/store/queries/tokens.sql
@@ -36,3 +36,52 @@ WHERE value_hash = $1
   AND disabled = FALSE
   AND (expires_at IS NULL OR expires_at > NOW())
   AND (max_uses = 0 OR current_uses < max_uses);
+
+-- name: InsertTokenProjection :exec
+-- TokenCreated handler. ON CONFLICT DO NOTHING for replay safety —
+-- the reconciler may re-deliver the event; if a row already exists
+-- under the same id, leave it alone. Composite-key partials
+-- (TokenRenamed/Used/etc) own subsequent mutations.
+INSERT INTO tokens_projection (
+    id, value_hash, name, one_time, max_uses, expires_at,
+    created_at, created_by, owner_id, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: RenameTokenProjection :exec
+-- TokenRenamed handler. projection_version guard rejects stale
+-- reconciler replays.
+UPDATE tokens_projection
+SET name              = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: IncrementTokenUseProjection :exec
+-- TokenUsed handler. Uses current_uses + 1 (matches PL/pgSQL); a
+-- duplicate event from the reconciler would erroneously bump the
+-- counter twice without the projection_version guard, so the guard
+-- is load-bearing here, not just defensive.
+UPDATE tokens_projection
+SET current_uses      = current_uses + 1,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2;
+
+-- name: SetTokenDisabledProjection :exec
+-- TokenDisabled / TokenEnabled handler — same shape, parameterised
+-- on the disabled bool. Listener picks the bool per event_type.
+UPDATE tokens_projection
+SET disabled          = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: SoftDeleteTokenProjection :exec
+-- TokenDeleted handler. Marks the row deleted; row stays so audit
+-- queries can resolve token names by id.
+UPDATE tokens_projection
+SET is_deleted        = TRUE,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2;


### PR DESCRIPTION
## Summary

Eighth port under the projector-migration pattern. Replaces `project_token_event` PL/pgSQL with `projectors.TokenListener`.

Six event types, each a single statement:
- `TokenCreated` — INSERT … ON CONFLICT DO NOTHING (replay-safe)
- `TokenRenamed` — UPDATE name
- `TokenUsed` — UPDATE current_uses += 1
- `TokenDisabled` — UPDATE disabled = TRUE
- `TokenEnabled` — UPDATE disabled = FALSE
- `TokenDeleted` — UPDATE is_deleted = TRUE

Tightening: every UPDATE has a `WHERE projection_version < $N` guard rejecting stale reconciler replays. Load-bearing for `TokenUsed` since a duplicate replay would erroneously bump current_uses twice.

> ⚠️ **Known issue (#125):** the `tokens` entry in `AllRebuildTargets` will dispatch to the no-op stub after this PR merges, breaking emergency rebuild via `RebuildAll(ctx, "tokens")`. Same pattern affects `roles` (already broken since #101) and will affect `user_selections` after #106. Tracked separately at #125; the fix is to dispatch via the Go listener pipeline in `runOneTarget`.

## Read-your-writes preserved

`token_handler.{Create,Rename,SetDisabled,Delete}Token` reads back from `tokens_projection` AFTER `AppendEvent` returns. `fireListeners` is synchronous, so the listener has already executed.

## Test plan

Tests written FIRST per saved TDD feedback.

- [x] Pure decoders: happy paths, defaults (name/one_time/max_uses/expires_at/owner_id), required value_hash, wrong stream/event type
- [x] Integration: full Create→Rename→Use(2x)→Disable→Enable→Delete lifecycle, current_uses increments, projection_version stale-replay guard, wrong-stream-type ignored
- [x] All tests pass locally (`go test ./server/internal/projectors/...`)

Refs tracker #107. Closes #103.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server-side token projection and lifecycle: create, rename, use counting, disable/enable, and soft-delete with replay/version guards.
* **Refactor**
  * Token projection moved into the Go projector layer for runtime-driven projections.
* **Tests**
  * Comprehensive tests for event decoding, listener lifecycle, stale-replay protection, and deletion semantics.
* **Chores**
  * Migration updated to wire the new projector at runtime (with down-path restoring previous DB-side logic).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->