### PR TITLE
feat: port project_identity_provider_event to Go listener (#104)

### DIFF
--- a/internal/projectors/identity_provider.go
+++ b/internal/projectors/identity_provider.go
@@ -74,6 +74,21 @@ type IdentityProviderUpdatedPayload struct {
 	GroupMapping             []byte // nil if absent; raw JSONB bytes if present
 }
 
+// LogValue mirrors the Created variant's masking on
+// ClientSecretEncrypted. The listener doesn't currently log this
+// payload directly, but symmetry keeps the safety from regressing
+// if a future caller adds `slog.Any("payload", payload)` to a Warn.
+// "[REDACTED]" only emitted when the secret was set in the payload
+// — nil-pointer "not present" stays nil so log readers can tell the
+// update didn't touch the secret.
+func (p IdentityProviderUpdatedPayload) LogValue() slog.Value {
+	attrs := []slog.Attr{slog.String("id", p.ID)}
+	if p.ClientSecretEncrypted != nil {
+		attrs = append(attrs, slog.String("client_secret_encrypted", "[REDACTED]"))
+	}
+	return slog.GroupValue(attrs...)
+}
+
 // IdentityLinkPayload covers IdentityLinked + IdentityLinkLoginUpdated.
 // Both reference (provider_id, external_id) as the lookup key.
 type IdentityLinkPayload struct {

--- a/internal/projectors/identity_provider.go
+++ b/internal/projectors/identity_provider.go
@@ -1,0 +1,341 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// IdentityProviderCreatedPayload represents the decoded shape of an
+// IdentityProviderCreated event. Pointers + zero-value defaults
+// mirror the PL/pgSQL projector's COALESCE/`CASE WHEN ... IS NOT NULL`
+// behaviour: missing optional fields land at the same defaults the
+// PL/pgSQL version produced.
+type IdentityProviderCreatedPayload struct {
+	ID                       string
+	Name                     string
+	Slug                     string
+	ProviderType             string
+	ClientID                 string
+	ClientSecretEncrypted    string
+	IssuerURL                string
+	AuthorizationURL         string
+	TokenURL                 string
+	UserinfoURL              string
+	Scopes                   []string
+	AutoCreateUsers          bool
+	AutoLinkByEmail          bool
+	DefaultRoleID            string
+	DisablePasswordForLinked bool
+	GroupClaim               string
+	GroupMapping             []byte // raw JSONB bytes; preserved as-sent
+	CreatedBy                string
+}
+
+// LogValue masks the encrypted client secret when the payload is
+// dumped to structured logs. Mirrors the LpsPasswordRotatedPayload /
+// LuksKeyRotatedPayload pattern.
+func (p IdentityProviderCreatedPayload) LogValue() slog.Value {
+	return slog.GroupValue(
+		slog.String("id", p.ID),
+		slog.String("name", p.Name),
+		slog.String("slug", p.Slug),
+		slog.String("provider_type", p.ProviderType),
+		slog.String("client_id", p.ClientID),
+		slog.String("client_secret_encrypted", "[REDACTED]"),
+		slog.String("issuer_url", p.IssuerURL),
+	)
+}
+
+// IdentityProviderUpdatedPayload — partial update with pointer fields
+// that distinguish "field present" from "field omitted". The
+// PL/pgSQL projector mixes COALESCE (preserve on NULL) and
+// `COALESCE(NULLIF(payload, ''), existing)` (preserve on missing OR
+// empty-string) per field; we collapse empty-string to nil at the
+// listener layer for the NULLIF-shaped fields.
+type IdentityProviderUpdatedPayload struct {
+	ID                       string
+	Name                     *string
+	Enabled                  *bool
+	ClientID                 *string // NULLIF — empty collapsed to nil
+	ClientSecretEncrypted    *string // NULLIF
+	IssuerURL                *string // NULLIF
+	AuthorizationURL         *string
+	TokenURL                 *string
+	UserinfoURL              *string
+	Scopes                   *[]string
+	AutoCreateUsers          *bool
+	AutoLinkByEmail          *bool
+	DefaultRoleID            *string
+	DisablePasswordForLinked *bool
+	GroupClaim               *string
+	GroupMapping             []byte // nil if absent; raw JSONB bytes if present
+}
+
+// IdentityLinkPayload covers IdentityLinked + IdentityLinkLoginUpdated.
+// Both reference (provider_id, external_id) as the lookup key.
+type IdentityLinkPayload struct {
+	ID            string // event.stream_id (the link's id)
+	UserID        string
+	ProviderID    string
+	ExternalID    string
+	ExternalEmail string
+	ExternalName  string
+}
+
+// SCIMTokenPayload covers IdentityProviderSCIMEnabled +
+// IdentityProviderSCIMTokenRotated. Both carry a scim_token_hash.
+type SCIMTokenPayload struct {
+	ID            string
+	ScimTokenHash string
+}
+
+type idpCreatedRaw struct {
+	Name                     string          `json:"name"`
+	Slug                     string          `json:"slug"`
+	ProviderType             *string         `json:"provider_type,omitempty"`
+	ClientID                 string          `json:"client_id"`
+	ClientSecretEncrypted    *string         `json:"client_secret_encrypted,omitempty"`
+	IssuerURL                string          `json:"issuer_url"`
+	AuthorizationURL         *string         `json:"authorization_url,omitempty"`
+	TokenURL                 *string         `json:"token_url,omitempty"`
+	UserinfoURL              *string         `json:"userinfo_url,omitempty"`
+	Scopes                   *[]string       `json:"scopes,omitempty"`
+	AutoCreateUsers          *bool           `json:"auto_create_users,omitempty"`
+	AutoLinkByEmail          *bool           `json:"auto_link_by_email,omitempty"`
+	DefaultRoleID            *string         `json:"default_role_id,omitempty"`
+	DisablePasswordForLinked *bool           `json:"disable_password_for_linked,omitempty"`
+	GroupClaim               *string         `json:"group_claim,omitempty"`
+	GroupMapping             json.RawMessage `json:"group_mapping,omitempty"`
+}
+
+// IdentityProviderCreatedFromEvent decodes IdentityProviderCreated.
+// Returns ErrIgnoredEvent for any other (stream, event_type).
+func IdentityProviderCreatedFromEvent(e store.PersistedEvent) (IdentityProviderCreatedPayload, error) {
+	if e.StreamType != "identity_provider" || e.EventType != "IdentityProviderCreated" {
+		return IdentityProviderCreatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return IdentityProviderCreatedPayload{}, fmt.Errorf("projector: empty IdentityProviderCreated payload")
+	}
+	var raw idpCreatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return IdentityProviderCreatedPayload{}, fmt.Errorf("projector: invalid IdentityProviderCreated payload: %w", err)
+	}
+	switch {
+	case raw.Name == "":
+		return IdentityProviderCreatedPayload{}, fmt.Errorf("projector: IdentityProviderCreated requires name")
+	case raw.Slug == "":
+		return IdentityProviderCreatedPayload{}, fmt.Errorf("projector: IdentityProviderCreated requires slug")
+	case raw.ClientID == "":
+		return IdentityProviderCreatedPayload{}, fmt.Errorf("projector: IdentityProviderCreated requires client_id")
+	case raw.IssuerURL == "":
+		return IdentityProviderCreatedPayload{}, fmt.Errorf("projector: IdentityProviderCreated requires issuer_url")
+	}
+	out := IdentityProviderCreatedPayload{
+		ID:           e.StreamID,
+		Name:         raw.Name,
+		Slug:         raw.Slug,
+		ProviderType: "oidc",
+		ClientID:     raw.ClientID,
+		IssuerURL:    raw.IssuerURL,
+		Scopes:       []string{},
+		CreatedBy:    e.ActorID,
+		GroupMapping: []byte("{}"),
+	}
+	if raw.ProviderType != nil && *raw.ProviderType != "" {
+		out.ProviderType = *raw.ProviderType
+	}
+	if raw.ClientSecretEncrypted != nil {
+		out.ClientSecretEncrypted = *raw.ClientSecretEncrypted
+	}
+	if raw.AuthorizationURL != nil {
+		out.AuthorizationURL = *raw.AuthorizationURL
+	}
+	if raw.TokenURL != nil {
+		out.TokenURL = *raw.TokenURL
+	}
+	if raw.UserinfoURL != nil {
+		out.UserinfoURL = *raw.UserinfoURL
+	}
+	if raw.Scopes != nil {
+		out.Scopes = *raw.Scopes
+	}
+	if raw.AutoCreateUsers != nil {
+		out.AutoCreateUsers = *raw.AutoCreateUsers
+	}
+	if raw.AutoLinkByEmail != nil {
+		out.AutoLinkByEmail = *raw.AutoLinkByEmail
+	}
+	if raw.DefaultRoleID != nil {
+		out.DefaultRoleID = *raw.DefaultRoleID
+	}
+	if raw.DisablePasswordForLinked != nil {
+		out.DisablePasswordForLinked = *raw.DisablePasswordForLinked
+	}
+	if raw.GroupClaim != nil {
+		out.GroupClaim = *raw.GroupClaim
+	}
+	if len(raw.GroupMapping) > 0 {
+		out.GroupMapping = raw.GroupMapping
+	}
+	return out, nil
+}
+
+type idpUpdatedRaw struct {
+	Name                     *string         `json:"name,omitempty"`
+	Enabled                  *bool           `json:"enabled,omitempty"`
+	ClientID                 *string         `json:"client_id,omitempty"`
+	ClientSecretEncrypted    *string         `json:"client_secret_encrypted,omitempty"`
+	IssuerURL                *string         `json:"issuer_url,omitempty"`
+	AuthorizationURL         *string         `json:"authorization_url,omitempty"`
+	TokenURL                 *string         `json:"token_url,omitempty"`
+	UserinfoURL              *string         `json:"userinfo_url,omitempty"`
+	Scopes                   *[]string       `json:"scopes,omitempty"`
+	AutoCreateUsers          *bool           `json:"auto_create_users,omitempty"`
+	AutoLinkByEmail          *bool           `json:"auto_link_by_email,omitempty"`
+	DefaultRoleID            *string         `json:"default_role_id,omitempty"`
+	DisablePasswordForLinked *bool           `json:"disable_password_for_linked,omitempty"`
+	GroupClaim               *string         `json:"group_claim,omitempty"`
+	GroupMapping             json.RawMessage `json:"group_mapping,omitempty"`
+}
+
+// IdentityProviderUpdatedFromEvent decodes IdentityProviderUpdated.
+// Empty-string is collapsed to nil for the NULLIF-semantic fields
+// (client_id, client_secret_encrypted, issuer_url) to match the
+// PL/pgSQL projector's `COALESCE(NULLIF(payload, ''), existing)`.
+func IdentityProviderUpdatedFromEvent(e store.PersistedEvent) (IdentityProviderUpdatedPayload, error) {
+	if e.StreamType != "identity_provider" || e.EventType != "IdentityProviderUpdated" {
+		return IdentityProviderUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := IdentityProviderUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw idpUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return IdentityProviderUpdatedPayload{}, fmt.Errorf("projector: invalid IdentityProviderUpdated payload: %w", err)
+	}
+	out.Name = raw.Name
+	out.Enabled = raw.Enabled
+	out.ClientID = nullifEmpty(raw.ClientID)
+	out.ClientSecretEncrypted = nullifEmpty(raw.ClientSecretEncrypted)
+	out.IssuerURL = nullifEmpty(raw.IssuerURL)
+	out.AuthorizationURL = raw.AuthorizationURL
+	out.TokenURL = raw.TokenURL
+	out.UserinfoURL = raw.UserinfoURL
+	out.Scopes = raw.Scopes
+	out.AutoCreateUsers = raw.AutoCreateUsers
+	out.AutoLinkByEmail = raw.AutoLinkByEmail
+	out.DefaultRoleID = raw.DefaultRoleID
+	out.DisablePasswordForLinked = raw.DisablePasswordForLinked
+	out.GroupClaim = raw.GroupClaim
+	if len(raw.GroupMapping) > 0 {
+		out.GroupMapping = raw.GroupMapping
+	}
+	return out, nil
+}
+
+// IdentityLinkedFromEvent decodes IdentityLinked. user_id, provider_id
+// and external_id are required (composite key on the projection).
+func IdentityLinkedFromEvent(e store.PersistedEvent) (IdentityLinkPayload, error) {
+	if e.StreamType != "identity_provider" || e.EventType != "IdentityLinked" {
+		return IdentityLinkPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return IdentityLinkPayload{}, fmt.Errorf("projector: empty IdentityLinked payload")
+	}
+	var raw struct {
+		UserID        string  `json:"user_id"`
+		ProviderID    string  `json:"provider_id"`
+		ExternalID    string  `json:"external_id"`
+		ExternalEmail *string `json:"external_email,omitempty"`
+		ExternalName  *string `json:"external_name,omitempty"`
+	}
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return IdentityLinkPayload{}, fmt.Errorf("projector: invalid IdentityLinked payload: %w", err)
+	}
+	switch {
+	case raw.UserID == "":
+		return IdentityLinkPayload{}, fmt.Errorf("projector: IdentityLinked requires user_id")
+	case raw.ProviderID == "":
+		return IdentityLinkPayload{}, fmt.Errorf("projector: IdentityLinked requires provider_id")
+	case raw.ExternalID == "":
+		return IdentityLinkPayload{}, fmt.Errorf("projector: IdentityLinked requires external_id")
+	}
+	out := IdentityLinkPayload{
+		ID: e.StreamID, UserID: raw.UserID, ProviderID: raw.ProviderID, ExternalID: raw.ExternalID,
+	}
+	if raw.ExternalEmail != nil {
+		out.ExternalEmail = *raw.ExternalEmail
+	}
+	if raw.ExternalName != nil {
+		out.ExternalName = *raw.ExternalName
+	}
+	return out, nil
+}
+
+// IdentityLinkLoginUpdatedFromEvent decodes IdentityLinkLoginUpdated.
+// provider_id + external_id are the lookup key; external_email and
+// external_name are NULLIF-semantic (empty preserves existing).
+func IdentityLinkLoginUpdatedFromEvent(e store.PersistedEvent) (IdentityLinkPayload, error) {
+	if e.StreamType != "identity_provider" || e.EventType != "IdentityLinkLoginUpdated" {
+		return IdentityLinkPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return IdentityLinkPayload{}, fmt.Errorf("projector: empty IdentityLinkLoginUpdated payload")
+	}
+	var raw struct {
+		ProviderID    string `json:"provider_id"`
+		ExternalID    string `json:"external_id"`
+		ExternalEmail string `json:"external_email"`
+		ExternalName  string `json:"external_name"`
+	}
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return IdentityLinkPayload{}, fmt.Errorf("projector: invalid IdentityLinkLoginUpdated payload: %w", err)
+	}
+	switch {
+	case raw.ProviderID == "":
+		return IdentityLinkPayload{}, fmt.Errorf("projector: IdentityLinkLoginUpdated requires provider_id")
+	case raw.ExternalID == "":
+		return IdentityLinkPayload{}, fmt.Errorf("projector: IdentityLinkLoginUpdated requires external_id")
+	}
+	return IdentityLinkPayload{
+		ID:            e.StreamID,
+		ProviderID:    raw.ProviderID,
+		ExternalID:    raw.ExternalID,
+		ExternalEmail: raw.ExternalEmail,
+		ExternalName:  raw.ExternalName,
+	}, nil
+}
+
+// SCIMTokenFromEvent decodes IdentityProviderSCIMEnabled or
+// IdentityProviderSCIMTokenRotated. Both carry the same shape;
+// a single decoder + caller-side dispatch keeps the listener clean.
+func SCIMTokenFromEvent(e store.PersistedEvent, eventType string) (SCIMTokenPayload, error) {
+	if e.StreamType != "identity_provider" || e.EventType != eventType {
+		return SCIMTokenPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return SCIMTokenPayload{}, fmt.Errorf("projector: empty %s payload", eventType)
+	}
+	var raw struct {
+		ScimTokenHash string `json:"scim_token_hash"`
+	}
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return SCIMTokenPayload{}, fmt.Errorf("projector: invalid %s payload: %w", eventType, err)
+	}
+	if raw.ScimTokenHash == "" {
+		return SCIMTokenPayload{}, fmt.Errorf("projector: %s requires scim_token_hash", eventType)
+	}
+	return SCIMTokenPayload{ID: e.StreamID, ScimTokenHash: raw.ScimTokenHash}, nil
+}
+
+func nullifEmpty(p *string) *string {
+	if p == nil || *p == "" {
+		return nil
+	}
+	return p
+}

--- a/internal/projectors/identity_provider_listener.go
+++ b/internal/projectors/identity_provider_listener.go
@@ -263,8 +263,8 @@ func applyIdentityLinkLoginUpdated(ctx context.Context, st *store.Store, logger 
 		ProviderID:        payload.ProviderID,
 		ExternalID:        payload.ExternalID,
 		LastLoginAt:       &loginAt,
-		Column4:           payload.ExternalEmail,
-		Column5:           payload.ExternalName,
+		ExternalEmail:     payload.ExternalEmail,
+		ExternalName:      payload.ExternalName,
 		ProjectionVersion: deref(e.SequenceNum),
 	}); err != nil {
 		logger.Warn("identity_provider projector: failed to update identity_link login",

--- a/internal/projectors/identity_provider_listener.go
+++ b/internal/projectors/identity_provider_listener.go
@@ -1,0 +1,280 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// IdentityProviderListener returns a store.EventListener that applies
+// every identity_provider stream event the deleted PL/pgSQL
+// project_identity_provider_event handled. Nine event types — the
+// largest projector in tracker #107.
+//
+// Event-type families:
+//   - IdP CRUD: Created (INSERT), Updated (partial UPDATE),
+//     Deleted (soft + cascade DELETE on identity_links + scim_group_mapping).
+//   - SCIM toggles: SCIMEnabled, SCIMDisabled (cascade DELETE on
+//     scim_group_mapping), SCIMTokenRotated.
+//   - Identity links: IdentityLinked (UPSERT), IdentityLinkLoginUpdated,
+//     IdentityUnlinked (DELETE).
+//
+// Multi-write listeners (Deleted, SCIMDisabled) follow the
+// asymmetric-guard discipline: the guarded UPDATE is :execrows, and
+// the listener short-circuits the cascade DELETE when n == 0
+// (stale projection_version replay).
+//
+// Wired in projectors.WireAll. Refs #104, tracker #107.
+func IdentityProviderListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "identity_provider" {
+			return
+		}
+		switch e.EventType {
+		case "IdentityProviderCreated":
+			applyIdentityProviderCreated(ctx, st, logger, e)
+		case "IdentityProviderUpdated":
+			applyIdentityProviderUpdated(ctx, st, logger, e)
+		case "IdentityProviderDeleted":
+			applyIdentityProviderDeleted(ctx, st, logger, e)
+		case "IdentityProviderSCIMEnabled":
+			applyIdentityProviderSCIMEnabled(ctx, st, logger, e)
+		case "IdentityProviderSCIMDisabled":
+			applyIdentityProviderSCIMDisabled(ctx, st, logger, e)
+		case "IdentityProviderSCIMTokenRotated":
+			applyIdentityProviderSCIMTokenRotated(ctx, st, logger, e)
+		case "IdentityLinked":
+			applyIdentityLinked(ctx, st, logger, e)
+		case "IdentityLinkLoginUpdated":
+			applyIdentityLinkLoginUpdated(ctx, st, logger, e)
+		case "IdentityUnlinked":
+			applyIdentityUnlinked(ctx, st, logger, e)
+		}
+	}
+}
+
+func applyIdentityProviderCreated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := IdentityProviderCreatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("identity_provider projector: invalid IdentityProviderCreated payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().InsertIdentityProviderProjection(ctx, db.InsertIdentityProviderProjectionParams{
+		ID:                       payload.ID,
+		Name:                     payload.Name,
+		Slug:                     payload.Slug,
+		ProviderType:             payload.ProviderType,
+		ClientID:                 payload.ClientID,
+		ClientSecretEncrypted:    payload.ClientSecretEncrypted,
+		IssuerUrl:                payload.IssuerURL,
+		AuthorizationUrl:         payload.AuthorizationURL,
+		TokenUrl:                 payload.TokenURL,
+		UserinfoUrl:              payload.UserinfoURL,
+		Scopes:                   payload.Scopes,
+		AutoCreateUsers:          payload.AutoCreateUsers,
+		AutoLinkByEmail:          payload.AutoLinkByEmail,
+		DefaultRoleID:            payload.DefaultRoleID,
+		DisablePasswordForLinked: payload.DisablePasswordForLinked,
+		GroupClaim:               payload.GroupClaim,
+		GroupMapping:             payload.GroupMapping,
+		CreatedAt:                e.OccurredAt,
+		CreatedBy:                payload.CreatedBy,
+		ProjectionVersion:        deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("identity_provider projector: failed to insert IdentityProviderCreated",
+			"event_id", e.ID, "idp_id", payload.ID, "error", err)
+	}
+}
+
+func applyIdentityProviderUpdated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := IdentityProviderUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("identity_provider projector: invalid IdentityProviderUpdated payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().UpdateIdentityProviderProjection(ctx, db.UpdateIdentityProviderProjectionParams{
+		ID:                       payload.ID,
+		Name:                     payload.Name,
+		Enabled:                  payload.Enabled,
+		ClientID:                 payload.ClientID,
+		ClientSecretEncrypted:    payload.ClientSecretEncrypted,
+		IssuerUrl:                payload.IssuerURL,
+		AuthorizationUrl:         payload.AuthorizationURL,
+		TokenUrl:                 payload.TokenURL,
+		UserinfoUrl:              payload.UserinfoURL,
+		Scopes:                   derefSlice(payload.Scopes),
+		AutoCreateUsers:          payload.AutoCreateUsers,
+		AutoLinkByEmail:          payload.AutoLinkByEmail,
+		DefaultRoleID:            payload.DefaultRoleID,
+		DisablePasswordForLinked: payload.DisablePasswordForLinked,
+		GroupClaim:               payload.GroupClaim,
+		GroupMapping:             payload.GroupMapping,
+		UpdatedAt:                e.OccurredAt,
+		ProjectionVersion:        deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("identity_provider projector: failed to apply IdentityProviderUpdated",
+			"event_id", e.ID, "idp_id", payload.ID, "error", err)
+	}
+}
+
+func applyIdentityProviderDeleted(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	idpID := e.StreamID
+	if err := st.WithTx(ctx, func(q *store.Queries) error {
+		// Asymmetric-guard rule: SoftDelete is guarded by
+		// projection_version; cascades are not. Short-circuit on
+		// n == 0 (stale replay) to keep memberships + mappings.
+		n, err := q.SoftDeleteIdentityProviderProjection(ctx, db.SoftDeleteIdentityProviderProjectionParams{
+			ID:                idpID,
+			UpdatedAt:         e.OccurredAt,
+			ProjectionVersion: deref(e.SequenceNum),
+		})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return nil
+		}
+		if err := q.DeleteIdentityLinksByProvider(ctx, idpID); err != nil {
+			return err
+		}
+		return q.DeleteSCIMGroupMappingsByProvider(ctx, idpID)
+	}); err != nil {
+		logger.Warn("identity_provider projector: failed to apply IdentityProviderDeleted",
+			"event_id", e.ID, "idp_id", idpID, "error", err)
+	}
+}
+
+func applyIdentityProviderSCIMEnabled(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := SCIMTokenFromEvent(e, "IdentityProviderSCIMEnabled")
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("identity_provider projector: invalid IdentityProviderSCIMEnabled payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().SetIdentityProviderSCIMEnabled(ctx, db.SetIdentityProviderSCIMEnabledParams{
+		ID:                payload.ID,
+		ScimTokenHash:     payload.ScimTokenHash,
+		UpdatedAt:         e.OccurredAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("identity_provider projector: failed to enable SCIM",
+			"event_id", e.ID, "idp_id", payload.ID, "error", err)
+	}
+}
+
+func applyIdentityProviderSCIMDisabled(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	idpID := e.StreamID
+	if err := st.WithTx(ctx, func(q *store.Queries) error {
+		// Same asymmetric-guard discipline: cascade only if the
+		// guarded SCIM-disable UPDATE actually flipped a row.
+		n, err := q.SetIdentityProviderSCIMDisabled(ctx, db.SetIdentityProviderSCIMDisabledParams{
+			ID:                idpID,
+			UpdatedAt:         e.OccurredAt,
+			ProjectionVersion: deref(e.SequenceNum),
+		})
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return nil
+		}
+		return q.DeleteSCIMGroupMappingsByProvider(ctx, idpID)
+	}); err != nil {
+		logger.Warn("identity_provider projector: failed to disable SCIM",
+			"event_id", e.ID, "idp_id", idpID, "error", err)
+	}
+}
+
+func applyIdentityProviderSCIMTokenRotated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := SCIMTokenFromEvent(e, "IdentityProviderSCIMTokenRotated")
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("identity_provider projector: invalid IdentityProviderSCIMTokenRotated payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().RotateIdentityProviderSCIMToken(ctx, db.RotateIdentityProviderSCIMTokenParams{
+		ID:                payload.ID,
+		ScimTokenHash:     payload.ScimTokenHash,
+		UpdatedAt:         e.OccurredAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("identity_provider projector: failed to rotate SCIM token",
+			"event_id", e.ID, "idp_id", payload.ID, "error", err)
+	}
+}
+
+func applyIdentityLinked(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := IdentityLinkedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("identity_provider projector: invalid IdentityLinked payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().UpsertIdentityLink(ctx, db.UpsertIdentityLinkParams{
+		ID:                payload.ID,
+		UserID:            payload.UserID,
+		ProviderID:        payload.ProviderID,
+		ExternalID:        payload.ExternalID,
+		ExternalEmail:     payload.ExternalEmail,
+		ExternalName:      payload.ExternalName,
+		LinkedAt:          e.OccurredAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("identity_provider projector: failed to upsert identity_link",
+			"event_id", e.ID, "link_id", payload.ID, "error", err)
+	}
+}
+
+func applyIdentityLinkLoginUpdated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := IdentityLinkLoginUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("identity_provider projector: invalid IdentityLinkLoginUpdated payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	loginAt := e.OccurredAt
+	if err := st.Queries().UpdateIdentityLinkLogin(ctx, db.UpdateIdentityLinkLoginParams{
+		ProviderID:        payload.ProviderID,
+		ExternalID:        payload.ExternalID,
+		LastLoginAt:       &loginAt,
+		Column4:           payload.ExternalEmail,
+		Column5:           payload.ExternalName,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("identity_provider projector: failed to update identity_link login",
+			"event_id", e.ID, "provider_id", payload.ProviderID, "external_id", payload.ExternalID, "error", err)
+	}
+}
+
+func applyIdentityUnlinked(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	if err := st.Queries().DeleteIdentityLinkByID(ctx, e.StreamID); err != nil {
+		logger.Warn("identity_provider projector: failed to delete identity_link",
+			"event_id", e.ID, "link_id", e.StreamID, "error", err)
+	}
+}

--- a/internal/projectors/identity_provider_test.go
+++ b/internal/projectors/identity_provider_test.go
@@ -1,0 +1,481 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestIdentityProviderCreatedFromEvent_Pure exercises the decoder
+// for IdentityProviderCreated. PL/pgSQL defaulted: provider_type='oidc',
+// scopes='{}', auto_create_users=FALSE, auto_link_by_email=FALSE,
+// default_role_id='', etc. Pointer fields on the encrypted secret
+// preserve the empty-vs-omitted distinction.
+func TestIdentityProviderCreatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.IdentityProviderCreatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "idp-1",
+			EventType: "IdentityProviderCreated", ActorID: "actor-1",
+			Data: jsonOrFail(t, map[string]any{
+				"name":                        "Google",
+				"slug":                        "google",
+				"provider_type":               "oidc",
+				"client_id":                   "client-abc",
+				"client_secret_encrypted":     "ENC:secret",
+				"issuer_url":                  "https://accounts.google.com",
+				"authorization_url":           "https://oauth/auth",
+				"token_url":                   "https://oauth/token",
+				"userinfo_url":                "https://oauth/userinfo",
+				"scopes":                      []string{"openid", "email", "profile"},
+				"auto_create_users":           true,
+				"auto_link_by_email":          true,
+				"default_role_id":             "role-default",
+				"disable_password_for_linked": true,
+				"group_claim":                 "groups",
+				"group_mapping":               map[string]string{"engineering": "group-eng"},
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "idp-1", got.ID)
+		assert.Equal(t, "Google", got.Name)
+		assert.Equal(t, "google", got.Slug)
+		assert.Equal(t, "oidc", got.ProviderType)
+		assert.Equal(t, "client-abc", got.ClientID)
+		assert.Equal(t, "ENC:secret", got.ClientSecretEncrypted)
+		assert.Equal(t, "https://accounts.google.com", got.IssuerURL)
+		assert.Equal(t, []string{"openid", "email", "profile"}, got.Scopes)
+		assert.True(t, got.AutoCreateUsers)
+		assert.True(t, got.AutoLinkByEmail)
+		assert.Equal(t, "role-default", got.DefaultRoleID)
+		assert.True(t, got.DisablePasswordForLinked)
+		assert.Equal(t, "groups", got.GroupClaim)
+		assert.NotEmpty(t, got.GroupMapping, "group_mapping JSONB round-trips")
+		assert.Equal(t, "actor-1", got.CreatedBy)
+	})
+
+	t.Run("defaults: provider_type='oidc', scopes empty, bools false, strings empty", func(t *testing.T) {
+		got, err := projectors.IdentityProviderCreatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "idp-2",
+			EventType: "IdentityProviderCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{
+				"name":       "Bare",
+				"slug":       "bare",
+				"client_id":  "c",
+				"issuer_url": "https://example.com",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "oidc", got.ProviderType, "provider_type defaults to 'oidc'")
+		assert.Equal(t, "", got.ClientSecretEncrypted)
+		assert.Equal(t, []string{}, got.Scopes)
+		assert.False(t, got.AutoCreateUsers)
+		assert.False(t, got.AutoLinkByEmail)
+		assert.Equal(t, "", got.DefaultRoleID)
+		assert.False(t, got.DisablePasswordForLinked)
+		assert.Equal(t, "", got.GroupClaim)
+	})
+
+	t.Run("required fields validated", func(t *testing.T) {
+		base := map[string]any{
+			"name":       "X",
+			"slug":       "x",
+			"client_id":  "c",
+			"issuer_url": "https://x.example.com",
+		}
+		for _, drop := range []string{"name", "slug", "client_id", "issuer_url"} {
+			t.Run("missing "+drop, func(t *testing.T) {
+				payload := map[string]any{}
+				for k, v := range base {
+					if k == drop {
+						continue
+					}
+					payload[k] = v
+				}
+				_, err := projectors.IdentityProviderCreatedFromEvent(store.PersistedEvent{
+					StreamType: "identity_provider", StreamID: "idp-x",
+					EventType: "IdentityProviderCreated", ActorID: "u",
+					Data: jsonOrFail(t, payload),
+				})
+				require.Error(t, err)
+				assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+				assert.Contains(t, err.Error(), drop)
+			})
+		}
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.IdentityProviderCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "IdentityProviderCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.IdentityProviderCreatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", EventType: "IdentityProviderUpdated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestIdentityProviderListener_FullLifecycle walks Create → Update →
+// SCIM Enable → SCIM TokenRotated → SCIM Disable → Delete and asserts
+// the projection state at each step.
+func TestIdentityProviderListener_FullLifecycle(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	idpID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderCreated",
+		Data: map[string]any{
+			"name":       "test-idp",
+			"slug":       "test-" + testutil.NewID(),
+			"client_id":  "c",
+			"issuer_url": "https://idp.example.com",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	idp, err := st.Queries().GetIdentityProviderByID(ctx, idpID)
+	require.NoError(t, err)
+	assert.Equal(t, "test-idp", idp.Name)
+	assert.True(t, idp.Enabled, "newly-created IdP starts enabled")
+	assert.False(t, idp.IsDeleted)
+	assert.False(t, idp.ScimEnabled)
+
+	// Update name + flip enabled.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderUpdated",
+		Data: map[string]any{"name": "renamed", "enabled": false},
+		ActorType: "user", ActorID: "u",
+	}))
+	idp, err = st.Queries().GetIdentityProviderByID(ctx, idpID)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", idp.Name)
+	assert.False(t, idp.Enabled)
+	assert.Equal(t, "c", idp.ClientID, "client_id preserved (omitted)")
+
+	// SCIM Enable.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderSCIMEnabled",
+		Data:      map[string]any{"scim_token_hash": "hash-1"},
+		ActorType: "user", ActorID: "u",
+	}))
+	idp, err = st.Queries().GetIdentityProviderByID(ctx, idpID)
+	require.NoError(t, err)
+	assert.True(t, idp.ScimEnabled)
+	assert.Equal(t, "hash-1", idp.ScimTokenHash)
+
+	// Token rotate.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderSCIMTokenRotated",
+		Data:      map[string]any{"scim_token_hash": "hash-2"},
+		ActorType: "user", ActorID: "u",
+	}))
+	idp, err = st.Queries().GetIdentityProviderByID(ctx, idpID)
+	require.NoError(t, err)
+	assert.True(t, idp.ScimEnabled, "rotation does not disable")
+	assert.Equal(t, "hash-2", idp.ScimTokenHash)
+
+	// SCIM Disable.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderSCIMDisabled",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+	idp, err = st.Queries().GetIdentityProviderByID(ctx, idpID)
+	require.NoError(t, err)
+	assert.False(t, idp.ScimEnabled)
+	assert.Equal(t, "", idp.ScimTokenHash, "token cleared on disable")
+
+	// Delete.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+	_, err = st.Queries().GetIdentityProviderByID(ctx, idpID)
+	require.Error(t, err, "GetIdentityProviderByID excludes is_deleted=TRUE rows")
+
+	var isDeleted, enabled, scimEnabled bool
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT is_deleted, enabled, scim_enabled FROM identity_providers_projection WHERE id = $1", idpID,
+	).Scan(&isDeleted, &enabled, &scimEnabled))
+	assert.True(t, isDeleted)
+	assert.False(t, enabled, "delete also flips enabled to FALSE")
+	assert.False(t, scimEnabled, "delete also flips scim_enabled to FALSE")
+}
+
+// TestIdentityProviderListener_DeleteCascadesIdentityLinksAndSCIM
+// confirms IdentityProviderDeleted cleans up identity_links_projection
+// AND scim_group_mapping_projection rows referencing this provider,
+// inside store.WithTx so the projection never observes the
+// "provider deleted but child rows linger" intermediate state.
+func TestIdentityProviderListener_DeleteCascadesIdentityLinksAndSCIM(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	idpID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderCreated",
+		Data: map[string]any{
+			"name": "x", "slug": "x-" + testutil.NewID(),
+			"client_id": "c", "issuer_url": "https://x.example.com",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Plant an identity_links row + scim_group_mapping row.
+	_, err := st.Pool().Exec(ctx,
+		"INSERT INTO identity_links_projection (id, user_id, provider_id, external_id) VALUES ($1, $2, $3, $4)",
+		"link-"+testutil.NewID(), userID, idpID, "ext-1",
+	)
+	require.NoError(t, err)
+	groupID := testutil.CreateTestUserGroup(t, st, "actor", "test-group")
+	_, err = st.Pool().Exec(ctx,
+		"INSERT INTO scim_group_mapping_projection (id, provider_id, scim_group_id, user_group_id) VALUES ($1, $2, $3, $4)",
+		"mapping-"+testutil.NewID(), idpID, "sg-1", groupID,
+	)
+	require.NoError(t, err)
+
+	// Delete the IdP.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM identity_links_projection WHERE provider_id = $1", idpID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "identity_links_projection rows for the deleted IdP are removed")
+
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id = $1", idpID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "scim_group_mapping_projection rows for the deleted IdP are removed")
+}
+
+// TestIdentityProviderListener_SCIMDisableCascadesGroupMappings
+// confirms IdentityProviderSCIMDisabled clears the scim_group_mapping
+// rows for this provider — operators expect re-enabling SCIM to
+// require fresh group mapping configuration.
+func TestIdentityProviderListener_SCIMDisableCascadesGroupMappings(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	idpID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderCreated",
+		Data: map[string]any{
+			"name": "x", "slug": "x-" + testutil.NewID(),
+			"client_id": "c", "issuer_url": "https://x.example.com",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	groupID := testutil.CreateTestUserGroup(t, st, "actor", "test-group-scim")
+	_, err := st.Pool().Exec(ctx,
+		"INSERT INTO scim_group_mapping_projection (id, provider_id, scim_group_id, user_group_id) VALUES ($1, $2, $3, $4)",
+		"mapping-"+testutil.NewID(), idpID, "sg-x", groupID,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderSCIMDisabled",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id = $1", idpID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "SCIM disable wipes group mappings for that provider")
+}
+
+// TestIdentityLinkListener_LinkUpdateUnlink walks IdentityLinked →
+// IdentityLinkLoginUpdated → IdentityUnlinked.
+func TestIdentityLinkListener_LinkUpdateUnlink(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	idpID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderCreated",
+		Data: map[string]any{
+			"name": "x", "slug": "x-" + testutil.NewID(),
+			"client_id": "c", "issuer_url": "https://x.example.com",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	linkID := "link-" + testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: linkID,
+		EventType: "IdentityLinked",
+		Data: map[string]any{
+			"user_id":        userID,
+			"provider_id":    idpID,
+			"external_id":    "ext-1",
+			"external_email": "user@external.com",
+			"external_name":  "External User",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	link, err := st.Queries().GetIdentityLinkByProviderAndExternalID(ctx, db.GetIdentityLinkByProviderAndExternalIDParams{
+		ProviderID: idpID, ExternalID: "ext-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "user@external.com", link.ExternalEmail)
+	assert.Equal(t, "External User", link.ExternalName)
+
+	// Re-link with login update (UPSERT path).
+	time.Sleep(10 * time.Millisecond) // ensure distinct timestamp
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: linkID,
+		EventType: "IdentityLinkLoginUpdated",
+		Data: map[string]any{
+			"provider_id":    idpID,
+			"external_id":    "ext-1",
+			"external_name":  "Updated Name",
+		},
+		ActorType: "user", ActorID: userID,
+	}))
+	link, err = st.Queries().GetIdentityLinkByProviderAndExternalID(ctx, db.GetIdentityLinkByProviderAndExternalIDParams{
+		ProviderID: idpID, ExternalID: "ext-1",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "Updated Name", link.ExternalName)
+	assert.Equal(t, "user@external.com", link.ExternalEmail, "external_email preserved (omitted via NULLIF)")
+
+	// Unlink.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: linkID,
+		EventType: "IdentityUnlinked",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: userID,
+	}))
+	_, err = st.Queries().GetIdentityLinkByProviderAndExternalID(ctx, db.GetIdentityLinkByProviderAndExternalIDParams{
+		ProviderID: idpID, ExternalID: "ext-1",
+	})
+	require.Error(t, err, "IdentityUnlinked removes the row")
+}
+
+// TestIdentityProviderListener_StaleDeleteReplay regression-locks the
+// asymmetric-guard rule from `feedback_projector_multiwrite_guard_asymmetry`:
+// IdentityProviderDeleted's SoftDelete update is guarded by
+// projection_version, but the cascade DELETEs on identity_links and
+// scim_group_mapping are unguarded. Listener must short-circuit when
+// soft-delete affects 0 rows.
+func TestIdentityProviderListener_StaleDeleteReplay(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	idpID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+
+	// Land + update so projection_version > 0.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderCreated",
+		Data: map[string]any{
+			"name": "live", "slug": "live-" + testutil.NewID(),
+			"client_id": "c", "issuer_url": "https://x.example.com",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderUpdated",
+		Data:      map[string]any{"name": "still-live"},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetIdentityProviderByID(ctx, idpID)
+	require.NoError(t, err)
+
+	// Plant a link + mapping that a stale replay would wrongly nuke.
+	_, err = st.Pool().Exec(ctx,
+		"INSERT INTO identity_links_projection (id, user_id, provider_id, external_id) VALUES ($1, $2, $3, $4)",
+		"link-"+testutil.NewID(), userID, idpID, "ext-2",
+	)
+	require.NoError(t, err)
+	groupID := testutil.CreateTestUserGroup(t, st, "actor", "test-group-stale")
+	_, err = st.Pool().Exec(ctx,
+		"INSERT INTO scim_group_mapping_projection (id, provider_id, scim_group_id, user_group_id) VALUES ($1, $2, $3, $4)",
+		"mapping-"+testutil.NewID(), idpID, "sg-y", groupID,
+	)
+	require.NoError(t, err)
+
+	// Drive the listener with a stale projection_version.
+	older := live.ProjectionVersion - 5
+	listener := projectors.IdentityProviderListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "identity_provider",
+		StreamID:    idpID,
+		EventType:   "IdentityProviderDeleted",
+		Data:        []byte("{}"),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  live.CreatedAt,
+	})
+
+	// Identity link + SCIM mapping survive.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM identity_links_projection WHERE provider_id = $1", idpID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale IdentityProviderDeleted must NOT cascade-delete identity_links")
+
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id = $1", idpID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale IdentityProviderDeleted must NOT cascade-delete scim_group_mappings")
+
+	stillAlive, err := st.Queries().GetIdentityProviderByID(ctx, idpID)
+	require.NoError(t, err)
+	assert.False(t, stillAlive.IsDeleted)
+}
+
+// TestIdentityProviderListener_IgnoresWrongStreamType — defensive.
+func TestIdentityProviderListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	idpID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", // wrong
+		StreamID:   idpID,
+		EventType:  "IdentityProviderCreated",
+		Data: map[string]any{
+			"name": "ghost", "slug": "ghost", "client_id": "c", "issuer_url": "https://x",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	_, err := st.Queries().GetIdentityProviderByID(ctx, idpID)
+	require.Error(t, err, "wrong-stream-type IdentityProviderCreated must NOT create a row")
+}

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -60,7 +60,11 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "token_projector"),
 	))
-	// Subsequent ports under #104–#106 add their listener here.
+	st.RegisterEventListener(IdentityProviderListener(
+		st,
+		loggerFor(logger, "identity_provider_projector"),
+	))
+	// Subsequent ports under #105–#106 add their listener here.
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/identity_links.sql.go
+++ b/internal/store/generated/identity_links.sql.go
@@ -22,6 +22,17 @@ func (q *Queries) CountIdentityLinksForUser(ctx context.Context, userID string) 
 	return count, err
 }
 
+const deleteIdentityLinkByID = `-- name: DeleteIdentityLinkByID :exec
+DELETE FROM identity_links_projection WHERE id = $1
+`
+
+// IdentityUnlinked handler. Stream_id IS the link id (set by the
+// handler that emitted IdentityLinked).
+func (q *Queries) DeleteIdentityLinkByID(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, deleteIdentityLinkByID, id)
+	return err
+}
+
 const getIdentityLinkByID = `-- name: GetIdentityLinkByID :one
 SELECT id, user_id, provider_id, external_id, external_email, external_name, linked_at, last_login_at, projection_version FROM identity_links_projection
 WHERE id = $1
@@ -226,4 +237,82 @@ func (q *Queries) ListLinkedProviderIDsForUser(ctx context.Context, userID strin
 		return nil, err
 	}
 	return items, nil
+}
+
+const updateIdentityLinkLogin = `-- name: UpdateIdentityLinkLogin :exec
+UPDATE identity_links_projection
+SET last_login_at = $3,
+    external_email = COALESCE(NULLIF($4::TEXT, ''), external_email),
+    external_name = COALESCE(NULLIF($5::TEXT, ''), external_name),
+    projection_version = $6
+WHERE provider_id = $1
+  AND external_id = $2
+  AND projection_version < $6
+`
+
+type UpdateIdentityLinkLoginParams struct {
+	ProviderID        string     `json:"provider_id"`
+	ExternalID        string     `json:"external_id"`
+	LastLoginAt       *time.Time `json:"last_login_at"`
+	Column4           string     `json:"column_4"`
+	Column5           string     `json:"column_5"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// IdentityLinkLoginUpdated handler. Empty external_email /
+// external_name preserve existing (NULLIF semantics) — the handler
+// emits this on every successful SSO login but doesn't always carry
+// email/name updates.
+func (q *Queries) UpdateIdentityLinkLogin(ctx context.Context, arg UpdateIdentityLinkLoginParams) error {
+	_, err := q.db.Exec(ctx, updateIdentityLinkLogin,
+		arg.ProviderID,
+		arg.ExternalID,
+		arg.LastLoginAt,
+		arg.Column4,
+		arg.Column5,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const upsertIdentityLink = `-- name: UpsertIdentityLink :exec
+INSERT INTO identity_links_projection (
+    id, user_id, provider_id, external_id,
+    external_email, external_name,
+    linked_at, last_login_at, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $7, $8)
+ON CONFLICT (provider_id, external_id) DO UPDATE SET
+    external_email = EXCLUDED.external_email,
+    external_name = EXCLUDED.external_name,
+    last_login_at = EXCLUDED.last_login_at,
+    projection_version = EXCLUDED.projection_version
+`
+
+type UpsertIdentityLinkParams struct {
+	ID                string    `json:"id"`
+	UserID            string    `json:"user_id"`
+	ProviderID        string    `json:"provider_id"`
+	ExternalID        string    `json:"external_id"`
+	ExternalEmail     string    `json:"external_email"`
+	ExternalName      string    `json:"external_name"`
+	LinkedAt          time.Time `json:"linked_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// IdentityLinked handler. ON CONFLICT (provider_id, external_id) DO
+// UPDATE matches the PL/pgSQL projector — re-linking the same
+// external identity (e.g. on next login) refreshes external_email,
+// external_name, and last_login_at without minting a new row.
+func (q *Queries) UpsertIdentityLink(ctx context.Context, arg UpsertIdentityLinkParams) error {
+	_, err := q.db.Exec(ctx, upsertIdentityLink,
+		arg.ID,
+		arg.UserID,
+		arg.ProviderID,
+		arg.ExternalID,
+		arg.ExternalEmail,
+		arg.ExternalName,
+		arg.LinkedAt,
+		arg.ProjectionVersion,
+	)
+	return err
 }

--- a/internal/store/generated/identity_links.sql.go
+++ b/internal/store/generated/identity_links.sql.go
@@ -241,22 +241,22 @@ func (q *Queries) ListLinkedProviderIDsForUser(ctx context.Context, userID strin
 
 const updateIdentityLinkLogin = `-- name: UpdateIdentityLinkLogin :exec
 UPDATE identity_links_projection
-SET last_login_at = $3,
-    external_email = COALESCE(NULLIF($4::TEXT, ''), external_email),
-    external_name = COALESCE(NULLIF($5::TEXT, ''), external_name),
-    projection_version = $6
-WHERE provider_id = $1
-  AND external_id = $2
-  AND projection_version < $6
+SET last_login_at = $1,
+    external_email = COALESCE(NULLIF($2::TEXT, ''), external_email),
+    external_name = COALESCE(NULLIF($3::TEXT, ''), external_name),
+    projection_version = $4
+WHERE provider_id = $5
+  AND external_id = $6
+  AND projection_version < $4
 `
 
 type UpdateIdentityLinkLoginParams struct {
+	LastLoginAt       *time.Time `json:"last_login_at"`
+	ExternalEmail     string     `json:"external_email"`
+	ExternalName      string     `json:"external_name"`
+	ProjectionVersion int64      `json:"projection_version"`
 	ProviderID        string     `json:"provider_id"`
 	ExternalID        string     `json:"external_id"`
-	LastLoginAt       *time.Time `json:"last_login_at"`
-	Column4           string     `json:"column_4"`
-	Column5           string     `json:"column_5"`
-	ProjectionVersion int64      `json:"projection_version"`
 }
 
 // IdentityLinkLoginUpdated handler. Empty external_email /
@@ -265,12 +265,12 @@ type UpdateIdentityLinkLoginParams struct {
 // email/name updates.
 func (q *Queries) UpdateIdentityLinkLogin(ctx context.Context, arg UpdateIdentityLinkLoginParams) error {
 	_, err := q.db.Exec(ctx, updateIdentityLinkLogin,
+		arg.LastLoginAt,
+		arg.ExternalEmail,
+		arg.ExternalName,
+		arg.ProjectionVersion,
 		arg.ProviderID,
 		arg.ExternalID,
-		arg.LastLoginAt,
-		arg.Column4,
-		arg.Column5,
-		arg.ProjectionVersion,
 	)
 	return err
 }

--- a/internal/store/generated/identity_providers.sql.go
+++ b/internal/store/generated/identity_providers.sql.go
@@ -7,6 +7,7 @@ package generated
 
 import (
 	"context"
+	"time"
 )
 
 const countIdentityProviders = `-- name: CountIdentityProviders :one
@@ -19,6 +20,29 @@ func (q *Queries) CountIdentityProviders(ctx context.Context) (int64, error) {
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const deleteIdentityLinksByProvider = `-- name: DeleteIdentityLinksByProvider :exec
+DELETE FROM identity_links_projection WHERE provider_id = $1
+`
+
+// IdentityProviderDeleted handler — second half (cascade). Run only
+// if SoftDeleteIdentityProviderProjection affected a row.
+func (q *Queries) DeleteIdentityLinksByProvider(ctx context.Context, providerID string) error {
+	_, err := q.db.Exec(ctx, deleteIdentityLinksByProvider, providerID)
+	return err
+}
+
+const deleteSCIMGroupMappingsByProvider = `-- name: DeleteSCIMGroupMappingsByProvider :exec
+DELETE FROM scim_group_mapping_projection WHERE provider_id = $1
+`
+
+// IdentityProviderDeleted handler — third half (cascade). Also reused
+// by IdentityProviderSCIMDisabled (where SCIM mapping cleanup is the
+// only side-effect besides flipping scim_enabled).
+func (q *Queries) DeleteSCIMGroupMappingsByProvider(ctx context.Context, providerID string) error {
+	_, err := q.db.Exec(ctx, deleteSCIMGroupMappingsByProvider, providerID)
+	return err
 }
 
 const getIdentityProviderByID = `-- name: GetIdentityProviderByID :one
@@ -155,6 +179,71 @@ func (q *Queries) GetLinkedProvidersDisablingPassword(ctx context.Context, userI
 	return items, nil
 }
 
+const insertIdentityProviderProjection = `-- name: InsertIdentityProviderProjection :exec
+INSERT INTO identity_providers_projection (
+    id, name, slug, provider_type, enabled,
+    client_id, client_secret_encrypted,
+    issuer_url, authorization_url, token_url, userinfo_url,
+    scopes, auto_create_users, auto_link_by_email,
+    default_role_id, disable_password_for_linked,
+    group_claim, group_mapping,
+    created_at, created_by, updated_at, projection_version
+) VALUES ($1, $2, $3, $4, TRUE, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $18, $20)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertIdentityProviderProjectionParams struct {
+	ID                       string    `json:"id"`
+	Name                     string    `json:"name"`
+	Slug                     string    `json:"slug"`
+	ProviderType             string    `json:"provider_type"`
+	ClientID                 string    `json:"client_id"`
+	ClientSecretEncrypted    string    `json:"client_secret_encrypted"`
+	IssuerUrl                string    `json:"issuer_url"`
+	AuthorizationUrl         string    `json:"authorization_url"`
+	TokenUrl                 string    `json:"token_url"`
+	UserinfoUrl              string    `json:"userinfo_url"`
+	Scopes                   []string  `json:"scopes"`
+	AutoCreateUsers          bool      `json:"auto_create_users"`
+	AutoLinkByEmail          bool      `json:"auto_link_by_email"`
+	DefaultRoleID            string    `json:"default_role_id"`
+	DisablePasswordForLinked bool      `json:"disable_password_for_linked"`
+	GroupClaim               string    `json:"group_claim"`
+	GroupMapping             []byte    `json:"group_mapping"`
+	CreatedAt                time.Time `json:"created_at"`
+	CreatedBy                string    `json:"created_by"`
+	ProjectionVersion        int64     `json:"projection_version"`
+}
+
+// IdentityProviderCreated handler. ON CONFLICT DO NOTHING for replay
+// safety (reconciler may re-deliver the event). All COALESCE defaults
+// are normalized to zero values at the listener layer.
+func (q *Queries) InsertIdentityProviderProjection(ctx context.Context, arg InsertIdentityProviderProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertIdentityProviderProjection,
+		arg.ID,
+		arg.Name,
+		arg.Slug,
+		arg.ProviderType,
+		arg.ClientID,
+		arg.ClientSecretEncrypted,
+		arg.IssuerUrl,
+		arg.AuthorizationUrl,
+		arg.TokenUrl,
+		arg.UserinfoUrl,
+		arg.Scopes,
+		arg.AutoCreateUsers,
+		arg.AutoLinkByEmail,
+		arg.DefaultRoleID,
+		arg.DisablePasswordForLinked,
+		arg.GroupClaim,
+		arg.GroupMapping,
+		arg.CreatedAt,
+		arg.CreatedBy,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
 const listEnabledIdentityProviders = `-- name: ListEnabledIdentityProviders :many
 SELECT id, name, slug, provider_type, enabled, client_id, client_secret_encrypted, issuer_url, authorization_url, token_url, userinfo_url, scopes, auto_create_users, auto_link_by_email, default_role_id, attribute_mapping, disable_password_for_linked, group_claim, group_mapping, created_at, created_by, updated_at, is_deleted, projection_version, scim_enabled, scim_token_hash FROM identity_providers_projection
 WHERE is_deleted = FALSE AND enabled = TRUE
@@ -265,4 +354,191 @@ func (q *Queries) ListIdentityProviders(ctx context.Context, arg ListIdentityPro
 		return nil, err
 	}
 	return items, nil
+}
+
+const rotateIdentityProviderSCIMToken = `-- name: RotateIdentityProviderSCIMToken :exec
+UPDATE identity_providers_projection
+SET scim_token_hash = $2,
+    updated_at = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type RotateIdentityProviderSCIMTokenParams struct {
+	ID                string    `json:"id"`
+	ScimTokenHash     string    `json:"scim_token_hash"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// IdentityProviderSCIMTokenRotated handler. Updates only the hash
+// (does not touch scim_enabled, so accidental rotation on a disabled
+// provider stays disabled).
+func (q *Queries) RotateIdentityProviderSCIMToken(ctx context.Context, arg RotateIdentityProviderSCIMTokenParams) error {
+	_, err := q.db.Exec(ctx, rotateIdentityProviderSCIMToken,
+		arg.ID,
+		arg.ScimTokenHash,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const setIdentityProviderSCIMDisabled = `-- name: SetIdentityProviderSCIMDisabled :execrows
+UPDATE identity_providers_projection
+SET scim_enabled = FALSE,
+    scim_token_hash = '',
+    updated_at = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type SetIdentityProviderSCIMDisabledParams struct {
+	ID                string    `json:"id"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// IdentityProviderSCIMDisabled handler. Returns rows-affected so the
+// listener can SHORT-CIRCUIT the SCIM mapping cascade DELETE on stale
+// replay.
+func (q *Queries) SetIdentityProviderSCIMDisabled(ctx context.Context, arg SetIdentityProviderSCIMDisabledParams) (int64, error) {
+	result, err := q.db.Exec(ctx, setIdentityProviderSCIMDisabled, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const setIdentityProviderSCIMEnabled = `-- name: SetIdentityProviderSCIMEnabled :exec
+UPDATE identity_providers_projection
+SET scim_enabled = TRUE,
+    scim_token_hash = $2,
+    updated_at = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type SetIdentityProviderSCIMEnabledParams struct {
+	ID                string    `json:"id"`
+	ScimTokenHash     string    `json:"scim_token_hash"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// IdentityProviderSCIMEnabled handler. scim_token_hash is required
+// on enable — the handler never emits this event without one.
+func (q *Queries) SetIdentityProviderSCIMEnabled(ctx context.Context, arg SetIdentityProviderSCIMEnabledParams) error {
+	_, err := q.db.Exec(ctx, setIdentityProviderSCIMEnabled,
+		arg.ID,
+		arg.ScimTokenHash,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const softDeleteIdentityProviderProjection = `-- name: SoftDeleteIdentityProviderProjection :execrows
+UPDATE identity_providers_projection
+SET is_deleted = TRUE,
+    enabled = FALSE,
+    scim_enabled = FALSE,
+    updated_at = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type SoftDeleteIdentityProviderProjectionParams struct {
+	ID                string    `json:"id"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// IdentityProviderDeleted handler — first half. Returns rows-affected
+// so the listener can SHORT-CIRCUIT the cascade DELETEs when
+// projection_version guard rejects a stale replay (per the
+// multi-write-asymmetric-guard discipline that CR caught on #101).
+func (q *Queries) SoftDeleteIdentityProviderProjection(ctx context.Context, arg SoftDeleteIdentityProviderProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteIdentityProviderProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateIdentityProviderProjection = `-- name: UpdateIdentityProviderProjection :exec
+UPDATE identity_providers_projection
+SET name = COALESCE($1::TEXT, name),
+    enabled = COALESCE($2::BOOLEAN, enabled),
+    client_id = COALESCE($3::TEXT, client_id),
+    client_secret_encrypted = COALESCE($4::TEXT, client_secret_encrypted),
+    issuer_url = COALESCE($5::TEXT, issuer_url),
+    authorization_url = COALESCE($6::TEXT, authorization_url),
+    token_url = COALESCE($7::TEXT, token_url),
+    userinfo_url = COALESCE($8::TEXT, userinfo_url),
+    scopes = COALESCE($9::TEXT[], scopes),
+    auto_create_users = COALESCE($10::BOOLEAN, auto_create_users),
+    auto_link_by_email = COALESCE($11::BOOLEAN, auto_link_by_email),
+    default_role_id = COALESCE($12::TEXT, default_role_id),
+    disable_password_for_linked = COALESCE($13::BOOLEAN, disable_password_for_linked),
+    group_claim = COALESCE($14::TEXT, group_claim),
+    group_mapping = COALESCE($15::JSONB, group_mapping),
+    updated_at = $16,
+    projection_version = $17
+WHERE id = $18
+  AND projection_version < $17
+`
+
+type UpdateIdentityProviderProjectionParams struct {
+	Name                     *string   `json:"name"`
+	Enabled                  *bool     `json:"enabled"`
+	ClientID                 *string   `json:"client_id"`
+	ClientSecretEncrypted    *string   `json:"client_secret_encrypted"`
+	IssuerUrl                *string   `json:"issuer_url"`
+	AuthorizationUrl         *string   `json:"authorization_url"`
+	TokenUrl                 *string   `json:"token_url"`
+	UserinfoUrl              *string   `json:"userinfo_url"`
+	Scopes                   []string  `json:"scopes"`
+	AutoCreateUsers          *bool     `json:"auto_create_users"`
+	AutoLinkByEmail          *bool     `json:"auto_link_by_email"`
+	DefaultRoleID            *string   `json:"default_role_id"`
+	DisablePasswordForLinked *bool     `json:"disable_password_for_linked"`
+	GroupClaim               *string   `json:"group_claim"`
+	GroupMapping             []byte    `json:"group_mapping"`
+	UpdatedAt                time.Time `json:"updated_at"`
+	ProjectionVersion        int64     `json:"projection_version"`
+	ID                       string    `json:"id"`
+}
+
+// IdentityProviderUpdated handler. nil pointer params land as SQL NULL
+// which COALESCE preserves the existing column value. The listener
+// collapses empty-string to nil for NULLIF-shaped fields (client_id,
+// client_secret_encrypted, issuer_url) before dispatch. Stale-replay
+// guard via projection_version.
+func (q *Queries) UpdateIdentityProviderProjection(ctx context.Context, arg UpdateIdentityProviderProjectionParams) error {
+	_, err := q.db.Exec(ctx, updateIdentityProviderProjection,
+		arg.Name,
+		arg.Enabled,
+		arg.ClientID,
+		arg.ClientSecretEncrypted,
+		arg.IssuerUrl,
+		arg.AuthorizationUrl,
+		arg.TokenUrl,
+		arg.UserinfoUrl,
+		arg.Scopes,
+		arg.AutoCreateUsers,
+		arg.AutoLinkByEmail,
+		arg.DefaultRoleID,
+		arg.DisablePasswordForLinked,
+		arg.GroupClaim,
+		arg.GroupMapping,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+		arg.ID,
+	)
+	return err
 }

--- a/internal/store/migrations/025_identity_provider_projector_to_go.sql
+++ b/internal/store/migrations/025_identity_provider_projector_to_go.sql
@@ -1,0 +1,185 @@
+-- Replace project_identity_provider_event() with a no-op stub. The
+-- actual projection logic now lives in
+-- projectors.IdentityProviderListener (Go, post-commit). The shared
+-- project_event() dispatcher trigger still PERFORMs
+-- project_identity_provider_event(NEW); the no-op stub keeps the
+-- dispatch quiet until the dispatcher is rewritten to skip ported
+-- stream types.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. All nine event types (IdP CRUD + SCIM toggles +
+--     identity-link CRUD) atomic with the event commit.
+--   - After: Go listener fires post-commit. Multi-write paths
+--     (IdentityProviderDeleted, IdentityProviderSCIMDisabled) wrap
+--     their writes in store.WithTx. Per the asymmetric-guard
+--     discipline (CR caught it on #101, documented in
+--     `feedback_projector_multiwrite_guard_asymmetry`), the guarded
+--     soft-delete returns rows-affected and the listener
+--     SHORT-CIRCUITS the cascade DELETEs when n == 0 — preventing a
+--     stale RebuildAll-style replay from nuking live identity_links
+--     or scim_group_mappings on a never-actually-deleted IdP.
+--
+-- Tightening: every UPDATE has a `WHERE projection_version < $N`
+-- guard. The PL/pgSQL projector lacked these.
+--
+-- See manchtools/power-manage-server#104. Ninth port under the
+-- projector-migration pattern.
+--
+-- Refs tracker #107.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_identity_provider_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.IdentityProviderListener. See
+    -- migration comment + the listener wiring in cmd/control/main.go
+    -- via projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the original PL/pgSQL projector verbatim from migration 003.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_identity_provider_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'IdentityProviderCreated' THEN
+            INSERT INTO identity_providers_projection (
+                id, name, slug, provider_type, enabled,
+                client_id, client_secret_encrypted,
+                issuer_url, authorization_url, token_url, userinfo_url,
+                scopes, auto_create_users, auto_link_by_email,
+                default_role_id, disable_password_for_linked,
+                group_claim, group_mapping,
+                created_at, created_by, updated_at, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'name',
+                event.data->>'slug',
+                COALESCE(event.data->>'provider_type', 'oidc'),
+                TRUE,
+                event.data->>'client_id',
+                COALESCE(event.data->>'client_secret_encrypted', ''),
+                event.data->>'issuer_url',
+                COALESCE(event.data->>'authorization_url', ''),
+                COALESCE(event.data->>'token_url', ''),
+                COALESCE(event.data->>'userinfo_url', ''),
+                CASE WHEN jsonb_typeof(event.data->'scopes') = 'array' THEN ARRAY(SELECT jsonb_array_elements_text(event.data->'scopes')) ELSE '{}' END,
+                COALESCE((event.data->>'auto_create_users')::BOOLEAN, FALSE),
+                COALESCE((event.data->>'auto_link_by_email')::BOOLEAN, FALSE),
+                COALESCE(event.data->>'default_role_id', ''),
+                COALESCE((event.data->>'disable_password_for_linked')::BOOLEAN, FALSE),
+                COALESCE(event.data->>'group_claim', ''),
+                COALESCE((event.data->'group_mapping')::JSONB, '{}'),
+                event.occurred_at,
+                event.actor_id,
+                event.occurred_at,
+                event.sequence_num
+            );
+
+        WHEN 'IdentityProviderUpdated' THEN
+            UPDATE identity_providers_projection
+            SET name = COALESCE(event.data->>'name', name),
+                enabled = COALESCE((event.data->>'enabled')::BOOLEAN, enabled),
+                client_id = COALESCE(NULLIF(event.data->>'client_id', ''), client_id),
+                client_secret_encrypted = COALESCE(NULLIF(event.data->>'client_secret_encrypted', ''), client_secret_encrypted),
+                issuer_url = COALESCE(NULLIF(event.data->>'issuer_url', ''), issuer_url),
+                authorization_url = COALESCE(event.data->>'authorization_url', authorization_url),
+                token_url = COALESCE(event.data->>'token_url', token_url),
+                userinfo_url = COALESCE(event.data->>'userinfo_url', userinfo_url),
+                scopes = CASE WHEN jsonb_typeof(event.data->'scopes') = 'array' THEN ARRAY(SELECT jsonb_array_elements_text(event.data->'scopes')) ELSE scopes END,
+                auto_create_users = COALESCE((event.data->>'auto_create_users')::BOOLEAN, auto_create_users),
+                auto_link_by_email = COALESCE((event.data->>'auto_link_by_email')::BOOLEAN, auto_link_by_email),
+                default_role_id = COALESCE(event.data->>'default_role_id', default_role_id),
+                disable_password_for_linked = COALESCE((event.data->>'disable_password_for_linked')::BOOLEAN, disable_password_for_linked),
+                group_claim = COALESCE(event.data->>'group_claim', group_claim),
+                group_mapping = COALESCE((event.data->'group_mapping')::JSONB, group_mapping),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'IdentityProviderDeleted' THEN
+            UPDATE identity_providers_projection
+            SET is_deleted = TRUE,
+                enabled = FALSE,
+                scim_enabled = FALSE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            DELETE FROM identity_links_projection WHERE provider_id = event.stream_id;
+            DELETE FROM scim_group_mapping_projection WHERE provider_id = event.stream_id;
+
+        WHEN 'IdentityProviderSCIMEnabled' THEN
+            UPDATE identity_providers_projection
+            SET scim_enabled = TRUE,
+                scim_token_hash = event.data->>'scim_token_hash',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'IdentityProviderSCIMDisabled' THEN
+            UPDATE identity_providers_projection
+            SET scim_enabled = FALSE,
+                scim_token_hash = '',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            DELETE FROM scim_group_mapping_projection WHERE provider_id = event.stream_id;
+
+        WHEN 'IdentityProviderSCIMTokenRotated' THEN
+            UPDATE identity_providers_projection
+            SET scim_token_hash = event.data->>'scim_token_hash',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'IdentityLinked' THEN
+            INSERT INTO identity_links_projection (
+                id, user_id, provider_id, external_id,
+                external_email, external_name,
+                linked_at, last_login_at, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'user_id',
+                event.data->>'provider_id',
+                event.data->>'external_id',
+                COALESCE(event.data->>'external_email', ''),
+                COALESCE(event.data->>'external_name', ''),
+                event.occurred_at,
+                event.occurred_at,
+                event.sequence_num
+            )
+            ON CONFLICT (provider_id, external_id) DO UPDATE SET
+                external_email = EXCLUDED.external_email,
+                external_name = EXCLUDED.external_name,
+                last_login_at = EXCLUDED.last_login_at,
+                projection_version = EXCLUDED.projection_version;
+
+        WHEN 'IdentityLinkLoginUpdated' THEN
+            UPDATE identity_links_projection
+            SET last_login_at = event.occurred_at,
+                external_email = COALESCE(NULLIF(event.data->>'external_email', ''), external_email),
+                external_name = COALESCE(NULLIF(event.data->>'external_name', ''), external_name),
+                projection_version = event.sequence_num
+            WHERE provider_id = event.data->>'provider_id'
+              AND external_id = event.data->>'external_id';
+
+        WHEN 'IdentityUnlinked' THEN
+            DELETE FROM identity_links_projection
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/identity_links.sql
+++ b/internal/store/queries/identity_links.sql
@@ -53,13 +53,13 @@ ON CONFLICT (provider_id, external_id) DO UPDATE SET
 -- emits this on every successful SSO login but doesn't always carry
 -- email/name updates.
 UPDATE identity_links_projection
-SET last_login_at = $3,
-    external_email = COALESCE(NULLIF($4::TEXT, ''), external_email),
-    external_name = COALESCE(NULLIF($5::TEXT, ''), external_name),
-    projection_version = $6
-WHERE provider_id = $1
-  AND external_id = $2
-  AND projection_version < $6;
+SET last_login_at = sqlc.arg('last_login_at'),
+    external_email = COALESCE(NULLIF(sqlc.arg('external_email')::TEXT, ''), external_email),
+    external_name = COALESCE(NULLIF(sqlc.arg('external_name')::TEXT, ''), external_name),
+    projection_version = sqlc.arg('projection_version')
+WHERE provider_id = sqlc.arg('provider_id')
+  AND external_id = sqlc.arg('external_id')
+  AND projection_version < sqlc.arg('projection_version');
 
 -- name: DeleteIdentityLinkByID :exec
 -- IdentityUnlinked handler. Stream_id IS the link id (set by the

--- a/internal/store/queries/identity_links.sql
+++ b/internal/store/queries/identity_links.sql
@@ -30,3 +30,38 @@ SELECT il.*, u.has_password
 FROM identity_links_projection il
 JOIN users_projection u ON u.id = il.user_id
 WHERE il.provider_id = $1 AND u.is_deleted = FALSE;
+
+-- name: UpsertIdentityLink :exec
+-- IdentityLinked handler. ON CONFLICT (provider_id, external_id) DO
+-- UPDATE matches the PL/pgSQL projector — re-linking the same
+-- external identity (e.g. on next login) refreshes external_email,
+-- external_name, and last_login_at without minting a new row.
+INSERT INTO identity_links_projection (
+    id, user_id, provider_id, external_id,
+    external_email, external_name,
+    linked_at, last_login_at, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $7, $8)
+ON CONFLICT (provider_id, external_id) DO UPDATE SET
+    external_email = EXCLUDED.external_email,
+    external_name = EXCLUDED.external_name,
+    last_login_at = EXCLUDED.last_login_at,
+    projection_version = EXCLUDED.projection_version;
+
+-- name: UpdateIdentityLinkLogin :exec
+-- IdentityLinkLoginUpdated handler. Empty external_email /
+-- external_name preserve existing (NULLIF semantics) — the handler
+-- emits this on every successful SSO login but doesn't always carry
+-- email/name updates.
+UPDATE identity_links_projection
+SET last_login_at = $3,
+    external_email = COALESCE(NULLIF($4::TEXT, ''), external_email),
+    external_name = COALESCE(NULLIF($5::TEXT, ''), external_name),
+    projection_version = $6
+WHERE provider_id = $1
+  AND external_id = $2
+  AND projection_version < $6;
+
+-- name: DeleteIdentityLinkByID :exec
+-- IdentityUnlinked handler. Stream_id IS the link id (set by the
+-- handler that emitted IdentityLinked).
+DELETE FROM identity_links_projection WHERE id = $1;

--- a/internal/store/queries/identity_providers.sql
+++ b/internal/store/queries/identity_providers.sql
@@ -28,3 +28,104 @@ WHERE il.user_id = $1
   AND ip.is_deleted = FALSE
   AND ip.enabled = TRUE
   AND ip.disable_password_for_linked = TRUE;
+
+-- name: InsertIdentityProviderProjection :exec
+-- IdentityProviderCreated handler. ON CONFLICT DO NOTHING for replay
+-- safety (reconciler may re-deliver the event). All COALESCE defaults
+-- are normalized to zero values at the listener layer.
+INSERT INTO identity_providers_projection (
+    id, name, slug, provider_type, enabled,
+    client_id, client_secret_encrypted,
+    issuer_url, authorization_url, token_url, userinfo_url,
+    scopes, auto_create_users, auto_link_by_email,
+    default_role_id, disable_password_for_linked,
+    group_claim, group_mapping,
+    created_at, created_by, updated_at, projection_version
+) VALUES ($1, $2, $3, $4, TRUE, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $18, $20)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: UpdateIdentityProviderProjection :exec
+-- IdentityProviderUpdated handler. nil pointer params land as SQL NULL
+-- which COALESCE preserves the existing column value. The listener
+-- collapses empty-string to nil for NULLIF-shaped fields (client_id,
+-- client_secret_encrypted, issuer_url) before dispatch. Stale-replay
+-- guard via projection_version.
+UPDATE identity_providers_projection
+SET name = COALESCE(sqlc.narg('name')::TEXT, name),
+    enabled = COALESCE(sqlc.narg('enabled')::BOOLEAN, enabled),
+    client_id = COALESCE(sqlc.narg('client_id')::TEXT, client_id),
+    client_secret_encrypted = COALESCE(sqlc.narg('client_secret_encrypted')::TEXT, client_secret_encrypted),
+    issuer_url = COALESCE(sqlc.narg('issuer_url')::TEXT, issuer_url),
+    authorization_url = COALESCE(sqlc.narg('authorization_url')::TEXT, authorization_url),
+    token_url = COALESCE(sqlc.narg('token_url')::TEXT, token_url),
+    userinfo_url = COALESCE(sqlc.narg('userinfo_url')::TEXT, userinfo_url),
+    scopes = COALESCE(sqlc.narg('scopes')::TEXT[], scopes),
+    auto_create_users = COALESCE(sqlc.narg('auto_create_users')::BOOLEAN, auto_create_users),
+    auto_link_by_email = COALESCE(sqlc.narg('auto_link_by_email')::BOOLEAN, auto_link_by_email),
+    default_role_id = COALESCE(sqlc.narg('default_role_id')::TEXT, default_role_id),
+    disable_password_for_linked = COALESCE(sqlc.narg('disable_password_for_linked')::BOOLEAN, disable_password_for_linked),
+    group_claim = COALESCE(sqlc.narg('group_claim')::TEXT, group_claim),
+    group_mapping = COALESCE(sqlc.narg('group_mapping')::JSONB, group_mapping),
+    updated_at = sqlc.arg('updated_at'),
+    projection_version = sqlc.arg('projection_version')
+WHERE id = sqlc.arg('id')
+  AND projection_version < sqlc.arg('projection_version');
+
+-- name: SoftDeleteIdentityProviderProjection :execrows
+-- IdentityProviderDeleted handler — first half. Returns rows-affected
+-- so the listener can SHORT-CIRCUIT the cascade DELETEs when
+-- projection_version guard rejects a stale replay (per the
+-- multi-write-asymmetric-guard discipline that CR caught on #101).
+UPDATE identity_providers_projection
+SET is_deleted = TRUE,
+    enabled = FALSE,
+    scim_enabled = FALSE,
+    updated_at = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: DeleteIdentityLinksByProvider :exec
+-- IdentityProviderDeleted handler — second half (cascade). Run only
+-- if SoftDeleteIdentityProviderProjection affected a row.
+DELETE FROM identity_links_projection WHERE provider_id = $1;
+
+-- name: DeleteSCIMGroupMappingsByProvider :exec
+-- IdentityProviderDeleted handler — third half (cascade). Also reused
+-- by IdentityProviderSCIMDisabled (where SCIM mapping cleanup is the
+-- only side-effect besides flipping scim_enabled).
+DELETE FROM scim_group_mapping_projection WHERE provider_id = $1;
+
+-- name: SetIdentityProviderSCIMEnabled :exec
+-- IdentityProviderSCIMEnabled handler. scim_token_hash is required
+-- on enable — the handler never emits this event without one.
+UPDATE identity_providers_projection
+SET scim_enabled = TRUE,
+    scim_token_hash = $2,
+    updated_at = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: SetIdentityProviderSCIMDisabled :execrows
+-- IdentityProviderSCIMDisabled handler. Returns rows-affected so the
+-- listener can SHORT-CIRCUIT the SCIM mapping cascade DELETE on stale
+-- replay.
+UPDATE identity_providers_projection
+SET scim_enabled = FALSE,
+    scim_token_hash = '',
+    updated_at = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: RotateIdentityProviderSCIMToken :exec
+-- IdentityProviderSCIMTokenRotated handler. Updates only the hash
+-- (does not touch scim_enabled, so accidental rotation on a disabled
+-- provider stays disabled).
+UPDATE identity_providers_projection
+SET scim_token_hash = $2,
+    updated_at = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;


### PR DESCRIPTION
## Summary

Ninth port under the projector-migration pattern. Replaces `project_identity_provider_event` PL/pgSQL with `projectors.IdentityProviderListener` — the largest projector in tracker #107 (9 event types, two cross-table cascade DELETE paths, JSONB `group_mapping` field, encrypted client secret).

Event-type families:
- **IdP CRUD**: Created (INSERT, ON CONFLICT DO NOTHING), Updated (partial UPDATE — pointer fields with NULLIF-collapse for `client_id` / `client_secret_encrypted` / `issuer_url` matching PL/pgSQL semantics), Deleted (soft-delete + cascade DELETE on `identity_links` + `scim_group_mapping`).
- **SCIM toggles**: SCIMEnabled, SCIMDisabled (cascade DELETE on `scim_group_mapping`), SCIMTokenRotated.
- **Identity links**: IdentityLinked (UPSERT — re-linking same external identity refreshes email/name/last_login), IdentityLinkLoginUpdated (NULLIF-shaped fields), IdentityUnlinked (DELETE by id).

## Asymmetric-guard discipline applied

Multi-write listeners (`Deleted`, `SCIMDisabled`) wrap their writes in `store.WithTx`. The guarded UPDATEs (`SoftDeleteIdentityProviderProjection`, `SetIdentityProviderSCIMDisabled`) return rows-affected; the listener short-circuits the cascade DELETEs when `n == 0` (stale projection_version replay). This prevents an old replay from nuking live `identity_links` + `scim_group_mappings` on a never-actually-deleted IdP — same pattern CR caught on #101.

## LogValuer

`IdentityProviderCreatedPayload` implements `slog.LogValuer` to mask `client_secret_encrypted` from accidental structured-log dumps.

## Tightening

Every UPDATE has a `WHERE projection_version < $N` guard. The PL/pgSQL projector lacked these.

## Test plan

Tests written FIRST per saved TDD feedback.

- [x] Pure decoders: happy paths, defaults (provider_type='oidc', empty scopes, false bools), required-field validation per variant, wrong stream/event type
- [x] Integration: full Create→Update→SCIM Enable→TokenRotated→SCIM Disable→Delete lifecycle
- [x] Integration: Delete cascades to identity_links + scim_group_mapping
- [x] Integration: SCIMDisabled cascades to scim_group_mapping (only)
- [x] Integration: identity-link Link/Update/Unlink (UPSERT semantics)
- [x] Integration: stale-replay regression for IdentityProviderDeleted (live memberships + mappings survive)
- [x] Integration: wrong-stream-type ignored
- [x] All tests pass locally (`go test ./server/internal/projectors/...`)

> ⚠️ **#125** still applies: this projector's stream type isn't in `AllRebuildTargets`, so emergency rebuild via `RebuildAll` is unaffected today. Same caveat as the prior small-projector ports.

Refs tracker #107. Closes #104.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved identity provider projection logic to a Go-based listener with guarded, replay-safe updates and safer SCIM state transitions.

* **New Features**
  * Added upsert/update/delete flows for identity providers, identity links, and SCIM token rotation/management; short-circuiting prevents stale cascades.

* **Tests**
  * Added end-to-end and unit tests covering lifecycle, SCIM behaviors, link handling, and stale-replay protections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->