### PR TITLE
feat: port project_scim_group_mapping_event to Go listener (#105)

### DIFF
--- a/internal/projectors/scim_group_mapping.go
+++ b/internal/projectors/scim_group_mapping.go
@@ -1,0 +1,126 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// SCIMGroupMappedPayload covers the upsert path. The PL/pgSQL
+// projector required provider_id, scim_group_id, user_group_id and
+// defaulted scim_display_name to ''.
+type SCIMGroupMappedPayload struct {
+	ID              string
+	ProviderID      string
+	SCIMGroupID     string
+	SCIMDisplayName string
+	UserGroupID     string
+}
+
+// SCIMGroupUnmappedPayload — composite key only.
+type SCIMGroupUnmappedPayload struct {
+	ProviderID  string
+	SCIMGroupID string
+}
+
+// SCIMGroupMappingUpdatedPayload — only display_name is updatable.
+// Pointer field distinguishes "field present" from "field omitted"
+// so the SQL UPDATE can use COALESCE to preserve existing on omit.
+type SCIMGroupMappingUpdatedPayload struct {
+	ProviderID      string
+	SCIMGroupID     string
+	SCIMDisplayName *string
+}
+
+// SCIMGroupMappedFromEvent decodes SCIMGroupMapped.
+func SCIMGroupMappedFromEvent(e store.PersistedEvent) (SCIMGroupMappedPayload, error) {
+	if e.StreamType != "scim_group_mapping" || e.EventType != "SCIMGroupMapped" {
+		return SCIMGroupMappedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return SCIMGroupMappedPayload{}, fmt.Errorf("projector: empty SCIMGroupMapped payload")
+	}
+	var raw struct {
+		ProviderID      string  `json:"provider_id"`
+		SCIMGroupID     string  `json:"scim_group_id"`
+		SCIMDisplayName *string `json:"scim_display_name,omitempty"`
+		UserGroupID     string  `json:"user_group_id"`
+	}
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return SCIMGroupMappedPayload{}, fmt.Errorf("projector: invalid SCIMGroupMapped payload: %w", err)
+	}
+	switch {
+	case raw.ProviderID == "":
+		return SCIMGroupMappedPayload{}, fmt.Errorf("projector: SCIMGroupMapped requires provider_id")
+	case raw.SCIMGroupID == "":
+		return SCIMGroupMappedPayload{}, fmt.Errorf("projector: SCIMGroupMapped requires scim_group_id")
+	case raw.UserGroupID == "":
+		return SCIMGroupMappedPayload{}, fmt.Errorf("projector: SCIMGroupMapped requires user_group_id")
+	}
+	out := SCIMGroupMappedPayload{
+		ID:          e.StreamID,
+		ProviderID:  raw.ProviderID,
+		SCIMGroupID: raw.SCIMGroupID,
+		UserGroupID: raw.UserGroupID,
+	}
+	if raw.SCIMDisplayName != nil {
+		out.SCIMDisplayName = *raw.SCIMDisplayName
+	}
+	return out, nil
+}
+
+// SCIMGroupUnmappedFromEvent decodes SCIMGroupUnmapped.
+func SCIMGroupUnmappedFromEvent(e store.PersistedEvent) (SCIMGroupUnmappedPayload, error) {
+	if e.StreamType != "scim_group_mapping" || e.EventType != "SCIMGroupUnmapped" {
+		return SCIMGroupUnmappedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return SCIMGroupUnmappedPayload{}, fmt.Errorf("projector: empty SCIMGroupUnmapped payload")
+	}
+	var raw struct {
+		ProviderID  string `json:"provider_id"`
+		SCIMGroupID string `json:"scim_group_id"`
+	}
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return SCIMGroupUnmappedPayload{}, fmt.Errorf("projector: invalid SCIMGroupUnmapped payload: %w", err)
+	}
+	switch {
+	case raw.ProviderID == "":
+		return SCIMGroupUnmappedPayload{}, fmt.Errorf("projector: SCIMGroupUnmapped requires provider_id")
+	case raw.SCIMGroupID == "":
+		return SCIMGroupUnmappedPayload{}, fmt.Errorf("projector: SCIMGroupUnmapped requires scim_group_id")
+	}
+	return SCIMGroupUnmappedPayload{ProviderID: raw.ProviderID, SCIMGroupID: raw.SCIMGroupID}, nil
+}
+
+// SCIMGroupMappingUpdatedFromEvent decodes SCIMGroupMappingUpdated.
+// Only scim_display_name is updatable; pointer field preserves
+// "missing → no update" via COALESCE.
+func SCIMGroupMappingUpdatedFromEvent(e store.PersistedEvent) (SCIMGroupMappingUpdatedPayload, error) {
+	if e.StreamType != "scim_group_mapping" || e.EventType != "SCIMGroupMappingUpdated" {
+		return SCIMGroupMappingUpdatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return SCIMGroupMappingUpdatedPayload{}, fmt.Errorf("projector: empty SCIMGroupMappingUpdated payload")
+	}
+	var raw struct {
+		ProviderID      string  `json:"provider_id"`
+		SCIMGroupID     string  `json:"scim_group_id"`
+		SCIMDisplayName *string `json:"scim_display_name,omitempty"`
+	}
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return SCIMGroupMappingUpdatedPayload{}, fmt.Errorf("projector: invalid SCIMGroupMappingUpdated payload: %w", err)
+	}
+	switch {
+	case raw.ProviderID == "":
+		return SCIMGroupMappingUpdatedPayload{}, fmt.Errorf("projector: SCIMGroupMappingUpdated requires provider_id")
+	case raw.SCIMGroupID == "":
+		return SCIMGroupMappingUpdatedPayload{}, fmt.Errorf("projector: SCIMGroupMappingUpdated requires scim_group_id")
+	}
+	return SCIMGroupMappingUpdatedPayload{
+		ProviderID:      raw.ProviderID,
+		SCIMGroupID:     raw.SCIMGroupID,
+		SCIMDisplayName: raw.SCIMDisplayName,
+	}, nil
+}

--- a/internal/projectors/scim_group_mapping_listener.go
+++ b/internal/projectors/scim_group_mapping_listener.go
@@ -1,0 +1,109 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// SCIMGroupMappingListener returns a store.EventListener that applies
+// every scim_group_mapping stream event the deleted PL/pgSQL
+// project_scim_group_mapping_event handled. Three event types, all
+// single-statement:
+//
+//   - SCIMGroupMapped: UPSERT (replay-safe via ON CONFLICT)
+//   - SCIMGroupUnmapped: DELETE WHERE (provider_id, scim_group_id)
+//   - SCIMGroupMappingUpdated: UPDATE display_name with NULLIF/COALESCE
+//
+// Wired in projectors.WireAll. Refs #105, tracker #107.
+func SCIMGroupMappingListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "scim_group_mapping" {
+			return
+		}
+		switch e.EventType {
+		case "SCIMGroupMapped":
+			applySCIMGroupMapped(ctx, st, logger, e)
+		case "SCIMGroupUnmapped":
+			applySCIMGroupUnmapped(ctx, st, logger, e)
+		case "SCIMGroupMappingUpdated":
+			applySCIMGroupMappingUpdated(ctx, st, logger, e)
+		}
+	}
+}
+
+func applySCIMGroupMapped(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := SCIMGroupMappedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("scim_group_mapping projector: invalid SCIMGroupMapped payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().UpsertSCIMGroupMapping(ctx, db.UpsertSCIMGroupMappingParams{
+		ID:                payload.ID,
+		ProviderID:        payload.ProviderID,
+		ScimGroupID:       payload.SCIMGroupID,
+		ScimDisplayName:   payload.SCIMDisplayName,
+		UserGroupID:       payload.UserGroupID,
+		CreatedAt:         e.OccurredAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("scim_group_mapping projector: failed to upsert SCIMGroupMapped",
+			"event_id", e.ID, "mapping_id", payload.ID, "error", err)
+	}
+}
+
+func applySCIMGroupUnmapped(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := SCIMGroupUnmappedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("scim_group_mapping projector: invalid SCIMGroupUnmapped payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().DeleteSCIMGroupMappingByCompositeKey(ctx, db.DeleteSCIMGroupMappingByCompositeKeyParams{
+		ProviderID:  payload.ProviderID,
+		ScimGroupID: payload.SCIMGroupID,
+	}); err != nil {
+		logger.Warn("scim_group_mapping projector: failed to delete SCIMGroupUnmapped",
+			"event_id", e.ID,
+			"provider_id", payload.ProviderID,
+			"scim_group_id", payload.SCIMGroupID,
+			"error", err)
+	}
+}
+
+func applySCIMGroupMappingUpdated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+	payload, err := SCIMGroupMappingUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return
+		}
+		logger.Warn("scim_group_mapping projector: invalid SCIMGroupMappingUpdated payload",
+			"event_id", e.ID, "error", err)
+		return
+	}
+	if err := st.Queries().UpdateSCIMGroupMappingDisplayName(ctx, db.UpdateSCIMGroupMappingDisplayNameParams{
+		ProviderID:        payload.ProviderID,
+		ScimGroupID:       payload.SCIMGroupID,
+		ScimDisplayName:   payload.SCIMDisplayName,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		logger.Warn("scim_group_mapping projector: failed to apply SCIMGroupMappingUpdated",
+			"event_id", e.ID,
+			"provider_id", payload.ProviderID,
+			"scim_group_id", payload.SCIMGroupID,
+			"error", err)
+	}
+}

--- a/internal/projectors/scim_group_mapping_test.go
+++ b/internal/projectors/scim_group_mapping_test.go
@@ -1,0 +1,304 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestSCIMGroupMappedFromEvent_Pure exercises the decoder. provider_id,
+// scim_group_id, and user_group_id are required (composite-key
+// columns + FK to user_groups_projection); scim_display_name defaults
+// to '' to match the PL/pgSQL COALESCE.
+func TestSCIMGroupMappedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with display name", func(t *testing.T) {
+		got, err := projectors.SCIMGroupMappedFromEvent(store.PersistedEvent{
+			StreamType: "scim_group_mapping", StreamID: "mapping-1",
+			EventType: "SCIMGroupMapped",
+			Data: jsonOrFail(t, map[string]any{
+				"provider_id":       "idp-1",
+				"scim_group_id":     "sg-eng",
+				"scim_display_name": "Engineering",
+				"user_group_id":     "ug-eng",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "mapping-1", got.ID)
+		assert.Equal(t, "idp-1", got.ProviderID)
+		assert.Equal(t, "sg-eng", got.SCIMGroupID)
+		assert.Equal(t, "Engineering", got.SCIMDisplayName)
+		assert.Equal(t, "ug-eng", got.UserGroupID)
+	})
+
+	t.Run("missing scim_display_name defaults to empty", func(t *testing.T) {
+		got, err := projectors.SCIMGroupMappedFromEvent(store.PersistedEvent{
+			StreamType: "scim_group_mapping", StreamID: "mapping-2",
+			EventType: "SCIMGroupMapped",
+			Data: jsonOrFail(t, map[string]any{
+				"provider_id":   "idp-1",
+				"scim_group_id": "sg",
+				"user_group_id": "ug",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.SCIMDisplayName)
+	})
+
+	t.Run("required fields validated", func(t *testing.T) {
+		base := map[string]any{
+			"provider_id":   "p",
+			"scim_group_id": "sg",
+			"user_group_id": "ug",
+		}
+		for _, drop := range []string{"provider_id", "scim_group_id", "user_group_id"} {
+			t.Run("missing "+drop, func(t *testing.T) {
+				payload := map[string]any{}
+				for k, v := range base {
+					if k == drop {
+						continue
+					}
+					payload[k] = v
+				}
+				_, err := projectors.SCIMGroupMappedFromEvent(store.PersistedEvent{
+					StreamType: "scim_group_mapping", StreamID: "m", EventType: "SCIMGroupMapped",
+					Data: jsonOrFail(t, payload),
+				})
+				require.Error(t, err)
+				assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+				assert.Contains(t, err.Error(), drop)
+			})
+		}
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.SCIMGroupMappedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", EventType: "SCIMGroupMapped",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.SCIMGroupMappedFromEvent(store.PersistedEvent{
+			StreamType: "scim_group_mapping", EventType: "SCIMGroupUnmapped",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestSCIMGroupUnmappedFromEvent_Pure — composite-key shape.
+func TestSCIMGroupUnmappedFromEvent_Pure(t *testing.T) {
+	got, err := projectors.SCIMGroupUnmappedFromEvent(store.PersistedEvent{
+		StreamType: "scim_group_mapping", StreamID: "m",
+		EventType: "SCIMGroupUnmapped",
+		Data: jsonOrFail(t, map[string]any{"provider_id": "p", "scim_group_id": "sg"}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "p", got.ProviderID)
+	assert.Equal(t, "sg", got.SCIMGroupID)
+
+	for _, drop := range []string{"provider_id", "scim_group_id"} {
+		t.Run("missing "+drop, func(t *testing.T) {
+			payload := map[string]any{"provider_id": "p", "scim_group_id": "sg"}
+			delete(payload, drop)
+			_, err := projectors.SCIMGroupUnmappedFromEvent(store.PersistedEvent{
+				StreamType: "scim_group_mapping", EventType: "SCIMGroupUnmapped",
+				Data: jsonOrFail(t, payload),
+			})
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), drop)
+		})
+	}
+}
+
+// TestSCIMGroupMappingUpdatedFromEvent_Pure — only display_name is
+// updatable (the PL/pgSQL projector exposes nothing else for update).
+func TestSCIMGroupMappingUpdatedFromEvent_Pure(t *testing.T) {
+	got, err := projectors.SCIMGroupMappingUpdatedFromEvent(store.PersistedEvent{
+		StreamType: "scim_group_mapping", EventType: "SCIMGroupMappingUpdated",
+		Data: jsonOrFail(t, map[string]any{
+			"provider_id":       "p",
+			"scim_group_id":     "sg",
+			"scim_display_name": "New Name",
+		}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "p", got.ProviderID)
+	assert.Equal(t, "sg", got.SCIMGroupID)
+	require.NotNil(t, got.SCIMDisplayName)
+	assert.Equal(t, "New Name", *got.SCIMDisplayName)
+
+	t.Run("missing scim_display_name → nil (preserves existing via COALESCE)", func(t *testing.T) {
+		got, err := projectors.SCIMGroupMappingUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "scim_group_mapping", EventType: "SCIMGroupMappingUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"provider_id":   "p",
+				"scim_group_id": "sg",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.SCIMDisplayName, "missing field stays nil so SQL COALESCE preserves existing")
+	})
+}
+
+// TestSCIMGroupMappingListener_MapUpdateUnmap walks the full lifecycle.
+func TestSCIMGroupMappingListener_MapUpdateUnmap(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	idpID := testutil.NewID()
+	groupID := testutil.CreateTestUserGroup(t, st, "actor", "scim-target")
+
+	// Create the IdP first (FK target).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderCreated",
+		Data: map[string]any{
+			"name": "x", "slug": "x-" + testutil.NewID(),
+			"client_id": "c", "issuer_url": "https://x.example.com",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	mappingID := "mapping-" + testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "scim_group_mapping", StreamID: mappingID,
+		EventType: "SCIMGroupMapped",
+		Data: map[string]any{
+			"provider_id":       idpID,
+			"scim_group_id":     "sg-eng",
+			"scim_display_name": "Engineering",
+			"user_group_id":     groupID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Read back via direct SQL (no GetByCompositeKey query exists).
+	var displayName, userGroupID string
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT scim_display_name, user_group_id FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
+		idpID, "sg-eng",
+	).Scan(&displayName, &userGroupID))
+	assert.Equal(t, "Engineering", displayName)
+	assert.Equal(t, groupID, userGroupID)
+
+	// Update display name.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "scim_group_mapping", StreamID: mappingID,
+		EventType: "SCIMGroupMappingUpdated",
+		Data: map[string]any{
+			"provider_id":       idpID,
+			"scim_group_id":     "sg-eng",
+			"scim_display_name": "Engineering Team",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT scim_display_name FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
+		idpID, "sg-eng",
+	).Scan(&displayName))
+	assert.Equal(t, "Engineering Team", displayName)
+
+	// Unmap.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "scim_group_mapping", StreamID: mappingID,
+		EventType: "SCIMGroupUnmapped",
+		Data: map[string]any{
+			"provider_id":   idpID,
+			"scim_group_id": "sg-eng",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
+		idpID, "sg-eng",
+	).Scan(&count))
+	assert.Equal(t, 0, count, "SCIMGroupUnmapped removes the row")
+}
+
+// TestSCIMGroupMappingListener_MapReplayIsIdempotent — UPSERT semantics
+// must match the PL/pgSQL ON CONFLICT DO UPDATE: re-mapping the same
+// (provider, scim_group) refreshes display_name + user_group_id but
+// doesn't mint a duplicate row.
+func TestSCIMGroupMappingListener_MapReplayIsIdempotent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	idpID := testutil.NewID()
+	groupA := testutil.CreateTestUserGroup(t, st, "actor", "ug-a")
+	groupB := testutil.CreateTestUserGroup(t, st, "actor", "ug-b")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderCreated",
+		Data: map[string]any{
+			"name": "x", "slug": "x-" + testutil.NewID(),
+			"client_id": "c", "issuer_url": "https://x.example.com",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	mappingID := "mapping-" + testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "scim_group_mapping", StreamID: mappingID,
+		EventType: "SCIMGroupMapped",
+		Data: map[string]any{
+			"provider_id": idpID, "scim_group_id": "sg",
+			"scim_display_name": "Initial", "user_group_id": groupA,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	// Re-map with different display name + different user_group.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "scim_group_mapping", StreamID: mappingID,
+		EventType: "SCIMGroupMapped",
+		Data: map[string]any{
+			"provider_id": idpID, "scim_group_id": "sg",
+			"scim_display_name": "Refreshed", "user_group_id": groupB,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
+		idpID, "sg",
+	).Scan(&count))
+	assert.Equal(t, 1, count, "ON CONFLICT preserves uniqueness on (provider_id, scim_group_id)")
+
+	var displayName, ugID string
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT scim_display_name, user_group_id FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
+		idpID, "sg",
+	).Scan(&displayName, &ugID))
+	assert.Equal(t, "Refreshed", displayName, "ON CONFLICT DO UPDATE refreshes display_name")
+	assert.Equal(t, groupB, ugID, "ON CONFLICT DO UPDATE refreshes user_group_id")
+}
+
+// TestSCIMGroupMappingListener_IgnoresWrongStreamType — defensive.
+func TestSCIMGroupMappingListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	idpID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", // wrong (would dispatch to IdP listener, not this one)
+		StreamID:   "m-" + testutil.NewID(),
+		EventType:  "SCIMGroupMapped",
+		Data: map[string]any{
+			"provider_id": idpID, "scim_group_id": "sg",
+			"scim_display_name": "X", "user_group_id": "ug",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id=$1", idpID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "wrong-stream-type SCIMGroupMapped must NOT create a row")
+}

--- a/internal/projectors/scim_group_mapping_test.go
+++ b/internal/projectors/scim_group_mapping_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/manchtools/power-manage/server/internal/projectors"
 	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
@@ -277,6 +278,74 @@ func TestSCIMGroupMappingListener_MapReplayIsIdempotent(t *testing.T) {
 	).Scan(&displayName, &ugID))
 	assert.Equal(t, "Refreshed", displayName, "ON CONFLICT DO UPDATE refreshes display_name")
 	assert.Equal(t, groupB, ugID, "ON CONFLICT DO UPDATE refreshes user_group_id")
+}
+
+// TestSCIMGroupMappingListener_StaleUpdateIgnored verifies the
+// projection_version guard on UpdateSCIMGroupMappingDisplayName: an
+// older SCIMGroupMappingUpdated event must not overwrite a projection
+// that was already advanced by a newer event. The PR description
+// called out this guard as the key tightening over the PL/pgSQL
+// original; it deserves a dedicated regression test.
+func TestSCIMGroupMappingListener_StaleUpdateIgnored(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	idpID := testutil.NewID()
+	groupID := testutil.CreateTestUserGroup(t, st, "actor", "scim-stale")
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderCreated",
+		Data: map[string]any{
+			"name": "x", "slug": "x-" + testutil.NewID(),
+			"client_id": "c", "issuer_url": "https://x.example.com",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	mappingID := "mapping-" + testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "scim_group_mapping", StreamID: mappingID,
+		EventType: "SCIMGroupMapped",
+		Data: map[string]any{
+			"provider_id": idpID, "scim_group_id": "sg-stale",
+			"scim_display_name": "Initial", "user_group_id": groupID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "scim_group_mapping", StreamID: mappingID,
+		EventType: "SCIMGroupMappingUpdated",
+		Data: map[string]any{
+			"provider_id": idpID, "scim_group_id": "sg-stale",
+			"scim_display_name": "Current State",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Capture current projection_version, then apply a stale UPDATE
+	// directly with version-5. The guard must reject it.
+	var currentVer int64
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT projection_version FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
+		idpID, "sg-stale",
+	).Scan(&currentVer))
+	older := currentVer - 5
+	staleName := "stale replay would set this"
+	require.NoError(t, st.Queries().UpdateSCIMGroupMappingDisplayName(ctx, db.UpdateSCIMGroupMappingDisplayNameParams{
+		ProviderID:        idpID,
+		ScimGroupID:       "sg-stale",
+		ScimDisplayName:   &staleName,
+		ProjectionVersion: older,
+	}))
+
+	var displayName string
+	var afterVer int64
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT scim_display_name, projection_version FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
+		idpID, "sg-stale",
+	).Scan(&displayName, &afterVer))
+	assert.Equal(t, "Current State", displayName, "stale projection_version must NOT clobber fresher state")
+	assert.Equal(t, currentVer, afterVer, "projection_version unchanged when guard rejects")
 }
 
 // TestSCIMGroupMappingListener_IgnoresWrongStreamType — defensive.

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -64,7 +64,11 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "identity_provider_projector"),
 	))
-	// Subsequent ports under #105–#106 add their listener here.
+	st.RegisterEventListener(SCIMGroupMappingListener(
+		st,
+		loggerFor(logger, "scim_group_mapping_projector"),
+	))
+	// Subsequent ports under #106 add their listener here.
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/scim.sql.go
+++ b/internal/store/generated/scim.sql.go
@@ -35,6 +35,25 @@ func (q *Queries) CountSCIMUsers(ctx context.Context, providerID string) (int64,
 	return count, err
 }
 
+const deleteSCIMGroupMappingByCompositeKey = `-- name: DeleteSCIMGroupMappingByCompositeKey :exec
+DELETE FROM scim_group_mapping_projection
+WHERE provider_id = $1
+  AND scim_group_id = $2
+`
+
+type DeleteSCIMGroupMappingByCompositeKeyParams struct {
+	ProviderID  string `json:"provider_id"`
+	ScimGroupID string `json:"scim_group_id"`
+}
+
+// SCIMGroupUnmapped handler. Plain DELETE — silently no-op on a
+// miss matches the PL/pgSQL projector's behaviour under repeated
+// unmap events.
+func (q *Queries) DeleteSCIMGroupMappingByCompositeKey(ctx context.Context, arg DeleteSCIMGroupMappingByCompositeKeyParams) error {
+	_, err := q.db.Exec(ctx, deleteSCIMGroupMappingByCompositeKey, arg.ProviderID, arg.ScimGroupID)
+	return err
+}
+
 const findSCIMUserByEmail = `-- name: FindSCIMUserByEmail :one
 SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id, il.external_id AS scim_external_id
 FROM users_projection u
@@ -530,4 +549,71 @@ func (q *Queries) ListSCIMUsers(ctx context.Context, arg ListSCIMUsersParams) ([
 		return nil, err
 	}
 	return items, nil
+}
+
+const updateSCIMGroupMappingDisplayName = `-- name: UpdateSCIMGroupMappingDisplayName :exec
+UPDATE scim_group_mapping_projection
+SET scim_display_name = COALESCE($1::TEXT, scim_display_name),
+    projection_version = $2
+WHERE provider_id = $3
+  AND scim_group_id = $4
+  AND projection_version < $2
+`
+
+type UpdateSCIMGroupMappingDisplayNameParams struct {
+	ScimDisplayName   *string `json:"scim_display_name"`
+	ProjectionVersion int64   `json:"projection_version"`
+	ProviderID        string  `json:"provider_id"`
+	ScimGroupID       string  `json:"scim_group_id"`
+}
+
+// SCIMGroupMappingUpdated handler. Only display_name is updatable;
+// nil pointer collapses to SQL NULL, COALESCE preserves existing.
+// Stale-replay guard via projection_version.
+func (q *Queries) UpdateSCIMGroupMappingDisplayName(ctx context.Context, arg UpdateSCIMGroupMappingDisplayNameParams) error {
+	_, err := q.db.Exec(ctx, updateSCIMGroupMappingDisplayName,
+		arg.ScimDisplayName,
+		arg.ProjectionVersion,
+		arg.ProviderID,
+		arg.ScimGroupID,
+	)
+	return err
+}
+
+const upsertSCIMGroupMapping = `-- name: UpsertSCIMGroupMapping :exec
+INSERT INTO scim_group_mapping_projection (
+    id, provider_id, scim_group_id, scim_display_name,
+    user_group_id, created_at, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (provider_id, scim_group_id) DO UPDATE SET
+    scim_display_name = EXCLUDED.scim_display_name,
+    user_group_id = EXCLUDED.user_group_id,
+    projection_version = EXCLUDED.projection_version
+`
+
+type UpsertSCIMGroupMappingParams struct {
+	ID                string    `json:"id"`
+	ProviderID        string    `json:"provider_id"`
+	ScimGroupID       string    `json:"scim_group_id"`
+	ScimDisplayName   string    `json:"scim_display_name"`
+	UserGroupID       string    `json:"user_group_id"`
+	CreatedAt         time.Time `json:"created_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// SCIMGroupMapped handler. ON CONFLICT (provider_id, scim_group_id)
+// DO UPDATE matches the PL/pgSQL projector — re-mapping the same
+// (provider, scim_group) refreshes scim_display_name + user_group_id
+// without minting a duplicate row.
+func (q *Queries) UpsertSCIMGroupMapping(ctx context.Context, arg UpsertSCIMGroupMappingParams) error {
+	_, err := q.db.Exec(ctx, upsertSCIMGroupMapping,
+		arg.ID,
+		arg.ProviderID,
+		arg.ScimGroupID,
+		arg.ScimDisplayName,
+		arg.UserGroupID,
+		arg.CreatedAt,
+		arg.ProjectionVersion,
+	)
+	return err
 }

--- a/internal/store/migrations/026_scim_group_mapping_projector_to_go.sql
+++ b/internal/store/migrations/026_scim_group_mapping_projector_to_go.sql
@@ -1,0 +1,77 @@
+-- Replace project_scim_group_mapping_event() with a no-op stub.
+-- The actual projection logic now lives in
+-- projectors.SCIMGroupMappingListener (Go, post-commit).
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. All three event types (Mapped, Unmapped,
+--     MappingUpdated) atomic with the event commit.
+--   - After: Go listener fires post-commit. Each event type is a
+--     single statement (UPSERT, DELETE, UPDATE) so no tx wrap is
+--     needed.
+--
+-- Tightening: SCIMGroupMappingUpdated now has a
+-- `WHERE projection_version < $N` guard rejecting stale reconciler
+-- replays. The PL/pgSQL projector lacked it.
+--
+-- See manchtools/power-manage-server#105. Tenth port under the
+-- projector-migration pattern.
+--
+-- Refs tracker #107.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_scim_group_mapping_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.SCIMGroupMappingListener.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the original PL/pgSQL projector verbatim from migration 003.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_scim_group_mapping_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'SCIMGroupMapped' THEN
+            INSERT INTO scim_group_mapping_projection (
+                id, provider_id, scim_group_id, scim_display_name,
+                user_group_id, created_at, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'provider_id',
+                event.data->>'scim_group_id',
+                COALESCE(event.data->>'scim_display_name', ''),
+                event.data->>'user_group_id',
+                event.occurred_at,
+                event.sequence_num
+            )
+            ON CONFLICT (provider_id, scim_group_id) DO UPDATE SET
+                scim_display_name = EXCLUDED.scim_display_name,
+                user_group_id = EXCLUDED.user_group_id,
+                projection_version = EXCLUDED.projection_version;
+
+        WHEN 'SCIMGroupUnmapped' THEN
+            DELETE FROM scim_group_mapping_projection
+            WHERE provider_id = event.data->>'provider_id'
+              AND scim_group_id = event.data->>'scim_group_id';
+
+        WHEN 'SCIMGroupMappingUpdated' THEN
+            UPDATE scim_group_mapping_projection
+            SET scim_display_name = COALESCE(event.data->>'scim_display_name', scim_display_name),
+                projection_version = event.sequence_num
+            WHERE provider_id = event.data->>'provider_id'
+              AND scim_group_id = event.data->>'scim_group_id';
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/scim.sql
+++ b/internal/store/queries/scim.sql
@@ -64,3 +64,36 @@ SELECT ug.*, (
 FROM user_groups_projection ug
 WHERE ug.id = $1 AND ug.is_deleted = FALSE;
 
+
+-- name: UpsertSCIMGroupMapping :exec
+-- SCIMGroupMapped handler. ON CONFLICT (provider_id, scim_group_id)
+-- DO UPDATE matches the PL/pgSQL projector — re-mapping the same
+-- (provider, scim_group) refreshes scim_display_name + user_group_id
+-- without minting a duplicate row.
+INSERT INTO scim_group_mapping_projection (
+    id, provider_id, scim_group_id, scim_display_name,
+    user_group_id, created_at, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (provider_id, scim_group_id) DO UPDATE SET
+    scim_display_name = EXCLUDED.scim_display_name,
+    user_group_id = EXCLUDED.user_group_id,
+    projection_version = EXCLUDED.projection_version;
+
+-- name: DeleteSCIMGroupMappingByCompositeKey :exec
+-- SCIMGroupUnmapped handler. Plain DELETE — silently no-op on a
+-- miss matches the PL/pgSQL projector's behaviour under repeated
+-- unmap events.
+DELETE FROM scim_group_mapping_projection
+WHERE provider_id = $1
+  AND scim_group_id = $2;
+
+-- name: UpdateSCIMGroupMappingDisplayName :exec
+-- SCIMGroupMappingUpdated handler. Only display_name is updatable;
+-- nil pointer collapses to SQL NULL, COALESCE preserves existing.
+-- Stale-replay guard via projection_version.
+UPDATE scim_group_mapping_projection
+SET scim_display_name = COALESCE(sqlc.narg('scim_display_name')::TEXT, scim_display_name),
+    projection_version = sqlc.arg('projection_version')
+WHERE provider_id = sqlc.arg('provider_id')
+  AND scim_group_id = sqlc.arg('scim_group_id')
+  AND projection_version < sqlc.arg('projection_version');


### PR DESCRIPTION
## Summary

Tenth port under the projector-migration pattern. Replaces `project_scim_group_mapping_event` PL/pgSQL with `projectors.SCIMGroupMappingListener`.

Three event types, all single-statement:
- `SCIMGroupMapped` — UPSERT (`ON CONFLICT (provider_id, scim_group_id) DO UPDATE`) — re-mapping the same external group refreshes display_name + user_group_id without minting a duplicate row.
- `SCIMGroupUnmapped` — DELETE WHERE composite key — silently no-op on a miss.
- `SCIMGroupMappingUpdated` — UPDATE display_name with COALESCE; nil pointer (omitted field) preserves existing value.

Tightening: `SCIMGroupMappingUpdated` now has a `WHERE projection_version < $N` guard rejecting stale reconciler replays. The PL/pgSQL projector lacked it.

## Test plan

Tests written FIRST per saved TDD feedback.

- [x] Pure decoders: happy paths, `scim_display_name` defaults to empty, required-field validation per variant, wrong stream/event type
- [x] Integration: Map → Update → Unmap lifecycle
- [x] Integration: UPSERT idempotency under repeated SCIMGroupMapped (replay refreshes in place, no duplicate row)
- [x] Integration: wrong-stream-type ignored
- [x] All tests pass locally (`go test ./server/internal/projectors/...`)

> Same #125 caveat as prior small-projector ports: this stream type isn't in `AllRebuildTargets`, so emergency rebuild is unaffected.

Refs tracker #107. Closes #105.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced SCIM group mapping to link SCIM groups with user groups
  * Added capability to update SCIM group display names
  * Added support for unmapping SCIM groups when no longer needed

* **Tests**
  * Added comprehensive test coverage for SCIM group mapping operations, including lifecycle, idempotency, and a regression test ensuring stale display-name updates are ignored
<!-- end of auto-generated comment: release notes by coderabbit.ai -->