### PR TITLE
feat: port project_user_selection_event to Go listener (#106)

### DIFF
--- a/internal/projectors/user_selection.go
+++ b/internal/projectors/user_selection.go
@@ -8,8 +8,15 @@ import (
 )
 
 // UserSelectionChangedPayload mirrors the PL/pgSQL projector's
-// COALESCE on the boolean — missing or non-bool `selected` defaults
-// to FALSE. The composite-key fields are required.
+// `selected` handling for the omitted-field case (defaults to
+// FALSE), but tightens the non-bool case: a non-bool `selected`
+// (e.g. a string or number) makes json.Unmarshal fail and the whole
+// event is rejected at the decoder, where the PL/pgSQL projector's
+// `COALESCE((event.data->>'selected')::BOOLEAN, FALSE)` would have
+// silently coerced it to NULL → FALSE. This is a deliberate
+// hardening — malformed payloads should fail loudly, not produce
+// silently-defaulted projection rows. Composite-key fields
+// (device_id, source_type, source_id) remain required.
 type UserSelectionChangedPayload struct {
 	ID         string
 	DeviceID   string

--- a/internal/projectors/user_selection.go
+++ b/internal/projectors/user_selection.go
@@ -1,0 +1,58 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// UserSelectionChangedPayload mirrors the PL/pgSQL projector's
+// COALESCE on the boolean — missing or non-bool `selected` defaults
+// to FALSE. The composite-key fields are required.
+type UserSelectionChangedPayload struct {
+	ID         string
+	DeviceID   string
+	SourceType string
+	SourceID   string
+	Selected   bool
+	CreatedBy  string
+}
+
+// UserSelectionChangedFromEvent decodes UserSelectionChanged.
+func UserSelectionChangedFromEvent(e store.PersistedEvent) (UserSelectionChangedPayload, error) {
+	if e.StreamType != "user_selection" || e.EventType != "UserSelectionChanged" {
+		return UserSelectionChangedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserSelectionChangedPayload{}, fmt.Errorf("projector: empty UserSelectionChanged payload")
+	}
+	var raw struct {
+		DeviceID   string `json:"device_id"`
+		SourceType string `json:"source_type"`
+		SourceID   string `json:"source_id"`
+		Selected   *bool  `json:"selected,omitempty"`
+	}
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserSelectionChangedPayload{}, fmt.Errorf("projector: invalid UserSelectionChanged payload: %w", err)
+	}
+	switch {
+	case raw.DeviceID == "":
+		return UserSelectionChangedPayload{}, fmt.Errorf("projector: UserSelectionChanged requires device_id")
+	case raw.SourceType == "":
+		return UserSelectionChangedPayload{}, fmt.Errorf("projector: UserSelectionChanged requires source_type")
+	case raw.SourceID == "":
+		return UserSelectionChangedPayload{}, fmt.Errorf("projector: UserSelectionChanged requires source_id")
+	}
+	out := UserSelectionChangedPayload{
+		ID:         e.StreamID,
+		DeviceID:   raw.DeviceID,
+		SourceType: raw.SourceType,
+		SourceID:   raw.SourceID,
+		CreatedBy:  e.ActorID,
+	}
+	if raw.Selected != nil {
+		out.Selected = *raw.Selected
+	}
+	return out, nil
+}

--- a/internal/projectors/user_selection_listener.go
+++ b/internal/projectors/user_selection_listener.go
@@ -1,0 +1,58 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// UserSelectionListener returns a store.EventListener that applies
+// UserSelectionChanged events to user_selections_projection.
+// Single event type, single UPSERT — no transaction wrap needed.
+//
+// Replaces the deleted PL/pgSQL project_user_selection_event.
+// Wired in projectors.WireAll. Refs #106, tracker #107.
+func UserSelectionListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "user_selection" {
+			return
+		}
+		if e.EventType != "UserSelectionChanged" {
+			return
+		}
+
+		payload, err := UserSelectionChangedFromEvent(e)
+		if err != nil {
+			if errors.Is(err, ErrIgnoredEvent) {
+				return
+			}
+			logger.Warn("user_selection projector: invalid UserSelectionChanged payload",
+				"event_id", e.ID, "error", err)
+			return
+		}
+
+		if err := st.Queries().UpsertUserSelectionProjection(ctx, db.UpsertUserSelectionProjectionParams{
+			ID:                payload.ID,
+			DeviceID:          payload.DeviceID,
+			SourceType:        payload.SourceType,
+			SourceID:          payload.SourceID,
+			Selected:          payload.Selected,
+			UpdatedAt:         e.OccurredAt,
+			CreatedBy:         payload.CreatedBy,
+			ProjectionVersion: deref(e.SequenceNum),
+		}); err != nil {
+			logger.Warn("user_selection projector: failed to upsert UserSelectionChanged",
+				"event_id", e.ID,
+				"device_id", payload.DeviceID,
+				"source_type", payload.SourceType,
+				"source_id", payload.SourceID,
+				"error", err)
+		}
+	}
+}

--- a/internal/projectors/user_selection_test.go
+++ b/internal/projectors/user_selection_test.go
@@ -1,0 +1,266 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestUserSelectionChangedFromEvent_Pure exercises the decoder.
+// PL/pgSQL projector required device_id/source_type/source_id and
+// defaulted selected to FALSE on missing/non-bool.
+func TestUserSelectionChangedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with selected=true", func(t *testing.T) {
+		got, err := projectors.UserSelectionChangedFromEvent(store.PersistedEvent{
+			StreamType: "user_selection", StreamID: "sel-1",
+			EventType: "UserSelectionChanged", ActorID: "actor-1",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":   "dev-1",
+				"source_type": "user",
+				"source_id":   "user-1",
+				"selected":    true,
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "sel-1", got.ID)
+		assert.Equal(t, "dev-1", got.DeviceID)
+		assert.Equal(t, "user", got.SourceType)
+		assert.Equal(t, "user-1", got.SourceID)
+		assert.True(t, got.Selected)
+		assert.Equal(t, "actor-1", got.CreatedBy)
+	})
+
+	t.Run("missing selected defaults to false", func(t *testing.T) {
+		got, err := projectors.UserSelectionChangedFromEvent(store.PersistedEvent{
+			StreamType: "user_selection", StreamID: "sel-2",
+			EventType: "UserSelectionChanged", ActorID: "actor-1",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":   "dev-2",
+				"source_type": "user_group",
+				"source_id":   "ug-1",
+			}),
+		})
+		require.NoError(t, err)
+		assert.False(t, got.Selected, "missing selected → false (matches PL/pgSQL COALESCE default)")
+	})
+
+	t.Run("required fields validated", func(t *testing.T) {
+		base := map[string]any{
+			"device_id":   "d",
+			"source_type": "user",
+			"source_id":   "s",
+		}
+		for _, drop := range []string{"device_id", "source_type", "source_id"} {
+			t.Run("missing "+drop, func(t *testing.T) {
+				payload := map[string]any{}
+				for k, v := range base {
+					if k == drop {
+						continue
+					}
+					payload[k] = v
+				}
+				_, err := projectors.UserSelectionChangedFromEvent(store.PersistedEvent{
+					StreamType: "user_selection", StreamID: "s", EventType: "UserSelectionChanged", ActorID: "a",
+					Data: jsonOrFail(t, payload),
+				})
+				require.Error(t, err)
+				assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+				assert.Contains(t, err.Error(), drop)
+			})
+		}
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.UserSelectionChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "UserSelectionChanged",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.UserSelectionChangedFromEvent(store.PersistedEvent{
+			StreamType: "user_selection", EventType: "Whatever",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.UserSelectionChangedFromEvent(store.PersistedEvent{
+			StreamType: "user_selection", EventType: "UserSelectionChanged",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestUserSelectionListener_UpsertSelectThenDeselect walks the
+// flip-flop path. UPSERT semantics matter: the second event for the
+// same (device, source_type, source_id) must update the existing row,
+// not insert a duplicate.
+func TestUserSelectionListener_UpsertSelectThenDeselect(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := "dev-" + testutil.NewID()
+	sourceID := "user-" + testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_selection", StreamID: testutil.NewID(),
+		EventType: "UserSelectionChanged",
+		Data: map[string]any{
+			"device_id": deviceID, "source_type": "user", "source_id": sourceID,
+			"selected": true,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	var selected bool
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT selected FROM user_selections_projection WHERE device_id=$1 AND source_type='user' AND source_id=$2",
+		deviceID, sourceID,
+	).Scan(&selected))
+	assert.True(t, selected, "first UserSelectionChanged inserts with selected=true")
+
+	// Flip to false (UPSERT path).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_selection", StreamID: testutil.NewID(),
+		EventType: "UserSelectionChanged",
+		Data: map[string]any{
+			"device_id": deviceID, "source_type": "user", "source_id": sourceID,
+			"selected": false,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT selected FROM user_selections_projection WHERE device_id=$1 AND source_type='user' AND source_id=$2",
+		deviceID, sourceID,
+	).Scan(&selected))
+	assert.False(t, selected, "second UserSelectionChanged with selected=false flips the existing row")
+
+	// Confirm exactly one row (UPSERT, not duplicate insert).
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM user_selections_projection WHERE device_id=$1 AND source_type='user' AND source_id=$2",
+		deviceID, sourceID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "ON CONFLICT (device_id, source_type, source_id) keeps the row unique")
+}
+
+// TestUserSelectionListener_PerSourceTypeScope confirms (device, user)
+// and (device, user_group) selections coexist independently. A
+// regression that drops source_type from the UPSERT key would silently
+// merge them.
+func TestUserSelectionListener_PerSourceTypeScope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := "dev-" + testutil.NewID()
+
+	for _, st_ := range []string{"user", "user_group"} {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "user_selection", StreamID: testutil.NewID(),
+			EventType: "UserSelectionChanged",
+			Data: map[string]any{
+				"device_id": deviceID, "source_type": st_, "source_id": "src-" + st_,
+				"selected": true,
+			},
+			ActorType: "user", ActorID: "u",
+		}))
+	}
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM user_selections_projection WHERE device_id=$1", deviceID,
+	).Scan(&count))
+	assert.Equal(t, 2, count, "different source_types must NOT collapse into one row")
+}
+
+// TestUserSelectionListener_StaleReplayRejected confirms the
+// projection_version guard on the UPSERT's update path. PR description
+// flags this as the key tightening over the PL/pgSQL original (which
+// had no guard).
+func TestUserSelectionListener_StaleReplayRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := "dev-" + testutil.NewID()
+	sourceID := "user-" + testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_selection", StreamID: testutil.NewID(),
+		EventType: "UserSelectionChanged",
+		Data: map[string]any{
+			"device_id": deviceID, "source_type": "user", "source_id": sourceID,
+			"selected": true,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	// Apply a "current" deselect (version advances).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_selection", StreamID: testutil.NewID(),
+		EventType: "UserSelectionChanged",
+		Data: map[string]any{
+			"device_id": deviceID, "source_type": "user", "source_id": sourceID,
+			"selected": false,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	var currentVer int64
+	var currentSelected bool
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT projection_version, selected FROM user_selections_projection WHERE device_id=$1 AND source_type='user' AND source_id=$2",
+		deviceID, sourceID,
+	).Scan(&currentVer, &currentSelected))
+	require.False(t, currentSelected)
+
+	// Stale replay would re-set selected=TRUE; the guard must reject.
+	older := currentVer - 5
+	staleID := testutil.NewID()
+	require.NoError(t, st.Queries().UpsertUserSelectionProjection(ctx, db.UpsertUserSelectionProjectionParams{
+		ID:                staleID,
+		DeviceID:          deviceID,
+		SourceType:        "user",
+		SourceID:          sourceID,
+		Selected:          true,
+		UpdatedAt:         time.Now().UTC(),
+		CreatedBy:         "stale",
+		ProjectionVersion: older,
+	}))
+
+	var afterVer int64
+	var afterSelected bool
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT projection_version, selected FROM user_selections_projection WHERE device_id=$1 AND source_type='user' AND source_id=$2",
+		deviceID, sourceID,
+	).Scan(&afterVer, &afterSelected))
+	assert.False(t, afterSelected, "stale projection_version must NOT clobber fresher selected=false state")
+	assert.Equal(t, currentVer, afterVer)
+}
+
+// TestUserSelectionListener_IgnoresWrongStreamType — defensive.
+func TestUserSelectionListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := "dev-" + testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", // wrong
+		StreamID:   testutil.NewID(),
+		EventType:  "UserSelectionChanged",
+		Data: map[string]any{
+			"device_id": deviceID, "source_type": "user", "source_id": "x", "selected": true,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM user_selections_projection WHERE device_id=$1", deviceID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "wrong-stream-type UserSelectionChanged must NOT create a row")
+}

--- a/internal/projectors/user_selection_test.go
+++ b/internal/projectors/user_selection_test.go
@@ -98,6 +98,27 @@ func TestUserSelectionChangedFromEvent_Pure(t *testing.T) {
 		require.Error(t, err)
 		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
 	})
+
+	t.Run("non-boolean selected is a validation error", func(t *testing.T) {
+		// Pins the contract documented on UserSelectionChangedPayload:
+		// the deleted PL/pgSQL projector silently coerced non-bool
+		// values via `::BOOLEAN` → NULL → COALESCE → FALSE. The Go
+		// decoder deliberately rejects them at json.Unmarshal time
+		// so malformed payloads fail loudly instead of producing
+		// silently-defaulted projection rows.
+		for _, badSelected := range []any{"true", "false", 1, 0, []any{}, map[string]any{}} {
+			_, err := projectors.UserSelectionChangedFromEvent(store.PersistedEvent{
+				StreamType: "user_selection", EventType: "UserSelectionChanged",
+				Data: jsonOrFail(t, map[string]any{
+					"device_id": "d", "source_type": "user", "source_id": "s",
+					"selected": badSelected,
+				}),
+			})
+			require.Errorf(t, err, "non-bool selected=%v should be rejected", badSelected)
+			assert.Falsef(t, errors.Is(err, projectors.ErrIgnoredEvent),
+				"non-bool selected=%v must NOT be silently swallowed as ErrIgnoredEvent", badSelected)
+		}
+	})
 }
 
 // TestUserSelectionListener_UpsertSelectThenDeselect walks the

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -68,7 +68,14 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "scim_group_mapping_projector"),
 	))
-	// Subsequent ports under #106 add their listener here.
+	st.RegisterEventListener(UserSelectionListener(
+		st,
+		loggerFor(logger, "user_selection_projector"),
+	))
+	// All 11 ports of tracker #107 are now wired here. Future ports
+	// of the un-ported domain projectors (user, device, action,
+	// execution, assignment, compliance, etc.) will land in a
+	// separate tracker.
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/user_selections.sql.go
+++ b/internal/store/generated/user_selections.sql.go
@@ -7,6 +7,7 @@ package generated
 
 import (
 	"context"
+	"time"
 )
 
 const getUserSelection = `-- name: GetUserSelection :one
@@ -132,4 +133,47 @@ func (q *Queries) ListUserSelectionsForDevice(ctx context.Context, deviceID stri
 		return nil, err
 	}
 	return items, nil
+}
+
+const upsertUserSelectionProjection = `-- name: UpsertUserSelectionProjection :exec
+INSERT INTO user_selections_projection (
+    id, device_id, source_type, source_id, selected,
+    updated_at, created_by, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (device_id, source_type, source_id) DO UPDATE SET
+    selected = EXCLUDED.selected,
+    updated_at = EXCLUDED.updated_at,
+    projection_version = EXCLUDED.projection_version
+WHERE user_selections_projection.projection_version < EXCLUDED.projection_version
+`
+
+type UpsertUserSelectionProjectionParams struct {
+	ID                string    `json:"id"`
+	DeviceID          string    `json:"device_id"`
+	SourceType        string    `json:"source_type"`
+	SourceID          string    `json:"source_id"`
+	Selected          bool      `json:"selected"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	CreatedBy         string    `json:"created_by"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// UserSelectionChanged handler. ON CONFLICT (device_id, source_type,
+// source_id) DO UPDATE matches the PL/pgSQL projector — repeated
+// selection toggles refresh the row in place. Stale-replay guard
+// on the conflict-update path: only overwrite if the incoming
+// projection_version is newer (matching the WHERE-guard pattern
+// established for other ports).
+func (q *Queries) UpsertUserSelectionProjection(ctx context.Context, arg UpsertUserSelectionProjectionParams) error {
+	_, err := q.db.Exec(ctx, upsertUserSelectionProjection,
+		arg.ID,
+		arg.DeviceID,
+		arg.SourceType,
+		arg.SourceID,
+		arg.Selected,
+		arg.UpdatedAt,
+		arg.CreatedBy,
+		arg.ProjectionVersion,
+	)
+	return err
 }

--- a/internal/store/migrations/027_user_selection_projector_to_go.sql
+++ b/internal/store/migrations/027_user_selection_projector_to_go.sql
@@ -1,0 +1,71 @@
+-- Replace project_user_selection_event() with a no-op stub. The
+-- actual projection logic now lives in
+-- projectors.UserSelectionListener (Go, post-commit).
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. The single event type (UserSelectionChanged) +
+--     UPSERT atomic with the event commit.
+--   - After: Go listener fires post-commit. Single UPSERT statement
+--     so no tx wrap needed.
+--
+-- Tightening: the UPSERT's conflict-update path now has a
+-- `WHERE user_selections_projection.projection_version <
+-- EXCLUDED.projection_version` guard rejecting stale reconciler
+-- replays. The PL/pgSQL projector lacked it.
+--
+-- ⚠️ Known issue (#125): the `user_selections` entry in
+-- AllRebuildTargets will dispatch to the no-op stub after this PR
+-- merges, breaking emergency rebuild via RebuildAll(ctx,
+-- "user_selections"). Same pattern affects `roles` and `tokens`
+-- since their respective ports merged. Tracked separately at #125.
+--
+-- See manchtools/power-manage-server#106. Eleventh and final port
+-- under tracker #107's projector-migration pattern.
+--
+-- Refs tracker #107.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_selection_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.UserSelectionListener.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the original PL/pgSQL projector verbatim from migration 002.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_selection_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'UserSelectionChanged' THEN
+            INSERT INTO user_selections_projection (
+                id, device_id, source_type, source_id, selected,
+                updated_at, created_by, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'device_id',
+                event.data->>'source_type',
+                event.data->>'source_id',
+                COALESCE((event.data->>'selected')::BOOLEAN, FALSE),
+                event.occurred_at,
+                event.actor_id,
+                event.sequence_num
+            ) ON CONFLICT (device_id, source_type, source_id) DO UPDATE
+            SET selected = COALESCE((event.data->>'selected')::BOOLEAN, FALSE),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/user_selections.sql
+++ b/internal/store/queries/user_selections.sql
@@ -36,3 +36,20 @@ WHERE asn.mode = 1 AND asn.is_deleted = FALSE
     OR (asn.target_type = 'user_group' AND asn.target_id IN (SELECT group_id FROM owner_groups))
   )
 ORDER BY asn.created_at DESC;
+
+-- name: UpsertUserSelectionProjection :exec
+-- UserSelectionChanged handler. ON CONFLICT (device_id, source_type,
+-- source_id) DO UPDATE matches the PL/pgSQL projector — repeated
+-- selection toggles refresh the row in place. Stale-replay guard
+-- on the conflict-update path: only overwrite if the incoming
+-- projection_version is newer (matching the WHERE-guard pattern
+-- established for other ports).
+INSERT INTO user_selections_projection (
+    id, device_id, source_type, source_id, selected,
+    updated_at, created_by, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (device_id, source_type, source_id) DO UPDATE SET
+    selected = EXCLUDED.selected,
+    updated_at = EXCLUDED.updated_at,
+    projection_version = EXCLUDED.projection_version
+WHERE user_selections_projection.projection_version < EXCLUDED.projection_version;

--- a/internal/store/queries/user_selections.sql
+++ b/internal/store/queries/user_selections.sql
@@ -44,6 +44,15 @@ ORDER BY asn.created_at DESC;
 -- on the conflict-update path: only overwrite if the incoming
 -- projection_version is newer (matching the WHERE-guard pattern
 -- established for other ports).
+--
+-- Note on `id` and `created_by`: the conflict-update branch does
+-- NOT touch them, so a row's `id` always reflects the FIRST
+-- UserSelectionChanged event for the composite key, not the most
+-- recent one. Queries scope by (device_id, source_type, source_id)
+-- and never join on `id`, so this is invisible to consumers — but
+-- a developer eyeballing event_id vs row_id during debugging
+-- should expect the divergence. Same shape as the deleted
+-- PL/pgSQL projector.
 INSERT INTO user_selections_projection (
     id, device_id, source_type, source_id, selected,
     updated_at, created_by, projection_version


### PR DESCRIPTION
## Summary

**Eleventh and FINAL port** under tracker #107's projector-migration pattern. Replaces `project_user_selection_event` PL/pgSQL with `projectors.UserSelectionListener`.

Single event type (`UserSelectionChanged`), single UPSERT statement — no transaction wrap needed. `ON CONFLICT (device_id, source_type, source_id) DO UPDATE` matches the PL/pgSQL projector — repeated selection toggles refresh the row in place.

Tightening: the conflict-update path now has a `WHERE projection_version < EXCLUDED.projection_version` guard rejecting stale reconciler replays. The PL/pgSQL projector lacked it.

> ⚠️ **Known issue (#125):** the `user_selections` entry in `AllRebuildTargets` will dispatch to the no-op stub after this PR merges, breaking emergency rebuild via `RebuildAll(ctx, "user_selections")`. Same pattern affects `roles` + `tokens` (already broken since their respective ports merged). The fix is to dispatch via the Go listener pipeline in `runOneTarget`; filed separately at #125 — recommend tackling that BEFORE the cleanup migration after this PR merges, so the cleanup migration can also drop the affected `AllRebuildTargets` entries that point at no-op stubs.

## Test plan

Tests written FIRST per saved TDD feedback.

- [x] Pure decoder: happy paths, default `selected=false` on missing, required-field validation per variant, wrong stream/event type, malformed payload
- [x] Integration: Select→Deselect (UPSERT in place, no duplicate row)
- [x] Integration: per-source-type scoping (`user` vs `user_group` don't collapse into one row)
- [x] Integration: `projection_version` stale-replay guard
- [x] Integration: wrong-stream-type ignored
- [x] All tests pass locally (`go test ./server/internal/projectors/...`)

## Tracker #107 progress

After #106 merges: **11 / 11 ports complete.** Ready for the cleanup migration + the un-ported-domain-projector future tracker.

Refs tracker #107. Closes #106.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add user selection projection to record selections per device/source with per-source scoping and stable IDs.
  * Upsert behavior prevents stale updates from overwriting newer selection states.

* **Chores**
  * Projection wiring updated to register the new listener; database projector disabled in migration (app-level projector used).

* **Tests**
  * Added tests covering event validation, upsert logic, scoping, and stale-replay protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->