### PR TITLE
chore: server error-handling + audit-log sweep

### DIFF
--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -126,7 +126,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 		)
 	}
 
-	h.logger.Info("user logged in", "user_id", user.ID, "email", user.Email)
+	h.logger.Info("user logged in", "user_id", user.ID)
 
 	protoUser := userToProto(user)
 	// Populate user roles

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -115,7 +115,8 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 		ActorType:  "user",
 		ActorID:    user.ID,
 	}); err != nil {
-		h.logger.Warn("failed to append UserLoggedIn event", "user_id", user.ID, "error", err)
+		h.logger.Error("AUDIT GAP: failed to append UserLoggedIn event; password login proceeded without audit record",
+			"user_id", user.ID, "error", err)
 	} else {
 		h.logger.Debug("event appended",
 			"request_id", middleware.RequestIDFromContext(ctx),

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -629,13 +629,13 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 	// Get current passwords
 	current, err := h.store.Queries().GetCurrentLpsPasswords(ctx, req.Msg.DeviceId)
 	if err != nil {
-		return nil, fmt.Errorf("get current LPS passwords: %w", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load current LPS passwords")
 	}
 
 	// Get password history
 	history, err := h.store.Queries().GetLpsPasswordHistory(ctx, req.Msg.DeviceId)
 	if err != nil {
-		return nil, fmt.Errorf("get LPS password history: %w", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load LPS password history")
 	}
 
 	// Convert to proto
@@ -658,7 +658,7 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 
 		decPassword, err := h.encryptor.Decrypt(p.Password)
 		if err != nil {
-			return nil, fmt.Errorf("decrypt LPS password: %w", err)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LPS password")
 		}
 		entry := &pm.LpsPassword{
 			DeviceId:       p.DeviceID,
@@ -682,7 +682,7 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 
 		decPassword, err := h.encryptor.Decrypt(p.Password)
 		if err != nil {
-			return nil, fmt.Errorf("decrypt LPS password: %w", err)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LPS password")
 		}
 		entry := &pm.LpsPassword{
 			DeviceId:       p.DeviceID,
@@ -707,12 +707,12 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 
 	current, err := h.store.Queries().GetCurrentLuksKeys(ctx, req.Msg.DeviceId)
 	if err != nil {
-		return nil, fmt.Errorf("get current LUKS keys: %w", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load current LUKS keys")
 	}
 
 	history, err := h.store.Queries().GetLuksKeyHistory(ctx, req.Msg.DeviceId)
 	if err != nil {
-		return nil, fmt.Errorf("get LUKS key history: %w", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load LUKS key history")
 	}
 
 	resp := &pm.GetDeviceLuksKeysResponse{}
@@ -732,7 +732,7 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 
 		decPassphrase, err := h.encryptor.Decrypt(k.Passphrase)
 		if err != nil {
-			return nil, fmt.Errorf("decrypt LUKS passphrase: %w", err)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LUKS passphrase")
 		}
 		entry := &pm.LuksKey{
 			DeviceId:       k.DeviceID,
@@ -765,7 +765,7 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 
 		decPassphrase, err := h.encryptor.Decrypt(k.Passphrase)
 		if err != nil {
-			return nil, fmt.Errorf("decrypt LUKS passphrase: %w", err)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LUKS passphrase")
 		}
 		entry := &pm.LuksKey{
 			DeviceId:       k.DeviceID,

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -658,6 +658,12 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 
 		decPassword, err := h.encryptor.Decrypt(p.Password)
 		if err != nil {
+			// Decrypt failure on stored material is alarming —
+			// possible key-rotation drift, corrupted ciphertext,
+			// or HSM/KMS issue. Log device + action context so
+			// operators can triage without re-running the RPC.
+			h.logger.Error("failed to decrypt LPS password (current)",
+				"device_id", p.DeviceID, "action_id", p.ActionID, "error", err)
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LPS password")
 		}
 		entry := &pm.LpsPassword{
@@ -682,6 +688,8 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 
 		decPassword, err := h.encryptor.Decrypt(p.Password)
 		if err != nil {
+			h.logger.Error("failed to decrypt LPS password (history)",
+				"device_id", p.DeviceID, "action_id", p.ActionID, "error", err)
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LPS password")
 		}
 		entry := &pm.LpsPassword{
@@ -732,6 +740,8 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 
 		decPassphrase, err := h.encryptor.Decrypt(k.Passphrase)
 		if err != nil {
+			h.logger.Error("failed to decrypt LUKS passphrase (current)",
+				"device_id", k.DeviceID, "action_id", k.ActionID, "device_path", k.DevicePath, "error", err)
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LUKS passphrase")
 		}
 		entry := &pm.LuksKey{
@@ -765,6 +775,8 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 
 		decPassphrase, err := h.encryptor.Decrypt(k.Passphrase)
 		if err != nil {
+			h.logger.Error("failed to decrypt LUKS passphrase (history)",
+				"device_id", k.DeviceID, "action_id", k.ActionID, "device_path", k.DevicePath, "error", err)
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LUKS passphrase")
 		}
 		entry := &pm.LuksKey{

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -65,6 +65,7 @@ const (
 	ErrDynamicGroupManualModify = "dynamic_group_manual_modify"
 	ErrCannotDeleteSystemRole   = "cannot_delete_system_role"
 	ErrCannotRenameSystemRole   = "cannot_rename_system_role"
+	ErrCannotRemoveLastAdmin    = "cannot_remove_last_admin"
 	ErrRoleInUse                = "role_in_use"
 	ErrSCIMAlreadyEnabled       = "scim_already_enabled"
 	ErrSCIMNotEnabled           = "scim_not_enabled"

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -356,7 +356,7 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count users")
 		}
 		if userCount <= 1 {
-			return nil, apiErrorCtx(ctx, ErrCannotRenameSystemRole, connect.CodeFailedPrecondition, "cannot remove last user from Admin role")
+			return nil, apiErrorCtx(ctx, ErrCannotRemoveLastAdmin, connect.CodeFailedPrecondition, "cannot remove last user from Admin role")
 		}
 	}
 

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -262,7 +262,6 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 				"user_id", linkResult.UserID,
 				"is_new", linkResult.IsNew,
 				"slug", req.Msg.Slug,
-				"email", claims.Email,
 				"subject", claims.Subject,
 			)
 			return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "account not found")

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -241,13 +241,13 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 		return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, "failed to verify id_token")
 	}
 
-	h.logger.Info("SSO claims verified", "slug", req.Msg.Slug, "email", claims.Email, "subject", claims.Subject)
+	h.logger.Info("SSO claims verified", "slug", req.Msg.Slug, "subject", claims.Subject)
 
 	// Link or create user
 	linker := idp.NewLinker(h.store.Queries(), &storeEventAdapter{store: h.store})
 	linkResult, err := linker.LinkOrCreate(ctx, provider, claims)
 	if err != nil {
-		h.logger.Warn("SSO user link/create failed", "error", err, "slug", req.Msg.Slug, "email", claims.Email)
+		h.logger.Warn("SSO user link/create failed", "error", err, "slug", req.Msg.Slug, "subject", claims.Subject)
 		if errors.Is(err, idp.ErrNoMatchingAccount) {
 			return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, err.Error())
 		}

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -331,7 +331,8 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 		ActorType: "user",
 		ActorID:   user.ID,
 	}); err != nil {
-		h.logger.Warn("failed to append UserLoggedIn event", "user_id", user.ID, "provider", provider.Slug, "error", err)
+		h.logger.Error("AUDIT GAP: failed to append UserLoggedIn event; SSO login proceeded without audit record",
+			"user_id", user.ID, "provider", provider.Slug, "error", err)
 	} else {
 		h.logger.Debug("event appended",
 			"request_id", middleware.RequestIDFromContext(ctx),

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -75,11 +75,6 @@ func (h *TOTPHandler) SetupTOTP(ctx context.Context, req *connect.Request[pm.Set
 	}
 
 	// Store via event
-	hashesAny := make([]any, len(hashes))
-	for i, h := range hashes {
-		hashesAny[i] = h
-	}
-
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "totp",
 		StreamID:   userCtx.ID,
@@ -402,7 +397,13 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to generate tokens")
 	}
 
-	// Emit login event
+	// Emit login event. Audit-grade: a UserLoggedIn append failure
+	// USED to log at Warn and let the login proceed with valid
+	// tokens, which meant an attacker capable of triggering
+	// event-store exhaustion could perform unlogged logins. Now
+	// logged at Error so audit-trail gaps surface in operator
+	// alerts; the RPC still succeeds (tokens already minted, no
+	// safe rollback) but the gap is loud rather than silent.
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   claims.UserID,
@@ -411,7 +412,8 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 		ActorType:  "user",
 		ActorID:    claims.UserID,
 	}); err != nil {
-		h.logger.Warn("failed to append UserLoggedIn event", "user_id", claims.UserID, "error", err)
+		h.logger.Error("AUDIT GAP: failed to append UserLoggedIn event; login proceeded without audit record",
+			"user_id", claims.UserID, "error", err)
 	} else {
 		h.logger.Debug("event appended",
 			"request_id", middleware.RequestIDFromContext(ctx),

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -3,10 +3,12 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -76,15 +78,20 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 	// structured AlreadyExists response in the common case. The
 	// projection's UNIQUE WHERE NOT is_deleted constraint still
 	// backstops correctness against the rare race where two
-	// concurrent CreateUser calls slip past this check; that path
-	// will surface as the generic Internal error from the
-	// AppendEvent failure below, which matches the previous
-	// behaviour for true unique violations the 23505-retry loop
-	// masks. This pre-check restores AlreadyExists semantics for
-	// the typical (non-racing) path that clients want to
-	// localize.
+	// concurrent CreateUser calls slip past this check.
+	//
+	// Distinguish three branches: row found → AlreadyExists;
+	// pgx.ErrNoRows → proceed (the email is free); any other
+	// error → surface as Internal so a transient DB problem
+	// doesn't get silently mistaken for "free to create" and
+	// then re-surface as the generic Internal from AppendEvent
+	// later — matching the established pattern in
+	// auth_handler.go:59 and sso_handler.go:179.
 	if _, err := h.store.Queries().GetUserByEmail(ctx, req.Msg.Email); err == nil {
 		return nil, apiErrorCtx(ctx, ErrEmailAlreadyExists, connect.CodeAlreadyExists, "email already exists")
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		h.logger.Error("failed to pre-check email uniqueness", "email", req.Msg.Email, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check email uniqueness")
 	}
 
 	// Assign Linux UID and derive username

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -90,7 +90,11 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 	if _, err := h.store.Queries().GetUserByEmail(ctx, req.Msg.Email); err == nil {
 		return nil, apiErrorCtx(ctx, ErrEmailAlreadyExists, connect.CodeAlreadyExists, "email already exists")
 	} else if !errors.Is(err, pgx.ErrNoRows) {
-		h.logger.Error("failed to pre-check email uniqueness", "email", req.Msg.Email, "error", err)
+		// Don't log raw email (PII). At this point the user doesn't
+		// exist yet (we're checking IF they should), so there's no
+		// user_id either. Operators triaging this can correlate
+		// from the request_id in the surrounding handler logs.
+		h.logger.Error("failed to pre-check email uniqueness", "error", err)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check email uniqueness")
 	}
 
@@ -138,7 +142,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 		// want a specific already-exists error code. For now,
 		// return a structured Internal error and log the actual
 		// cause so operators can triage.
-		h.logger.Error("failed to append UserCreated event", "user_id", id, "email", req.Msg.Email, "error", err)
+		h.logger.Error("failed to append UserCreated event", "user_id", id, "error", err)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create user")
 	}
 
@@ -156,7 +160,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 			// least surface this in operator logs so the gap can be
 			// triaged before a confused user files a ticket.
 			h.logger.Error("failed to look up default User role; new user created with no roles",
-				"user_id", id, "email", req.Msg.Email, "error", err)
+				"user_id", id, "error", err)
 		}
 	}
 	for _, roleID := range roleIDs {

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -102,7 +102,22 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 		ActorID:   userCtx.ID,
 	})
 	if err != nil {
-		return nil, apiErrorCtx(ctx, ErrEmailAlreadyExists, connect.CodeAlreadyExists, "email already exists")
+		// The previous code mapped EVERY AppendEvent failure to
+		// ErrEmailAlreadyExists / CodeAlreadyExists, which lied
+		// to clients on DB outages, projection-trigger violations,
+		// concurrent stream-version conflicts (which Store.AppendEvent
+		// retries internally and surfaces as "version conflict
+		// after N retries"), or any transient append failure.
+		// Detecting a true duplicate-email violation HERE is
+		// unreliable because Store.AppendEvent's internal
+		// 23505-retry loop masks the original PgError.
+		// Defer-to-handler-pre-check is the cleaner fix: callers
+		// should look up the email BEFORE AppendEvent if they
+		// want a specific already-exists error code. For now,
+		// return a structured Internal error and log the actual
+		// cause so operators can triage.
+		slog.Error("failed to append UserCreated event", "user_id", id, "email", req.Msg.Email, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create user")
 	}
 
 	// Auto-assign specified roles, or default User role if none specified
@@ -112,6 +127,14 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 		userRole, err := h.store.Queries().GetRoleByName(ctx, "User")
 		if err == nil {
 			roleIDs = []string{userRole.ID}
+		} else {
+			// The default-role lookup used to fail silently, leaving
+			// a freshly-created user with zero permissions. The user
+			// is already created so we can't fail the RPC, but at
+			// least surface this in operator logs so the gap can be
+			// triaged before a confused user files a ticket.
+			slog.Error("failed to look up default User role; new user created with no roles",
+				"user_id", id, "email", req.Msg.Email, "error", err)
 		}
 	}
 	for _, roleID := range roleIDs {
@@ -126,7 +149,14 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 			ActorType: "user",
 			ActorID:   userCtx.ID,
 		}); err != nil {
-			slog.Warn("failed to append UserRoleAssigned event", "user_id", id, "role_id", roleID, "error", err)
+			// Escalated from Warn to Error: a UserRoleAssigned
+			// failure leaves the user with one fewer role than the
+			// caller asked for, silently. Operators triaging
+			// "user has no permissions despite being assigned the
+			// admin role" need this in journalctl ERROR output, not
+			// hidden in Warn.
+			slog.Error("failed to append UserRoleAssigned event; user will be missing this role",
+				"user_id", id, "role_id", roleID, "error", err)
 		}
 	}
 

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -116,7 +116,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 		// want a specific already-exists error code. For now,
 		// return a structured Internal error and log the actual
 		// cause so operators can triage.
-		slog.Error("failed to append UserCreated event", "user_id", id, "email", req.Msg.Email, "error", err)
+		h.logger.Error("failed to append UserCreated event", "user_id", id, "email", req.Msg.Email, "error", err)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create user")
 	}
 
@@ -133,7 +133,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 			// is already created so we can't fail the RPC, but at
 			// least surface this in operator logs so the gap can be
 			// triaged before a confused user files a ticket.
-			slog.Error("failed to look up default User role; new user created with no roles",
+			h.logger.Error("failed to look up default User role; new user created with no roles",
 				"user_id", id, "email", req.Msg.Email, "error", err)
 		}
 	}
@@ -155,7 +155,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 			// "user has no permissions despite being assigned the
 			// admin role" need this in journalctl ERROR output, not
 			// hidden in Warn.
-			slog.Error("failed to append UserRoleAssigned event; user will be missing this role",
+			h.logger.Error("failed to append UserRoleAssigned event; user will be missing this role",
 				"user_id", id, "role_id", roleID, "error", err)
 		}
 	}
@@ -270,7 +270,7 @@ func (h *UserHandler) ListUsers(ctx context.Context, req *connect.Request[pm.Lis
 	// Populate inherited roles from user group memberships
 	inheritedRoles, err := h.store.Queries().ListAllInheritedRoles(ctx)
 	if err != nil {
-		slog.Warn("failed to load inherited roles", "error", err)
+		h.logger.Warn("failed to load inherited roles", "error", err)
 	} else {
 		inheritedMap := make(map[string][]*pm.InheritedRole)
 		for _, ir := range inheritedRoles {

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -72,6 +72,21 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 
 	id := ulid.Make().String()
 
+	// Pre-check for an already-existing email so clients get a
+	// structured AlreadyExists response in the common case. The
+	// projection's UNIQUE WHERE NOT is_deleted constraint still
+	// backstops correctness against the rare race where two
+	// concurrent CreateUser calls slip past this check; that path
+	// will surface as the generic Internal error from the
+	// AppendEvent failure below, which matches the previous
+	// behaviour for true unique violations the 23505-retry loop
+	// masks. This pre-check restores AlreadyExists semantics for
+	// the typical (non-racing) path that clients want to
+	// localize.
+	if _, err := h.store.Queries().GetUserByEmail(ctx, req.Msg.Email); err == nil {
+		return nil, apiErrorCtx(ctx, ErrEmailAlreadyExists, connect.CodeAlreadyExists, "email already exists")
+	}
+
 	// Assign Linux UID and derive username
 	linuxUID, err := h.store.Queries().GetNextLinuxUID(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

Seven related fixes from the recent audit + sibling sweeps. All independent of the in-flight projector ports — touches different files than #129.

1. **GetDeviceLpsPasswords + GetDeviceLuksKeys** (HIGH per audit): 6 bare \`fmt.Errorf\` returns replaced with \`apiErrorCtx\`. Clients now receive structured \`ErrorDetail\` instead of opaque wrapped-error strings. Covers all error paths: GetCurrent / GetHistory / Decrypt × 2 in each handler.

2. **CreateUser**: drop the misleading "any AppendEvent failure → ErrEmailAlreadyExists" branch. \`Store.AppendEvent\`'s internal 23505-retry loop masks the original \`PgError\`, so distinguishing a true unique violation from a transient failure is unreliable here. Surfaces structured Internal error + logs the actual cause. (A future caller-level pre-check before AppendEvent could restore the AlreadyExists code; deferred.)

3. **CreateUser**: \`GetRoleByName("User")\` failure escalated from silent \`if err == nil\` to a logged Error so operators can triage "user has no roles" cases without waiting for user tickets.

4. **CreateUser**: \`UserRoleAssigned\` append failures escalated from Warn to Error with explicit "user will be missing this role" wording.

5. **role_handler.go:359**: fixed wrong error constant — was returning \`ErrCannotRenameSystemRole\` ("System roles cannot be modified") for the "cannot remove last user from Admin role" precondition. New \`ErrCannotRemoveLastAdmin\` constant added in errors.go.

6. **UserLoggedIn audit gaps**: append failures across \`totp_handler\`, \`sso_handler\`, \`auth_handler\` escalated from Warn to Error with "AUDIT GAP" prefix. RPCs still succeed (tokens already minted, no safe rollback) but the gap is loud — matches the security framing that an attacker triggering event-store exhaustion could otherwise perform unlogged logins.

7. **Dead code**: \`hashesAny\` in \`totp_handler.go\` was allocated from \`hashes\` but never used; the event payload uses \`hashes\` directly.

## Cross-repo dependency (must merge first)

\`TestErrorCodeParityWithTSSDK\` reads \`sdk/ts/errors.ts\` via filesystem. CI must check out SDK at a commit that includes the matching const for parity to pass.

- **SDK**: https://github.com/manchtools/power-manage-sdk/pull/45 (one-line addition: \`ErrCannotRemoveLastAdmin\`)
- **Web**: \`dc84f65\` (already pushed direct-to-main per project workflow — adds \`error_cannot_remove_last_admin\` paraglide keys for en + de)

## Test plan

- [x] \`go build ./server/...\` clean
- [x] \`TestErrorCodeParityWithTSSDK\` passes locally (workspace SDK has the const)
- [x] Targeted: \`TestCreateUser\`, \`TestCreateRole\`, \`TestRevokeRole\` all pass
- [x] No file overlap with PR #129; safe to land in either order

Refs the audit findings list (Critical & High device_handler.go:632, plus 6 mediums + 1 dead code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Audit append failures during login (password, SSO, TOTP) now log as explicit errors ("AUDIT GAP") but no longer block login.
  * Device password/key retrieval and decryption failures now return standardized API errors.

* **Improvements**
  * Clearer error when removing the last Admin user.
  * User creation: early duplicate-email check, clearer failure handling, and auto-assignment of the built-in User role when none provided.
* **Privacy**
  * Login logs no longer include user email.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->