### PR TITLE
fix: route ported projectors through Go applier in RebuildAll (#125)

### DIFF
--- a/internal/projectors/role_listener.go
+++ b/internal/projectors/role_listener.go
@@ -30,28 +30,66 @@ func RoleListener(st *store.Store, logger *slog.Logger) store.EventListener {
 		if e.StreamType != "role" {
 			return
 		}
-		switch e.EventType {
-		case "RoleCreated":
-			applyRoleCreated(ctx, st, logger, e)
-		case "RoleUpdated":
-			applyRoleUpdated(ctx, st, logger, e)
-		case "RoleDeleted":
-			applyRoleDeleted(ctx, st, logger, e)
+		// RoleDeleted needs the SoftDelete + cascade DELETE wrapped
+		// in a transaction so the projection never observes "role
+		// marked deleted but memberships remain". The other event
+		// types are single statements and run on the autocommit
+		// connection. ApplyRole handles all three when called with
+		// tx-bound queries (the rebuild path), so we share its body
+		// for RoleDeleted via WithTx and short-circuit the simple
+		// cases through the pool.
+		if e.EventType == "RoleDeleted" {
+			err := st.WithTx(ctx, func(q *store.Queries) error {
+				return ApplyRole(ctx, q, e)
+			})
+			if err != nil {
+				logger.Warn("role projector: failed to apply RoleDeleted",
+					"event_id", e.ID, "role_id", e.StreamID, "error", err)
+			}
+			return
+		}
+		if err := ApplyRole(ctx, st.Queries(), e); err != nil {
+			logger.Warn("role projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "role_id", e.StreamID, "error", err)
 		}
 	}
 }
 
-func applyRoleCreated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+// ApplyRole is the transactional core of the role projector. The
+// listener wraps it for live-event dispatch (using WithTx for
+// RoleDeleted's two-write atomicity); the rebuild path
+// (manchtools/power-manage-server#125) registers it via
+// RegisterRebuildApply so RebuildAll re-derives the projection from
+// the event store instead of dispatching to the no-op PL/pgSQL stub.
+//
+// The asymmetric-guard discipline for RoleDeleted is preserved:
+// when the version-guarded SoftDelete affects zero rows, the cascade
+// DELETE is skipped — a stale RoleDeleted re-applied later must not
+// silently nuke a freshly-restored role's memberships (CR #123).
+func ApplyRole(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "role" {
+		return nil
+	}
+	switch e.EventType {
+	case "RoleCreated":
+		return applyRoleCreated(ctx, q, e)
+	case "RoleUpdated":
+		return applyRoleUpdated(ctx, q, e)
+	case "RoleDeleted":
+		return applyRoleDeleted(ctx, q, e)
+	}
+	return nil
+}
+
+func applyRoleCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := RoleCreatedFromEvent(e)
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("role projector: invalid RoleCreated payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().InsertRoleProjection(ctx, db.InsertRoleProjectionParams{
+	return q.InsertRoleProjection(ctx, db.InsertRoleProjectionParams{
 		ID:                payload.ID,
 		Name:              payload.Name,
 		Description:       payload.Description,
@@ -60,62 +98,41 @@ func applyRoleCreated(ctx context.Context, st *store.Store, logger *slog.Logger,
 		CreatedAt:         e.OccurredAt,
 		CreatedBy:         payload.CreatedBy,
 		ProjectionVersion: deref(e.SequenceNum),
-	}); err != nil {
-		logger.Warn("role projector: failed to insert RoleCreated",
-			"event_id", e.ID, "role_id", payload.ID, "error", err)
-	}
+	})
 }
 
-func applyRoleUpdated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applyRoleUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := RoleUpdatedFromEvent(e)
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("role projector: invalid RoleUpdated payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
 	updatedAt := e.OccurredAt
-	if err := st.Queries().UpdateRoleProjection(ctx, db.UpdateRoleProjectionParams{
+	return q.UpdateRoleProjection(ctx, db.UpdateRoleProjectionParams{
 		ID:                payload.ID,
 		Name:              payload.Name,
 		Description:       payload.Description,
 		Permissions:       derefSlice(payload.Permissions),
 		UpdatedAt:         &updatedAt,
 		ProjectionVersion: deref(e.SequenceNum),
-	}); err != nil {
-		logger.Warn("role projector: failed to apply RoleUpdated",
-			"event_id", e.ID, "role_id", payload.ID, "error", err)
-	}
+	})
 }
 
-func applyRoleDeleted(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
-	roleID := e.StreamID
-	if err := st.WithTx(ctx, func(q *store.Queries) error {
-		// SoftDeleteRoleProjection returns rows-affected. If the
-		// projection_version guard rejected the UPDATE (stale
-		// reconciler replay, or row already at a newer version), we
-		// must NOT cascade the membership delete — otherwise an old
-		// RoleDeleted re-applied later would silently nuke a
-		// freshly-restored role's memberships. CR caught this on PR
-		// #123.
-		n, err := q.SoftDeleteRoleProjection(ctx, db.SoftDeleteRoleProjectionParams{
-			ID:                roleID,
-			UpdatedAt:         &e.OccurredAt,
-			ProjectionVersion: deref(e.SequenceNum),
-		})
-		if err != nil {
-			return err
-		}
-		if n == 0 {
-			return nil
-		}
-		return q.DeleteUserRolesByRole(ctx, roleID)
-	}); err != nil {
-		logger.Warn("role projector: failed to apply RoleDeleted",
-			"event_id", e.ID, "role_id", roleID, "error", err)
+func applyRoleDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	n, err := q.SoftDeleteRoleProjection(ctx, db.SoftDeleteRoleProjectionParams{
+		ID:                e.StreamID,
+		UpdatedAt:         &e.OccurredAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
 	}
+	if n == 0 {
+		return nil
+	}
+	return q.DeleteUserRolesByRole(ctx, e.StreamID)
 }
 
 // derefSlice returns the value behind a pointer slice, or nil when

--- a/internal/projectors/token_listener.go
+++ b/internal/projectors/token_listener.go
@@ -30,53 +30,57 @@ func TokenListener(st *store.Store, logger *slog.Logger) store.EventListener {
 		return func(context.Context, store.PersistedEvent) {}
 	}
 	return func(ctx context.Context, e store.PersistedEvent) {
-		if e.StreamType != "token" {
-			return
-		}
-		switch e.EventType {
-		case "TokenCreated":
-			applyTokenCreated(ctx, st, logger, e)
-		case "TokenRenamed":
-			applyTokenRenamed(ctx, st, logger, e)
-		case "TokenUsed":
-			applyTokenSimpleUpdate(ctx, st, logger, e, func(q *store.Queries, ver int64) error {
-				return q.IncrementTokenUseProjection(ctx, db.IncrementTokenUseProjectionParams{
-					ID: e.StreamID, ProjectionVersion: ver,
-				})
-			})
-		case "TokenDisabled":
-			applyTokenSimpleUpdate(ctx, st, logger, e, func(q *store.Queries, ver int64) error {
-				return q.SetTokenDisabledProjection(ctx, db.SetTokenDisabledProjectionParams{
-					ID: e.StreamID, Disabled: true, ProjectionVersion: ver,
-				})
-			})
-		case "TokenEnabled":
-			applyTokenSimpleUpdate(ctx, st, logger, e, func(q *store.Queries, ver int64) error {
-				return q.SetTokenDisabledProjection(ctx, db.SetTokenDisabledProjectionParams{
-					ID: e.StreamID, Disabled: false, ProjectionVersion: ver,
-				})
-			})
-		case "TokenDeleted":
-			applyTokenSimpleUpdate(ctx, st, logger, e, func(q *store.Queries, ver int64) error {
-				return q.SoftDeleteTokenProjection(ctx, db.SoftDeleteTokenProjectionParams{
-					ID: e.StreamID, ProjectionVersion: ver,
-				})
-			})
+		if err := ApplyToken(ctx, st.Queries(), e); err != nil {
+			logger.Warn("token projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "token_id", e.StreamID, "error", err)
 		}
 	}
 }
 
-func applyTokenCreated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+// ApplyToken is the transactional core of the token projector. The
+// listener wraps it for live-event dispatch; the rebuild path
+// (manchtools/power-manage-server#125) registers it via
+// RegisterRebuildApply so RebuildAll re-derives the projection from
+// the event store instead of dispatching to the no-op PL/pgSQL stub.
+func ApplyToken(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "token" {
+		return nil
+	}
+	ver := deref(e.SequenceNum)
+	switch e.EventType {
+	case "TokenCreated":
+		return applyTokenCreated(ctx, q, e)
+	case "TokenRenamed":
+		return applyTokenRenamed(ctx, q, e)
+	case "TokenUsed":
+		return q.IncrementTokenUseProjection(ctx, db.IncrementTokenUseProjectionParams{
+			ID: e.StreamID, ProjectionVersion: ver,
+		})
+	case "TokenDisabled":
+		return q.SetTokenDisabledProjection(ctx, db.SetTokenDisabledProjectionParams{
+			ID: e.StreamID, Disabled: true, ProjectionVersion: ver,
+		})
+	case "TokenEnabled":
+		return q.SetTokenDisabledProjection(ctx, db.SetTokenDisabledProjectionParams{
+			ID: e.StreamID, Disabled: false, ProjectionVersion: ver,
+		})
+	case "TokenDeleted":
+		return q.SoftDeleteTokenProjection(ctx, db.SoftDeleteTokenProjectionParams{
+			ID: e.StreamID, ProjectionVersion: ver,
+		})
+	}
+	return nil
+}
+
+func applyTokenCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := TokenCreatedFromEvent(e)
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("token projector: invalid TokenCreated payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().InsertTokenProjection(ctx, db.InsertTokenProjectionParams{
+	return q.InsertTokenProjection(ctx, db.InsertTokenProjectionParams{
 		ID:                payload.ID,
 		ValueHash:         payload.ValueHash,
 		Name:              payload.Name,
@@ -87,43 +91,20 @@ func applyTokenCreated(ctx context.Context, st *store.Store, logger *slog.Logger
 		CreatedBy:         payload.CreatedBy,
 		OwnerID:           payload.OwnerID,
 		ProjectionVersion: deref(e.SequenceNum),
-	}); err != nil {
-		logger.Warn("token projector: failed to insert TokenCreated",
-			"event_id", e.ID, "token_id", payload.ID, "error", err)
-	}
+	})
 }
 
-func applyTokenRenamed(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applyTokenRenamed(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := TokenRenamedFromEvent(e)
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("token projector: invalid TokenRenamed payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().RenameTokenProjection(ctx, db.RenameTokenProjectionParams{
+	return q.RenameTokenProjection(ctx, db.RenameTokenProjectionParams{
 		ID:                payload.ID,
 		Name:              payload.Name,
 		ProjectionVersion: deref(e.SequenceNum),
-	}); err != nil {
-		logger.Warn("token projector: failed to apply TokenRenamed",
-			"event_id", e.ID, "token_id", payload.ID, "error", err)
-	}
-}
-
-// applyTokenSimpleUpdate is the shared scaffold for the four
-// no-payload event types (Used, Disabled, Enabled, Deleted). They
-// all key off StreamID + the event sequence_num and differ only in
-// which sqlc query they call — the closure isolates that one
-// difference.
-func applyTokenSimpleUpdate(
-	ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent,
-	apply func(q *store.Queries, projectionVersion int64) error,
-) {
-	if err := apply(st.Queries(), deref(e.SequenceNum)); err != nil {
-		logger.Warn("token projector: failed to apply token update",
-			"event_id", e.ID, "event_type", e.EventType, "token_id", e.StreamID, "error", err)
-	}
+	})
 }

--- a/internal/projectors/user_selection_listener.go
+++ b/internal/projectors/user_selection_listener.go
@@ -20,39 +20,46 @@ func UserSelectionListener(st *store.Store, logger *slog.Logger) store.EventList
 		return func(context.Context, store.PersistedEvent) {}
 	}
 	return func(ctx context.Context, e store.PersistedEvent) {
-		if e.StreamType != "user_selection" {
-			return
-		}
-		if e.EventType != "UserSelectionChanged" {
-			return
-		}
-
-		payload, err := UserSelectionChangedFromEvent(e)
-		if err != nil {
-			if errors.Is(err, ErrIgnoredEvent) {
-				return
-			}
-			logger.Warn("user_selection projector: invalid UserSelectionChanged payload",
-				"event_id", e.ID, "error", err)
-			return
-		}
-
-		if err := st.Queries().UpsertUserSelectionProjection(ctx, db.UpsertUserSelectionProjectionParams{
-			ID:                payload.ID,
-			DeviceID:          payload.DeviceID,
-			SourceType:        payload.SourceType,
-			SourceID:          payload.SourceID,
-			Selected:          payload.Selected,
-			UpdatedAt:         e.OccurredAt,
-			CreatedBy:         payload.CreatedBy,
-			ProjectionVersion: deref(e.SequenceNum),
-		}); err != nil {
-			logger.Warn("user_selection projector: failed to upsert UserSelectionChanged",
+		if err := ApplyUserSelection(ctx, st.Queries(), e); err != nil {
+			logger.Warn("user_selection projector: failed to apply UserSelectionChanged",
 				"event_id", e.ID,
-				"device_id", payload.DeviceID,
-				"source_type", payload.SourceType,
-				"source_id", payload.SourceID,
+				"stream_id", e.StreamID,
 				"error", err)
 		}
 	}
 }
+
+// ApplyUserSelection is the transactional core of the user_selection
+// projector. The listener wraps it for live-event dispatch; the
+// rebuild path (manchtools/power-manage-server#125) registers it via
+// RegisterRebuildApply so RebuildAll re-derives the projection from
+// the event store instead of dispatching to the no-op PL/pgSQL stub.
+//
+// Returns nil for non-matching stream/event types so the rebuild
+// loop treats them as harmless no-ops.
+func ApplyUserSelection(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "user_selection" {
+		return nil
+	}
+	if e.EventType != "UserSelectionChanged" {
+		return nil
+	}
+	payload, err := UserSelectionChangedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	return q.UpsertUserSelectionProjection(ctx, db.UpsertUserSelectionProjectionParams{
+		ID:                payload.ID,
+		DeviceID:          payload.DeviceID,
+		SourceType:        payload.SourceType,
+		SourceID:          payload.SourceID,
+		Selected:          payload.Selected,
+		UpdatedAt:         e.OccurredAt,
+		CreatedBy:         payload.CreatedBy,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+}
+

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -76,6 +76,20 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 	// of the un-ported domain projectors (user, device, action,
 	// execution, assignment, compliance, etc.) will land in a
 	// separate tracker.
+
+	// Rebuild appliers (manchtools/power-manage-server#125). Only
+	// the ported projectors that own a rebuildTarget in
+	// store.AllRebuildTargets need this wiring — RebuildAll
+	// dispatches everything else through the legacy PL/pgSQL
+	// Function. Of the 11 #107 ports, three own rebuild targets:
+	// roles, tokens, user_selections. The other eight projector
+	// streams (security_alert, totp, lps_password, luks_key,
+	// server_settings, user_role, identity_provider,
+	// scim_group_mapping) never had a rebuild target so RebuildAll
+	// does not touch them.
+	st.RegisterRebuildApply("roles", ApplyRole)
+	st.RegisterRebuildApply("tokens", ApplyToken)
+	st.RegisterRebuildApply("user_selections", ApplyUserSelection)
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -220,7 +220,7 @@ func (s *Store) RebuildAll(ctx context.Context, targetNames ...string) (RebuildR
 	err = pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
 		for _, t := range targets {
 			tStart := time.Now()
-			applied, runErr := runOneTarget(ctx, tx, t)
+			applied, runErr := s.runOneTarget(ctx, tx, t)
 			if runErr != nil {
 				return fmt.Errorf("rebuild target %q: %w", t.Name, runErr)
 			}
@@ -264,7 +264,7 @@ func (s *Store) RebuildAll(ctx context.Context, targetNames ...string) (RebuildR
 // roundtrip plus the Postgres-side projector execution. For a
 // production-scale event store (10k–100k events) this completes in
 // seconds — fine for an emergency-rebuild operator command.
-func runOneTarget(ctx context.Context, tx pgx.Tx, t rebuildTarget) (int64, error) {
+func (s *Store) runOneTarget(ctx context.Context, tx pgx.Tx, t rebuildTarget) (int64, error) {
 	for _, table := range t.Tables {
 		stmt := "TRUNCATE TABLE " + table
 		if t.Cascade {
@@ -275,6 +275,64 @@ func runOneTarget(ctx context.Context, tx pgx.Tx, t rebuildTarget) (int64, error
 		}
 	}
 
+	if apply := s.rebuildApplyFor(t.Name); apply != nil {
+		return s.dispatchViaGoApplier(ctx, tx, t, apply)
+	}
+	return s.dispatchViaPlpgsql(ctx, tx, t)
+}
+
+// dispatchViaGoApplier replays every event matching the target's
+// stream types through the registered Go applier. Loads the full
+// event row into Go (we need the payload, actor, occurred_at —
+// PL/pgSQL dispatch only needed the row composite). Each apply runs
+// against tx-bound queries so writes share atomicity with the outer
+// rebuild transaction.
+//
+// Refs manchtools/power-manage-server#125.
+func (s *Store) dispatchViaGoApplier(ctx context.Context, tx pgx.Tx, t rebuildTarget, apply RebuildApply) (int64, error) {
+	q := s.queries.WithTx(tx)
+	rows, err := tx.Query(ctx,
+		`SELECT id, sequence_num, stream_type, stream_id, stream_version,
+		        event_type, data, metadata, actor_type, actor_id, occurred_at
+		   FROM events
+		  WHERE stream_type = ANY($1)
+		  ORDER BY sequence_num`,
+		t.StreamTypes,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("load events for %s: %w", t.Name, err)
+	}
+	events := make([]PersistedEvent, 0, 256)
+	for rows.Next() {
+		var ev PersistedEvent
+		if err := rows.Scan(
+			&ev.ID, &ev.SequenceNum, &ev.StreamType, &ev.StreamID, &ev.StreamVersion,
+			&ev.EventType, &ev.Data, &ev.Metadata, &ev.ActorType, &ev.ActorID, &ev.OccurredAt,
+		); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("scan event row for %s: %w", t.Name, err)
+		}
+		events = append(events, ev)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("iterate events for %s: %w", t.Name, err)
+	}
+
+	for _, ev := range events {
+		if err := apply(ctx, q, ev); err != nil {
+			return 0, fmt.Errorf("apply event %s for %s: %w", ev.ID, t.Name, err)
+		}
+	}
+	return int64(len(events)), nil
+}
+
+// dispatchViaPlpgsql runs the legacy `SELECT project_<X>_event(events.*)`
+// dispatch for targets that have not yet been ported to a Go
+// projector. Once tracker #107's last domain projector is ported and
+// the PL/pgSQL stubs are dropped, this branch and the rebuildTarget
+// Function field can be removed.
+func (s *Store) dispatchViaPlpgsql(ctx context.Context, tx pgx.Tx, t rebuildTarget) (int64, error) {
 	rows, err := tx.Query(ctx,
 		"SELECT id FROM events WHERE stream_type = ANY($1) ORDER BY sequence_num",
 		t.StreamTypes,

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -110,6 +110,145 @@ func TestRebuildAll_UnknownTargetIsRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "nonexistent")
 }
 
+// TestRebuildAll_PortedProjector_RoundTrip — covers the regression
+// from manchtools/power-manage-server#125: once a projector is
+// ported to a Go listener, the corresponding PL/pgSQL
+// project_<X>_event() becomes a no-op stub. RebuildAll then
+// TRUNCATEs the projection and dispatches every event through the
+// stub, leaving the projection empty.
+//
+// The fix routes ported targets through a Go applier registered in
+// projectors.WireAll. This test exercises that path end-to-end on
+// the "roles" target — the first ported projector that owned a
+// rebuild target — by creating a role via the live pipeline,
+// truncating its projection, calling RebuildAll, and asserting the
+// row reappears with the same fields.
+func TestRebuildAll_PortedProjector_RoundTrip(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	roleID := testutil.CreateTestRole(t, st, adminID, "RebuildPortedRole", []string{"users:read"})
+
+	before, err := st.Queries().GetRoleByID(ctx, roleID)
+	require.NoError(t, err, "role must exist after live pipeline projection")
+	assert.Equal(t, "RebuildPortedRole", before.Name)
+
+	_, err = st.Pool().Exec(ctx, "TRUNCATE roles_projection CASCADE")
+	require.NoError(t, err)
+
+	_, err = st.Queries().GetRoleByID(ctx, roleID)
+	require.Error(t, err, "post-truncate fetch must fail; if it doesn't the truncate didn't take")
+
+	res, err := st.RebuildAll(ctx, "roles")
+	require.NoError(t, err)
+	require.Len(t, res.Targets, 1)
+	assert.Equal(t, "roles", res.Targets[0].Name)
+	assert.Greater(t, res.Targets[0].EventsApplied, int64(0),
+		"at least the RoleCreated event must have been replayed")
+
+	after, err := st.Queries().GetRoleByID(ctx, roleID)
+	require.NoError(t, err, "rebuild must restore the role projection — issue #125 regression if this fails")
+	assert.Equal(t, before.Name, after.Name)
+	assert.Equal(t, before.ID, after.ID)
+}
+
+// TestRebuildAll_PortedToken_RoundTrip — same #125 regression
+// coverage as the roles test, but for the tokens target. Different
+// applier path, so deserves its own test rather than relying on the
+// roles test as a stand-in.
+func TestRebuildAll_PortedToken_RoundTrip(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	tokenID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "token",
+		StreamID:   tokenID,
+		EventType:  "TokenCreated",
+		Data: map[string]any{
+			"id":         tokenID,
+			"value_hash": "test-hash",
+			"name":       "RebuildPortedToken",
+			"one_time":   false,
+			"max_uses":   nil,
+			"expires_at": nil,
+			"owner_id":   adminID,
+			"created_by": adminID,
+		},
+		ActorType: "user",
+		ActorID:   adminID,
+	}))
+
+	before, err := st.Queries().GetTokenByID(ctx, generated.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err, "token must exist after live pipeline projection")
+	assert.Equal(t, "RebuildPortedToken", before.Name)
+
+	_, err = st.Pool().Exec(ctx, "TRUNCATE tokens_projection CASCADE")
+	require.NoError(t, err)
+
+	res, err := st.RebuildAll(ctx, "tokens")
+	require.NoError(t, err)
+	assert.Greater(t, res.Targets[0].EventsApplied, int64(0))
+
+	after, err := st.Queries().GetTokenByID(ctx, generated.GetTokenByIDParams{ID: tokenID})
+	require.NoError(t, err, "rebuild must restore the token projection — issue #125 regression if this fails")
+	assert.Equal(t, before.Name, after.Name)
+	assert.Equal(t, before.ID, after.ID)
+}
+
+// TestRebuildAll_PortedUserSelection_RoundTrip — third ported target
+// with a rebuild entry. Different applier (single UPSERT, no
+// transaction wrap) so worth its own coverage even though the role
+// + token tests already prove the dispatcher path.
+func TestRebuildAll_PortedUserSelection_RoundTrip(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "rebuild-user-selection-host")
+	groupID := testutil.CreateTestUserGroup(t, st, adminID, "RebuildPortedSelectionGroup")
+
+	selectionID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_selection",
+		StreamID:   selectionID,
+		EventType:  "UserSelectionChanged",
+		Data: map[string]any{
+			"id":          selectionID,
+			"device_id":   deviceID,
+			"source_type": "user_group",
+			"source_id":   groupID,
+			"selected":    true,
+			"created_by":  adminID,
+		},
+		ActorType: "user",
+		ActorID:   adminID,
+	}))
+
+	before, err := st.Queries().GetUserSelection(ctx, generated.GetUserSelectionParams{
+		DeviceID: deviceID, SourceType: "user_group", SourceID: groupID,
+	})
+	require.NoError(t, err, "selection must exist after live pipeline projection")
+	assert.True(t, before.Selected)
+
+	_, err = st.Pool().Exec(ctx, "TRUNCATE user_selections_projection CASCADE")
+	require.NoError(t, err)
+
+	res, err := st.RebuildAll(ctx, "user_selections")
+	require.NoError(t, err)
+	assert.Greater(t, res.Targets[0].EventsApplied, int64(0))
+
+	after, err := st.Queries().GetUserSelection(ctx, generated.GetUserSelectionParams{
+		DeviceID: deviceID, SourceType: "user_group", SourceID: groupID,
+	})
+	require.NoError(t, err, "rebuild must restore the user_selection projection — issue #125 regression if this fails")
+	assert.Equal(t, before.ID, after.ID)
+	assert.Equal(t, before.Selected, after.Selected)
+}
+
 // TestRebuildAll_TransactionalAtomicity — if the projector function
 // fails partway through replay, the whole rebuild must roll back so
 // the projection is not left half-replayed against a TRUNCATE'd

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -189,8 +189,12 @@ func TestRebuildAll_PortedToken_RoundTrip(t *testing.T) {
 	_, err = st.Pool().Exec(ctx, "TRUNCATE tokens_projection CASCADE")
 	require.NoError(t, err)
 
+	_, err = st.Queries().GetTokenByID(ctx, generated.GetTokenByIDParams{ID: tokenID})
+	require.Error(t, err, "post-truncate fetch must fail; if it doesn't the truncate didn't take")
+
 	res, err := st.RebuildAll(ctx, "tokens")
 	require.NoError(t, err)
+	require.Len(t, res.Targets, 1)
 	assert.Greater(t, res.Targets[0].EventsApplied, int64(0))
 
 	after, err := st.Queries().GetTokenByID(ctx, generated.GetTokenByIDParams{ID: tokenID})
@@ -237,8 +241,14 @@ func TestRebuildAll_PortedUserSelection_RoundTrip(t *testing.T) {
 	_, err = st.Pool().Exec(ctx, "TRUNCATE user_selections_projection CASCADE")
 	require.NoError(t, err)
 
+	_, err = st.Queries().GetUserSelection(ctx, generated.GetUserSelectionParams{
+		DeviceID: deviceID, SourceType: "user_group", SourceID: groupID,
+	})
+	require.Error(t, err, "post-truncate fetch must fail; if it doesn't the truncate didn't take")
+
 	res, err := st.RebuildAll(ctx, "user_selections")
 	require.NoError(t, err)
+	require.Len(t, res.Targets, 1)
 	assert.Greater(t, res.Targets[0].EventsApplied, int64(0))
 
 	after, err := st.Queries().GetUserSelection(ctx, generated.GetUserSelectionParams{

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -195,6 +195,7 @@ func TestRebuildAll_PortedToken_RoundTrip(t *testing.T) {
 	res, err := st.RebuildAll(ctx, "tokens")
 	require.NoError(t, err)
 	require.Len(t, res.Targets, 1)
+	assert.Equal(t, "tokens", res.Targets[0].Name)
 	assert.Greater(t, res.Targets[0].EventsApplied, int64(0))
 
 	after, err := st.Queries().GetTokenByID(ctx, generated.GetTokenByIDParams{ID: tokenID})
@@ -249,6 +250,7 @@ func TestRebuildAll_PortedUserSelection_RoundTrip(t *testing.T) {
 	res, err := st.RebuildAll(ctx, "user_selections")
 	require.NoError(t, err)
 	require.Len(t, res.Targets, 1)
+	assert.Equal(t, "user_selections", res.Targets[0].Name)
 	assert.Greater(t, res.Targets[0].EventsApplied, int64(0))
 
 	after, err := st.Queries().GetUserSelection(ctx, generated.GetUserSelectionParams{

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -52,18 +52,34 @@ type Event struct {
 // failures are observability, not correctness.
 type EventListener func(ctx context.Context, ev PersistedEvent)
 
+// RebuildApply replays one event during a RebuildAll pass. It runs
+// inside the rebuild's outer transaction, so the supplied *Queries is
+// already tx-bound — applier writes commit (or roll back) atomically
+// with the surrounding TRUNCATEs and other targets in the same
+// rebuild. Applier returns an error to abort the entire rebuild;
+// successful no-ops (event type the projector doesn't care about)
+// must return nil.
+//
+// Wired in projectors.WireAll for every Go-ported projector that
+// owns an entry in AllRebuildTargets. RebuildAll falls back to the
+// PL/pgSQL Function dispatch when no applier is registered for the
+// target — preserves operator behaviour for not-yet-ported targets.
+//
+// Refs manchtools/power-manage-server#125.
+type RebuildApply func(ctx context.Context, q *Queries, ev PersistedEvent) error
+
 // Store wraps the database connection and provides access to queries.
 type Store struct {
 	pool    *pgxpool.Pool
 	queries *Queries
 
-	// listenersMu guards listeners + OnEventAppended. Documented
-	// usage is "register at boot, then start serving", but Go's race
-	// detector won't catch a future caller that registers after
-	// AppendEvent is in flight (concurrent slice append + range read
-	// is a data race). RWMutex is cheap on the hot read path
-	// (fireListeners holds RLock) and lets boot code register without
-	// extra ceremony.
+	// listenersMu guards listeners + OnEventAppended +
+	// rebuildAppliers. Documented usage is "register at boot, then
+	// start serving", but Go's race detector won't catch a future
+	// caller that registers after AppendEvent is in flight
+	// (concurrent slice append + range read is a data race). RWMutex
+	// is cheap on the hot read path (fireListeners holds RLock) and
+	// lets boot code register without extra ceremony.
 	listenersMu sync.RWMutex
 
 	// listeners are invoked after every successful AppendEvent /
@@ -73,6 +89,14 @@ type Store struct {
 	// can append additional consumers without callers stomping on
 	// each other.
 	listeners []EventListener
+
+	// rebuildAppliers maps a rebuild-target name to a Go applier
+	// that runOneTarget calls per event in lieu of the no-op
+	// PL/pgSQL stub left behind by tracker #107 ports. Populated at
+	// boot via projectors.WireAll → RegisterRebuildApply. Lookup is
+	// guarded by listenersMu (same boot-once-then-read posture as
+	// listeners). See manchtools/power-manage-server#125.
+	rebuildAppliers map[string]RebuildApply
 
 	// OnEventAppended is preserved for backwards compatibility with
 	// the search-indexing wiring at cmd/control/main.go. Setting it
@@ -94,6 +118,34 @@ func (s *Store) RegisterEventListener(fn EventListener) {
 	s.listenersMu.Lock()
 	s.listeners = append(s.listeners, fn)
 	s.listenersMu.Unlock()
+}
+
+// RegisterRebuildApply binds a Go applier to a named rebuild target.
+// Subsequent RebuildAll calls dispatch matching events through this
+// closure instead of the (now no-op) PL/pgSQL project_<X>_event()
+// stub. Re-registering the same name overwrites — boot-time wiring
+// is expected to call this once per target.
+//
+// Refs manchtools/power-manage-server#125.
+func (s *Store) RegisterRebuildApply(name string, fn RebuildApply) {
+	if fn == nil || name == "" {
+		return
+	}
+	s.listenersMu.Lock()
+	if s.rebuildAppliers == nil {
+		s.rebuildAppliers = make(map[string]RebuildApply)
+	}
+	s.rebuildAppliers[name] = fn
+	s.listenersMu.Unlock()
+}
+
+// rebuildApplyFor returns the registered applier for a target name,
+// or nil when no Go applier is wired (in which case runOneTarget
+// falls back to PL/pgSQL Function dispatch).
+func (s *Store) rebuildApplyFor(name string) RebuildApply {
+	s.listenersMu.RLock()
+	defer s.listenersMu.RUnlock()
+	return s.rebuildAppliers[name]
 }
 
 // fireListeners invokes both the legacy OnEventAppended callback (if


### PR DESCRIPTION
## Summary

Closes manchtools/power-manage-server#125.

After tracker #107 ported eleven projectors from PL/pgSQL to Go listeners, the legacy `RebuildAll` dispatcher kept calling the `project_<X>_event()` PL/pgSQL functions — now no-op stubs — for every event matching a target's stream types. The result for the three ported projectors that own a `rebuildTarget` (`roles`, `tokens`, `user_selections`) was that emergency rebuilds TRUNCATEd the projection and then dispatched every replayed event to a no-op, leaving the projection permanently empty.

This change wires a Go-side applier registry into the rebuild pipeline:

- `store.RebuildApply` + `Store.RegisterRebuildApply` — new boot-time registry that maps a target name to a Go closure operating on tx-bound queries.
- `runOneTarget` — split into `dispatchViaGoApplier` (used when a Go applier is registered) and `dispatchViaPlpgsql` (legacy path for not-yet-ported targets).
- `projectors.{ApplyRole,ApplyToken,ApplyUserSelection}` — exposed as the transactional cores of the three affected listeners. The listener wrappers now delegate to them, and `WireAll` registers them under the matching `AllRebuildTargets` names.
- The asymmetric-guard discipline introduced in CR #123 for `ApplyRole.RoleDeleted` (skip the cascade DELETE when the version-guarded SoftDelete affected zero rows) is preserved — the listener still wraps in `WithTx` for atomicity and the rebuild path inherits atomicity from the outer rebuild transaction.

This unblocks the cleanup migration that drops the eleven PL/pgSQL stubs and the `project_event()` dispatcher.

## Test plan

- [x] New `TestRebuildAll_PortedRole_RoundTrip` — proves `RebuildAll(ctx, "roles")` restores the projection after a TRUNCATE. Fails red without the fix (no rows in result set), passes green with it.
- [x] New `TestRebuildAll_PortedToken_RoundTrip` — same shape for the tokens target.
- [x] New `TestRebuildAll_PortedUserSelection_RoundTrip` — same shape for the user_selections target.
- [x] Existing `TestRebuildAll_RoundTripsThroughEventStore` (users, not yet ported) still passes — fallback path unchanged.
- [x] Existing `TestRebuildAll_NoArgsRebuildsEverything` still passes — every registered target rebuilds.
- [x] Existing `TestRebuildAll_UnknownTargetIsRejected` still passes — selectTargets validation unchanged.
- [x] Existing role/token/user_selection listener tests pass — confirms the listener-side refactor is behaviour-preserving (asymmetric guard, ignored-event handling, payload-decode errors).
- [x] `go build ./...` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized event processing for roles, tokens, and user selections with transactional handling and consolidated error propagation.
* **New Features**
  * Added a Go-based rebuild pathway with registration and wiring for projector targets as an alternative to DB-side replay.
* **Tests**
  * Added end-to-end rebuild round-trip tests for roles, tokens, and user selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->