### PR TITLE
chore: drop ported projector stubs after tracker #107 + #125

### DIFF
--- a/internal/store/migration_028_test.go
+++ b/internal/store/migration_028_test.go
@@ -1,0 +1,77 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestMigration028_DroppedStubsAreGone — migration 028 drops the ten
+// no-op PL/pgSQL projector stubs left behind by tracker #107. If any
+// future migration restores them (or someone re-adds one by accident),
+// this test fails. Bug-class avoidance: silent re-creation of a stub
+// would let a future event-store path call into a no-op without
+// projecting, which is exactly the #125 footgun this cleanup is
+// closing.
+func TestMigration028_DroppedStubsAreGone(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	droppedStubs := []string{
+		"project_token_event",
+		"project_user_selection_event",
+		"project_role_event",
+		"project_user_role_event",
+		"project_totp_event",
+		"project_identity_provider_event",
+		"project_scim_group_mapping_event",
+		"project_server_settings_event",
+		"project_lps_password_event",
+		"project_luks_key_event",
+	}
+	for _, fn := range droppedStubs {
+		var exists bool
+		err := st.Pool().QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM pg_proc WHERE proname = $1)`, fn,
+		).Scan(&exists)
+		require.NoError(t, err)
+		assert.False(t, exists, "%s must be dropped by migration 028 — re-introducing it reopens issue #125", fn)
+	}
+}
+
+// TestMigration028_UnportedProjectorsRemain — the eleven still-PL/pgSQL
+// projectors must survive migration 028 untouched, otherwise the
+// dispatcher would trigger "function does not exist" errors for
+// every event of those stream types. Sibling-sweep coverage paired
+// with TestMigration028_DroppedStubsAreGone.
+func TestMigration028_UnportedProjectorsRemain(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	keptProjectors := []string{
+		"project_user_event",
+		"project_device_event",
+		"project_action_event",
+		"project_definition_event",
+		"project_action_set_event",
+		"project_device_group_event",
+		"project_assignment_event",
+		"project_execution_event",
+		"project_user_group_event",
+		"project_compliance_event",
+		"project_compliance_policy_event",
+		"project_event", // the dispatcher itself
+	}
+	for _, fn := range keptProjectors {
+		var exists bool
+		err := st.Pool().QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM pg_proc WHERE proname = $1)`, fn,
+		).Scan(&exists)
+		require.NoError(t, err)
+		assert.True(t, exists, "%s must survive migration 028 — its stream type is not yet ported to Go", fn)
+	}
+}

--- a/internal/store/migrations/028_drop_ported_projector_stubs.sql
+++ b/internal/store/migrations/028_drop_ported_projector_stubs.sql
@@ -1,0 +1,436 @@
+-- Cleanup after tracker #107: ten of the eleven Go-ported projectors
+-- left no-op PL/pgSQL stubs behind so the shared project_event()
+-- dispatcher trigger could keep PERFORMing them without raising
+-- projection_errors. (security_alert dropped its stub already in
+-- migration 017.) PR #131 (manchtools/power-manage-server#125) routed
+-- the three rebuild targets through Go appliers, severing the last
+-- caller of those stubs.
+--
+-- This migration:
+--   1. Rewrites project_event() to remove the WHEN clauses for the ten
+--      ported stream types — live INSERT-into-events traffic stops
+--      paying the per-event PERFORM cost on the no-op stubs and stops
+--      writing projection_errors rows when the stub itself raises.
+--   2. Drops the ten no-op stub functions so accidental future calls
+--      from operator psql sessions surface as a clean
+--      "function does not exist" instead of silently no-oping.
+--
+-- The shared project_event() trigger stays in place: eleven domain
+-- projectors are still PL/pgSQL (user, device, action, definition,
+-- action_set, device_group, assignment, execution, user_group,
+-- compliance, compliance_policy) and depend on it. A follow-up tracker
+-- will port those.
+--
+-- See manchtools/power-manage-server#107 + #125.
+
+-- +goose Up
+
+-- ----------------------------------------------------------------------
+-- 1. Trim project_event() down to the eleven still-PL/pgSQL projectors.
+-- ----------------------------------------------------------------------
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_event() RETURNS trigger AS $$
+BEGIN
+    CASE NEW.stream_type
+        WHEN 'user' THEN
+            BEGIN
+                PERFORM project_user_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'device' THEN
+            BEGIN
+                PERFORM project_device_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'action' THEN
+            BEGIN
+                PERFORM project_action_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'definition' THEN
+            BEGIN
+                PERFORM project_action_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, 'definition->action', SQLERRM);
+            END;
+
+            BEGIN
+                PERFORM project_definition_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, 'definition->definition', SQLERRM);
+            END;
+
+        WHEN 'action_set' THEN
+            BEGIN
+                PERFORM project_action_set_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'device_group' THEN
+            BEGIN
+                PERFORM project_device_group_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'assignment' THEN
+            BEGIN
+                PERFORM project_assignment_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'execution' THEN
+            BEGIN
+                PERFORM project_execution_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'user_group' THEN
+            BEGIN
+                PERFORM project_user_group_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'compliance' THEN
+            BEGIN
+                PERFORM project_compliance_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'compliance_policy' THEN
+            BEGIN
+                PERFORM project_compliance_policy_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        ELSE
+            -- The ten ported stream types (token, user_selection, role,
+            -- user_role, totp, identity_provider, scim_group_mapping,
+            -- server_settings, lps_password, luks_key) and security_alert
+            -- are projected by Go listeners registered in
+            -- projectors.WireAll. Hitting this branch for any of them is
+            -- expected and intentional.
+            NULL;
+    END CASE;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- ----------------------------------------------------------------------
+-- 2. Drop the ten no-op stubs left behind by tracker #107.
+-- ----------------------------------------------------------------------
+
+DROP FUNCTION IF EXISTS project_token_event(events);
+DROP FUNCTION IF EXISTS project_user_selection_event(events);
+DROP FUNCTION IF EXISTS project_role_event(events);
+DROP FUNCTION IF EXISTS project_user_role_event(events);
+DROP FUNCTION IF EXISTS project_totp_event(events);
+DROP FUNCTION IF EXISTS project_identity_provider_event(events);
+DROP FUNCTION IF EXISTS project_scim_group_mapping_event(events);
+DROP FUNCTION IF EXISTS project_server_settings_event(events);
+DROP FUNCTION IF EXISTS project_lps_password_event(events);
+DROP FUNCTION IF EXISTS project_luks_key_event(events);
+
+
+-- +goose Down
+
+-- Restore the no-op stubs first so project_event() has functions to
+-- PERFORM when we put the WHEN clauses back.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_token_event(event events) RETURNS void AS $$
+BEGIN
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_selection_event(event events) RETURNS void AS $$
+BEGIN
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_role_event(event events) RETURNS void AS $$
+BEGIN
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_role_event(event events) RETURNS void AS $$
+BEGIN
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_totp_event(event events) RETURNS void AS $$
+BEGIN
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_identity_provider_event(event events) RETURNS void AS $$
+BEGIN
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_scim_group_mapping_event(event events) RETURNS void AS $$
+BEGIN
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_server_settings_event(event events) RETURNS void AS $$
+BEGIN
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_lps_password_event(event events) RETURNS void AS $$
+BEGIN
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_luks_key_event(event events) RETURNS void AS $$
+BEGIN
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- Restore the dispatcher with all 21 WHEN clauses (state right before
+-- this migration ran).
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_event() RETURNS trigger AS $$
+BEGIN
+    CASE NEW.stream_type
+        WHEN 'user' THEN
+            BEGIN
+                PERFORM project_user_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'token' THEN
+            BEGIN
+                PERFORM project_token_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'device' THEN
+            BEGIN
+                PERFORM project_device_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'action' THEN
+            BEGIN
+                PERFORM project_action_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'definition' THEN
+            BEGIN
+                PERFORM project_action_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, 'definition->action', SQLERRM);
+            END;
+
+            BEGIN
+                PERFORM project_definition_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, 'definition->definition', SQLERRM);
+            END;
+
+        WHEN 'action_set' THEN
+            BEGIN
+                PERFORM project_action_set_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'device_group' THEN
+            BEGIN
+                PERFORM project_device_group_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'assignment' THEN
+            BEGIN
+                PERFORM project_assignment_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'execution' THEN
+            BEGIN
+                PERFORM project_execution_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'user_selection' THEN
+            BEGIN
+                PERFORM project_user_selection_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'role' THEN
+            BEGIN
+                PERFORM project_role_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'user_role' THEN
+            BEGIN
+                PERFORM project_user_role_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'totp' THEN
+            BEGIN
+                PERFORM project_totp_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'user_group' THEN
+            BEGIN
+                PERFORM project_user_group_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'identity_provider' THEN
+            BEGIN
+                PERFORM project_identity_provider_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'scim_group_mapping' THEN
+            BEGIN
+                PERFORM project_scim_group_mapping_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'compliance' THEN
+            BEGIN
+                PERFORM project_compliance_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'compliance_policy' THEN
+            BEGIN
+                PERFORM project_compliance_policy_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'server_settings' THEN
+            BEGIN
+                PERFORM project_server_settings_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'lps_password' THEN
+            BEGIN
+                PERFORM project_lps_password_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        WHEN 'luks_key' THEN
+            BEGIN
+                PERFORM project_luks_key_event(NEW);
+            EXCEPTION WHEN OTHERS THEN
+                INSERT INTO projection_errors (event_id, event_type, stream_type, error_message)
+                VALUES (NEW.id, NEW.event_type, NEW.stream_type, SQLERRM);
+            END;
+
+        ELSE
+            NULL;
+    END CASE;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/migrations/028_drop_ported_projector_stubs.sql
+++ b/internal/store/migrations/028_drop_ported_projector_stubs.sql
@@ -163,6 +163,16 @@ DROP FUNCTION IF EXISTS project_luks_key_event(events);
 
 -- Restore the no-op stubs first so project_event() has functions to
 -- PERFORM when we put the WHEN clauses back.
+--
+-- These no-op restorations match the stub shape the per-port
+-- migrations (018-027) left behind. Goose runs Downs in reverse
+-- order, so a `goose down` from 028 to 017 executes 028's Down
+-- first (this block — restores stubs) then 027's Down, 026's Down,
+-- etc., each of which overwrites its respective stub with the
+-- original full PL/pgSQL implementation. End state at version 017
+-- is the pre-#107 schema with every projector PL/pgSQL.
+
+
 
 -- +goose StatementBegin
 CREATE OR REPLACE FUNCTION project_token_event(event events) RETURNS void AS $$

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -269,6 +269,24 @@ func (s *Store) RebuildAll(ctx context.Context, targetNames ...string) (RebuildR
 // production-scale event store (10k–100k events) this completes in
 // seconds — fine for an emergency-rebuild operator command.
 func (s *Store) runOneTarget(ctx context.Context, tx pgx.Tx, t rebuildTarget) (int64, error) {
+	// Resolve the dispatch strategy BEFORE issuing any TRUNCATE.
+	// TRUNCATE takes ACCESS EXCLUSIVE on every named table; even
+	// though the outer rebuild transaction rolls those locks back
+	// on error, holding them briefly still blocks readers and
+	// writers and makes safety contingent on the surrounding tx.
+	// A miswired ported target — no Go applier registered AND no
+	// PL/pgSQL Function — would otherwise lock the projection
+	// before failing. dispatchViaPlpgsql with an empty Function
+	// name builds valid SQL that returns rows without invoking any
+	// projector, so the operator would see "rebuild succeeded"
+	// against the freshly truncated table; this guard exists to
+	// turn that silent-no-op (the #125 footgun) into a clear
+	// error.
+	apply := s.rebuildApplyFor(t.Name)
+	if apply == nil && t.Function == "" {
+		return 0, fmt.Errorf("rebuild target %q has no PL/pgSQL Function and no Go applier registered (projectors.WireAll wiring may have drifted)", t.Name)
+	}
+
 	for _, table := range t.Tables {
 		stmt := "TRUNCATE TABLE " + table
 		if t.Cascade {
@@ -279,18 +297,8 @@ func (s *Store) runOneTarget(ctx context.Context, tx pgx.Tx, t rebuildTarget) (i
 		}
 	}
 
-	if apply := s.rebuildApplyFor(t.Name); apply != nil {
+	if apply != nil {
 		return s.dispatchViaGoApplier(ctx, tx, t, apply)
-	}
-	// Defensive guard against the silent-no-op rebuild that
-	// motivated #125: if no Go applier is registered AND no PL/pgSQL
-	// Function is set, dispatchViaPlpgsql would build a SELECT with
-	// an empty function name, which is valid SQL that returns rows
-	// without invoking any projector. The TRUNCATE above has already
-	// wiped the projection, so operators would see "rebuild
-	// succeeded" against an empty table. Fail loudly instead.
-	if t.Function == "" {
-		return 0, fmt.Errorf("rebuild target %q has no PL/pgSQL Function and no Go applier registered (projectors.WireAll wiring may have drifted)", t.Name)
 	}
 	return s.dispatchViaPlpgsql(ctx, tx, t)
 }

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -75,11 +75,13 @@ type TargetResult struct {
 // applies both 'action' and 'definition' events because compliance-
 // policy definitions create derived action rows).
 //
-// Function is the PL/pgSQL function name that gets called per
-// matching event. During the Phase 1 migration this is
-// project_<X>_event(); once a stream type is ported (#96–#106),
-// callers swap this to a Go projector dispatcher and the PL/pgSQL
-// function is dropped from the schema.
+// Function is the PL/pgSQL function name dispatched per matching
+// event when no Go applier is registered for this target. After
+// migration 028 the three ported targets (roles, tokens,
+// user_selections) leave Function empty — RebuildAll dispatches
+// them through the Go appliers wired in projectors.WireAll. The
+// remaining unported targets still carry their project_<X>_event()
+// reference until their respective ports land.
 type rebuildTarget struct {
 	Name        string
 	Tables      []string
@@ -111,10 +113,10 @@ var AllRebuildTargets = []rebuildTarget{
 		Function:    "project_user_event",
 	},
 	{
+		// Ported to projectors.ApplyToken via projectors.WireAll.
 		Name:        "tokens",
 		Tables:      []string{"tokens_projection"},
 		StreamTypes: []string{"token"},
-		Function:    "project_token_event",
 	},
 	{
 		Name:        "devices",
@@ -167,17 +169,17 @@ var AllRebuildTargets = []rebuildTarget{
 		Function:    "project_assignment_event",
 	},
 	{
+		// Ported to projectors.ApplyUserSelection via projectors.WireAll.
 		Name:        "user_selections",
 		Tables:      []string{"user_selections_projection"},
 		StreamTypes: []string{"user_selection"},
-		Function:    "project_user_selection_event",
 	},
 	{
+		// Ported to projectors.ApplyRole via projectors.WireAll.
 		Name:        "roles",
 		Tables:      []string{"roles_projection"},
 		Cascade:     true,
 		StreamTypes: []string{"role"},
-		Function:    "project_role_event",
 	},
 	{
 		Name:        "user_groups",

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -280,6 +280,16 @@ func (s *Store) runOneTarget(ctx context.Context, tx pgx.Tx, t rebuildTarget) (i
 	if apply := s.rebuildApplyFor(t.Name); apply != nil {
 		return s.dispatchViaGoApplier(ctx, tx, t, apply)
 	}
+	// Defensive guard against the silent-no-op rebuild that
+	// motivated #125: if no Go applier is registered AND no PL/pgSQL
+	// Function is set, dispatchViaPlpgsql would build a SELECT with
+	// an empty function name, which is valid SQL that returns rows
+	// without invoking any projector. The TRUNCATE above has already
+	// wiped the projection, so operators would see "rebuild
+	// succeeded" against an empty table. Fail loudly instead.
+	if t.Function == "" {
+		return 0, fmt.Errorf("rebuild target %q has no PL/pgSQL Function and no Go applier registered (projectors.WireAll wiring may have drifted)", t.Name)
+	}
 	return s.dispatchViaPlpgsql(ctx, tx, t)
 }
 

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -21,9 +21,11 @@
 // half-replayed against a TRUNCATE'd table.
 //
 // Once a stream type's project_<stream>_event() is ported to a Go
-// projector (#96–#106), this file's per-target Function field gets
-// flipped from a PL/pgSQL call to a Go projector invocation. The
-// callers and operator surface stay identical.
+// projector (#96–#106), the PL/pgSQL stub is dropped via a cleanup
+// migration, this target's Function field is cleared, and
+// RebuildAll dispatches through the Go applier registered via
+// projectors.WireAll → RegisterRebuildApply. The callers and
+// operator surface stay identical.
 //
 // Refs manchtools/power-manage-server#94, manchtools/power-manage-server#107.
 package store

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -275,12 +275,33 @@ func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
 	st := testutil.SetupPostgresWithoutProjectors(t)
 	ctx := context.Background()
 
-	_, err := st.RebuildAll(ctx, "roles")
+	// Seed a row directly into the projection so we can prove the
+	// guard fires BEFORE the destructive TRUNCATE — a miswired
+	// ported target should not even briefly hold ACCESS EXCLUSIVE
+	// on roles_projection.
+	roleID := testutil.NewID()
+	_, err := st.Pool().Exec(ctx,
+		`INSERT INTO roles_projection (id, name, description, permissions, is_system, created_at, projection_version)
+		 VALUES ($1, 'guard-canary', '', ARRAY[]::TEXT[], false, NOW(), 0)`,
+		roleID,
+	)
+	require.NoError(t, err)
+
+	_, err = st.RebuildAll(ctx, "roles")
 	require.Error(t, err, "rebuild must fail when the Go applier is unwired and Function is empty")
 	assert.Contains(t, err.Error(), "no PL/pgSQL Function and no Go applier registered",
 		"error must name the missing-applier failure mode so operators can wire WireAll")
 	assert.Contains(t, err.Error(), "roles",
 		"error must name the offending target")
+
+	// The canary row must still be there — the guard fail-fasts
+	// before TRUNCATE, so the projection is untouched.
+	var count int
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		`SELECT COUNT(*) FROM roles_projection WHERE id = $1`, roleID,
+	).Scan(&count))
+	assert.Equal(t, 1, count,
+		"the guard must reject before TRUNCATE; finding zero rows means a destructive op fired before the dispatch-strategy check")
 }
 
 // TestRebuildAll_TransactionalAtomicity — if the projector function

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -261,6 +261,28 @@ func TestRebuildAll_PortedUserSelection_RoundTrip(t *testing.T) {
 	assert.Equal(t, before.Selected, after.Selected)
 }
 
+// TestRebuildAll_GoApplierMissingFailsLoudly — defensive guard for
+// the silent-no-op rebuild that motivated #125. After migration 028
+// the three ported targets carry an empty Function; if the Go
+// applier registration ever drifts (a WireAll entry is removed, a
+// refactor renames the target, a code path constructs a Store
+// without wiring), runOneTarget must fail loudly instead of falling
+// through to dispatchViaPlpgsql with an empty function name —
+// which builds valid SQL that returns rows without invoking any
+// projector and reports "rebuild succeeded" against the freshly
+// truncated projection. CR caught this on PR #132.
+func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+
+	_, err := st.RebuildAll(ctx, "roles")
+	require.Error(t, err, "rebuild must fail when the Go applier is unwired and Function is empty")
+	assert.Contains(t, err.Error(), "no PL/pgSQL Function and no Go applier registered",
+		"error must name the missing-applier failure mode so operators can wire WireAll")
+	assert.Contains(t, err.Error(), "roles",
+		"error must name the offending target")
+}
+
 // TestRebuildAll_TransactionalAtomicity — if the projector function
 // fails partway through replay, the whole rebuild must roll back so
 // the projection is not left half-replayed against a TRUNCATE'd

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -300,8 +300,10 @@ func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
 	assert.Contains(t, err.Error(), "roles",
 		"error must name the offending target")
 
-	// The canary row must still be there — the guard fail-fasts
-	// before TRUNCATE, so the projection is untouched.
+	// The canary row must still be there. As called out above,
+	// this only proves the user-visible invariant (failed rebuild
+	// leaves the projection intact); strict pre-TRUNCATE ordering
+	// is verified by reading runOneTarget.
 	var count int
 	require.NoError(t, st.Pool().QueryRow(ctx,
 		`SELECT COUNT(*) FROM roles_projection WHERE id = $1`, roleID,

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -270,7 +270,7 @@ func TestRebuildAll_PortedUserSelection_RoundTrip(t *testing.T) {
 // through to dispatchViaPlpgsql with an empty function name —
 // which builds valid SQL that returns rows without invoking any
 // projector and reports "rebuild succeeded" against the freshly
-// truncated projection. CR caught this on PR #132.
+// truncated projection.
 func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
 	st := testutil.SetupPostgresWithoutProjectors(t)
 	ctx := context.Background()

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -275,10 +275,16 @@ func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
 	st := testutil.SetupPostgresWithoutProjectors(t)
 	ctx := context.Background()
 
-	// Seed a row directly into the projection so we can prove the
-	// guard fires BEFORE the destructive TRUNCATE — a miswired
-	// ported target should not even briefly hold ACCESS EXCLUSIVE
-	// on roles_projection.
+	// Seed a row directly into the projection. The post-rebuild
+	// invariant we assert is that the projection is untouched as
+	// observed from an external connection — strictly, this only
+	// catches the user-visible failure mode. The whole RebuildAll
+	// runs inside pgx.BeginFunc, so a hypothetical "TRUNCATE then
+	// error" would also roll back and look identical from the
+	// outside. The guarantee that the guard fires *before* TRUNCATE
+	// (and therefore avoids briefly holding ACCESS EXCLUSIVE on a
+	// production projection) is verified by reading runOneTarget,
+	// not by this test alone.
 	roleID := testutil.NewID()
 	_, err := st.Pool().Exec(ctx,
 		`INSERT INTO roles_projection (id, name, description, permissions, is_system, created_at, projection_version)
@@ -301,7 +307,7 @@ func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
 		`SELECT COUNT(*) FROM roles_projection WHERE id = $1`, roleID,
 	).Scan(&count))
 	assert.Equal(t, 1, count,
-		"the guard must reject before TRUNCATE; finding zero rows means a destructive op fired before the dispatch-strategy check")
+		"projection must survive the failed rebuild; finding zero rows means either the guard ran too late or the outer transaction failed to roll back a destructive op")
 }
 
 // TestRebuildAll_TransactionalAtomicity — if the projector function

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -70,7 +70,13 @@ func setupPostgresContainer(t *testing.T) *store.Store {
 		// the suite. CR caught this on PR #132.
 		termCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		_ = container.Terminate(termCtx)
+		if err := container.Terminate(termCtx); err != nil {
+			// Log without failing the test — the test result is
+			// already finalized at cleanup time. Surfacing the error
+			// gives operators a chance to spot leaked containers or
+			// flaky Docker teardown.
+			t.Logf("testutil: terminate postgres container: %v", err)
+		}
 	})
 
 	connStr, err := container.ConnectionString(ctx, "sslmode=disable")

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -86,6 +86,47 @@ func SetupPostgres(t *testing.T) *store.Store {
 	return st
 }
 
+// SetupPostgresWithoutProjectors is identical to SetupPostgres but
+// skips projectors.WireAll. Used only to exercise failure modes
+// that depend on the projector pipeline being unwired — e.g. the
+// RebuildAll guard that fires when neither a Go applier nor a
+// PL/pgSQL Function is set for a target.
+//
+// Production code paths must always call WireAll; never use this
+// helper for tests that read projection state.
+func SetupPostgresWithoutProjectors(t *testing.T) *store.Store {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := postgres.Run(ctx,
+		"postgres:17-alpine",
+		postgres.WithDatabase("power_manage_test"),
+		postgres.WithUsername("test"),
+		postgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(30*time.Second)),
+	)
+	if err != nil {
+		t.Fatalf("start postgres container: %v", err)
+	}
+	t.Cleanup(func() { container.Terminate(context.Background()) })
+
+	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		t.Fatalf("get connection string: %v", err)
+	}
+
+	st, err := store.New(ctx, connStr)
+	if err != nil {
+		t.Fatalf("create store: %v", err)
+	}
+	t.Cleanup(func() { st.Close() })
+
+	return st
+}
+
 // CreateTestUser creates a user via events and returns the user ID.
 func CreateTestUser(t *testing.T, st *store.Store, email, password, role string) string {
 	t.Helper()

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -42,9 +42,12 @@ func NewID() string {
 	return ulid.MustNew(ulid.Timestamp(time.Now()), entropy).String()
 }
 
-// SetupPostgres starts a PostgreSQL testcontainer and returns a connected Store.
-// The container is stopped when the test completes.
-func SetupPostgres(t *testing.T) *store.Store {
+// setupPostgresContainer is the shared bootstrap used by both public
+// helpers. Production-parity bits (image tag, wait strategy, cleanup
+// hooks) live here exactly once so the two helpers cannot drift —
+// e.g. an image bump applies uniformly. Returns the connected Store;
+// callers decide whether to wire projectors.
+func setupPostgresContainer(t *testing.T) *store.Store {
 	t.Helper()
 	ctx := context.Background()
 
@@ -73,6 +76,14 @@ func SetupPostgres(t *testing.T) *store.Store {
 		t.Fatalf("create store: %v", err)
 	}
 	t.Cleanup(func() { st.Close() })
+	return st
+}
+
+// SetupPostgres starts a PostgreSQL testcontainer and returns a connected Store.
+// The container is stopped when the test completes.
+func SetupPostgres(t *testing.T) *store.Store {
+	t.Helper()
+	st := setupPostgresContainer(t)
 
 	// Wire the same Go-side projector listeners that production
 	// boot wires in cmd/control/main.go. Without this, handlers
@@ -96,35 +107,7 @@ func SetupPostgres(t *testing.T) *store.Store {
 // helper for tests that read projection state.
 func SetupPostgresWithoutProjectors(t *testing.T) *store.Store {
 	t.Helper()
-	ctx := context.Background()
-
-	container, err := postgres.Run(ctx,
-		"postgres:17-alpine",
-		postgres.WithDatabase("power_manage_test"),
-		postgres.WithUsername("test"),
-		postgres.WithPassword("test"),
-		testcontainers.WithWaitStrategy(
-			wait.ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(30*time.Second)),
-	)
-	if err != nil {
-		t.Fatalf("start postgres container: %v", err)
-	}
-	t.Cleanup(func() { container.Terminate(context.Background()) })
-
-	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		t.Fatalf("get connection string: %v", err)
-	}
-
-	st, err := store.New(ctx, connStr)
-	if err != nil {
-		t.Fatalf("create store: %v", err)
-	}
-	t.Cleanup(func() { st.Close() })
-
-	return st
+	return setupPostgresContainer(t)
 }
 
 // CreateTestUser creates a user via events and returns the user ID.

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -67,7 +67,7 @@ func setupPostgresContainer(t *testing.T) *store.Store {
 	t.Cleanup(func() {
 		// Bound the teardown so a wedged Docker daemon cannot hang
 		// the cleanup goroutine indefinitely and stall the rest of
-		// the suite. CR caught this on PR #132.
+		// the suite.
 		termCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
 		if err := container.Terminate(termCtx); err != nil {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -64,7 +64,14 @@ func setupPostgresContainer(t *testing.T) *store.Store {
 	if err != nil {
 		t.Fatalf("start postgres container: %v", err)
 	}
-	t.Cleanup(func() { container.Terminate(context.Background()) })
+	t.Cleanup(func() {
+		// Bound the teardown so a wedged Docker daemon cannot hang
+		// the cleanup goroutine indefinitely and stall the rest of
+		// the suite. CR caught this on PR #132.
+		termCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = container.Terminate(termCtx)
+	})
 
 	connStr, err := container.ConnectionString(ctx, "sslmode=disable")
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes the cleanup that #131 (manchtools/power-manage-server#125) unblocked.

Tracker #107 ported eleven domain projectors from PL/pgSQL to Go listeners but left behind ten no-op PL/pgSQL stubs (security_alert dropped its stub already in #017) so the shared \`project_event()\` dispatcher trigger could keep \`PERFORM\`ing them without raising \`projection_errors\`. PR #131 routed the three rebuild targets through Go appliers, severing the last caller of those stubs.

This change closes out the cleanup:

- **Migration 028** trims \`project_event()\` down to the eleven still-PL/pgSQL projectors (user, device, action, definition, action_set, device_group, assignment, execution, user_group, compliance, compliance_policy) and \`DROP\`s the ten no-op stubs. Live INSERT-into-\`events\` traffic stops paying the per-event \`PERFORM\` cost on no-ops, and accidental future calls from operator psql sessions surface as a clean \"function does not exist\" error instead of silently no-oping.
- **\`rebuildTarget.Function\`** is cleared for the three ported targets (roles, tokens, user_selections). The Go appliers wired in \`projectors.WireAll\` already handle them; carrying the now-dropped function name was misleading.
- **\`TestMigration028_DroppedStubsAreGone\`** asserts each of the ten stubs is absent after migration — re-introducing one would reopen the #125 footgun.
- **\`TestMigration028_UnportedProjectorsRemain\`** asserts the eleven kept projectors plus the dispatcher itself survived.

The shared \`project_event()\` trigger stays in place because eleven domain projectors still depend on it; a follow-up tracker will port them.

## Test plan

- [x] New \`TestMigration028_DroppedStubsAreGone\` — proves each dropped stub is absent post-migration.
- [x] New \`TestMigration028_UnportedProjectorsRemain\` — proves the eleven unported projectors plus \`project_event()\` survived.
- [x] Existing \`TestRebuildAll_PortedRole_RoundTrip\`, \`_PortedToken_\`, \`_PortedUserSelection_\` continue to pass — the Go appliers still rebuild after the PL/pgSQL stubs are gone.
- [x] Existing \`TestRebuildAll_RoundTripsThroughEventStore\` (users) + \`TestRebuildAll_NoArgsRebuildsEverything\` continue to pass — the eleven unported targets still dispatch via the trimmed \`project_event()\`.
- [x] Existing role / token / user_selection listener tests pass.
- [x] \`go build ./...\` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests that confirm ported projector stubs are removed, unported projectors remain, and rebuilds fail loudly when Go-side projectors are unwired.

* **Chores**
  * Applied a migration that drops legacy no-op projector stubs and simplifies dispatcher routing.
  * Added a test helper to set up Postgres without wiring Go projectors.

* **Refactor**
  * Ported several rebuild targets from PL/pgSQL dispatch to Go-based projectors.

* **Bug Fixes**
  * Rebuild now returns a clear error when no applier is registered for a target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->