### PR TITLE
perf: scope inherited-roles query to the user-list page (drop unscoped variant)

### DIFF
--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -288,28 +288,34 @@ func (h *UserHandler) ListUsers(ctx context.Context, req *connect.Request[pm.Lis
 	nextPageToken := buildNextPageToken(int32(len(users)), offset, pageSize, count)
 
 	protoUsers := make([]*pm.User, len(users))
+	pageUserIDs := make([]string, len(users))
 	for i, u := range users {
 		protoUsers[i] = userToProto(u)
 		h.populateUserRoles(ctx, protoUsers[i])
+		pageUserIDs[i] = u.ID
 	}
 
-	// Populate inherited roles from user group memberships
-	inheritedRoles, err := h.store.Queries().ListAllInheritedRoles(ctx)
-	if err != nil {
-		h.logger.Warn("failed to load inherited roles", "error", err)
-	} else {
-		inheritedMap := make(map[string][]*pm.InheritedRole)
-		for _, ir := range inheritedRoles {
-			inheritedMap[ir.UserID] = append(inheritedMap[ir.UserID], &pm.InheritedRole{
-				RoleId:    ir.RoleID,
-				RoleName:  ir.RoleName,
-				GroupId:   ir.GroupID,
-				GroupName: ir.GroupName,
-			})
-		}
-		for _, u := range protoUsers {
-			if roles, ok := inheritedMap[u.Id]; ok {
-				u.InheritedRoles = roles
+	// Populate inherited roles from user group memberships. Scope
+	// to the page's user IDs so the query cost stays page-bounded
+	// instead of linear with system-wide group membership count.
+	if len(pageUserIDs) > 0 {
+		inheritedRoles, err := h.store.Queries().ListInheritedRolesByUserIDs(ctx, pageUserIDs)
+		if err != nil {
+			h.logger.Warn("failed to load inherited roles", "error", err)
+		} else {
+			inheritedMap := make(map[string][]*pm.InheritedRole)
+			for _, ir := range inheritedRoles {
+				inheritedMap[ir.UserID] = append(inheritedMap[ir.UserID], &pm.InheritedRole{
+					RoleId:    ir.RoleID,
+					RoleName:  ir.RoleName,
+					GroupId:   ir.GroupID,
+					GroupName: ir.GroupName,
+				})
+			}
+			for _, u := range protoUsers {
+				if roles, ok := inheritedMap[u.Id]; ok {
+					u.InheritedRoles = roles
+				}
 			}
 		}
 	}

--- a/internal/store/generated/user_groups.sql.go
+++ b/internal/store/generated/user_groups.sql.go
@@ -204,17 +204,18 @@ func (q *Queries) IsUserInGroup(ctx context.Context, arg IsUserInGroupParams) (b
 	return is_member, err
 }
 
-const listAllInheritedRoles = `-- name: ListAllInheritedRoles :many
+const listInheritedRolesByUserIDs = `-- name: ListInheritedRolesByUserIDs :many
 SELECT ugm.user_id, r.id AS role_id, r.name AS role_name,
        ug.id AS group_id, ug.name AS group_name
 FROM user_group_members_projection ugm
 JOIN user_group_roles_projection ugr ON ugr.group_id = ugm.group_id
 JOIN roles_projection r ON r.id = ugr.role_id AND r.is_deleted = FALSE
 JOIN user_groups_projection ug ON ug.id = ugm.group_id AND ug.is_deleted = FALSE
+WHERE ugm.user_id = ANY($1::TEXT[])
 ORDER BY ugm.user_id, ug.name, r.name
 `
 
-type ListAllInheritedRolesRow struct {
+type ListInheritedRolesByUserIDsRow struct {
 	UserID    string `json:"user_id"`
 	RoleID    string `json:"role_id"`
 	RoleName  string `json:"role_name"`
@@ -222,15 +223,21 @@ type ListAllInheritedRolesRow struct {
 	GroupName string `json:"group_name"`
 }
 
-func (q *Queries) ListAllInheritedRoles(ctx context.Context) ([]ListAllInheritedRolesRow, error) {
-	rows, err := q.db.Query(ctx, listAllInheritedRoles)
+// Inherited roles for a specific set of user IDs (typically a
+// single page from the user list). Always pass the IDs you actually
+// need — there is no unscoped variant on purpose, because scanning
+// every user_group_members_projection row is wasteful at scale and
+// previously caused linear-with-system-membership-count cost on
+// every paginated ListUsers call.
+func (q *Queries) ListInheritedRolesByUserIDs(ctx context.Context, dollar_1 []string) ([]ListInheritedRolesByUserIDsRow, error) {
+	rows, err := q.db.Query(ctx, listInheritedRolesByUserIDs, dollar_1)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListAllInheritedRolesRow{}
+	items := []ListInheritedRolesByUserIDsRow{}
 	for rows.Next() {
-		var i ListAllInheritedRolesRow
+		var i ListInheritedRolesByUserIDsRow
 		if err := rows.Scan(
 			&i.UserID,
 			&i.RoleID,

--- a/internal/store/queries/user_groups.sql
+++ b/internal/store/queries/user_groups.sql
@@ -66,13 +66,20 @@ WHERE r.is_deleted = FALSE AND (
     )
 );
 
--- name: ListAllInheritedRoles :many
+-- name: ListInheritedRolesByUserIDs :many
+-- Inherited roles for a specific set of user IDs (typically a
+-- single page from the user list). Always pass the IDs you actually
+-- need — there is no unscoped variant on purpose, because scanning
+-- every user_group_members_projection row is wasteful at scale and
+-- previously caused linear-with-system-membership-count cost on
+-- every paginated ListUsers call.
 SELECT ugm.user_id, r.id AS role_id, r.name AS role_name,
        ug.id AS group_id, ug.name AS group_name
 FROM user_group_members_projection ugm
 JOIN user_group_roles_projection ugr ON ugr.group_id = ugm.group_id
 JOIN roles_projection r ON r.id = ugr.role_id AND r.is_deleted = FALSE
 JOIN user_groups_projection ug ON ug.id = ugm.group_id AND ug.is_deleted = FALSE
+WHERE ugm.user_id = ANY($1::TEXT[])
 ORDER BY ugm.user_id, ug.name, r.name;
 
 -- name: ValidateUserGroupQuery :one


### PR DESCRIPTION
## Summary

\`ListUsers\` populated each page user's inherited roles by calling \`ListAllInheritedRoles\`, which scanned every row of \`user_group_members_projection × user_group_roles_projection × roles_projection × user_groups_projection\` — regardless of how many users were on the page. The handler then filtered down to the page in Go. Cost grew linearly with system-wide group membership count on every paginated request, with no benefit for the common case of small page sizes.

Replace the unscoped query with \`ListInheritedRolesByUserIDs\`, which takes the page's user IDs as \`TEXT[]\` and filters at the database layer. The handler now passes \`pageUserIDs\` (collected during the existing user→proto conversion) and the database returns only the rows it cares about.

Drop the unscoped \`ListAllInheritedRoles\` entirely — leaving it around invites a future caller to reach for it and reopen the perf bug.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test -run TestListUsers ./internal/api/...\` passes.
- [x] sqlc regen clean (new query generated, old query removed).
- [x] No remaining callers of \`ListAllInheritedRoles\` after sweep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized user list loading to fetch inherited roles more efficiently by processing roles on a per-page basis, resulting in faster page load times when viewing user listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->