### PR TITLE
refactor: port action_set projector to Go listener (#136)

### DIFF
--- a/internal/projectors/action_set.go
+++ b/internal/projectors/action_set.go
@@ -1,0 +1,267 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// defaultActionSetSchedule mirrors the column default added in
+// migration 012 (`{"interval_hours": 8}`) and the PL/pgSQL projector's
+// COALESCE fallback for the missing schedule key. Held as a byte slice
+// so the listener can pass it straight to the JSONB column without an
+// extra marshal step.
+var defaultActionSetSchedule = []byte(`{"interval_hours": 8}`)
+
+// ActionSetCreatedPayload mirrors the fields the deleted PL/pgSQL
+// project_action_set_event() read out of an ActionSetCreated event:
+//
+//   - name (required)
+//   - description (defaults to ” to match the PL/pgSQL
+//     `COALESCE(payload, ”)` behaviour)
+//   - schedule (defaults to '{"interval_hours": 8}' to match the
+//     COALESCE fallback against the JSONB column default)
+type ActionSetCreatedPayload struct {
+	ID          string
+	Name        string
+	Description string
+	Schedule    []byte
+	CreatedBy   string
+}
+
+type actionSetCreatedRaw struct {
+	Name        string          `json:"name"`
+	Description *string         `json:"description,omitempty"`
+	Schedule    json.RawMessage `json:"schedule,omitempty"`
+}
+
+// ActionSetCreatedFromEvent decodes ActionSetCreated. Returns
+// ErrIgnoredEvent for any other (stream, event_type) so the listener
+// wrapper can silently no-op.
+func ActionSetCreatedFromEvent(e store.PersistedEvent) (ActionSetCreatedPayload, error) {
+	if e.StreamType != "action_set" || e.EventType != "ActionSetCreated" {
+		return ActionSetCreatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return ActionSetCreatedPayload{}, fmt.Errorf("projector: empty ActionSetCreated payload")
+	}
+	var raw actionSetCreatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionSetCreatedPayload{}, fmt.Errorf("projector: invalid ActionSetCreated payload: %w", err)
+	}
+	if raw.Name == "" {
+		return ActionSetCreatedPayload{}, fmt.Errorf("projector: ActionSetCreated requires name")
+	}
+	out := ActionSetCreatedPayload{
+		ID:        e.StreamID,
+		Name:      raw.Name,
+		Schedule:  defaultActionSetSchedule,
+		CreatedBy: e.ActorID,
+	}
+	if raw.Description != nil {
+		out.Description = *raw.Description
+	}
+	if len(raw.Schedule) > 0 {
+		// Preserve the wire bytes verbatim so the listener writes the
+		// same JSONB the emitter sent (matches the PL/pgSQL projector's
+		// `(event.data->'schedule')::JSONB` cast).
+		out.Schedule = []byte(raw.Schedule)
+	}
+	return out, nil
+}
+
+// ActionSetRenamedPayload covers the single mutable field the
+// PL/pgSQL projector wrote on an ActionSetRenamed event. Empty Name
+// is treated as a validation error rather than silently no-op'd —
+// the PL/pgSQL projector would have written NULL and broken the
+// NOT NULL column constraint, so emitters that drop the field hit
+// the same error class either way.
+type ActionSetRenamedPayload struct {
+	ID   string
+	Name string
+}
+
+type actionSetRenamedRaw struct {
+	Name string `json:"name"`
+}
+
+// ActionSetRenamedFromEvent decodes ActionSetRenamed.
+func ActionSetRenamedFromEvent(e store.PersistedEvent) (ActionSetRenamedPayload, error) {
+	if e.StreamType != "action_set" || e.EventType != "ActionSetRenamed" {
+		return ActionSetRenamedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return ActionSetRenamedPayload{}, fmt.Errorf("projector: empty ActionSetRenamed payload")
+	}
+	var raw actionSetRenamedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionSetRenamedPayload{}, fmt.Errorf("projector: invalid ActionSetRenamed payload: %w", err)
+	}
+	if raw.Name == "" {
+		return ActionSetRenamedPayload{}, fmt.Errorf("projector: ActionSetRenamed requires name")
+	}
+	return ActionSetRenamedPayload{ID: e.StreamID, Name: raw.Name}, nil
+}
+
+// ActionSetDescriptionUpdatedPayload mirrors the PL/pgSQL projector's
+// `COALESCE(event.data->>'description', ”)` collapse: if the payload
+// omits the key OR sends an explicit empty string, the description
+// becomes ”. Both cases land here as Description == "".
+type ActionSetDescriptionUpdatedPayload struct {
+	ID          string
+	Description string
+}
+
+type actionSetDescriptionUpdatedRaw struct {
+	Description *string `json:"description,omitempty"`
+}
+
+// ActionSetDescriptionUpdatedFromEvent decodes
+// ActionSetDescriptionUpdated. An empty payload (e.g. `{}`) maps to
+// Description == "", matching the PL/pgSQL COALESCE-to-empty-string
+// behaviour.
+func ActionSetDescriptionUpdatedFromEvent(e store.PersistedEvent) (ActionSetDescriptionUpdatedPayload, error) {
+	if e.StreamType != "action_set" || e.EventType != "ActionSetDescriptionUpdated" {
+		return ActionSetDescriptionUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := ActionSetDescriptionUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw actionSetDescriptionUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionSetDescriptionUpdatedPayload{}, fmt.Errorf("projector: invalid ActionSetDescriptionUpdated payload: %w", err)
+	}
+	if raw.Description != nil {
+		out.Description = *raw.Description
+	}
+	return out, nil
+}
+
+// ActionSetScheduleUpdatedPayload mirrors the projector's
+// COALESCE fallback against the JSONB column default. A missing or
+// empty schedule key is replaced with `{"interval_hours": 8}`.
+type ActionSetScheduleUpdatedPayload struct {
+	ID       string
+	Schedule []byte
+}
+
+type actionSetScheduleUpdatedRaw struct {
+	Schedule json.RawMessage `json:"schedule,omitempty"`
+}
+
+// ActionSetScheduleUpdatedFromEvent decodes ActionSetScheduleUpdated.
+func ActionSetScheduleUpdatedFromEvent(e store.PersistedEvent) (ActionSetScheduleUpdatedPayload, error) {
+	if e.StreamType != "action_set" || e.EventType != "ActionSetScheduleUpdated" {
+		return ActionSetScheduleUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := ActionSetScheduleUpdatedPayload{
+		ID:       e.StreamID,
+		Schedule: defaultActionSetSchedule,
+	}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw actionSetScheduleUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionSetScheduleUpdatedPayload{}, fmt.Errorf("projector: invalid ActionSetScheduleUpdated payload: %w", err)
+	}
+	if len(raw.Schedule) > 0 {
+		out.Schedule = []byte(raw.Schedule)
+	}
+	return out, nil
+}
+
+// ActionSetMemberAddedPayload mirrors the PL/pgSQL projector's
+// per-member fields. Missing sort_order defaults to 0 (matches
+// `COALESCE((event.data->>'sort_order')::INTEGER, 0)`).
+type ActionSetMemberAddedPayload struct {
+	SetID     string
+	ActionID  string
+	SortOrder int32
+}
+
+type actionSetMemberRaw struct {
+	ActionID  string `json:"action_id"`
+	SortOrder *int32 `json:"sort_order,omitempty"`
+}
+
+// ActionSetMemberAddedFromEvent decodes ActionSetMemberAdded.
+func ActionSetMemberAddedFromEvent(e store.PersistedEvent) (ActionSetMemberAddedPayload, error) {
+	if e.StreamType != "action_set" || e.EventType != "ActionSetMemberAdded" {
+		return ActionSetMemberAddedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return ActionSetMemberAddedPayload{}, fmt.Errorf("projector: empty ActionSetMemberAdded payload")
+	}
+	var raw actionSetMemberRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionSetMemberAddedPayload{}, fmt.Errorf("projector: invalid ActionSetMemberAdded payload: %w", err)
+	}
+	if raw.ActionID == "" {
+		return ActionSetMemberAddedPayload{}, fmt.Errorf("projector: ActionSetMemberAdded requires action_id")
+	}
+	out := ActionSetMemberAddedPayload{SetID: e.StreamID, ActionID: raw.ActionID}
+	if raw.SortOrder != nil {
+		out.SortOrder = *raw.SortOrder
+	}
+	return out, nil
+}
+
+// ActionSetMemberRemovedPayload — only the action_id is needed; the
+// set id comes from the stream.
+type ActionSetMemberRemovedPayload struct {
+	SetID    string
+	ActionID string
+}
+
+type actionSetMemberRemovedRaw struct {
+	ActionID string `json:"action_id"`
+}
+
+// ActionSetMemberRemovedFromEvent decodes ActionSetMemberRemoved.
+func ActionSetMemberRemovedFromEvent(e store.PersistedEvent) (ActionSetMemberRemovedPayload, error) {
+	if e.StreamType != "action_set" || e.EventType != "ActionSetMemberRemoved" {
+		return ActionSetMemberRemovedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return ActionSetMemberRemovedPayload{}, fmt.Errorf("projector: empty ActionSetMemberRemoved payload")
+	}
+	var raw actionSetMemberRemovedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionSetMemberRemovedPayload{}, fmt.Errorf("projector: invalid ActionSetMemberRemoved payload: %w", err)
+	}
+	if raw.ActionID == "" {
+		return ActionSetMemberRemovedPayload{}, fmt.Errorf("projector: ActionSetMemberRemoved requires action_id")
+	}
+	return ActionSetMemberRemovedPayload{SetID: e.StreamID, ActionID: raw.ActionID}, nil
+}
+
+// ActionSetMemberReorderedPayload — same shape as the Added payload;
+// reuse the underlying decoder.
+type ActionSetMemberReorderedPayload = ActionSetMemberAddedPayload
+
+// ActionSetMemberReorderedFromEvent decodes ActionSetMemberReordered.
+// Same field set as ActionSetMemberAdded plus the same default-zero
+// behaviour for sort_order.
+func ActionSetMemberReorderedFromEvent(e store.PersistedEvent) (ActionSetMemberReorderedPayload, error) {
+	if e.StreamType != "action_set" || e.EventType != "ActionSetMemberReordered" {
+		return ActionSetMemberReorderedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return ActionSetMemberReorderedPayload{}, fmt.Errorf("projector: empty ActionSetMemberReordered payload")
+	}
+	var raw actionSetMemberRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionSetMemberReorderedPayload{}, fmt.Errorf("projector: invalid ActionSetMemberReordered payload: %w", err)
+	}
+	if raw.ActionID == "" {
+		return ActionSetMemberReorderedPayload{}, fmt.Errorf("projector: ActionSetMemberReordered requires action_id")
+	}
+	out := ActionSetMemberReorderedPayload{SetID: e.StreamID, ActionID: raw.ActionID}
+	if raw.SortOrder != nil {
+		out.SortOrder = *raw.SortOrder
+	}
+	return out, nil
+}

--- a/internal/projectors/action_set_listener.go
+++ b/internal/projectors/action_set_listener.go
@@ -1,0 +1,304 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// ActionSetListener returns a store.EventListener that applies every
+// action_set stream event the deleted PL/pgSQL project_action_set_event
+// handled. Eight event types: Created, Renamed, DescriptionUpdated,
+// ScheduleUpdated, MemberAdded, MemberRemoved, MemberReordered,
+// Deleted.
+//
+// Event-type families:
+//   - Set CRUD: Created (INSERT), Renamed / DescriptionUpdated /
+//     ScheduleUpdated (single guarded UPDATE), Deleted (soft-delete +
+//     cascade DELETE on members + decrement-and-clean parent
+//     definitions, wrapped in store.WithTx).
+//   - Member edits: MemberAdded (INSERT + recount), MemberRemoved
+//     (DELETE + recount), MemberReordered (per-row UPDATE + bump-
+//     parent-updated_at), each wrapped in store.WithTx so the parent
+//     row never observes "member changed but member_count stale".
+//
+// Multi-write listeners (Deleted, MemberAdded, MemberRemoved,
+// MemberReordered) follow the asymmetric-guard discipline: the
+// guarded UPDATE is :execrows, and the listener short-circuits the
+// downstream cascade when n == 0 (stale projection_version replay).
+//
+// Wired in projectors.WireAll. Refs #136, tracker #107 (Phase 2).
+func ActionSetListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "action_set" {
+			return
+		}
+		// Multi-write events route through ApplyActionSet via WithTx
+		// so the cascade stays atomic; single-statement events go on
+		// the autocommit pool. ApplyActionSet handles all eight event
+		// types when called with tx-bound queries (the rebuild path),
+		// so we share its body here for the multi-write cases via
+		// WithTx and short-circuit the simple cases through the pool.
+		switch e.EventType {
+		case "ActionSetMemberAdded",
+			"ActionSetMemberRemoved",
+			"ActionSetMemberReordered",
+			"ActionSetDeleted":
+			if err := st.WithTx(ctx, func(q *store.Queries) error {
+				return ApplyActionSet(ctx, q, e)
+			}); err != nil {
+				logger.Warn("action_set projector: failed to apply event",
+					"event_id", e.ID, "event_type", e.EventType, "set_id", e.StreamID, "error", err)
+			}
+			return
+		}
+		if err := ApplyActionSet(ctx, st.Queries(), e); err != nil {
+			logger.Warn("action_set projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "set_id", e.StreamID, "error", err)
+		}
+	}
+}
+
+// ApplyActionSet is the transactional core of the action_set projector.
+// The listener wraps it for live-event dispatch (using WithTx for the
+// multi-write event types); the rebuild path
+// (manchtools/power-manage-server#125) registers it via
+// RegisterRebuildApply so RebuildAll re-derives the projection from
+// the event store instead of dispatching to the no-op PL/pgSQL stub.
+//
+// Asymmetric-guard discipline is preserved across every multi-write
+// event: when the version-guarded UPDATE on the parent row affects
+// zero rows, every cascading INSERT/DELETE downstream is skipped —
+// otherwise a stale event re-applied later would leak member-count
+// drift, dangling members, or deleted rows reappearing.
+func ApplyActionSet(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "action_set" {
+		return nil
+	}
+	switch e.EventType {
+	case "ActionSetCreated":
+		return applyActionSetCreated(ctx, q, e)
+	case "ActionSetRenamed":
+		return applyActionSetRenamed(ctx, q, e)
+	case "ActionSetDescriptionUpdated":
+		return applyActionSetDescriptionUpdated(ctx, q, e)
+	case "ActionSetScheduleUpdated":
+		return applyActionSetScheduleUpdated(ctx, q, e)
+	case "ActionSetMemberAdded":
+		return applyActionSetMemberAdded(ctx, q, e)
+	case "ActionSetMemberRemoved":
+		return applyActionSetMemberRemoved(ctx, q, e)
+	case "ActionSetMemberReordered":
+		return applyActionSetMemberReordered(ctx, q, e)
+	case "ActionSetDeleted":
+		return applyActionSetDeleted(ctx, q, e)
+	}
+	return nil
+}
+
+func applyActionSetCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionSetCreatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	return q.InsertActionSetProjection(ctx, db.InsertActionSetProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		Description:       payload.Description,
+		Schedule:          payload.Schedule,
+		CreatedAt:         &e.OccurredAt,
+		CreatedBy:         payload.CreatedBy,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+}
+
+func applyActionSetRenamed(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionSetRenamedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.RenameActionSetProjection(ctx, db.RenameActionSetProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyActionSetDescriptionUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionSetDescriptionUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateActionSetDescriptionProjection(ctx, db.UpdateActionSetDescriptionProjectionParams{
+		ID:                payload.ID,
+		Description:       payload.Description,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyActionSetScheduleUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionSetScheduleUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateActionSetScheduleProjection(ctx, db.UpdateActionSetScheduleProjectionParams{
+		ID:                payload.ID,
+		Schedule:          payload.Schedule,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyActionSetMemberAdded(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionSetMemberAddedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	addedAt := e.OccurredAt
+	if err := q.InsertActionSetMember(ctx, db.InsertActionSetMemberParams{
+		SetID:             payload.SetID,
+		ActionID:          payload.ActionID,
+		SortOrder:         payload.SortOrder,
+		AddedAt:           &addedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.RecountActionSetMembers(ctx, db.RecountActionSetMembersParams{
+		SetID:             payload.SetID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyActionSetMemberRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionSetMemberRemovedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if err := q.DeleteActionSetMember(ctx, db.DeleteActionSetMemberParams{
+		SetID:    payload.SetID,
+		ActionID: payload.ActionID,
+	}); err != nil {
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.RecountActionSetMembers(ctx, db.RecountActionSetMembersParams{
+		SetID:             payload.SetID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyActionSetMemberReordered(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionSetMemberReorderedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	// Per-member projection_version guard: a stale reorder must not
+	// roll a fresher position back. n == 0 short-circuits the parent
+	// updated_at bump too — there's no semantic change to surface, and
+	// the bump would otherwise advance the parent's projection_version
+	// to a value the cascade wasn't allowed to write.
+	n, err := q.UpdateActionSetMemberSortOrder(ctx, db.UpdateActionSetMemberSortOrderParams{
+		SetID:             payload.SetID,
+		ActionID:          payload.ActionID,
+		SortOrder:         payload.SortOrder,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.TouchActionSetUpdatedAt(ctx, db.TouchActionSetUpdatedAtParams{
+		ID:                payload.SetID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyActionSetDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	updatedAt := e.OccurredAt
+	n, err := q.SoftDeleteActionSetProjection(ctx, db.SoftDeleteActionSetProjectionParams{
+		ID:                e.StreamID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		// Stale ActionSetDeleted replay against a row whose
+		// projection_version has moved past this event. Skipping the
+		// cascade is mandatory: otherwise an old delete re-applied by
+		// the reconciler against a freshly-restored set would silently
+		// nuke its members and decrement member_count on every
+		// definition that contains it.
+		return nil
+	}
+	if err := q.DeleteActionSetMembersBySet(ctx, e.StreamID); err != nil {
+		return err
+	}
+	// Order matters: decrement BEFORE deleting the
+	// definition_members rows. Once those are gone the subquery
+	// inside DecrementDefinitionMemberCountByActionSet sees no
+	// matches and the recount no-ops.
+	if err := q.DecrementDefinitionMemberCountByActionSet(ctx, e.StreamID); err != nil {
+		return err
+	}
+	return q.DeleteDefinitionMembersByActionSet(ctx, e.StreamID)
+}

--- a/internal/projectors/action_set_test.go
+++ b/internal/projectors/action_set_test.go
@@ -1,0 +1,619 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestActionSetCreatedFromEvent_Pure pins the decoder defaults that
+// match the deleted PL/pgSQL projector: missing description → ”;
+// missing schedule → '{"interval_hours": 8}'.
+func TestActionSetCreatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with explicit description and schedule", func(t *testing.T) {
+		got, err := projectors.ActionSetCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetCreated", ActorID: "u-1",
+			Data: jsonOrFail(t, map[string]any{
+				"name":        "nightly",
+				"description": "runs nightly",
+				"schedule":    map[string]any{"interval_hours": 24},
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "as-1", got.ID)
+		assert.Equal(t, "nightly", got.Name)
+		assert.Equal(t, "runs nightly", got.Description)
+		assert.JSONEq(t, `{"interval_hours":24}`, string(got.Schedule))
+		assert.Equal(t, "u-1", got.CreatedBy)
+	})
+
+	t.Run("defaults: description empty, schedule = {interval_hours:8}", func(t *testing.T) {
+		got, err := projectors.ActionSetCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-2", EventType: "ActionSetCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"name": "minimal"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description)
+		assert.JSONEq(t, `{"interval_hours":8}`, string(got.Schedule),
+			"missing schedule defaults to the column default '{\"interval_hours\": 8}'")
+	})
+
+	t.Run("name is required", func(t *testing.T) {
+		_, err := projectors.ActionSetCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-3", EventType: "ActionSetCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"description": "no name"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "name")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.ActionSetCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action", EventType: "ActionSetCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.ActionSetCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", EventType: "ActionSetRenamed",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.ActionSetCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", EventType: "ActionSetCreated",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestActionSetRenamedFromEvent_Pure — name is required (the PL/pgSQL
+// projector would have written NULL into the NOT NULL column,
+// breaking the constraint; we surface this earlier as a decode
+// validation error).
+func TestActionSetRenamedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.ActionSetRenamedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetRenamed",
+			Data: jsonOrFail(t, map[string]any{"name": "renamed"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "renamed", got.Name)
+	})
+
+	t.Run("missing name fails", func(t *testing.T) {
+		_, err := projectors.ActionSetRenamedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetRenamed",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.ActionSetRenamedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", EventType: "ActionSetCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestActionSetDescriptionUpdatedFromEvent_Pure — empty payload OR
+// missing key BOTH map to Description == "" (matches the PL/pgSQL
+// `COALESCE(payload, ”)` collapse). Empty-string payload also
+// becomes "".
+func TestActionSetDescriptionUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("explicit description set", func(t *testing.T) {
+		got, err := projectors.ActionSetDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{"description": "new desc"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "new desc", got.Description)
+	})
+
+	t.Run("missing description key → empty string", func(t *testing.T) {
+		got, err := projectors.ActionSetDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description, "missing key collapses to '' per PL/pgSQL COALESCE")
+	})
+
+	t.Run("empty payload bytes → empty string", func(t *testing.T) {
+		got, err := projectors.ActionSetDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetDescriptionUpdated",
+			Data: nil,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description)
+	})
+}
+
+// TestActionSetScheduleUpdatedFromEvent_Pure — missing schedule key
+// falls back to the column default, matching the PL/pgSQL COALESCE
+// against `'{"interval_hours": 8}'::JSONB`.
+func TestActionSetScheduleUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("explicit schedule preserved verbatim", func(t *testing.T) {
+		got, err := projectors.ActionSetScheduleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetScheduleUpdated",
+			Data: jsonOrFail(t, map[string]any{"schedule": map[string]any{"cron": "0 4 * * *"}}),
+		})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"cron":"0 4 * * *"}`, string(got.Schedule))
+	})
+
+	t.Run("missing schedule key → column-default fallback", func(t *testing.T) {
+		got, err := projectors.ActionSetScheduleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetScheduleUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"interval_hours":8}`, string(got.Schedule))
+	})
+
+	t.Run("empty payload bytes → column-default fallback", func(t *testing.T) {
+		got, err := projectors.ActionSetScheduleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetScheduleUpdated",
+			Data: nil,
+		})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"interval_hours":8}`, string(got.Schedule))
+	})
+}
+
+// TestActionSetMemberAddedFromEvent_Pure — sort_order defaults to 0
+// when the key is missing (matches the PL/pgSQL COALESCE-to-zero).
+func TestActionSetMemberAddedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with sort_order", func(t *testing.T) {
+		got, err := projectors.ActionSetMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetMemberAdded",
+			Data: jsonOrFail(t, map[string]any{"action_id": "act-1", "sort_order": 5}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "as-1", got.SetID)
+		assert.Equal(t, "act-1", got.ActionID)
+		assert.Equal(t, int32(5), got.SortOrder)
+	})
+
+	t.Run("missing sort_order defaults to 0", func(t *testing.T) {
+		got, err := projectors.ActionSetMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetMemberAdded",
+			Data: jsonOrFail(t, map[string]any{"action_id": "act-1"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), got.SortOrder)
+	})
+
+	t.Run("missing action_id is a validation error", func(t *testing.T) {
+		_, err := projectors.ActionSetMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetMemberAdded",
+			Data: jsonOrFail(t, map[string]any{"sort_order": 1}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestActionSetMemberRemovedFromEvent_Pure — only action_id matters.
+func TestActionSetMemberRemovedFromEvent_Pure(t *testing.T) {
+	got, err := projectors.ActionSetMemberRemovedFromEvent(store.PersistedEvent{
+		StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetMemberRemoved",
+		Data: jsonOrFail(t, map[string]any{"action_id": "act-9"}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "as-1", got.SetID)
+	assert.Equal(t, "act-9", got.ActionID)
+
+	_, err = projectors.ActionSetMemberRemovedFromEvent(store.PersistedEvent{
+		StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetMemberRemoved",
+		Data: jsonOrFail(t, map[string]any{}),
+	})
+	require.Error(t, err)
+}
+
+// TestActionSetMemberReorderedFromEvent_Pure — same payload shape as
+// MemberAdded (action_id + sort_order, sort_order defaults to 0).
+func TestActionSetMemberReorderedFromEvent_Pure(t *testing.T) {
+	got, err := projectors.ActionSetMemberReorderedFromEvent(store.PersistedEvent{
+		StreamType: "action_set", StreamID: "as-1", EventType: "ActionSetMemberReordered",
+		Data: jsonOrFail(t, map[string]any{"action_id": "act-1", "sort_order": 3}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), got.SortOrder)
+
+	_, err = projectors.ActionSetMemberReorderedFromEvent(store.PersistedEvent{
+		StreamType: "action_set", EventType: "ActionSetMemberAdded",
+	})
+	assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+}
+
+// TestActionSetListener_CreateRenameDescribeSchedule covers the four
+// single-statement events end-to-end. Confirms the rename / desc /
+// schedule UPDATEs all land on the row and the post-event row reads
+// back the right state.
+func TestActionSetListener_CreateRenameDescribeSchedule(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data: map[string]any{
+			"name":        "initial",
+			"description": "first",
+			"schedule":    map[string]any{"interval_hours": 12},
+		},
+		ActorType: "user", ActorID: "u-1",
+	}))
+
+	got, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, "initial", got.Name)
+	assert.Equal(t, "first", got.Description)
+	assert.JSONEq(t, `{"interval_hours":12}`, string(got.Schedule))
+	assert.Greater(t, got.ProjectionVersion, int64(0))
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetRenamed",
+		Data:      map[string]any{"name": "renamed"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", got.Name)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetDescriptionUpdated",
+		Data:      map[string]any{"description": "second"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, "second", got.Description)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetScheduleUpdated",
+		Data:      map[string]any{"schedule": map[string]any{"cron": "*/5 * * * *"}},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"cron":"*/5 * * * *"}`, string(got.Schedule))
+}
+
+// TestActionSetListener_MemberAddRemoveRecounts covers the
+// MemberAdded → MemberRemoved cycle and asserts member_count tracks
+// the live row count after each.
+func TestActionSetListener_MemberAddRemoveRecounts(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data:      map[string]any{"name": "members"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Two members.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"action_id": "act-A", "sort_order": 0},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"action_id": "act-B", "sort_order": 1},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	got, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), got.MemberCount)
+
+	// Repeat-add the same member: ON CONFLICT DO NOTHING preserves
+	// idempotency; member_count stays at 2.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"action_id": "act-A", "sort_order": 99},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), got.MemberCount, "repeat-add of an existing member must not double-count")
+
+	// Remove one.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberRemoved",
+		Data:      map[string]any{"action_id": "act-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), got.MemberCount)
+
+	// Remove the same again: DELETE no-ops, recount stays at 1.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberRemoved",
+		Data:      map[string]any{"action_id": "act-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), got.MemberCount, "double-remove must be idempotent (DELETE-then-recount)")
+}
+
+// TestActionSetListener_MemberReorderUpdatesRow verifies the per-
+// member sort_order changes and the parent's updated_at +
+// projection_version bump.
+func TestActionSetListener_MemberReorderUpdatesRow(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data:      map[string]any{"name": "reorder"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"action_id": "act-A", "sort_order": 0},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	beforeReorder, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	beforeVersion := beforeReorder.ProjectionVersion
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberReordered",
+		Data:      map[string]any{"action_id": "act-A", "sort_order": 42},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	member, err := st.Queries().GetActionSetMember(ctx, db.GetActionSetMemberParams{
+		SetID: setID, ActionID: "act-A",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(42), member.SortOrder)
+
+	after, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Greater(t, after.ProjectionVersion, beforeVersion,
+		"reorder bumps parent projection_version + updated_at")
+}
+
+// TestActionSetListener_DeleteCascadesMembersAndDefinitions confirms
+// ActionSetDeleted soft-deletes the set, wipes every member row, AND
+// (the cross-stream cascade that makes this projector trickier than
+// role) decrements member_count on every parent definition that
+// contained the set, then deletes the matching
+// definition_members rows.
+func TestActionSetListener_DeleteCascadesMembersAndDefinitions(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+	defID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data:      map[string]any{"name": "to-delete"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"action_id": "act-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"action_id": "act-B"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Plant a definitions_projection row + a definition_members
+	// row that references our action set. Direct SQL because the
+	// definition projector is still PL/pgSQL — we don't want to
+	// couple this test to its event flow.
+	_, err := st.Pool().Exec(ctx,
+		`INSERT INTO definitions_projection (id, name, member_count, created_at, created_by, projection_version)
+		 VALUES ($1, $2, 1, NOW(), '', 0)`,
+		defID, "wraps-our-set",
+	)
+	require.NoError(t, err)
+	_, err = st.Pool().Exec(ctx,
+		`INSERT INTO definition_members_projection (definition_id, action_set_id, sort_order, added_at)
+		 VALUES ($1, $2, 0, NOW())`,
+		defID, setID,
+	)
+	require.NoError(t, err)
+
+	// Delete the set.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Set row marked deleted.
+	var isDeleted bool
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT is_deleted FROM action_sets_projection WHERE id = $1", setID,
+	).Scan(&isDeleted))
+	assert.True(t, isDeleted)
+
+	// Members wiped.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM action_set_members_projection WHERE set_id = $1", setID,
+	).Scan(&count))
+	assert.Equal(t, 0, count)
+
+	// definition_members rows for this set wiped.
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM definition_members_projection WHERE action_set_id = $1", setID,
+	).Scan(&count))
+	assert.Equal(t, 0, count)
+
+	// Parent definition's member_count decremented (1 → 0).
+	var memberCount int32
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT member_count FROM definitions_projection WHERE id = $1", defID,
+	).Scan(&memberCount))
+	assert.Equal(t, int32(0), memberCount,
+		"parent definitions referencing the deleted set must have member_count decremented")
+}
+
+// TestActionSetListener_StaleReplayRejected — UPDATE form (Renamed)
+// doesn't clobber a fresher row when re-applied with an older
+// projection_version. Mirrors the role projector's stale-replay
+// regression test.
+func TestActionSetListener_StaleReplayRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data:      map[string]any{"name": "first"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetRenamed",
+		Data:      map[string]any{"name": "current"},
+		ActorType: "user", ActorID: "u",
+	}))
+	current, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	currentVersion := current.ProjectionVersion
+
+	older := currentVersion - 5
+	updatedAt := current.CreatedAt
+	n, err := st.Queries().RenameActionSetProjection(ctx, db.RenameActionSetProjectionParams{
+		ID:                setID,
+		Name:              "stale-would-set-this",
+		UpdatedAt:         updatedAt,
+		ProjectionVersion: older,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "stale projection_version UPDATE must affect zero rows")
+
+	after, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, "current", after.Name)
+	assert.Equal(t, currentVersion, after.ProjectionVersion)
+}
+
+// TestActionSetListener_StaleDeleteReplayDoesNotNukeMembers locks the
+// asymmetric-guard discipline for the most cascade-heavy event type:
+// when the version-guarded SoftDelete affects zero rows, every
+// downstream cascade (member wipe, parent-definition decrement,
+// definition_members wipe) MUST be skipped.
+func TestActionSetListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+	defID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data:      map[string]any{"name": "live"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"action_id": "act-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+
+	_, err = st.Pool().Exec(ctx,
+		`INSERT INTO definitions_projection (id, name, member_count, created_at, created_by, projection_version)
+		 VALUES ($1, $2, 1, NOW(), '', 0)`,
+		defID, "still-references-live-set",
+	)
+	require.NoError(t, err)
+	_, err = st.Pool().Exec(ctx,
+		`INSERT INTO definition_members_projection (definition_id, action_set_id, sort_order, added_at)
+		 VALUES ($1, $2, 0, NOW())`,
+		defID, setID,
+	)
+	require.NoError(t, err)
+
+	// Drive the listener with a stale ActionSetDeleted (older
+	// projection_version than the row currently has).
+	older := live.ProjectionVersion - 5
+	staleAt := *live.CreatedAt
+	listener := projectors.ActionSetListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "action_set",
+		StreamID:    setID,
+		EventType:   "ActionSetDeleted",
+		Data:        []byte("{}"),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
+	})
+
+	// Set still alive.
+	stillAlive, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.False(t, stillAlive.IsDeleted, "stale ActionSetDeleted must NOT flip is_deleted")
+
+	// Member still there.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM action_set_members_projection WHERE set_id = $1", setID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale ActionSetDeleted must NOT cascade-delete members")
+
+	// definition_members row still there.
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM definition_members_projection WHERE action_set_id = $1", setID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale ActionSetDeleted must NOT cascade-delete definition_members")
+
+	// Parent definition's member_count untouched.
+	var memberCount int32
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT member_count FROM definitions_projection WHERE id = $1", defID,
+	).Scan(&memberCount))
+	assert.Equal(t, int32(1), memberCount,
+		"stale ActionSetDeleted must NOT decrement live definitions' member_count")
+}
+
+// TestActionSetListener_IgnoresWrongStreamType — defensive.
+func TestActionSetListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", // wrong stream
+		StreamID:   setID,
+		EventType:  "ActionSetCreated",
+		Data:       map[string]any{"name": "ghost"},
+		ActorType:  "user", ActorID: "u",
+	}))
+
+	_, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.Error(t, err, "wrong-stream-type ActionSetCreated must NOT create a row")
+}

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -72,24 +72,27 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "user_selection_projector"),
 	))
-	// All 11 ports of tracker #107 are now wired here. Future ports
-	// of the un-ported domain projectors (user, device, action,
-	// execution, assignment, compliance, etc.) will land in a
-	// separate tracker.
+	st.RegisterEventListener(ActionSetListener(
+		st,
+		loggerFor(logger, "action_set_projector"),
+	))
+	// All 11 ports of tracker #107 are now wired here, plus the
+	// first Phase 2 port (action_set, #136). Future Phase 2 ports of
+	// the remaining domain projectors (user, device, action,
+	// definition, device_group, assignment, execution, user_group,
+	// compliance, compliance_policy) land here too.
 
 	// Rebuild appliers (manchtools/power-manage-server#125). Only
 	// the ported projectors that own a rebuildTarget in
 	// store.AllRebuildTargets need this wiring — RebuildAll
 	// dispatches everything else through the legacy PL/pgSQL
 	// Function. Of the 11 #107 ports, three own rebuild targets:
-	// roles, tokens, user_selections. The other eight projector
-	// streams (security_alert, totp, lps_password, luks_key,
-	// server_settings, user_role, identity_provider,
-	// scim_group_mapping) never had a rebuild target so RebuildAll
-	// does not touch them.
+	// roles, tokens, user_selections. The action_set port (#136)
+	// adds a fourth.
 	st.RegisterRebuildApply("roles", ApplyRole)
 	st.RegisterRebuildApply("tokens", ApplyToken)
 	st.RegisterRebuildApply("user_selections", ApplyUserSelection)
+	st.RegisterRebuildApply("action_sets", ApplyActionSet)
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/action_sets.sql.go
+++ b/internal/store/generated/action_sets.sql.go
@@ -25,6 +25,75 @@ func (q *Queries) CountActionSets(ctx context.Context, unassignedOnly bool) (int
 	return count, err
 }
 
+const decrementDefinitionMemberCountByActionSet = `-- name: DecrementDefinitionMemberCountByActionSet :exec
+UPDATE definitions_projection
+SET member_count = member_count - 1
+WHERE id IN (
+    SELECT definition_id FROM definition_members_projection WHERE action_set_id = $1
+)
+`
+
+// ActionSetDeleted handler — third half. Mirrors the PL/pgSQL
+// subquery `UPDATE definitions_projection SET member_count = member_count - 1
+// WHERE id IN (SELECT definition_id FROM definition_members_projection
+// WHERE action_set_id = ...)`. Runs BEFORE
+// DeleteDefinitionMembersByActionSet — once we delete those member
+// rows the subquery would return empty and the recount would no-op.
+// definitions_projection is still owned by the PL/pgSQL projector
+// (project_definition_event), so no projection_version guard here:
+// doing one would require coordinating versioning across two
+// projector codebases. The cascade itself is gated by
+// SoftDeleteActionSetProjection's :execrows short-circuit upstream.
+func (q *Queries) DecrementDefinitionMemberCountByActionSet(ctx context.Context, actionSetID string) error {
+	_, err := q.db.Exec(ctx, decrementDefinitionMemberCountByActionSet, actionSetID)
+	return err
+}
+
+const deleteActionSetMember = `-- name: DeleteActionSetMember :exec
+DELETE FROM action_set_members_projection
+WHERE set_id = $1
+  AND action_id = $2
+`
+
+type DeleteActionSetMemberParams struct {
+	SetID    string `json:"set_id"`
+	ActionID string `json:"action_id"`
+}
+
+// ActionSetMemberRemoved handler — first half. Plain DELETE — silently
+// no-op on a miss matches the PL/pgSQL projector's behaviour.
+func (q *Queries) DeleteActionSetMember(ctx context.Context, arg DeleteActionSetMemberParams) error {
+	_, err := q.db.Exec(ctx, deleteActionSetMember, arg.SetID, arg.ActionID)
+	return err
+}
+
+const deleteActionSetMembersBySet = `-- name: DeleteActionSetMembersBySet :exec
+DELETE FROM action_set_members_projection WHERE set_id = $1
+`
+
+// ActionSetDeleted handler — second half. Wipes every member row for
+// the deleted set. Wrapped with SoftDeleteActionSetProjection +
+// DecrementDefinitionMemberCountByActionSet +
+// DeleteDefinitionMembersByActionSet inside store.WithTx for inter-
+// write atomicity.
+func (q *Queries) DeleteActionSetMembersBySet(ctx context.Context, setID string) error {
+	_, err := q.db.Exec(ctx, deleteActionSetMembersBySet, setID)
+	return err
+}
+
+const deleteDefinitionMembersByActionSet = `-- name: DeleteDefinitionMembersByActionSet :exec
+DELETE FROM definition_members_projection WHERE action_set_id = $1
+`
+
+// ActionSetDeleted handler — fourth half. Removes every
+// definition_members_projection row that referenced the deleted set
+// so the parent definition's member list no longer surfaces the
+// ghost.
+func (q *Queries) DeleteDefinitionMembersByActionSet(ctx context.Context, actionSetID string) error {
+	_, err := q.db.Exec(ctx, deleteDefinitionMembersByActionSet, actionSetID)
+	return err
+}
+
 const getActionSetByID = `-- name: GetActionSetByID :one
 
 SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, updated_at, schedule FROM action_sets_projection
@@ -94,6 +163,79 @@ func (q *Queries) GetActionSetMember(ctx context.Context, arg GetActionSetMember
 		&i.ProjectionVersion,
 	)
 	return i, err
+}
+
+const insertActionSetMember = `-- name: InsertActionSetMember :exec
+INSERT INTO action_set_members_projection (
+    set_id, action_id, sort_order, added_at, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (set_id, action_id) DO NOTHING
+`
+
+type InsertActionSetMemberParams struct {
+	SetID             string     `json:"set_id"`
+	ActionID          string     `json:"action_id"`
+	SortOrder         int32      `json:"sort_order"`
+	AddedAt           *time.Time `json:"added_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ActionSetMemberAdded handler — first half. ON CONFLICT DO NOTHING
+// preserves the PL/pgSQL projector's idempotency under reconciler
+// replays. The composite PK (set_id, action_id) makes this safe.
+func (q *Queries) InsertActionSetMember(ctx context.Context, arg InsertActionSetMemberParams) error {
+	_, err := q.db.Exec(ctx, insertActionSetMember,
+		arg.SetID,
+		arg.ActionID,
+		arg.SortOrder,
+		arg.AddedAt,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const insertActionSetProjection = `-- name: InsertActionSetProjection :exec
+
+INSERT INTO action_sets_projection (
+    id, name, description, schedule,
+    created_at, updated_at, created_by, projection_version
+) VALUES ($1, $2, $3, $4, $5, $5, $6, $7)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertActionSetProjectionParams struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	Description       string     `json:"description"`
+	Schedule          []byte     `json:"schedule"`
+	CreatedAt         *time.Time `json:"created_at"`
+	CreatedBy         string     `json:"created_by"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// Projector writes (manchtools/power-manage-server#136). Replaces the
+// deleted PL/pgSQL project_action_set_event() function; called from
+// projectors.ApplyActionSet via projectors.ActionSetListener.
+//
+// Tightening vs the PL/pgSQL projector: every UPDATE carries an
+// explicit `WHERE projection_version < $N` guard and uses :execrows
+// so the listener can short-circuit cascades on stale-replay
+// (asymmetric-guard discipline; see role_listener for the canonical
+// shape).
+// ActionSetCreated handler. ON CONFLICT DO NOTHING for replay safety.
+// Schedule defaults to '{"interval_hours": 8}' (the column default
+// mirrors the PL/pgSQL COALESCE fallback for the missing payload key).
+func (q *Queries) InsertActionSetProjection(ctx context.Context, arg InsertActionSetProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertActionSetProjection,
+		arg.ID,
+		arg.Name,
+		arg.Description,
+		arg.Schedule,
+		arg.CreatedAt,
+		arg.CreatedBy,
+		arg.ProjectionVersion,
+	)
+	return err
 }
 
 const listActionSetMembers = `-- name: ListActionSetMembers :many
@@ -234,4 +376,211 @@ func (q *Queries) ListActionsInSet(ctx context.Context, setID string) ([]Actions
 		return nil, err
 	}
 	return items, nil
+}
+
+const recountActionSetMembers = `-- name: RecountActionSetMembers :execrows
+UPDATE action_sets_projection
+SET member_count      = (SELECT COUNT(*) FROM action_set_members_projection WHERE set_id = $1),
+    updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type RecountActionSetMembersParams struct {
+	SetID             string     `json:"set_id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ActionSetMemberAdded / ActionSetMemberRemoved handler — second half.
+// Recomputes member_count from the live row count, mirroring the
+// PL/pgSQL `(SELECT COUNT(*) ...)` subquery. Guarded so a stale replay
+// doesn't roll member_count backwards or stamp an old version.
+func (q *Queries) RecountActionSetMembers(ctx context.Context, arg RecountActionSetMembersParams) (int64, error) {
+	result, err := q.db.Exec(ctx, recountActionSetMembers, arg.SetID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const renameActionSetProjection = `-- name: RenameActionSetProjection :execrows
+UPDATE action_sets_projection
+SET name              = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type RenameActionSetProjectionParams struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ActionSetRenamed handler. Stale-replay guard via projection_version.
+func (q *Queries) RenameActionSetProjection(ctx context.Context, arg RenameActionSetProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, renameActionSetProjection,
+		arg.ID,
+		arg.Name,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const softDeleteActionSetProjection = `-- name: SoftDeleteActionSetProjection :execrows
+UPDATE action_sets_projection
+SET is_deleted        = TRUE,
+    updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type SoftDeleteActionSetProjectionParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ActionSetDeleted handler — first half. Returns rows-affected so the
+// listener can SKIP the cascade (members + parent-definition recount +
+// definition_members cleanup) when the projection_version guard
+// rejects a stale replay; otherwise an old ActionSetDeleted re-applied
+// by the reconciler would silently nuke a freshly-restored set's
+// members and decrement live definitions' member_count.
+func (q *Queries) SoftDeleteActionSetProjection(ctx context.Context, arg SoftDeleteActionSetProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteActionSetProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const touchActionSetUpdatedAt = `-- name: TouchActionSetUpdatedAt :execrows
+UPDATE action_sets_projection
+SET updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type TouchActionSetUpdatedAtParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ActionSetMemberReordered handler — second half. Bumps updated_at +
+// projection_version on the parent set so listing/cache invalidation
+// sees the change. Guarded for stale-replay safety.
+func (q *Queries) TouchActionSetUpdatedAt(ctx context.Context, arg TouchActionSetUpdatedAtParams) (int64, error) {
+	result, err := q.db.Exec(ctx, touchActionSetUpdatedAt, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateActionSetDescriptionProjection = `-- name: UpdateActionSetDescriptionProjection :execrows
+UPDATE action_sets_projection
+SET description       = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateActionSetDescriptionProjectionParams struct {
+	ID                string     `json:"id"`
+	Description       string     `json:"description"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ActionSetDescriptionUpdated handler. Empty-string description is a
+// valid value (matches the PL/pgSQL `COALESCE(payload, ”)` collapse —
+// the listener decoder substitutes ” when the payload key is missing).
+func (q *Queries) UpdateActionSetDescriptionProjection(ctx context.Context, arg UpdateActionSetDescriptionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateActionSetDescriptionProjection,
+		arg.ID,
+		arg.Description,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateActionSetMemberSortOrder = `-- name: UpdateActionSetMemberSortOrder :execrows
+UPDATE action_set_members_projection
+SET sort_order        = $3,
+    projection_version = $4
+WHERE set_id = $1
+  AND action_id = $2
+  AND projection_version < $4
+`
+
+type UpdateActionSetMemberSortOrderParams struct {
+	SetID             string `json:"set_id"`
+	ActionID          string `json:"action_id"`
+	SortOrder         int32  `json:"sort_order"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// ActionSetMemberReordered handler — first half. Per-member
+// projection_version guards the row so a stale reorder cannot clobber
+// a fresher position.
+func (q *Queries) UpdateActionSetMemberSortOrder(ctx context.Context, arg UpdateActionSetMemberSortOrderParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateActionSetMemberSortOrder,
+		arg.SetID,
+		arg.ActionID,
+		arg.SortOrder,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateActionSetScheduleProjection = `-- name: UpdateActionSetScheduleProjection :execrows
+UPDATE action_sets_projection
+SET schedule          = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateActionSetScheduleProjectionParams struct {
+	ID                string     `json:"id"`
+	Schedule          []byte     `json:"schedule"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ActionSetScheduleUpdated handler. The decoder defaults a missing
+// schedule key to the column default '{"interval_hours": 8}' so this
+// query always receives a non-NULL JSONB blob.
+func (q *Queries) UpdateActionSetScheduleProjection(ctx context.Context, arg UpdateActionSetScheduleProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateActionSetScheduleProjection,
+		arg.ID,
+		arg.Schedule,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/internal/store/migrations/030_action_set_projector_to_go.sql
+++ b/internal/store/migrations/030_action_set_projector_to_go.sql
@@ -1,0 +1,165 @@
+-- Replace project_action_set_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.ActionSetListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger still
+-- PERFORMs project_action_set_event(NEW) for every action_set-stream
+-- event; the no-op stub keeps that dispatch quiet (no
+-- plpgsql_projection_errors entries) until the Phase 2 cleanup
+-- migration drops every still-PL/pgSQL WHEN clause from the
+-- dispatcher.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. The eight event types (Created, Renamed,
+--     DescriptionUpdated, ScheduleUpdated, MemberAdded,
+--     MemberRemoved, MemberReordered, Deleted) and their cascades
+--     were atomic with the event commit.
+--   - After: Go listener fires post-commit. Every multi-write event
+--     (MemberAdded/Removed/Reordered/Deleted) wraps its writes in
+--     store.WithTx so the cascade stays atomic with itself, but not
+--     with the event commit. The handler's read-after-write paths
+--     (CreateActionSet/RenameActionSet/AddActionToSet etc. reading
+--     back from action_sets_projection) still see the projection
+--     because fireListeners is synchronous — the listener has
+--     already run by the time AppendEvent returns.
+--
+-- Tightening: every UPDATE on action_sets_projection (Renamed,
+-- DescriptionUpdated, ScheduleUpdated, member_count recount,
+-- updated_at touch, soft-delete) and every UPDATE on
+-- action_set_members_projection (sort_order reorder) now has an
+-- explicit `WHERE projection_version < $N` guard, rejecting stale
+-- reconciler replays. The PL/pgSQL projector stamped
+-- projection_version without a guard.
+--
+-- Asymmetric-guard discipline (per the role + identity_provider
+-- ports): the guarded SoftDelete uses :execrows, and the listener
+-- short-circuits the cascade (member wipe + parent-definition
+-- decrement + definition_members cleanup) when n == 0 — otherwise
+-- a stale ActionSetDeleted re-applied later would silently nuke a
+-- freshly-restored set's members and decrement live definitions'
+-- member_count.
+--
+-- See manchtools/power-manage-server#136. First port under Phase 2
+-- of tracker #107's projector-migration pattern.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_action_set_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.ActionSetListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the PL/pgSQL projector verbatim from migration 012 (the
+-- last definition before this port). Migration 012 added the
+-- ScheduleUpdated event + the schedule column to ActionSetCreated;
+-- restoring that body is the correct rollback target since 012's
+-- shape was the live state immediately before this migration ran.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_action_set_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'ActionSetCreated' THEN
+            INSERT INTO action_sets_projection (
+                id, name, description, schedule, created_at, updated_at, created_by, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'name',
+                COALESCE(event.data->>'description', ''),
+                COALESCE((event.data->'schedule')::JSONB, '{"interval_hours": 8}'::JSONB),
+                event.occurred_at,
+                event.occurred_at,
+                event.actor_id,
+                event.sequence_num
+            );
+
+        WHEN 'ActionSetRenamed' THEN
+            UPDATE action_sets_projection
+            SET name = event.data->>'name',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ActionSetDescriptionUpdated' THEN
+            UPDATE action_sets_projection
+            SET description = COALESCE(event.data->>'description', ''),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ActionSetScheduleUpdated' THEN
+            UPDATE action_sets_projection
+            SET schedule = COALESCE((event.data->'schedule')::JSONB, '{"interval_hours": 8}'::JSONB),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ActionSetMemberAdded' THEN
+            INSERT INTO action_set_members_projection (
+                set_id, action_id, sort_order, added_at, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'action_id',
+                COALESCE((event.data->>'sort_order')::INTEGER, 0),
+                event.occurred_at,
+                event.sequence_num
+            ) ON CONFLICT (set_id, action_id) DO NOTHING;
+
+            UPDATE action_sets_projection
+            SET member_count = (SELECT COUNT(*) FROM action_set_members_projection WHERE set_id = event.stream_id),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ActionSetMemberRemoved' THEN
+            DELETE FROM action_set_members_projection
+            WHERE set_id = event.stream_id AND action_id = event.data->>'action_id';
+
+            UPDATE action_sets_projection
+            SET member_count = (SELECT COUNT(*) FROM action_set_members_projection WHERE set_id = event.stream_id),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ActionSetMemberReordered' THEN
+            UPDATE action_set_members_projection
+            SET sort_order = COALESCE((event.data->>'sort_order')::INTEGER, 0),
+                projection_version = event.sequence_num
+            WHERE set_id = event.stream_id AND action_id = event.data->>'action_id';
+
+            UPDATE action_sets_projection
+            SET updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ActionSetDeleted' THEN
+            UPDATE action_sets_projection
+            SET is_deleted = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            DELETE FROM action_set_members_projection WHERE set_id = event.stream_id;
+
+            UPDATE definitions_projection
+            SET member_count = member_count - 1
+            WHERE id IN (
+                SELECT definition_id FROM definition_members_projection WHERE action_set_id = event.stream_id
+            );
+
+            DELETE FROM definition_members_projection WHERE action_set_id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/action_sets.sql
+++ b/internal/store/queries/action_sets.sql
@@ -43,3 +43,150 @@ SELECT a.* FROM actions_projection a
 JOIN action_set_members_projection m ON a.id = m.action_id
 WHERE m.set_id = $1 AND a.is_deleted = FALSE
 ORDER BY m.sort_order ASC;
+
+-- Projector writes (manchtools/power-manage-server#136). Replaces the
+-- deleted PL/pgSQL project_action_set_event() function; called from
+-- projectors.ApplyActionSet via projectors.ActionSetListener.
+--
+-- Tightening vs the PL/pgSQL projector: every UPDATE carries an
+-- explicit `WHERE projection_version < $N` guard and uses :execrows
+-- so the listener can short-circuit cascades on stale-replay
+-- (asymmetric-guard discipline; see role_listener for the canonical
+-- shape).
+
+-- name: InsertActionSetProjection :exec
+-- ActionSetCreated handler. ON CONFLICT DO NOTHING for replay safety.
+-- Schedule defaults to '{"interval_hours": 8}' (the column default
+-- mirrors the PL/pgSQL COALESCE fallback for the missing payload key).
+INSERT INTO action_sets_projection (
+    id, name, description, schedule,
+    created_at, updated_at, created_by, projection_version
+) VALUES ($1, $2, $3, $4, $5, $5, $6, $7)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: RenameActionSetProjection :execrows
+-- ActionSetRenamed handler. Stale-replay guard via projection_version.
+UPDATE action_sets_projection
+SET name              = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: UpdateActionSetDescriptionProjection :execrows
+-- ActionSetDescriptionUpdated handler. Empty-string description is a
+-- valid value (matches the PL/pgSQL `COALESCE(payload, '')` collapse —
+-- the listener decoder substitutes '' when the payload key is missing).
+UPDATE action_sets_projection
+SET description       = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: UpdateActionSetScheduleProjection :execrows
+-- ActionSetScheduleUpdated handler. The decoder defaults a missing
+-- schedule key to the column default '{"interval_hours": 8}' so this
+-- query always receives a non-NULL JSONB blob.
+UPDATE action_sets_projection
+SET schedule          = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: InsertActionSetMember :exec
+-- ActionSetMemberAdded handler — first half. ON CONFLICT DO NOTHING
+-- preserves the PL/pgSQL projector's idempotency under reconciler
+-- replays. The composite PK (set_id, action_id) makes this safe.
+INSERT INTO action_set_members_projection (
+    set_id, action_id, sort_order, added_at, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (set_id, action_id) DO NOTHING;
+
+-- name: DeleteActionSetMember :exec
+-- ActionSetMemberRemoved handler — first half. Plain DELETE — silently
+-- no-op on a miss matches the PL/pgSQL projector's behaviour.
+DELETE FROM action_set_members_projection
+WHERE set_id = $1
+  AND action_id = $2;
+
+-- name: UpdateActionSetMemberSortOrder :execrows
+-- ActionSetMemberReordered handler — first half. Per-member
+-- projection_version guards the row so a stale reorder cannot clobber
+-- a fresher position.
+UPDATE action_set_members_projection
+SET sort_order        = $3,
+    projection_version = $4
+WHERE set_id = $1
+  AND action_id = $2
+  AND projection_version < $4;
+
+-- name: RecountActionSetMembers :execrows
+-- ActionSetMemberAdded / ActionSetMemberRemoved handler — second half.
+-- Recomputes member_count from the live row count, mirroring the
+-- PL/pgSQL `(SELECT COUNT(*) ...)` subquery. Guarded so a stale replay
+-- doesn't roll member_count backwards or stamp an old version.
+UPDATE action_sets_projection
+SET member_count      = (SELECT COUNT(*) FROM action_set_members_projection WHERE set_id = $1),
+    updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: TouchActionSetUpdatedAt :execrows
+-- ActionSetMemberReordered handler — second half. Bumps updated_at +
+-- projection_version on the parent set so listing/cache invalidation
+-- sees the change. Guarded for stale-replay safety.
+UPDATE action_sets_projection
+SET updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: SoftDeleteActionSetProjection :execrows
+-- ActionSetDeleted handler — first half. Returns rows-affected so the
+-- listener can SKIP the cascade (members + parent-definition recount +
+-- definition_members cleanup) when the projection_version guard
+-- rejects a stale replay; otherwise an old ActionSetDeleted re-applied
+-- by the reconciler would silently nuke a freshly-restored set's
+-- members and decrement live definitions' member_count.
+UPDATE action_sets_projection
+SET is_deleted        = TRUE,
+    updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: DeleteActionSetMembersBySet :exec
+-- ActionSetDeleted handler — second half. Wipes every member row for
+-- the deleted set. Wrapped with SoftDeleteActionSetProjection +
+-- DecrementDefinitionMemberCountByActionSet +
+-- DeleteDefinitionMembersByActionSet inside store.WithTx for inter-
+-- write atomicity.
+DELETE FROM action_set_members_projection WHERE set_id = $1;
+
+-- name: DecrementDefinitionMemberCountByActionSet :exec
+-- ActionSetDeleted handler — third half. Mirrors the PL/pgSQL
+-- subquery `UPDATE definitions_projection SET member_count = member_count - 1
+-- WHERE id IN (SELECT definition_id FROM definition_members_projection
+-- WHERE action_set_id = ...)`. Runs BEFORE
+-- DeleteDefinitionMembersByActionSet — once we delete those member
+-- rows the subquery would return empty and the recount would no-op.
+-- definitions_projection is still owned by the PL/pgSQL projector
+-- (project_definition_event), so no projection_version guard here:
+-- doing one would require coordinating versioning across two
+-- projector codebases. The cascade itself is gated by
+-- SoftDeleteActionSetProjection's :execrows short-circuit upstream.
+UPDATE definitions_projection
+SET member_count = member_count - 1
+WHERE id IN (
+    SELECT definition_id FROM definition_members_projection WHERE action_set_id = $1
+);
+
+-- name: DeleteDefinitionMembersByActionSet :exec
+-- ActionSetDeleted handler — fourth half. Removes every
+-- definition_members_projection row that referenced the deleted set
+-- so the parent definition's member list no longer surfaces the
+-- ghost.
+DELETE FROM definition_members_projection WHERE action_set_id = $1;

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -144,11 +144,27 @@ var AllRebuildTargets = []rebuildTarget{
 		Function:    "project_execution_event",
 	},
 	{
+		// Ported to projectors.ApplyActionSet via projectors.WireAll
+		// (manchtools/power-manage-server#136). RebuildAll dispatches
+		// through the Go applier; the no-op PL/pgSQL stub left behind
+		// by the migration is retained so the live trigger pipeline
+		// in project_event() stays quiet until the dispatcher itself
+		// drops its `WHEN 'action_set'` clause in the Phase 2 cleanup.
+		//
+		// Both action_sets_projection AND action_set_members_projection
+		// must be TRUNCATEd: the legacy rebuild_action_sets_projection()
+		// truncated both, and replaying events through ApplyActionSet
+		// requires the same starting state (otherwise pre-rebuild
+		// member rows leak through ON CONFLICT DO NOTHING and the
+		// recounted member_count + sort_orders end up echoing a hybrid
+		// of pre- and post-rebuild state). Listed in declaration order;
+		// CASCADE on the parent isn't strictly required since there's
+		// no FK linking the tables, but it's kept for symmetry with the
+		// legacy PL/pgSQL behaviour.
 		Name:        "action_sets",
-		Tables:      []string{"action_sets_projection"},
+		Tables:      []string{"action_sets_projection", "action_set_members_projection"},
 		Cascade:     true,
 		StreamTypes: []string{"action_set"},
-		Function:    "project_action_set_event",
 	},
 	{
 		Name:        "definitions",


### PR DESCRIPTION
## Summary

First Phase 2 projector port from tracker [#136](https://github.com/manchtools/power-manage-server/issues/136). Ports \`project_action_set_event\` from PL/pgSQL to a Go listener using the canonical pattern validated by all 11 Phase 1 ports.

The action_set projector is the simplest of Phase 2 (per #136's
ordering recommendation) and the explicit "build pattern muscle"
first port for medium-projector territory.

## What landed

- **Pure decoder** \`internal/projectors/action_set.go\` — handles all
  7 event types (ActionSetCreated, ActionSetRenamed,
  ActionSetDescriptionUpdated, ActionSetMemberAdded,
  ActionSetMemberRemoved, ActionSetMemberReordered, ActionSetDeleted).
  Defaults match the PL/pgSQL projector exactly.
- **Listener** \`internal/projectors/action_set_listener.go\` — uses
  \`st.WithTx\` for the multi-write events (member add/remove/delete
  cascade). Stale-replay guard via \`projection_version\` on every
  UPDATE; \`:execrows\` short-circuit on \`n == 0\` per the
  identity_provider model (avoids the F020/F021 LPS hazard).
- **TDD test file** \`internal/projectors/action_set_test.go\` — 619
  LOC. Per-event decoder tests + a full-lifecycle listener test
  with real Postgres via \`testutil.SetupPostgres\`.
- **Migration** \`030_action_set_projector_to_go.sql\` — no-ops the
  PL/pgSQL \`project_action_set_event(events)\` function. Wrapped
  in \`-- +goose StatementBegin\` / \`-- +goose StatementEnd\` per the
  goose-with-PL/pgSQL rule.
- **WireAll registration** — registers the listener and the rebuild
  applier (\`st.RegisterRebuildApply("action_sets", ApplyActionSet)\`).
  The runOneTarget guard at rebuild.go:286 is the safety net.
- **sqlc queries** \`internal/store/queries/action_sets.sql\` — guarded
  UPDATE/UPSERT statements + the cascade DELETE on definitions
  member_count.

## Test plan

- [ ] Lint workflow (added in PR #141) green
- [ ] Tests workflow green (real Postgres via testcontainers)
- [ ] Rebuild path: \`RebuildAll\` against a fresh DB reproduces the
      same projection state the PL/pgSQL projector would have
      produced.

Part of #136.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal infrastructure refactoring to migrate event projection logic, improving system architecture and maintainability with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->