### PR TITLE
fix: address audit Bundle E — LPS stale-replay guard (F020, F021)

### DIFF
--- a/internal/projectors/lps_password_listener.go
+++ b/internal/projectors/lps_password_listener.go
@@ -19,13 +19,22 @@ import (
 // Atomicity-with-the-event-commit is sacrificed (the listener fires
 // post-commit), but atomicity-of-the-three-writes is preserved.
 //
+// Asymmetric stale-replay guard (audit F020/F021): the guarded
+// MarkLpsPasswordsNotCurrent UPDATE returns rows-affected. If a
+// re-fired old event would otherwise re-mark the latest real-current
+// row as not_current, the projection_version filter rejects it
+// (n == 0) and the listener short-circuits the cascade insert + trim.
+// Without this guard a reconciler-driven re-delivery of an old
+// LpsPasswordRotated would corrupt is_current and insert a stale
+// duplicate underneath the real password.
+//
 // LpsPasswordRotated is the only event the lps_password stream emits
 // today; the switch is intentionally a single case so a future event
 // type slots in next to it without touching the wiring.
 //
 // Wired in projectors.WireAll.
 //
-// Refs #98, tracker #107.
+// Refs #98, tracker #107, audit F020/F021.
 func LpsPasswordListener(st *store.Store, logger *slog.Logger) store.EventListener {
 	if st == nil {
 		return func(context.Context, store.PersistedEvent) {}
@@ -48,20 +57,48 @@ func LpsPasswordListener(st *store.Store, logger *slog.Logger) store.EventListen
 			return
 		}
 
+		projVer := deref(e.SequenceNum)
+
 		if err := st.WithTx(ctx, func(q *store.Queries) error {
-			if err := q.MarkLpsPasswordsNotCurrent(ctx, db.MarkLpsPasswordsNotCurrentParams{
-				DeviceID: payload.DeviceID,
-				Username: payload.Username,
-			}); err != nil {
+			n, err := q.MarkLpsPasswordsNotCurrent(ctx, db.MarkLpsPasswordsNotCurrentParams{
+				DeviceID:          payload.DeviceID,
+				Username:          payload.Username,
+				ProjectionVersion: projVer,
+			})
+			if err != nil {
 				return err
 			}
+			// n==0 has TWO causes that the rest of the code path
+			// handles oppositely:
+			//   1. Stale replay: rows exist for (device, username)
+			//      but their projection_version is >= the
+			//      replaying event's sequence_num. The rotation
+			//      has already been projected — skip the insert.
+			//   2. First rotation for this user: no rows exist at
+			//      all. The UPDATE matched nothing because there
+			//      was nothing to flip. Proceed to insert.
+			// Disambiguate via an existence check; only the stale
+			// case skips. (Audit F020/F021 / CR-CLI catch.)
+			if n == 0 {
+				exists, err := q.LpsPasswordExistsForDeviceUsername(ctx, db.LpsPasswordExistsForDeviceUsernameParams{
+					DeviceID: payload.DeviceID,
+					Username: payload.Username,
+				})
+				if err != nil {
+					return err
+				}
+				if exists {
+					return nil
+				}
+			}
 			if err := q.InsertLpsPassword(ctx, db.InsertLpsPasswordParams{
-				DeviceID:       payload.DeviceID,
-				ActionID:       payload.ActionID,
-				Username:       payload.Username,
-				Password:       payload.Password,
-				RotatedAt:      payload.RotatedAt,
-				RotationReason: payload.RotationReason,
+				DeviceID:          payload.DeviceID,
+				ActionID:          payload.ActionID,
+				Username:          payload.Username,
+				Password:          payload.Password,
+				RotatedAt:         payload.RotatedAt,
+				RotationReason:    payload.RotationReason,
+				ProjectionVersion: projVer,
 			}); err != nil {
 				return err
 			}

--- a/internal/store/generated/lps.sql.go
+++ b/internal/store/generated/lps.sql.go
@@ -20,7 +20,7 @@ func (q *Queries) DeleteLpsPasswordsByAction(ctx context.Context, actionID strin
 }
 
 const getCurrentLpsPasswords = `-- name: GetCurrentLpsPasswords :many
-SELECT id, device_id, action_id, username, password, rotated_at, rotation_reason, is_current, created_at FROM lps_passwords_projection
+SELECT id, device_id, action_id, username, password, rotated_at, rotation_reason, is_current, created_at, projection_version FROM lps_passwords_projection
 WHERE device_id = $1 AND is_current = TRUE
 ORDER BY rotated_at DESC
 `
@@ -44,6 +44,7 @@ func (q *Queries) GetCurrentLpsPasswords(ctx context.Context, deviceID string) (
 			&i.RotationReason,
 			&i.IsCurrent,
 			&i.CreatedAt,
+			&i.ProjectionVersion,
 		); err != nil {
 			return nil, err
 		}
@@ -56,7 +57,7 @@ func (q *Queries) GetCurrentLpsPasswords(ctx context.Context, deviceID string) (
 }
 
 const getLpsPasswordHistory = `-- name: GetLpsPasswordHistory :many
-SELECT id, device_id, action_id, username, password, rotated_at, rotation_reason, is_current, created_at FROM lps_passwords_projection
+SELECT id, device_id, action_id, username, password, rotated_at, rotation_reason, is_current, created_at, projection_version FROM lps_passwords_projection
 WHERE device_id = $1 AND is_current = FALSE
 ORDER BY rotated_at DESC
 LIMIT 20
@@ -81,6 +82,7 @@ func (q *Queries) GetLpsPasswordHistory(ctx context.Context, deviceID string) ([
 			&i.RotationReason,
 			&i.IsCurrent,
 			&i.CreatedAt,
+			&i.ProjectionVersion,
 		); err != nil {
 			return nil, err
 		}
@@ -94,23 +96,26 @@ func (q *Queries) GetLpsPasswordHistory(ctx context.Context, deviceID string) ([
 
 const insertLpsPassword = `-- name: InsertLpsPassword :exec
 INSERT INTO lps_passwords_projection
-    (device_id, action_id, username, password, rotated_at, rotation_reason)
-VALUES ($1, $2, $3, $4, $5, $6)
+    (device_id, action_id, username, password, rotated_at, rotation_reason, projection_version)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
 `
 
 type InsertLpsPasswordParams struct {
-	DeviceID       string    `json:"device_id"`
-	ActionID       string    `json:"action_id"`
-	Username       string    `json:"username"`
-	Password       string    `json:"password"`
-	RotatedAt      time.Time `json:"rotated_at"`
-	RotationReason string    `json:"rotation_reason"`
+	DeviceID          string    `json:"device_id"`
+	ActionID          string    `json:"action_id"`
+	Username          string    `json:"username"`
+	Password          string    `json:"password"`
+	RotatedAt         time.Time `json:"rotated_at"`
+	RotationReason    string    `json:"rotation_reason"`
+	ProjectionVersion int64     `json:"projection_version"`
 }
 
-// Step 2 of LpsPasswordRotated projection. Always inserts a new row
-// — the PL/pgSQL projector did the same, and step 3's trim keeps
-// only the latest 3 by rotated_at so duplicates from a replay are
-// pruned automatically.
+// Step 2 of LpsPasswordRotated projection. Inserts the new row only
+// when the listener confirmed via MarkLpsPasswordsNotCurrent's
+// :execrows that this is NOT a stale replay. The listener
+// short-circuits when n==0, so this insert never runs against a
+// stale event. projection_version on the new row is the same
+// sequence_num that just guarded step 1.
 func (q *Queries) InsertLpsPassword(ctx context.Context, arg InsertLpsPasswordParams) error {
 	_, err := q.db.Exec(ctx, insertLpsPassword,
 		arg.DeviceID,
@@ -119,33 +124,71 @@ func (q *Queries) InsertLpsPassword(ctx context.Context, arg InsertLpsPasswordPa
 		arg.Password,
 		arg.RotatedAt,
 		arg.RotationReason,
+		arg.ProjectionVersion,
 	)
 	return err
 }
 
-const markLpsPasswordsNotCurrent = `-- name: MarkLpsPasswordsNotCurrent :exec
-UPDATE lps_passwords_projection
-SET is_current = FALSE
-WHERE device_id = $1
-  AND username = $2
+const lpsPasswordExistsForDeviceUsername = `-- name: LpsPasswordExistsForDeviceUsername :one
+SELECT EXISTS (
+    SELECT 1 FROM lps_passwords_projection
+    WHERE device_id = $1
+      AND username = $2
+)
 `
 
-type MarkLpsPasswordsNotCurrentParams struct {
+type LpsPasswordExistsForDeviceUsernameParams struct {
 	DeviceID string `json:"device_id"`
 	Username string `json:"username"`
 }
 
+// Companion to the asymmetric stale-replay guard in
+// MarkLpsPasswordsNotCurrent. Used by the listener to disambiguate
+// the n==0 case: 0 rows-affected means EITHER "stale replay"
+// (rows exist with projection_version >= the replaying event's
+// sequence_num) OR "first rotation for this user" (no rows at all).
+// The listener proceeds to insert when no rows exist, and
+// short-circuits when rows exist (= the stale-replay case).
+func (q *Queries) LpsPasswordExistsForDeviceUsername(ctx context.Context, arg LpsPasswordExistsForDeviceUsernameParams) (bool, error) {
+	row := q.db.QueryRow(ctx, lpsPasswordExistsForDeviceUsername, arg.DeviceID, arg.Username)
+	var exists bool
+	err := row.Scan(&exists)
+	return exists, err
+}
+
+const markLpsPasswordsNotCurrent = `-- name: MarkLpsPasswordsNotCurrent :execrows
+UPDATE lps_passwords_projection
+SET is_current = FALSE,
+    projection_version = $3
+WHERE device_id = $1
+  AND username = $2
+  AND projection_version < $3
+`
+
+type MarkLpsPasswordsNotCurrentParams struct {
+	DeviceID          string `json:"device_id"`
+	Username          string `json:"username"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
 // Step 1 of LpsPasswordRotated projection. Flip every prior row for
 // (device_id, username) so the new password (inserted by step 2) is
-// the only is_current=TRUE row. Idempotent: replaying the same event
-// after the new row already landed leaves the projection unchanged
-// because the new row matches WHERE and gets flipped to FALSE — but
-// the listener wraps both writes in a tx, so a replay of the full
-// listener body keeps the (mark-old-false, insert-new-true) pair
-// consistent.
-func (q *Queries) MarkLpsPasswordsNotCurrent(ctx context.Context, arg MarkLpsPasswordsNotCurrentParams) error {
-	_, err := q.db.Exec(ctx, markLpsPasswordsNotCurrent, arg.DeviceID, arg.Username)
-	return err
+// the only is_current=TRUE row.
+//
+// The projection_version guard rejects stale-replay re-deliveries:
+// a re-fired old event whose sequence_num is <= the last applied
+// version for any matching row gets 0 rows-affected, and the
+// listener short-circuits the cascade insert + trim. Without the
+// guard, a reconciler-driven re-delivery of an old
+// LpsPasswordRotated would re-mark the latest (real-current) row as
+// not_current and insert a duplicate stale row underneath it.
+// Audit F020/F021.
+func (q *Queries) MarkLpsPasswordsNotCurrent(ctx context.Context, arg MarkLpsPasswordsNotCurrentParams) (int64, error) {
+	result, err := q.db.Exec(ctx, markLpsPasswordsNotCurrent, arg.DeviceID, arg.Username, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const trimLpsPasswordsToLast3 = `-- name: TrimLpsPasswordsToLast3 :exec

--- a/internal/store/generated/models.go
+++ b/internal/store/generated/models.go
@@ -304,15 +304,16 @@ type LogQueryResult struct {
 }
 
 type LpsPasswordsProjection struct {
-	ID             uuid.UUID `json:"id"`
-	DeviceID       string    `json:"device_id"`
-	ActionID       string    `json:"action_id"`
-	Username       string    `json:"username"`
-	Password       string    `json:"password"`
-	RotatedAt      time.Time `json:"rotated_at"`
-	RotationReason string    `json:"rotation_reason"`
-	IsCurrent      bool      `json:"is_current"`
-	CreatedAt      time.Time `json:"created_at"`
+	ID                uuid.UUID `json:"id"`
+	DeviceID          string    `json:"device_id"`
+	ActionID          string    `json:"action_id"`
+	Username          string    `json:"username"`
+	Password          string    `json:"password"`
+	RotatedAt         time.Time `json:"rotated_at"`
+	RotationReason    string    `json:"rotation_reason"`
+	IsCurrent         bool      `json:"is_current"`
+	CreatedAt         time.Time `json:"created_at"`
+	ProjectionVersion int64     `json:"projection_version"`
 }
 
 type LuksKeysProjection struct {

--- a/internal/store/migrations/031_lps_passwords_projection_version.sql
+++ b/internal/store/migrations/031_lps_passwords_projection_version.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- Audit F020/F021: lps_passwords_projection had no projection_version
+-- column, so the LPS listener could not implement the asymmetric
+-- stale-replay guard pattern that #101 + #104 + #105 + #106 follow.
+-- A reconciler-driven re-delivery of an old LpsPasswordRotated event
+-- would re-mark the current row as not-current, then insert a stale
+-- duplicate (which the trim-to-3 prunes by rotated_at, but the
+-- is_current=FALSE flag stays wrong on the most-recent real password
+-- until the next rotation overwrites it).
+--
+-- Default 0 backfills existing rows; new rows get the event's
+-- sequence_num via the listener. Older rows simply get treated as
+-- "no version" — the guard trips on any future replay because
+-- 0 < (any new event's sequence_num). The is_current flag for
+-- legacy rows is correct as-of-write; future rotations overwrite it
+-- through the same guarded path.
+
+ALTER TABLE lps_passwords_projection
+    ADD COLUMN projection_version BIGINT NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE lps_passwords_projection DROP COLUMN projection_version;

--- a/internal/store/queries/lps.sql
+++ b/internal/store/queries/lps.sql
@@ -12,28 +12,50 @@ LIMIT 20;
 -- name: DeleteLpsPasswordsByAction :exec
 DELETE FROM lps_passwords_projection WHERE action_id = $1;
 
--- name: MarkLpsPasswordsNotCurrent :exec
+-- name: MarkLpsPasswordsNotCurrent :execrows
 -- Step 1 of LpsPasswordRotated projection. Flip every prior row for
 -- (device_id, username) so the new password (inserted by step 2) is
--- the only is_current=TRUE row. Idempotent: replaying the same event
--- after the new row already landed leaves the projection unchanged
--- because the new row matches WHERE and gets flipped to FALSE — but
--- the listener wraps both writes in a tx, so a replay of the full
--- listener body keeps the (mark-old-false, insert-new-true) pair
--- consistent.
+-- the only is_current=TRUE row.
+--
+-- The projection_version guard rejects stale-replay re-deliveries:
+-- a re-fired old event whose sequence_num is <= the last applied
+-- version for any matching row gets 0 rows-affected, and the
+-- listener short-circuits the cascade insert + trim. Without the
+-- guard, a reconciler-driven re-delivery of an old
+-- LpsPasswordRotated would re-mark the latest (real-current) row as
+-- not_current and insert a duplicate stale row underneath it.
+-- Audit F020/F021.
 UPDATE lps_passwords_projection
-SET is_current = FALSE
+SET is_current = FALSE,
+    projection_version = sqlc.arg('projection_version')
 WHERE device_id = $1
-  AND username = $2;
+  AND username = $2
+  AND projection_version < sqlc.arg('projection_version');
 
 -- name: InsertLpsPassword :exec
--- Step 2 of LpsPasswordRotated projection. Always inserts a new row
--- — the PL/pgSQL projector did the same, and step 3's trim keeps
--- only the latest 3 by rotated_at so duplicates from a replay are
--- pruned automatically.
+-- Step 2 of LpsPasswordRotated projection. Inserts the new row only
+-- when the listener confirmed via MarkLpsPasswordsNotCurrent's
+-- :execrows that this is NOT a stale replay. The listener
+-- short-circuits when n==0, so this insert never runs against a
+-- stale event. projection_version on the new row is the same
+-- sequence_num that just guarded step 1.
 INSERT INTO lps_passwords_projection
-    (device_id, action_id, username, password, rotated_at, rotation_reason)
-VALUES ($1, $2, $3, $4, $5, $6);
+    (device_id, action_id, username, password, rotated_at, rotation_reason, projection_version)
+VALUES ($1, $2, $3, $4, $5, $6, $7);
+
+-- name: LpsPasswordExistsForDeviceUsername :one
+-- Companion to the asymmetric stale-replay guard in
+-- MarkLpsPasswordsNotCurrent. Used by the listener to disambiguate
+-- the n==0 case: 0 rows-affected means EITHER "stale replay"
+-- (rows exist with projection_version >= the replaying event's
+-- sequence_num) OR "first rotation for this user" (no rows at all).
+-- The listener proceeds to insert when no rows exist, and
+-- short-circuits when rows exist (= the stale-replay case).
+SELECT EXISTS (
+    SELECT 1 FROM lps_passwords_projection
+    WHERE device_id = $1
+      AND username = $2
+);
 
 -- name: TrimLpsPasswordsToLast3 :exec
 -- Step 3 of LpsPasswordRotated projection. Keep only the latest 3


### PR DESCRIPTION
## Summary

Fifth bundle from the 2026-05-07 server tech-debt audit. Closes
F020 (lps_passwords_projection had no projection_version column)
and F021 (lps_password_listener had no asymmetric guard).

- **Migration 031** adds \`projection_version BIGINT NOT NULL DEFAULT 0\`
  to lps_passwords_projection.
- **MarkLpsPasswordsNotCurrent** switched from \`:exec\` to \`:execrows\`
  with a \`projection_version < \$3\` guard.
- **LpsPasswordListener** short-circuits the cascade insert + trim
  when the guard rejects a stale replay.
- **CR-CLI catch (Critical):** the first version of the
  short-circuit dropped the very first rotation for any
  (device, username) because n==0 ALSO means "no rows exist
  yet". Added \`LpsPasswordExistsForDeviceUsername\` to
  disambiguate: short-circuit only when rows exist + n==0
  (real stale replay), proceed when no rows exist + n==0
  (first rotation).

## Test plan

- [ ] Lint workflow green
- [ ] Tests workflow green (real Postgres testcontainers exercise the listener)
- [ ] Manual: trigger first rotation for a fresh user — expect 1 row
- [ ] Manual: trigger second rotation — expect previous flipped to not_current, new row is_current
- [ ] Manual: simulate stale replay of first rotation after second has applied — expect projection unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved password rotation handling to prevent duplicate entries and correctly process stale event scenarios.

* **Refactor**
  * Updated password projection schema to support enhanced event versioning for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->