### PR TITLE
test: address audit Bundle F — permissions parity tests (F031, F040)

### DIFF
--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -66,6 +66,7 @@ func AllPermissions() []PermissionInfo {
 		{"ListActionSets", "Action Sets", "List action sets"},
 		{"RenameActionSet", "Action Sets", "Rename action sets"},
 		{"UpdateActionSetDescription", "Action Sets", "Update action set descriptions"},
+		{"UpdateActionSetSchedule", "Action Sets", "Update action set schedule"},
 		{"DeleteActionSet", "Action Sets", "Delete action sets"},
 		{"AddActionToSet", "Action Sets", "Add actions to sets"},
 		{"RemoveActionFromSet", "Action Sets", "Remove actions from sets"},
@@ -76,6 +77,7 @@ func AllPermissions() []PermissionInfo {
 		{"ListDefinitions", "Definitions", "List definitions"},
 		{"RenameDefinition", "Definitions", "Rename definitions"},
 		{"UpdateDefinitionDescription", "Definitions", "Update definition descriptions"},
+		{"UpdateDefinitionSchedule", "Definitions", "Update definition schedule"},
 		{"DeleteDefinition", "Definitions", "Delete definitions"},
 		{"AddActionSetToDefinition", "Definitions", "Add action sets to definitions"},
 		{"RemoveActionSetFromDefinition", "Definitions", "Remove action sets from definitions"},
@@ -94,6 +96,7 @@ func AllPermissions() []PermissionInfo {
 		{"ValidateDynamicQuery", "Device Groups", "Validate dynamic queries"},
 		{"EvaluateDynamicGroup", "Device Groups", "Evaluate dynamic groups"},
 		{"SetDeviceGroupSyncInterval", "Device Groups", "Set device group sync interval"},
+		{"SetDeviceGroupMaintenanceWindow", "Device Groups", "Set device group maintenance window"},
 		// Assignments
 		{"CreateAssignment", "Assignments", "Create assignments"},
 		{"DeleteAssignment", "Assignments", "Delete assignments"},
@@ -114,6 +117,7 @@ func AllPermissions() []PermissionInfo {
 		// Executions
 		{"GetExecution", "Executions", "View executions"},
 		{"ListExecutions", "Executions", "List executions"},
+		{"CancelExecution", "Executions", "Cancel pending executions"},
 		// OSQuery
 		{"DispatchOSQuery", "OSQuery", "Run OSQuery on device"},
 		{"GetOSQueryResult", "OSQuery", "View OSQuery results"},
@@ -175,6 +179,7 @@ func AllPermissions() []PermissionInfo {
 		{"UpdateUserGroupQuery", "User Groups", "Update user group queries"},
 		{"ValidateUserGroupQuery", "User Groups", "Validate user group queries"},
 		{"EvaluateDynamicUserGroup", "User Groups", "Evaluate dynamic user groups"},
+		{"SetUserGroupMaintenanceWindow", "User Groups", "Set user group maintenance window"},
 		// Identity Providers
 		{"CreateIdentityProvider", "Identity Providers", "Create identity providers"},
 		{"GetIdentityProvider", "Identity Providers", "View identity providers"},

--- a/internal/auth/permissions_parity_test.go
+++ b/internal/auth/permissions_parity_test.go
@@ -1,0 +1,115 @@
+package auth_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+	"github.com/manchtools/power-manage/server/internal/auth"
+)
+
+// rpcMethodNames returns the set of method names declared on the
+// generated ControlServiceHandler interface. These are the names
+// that match permission keys (stripped of :self / :assigned suffix)
+// and that PublicProcedures entries terminate in.
+func rpcMethodNames(t *testing.T) map[string]bool {
+	t.Helper()
+	iface := reflect.TypeOf((*pmv1connect.ControlServiceHandler)(nil)).Elem()
+	out := make(map[string]bool, iface.NumMethod())
+	for i := 0; i < iface.NumMethod(); i++ {
+		out[iface.Method(i).Name] = true
+	}
+	return out
+}
+
+// stripScope drops the optional :self / :assigned suffix from a
+// permission key. The base name is the RPC method name the
+// permission gates.
+func stripScope(key string) string {
+	if i := strings.IndexByte(key, ':'); i >= 0 {
+		return key[:i]
+	}
+	return key
+}
+
+// procedureName extracts the trailing RPC name from a fully-qualified
+// procedure string like "/pm.v1.ControlService/Login".
+func procedureName(procedure string) string {
+	if i := strings.LastIndexByte(procedure, '/'); i >= 0 && i < len(procedure)-1 {
+		return procedure[i+1:]
+	}
+	return procedure
+}
+
+// TestEveryPermissionMatchesAnRPC asserts that every PermissionInfo
+// in AllPermissions() has a base key (sans :self/:assigned scope
+// suffix) that is the name of an actual RPC on
+// pmv1connect.ControlServiceHandler. A drift here means a permission
+// can be assigned to a role but no handler will ever consult it —
+// invisible-deadweight UX in the role builder.
+func TestEveryPermissionMatchesAnRPC(t *testing.T) {
+	rpcs := rpcMethodNames(t)
+	for _, p := range auth.AllPermissions() {
+		base := stripScope(p.Key)
+		if !rpcs[base] {
+			t.Errorf("permission %q references non-existent RPC %q (no method on ControlServiceHandler)",
+				p.Key, base)
+		}
+	}
+}
+
+// TestEveryPublicProcedureIsAnRPC asserts that every entry in
+// PublicProcedures terminates in a method name that exists on
+// pmv1connect.ControlServiceHandler. A typo here would silently
+// leave the procedure auth-required (mostly safe — but a Login
+// typo would break login because the rate-limiter and the
+// auth-bypass check both key on the literal procedure string).
+func TestEveryPublicProcedureIsAnRPC(t *testing.T) {
+	rpcs := rpcMethodNames(t)
+	for procedure := range auth.PublicProcedures {
+		// Procedure must be the canonical Connect-RPC shape.
+		const prefix = "/pm.v1.ControlService/"
+		if !strings.HasPrefix(procedure, prefix) {
+			t.Errorf("PublicProcedures entry %q does not start with %q", procedure, prefix)
+			continue
+		}
+		method := procedureName(procedure)
+		if !rpcs[method] {
+			t.Errorf("PublicProcedures entry %q points at non-existent RPC %q (no method on ControlServiceHandler)",
+				procedure, method)
+		}
+	}
+}
+
+// TestEveryRPCIsCoveredByPermissionOrPublic is the inverse of the
+// two checks above: for every RPC on the generated handler, EITHER
+// it's listed in PublicProcedures (auth bypass) OR there's at least
+// one permission whose base key matches it. Catches new RPCs added
+// without permission wiring.
+func TestEveryRPCIsCoveredByPermissionOrPublic(t *testing.T) {
+	rpcs := rpcMethodNames(t)
+
+	// Build the inverse map: RPC name → covered (bool).
+	covered := make(map[string]bool, len(rpcs))
+	for name := range rpcs {
+		covered[name] = false
+	}
+
+	for procedure := range auth.PublicProcedures {
+		covered[procedureName(procedure)] = true
+	}
+	for _, p := range auth.AllPermissions() {
+		covered[stripScope(p.Key)] = true
+	}
+
+	var uncovered []string
+	for name, ok := range covered {
+		if !ok {
+			uncovered = append(uncovered, name)
+		}
+	}
+	if len(uncovered) > 0 {
+		t.Errorf("RPCs with no permission and not in PublicProcedures (drift hazard — every new RPC needs one or the other): %v", uncovered)
+	}
+}


### PR DESCRIPTION
## Summary

Sixth bundle from the 2026-05-07 server tech-debt audit. Closes
F031 + F040. Three new tests in
\`internal/auth/permissions_parity_test.go\` assert parity between
the generated \`pmv1connect.ControlServiceHandler\` interface and
the two auth-relevant Go-side maps:

- \`TestEveryPermissionMatchesAnRPC\` — every permission key (sans
  \`:self\`/\`:assigned\` scope) must be the name of an actual handler
  method.
- \`TestEveryPublicProcedureIsAnRPC\` — every PublicProcedures entry
  must terminate in a real RPC method name.
- \`TestEveryRPCIsCoveredByPermissionOrPublic\` — the inverse: every
  RPC on the handler must EITHER be in PublicProcedures OR have a
  permission entry.

## Drift caught on first run

The third test caught five RPCs from the maintenance-window (#58)
and deferred-dispatch (#57) features that landed without permission
wiring:

- UpdateActionSetSchedule
- UpdateDefinitionSchedule
- SetDeviceGroupMaintenanceWindow
- SetUserGroupMaintenanceWindow
- CancelExecution

All five added to \`AllPermissions()\` in their natural groups.

## CR-CLI feedback (deferred to #170)

CR-CLI on the merge-from-main suggested the govulncheck soft-fail
introduced in #169 should be split (hard-fail first-party / soft-
fail stdlib). Filed as #170 — outside the scope of this bundle.

## Test plan

- [ ] Lint workflow green
- [ ] Tests workflow green (the three new parity tests pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now cancel pending executions, providing enhanced control over scheduled operations
  * Added new permissions for managing and scheduling action sets and definitions
  * Added new permissions for setting and managing maintenance windows on device groups and user groups, improving operational flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->