### PR TITLE
fix: address audit Bundle G — misc + N+1 (F008, F026, F038, F041)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -736,7 +736,7 @@ func main() {
 	internalMux.Handle(internalPath, mtls.RequirePeerClass(logger, mtls.PeerClassGateway)(internalH))
 	internalMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	})
 
 	internalTLSCert, err := tls.LoadX509KeyPair(cfg.InternalTLSCert, cfg.InternalTLSKey)
@@ -881,34 +881,15 @@ func parseFlags() *Config {
 	envInt(&cfg.ValkeyDB, "CONTROL_VALKEY_DB")
 
 	// Validate dynamic group evaluation interval (0 to disable, min 30m, max 8h)
-	if cfg.DynamicGroupEvalInterval != 0 {
-		if cfg.DynamicGroupEvalInterval < 30*time.Minute {
-			cfg.DynamicGroupEvalInterval = 30 * time.Minute
-		} else if cfg.DynamicGroupEvalInterval > 8*time.Hour {
-			cfg.DynamicGroupEvalInterval = 8 * time.Hour
-		}
-	}
+	clampInterval(&cfg.DynamicGroupEvalInterval, 30*time.Minute, 8*time.Hour)
 
-	// Clamp system-action reconcile flags. Mirrors the DynamicGroup
-	// pattern above. A 0 sweep timeout would make
-	// context.WithTimeout return an already-cancelled context every
-	// tick, silently breaking the durability safety net; a negative
-	// interval would panic time.NewTicker. Round-3 review of rc11
-	// #77 caught the timeout footgun specifically; round-5 review
-	// added the floor/ceiling on the interval so a misconfigured
-	// 1ms tick can't flood the DB with sweep attempts.
-	if cfg.SystemActionReconcileInterval < 0 {
-		cfg.SystemActionReconcileInterval = 0 // treat as disabled, matching StartReconciliation
-	} else if cfg.SystemActionReconcileInterval > 0 {
-		if cfg.SystemActionReconcileInterval < 10*time.Second {
-			cfg.SystemActionReconcileInterval = 10 * time.Second
-		} else if cfg.SystemActionReconcileInterval > 8*time.Hour {
-			cfg.SystemActionReconcileInterval = 8 * time.Hour
-		}
-	}
-	if cfg.SystemActionReconcileTimeout <= 0 {
-		cfg.SystemActionReconcileTimeout = 5 * time.Minute
-	}
+	// Clamp system-action reconcile flags. The interval treats 0 as
+	// "disabled, matching StartReconciliation"; the timeout's 0 case
+	// would silently break the durability safety net via
+	// context.WithTimeout returning an already-cancelled context, so
+	// it falls back to the 5min default rather than disabling.
+	clampInterval(&cfg.SystemActionReconcileInterval, 10*time.Second, 8*time.Hour)
+	clampDurationFloor(&cfg.SystemActionReconcileTimeout, 5*time.Minute, 0)
 
 	if cfg.JWTSecret == "" {
 		fmt.Fprintln(os.Stderr, "FATAL: CONTROL_JWT_SECRET (or -jwt-secret) is required")
@@ -980,6 +961,46 @@ func ensureAdminUser(ctx context.Context, st *store.Store, email, password strin
 
 	logger.Info("admin user created", "email", email, "id", id)
 	return nil
+}
+
+// clampInterval clamps a duration into [minDur, maxDur]. A zero
+// value means "feature disabled" and is preserved unchanged — the
+// callers that consume the duration treat 0 specially (the dynamic-
+// group eval and system-action reconcile paths short-circuit at 0).
+// A negative value is normalised to 0 so a misconfigured -1
+// can't accidentally enable the feature with a tiny clamp value
+// downstream. Audit F041 — consolidates three open-coded clamps
+// in parseFlags.
+func clampInterval(target *time.Duration, minDur, maxDur time.Duration) {
+	if *target < 0 {
+		*target = 0
+		return
+	}
+	if *target == 0 {
+		return
+	}
+	if *target < minDur {
+		*target = minDur
+	} else if *target > maxDur {
+		*target = maxDur
+	}
+}
+
+// clampDurationFloor enforces a minimum on a duration, falling back
+// to a default when the input is non-positive. Used for fields where
+// "no value" (zero or negative) should NOT mean "feature disabled"
+// but instead "use the default" — the system-action reconcile
+// timeout is the canonical case (zero would silently break the
+// safety net via context.WithTimeout returning an already-cancelled
+// context).
+func clampDurationFloor(target *time.Duration, def, minDur time.Duration) {
+	if *target <= 0 {
+		*target = def
+		return
+	}
+	if *target < minDur {
+		*target = minDur
+	}
 }
 
 // envString overrides target with the environment variable value if set.

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -545,7 +545,7 @@ func main() {
 	})
 	opsMux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("ok"))
+		_, _ = w.Write([]byte("ok"))
 	})
 
 	// Create mTLS server

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -622,7 +622,6 @@ func (h *DeviceHandler) deviceToProtoWithAssignments(d db.DevicesProjection, ass
 	return device
 }
 
-// GetDeviceLpsPasswords returns current and historical LPS passwords for a device.
 // distinctIDs collects distinct non-empty values from id-typed slices,
 // preserving first-seen ordering. Used by the response loops below
 // to feed bulk-load queries (GetActionNamesByIDs / GetDeviceHostnamesByIDs)
@@ -681,6 +680,7 @@ func (h *DeviceHandler) loadDeviceHostnamesByIDs(ctx context.Context, ids []stri
 	return out
 }
 
+// GetDeviceLpsPasswords returns current and historical LPS passwords for a device.
 func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.Request[pm.GetDeviceLpsPasswordsRequest]) (*connect.Response[pm.GetDeviceLpsPasswordsResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -623,6 +623,64 @@ func (h *DeviceHandler) deviceToProtoWithAssignments(d db.DevicesProjection, ass
 }
 
 // GetDeviceLpsPasswords returns current and historical LPS passwords for a device.
+// distinctIDs collects distinct non-empty values from id-typed slices,
+// preserving first-seen ordering. Used by the response loops below
+// to feed bulk-load queries (GetActionNamesByIDs / GetDeviceHostnamesByIDs)
+// that audit F008 introduced — the previous shape made one round-trip
+// per row, which on a device with 50 LUKS keys was ~100 sequential
+// queries per RPC.
+func distinctIDs(idSlices ...[]string) []string {
+	seen := make(map[string]bool)
+	out := make([]string, 0)
+	for _, slice := range idSlices {
+		for _, id := range slice {
+			if id == "" || seen[id] {
+				continue
+			}
+			seen[id] = true
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+// loadActionNamesByIDs bulk-loads action_id → name. Failed lookups
+// (typically: action deleted between when the row was written and
+// when the RPC is served) drop out of the map; callers default to
+// empty string. Audit F008.
+func (h *DeviceHandler) loadActionNamesByIDs(ctx context.Context, ids []string) map[string]string {
+	if len(ids) == 0 {
+		return nil
+	}
+	rows, err := h.store.Queries().GetActionNamesByIDs(ctx, ids)
+	if err != nil {
+		logEnrichmentErr("GetActionNamesByIDs", "action_id_count", fmt.Sprint(len(ids)), err)
+		return nil
+	}
+	out := make(map[string]string, len(rows))
+	for _, r := range rows {
+		out[r.ID] = r.Name
+	}
+	return out
+}
+
+// loadDeviceHostnamesByIDs bulk-loads device_id → hostname. Audit F008.
+func (h *DeviceHandler) loadDeviceHostnamesByIDs(ctx context.Context, ids []string) map[string]string {
+	if len(ids) == 0 {
+		return nil
+	}
+	rows, err := h.store.Queries().GetDeviceHostnamesByIDs(ctx, ids)
+	if err != nil {
+		logEnrichmentErr("GetDeviceHostnamesByIDs", "device_id_count", fmt.Sprint(len(ids)), err)
+		return nil
+	}
+	out := make(map[string]string, len(rows))
+	for _, r := range rows {
+		out[r.ID] = r.Hostname
+	}
+	return out
+}
+
 func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.Request[pm.GetDeviceLpsPasswordsRequest]) (*connect.Response[pm.GetDeviceLpsPasswordsResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
@@ -640,28 +698,27 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load LPS password history")
 	}
 
+	// Bulk-load enrichment names (audit F008): one round-trip each
+	// instead of one per row inside the loops below. Both loops feed
+	// the same actionIDs set; only `current` rows have a per-row
+	// hostname.
+	actionIDsCurrent := make([]string, len(current))
+	deviceIDsCurrent := make([]string, len(current))
+	for i, p := range current {
+		actionIDsCurrent[i] = p.ActionID
+		deviceIDsCurrent[i] = p.DeviceID
+	}
+	actionIDsHistory := make([]string, len(history))
+	for i, p := range history {
+		actionIDsHistory[i] = p.ActionID
+	}
+	actionNames := h.loadActionNamesByIDs(ctx, distinctIDs(actionIDsCurrent, actionIDsHistory))
+	deviceHostnames := h.loadDeviceHostnamesByIDs(ctx, distinctIDs(deviceIDsCurrent))
+
 	// Convert to proto
 	resp := &pm.GetDeviceLpsPasswordsResponse{}
 
 	for _, p := range current {
-		// Look up action name
-		actionName := ""
-		action, err := h.store.Queries().GetActionByID(ctx, p.ActionID)
-		if err == nil {
-			actionName = action.Name
-		} else {
-			logEnrichmentErr("GetActionByID", "action_id", p.ActionID, err)
-		}
-
-		// Look up device hostname
-		deviceHostname := ""
-		device, err := h.store.Queries().GetDeviceByID(ctx, db.GetDeviceByIDParams{ID: p.DeviceID})
-		if err == nil {
-			deviceHostname = device.Hostname
-		} else {
-			logEnrichmentErr("GetDeviceByID", "device_id", p.DeviceID, err)
-		}
-
 		decPassword, err := h.encryptor.Decrypt(p.Password)
 		if err != nil {
 			// Decrypt failure on stored material is alarming —
@@ -674,9 +731,9 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 		}
 		entry := &pm.LpsPassword{
 			DeviceId:       p.DeviceID,
-			DeviceHostname: deviceHostname,
+			DeviceHostname: deviceHostnames[p.DeviceID],
 			ActionId:       p.ActionID,
-			ActionName:     actionName,
+			ActionName:     actionNames[p.ActionID],
 			Username:       p.Username,
 			Password:       decPassword,
 			RotationReason: p.RotationReason,
@@ -686,14 +743,6 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 	}
 
 	for _, p := range history {
-		actionName := ""
-		action, err := h.store.Queries().GetActionByID(ctx, p.ActionID)
-		if err == nil {
-			actionName = action.Name
-		} else {
-			logEnrichmentErr("GetActionByID", "action_id", p.ActionID, err)
-		}
-
 		decPassword, err := h.encryptor.Decrypt(p.Password)
 		if err != nil {
 			h.logger.Error("failed to decrypt LPS password (history)",
@@ -703,7 +752,7 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 		entry := &pm.LpsPassword{
 			DeviceId:       p.DeviceID,
 			ActionId:       p.ActionID,
-			ActionName:     actionName,
+			ActionName:     actionNames[p.ActionID],
 			Username:       p.Username,
 			Password:       decPassword,
 			RotationReason: p.RotationReason,
@@ -731,25 +780,24 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load LUKS key history")
 	}
 
+	// Bulk-load enrichment names (audit F008): one round-trip each
+	// instead of one per row.
+	actionIDsCurrent := make([]string, len(current))
+	deviceIDsCurrent := make([]string, len(current))
+	for i, k := range current {
+		actionIDsCurrent[i] = k.ActionID
+		deviceIDsCurrent[i] = k.DeviceID
+	}
+	actionIDsHistory := make([]string, len(history))
+	for i, k := range history {
+		actionIDsHistory[i] = k.ActionID
+	}
+	actionNames := h.loadActionNamesByIDs(ctx, distinctIDs(actionIDsCurrent, actionIDsHistory))
+	deviceHostnames := h.loadDeviceHostnamesByIDs(ctx, distinctIDs(deviceIDsCurrent))
+
 	resp := &pm.GetDeviceLuksKeysResponse{}
 
 	for _, k := range current {
-		actionName := ""
-		action, err := h.store.Queries().GetActionByID(ctx, k.ActionID)
-		if err == nil {
-			actionName = action.Name
-		} else {
-			logEnrichmentErr("GetActionByID", "action_id", k.ActionID, err)
-		}
-
-		deviceHostname := ""
-		device, err := h.store.Queries().GetDeviceByID(ctx, db.GetDeviceByIDParams{ID: k.DeviceID})
-		if err == nil {
-			deviceHostname = device.Hostname
-		} else {
-			logEnrichmentErr("GetDeviceByID", "device_id", k.DeviceID, err)
-		}
-
 		decPassphrase, err := h.encryptor.Decrypt(k.Passphrase)
 		if err != nil {
 			h.logger.Error("failed to decrypt LUKS passphrase (current)",
@@ -758,9 +806,9 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 		}
 		entry := &pm.LuksKey{
 			DeviceId:       k.DeviceID,
-			DeviceHostname: deviceHostname,
+			DeviceHostname: deviceHostnames[k.DeviceID],
 			ActionId:       k.ActionID,
-			ActionName:     actionName,
+			ActionName:     actionNames[k.ActionID],
 			DevicePath:     k.DevicePath,
 			Passphrase:     decPassphrase,
 			RotationReason: k.RotationReason,
@@ -779,14 +827,6 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 	}
 
 	for _, k := range history {
-		actionName := ""
-		action, err := h.store.Queries().GetActionByID(ctx, k.ActionID)
-		if err == nil {
-			actionName = action.Name
-		} else {
-			logEnrichmentErr("GetActionByID", "action_id", k.ActionID, err)
-		}
-
 		decPassphrase, err := h.encryptor.Decrypt(k.Passphrase)
 		if err != nil {
 			h.logger.Error("failed to decrypt LUKS passphrase (history)",
@@ -796,7 +836,7 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 		entry := &pm.LuksKey{
 			DeviceId:       k.DeviceID,
 			ActionId:       k.ActionID,
-			ActionName:     actionName,
+			ActionName:     actionNames[k.ActionID],
 			DevicePath:     k.DevicePath,
 			Passphrase:     decPassphrase,
 			RotationReason: k.RotationReason,

--- a/internal/store/generated/devices.sql.go
+++ b/internal/store/generated/devices.sql.go
@@ -127,6 +127,41 @@ func (q *Queries) GetDeviceByID(ctx context.Context, arg GetDeviceByIDParams) (D
 	return i, err
 }
 
+const getDeviceHostnamesByIDs = `-- name: GetDeviceHostnamesByIDs :many
+SELECT id, hostname FROM devices_projection
+WHERE id = ANY($1::TEXT[]) AND is_deleted = FALSE
+`
+
+type GetDeviceHostnamesByIDsRow struct {
+	ID       string `json:"id"`
+	Hostname string `json:"hostname"`
+}
+
+// Bulk-load hostname for a set of device IDs. Used by handler
+// response loops (e.g. GetDeviceLpsPasswords / GetDeviceLuksKeys)
+// that previously made one GetDeviceByID round-trip per row —
+// audit F008 flagged the resulting N+1 (50 LUKS keys × 2 lookups
+// ≈ 100 sequential round-trips per RPC).
+func (q *Queries) GetDeviceHostnamesByIDs(ctx context.Context, dollar_1 []string) ([]GetDeviceHostnamesByIDsRow, error) {
+	rows, err := q.db.Query(ctx, getDeviceHostnamesByIDs, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetDeviceHostnamesByIDsRow{}
+	for rows.Next() {
+		var i GetDeviceHostnamesByIDsRow
+		if err := rows.Scan(&i.ID, &i.Hostname); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getDeviceSyncInterval = `-- name: GetDeviceSyncInterval :one
 WITH device_override AS (
     SELECT CASE WHEN sync_interval_minutes > 0 THEN sync_interval_minutes END AS interval

--- a/internal/store/queries/devices.sql
+++ b/internal/store/queries/devices.sql
@@ -138,3 +138,12 @@ SELECT user_id FROM device_assigned_users_projection WHERE device_id = $1;
 
 -- name: ListDeviceAssignedGroupIDs :many
 SELECT group_id FROM device_assigned_groups_projection WHERE device_id = $1;
+
+-- name: GetDeviceHostnamesByIDs :many
+-- Bulk-load hostname for a set of device IDs. Used by handler
+-- response loops (e.g. GetDeviceLpsPasswords / GetDeviceLuksKeys)
+-- that previously made one GetDeviceByID round-trip per row —
+-- audit F008 flagged the resulting N+1 (50 LUKS keys × 2 lookups
+-- ≈ 100 sequential round-trips per RPC).
+SELECT id, hostname FROM devices_projection
+WHERE id = ANY($1::TEXT[]) AND is_deleted = FALSE;

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -186,11 +186,20 @@ func (s *Store) fireListeners(ctx context.Context, row PersistedEvent) {
 	// Snapshot under RLock so the dispatch loop runs without holding
 	// the mutex (listeners may take milliseconds; we don't want to
 	// block concurrent RegisterEventListener calls or other readers
-	// for that long). Slice header copy is safe because
-	// RegisterEventListener appends — never mutates an existing
-	// element. Logger is snapshotted under the same lock so a
-	// concurrent SetLogger doesn't race with the panic-recovery read
-	// inside the closure below.
+	// for that long).
+	//
+	// Slice-header copy of s.listeners is safe because
+	// RegisterEventListener uses append-only semantics: when it
+	// grows the backing array, Go allocates a NEW array and binds
+	// it to the new header, leaving the old array (which our
+	// snapshot still references) untouched. We never mutate an
+	// existing element in place. Concurrent writers can therefore
+	// continue to extend the canonical slice while this dispatch
+	// loop iterates the frozen snapshot. Audit F038.
+	//
+	// Logger is snapshotted under the same lock so a concurrent
+	// SetLogger doesn't race with the panic-recovery read inside
+	// the closure below.
 	s.listenersMu.RLock()
 	onEvent := s.OnEventAppended
 	listeners := s.listeners


### PR DESCRIPTION
## Summary

Final bundle from the 2026-05-07 server tech-debt audit. Closes
F008, F026, F038, F041. Filed F035 as #168 (sqlc query signature
change deferred).

- **F008** — N+1 in \`GetDeviceLpsPasswords\` + \`GetDeviceLuksKeys\`.
  Each handler made one \`GetActionByID\` + one \`GetDeviceByID\`
  per row (~100 sequential round-trips for 50 LUKS keys). New
  \`GetDeviceHostnamesByIDs\` sqlc query + two helper methods on
  DeviceHandler bulk-load distinct ids upfront; loops then read
  from in-memory maps. O(rows) → O(1) round-trips per RPC.
- **F026** — Standardised \`w.Write(...)\` discard form across
  health endpoints (\`_, _ =\` everywhere).
- **F038** — Comment improvement on \`Store.fireListeners\`
  snapshot — now spells out WHY the slice-header copy is safe
  under concurrent grow.
- **F041** — Consolidated three open-coded duration-clamp blocks
  in \`parseFlags\` into \`clampInterval\` (zero=disabled) and
  \`clampDurationFloor\` (zero=default).

CR-CLI returned 0 findings on the final commit.

## Test plan

- [ ] Lint workflow green
- [ ] Tests workflow green
- [ ] Spot check: \`GetDeviceLpsPasswords\` against a device with
      ≥10 historical passwords — query log should show 4 queries
      (current, history, action names, device hostnames) instead
      of ~22.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized interval clamping for configuration with clearer semantics (preserve disabled zero, normalize negatives).
  * Optimized device password/key endpoints to bulk-load related names/hostnames, reducing per-row DB lookups.
  * Harmonized internal health endpoint responses to a consistent write pattern.

* **Chores**
  * Clarified internal comments and documentation around event listener concurrency and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->