### PR TITLE
refactor: port device_group projector to Go listener (Part of #136)

### DIFF
--- a/internal/projectors/device_group.go
+++ b/internal/projectors/device_group.go
@@ -1,0 +1,310 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// defaultDeviceGroupMaintenanceWindow mirrors the PL/pgSQL projector's
+// COALESCE fallback against `'{}'::JSONB` for missing maintenance_window
+// payloads. Held as a byte slice so the listener can pass it straight to
+// the JSONB column without an extra marshal step.
+var defaultDeviceGroupMaintenanceWindow = []byte(`{}`)
+
+// DeviceGroupCreatedPayload mirrors the fields the deleted PL/pgSQL
+// project_device_group_event() read out of a DeviceGroupCreated event:
+//
+//   - name (required, NOT NULL column)
+//   - description (defaults to "" to match the PL/pgSQL
+//     `COALESCE(payload, "")` behaviour)
+//   - is_dynamic (defaults to FALSE to match the PL/pgSQL COALESCE
+//     fallback against the BOOLEAN column default)
+//   - dynamic_query (nullable; nil when the payload omits the key, or
+//     when the value is JSON null — matches the PL/pgSQL
+//     `event.data->>'dynamic_query'` which yields SQL NULL for both)
+type DeviceGroupCreatedPayload struct {
+	ID           string
+	Name         string
+	Description  string
+	IsDynamic    bool
+	DynamicQuery *string
+	CreatedBy    string
+}
+
+type deviceGroupCreatedRaw struct {
+	Name         string  `json:"name"`
+	Description  *string `json:"description,omitempty"`
+	IsDynamic    *bool   `json:"is_dynamic,omitempty"`
+	DynamicQuery *string `json:"dynamic_query,omitempty"`
+}
+
+// DeviceGroupCreatedFromEvent decodes DeviceGroupCreated. Returns
+// ErrIgnoredEvent for any other (stream, event_type) so the listener
+// wrapper can silently no-op.
+//
+// name is required because the underlying NOT NULL column would
+// otherwise fail the INSERT, surfacing as a Postgres constraint
+// violation rather than a projector-level validation error.
+func DeviceGroupCreatedFromEvent(e store.PersistedEvent) (DeviceGroupCreatedPayload, error) {
+	if e.StreamType != "device_group" || e.EventType != "DeviceGroupCreated" {
+		return DeviceGroupCreatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DeviceGroupCreatedPayload{}, fmt.Errorf("projector: empty DeviceGroupCreated payload")
+	}
+	var raw deviceGroupCreatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceGroupCreatedPayload{}, fmt.Errorf("projector: invalid DeviceGroupCreated payload: %w", err)
+	}
+	if raw.Name == "" {
+		return DeviceGroupCreatedPayload{}, fmt.Errorf("projector: DeviceGroupCreated requires name")
+	}
+	out := DeviceGroupCreatedPayload{
+		ID:           e.StreamID,
+		Name:         raw.Name,
+		DynamicQuery: raw.DynamicQuery,
+		CreatedBy:    e.ActorID,
+	}
+	if raw.Description != nil {
+		out.Description = *raw.Description
+	}
+	if raw.IsDynamic != nil {
+		out.IsDynamic = *raw.IsDynamic
+	}
+	return out, nil
+}
+
+// DeviceGroupRenamedPayload covers the single mutable field the
+// PL/pgSQL projector wrote on DeviceGroupRenamed. Empty Name is
+// treated as a validation error rather than silently no-op'd — the
+// PL/pgSQL projector would have written NULL and broken the NOT NULL
+// constraint, so emitters that drop the field hit the same error
+// class either way.
+type DeviceGroupRenamedPayload struct {
+	ID   string
+	Name string
+}
+
+type deviceGroupRenamedRaw struct {
+	Name string `json:"name"`
+}
+
+// DeviceGroupRenamedFromEvent decodes DeviceGroupRenamed.
+func DeviceGroupRenamedFromEvent(e store.PersistedEvent) (DeviceGroupRenamedPayload, error) {
+	if e.StreamType != "device_group" || e.EventType != "DeviceGroupRenamed" {
+		return DeviceGroupRenamedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DeviceGroupRenamedPayload{}, fmt.Errorf("projector: empty DeviceGroupRenamed payload")
+	}
+	var raw deviceGroupRenamedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceGroupRenamedPayload{}, fmt.Errorf("projector: invalid DeviceGroupRenamed payload: %w", err)
+	}
+	if raw.Name == "" {
+		return DeviceGroupRenamedPayload{}, fmt.Errorf("projector: DeviceGroupRenamed requires name")
+	}
+	return DeviceGroupRenamedPayload{ID: e.StreamID, Name: raw.Name}, nil
+}
+
+// DeviceGroupDescriptionUpdatedPayload mirrors the PL/pgSQL projector's
+// `COALESCE(event.data->>'description', "")` collapse: if the payload
+// omits the key OR sends an explicit empty string, the description
+// becomes "". Both cases land here as Description == "".
+type DeviceGroupDescriptionUpdatedPayload struct {
+	ID          string
+	Description string
+}
+
+type deviceGroupDescriptionUpdatedRaw struct {
+	Description *string `json:"description,omitempty"`
+}
+
+// DeviceGroupDescriptionUpdatedFromEvent decodes
+// DeviceGroupDescriptionUpdated. An empty payload (e.g. `{}`) maps to
+// Description == "", matching the PL/pgSQL COALESCE-to-empty-string
+// behaviour.
+func DeviceGroupDescriptionUpdatedFromEvent(e store.PersistedEvent) (DeviceGroupDescriptionUpdatedPayload, error) {
+	if e.StreamType != "device_group" || e.EventType != "DeviceGroupDescriptionUpdated" {
+		return DeviceGroupDescriptionUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := DeviceGroupDescriptionUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw deviceGroupDescriptionUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceGroupDescriptionUpdatedPayload{}, fmt.Errorf("projector: invalid DeviceGroupDescriptionUpdated payload: %w", err)
+	}
+	if raw.Description != nil {
+		out.Description = *raw.Description
+	}
+	return out, nil
+}
+
+// DeviceGroupQueryUpdatedPayload mirrors the PL/pgSQL projector's
+// dynamic-query toggle. is_dynamic defaults to FALSE when missing
+// (matches `COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE)`);
+// dynamic_query is nullable.
+type DeviceGroupQueryUpdatedPayload struct {
+	ID           string
+	IsDynamic    bool
+	DynamicQuery *string
+}
+
+type deviceGroupQueryUpdatedRaw struct {
+	IsDynamic    *bool   `json:"is_dynamic,omitempty"`
+	DynamicQuery *string `json:"dynamic_query,omitempty"`
+}
+
+// DeviceGroupQueryUpdatedFromEvent decodes DeviceGroupQueryUpdated.
+func DeviceGroupQueryUpdatedFromEvent(e store.PersistedEvent) (DeviceGroupQueryUpdatedPayload, error) {
+	if e.StreamType != "device_group" || e.EventType != "DeviceGroupQueryUpdated" {
+		return DeviceGroupQueryUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := DeviceGroupQueryUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw deviceGroupQueryUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceGroupQueryUpdatedPayload{}, fmt.Errorf("projector: invalid DeviceGroupQueryUpdated payload: %w", err)
+	}
+	if raw.IsDynamic != nil {
+		out.IsDynamic = *raw.IsDynamic
+	}
+	out.DynamicQuery = raw.DynamicQuery
+	return out, nil
+}
+
+// DeviceGroupSyncIntervalSetPayload mirrors the PL/pgSQL projector's
+// `COALESCE((event.data->>'sync_interval_minutes')::INTEGER, 0)` —
+// missing key collapses to 0.
+type DeviceGroupSyncIntervalSetPayload struct {
+	ID                  string
+	SyncIntervalMinutes int32
+}
+
+type deviceGroupSyncIntervalSetRaw struct {
+	SyncIntervalMinutes *int32 `json:"sync_interval_minutes,omitempty"`
+}
+
+// DeviceGroupSyncIntervalSetFromEvent decodes DeviceGroupSyncIntervalSet.
+func DeviceGroupSyncIntervalSetFromEvent(e store.PersistedEvent) (DeviceGroupSyncIntervalSetPayload, error) {
+	if e.StreamType != "device_group" || e.EventType != "DeviceGroupSyncIntervalSet" {
+		return DeviceGroupSyncIntervalSetPayload{}, ErrIgnoredEvent
+	}
+	out := DeviceGroupSyncIntervalSetPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw deviceGroupSyncIntervalSetRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceGroupSyncIntervalSetPayload{}, fmt.Errorf("projector: invalid DeviceGroupSyncIntervalSet payload: %w", err)
+	}
+	if raw.SyncIntervalMinutes != nil {
+		out.SyncIntervalMinutes = *raw.SyncIntervalMinutes
+	}
+	return out, nil
+}
+
+// DeviceGroupMaintenanceWindowSetPayload mirrors the PL/pgSQL
+// projector's `COALESCE(event.data->'maintenance_window', '{}'::JSONB)`
+// fallback. A missing key collapses to '{}' (held as raw bytes so the
+// listener writes the same JSONB shape the PL/pgSQL projector would
+// have produced).
+type DeviceGroupMaintenanceWindowSetPayload struct {
+	ID                string
+	MaintenanceWindow []byte
+}
+
+type deviceGroupMaintenanceWindowSetRaw struct {
+	MaintenanceWindow json.RawMessage `json:"maintenance_window,omitempty"`
+}
+
+// DeviceGroupMaintenanceWindowSetFromEvent decodes
+// DeviceGroupMaintenanceWindowSet.
+func DeviceGroupMaintenanceWindowSetFromEvent(e store.PersistedEvent) (DeviceGroupMaintenanceWindowSetPayload, error) {
+	if e.StreamType != "device_group" || e.EventType != "DeviceGroupMaintenanceWindowSet" {
+		return DeviceGroupMaintenanceWindowSetPayload{}, ErrIgnoredEvent
+	}
+	out := DeviceGroupMaintenanceWindowSetPayload{
+		ID:                e.StreamID,
+		MaintenanceWindow: defaultDeviceGroupMaintenanceWindow,
+	}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw deviceGroupMaintenanceWindowSetRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceGroupMaintenanceWindowSetPayload{}, fmt.Errorf("projector: invalid DeviceGroupMaintenanceWindowSet payload: %w", err)
+	}
+	if len(raw.MaintenanceWindow) > 0 {
+		// Preserve the wire bytes verbatim so the listener writes the
+		// same JSONB the emitter sent (matches the PL/pgSQL projector's
+		// `(event.data->'maintenance_window')::JSONB` cast).
+		out.MaintenanceWindow = []byte(raw.MaintenanceWindow)
+	}
+	return out, nil
+}
+
+// DeviceGroupMemberPayload covers DeviceGroupMemberAdded /
+// DeviceAddedToGroup and DeviceGroupMemberRemoved / DeviceRemovedFromGroup.
+// All four event names share the same payload shape; the listener
+// distinguishes add vs remove by event_type at dispatch.
+//
+// device_id is required: the PL/pgSQL projector would have INSERTed
+// NULL into the NOT NULL column otherwise, surfacing as a constraint
+// violation. Pre-validating here keeps the failure surface inside the
+// projector log instead of leaking through as a Postgres error.
+type DeviceGroupMemberPayload struct {
+	GroupID  string
+	DeviceID string
+}
+
+type deviceGroupMemberRaw struct {
+	DeviceID string `json:"device_id"`
+}
+
+// DeviceGroupMemberAddedFromEvent decodes the add-side member event.
+// Both 'DeviceGroupMemberAdded' and 'DeviceAddedToGroup' are accepted —
+// the PL/pgSQL projector handled them in the same WHEN branch and the
+// in-flight payload shapes are identical. Treat them as aliases.
+func DeviceGroupMemberAddedFromEvent(e store.PersistedEvent) (DeviceGroupMemberPayload, error) {
+	if e.StreamType != "device_group" {
+		return DeviceGroupMemberPayload{}, ErrIgnoredEvent
+	}
+	if e.EventType != "DeviceGroupMemberAdded" && e.EventType != "DeviceAddedToGroup" {
+		return DeviceGroupMemberPayload{}, ErrIgnoredEvent
+	}
+	return decodeDeviceGroupMember(e)
+}
+
+// DeviceGroupMemberRemovedFromEvent decodes the remove-side member event.
+// Both 'DeviceGroupMemberRemoved' and 'DeviceRemovedFromGroup' are
+// accepted as aliases — same WHEN branch in the PL/pgSQL projector.
+func DeviceGroupMemberRemovedFromEvent(e store.PersistedEvent) (DeviceGroupMemberPayload, error) {
+	if e.StreamType != "device_group" {
+		return DeviceGroupMemberPayload{}, ErrIgnoredEvent
+	}
+	if e.EventType != "DeviceGroupMemberRemoved" && e.EventType != "DeviceRemovedFromGroup" {
+		return DeviceGroupMemberPayload{}, ErrIgnoredEvent
+	}
+	return decodeDeviceGroupMember(e)
+}
+
+func decodeDeviceGroupMember(e store.PersistedEvent) (DeviceGroupMemberPayload, error) {
+	if len(e.Data) == 0 {
+		return DeviceGroupMemberPayload{}, fmt.Errorf("projector: empty %s payload", e.EventType)
+	}
+	var raw deviceGroupMemberRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceGroupMemberPayload{}, fmt.Errorf("projector: invalid %s payload: %w", e.EventType, err)
+	}
+	if raw.DeviceID == "" {
+		return DeviceGroupMemberPayload{}, fmt.Errorf("projector: %s requires device_id", e.EventType)
+	}
+	return DeviceGroupMemberPayload{GroupID: e.StreamID, DeviceID: raw.DeviceID}, nil
+}

--- a/internal/projectors/device_group_listener.go
+++ b/internal/projectors/device_group_listener.go
@@ -1,0 +1,371 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// reasonDeviceGroupCreated and reasonDeviceGroupQueryUpdated mirror the
+// PL/pgSQL projector's `INSERT INTO dynamic_group_evaluation_queue
+// (group_id, queued_at, reason) VALUES (..., ..., 'group_created' /
+// 'query_updated')` constants. Held as pointers so they can be passed
+// straight to the EnqueueDynamicDeviceGroupEvaluation params (the
+// reason column is nullable).
+var (
+	reasonDeviceGroupCreatedString       = "group_created"
+	reasonDeviceGroupQueryUpdatedString  = "query_updated"
+	reasonDeviceGroupCreatedPointer      = &reasonDeviceGroupCreatedString
+	reasonDeviceGroupQueryUpdatedPointer = &reasonDeviceGroupQueryUpdatedString
+)
+
+// DeviceGroupListener returns a store.EventListener that applies every
+// device_group stream event the deleted PL/pgSQL
+// project_device_group_event handled. Nine event types:
+// DeviceGroupCreated, DeviceGroupRenamed, DeviceGroupDescriptionUpdated,
+// DeviceGroupQueryUpdated, DeviceGroupSyncIntervalSet,
+// DeviceGroupMaintenanceWindowSet, DeviceGroupMemberAdded /
+// DeviceAddedToGroup, DeviceGroupMemberRemoved / DeviceRemovedFromGroup,
+// DeviceGroupDeleted.
+//
+// Event-type families:
+//   - Group CRUD: Created (INSERT + optional dynamic-queue enqueue),
+//     Renamed / DescriptionUpdated / SyncIntervalSet /
+//     MaintenanceWindowSet (single guarded UPDATE), QueryUpdated
+//     (UPDATE + optional flip-to-dynamic cascade), Deleted (soft-delete +
+//     member wipe + queue cleanup, wrapped in store.WithTx).
+//   - Membership edits: MemberAdded / DeviceAddedToGroup (INSERT +
+//     recount, gated by parent-is-dynamic short-circuit), MemberRemoved /
+//     DeviceRemovedFromGroup (DELETE + recount, same gate). Each wrapped
+//     in store.WithTx so the parent row never observes "member changed
+//     but member_count stale".
+//
+// Multi-write listeners (Created when dynamic, QueryUpdated when
+// flipping to dynamic, Deleted, MemberAdded, MemberRemoved) follow the
+// asymmetric-guard discipline: the guarded UPDATE on the parent row is
+// :execrows, and the listener short-circuits the downstream cascade
+// when n == 0 (stale projection_version replay).
+//
+// Dynamic-query engine scope: per #136 the dynamic-query evaluator
+// (evaluate_dynamic_group, evaluate_queued_dynamic_groups,
+// validate_dynamic_query) STAYS in PL/pgSQL until a later phase. The
+// Go listener only persists the query string column + (re-)enqueues
+// the group via EnqueueDynamicDeviceGroupEvaluation when is_dynamic
+// flips on; the evaluator runs unchanged inside Postgres.
+//
+// Wired in projectors.WireAll. Refs #136 (Phase 2 of tracker #107).
+func DeviceGroupListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "device_group" {
+			return
+		}
+		// Multi-write events route through ApplyDeviceGroup via WithTx
+		// so the cascade stays atomic; single-statement events go on
+		// the autocommit pool. ApplyDeviceGroup handles all event
+		// types when called with tx-bound queries (the rebuild path),
+		// so we share its body here for the multi-write cases via
+		// WithTx and short-circuit the simple cases through the pool.
+		switch e.EventType {
+		case "DeviceGroupCreated",
+			"DeviceGroupQueryUpdated",
+			"DeviceGroupDeleted",
+			"DeviceGroupMemberAdded",
+			"DeviceAddedToGroup",
+			"DeviceGroupMemberRemoved",
+			"DeviceRemovedFromGroup":
+			if err := st.WithTx(ctx, func(q *store.Queries) error {
+				return ApplyDeviceGroup(ctx, q, e)
+			}); err != nil {
+				logger.Warn("device_group projector: failed to apply event",
+					"event_id", e.ID, "event_type", e.EventType, "group_id", e.StreamID, "error", err)
+			}
+			return
+		}
+		if err := ApplyDeviceGroup(ctx, st.Queries(), e); err != nil {
+			logger.Warn("device_group projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "group_id", e.StreamID, "error", err)
+		}
+	}
+}
+
+// ApplyDeviceGroup is the transactional core of the device_group
+// projector. The listener wraps it for live-event dispatch (using
+// WithTx for the multi-write event types); the rebuild path
+// (manchtools/power-manage-server#125) registers it via
+// RegisterRebuildApply so RebuildAll re-derives the projection from
+// the event store instead of dispatching to the no-op PL/pgSQL stub.
+//
+// Asymmetric-guard discipline is preserved across every multi-write
+// event: when the version-guarded UPDATE on the parent row affects
+// zero rows, every cascading INSERT/DELETE downstream is skipped —
+// otherwise a stale event re-applied later would leak member-count
+// drift, dangling members, or deleted rows reappearing.
+func ApplyDeviceGroup(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "device_group" {
+		return nil
+	}
+	switch e.EventType {
+	case "DeviceGroupCreated":
+		return applyDeviceGroupCreated(ctx, q, e)
+	case "DeviceGroupRenamed":
+		return applyDeviceGroupRenamed(ctx, q, e)
+	case "DeviceGroupDescriptionUpdated":
+		return applyDeviceGroupDescriptionUpdated(ctx, q, e)
+	case "DeviceGroupQueryUpdated":
+		return applyDeviceGroupQueryUpdated(ctx, q, e)
+	case "DeviceGroupSyncIntervalSet":
+		return applyDeviceGroupSyncIntervalSet(ctx, q, e)
+	case "DeviceGroupMaintenanceWindowSet":
+		return applyDeviceGroupMaintenanceWindowSet(ctx, q, e)
+	case "DeviceGroupMemberAdded", "DeviceAddedToGroup":
+		return applyDeviceGroupMemberAdded(ctx, q, e)
+	case "DeviceGroupMemberRemoved", "DeviceRemovedFromGroup":
+		return applyDeviceGroupMemberRemoved(ctx, q, e)
+	case "DeviceGroupDeleted":
+		return applyDeviceGroupDeleted(ctx, q, e)
+	}
+	return nil
+}
+
+func applyDeviceGroupCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceGroupCreatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	createdAt := e.OccurredAt
+	if err := q.InsertDeviceGroupProjection(ctx, db.InsertDeviceGroupProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		Description:       payload.Description,
+		IsDynamic:         payload.IsDynamic,
+		DynamicQuery:      payload.DynamicQuery,
+		CreatedAt:         &createdAt,
+		CreatedBy:         payload.CreatedBy,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	if !payload.IsDynamic {
+		return nil
+	}
+	// Dynamic group: enqueue for the still-PL/pgSQL evaluator to pick
+	// up. ON CONFLICT DO UPDATE on (group_id) refreshes queued_at if
+	// the group was already queued, matching the PL/pgSQL projector.
+	return q.EnqueueDynamicDeviceGroupEvaluation(ctx, db.EnqueueDynamicDeviceGroupEvaluationParams{
+		GroupID: payload.ID,
+		Reason:  reasonDeviceGroupCreatedPointer,
+	})
+}
+
+func applyDeviceGroupRenamed(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceGroupRenamedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.RenameDeviceGroupProjection(ctx, db.RenameDeviceGroupProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceGroupDescriptionUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceGroupDescriptionUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.UpdateDeviceGroupDescriptionProjection(ctx, db.UpdateDeviceGroupDescriptionProjectionParams{
+		ID:                payload.ID,
+		Description:       payload.Description,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceGroupQueryUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceGroupQueryUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	n, err := q.UpdateDeviceGroupQueryProjection(ctx, db.UpdateDeviceGroupQueryProjectionParams{
+		ID:                payload.ID,
+		IsDynamic:         payload.IsDynamic,
+		DynamicQuery:      payload.DynamicQuery,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		// Stale DeviceGroupQueryUpdated replay against a row whose
+		// projection_version has moved past this event. Skipping the
+		// flip-to-dynamic cascade (member wipe + member_count reset +
+		// re-enqueue) is mandatory: otherwise an old QueryUpdated
+		// re-applied later would silently nuke the live group's
+		// members and re-enqueue a group whose query has already
+		// changed downstream.
+		return nil
+	}
+	if !payload.IsDynamic {
+		return nil
+	}
+	// Flip-to-dynamic cascade: wipe static members + zero member_count
+	// + (re-)enqueue for the evaluator. Mirrors the PL/pgSQL
+	// projector's order verbatim.
+	if err := q.WipeDeviceGroupMembers(ctx, payload.ID); err != nil {
+		return err
+	}
+	if err := q.ResetDeviceGroupMemberCount(ctx, payload.ID); err != nil {
+		return err
+	}
+	return q.EnqueueDynamicDeviceGroupEvaluation(ctx, db.EnqueueDynamicDeviceGroupEvaluationParams{
+		GroupID: payload.ID,
+		Reason:  reasonDeviceGroupQueryUpdatedPointer,
+	})
+}
+
+func applyDeviceGroupSyncIntervalSet(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceGroupSyncIntervalSetFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.UpdateDeviceGroupSyncIntervalProjection(ctx, db.UpdateDeviceGroupSyncIntervalProjectionParams{
+		ID:                  payload.ID,
+		SyncIntervalMinutes: payload.SyncIntervalMinutes,
+		ProjectionVersion:   deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceGroupMaintenanceWindowSet(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceGroupMaintenanceWindowSetFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.UpdateDeviceGroupMaintenanceWindowProjection(ctx, db.UpdateDeviceGroupMaintenanceWindowProjectionParams{
+		ID:                payload.ID,
+		MaintenanceWindow: payload.MaintenanceWindow,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceGroupMemberAdded(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceGroupMemberAddedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	// Atomic guard FIRST: bumps projection_version only when the
+	// parent exists, is static, alive, and the event is newer.
+	// n==0 means one of those preconditions failed — skip the
+	// membership mutation. Doing the version check AFTER the
+	// INSERT (the prior shape) let stale events recreate
+	// soft-deleted membership rows; CR caught the same hole on
+	// the user_group port (PR #174).
+	n, err := q.ClaimDeviceGroupForMembership(ctx, db.ClaimDeviceGroupForMembershipParams{
+		ID:                payload.GroupID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	addedAt := e.OccurredAt
+	if err := q.InsertDeviceGroupMember(ctx, db.InsertDeviceGroupMemberParams{
+		GroupID:           payload.GroupID,
+		DeviceID:          payload.DeviceID,
+		AddedAt:           &addedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return q.RecountDeviceGroupMembers(ctx, payload.GroupID)
+}
+
+func applyDeviceGroupMemberRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceGroupMemberRemovedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	n, err := q.ClaimDeviceGroupForMembership(ctx, db.ClaimDeviceGroupForMembershipParams{
+		ID:                payload.GroupID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	if err := q.DeleteDeviceGroupMember(ctx, db.DeleteDeviceGroupMemberParams{
+		GroupID:  payload.GroupID,
+		DeviceID: payload.DeviceID,
+	}); err != nil {
+		return err
+	}
+	return q.RecountDeviceGroupMembers(ctx, payload.GroupID)
+}
+
+func applyDeviceGroupDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	n, err := q.SoftDeleteDeviceGroupProjection(ctx, db.SoftDeleteDeviceGroupProjectionParams{
+		ID:                e.StreamID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		// Stale DeviceGroupDeleted replay against a row whose
+		// projection_version has moved past this event. Skipping the
+		// cascade (member wipe + dynamic-queue cleanup) is mandatory:
+		// otherwise an old delete re-applied by the reconciler against
+		// a freshly-restored group would silently nuke its members
+		// and remove its evaluation queue entry.
+		return nil
+	}
+	if err := q.DeleteDeviceGroupMembersByGroup(ctx, e.StreamID); err != nil {
+		return err
+	}
+	return q.DeleteDynamicDeviceGroupEvaluationQueueRow(ctx, e.StreamID)
+}

--- a/internal/projectors/device_group_listener.go
+++ b/internal/projectors/device_group_listener.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -210,31 +212,28 @@ func applyDeviceGroupQueryUpdated(ctx context.Context, q *store.Queries, e store
 		}
 		return err
 	}
-	n, err := q.UpdateDeviceGroupQueryProjection(ctx, db.UpdateDeviceGroupQueryProjectionParams{
+	prevIsDynamic, err := q.UpdateDeviceGroupQueryProjection(ctx, db.UpdateDeviceGroupQueryProjectionParams{
 		ID:                payload.ID,
 		IsDynamic:         payload.IsDynamic,
 		DynamicQuery:      payload.DynamicQuery,
 		ProjectionVersion: deref(e.SequenceNum),
 	})
 	if err != nil {
+		// pgx surfaces ErrNoRows when the inner UPDATE's version
+		// guard rejects a stale replay (the CTE join collapses to
+		// zero rows). Treat that as "skip cascade".
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
 		return err
 	}
-	if n == 0 {
-		// Stale DeviceGroupQueryUpdated replay against a row whose
-		// projection_version has moved past this event. Skipping the
-		// flip-to-dynamic cascade (member wipe + member_count reset +
-		// re-enqueue) is mandatory: otherwise an old QueryUpdated
-		// re-applied later would silently nuke the live group's
-		// members and re-enqueue a group whose query has already
-		// changed downstream.
+	// Cascade ONLY on a true static→dynamic flip. Editing the
+	// dynamic_query of an already-dynamic group must preserve the
+	// live evaluator-owned member set (sibling fix to the CR catch
+	// on the user_group port, PR #174).
+	if !payload.IsDynamic || prevIsDynamic {
 		return nil
 	}
-	if !payload.IsDynamic {
-		return nil
-	}
-	// Flip-to-dynamic cascade: wipe static members + zero member_count
-	// + (re-)enqueue for the evaluator. Mirrors the PL/pgSQL
-	// projector's order verbatim.
 	if err := q.WipeDeviceGroupMembers(ctx, payload.ID); err != nil {
 		return err
 	}

--- a/internal/projectors/device_group_test.go
+++ b/internal/projectors/device_group_test.go
@@ -782,6 +782,41 @@ func TestDeviceGroupListener_StaleMemberAddedDoesNotRecreateMembership(t *testin
 	assert.Equal(t, live.ProjectionVersion, after.ProjectionVersion)
 }
 
+// TestDeviceGroupListener_QueryUpdatedSteadyStateDynamicEditPreservesMembers
+// is the device_group sibling of the user_group regression that
+// CR caught on PR #174: editing the dynamic_query of an already-
+// dynamic group must NOT trigger the cascade. The cascade (member
+// wipe + member_count zero + re-enqueue) is for the static→dynamic
+// transition only — the evaluator owns the member set in steady
+// state and re-evaluates on its own schedule.
+func TestDeviceGroupListener_QueryUpdatedSteadyStateDynamicEditPreservesMembers(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupCreated",
+		Data:      map[string]any{"name": "dyn", "is_dynamic": true, "dynamic_query": "(env equals \"prod\")"},
+		ActorType: "user", ActorID: "u",
+	}))
+	_, err := st.Pool().Exec(ctx, `
+		INSERT INTO device_group_members_projection (group_id, device_id, added_at, projection_version)
+		VALUES ($1, 'dev-evaluator-populated', now(), 0)`, groupID)
+	require.NoError(t, err)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupQueryUpdated",
+		Data:      map[string]any{"is_dynamic": true, "dynamic_query": "(env equals \"staging\")"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "steady-state dynamic-query edit must NOT wipe evaluator-populated members")
+}
+
 // TestDeviceGroupListener_IgnoresWrongStreamType — defensive.
 func TestDeviceGroupListener_IgnoresWrongStreamType(t *testing.T) {
 	st := testutil.SetupPostgres(t)

--- a/internal/projectors/device_group_test.go
+++ b/internal/projectors/device_group_test.go
@@ -1,0 +1,801 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestDeviceGroupCreatedFromEvent_Pure pins the decoder defaults that
+// match the deleted PL/pgSQL projector: name is required (NOT NULL
+// column), missing description → "", missing is_dynamic → FALSE,
+// dynamic_query is nullable.
+func TestDeviceGroupCreatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.DeviceGroupCreatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupCreated", ActorID: "u-1",
+			Data: jsonOrFail(t, map[string]any{
+				"name":          "production",
+				"description":   "all production hosts",
+				"is_dynamic":    true,
+				"dynamic_query": `(device.labels.env equals "prod")`,
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dg-1", got.ID)
+		assert.Equal(t, "production", got.Name)
+		assert.Equal(t, "all production hosts", got.Description)
+		assert.True(t, got.IsDynamic)
+		require.NotNil(t, got.DynamicQuery)
+		assert.Equal(t, `(device.labels.env equals "prod")`, *got.DynamicQuery)
+		assert.Equal(t, "u-1", got.CreatedBy)
+	})
+
+	t.Run("defaults: description empty, is_dynamic false, dynamic_query nil", func(t *testing.T) {
+		got, err := projectors.DeviceGroupCreatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-2", EventType: "DeviceGroupCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"name": "minimal"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description)
+		assert.False(t, got.IsDynamic)
+		assert.Nil(t, got.DynamicQuery, "missing dynamic_query stays nil so the column collapses to SQL NULL")
+	})
+
+	t.Run("name is required", func(t *testing.T) {
+		_, err := projectors.DeviceGroupCreatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-3", EventType: "DeviceGroupCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"description": "no name"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "name")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceGroupCreatedFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceGroupCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.DeviceGroupCreatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", EventType: "DeviceGroupRenamed",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.DeviceGroupCreatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", EventType: "DeviceGroupCreated",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceGroupRenamedFromEvent_Pure — name is required (the PL/pgSQL
+// projector would have written NULL into the NOT NULL column,
+// breaking the constraint; we surface this earlier as a decode
+// validation error).
+func TestDeviceGroupRenamedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.DeviceGroupRenamedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupRenamed",
+			Data: jsonOrFail(t, map[string]any{"name": "renamed"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dg-1", got.ID)
+		assert.Equal(t, "renamed", got.Name)
+	})
+
+	t.Run("missing name fails", func(t *testing.T) {
+		_, err := projectors.DeviceGroupRenamedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupRenamed",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "name")
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceGroupRenamedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", EventType: "DeviceGroupCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceGroupDescriptionUpdatedFromEvent_Pure — empty payload
+// collapses to "" (mirrors the PL/pgSQL COALESCE-to-empty-string).
+func TestDeviceGroupDescriptionUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("explicit description", func(t *testing.T) {
+		got, err := projectors.DeviceGroupDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{"description": "new"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "new", got.Description)
+	})
+
+	t.Run("missing description → empty string", func(t *testing.T) {
+		got, err := projectors.DeviceGroupDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description, "missing description collapses to '' per PL/pgSQL COALESCE")
+	})
+
+	t.Run("empty payload bytes → empty string", func(t *testing.T) {
+		got, err := projectors.DeviceGroupDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupDescriptionUpdated",
+			Data: nil,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description)
+	})
+
+	t.Run("wrong stream type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceGroupDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceGroupDescriptionUpdated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceGroupQueryUpdatedFromEvent_Pure — missing is_dynamic
+// defaults to FALSE; missing dynamic_query stays nil.
+func TestDeviceGroupQueryUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("flip to dynamic with query", func(t *testing.T) {
+		got, err := projectors.DeviceGroupQueryUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupQueryUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"is_dynamic":    true,
+				"dynamic_query": "(device.labels.x equals \"y\")",
+			}),
+		})
+		require.NoError(t, err)
+		assert.True(t, got.IsDynamic)
+		require.NotNil(t, got.DynamicQuery)
+		assert.Equal(t, "(device.labels.x equals \"y\")", *got.DynamicQuery)
+	})
+
+	t.Run("empty payload → static, no query", func(t *testing.T) {
+		got, err := projectors.DeviceGroupQueryUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupQueryUpdated",
+			Data: nil,
+		})
+		require.NoError(t, err)
+		assert.False(t, got.IsDynamic)
+		assert.Nil(t, got.DynamicQuery)
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceGroupQueryUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", EventType: "DeviceGroupRenamed",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceGroupSyncIntervalSetFromEvent_Pure — missing key collapses
+// to 0 (matches PL/pgSQL COALESCE-to-zero).
+func TestDeviceGroupSyncIntervalSetFromEvent_Pure(t *testing.T) {
+	t.Run("explicit value", func(t *testing.T) {
+		got, err := projectors.DeviceGroupSyncIntervalSetFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupSyncIntervalSet",
+			Data: jsonOrFail(t, map[string]any{"sync_interval_minutes": 15}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(15), got.SyncIntervalMinutes)
+	})
+
+	t.Run("missing key → 0", func(t *testing.T) {
+		got, err := projectors.DeviceGroupSyncIntervalSetFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupSyncIntervalSet",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), got.SyncIntervalMinutes)
+	})
+
+	t.Run("wrong stream type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceGroupSyncIntervalSetFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceGroupSyncIntervalSet",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceGroupMaintenanceWindowSetFromEvent_Pure — missing key
+// defaults to '{}' (matches PL/pgSQL COALESCE fallback).
+func TestDeviceGroupMaintenanceWindowSetFromEvent_Pure(t *testing.T) {
+	t.Run("explicit window", func(t *testing.T) {
+		got, err := projectors.DeviceGroupMaintenanceWindowSetFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupMaintenanceWindowSet",
+			Data: jsonOrFail(t, map[string]any{
+				"maintenance_window": map[string]any{
+					"schedule": []any{map[string]any{"days": []string{"mon"}, "allow": "22:00-06:00"}},
+				},
+			}),
+		})
+		require.NoError(t, err)
+		assert.Contains(t, string(got.MaintenanceWindow), "schedule")
+	})
+
+	t.Run("missing key → '{}'", func(t *testing.T) {
+		got, err := projectors.DeviceGroupMaintenanceWindowSetFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupMaintenanceWindowSet",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.JSONEq(t, "{}", string(got.MaintenanceWindow))
+	})
+
+	t.Run("empty payload bytes → '{}'", func(t *testing.T) {
+		got, err := projectors.DeviceGroupMaintenanceWindowSetFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupMaintenanceWindowSet",
+			Data: nil,
+		})
+		require.NoError(t, err)
+		assert.JSONEq(t, "{}", string(got.MaintenanceWindow))
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceGroupMaintenanceWindowSetFromEvent(store.PersistedEvent{
+			StreamType: "device_group", EventType: "DeviceGroupRenamed",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceGroupMemberAddedFromEvent_Pure — device_id required;
+// both 'DeviceGroupMemberAdded' and 'DeviceAddedToGroup' are accepted.
+func TestDeviceGroupMemberAddedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path: DeviceGroupMemberAdded", func(t *testing.T) {
+		got, err := projectors.DeviceGroupMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupMemberAdded",
+			Data: jsonOrFail(t, map[string]any{"device_id": "dev-1"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dg-1", got.GroupID)
+		assert.Equal(t, "dev-1", got.DeviceID)
+	})
+
+	t.Run("happy path: DeviceAddedToGroup alias", func(t *testing.T) {
+		got, err := projectors.DeviceGroupMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceAddedToGroup",
+			Data: jsonOrFail(t, map[string]any{"device_id": "dev-1"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.DeviceID, "DeviceAddedToGroup must decode like DeviceGroupMemberAdded")
+	})
+
+	t.Run("device_id required", func(t *testing.T) {
+		_, err := projectors.DeviceGroupMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupMemberAdded",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "device_id")
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceGroupMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", EventType: "DeviceGroupMemberRemoved",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("wrong stream type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceGroupMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceGroupMemberAdded",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceGroupMemberRemovedFromEvent_Pure — same shape as Added
+// (both DeviceGroupMemberRemoved and DeviceRemovedFromGroup accepted).
+func TestDeviceGroupMemberRemovedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path: DeviceGroupMemberRemoved", func(t *testing.T) {
+		got, err := projectors.DeviceGroupMemberRemovedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupMemberRemoved",
+			Data: jsonOrFail(t, map[string]any{"device_id": "dev-1"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.DeviceID)
+	})
+
+	t.Run("happy path: DeviceRemovedFromGroup alias", func(t *testing.T) {
+		got, err := projectors.DeviceGroupMemberRemovedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceRemovedFromGroup",
+			Data: jsonOrFail(t, map[string]any{"device_id": "dev-1"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.DeviceID)
+	})
+
+	t.Run("device_id required", func(t *testing.T) {
+		_, err := projectors.DeviceGroupMemberRemovedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", StreamID: "dg-1", EventType: "DeviceGroupMemberRemoved",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "device_id")
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceGroupMemberRemovedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", EventType: "DeviceGroupMemberAdded",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceGroupListener_CreateLifecycle drives the full lifecycle of
+// a static group (Created → Renamed → MemberAdded → MemberRemoved →
+// Deleted) and asserts the projection lands in the right state at
+// every step.
+func TestDeviceGroupListener_CreateLifecycle(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupCreated",
+		Data:      map[string]any{"name": "lifecycle", "description": "test"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+
+	got, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, "lifecycle", got.Name)
+	assert.Equal(t, "test", got.Description)
+	assert.False(t, got.IsDynamic)
+	assert.Equal(t, int32(0), got.MemberCount)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupRenamed",
+		Data:      map[string]any{"name": "renamed"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", got.Name)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupMemberAdded",
+		Data:      map[string]any{"device_id": "dev-A"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupMemberAdded",
+		Data:      map[string]any{"device_id": "dev-B"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), got.MemberCount)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupMemberRemoved",
+		Data:      map[string]any{"device_id": "dev-A"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), got.MemberCount)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u-1",
+	}))
+
+	_, err = st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.Error(t, err, "GetDeviceGroupByID filters is_deleted=FALSE; deleted group is gone from this query")
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "DeviceGroupDeleted cascade must wipe member rows")
+}
+
+// TestDeviceGroupListener_AliasMemberEvents asserts the alias event
+// names (DeviceAddedToGroup / DeviceRemovedFromGroup) drive the same
+// add/remove path as the canonical names. The PL/pgSQL projector
+// dispatched both names through the same WHEN branch.
+func TestDeviceGroupListener_AliasMemberEvents(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupCreated",
+		Data:      map[string]any{"name": "aliases"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceAddedToGroup",
+		Data:      map[string]any{"device_id": "dev-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), got.MemberCount, "DeviceAddedToGroup must drive the same Add path")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceRemovedFromGroup",
+		Data:      map[string]any{"device_id": "dev-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), got.MemberCount, "DeviceRemovedFromGroup must drive the same Remove path")
+}
+
+// TestDeviceGroupListener_DynamicCreatedEnqueues confirms that creating
+// a dynamic group inserts a row into dynamic_group_evaluation_queue
+// with reason 'group_created' (the PL/pgSQL projector's behaviour).
+func TestDeviceGroupListener_DynamicCreatedEnqueues(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupCreated",
+		Data: map[string]any{
+			"name":          "dyn",
+			"is_dynamic":    true,
+			"dynamic_query": `(device.labels.x equals "y")`,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	got, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.True(t, got.IsDynamic)
+
+	var reason *string
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT reason FROM dynamic_group_evaluation_queue WHERE group_id = $1", groupID,
+	).Scan(&reason))
+	require.NotNil(t, reason)
+	assert.Equal(t, "group_created", *reason)
+}
+
+// TestDeviceGroupListener_QueryUpdatedFlipToDynamicCascade locks the
+// flip-to-dynamic cascade: when a previously-static group with members
+// gets a DeviceGroupQueryUpdated event with is_dynamic=true, the
+// listener must wipe every member row, zero member_count, and queue
+// the group for evaluation with reason 'query_updated'.
+func TestDeviceGroupListener_QueryUpdatedFlipToDynamicCascade(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupCreated",
+		Data:      map[string]any{"name": "static-then-dynamic"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupMemberAdded",
+		Data:      map[string]any{"device_id": "dev-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupMemberAdded",
+		Data:      map[string]any{"device_id": "dev-B"},
+		ActorType: "user", ActorID: "u",
+	}))
+	beforeFlip, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), beforeFlip.MemberCount)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupQueryUpdated",
+		Data: map[string]any{
+			"is_dynamic":    true,
+			"dynamic_query": `(device.labels.env equals "prod")`,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	afterFlip, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.True(t, afterFlip.IsDynamic, "group must be marked dynamic after flip")
+	assert.Equal(t, int32(0), afterFlip.MemberCount, "flip-to-dynamic must zero member_count")
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "flip-to-dynamic must wipe every static member row")
+
+	var reason *string
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT reason FROM dynamic_group_evaluation_queue WHERE group_id = $1", groupID,
+	).Scan(&reason))
+	require.NotNil(t, reason)
+	assert.Equal(t, "query_updated", *reason, "flip-to-dynamic must enqueue with reason 'query_updated'")
+}
+
+// TestDeviceGroupListener_DynamicGroupRejectsMemberMutations confirms
+// the parent-is-dynamic gate: member-mutation events are no-ops on
+// dynamic groups (the dynamic-query evaluator owns the member set).
+// Mirrors the PL/pgSQL `IF NOT EXISTS (... is_dynamic = TRUE)` guard.
+func TestDeviceGroupListener_DynamicGroupRejectsMemberMutations(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupCreated",
+		Data: map[string]any{
+			"name":          "dyn",
+			"is_dynamic":    true,
+			"dynamic_query": `(device.labels.x equals "y")`,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupMemberAdded",
+		Data:      map[string]any{"device_id": "dev-X"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "DeviceGroupMemberAdded against a dynamic group must be a no-op")
+
+	got, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), got.MemberCount, "member_count must stay at 0 — dynamic group's evaluator owns the count")
+}
+
+// TestDeviceGroupListener_StaleReplayRejected — UPDATE form (Renamed)
+// does not clobber a fresher row when re-applied with an older
+// projection_version. Mirrors the role/action_set/assignment pattern.
+func TestDeviceGroupListener_StaleReplayRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupCreated",
+		Data:      map[string]any{"name": "first"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupRenamed",
+		Data:      map[string]any{"name": "current"},
+		ActorType: "user", ActorID: "u",
+	}))
+	current, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	currentVersion := current.ProjectionVersion
+
+	older := currentVersion - 5
+	n, err := st.Queries().RenameDeviceGroupProjection(ctx, db.RenameDeviceGroupProjectionParams{
+		ID:                groupID,
+		Name:              "stale-would-set-this",
+		ProjectionVersion: older,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "stale projection_version UPDATE must affect zero rows")
+
+	after, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, "current", after.Name)
+	assert.Equal(t, currentVersion, after.ProjectionVersion)
+}
+
+// TestDeviceGroupListener_StaleDeleteReplayDoesNotNukeMembers locks the
+// asymmetric-guard discipline for the most cascade-heavy event type:
+// when the version-guarded SoftDelete affects zero rows, every
+// downstream cascade (member wipe + dynamic-queue cleanup) MUST be
+// skipped. Otherwise an old DeviceGroupDeleted re-applied later would
+// silently drop a freshly-restored group's members.
+func TestDeviceGroupListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupCreated",
+		Data:      map[string]any{"name": "live"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupMemberAdded",
+		Data:      map[string]any{"device_id": "dev-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+
+	// Drive the listener with a stale DeviceGroupDeleted (older
+	// projection_version than the row currently has).
+	older := live.ProjectionVersion - 5
+	staleAt := *live.CreatedAt
+	listener := projectors.DeviceGroupListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "device_group",
+		StreamID:    groupID,
+		EventType:   "DeviceGroupDeleted",
+		Data:        []byte("{}"),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
+	})
+
+	// Group still alive.
+	stillAlive, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.False(t, stillAlive.IsDeleted, "stale DeviceGroupDeleted must NOT flip is_deleted")
+
+	// Member still there.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale DeviceGroupDeleted must NOT cascade-delete members")
+}
+
+// TestDeviceGroupListener_StaleQueryUpdatedDoesNotNukeMembers locks
+// the asymmetric-guard discipline for the QueryUpdated flip-to-
+// dynamic cascade: when the version-guarded UpdateDeviceGroupQuery
+// affects zero rows, the cascade (member wipe + member_count reset +
+// re-enqueue) MUST be skipped. Otherwise an old QueryUpdated
+// re-applied by the reconciler against a live static group would
+// silently nuke its members and re-enqueue a group whose query has
+// already changed downstream.
+func TestDeviceGroupListener_StaleQueryUpdatedDoesNotNukeMembers(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupCreated",
+		Data:      map[string]any{"name": "live-static"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupMemberAdded",
+		Data:      map[string]any{"device_id": "dev-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+
+	older := live.ProjectionVersion - 5
+	staleAt := *live.CreatedAt
+	listener := projectors.DeviceGroupListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "device_group",
+		StreamID:    groupID,
+		EventType:   "DeviceGroupQueryUpdated",
+		Data:        jsonOrFail(t, map[string]any{"is_dynamic": true, "dynamic_query": "(x equals \"y\")"}),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
+	})
+
+	// Group must still be static — the guarded UPDATE rejected the
+	// stale flip-to-dynamic event.
+	stillStatic, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.False(t, stillStatic.IsDynamic, "stale QueryUpdated must NOT flip is_dynamic")
+
+	// Member still there because the cascade was skipped.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale QueryUpdated must NOT cascade-wipe static members")
+
+	// No queue entry — the cascade was skipped.
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM dynamic_group_evaluation_queue WHERE group_id = $1", groupID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "stale QueryUpdated must NOT enqueue the group")
+}
+
+// TestDeviceGroupListener_StaleMemberAddedDoesNotRecreateMembership
+// locks the same Claim-first hole CR caught on the user_group port
+// (PR #174). A stale DeviceGroupMemberAdded replayed after a Removed
+// must NOT reinsert the membership row, even though the INSERT
+// itself is idempotent: the version guard now runs BEFORE the
+// INSERT.
+func TestDeviceGroupListener_StaleMemberAddedDoesNotRecreateMembership(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+	deviceID := "dev-stale-add"
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupCreated",
+		Data:      map[string]any{"name": "stale-add-grp"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupMemberAdded",
+		Data:      map[string]any{"device_id": deviceID},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group", StreamID: groupID, EventType: "DeviceGroupMemberRemoved",
+		Data:      map[string]any{"device_id": deviceID},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), live.MemberCount)
+
+	older := live.ProjectionVersion - 5
+	staleAt := *live.CreatedAt
+	listener := projectors.DeviceGroupListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "device_group",
+		StreamID:    groupID,
+		EventType:   "DeviceGroupMemberAdded",
+		Data:        jsonOrFail(t, map[string]any{"device_id": deviceID}),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
+	})
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1 AND device_id = $2",
+		groupID, deviceID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "stale DeviceGroupMemberAdded must NOT recreate the membership row")
+
+	after, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), after.MemberCount)
+	assert.Equal(t, live.ProjectionVersion, after.ProjectionVersion)
+}
+
+// TestDeviceGroupListener_IgnoresWrongStreamType — defensive.
+func TestDeviceGroupListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	groupID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", // wrong stream
+		StreamID:   groupID,
+		EventType:  "DeviceGroupCreated",
+		Data:       map[string]any{"name": "should-not-write"},
+		ActorType:  "user", ActorID: "u",
+	}))
+
+	_, err := st.Queries().GetDeviceGroupByID(ctx, groupID)
+	require.Error(t, err, "wrong-stream-type DeviceGroupCreated must NOT create a device_groups_projection row")
+}

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -80,24 +80,29 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "assignment_projector"),
 	))
+	st.RegisterEventListener(DeviceGroupListener(
+		st,
+		loggerFor(logger, "device_group_projector"),
+	))
 	// All 11 ports of tracker #107 are now wired here, plus the
-	// first two Phase 2 ports (action_set #136, assignment #137).
-	// Future Phase 2 ports of the remaining domain projectors (user,
-	// device, action, definition, device_group, execution, user_group,
-	// compliance, compliance_policy) land here too.
+	// first three Phase 2 ports (action_set, assignment, device_group
+	// — all under tracker #136). Future Phase 2 ports of the remaining
+	// domain projectors (user, device, action, definition, execution,
+	// user_group, compliance, compliance_policy) land here too.
 
 	// Rebuild appliers (manchtools/power-manage-server#125). Only
 	// the ported projectors that own a rebuildTarget in
 	// store.AllRebuildTargets need this wiring — RebuildAll
 	// dispatches everything else through the legacy PL/pgSQL
 	// Function. Of the 11 #107 ports, three own rebuild targets:
-	// roles, tokens, user_selections. The action_set port (#136) and
-	// assignment port (#137) add two more.
+	// roles, tokens, user_selections. The Phase 2 ports add three
+	// more (action_sets, assignments, device_groups).
 	st.RegisterRebuildApply("roles", ApplyRole)
 	st.RegisterRebuildApply("tokens", ApplyToken)
 	st.RegisterRebuildApply("user_selections", ApplyUserSelection)
 	st.RegisterRebuildApply("action_sets", ApplyActionSet)
 	st.RegisterRebuildApply("assignments", ApplyAssignment)
+	st.RegisterRebuildApply("device_groups", ApplyDeviceGroup)
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/device_groups.sql.go
+++ b/internal/store/generated/device_groups.sql.go
@@ -10,6 +10,49 @@ import (
 	"time"
 )
 
+const claimDeviceGroupForMembership = `-- name: ClaimDeviceGroupForMembership :execrows
+UPDATE device_groups_projection
+SET projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+  AND is_deleted = FALSE
+  AND is_dynamic = FALSE
+`
+
+type ClaimDeviceGroupForMembershipParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// Atomic guard for the four member-mutation events
+// (DeviceGroupMemberAdded, DeviceAddedToGroup, DeviceGroupMemberRemoved,
+// DeviceRemovedFromGroup). Bumps projection_version only when ALL of:
+//
+//  1. The group exists.
+//  2. The group is NOT soft-deleted (a member event replayed after
+//     a Deleted must not bring rows back).
+//  3. The group is NOT dynamic (the dynamic-query evaluator owns
+//     the member set; explicit member events are no-ops there —
+//     mirrors the PL/pgSQL `IF NOT EXISTS (... is_dynamic = TRUE)`
+//     early-out).
+//  4. The event is newer than the current projection_version.
+//
+// Returns n=1 when the listener may proceed with the membership
+// mutation, n=0 when the event must be skipped. Doing the version
+// check BEFORE any child-row mutation prevents the stale-replay
+// holes CR caught on the user_group port (PR #174 / fingerprint
+// "Guard stale member replays before touching..."): without this
+// guard a stale MemberAdded after a Removed would recreate the
+// deleted membership row, and a stale MemberRemoved would delete
+// a live one.
+func (q *Queries) ClaimDeviceGroupForMembership(ctx context.Context, arg ClaimDeviceGroupForMembershipParams) (int64, error) {
+	result, err := q.db.Exec(ctx, claimDeviceGroupForMembership, arg.ID, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countDeviceGroups = `-- name: CountDeviceGroups :one
 SELECT COUNT(*) FROM device_groups_projection
 WHERE is_deleted = FALSE
@@ -33,6 +76,73 @@ func (q *Queries) CountMatchingDevicesForQuery(ctx context.Context, query string
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const deleteDeviceGroupMember = `-- name: DeleteDeviceGroupMember :exec
+DELETE FROM device_group_members_projection
+WHERE group_id = $1
+  AND device_id = $2
+`
+
+type DeleteDeviceGroupMemberParams struct {
+	GroupID  string `json:"group_id"`
+	DeviceID string `json:"device_id"`
+}
+
+// DeviceGroupMemberRemoved / DeviceRemovedFromGroup handler — second
+// half. Plain DELETE — silently no-op on a miss matches the PL/pgSQL
+// projector's behaviour.
+func (q *Queries) DeleteDeviceGroupMember(ctx context.Context, arg DeleteDeviceGroupMemberParams) error {
+	_, err := q.db.Exec(ctx, deleteDeviceGroupMember, arg.GroupID, arg.DeviceID)
+	return err
+}
+
+const deleteDeviceGroupMembersByGroup = `-- name: DeleteDeviceGroupMembersByGroup :exec
+DELETE FROM device_group_members_projection WHERE group_id = $1
+`
+
+// DeviceGroupDeleted handler — second half. Wipes every member row for
+// the deleted group. Wrapped with SoftDeleteDeviceGroupProjection +
+// DeleteDynamicDeviceGroupEvaluationQueueRow inside store.WithTx for
+// inter-write atomicity.
+func (q *Queries) DeleteDeviceGroupMembersByGroup(ctx context.Context, groupID string) error {
+	_, err := q.db.Exec(ctx, deleteDeviceGroupMembersByGroup, groupID)
+	return err
+}
+
+const deleteDynamicDeviceGroupEvaluationQueueRow = `-- name: DeleteDynamicDeviceGroupEvaluationQueueRow :exec
+DELETE FROM dynamic_group_evaluation_queue WHERE group_id = $1
+`
+
+// DeviceGroupDeleted handler — third half. Removes the queue entry so
+// the next dynamic-evaluation pass doesn't try to reconcile a deleted
+// group.
+func (q *Queries) DeleteDynamicDeviceGroupEvaluationQueueRow(ctx context.Context, groupID string) error {
+	_, err := q.db.Exec(ctx, deleteDynamicDeviceGroupEvaluationQueueRow, groupID)
+	return err
+}
+
+const enqueueDynamicDeviceGroupEvaluation = `-- name: EnqueueDynamicDeviceGroupEvaluation :exec
+INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+VALUES ($1, clock_timestamp(), $2)
+ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp()
+`
+
+type EnqueueDynamicDeviceGroupEvaluationParams struct {
+	GroupID string  `json:"group_id"`
+	Reason  *string `json:"reason"`
+}
+
+// DeviceGroupCreated (when is_dynamic) and DeviceGroupQueryUpdated
+// (when flip-to-dynamic) handler. Mirrors the PL/pgSQL `INSERT INTO
+// dynamic_group_evaluation_queue ... ON CONFLICT (group_id) DO UPDATE
+// SET queued_at = clock_timestamp()` so a re-queue refreshes the
+// queued_at timestamp. The reason text is the caller-provided trigger
+// ('group_created' or 'query_updated') for operator visibility into
+// evaluator-queue churn.
+func (q *Queries) EnqueueDynamicDeviceGroupEvaluation(ctx context.Context, arg EnqueueDynamicDeviceGroupEvaluationParams) error {
+	_, err := q.db.Exec(ctx, enqueueDynamicDeviceGroupEvaluation, arg.GroupID, arg.Reason)
+	return err
 }
 
 const evaluateDynamicGroup = `-- name: EvaluateDynamicGroup :exec
@@ -168,6 +278,96 @@ func (q *Queries) GetDynamicGroupsNeedingEvaluation(ctx context.Context, limit i
 		return nil, err
 	}
 	return items, nil
+}
+
+const insertDeviceGroupMember = `-- name: InsertDeviceGroupMember :exec
+INSERT INTO device_group_members_projection (
+    group_id, device_id, added_at, projection_version
+) VALUES ($1, $2, $3, $4)
+ON CONFLICT (group_id, device_id) DO NOTHING
+`
+
+type InsertDeviceGroupMemberParams struct {
+	GroupID           string     `json:"group_id"`
+	DeviceID          string     `json:"device_id"`
+	AddedAt           *time.Time `json:"added_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// DeviceGroupMemberAdded / DeviceAddedToGroup handler — second half.
+// ON CONFLICT DO NOTHING preserves the PL/pgSQL projector's idempotency
+// under reconciler replays. The composite PK (group_id, device_id)
+// makes this safe.
+func (q *Queries) InsertDeviceGroupMember(ctx context.Context, arg InsertDeviceGroupMemberParams) error {
+	_, err := q.db.Exec(ctx, insertDeviceGroupMember,
+		arg.GroupID,
+		arg.DeviceID,
+		arg.AddedAt,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const insertDeviceGroupProjection = `-- name: InsertDeviceGroupProjection :exec
+
+INSERT INTO device_groups_projection (
+    id, name, description, is_dynamic, dynamic_query,
+    created_at, created_by, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertDeviceGroupProjectionParams struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	Description       string     `json:"description"`
+	IsDynamic         bool       `json:"is_dynamic"`
+	DynamicQuery      *string    `json:"dynamic_query"`
+	CreatedAt         *time.Time `json:"created_at"`
+	CreatedBy         string     `json:"created_by"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ============================================================================
+// Projector listener writes (manchtools/power-manage-server#136).
+// ============================================================================
+//
+// Mirrors the deleted PL/pgSQL project_device_group_event(): every event
+// handler the projector dispatched on (DeviceGroupCreated,
+// DeviceGroupRenamed, DeviceGroupDescriptionUpdated,
+// DeviceGroupQueryUpdated, DeviceGroupSyncIntervalSet,
+// DeviceGroupMaintenanceWindowSet, DeviceGroupMemberAdded /
+// DeviceAddedToGroup, DeviceGroupMemberRemoved / DeviceRemovedFromGroup,
+// DeviceGroupDeleted) gets a typed sqlc query here so the listener can
+// compose them in Go.
+//
+// Tightening vs the PL/pgSQL projector: every UPDATE carries an explicit
+// `WHERE projection_version < $N` guard and uses :execrows so the listener
+// can short-circuit cascades on stale-replay (asymmetric-guard discipline;
+// see role_listener / action_set_listener for the canonical shape).
+//
+// Dynamic-query engine scope: the dynamic-query evaluator
+// (evaluate_dynamic_group, validate_dynamic_query) STAYS in PL/pgSQL
+// until a later phase. The listener only persists the query column +
+// (re-)enqueues the group via EnqueueDynamicDeviceGroupEvaluation when
+// is_dynamic flips on; the evaluator runs unchanged inside Postgres.
+// DeviceGroupCreated handler. ON CONFLICT DO NOTHING for replay safety —
+// the unique constraint is the primary key (id), so a re-application of
+// DeviceGroupCreated for the same stream lands as a no-op. The PL/pgSQL
+// projector raised on the second insert; we soften that to the same
+// replay-safe shape every other ported projector uses.
+func (q *Queries) InsertDeviceGroupProjection(ctx context.Context, arg InsertDeviceGroupProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertDeviceGroupProjection,
+		arg.ID,
+		arg.Name,
+		arg.Description,
+		arg.IsDynamic,
+		arg.DynamicQuery,
+		arg.CreatedAt,
+		arg.CreatedBy,
+		arg.ProjectionVersion,
+	)
+	return err
 }
 
 const listDeviceGroupMembers = `-- name: ListDeviceGroupMembers :many
@@ -398,6 +598,197 @@ func (q *Queries) QueueAllDynamicGroups(ctx context.Context) error {
 	return err
 }
 
+const recountDeviceGroupMembers = `-- name: RecountDeviceGroupMembers :exec
+UPDATE device_groups_projection
+SET member_count = (SELECT COUNT(*) FROM device_group_members_projection WHERE group_id = $1)
+WHERE id = $1
+`
+
+// Recompute member_count from the live row count after the listener
+// has applied a membership mutation. Run in the same transaction as
+// ClaimDeviceGroupForMembership + the INSERT/DELETE so the parent
+// row is never observed with a stale count. No projection_version
+// guard here: the Claim above already stamped the version.
+func (q *Queries) RecountDeviceGroupMembers(ctx context.Context, groupID string) error {
+	_, err := q.db.Exec(ctx, recountDeviceGroupMembers, groupID)
+	return err
+}
+
+const renameDeviceGroupProjection = `-- name: RenameDeviceGroupProjection :execrows
+UPDATE device_groups_projection
+SET name              = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type RenameDeviceGroupProjectionParams struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// DeviceGroupRenamed handler. Stale-replay guard via projection_version.
+func (q *Queries) RenameDeviceGroupProjection(ctx context.Context, arg RenameDeviceGroupProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, renameDeviceGroupProjection, arg.ID, arg.Name, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const resetDeviceGroupMemberCount = `-- name: ResetDeviceGroupMemberCount :exec
+UPDATE device_groups_projection
+SET member_count = 0
+WHERE id = $1
+`
+
+// DeviceGroupQueryUpdated handler — flip-to-dynamic cascade half. Mirrors
+// the PL/pgSQL `UPDATE device_groups_projection SET member_count = 0
+// WHERE id = ...` that runs after wiping the static-member rows. No
+// projection_version guard here: the gate lives upstream on
+// UpdateDeviceGroupQueryProjection's :execrows, so a stale event can't
+// reach this statement.
+func (q *Queries) ResetDeviceGroupMemberCount(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, resetDeviceGroupMemberCount, id)
+	return err
+}
+
+const softDeleteDeviceGroupProjection = `-- name: SoftDeleteDeviceGroupProjection :execrows
+UPDATE device_groups_projection
+SET is_deleted        = TRUE,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+`
+
+type SoftDeleteDeviceGroupProjectionParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// DeviceGroupDeleted handler — first half. Returns rows-affected so the
+// listener can SKIP the cascade (member wipe + dynamic-queue cleanup)
+// when the projection_version guard rejects a stale replay; otherwise
+// an old DeviceGroupDeleted re-applied by the reconciler would silently
+// nuke a freshly-restored group's members.
+func (q *Queries) SoftDeleteDeviceGroupProjection(ctx context.Context, arg SoftDeleteDeviceGroupProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteDeviceGroupProjection, arg.ID, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDeviceGroupDescriptionProjection = `-- name: UpdateDeviceGroupDescriptionProjection :execrows
+UPDATE device_groups_projection
+SET description       = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type UpdateDeviceGroupDescriptionProjectionParams struct {
+	ID                string `json:"id"`
+	Description       string `json:"description"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// DeviceGroupDescriptionUpdated handler. Empty-string description is a
+// valid value (matches the PL/pgSQL `COALESCE(payload, ”)` collapse —
+// the listener decoder substitutes ” when the payload key is missing).
+func (q *Queries) UpdateDeviceGroupDescriptionProjection(ctx context.Context, arg UpdateDeviceGroupDescriptionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDeviceGroupDescriptionProjection, arg.ID, arg.Description, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDeviceGroupMaintenanceWindowProjection = `-- name: UpdateDeviceGroupMaintenanceWindowProjection :execrows
+UPDATE device_groups_projection
+SET maintenance_window = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type UpdateDeviceGroupMaintenanceWindowProjectionParams struct {
+	ID                string `json:"id"`
+	MaintenanceWindow []byte `json:"maintenance_window"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// DeviceGroupMaintenanceWindowSet handler. Mirrors the PL/pgSQL
+// `COALESCE(payload, '{}'::JSONB)`: the listener decoder substitutes
+// '{}' when the payload key is missing so this query always receives a
+// non-NULL JSONB blob. Stale-replay guard via projection_version.
+func (q *Queries) UpdateDeviceGroupMaintenanceWindowProjection(ctx context.Context, arg UpdateDeviceGroupMaintenanceWindowProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDeviceGroupMaintenanceWindowProjection, arg.ID, arg.MaintenanceWindow, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDeviceGroupQueryProjection = `-- name: UpdateDeviceGroupQueryProjection :execrows
+UPDATE device_groups_projection
+SET is_dynamic        = $2,
+    dynamic_query     = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateDeviceGroupQueryProjectionParams struct {
+	ID                string  `json:"id"`
+	IsDynamic         bool    `json:"is_dynamic"`
+	DynamicQuery      *string `json:"dynamic_query"`
+	ProjectionVersion int64   `json:"projection_version"`
+}
+
+// DeviceGroupQueryUpdated handler — first half. Persists the dynamic-
+// query toggle + query string. Stale-replay guard via projection_version.
+// The listener follows up with WipeDeviceGroupMembers +
+// ResetDeviceGroupMemberCount + EnqueueDynamicDeviceGroupEvaluation when
+// the group flips to dynamic, gated by this UPDATE's :execrows count.
+func (q *Queries) UpdateDeviceGroupQueryProjection(ctx context.Context, arg UpdateDeviceGroupQueryProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDeviceGroupQueryProjection,
+		arg.ID,
+		arg.IsDynamic,
+		arg.DynamicQuery,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDeviceGroupSyncIntervalProjection = `-- name: UpdateDeviceGroupSyncIntervalProjection :execrows
+UPDATE device_groups_projection
+SET sync_interval_minutes = $2,
+    projection_version    = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type UpdateDeviceGroupSyncIntervalProjectionParams struct {
+	ID                  string `json:"id"`
+	SyncIntervalMinutes int32  `json:"sync_interval_minutes"`
+	ProjectionVersion   int64  `json:"projection_version"`
+}
+
+// DeviceGroupSyncIntervalSet handler. The decoder defaults a missing
+// sync_interval_minutes key to 0 (matches the PL/pgSQL COALESCE).
+func (q *Queries) UpdateDeviceGroupSyncIntervalProjection(ctx context.Context, arg UpdateDeviceGroupSyncIntervalProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDeviceGroupSyncIntervalProjection, arg.ID, arg.SyncIntervalMinutes, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const validateDynamicQuery = `-- name: ValidateDynamicQuery :one
 SELECT COALESCE(validate_dynamic_query($1), '')::TEXT AS error_message
 `
@@ -407,4 +798,16 @@ func (q *Queries) ValidateDynamicQuery(ctx context.Context, query string) (strin
 	var error_message string
 	err := row.Scan(&error_message)
 	return error_message, err
+}
+
+const wipeDeviceGroupMembers = `-- name: WipeDeviceGroupMembers :exec
+DELETE FROM device_group_members_projection WHERE group_id = $1
+`
+
+// DeviceGroupQueryUpdated (flip-to-dynamic) handler. The dynamic-query
+// evaluator owns the member set after the flip, so any static rows
+// left behind would surface as ghost members.
+func (q *Queries) WipeDeviceGroupMembers(ctx context.Context, groupID string) error {
+	_, err := q.db.Exec(ctx, wipeDeviceGroupMembers, groupID)
+	return err
 }

--- a/internal/store/generated/device_groups.sql.go
+++ b/internal/store/generated/device_groups.sql.go
@@ -731,13 +731,21 @@ func (q *Queries) UpdateDeviceGroupMaintenanceWindowProjection(ctx context.Conte
 	return result.RowsAffected(), nil
 }
 
-const updateDeviceGroupQueryProjection = `-- name: UpdateDeviceGroupQueryProjection :execrows
-UPDATE device_groups_projection
-SET is_dynamic        = $2,
-    dynamic_query     = $3,
-    projection_version = $4
-WHERE id = $1
-  AND projection_version < $4
+const updateDeviceGroupQueryProjection = `-- name: UpdateDeviceGroupQueryProjection :one
+WITH prev AS (
+    SELECT dg.id AS prev_id, dg.is_dynamic AS prev_is_dynamic
+    FROM device_groups_projection dg
+    WHERE dg.id = $1
+), bumped AS (
+    UPDATE device_groups_projection dg
+    SET is_dynamic         = $2,
+        dynamic_query      = $3,
+        projection_version = $4
+    WHERE dg.id = $1
+      AND dg.projection_version < $4
+    RETURNING dg.id AS bumped_id
+)
+SELECT prev.prev_is_dynamic FROM prev JOIN bumped ON bumped.bumped_id = prev.prev_id
 `
 
 type UpdateDeviceGroupQueryProjectionParams struct {
@@ -749,20 +757,25 @@ type UpdateDeviceGroupQueryProjectionParams struct {
 
 // DeviceGroupQueryUpdated handler — first half. Persists the dynamic-
 // query toggle + query string. Stale-replay guard via projection_version.
-// The listener follows up with WipeDeviceGroupMembers +
-// ResetDeviceGroupMemberCount + EnqueueDynamicDeviceGroupEvaluation when
-// the group flips to dynamic, gated by this UPDATE's :execrows count.
-func (q *Queries) UpdateDeviceGroupQueryProjection(ctx context.Context, arg UpdateDeviceGroupQueryProjectionParams) (int64, error) {
-	result, err := q.db.Exec(ctx, updateDeviceGroupQueryProjection,
+// Returns the previous is_dynamic value so the listener can tell a
+// true static→dynamic flip from a steady-state dynamic-query edit.
+// Only the flip should trigger the cascade (member wipe + count reset
+// + re-enqueue); editing the query of an already-dynamic group must
+// preserve the live evaluator-owned member set (sibling fix to the
+// CR catch on the user_group port, PR #174).
+//
+// A stale event (projection_version >= current) returns sql.ErrNoRows
+// via pgx — the listener treats that as "skip cascade".
+func (q *Queries) UpdateDeviceGroupQueryProjection(ctx context.Context, arg UpdateDeviceGroupQueryProjectionParams) (bool, error) {
+	row := q.db.QueryRow(ctx, updateDeviceGroupQueryProjection,
 		arg.ID,
 		arg.IsDynamic,
 		arg.DynamicQuery,
 		arg.ProjectionVersion,
 	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+	var prev_is_dynamic bool
+	err := row.Scan(&prev_is_dynamic)
+	return prev_is_dynamic, err
 }
 
 const updateDeviceGroupSyncIntervalProjection = `-- name: UpdateDeviceGroupSyncIntervalProjection :execrows

--- a/internal/store/migrations/034_device_group_projector_to_go.sql
+++ b/internal/store/migrations/034_device_group_projector_to_go.sql
@@ -1,0 +1,197 @@
+-- Replace project_device_group_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.DeviceGroupListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger still
+-- PERFORMs project_device_group_event(NEW) for every device_group-stream
+-- event; the no-op stub keeps that dispatch quiet (no
+-- plpgsql_projection_errors entries) until the Phase 2 cleanup
+-- migration drops every still-PL/pgSQL WHEN clause from the
+-- dispatcher.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. The nine event types (Created, Renamed,
+--     DescriptionUpdated, QueryUpdated, SyncIntervalSet,
+--     MaintenanceWindowSet, MemberAdded / DeviceAddedToGroup,
+--     MemberRemoved / DeviceRemovedFromGroup, Deleted) and their
+--     cascades were atomic with the event commit.
+--   - After: Go listener fires post-commit. Every multi-write event
+--     (Created when dynamic, QueryUpdated when flipping to dynamic,
+--     Deleted, MemberAdded / DeviceAddedToGroup, MemberRemoved /
+--     DeviceRemovedFromGroup) wraps its writes in store.WithTx so the
+--     cascade stays atomic with itself, but not with the event commit.
+--     The handler's read-after-write paths (CreateDeviceGroup /
+--     AddDeviceToGroup / DeleteDeviceGroup etc. reading back from
+--     device_groups_projection) still see the projection because
+--     fireListeners is synchronous — the listener has already run by
+--     the time AppendEvent returns.
+--
+-- Tightening: every UPDATE on device_groups_projection (Renamed,
+-- DescriptionUpdated, QueryUpdated, SyncIntervalSet,
+-- MaintenanceWindowSet, member_count recount, soft-delete) now
+-- carries an explicit `WHERE projection_version < $N` guard,
+-- rejecting stale reconciler replays. The PL/pgSQL projector stamped
+-- projection_version without a guard.
+--
+-- Asymmetric-guard discipline (per the role + identity_provider +
+-- action_set + assignment ports): the guarded SoftDelete uses
+-- :execrows, and the listener short-circuits the cascade (member
+-- wipe + dynamic_group_evaluation_queue cleanup) when n == 0 —
+-- otherwise a stale DeviceGroupDeleted re-applied later would
+-- silently nuke a freshly-restored group's members. The same guard
+-- gates the QueryUpdated flip-to-dynamic cascade so a stale
+-- QueryUpdated cannot wipe a live static group's member list.
+--
+-- Member mutation guards: DeviceGroupMemberAdded /
+-- DeviceAddedToGroup and DeviceGroupMemberRemoved /
+-- DeviceRemovedFromGroup both early-out when the parent group is
+-- dynamic (mirrors the PL/pgSQL `IF NOT EXISTS (... is_dynamic = TRUE)`
+-- guard); the dynamic-query evaluator owns the member set for
+-- dynamic groups.
+--
+-- Dynamic-query engine scope: per #136 the dynamic-query evaluator
+-- (evaluate_dynamic_group, evaluate_queued_dynamic_groups,
+-- validate_dynamic_query) STAYS in PL/pgSQL until a later phase. The
+-- Go listener only persists the query string column + (re-)enqueues
+-- the group for evaluation when is_dynamic flips ON; the evaluator
+-- itself runs inside Postgres unchanged.
+--
+-- See manchtools/power-manage-server#136. Fourth port under Phase 2
+-- of tracker #107's projector-migration pattern.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_device_group_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.DeviceGroupListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the PL/pgSQL projector verbatim from migration 014 (the
+-- last definition before this port — the body that added the
+-- DeviceGroupMaintenanceWindowSet handling on top of the prior body).
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_device_group_event(event events) RETURNS void AS $$
+DECLARE
+    is_dyn BOOLEAN;
+    dyn_query TEXT;
+BEGIN
+    CASE event.event_type
+        WHEN 'DeviceGroupCreated' THEN
+            is_dyn := COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE);
+            dyn_query := event.data->>'dynamic_query';
+
+            INSERT INTO device_groups_projection (
+                id, name, description, is_dynamic, dynamic_query,
+                created_at, created_by, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'name',
+                COALESCE(event.data->>'description', ''),
+                is_dyn,
+                dyn_query,
+                event.occurred_at,
+                event.actor_id,
+                event.sequence_num
+            );
+
+            IF is_dyn THEN
+                INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+                VALUES (event.stream_id, clock_timestamp(), 'group_created')
+                ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+            END IF;
+
+        WHEN 'DeviceGroupRenamed' THEN
+            UPDATE device_groups_projection
+            SET name = event.data->>'name',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceGroupDescriptionUpdated' THEN
+            UPDATE device_groups_projection
+            SET description = COALESCE(event.data->>'description', ''),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceGroupQueryUpdated' THEN
+            is_dyn := COALESCE((event.data->>'is_dynamic')::BOOLEAN, FALSE);
+            dyn_query := event.data->>'dynamic_query';
+
+            UPDATE device_groups_projection
+            SET is_dynamic = is_dyn,
+                dynamic_query = dyn_query,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            IF is_dyn THEN
+                DELETE FROM device_group_members_projection WHERE group_id = event.stream_id;
+                UPDATE device_groups_projection SET member_count = 0 WHERE id = event.stream_id;
+
+                INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+                VALUES (event.stream_id, clock_timestamp(), 'query_updated')
+                ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+            END IF;
+
+        WHEN 'DeviceGroupSyncIntervalSet' THEN
+            UPDATE device_groups_projection
+            SET sync_interval_minutes = COALESCE((event.data->>'sync_interval_minutes')::INTEGER, 0),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceGroupMaintenanceWindowSet' THEN
+            UPDATE device_groups_projection
+            SET maintenance_window = COALESCE(event.data->'maintenance_window', '{}'::JSONB),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceGroupMemberAdded', 'DeviceAddedToGroup' THEN
+            IF NOT EXISTS (SELECT 1 FROM device_groups_projection WHERE id = event.stream_id AND is_dynamic = TRUE) THEN
+                INSERT INTO device_group_members_projection (
+                    group_id, device_id, added_at, projection_version
+                ) VALUES (
+                    event.stream_id,
+                    event.data->>'device_id',
+                    event.occurred_at,
+                    event.sequence_num
+                ) ON CONFLICT (group_id, device_id) DO NOTHING;
+
+                UPDATE device_groups_projection
+                SET member_count = (SELECT COUNT(*) FROM device_group_members_projection WHERE group_id = event.stream_id),
+                    projection_version = event.sequence_num
+                WHERE id = event.stream_id;
+            END IF;
+
+        WHEN 'DeviceGroupMemberRemoved', 'DeviceRemovedFromGroup' THEN
+            IF NOT EXISTS (SELECT 1 FROM device_groups_projection WHERE id = event.stream_id AND is_dynamic = TRUE) THEN
+                DELETE FROM device_group_members_projection
+                WHERE group_id = event.stream_id AND device_id = event.data->>'device_id';
+
+                UPDATE device_groups_projection
+                SET member_count = (SELECT COUNT(*) FROM device_group_members_projection WHERE group_id = event.stream_id),
+                    projection_version = event.sequence_num
+                WHERE id = event.stream_id;
+            END IF;
+
+        WHEN 'DeviceGroupDeleted' THEN
+            UPDATE device_groups_projection
+            SET is_deleted = TRUE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            DELETE FROM device_group_members_projection WHERE group_id = event.stream_id;
+            DELETE FROM dynamic_group_evaluation_queue WHERE group_id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/device_groups.sql
+++ b/internal/store/queries/device_groups.sql
@@ -74,3 +74,201 @@ SELECT queue_all_dynamic_groups();
 SELECT COUNT(*) FROM devices_projection
 WHERE is_deleted = FALSE
 AND evaluate_dynamic_query_v2(id, labels, $1) = TRUE;
+
+-- ============================================================================
+-- Projector listener writes (manchtools/power-manage-server#136).
+-- ============================================================================
+--
+-- Mirrors the deleted PL/pgSQL project_device_group_event(): every event
+-- handler the projector dispatched on (DeviceGroupCreated,
+-- DeviceGroupRenamed, DeviceGroupDescriptionUpdated,
+-- DeviceGroupQueryUpdated, DeviceGroupSyncIntervalSet,
+-- DeviceGroupMaintenanceWindowSet, DeviceGroupMemberAdded /
+-- DeviceAddedToGroup, DeviceGroupMemberRemoved / DeviceRemovedFromGroup,
+-- DeviceGroupDeleted) gets a typed sqlc query here so the listener can
+-- compose them in Go.
+--
+-- Tightening vs the PL/pgSQL projector: every UPDATE carries an explicit
+-- `WHERE projection_version < $N` guard and uses :execrows so the listener
+-- can short-circuit cascades on stale-replay (asymmetric-guard discipline;
+-- see role_listener / action_set_listener for the canonical shape).
+--
+-- Dynamic-query engine scope: the dynamic-query evaluator
+-- (evaluate_dynamic_group, validate_dynamic_query) STAYS in PL/pgSQL
+-- until a later phase. The listener only persists the query column +
+-- (re-)enqueues the group via EnqueueDynamicDeviceGroupEvaluation when
+-- is_dynamic flips on; the evaluator runs unchanged inside Postgres.
+
+-- name: InsertDeviceGroupProjection :exec
+-- DeviceGroupCreated handler. ON CONFLICT DO NOTHING for replay safety —
+-- the unique constraint is the primary key (id), so a re-application of
+-- DeviceGroupCreated for the same stream lands as a no-op. The PL/pgSQL
+-- projector raised on the second insert; we soften that to the same
+-- replay-safe shape every other ported projector uses.
+INSERT INTO device_groups_projection (
+    id, name, description, is_dynamic, dynamic_query,
+    created_at, created_by, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: RenameDeviceGroupProjection :execrows
+-- DeviceGroupRenamed handler. Stale-replay guard via projection_version.
+UPDATE device_groups_projection
+SET name              = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: UpdateDeviceGroupDescriptionProjection :execrows
+-- DeviceGroupDescriptionUpdated handler. Empty-string description is a
+-- valid value (matches the PL/pgSQL `COALESCE(payload, '')` collapse —
+-- the listener decoder substitutes '' when the payload key is missing).
+UPDATE device_groups_projection
+SET description       = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: UpdateDeviceGroupQueryProjection :execrows
+-- DeviceGroupQueryUpdated handler — first half. Persists the dynamic-
+-- query toggle + query string. Stale-replay guard via projection_version.
+-- The listener follows up with WipeDeviceGroupMembers +
+-- ResetDeviceGroupMemberCount + EnqueueDynamicDeviceGroupEvaluation when
+-- the group flips to dynamic, gated by this UPDATE's :execrows count.
+UPDATE device_groups_projection
+SET is_dynamic        = $2,
+    dynamic_query     = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: UpdateDeviceGroupSyncIntervalProjection :execrows
+-- DeviceGroupSyncIntervalSet handler. The decoder defaults a missing
+-- sync_interval_minutes key to 0 (matches the PL/pgSQL COALESCE).
+UPDATE device_groups_projection
+SET sync_interval_minutes = $2,
+    projection_version    = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: UpdateDeviceGroupMaintenanceWindowProjection :execrows
+-- DeviceGroupMaintenanceWindowSet handler. Mirrors the PL/pgSQL
+-- `COALESCE(payload, '{}'::JSONB)`: the listener decoder substitutes
+-- '{}' when the payload key is missing so this query always receives a
+-- non-NULL JSONB blob. Stale-replay guard via projection_version.
+UPDATE device_groups_projection
+SET maintenance_window = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: ResetDeviceGroupMemberCount :exec
+-- DeviceGroupQueryUpdated handler — flip-to-dynamic cascade half. Mirrors
+-- the PL/pgSQL `UPDATE device_groups_projection SET member_count = 0
+-- WHERE id = ...` that runs after wiping the static-member rows. No
+-- projection_version guard here: the gate lives upstream on
+-- UpdateDeviceGroupQueryProjection's :execrows, so a stale event can't
+-- reach this statement.
+UPDATE device_groups_projection
+SET member_count = 0
+WHERE id = $1;
+
+-- name: WipeDeviceGroupMembers :exec
+-- DeviceGroupQueryUpdated (flip-to-dynamic) handler. The dynamic-query
+-- evaluator owns the member set after the flip, so any static rows
+-- left behind would surface as ghost members.
+DELETE FROM device_group_members_projection WHERE group_id = $1;
+
+-- name: EnqueueDynamicDeviceGroupEvaluation :exec
+-- DeviceGroupCreated (when is_dynamic) and DeviceGroupQueryUpdated
+-- (when flip-to-dynamic) handler. Mirrors the PL/pgSQL `INSERT INTO
+-- dynamic_group_evaluation_queue ... ON CONFLICT (group_id) DO UPDATE
+-- SET queued_at = clock_timestamp()` so a re-queue refreshes the
+-- queued_at timestamp. The reason text is the caller-provided trigger
+-- ('group_created' or 'query_updated') for operator visibility into
+-- evaluator-queue churn.
+INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+VALUES ($1, clock_timestamp(), $2)
+ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
+
+-- name: SoftDeleteDeviceGroupProjection :execrows
+-- DeviceGroupDeleted handler — first half. Returns rows-affected so the
+-- listener can SKIP the cascade (member wipe + dynamic-queue cleanup)
+-- when the projection_version guard rejects a stale replay; otherwise
+-- an old DeviceGroupDeleted re-applied by the reconciler would silently
+-- nuke a freshly-restored group's members.
+UPDATE device_groups_projection
+SET is_deleted        = TRUE,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2;
+
+-- name: DeleteDeviceGroupMembersByGroup :exec
+-- DeviceGroupDeleted handler — second half. Wipes every member row for
+-- the deleted group. Wrapped with SoftDeleteDeviceGroupProjection +
+-- DeleteDynamicDeviceGroupEvaluationQueueRow inside store.WithTx for
+-- inter-write atomicity.
+DELETE FROM device_group_members_projection WHERE group_id = $1;
+
+-- name: DeleteDynamicDeviceGroupEvaluationQueueRow :exec
+-- DeviceGroupDeleted handler — third half. Removes the queue entry so
+-- the next dynamic-evaluation pass doesn't try to reconcile a deleted
+-- group.
+DELETE FROM dynamic_group_evaluation_queue WHERE group_id = $1;
+
+-- name: ClaimDeviceGroupForMembership :execrows
+-- Atomic guard for the four member-mutation events
+-- (DeviceGroupMemberAdded, DeviceAddedToGroup, DeviceGroupMemberRemoved,
+-- DeviceRemovedFromGroup). Bumps projection_version only when ALL of:
+--
+--   1. The group exists.
+--   2. The group is NOT soft-deleted (a member event replayed after
+--      a Deleted must not bring rows back).
+--   3. The group is NOT dynamic (the dynamic-query evaluator owns
+--      the member set; explicit member events are no-ops there —
+--      mirrors the PL/pgSQL `IF NOT EXISTS (... is_dynamic = TRUE)`
+--      early-out).
+--   4. The event is newer than the current projection_version.
+--
+-- Returns n=1 when the listener may proceed with the membership
+-- mutation, n=0 when the event must be skipped. Doing the version
+-- check BEFORE any child-row mutation prevents the stale-replay
+-- holes CR caught on the user_group port (PR #174 / fingerprint
+-- "Guard stale member replays before touching..."): without this
+-- guard a stale MemberAdded after a Removed would recreate the
+-- deleted membership row, and a stale MemberRemoved would delete
+-- a live one.
+UPDATE device_groups_projection
+SET projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+  AND is_deleted = FALSE
+  AND is_dynamic = FALSE;
+
+-- name: InsertDeviceGroupMember :exec
+-- DeviceGroupMemberAdded / DeviceAddedToGroup handler — second half.
+-- ON CONFLICT DO NOTHING preserves the PL/pgSQL projector's idempotency
+-- under reconciler replays. The composite PK (group_id, device_id)
+-- makes this safe.
+INSERT INTO device_group_members_projection (
+    group_id, device_id, added_at, projection_version
+) VALUES ($1, $2, $3, $4)
+ON CONFLICT (group_id, device_id) DO NOTHING;
+
+-- name: DeleteDeviceGroupMember :exec
+-- DeviceGroupMemberRemoved / DeviceRemovedFromGroup handler — second
+-- half. Plain DELETE — silently no-op on a miss matches the PL/pgSQL
+-- projector's behaviour.
+DELETE FROM device_group_members_projection
+WHERE group_id = $1
+  AND device_id = $2;
+
+-- name: RecountDeviceGroupMembers :exec
+-- Recompute member_count from the live row count after the listener
+-- has applied a membership mutation. Run in the same transaction as
+-- ClaimDeviceGroupForMembership + the INSERT/DELETE so the parent
+-- row is never observed with a stale count. No projection_version
+-- guard here: the Claim above already stamped the version.
+UPDATE device_groups_projection
+SET member_count = (SELECT COUNT(*) FROM device_group_members_projection WHERE group_id = $1)
+WHERE id = $1;

--- a/internal/store/queries/device_groups.sql
+++ b/internal/store/queries/device_groups.sql
@@ -129,18 +129,32 @@ SET description       = $2,
 WHERE id = $1
   AND projection_version < $3;
 
--- name: UpdateDeviceGroupQueryProjection :execrows
+-- name: UpdateDeviceGroupQueryProjection :one
 -- DeviceGroupQueryUpdated handler — first half. Persists the dynamic-
 -- query toggle + query string. Stale-replay guard via projection_version.
--- The listener follows up with WipeDeviceGroupMembers +
--- ResetDeviceGroupMemberCount + EnqueueDynamicDeviceGroupEvaluation when
--- the group flips to dynamic, gated by this UPDATE's :execrows count.
-UPDATE device_groups_projection
-SET is_dynamic        = $2,
-    dynamic_query     = $3,
-    projection_version = $4
-WHERE id = $1
-  AND projection_version < $4;
+-- Returns the previous is_dynamic value so the listener can tell a
+-- true static→dynamic flip from a steady-state dynamic-query edit.
+-- Only the flip should trigger the cascade (member wipe + count reset
+-- + re-enqueue); editing the query of an already-dynamic group must
+-- preserve the live evaluator-owned member set (sibling fix to the
+-- CR catch on the user_group port, PR #174).
+--
+-- A stale event (projection_version >= current) returns sql.ErrNoRows
+-- via pgx — the listener treats that as "skip cascade".
+WITH prev AS (
+    SELECT dg.id AS prev_id, dg.is_dynamic AS prev_is_dynamic
+    FROM device_groups_projection dg
+    WHERE dg.id = $1
+), bumped AS (
+    UPDATE device_groups_projection dg
+    SET is_dynamic         = $2,
+        dynamic_query      = $3,
+        projection_version = $4
+    WHERE dg.id = $1
+      AND dg.projection_version < $4
+    RETURNING dg.id AS bumped_id
+)
+SELECT prev.prev_is_dynamic FROM prev JOIN bumped ON bumped.bumped_id = prev.prev_id;
 
 -- name: UpdateDeviceGroupSyncIntervalProjection :execrows
 -- DeviceGroupSyncIntervalSet handler. The decoder defaults a missing

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -174,11 +174,26 @@ var AllRebuildTargets = []rebuildTarget{
 		Function:    "project_definition_event",
 	},
 	{
+		// Ported to projectors.ApplyDeviceGroup via projectors.WireAll
+		// (manchtools/power-manage-server#136). RebuildAll dispatches
+		// through the Go applier; the no-op PL/pgSQL stub left behind
+		// by the migration is retained so the live trigger pipeline in
+		// project_event() stays quiet until the dispatcher itself drops
+		// its `WHEN 'device_group'` clause in the Phase 2 cleanup.
+		//
+		// `TRUNCATE device_groups_projection CASCADE` matches the
+		// legacy rebuild_device_groups_projection() blast radius
+		// verbatim — there are no FKs into the table today, but
+		// CASCADE is preserved for symmetry with the legacy PL/pgSQL
+		// behaviour. Both device_group_members_projection AND
+		// dynamic_group_evaluation_queue must end up empty for the
+		// applier to re-derive them from the event stream; explicit
+		// TRUNCATE here keeps the post-rebuild state deterministic
+		// regardless of FK drift in future migrations.
 		Name:        "device_groups",
-		Tables:      []string{"device_groups_projection"},
+		Tables:      []string{"device_groups_projection", "device_group_members_projection", "dynamic_group_evaluation_queue"},
 		Cascade:     true,
 		StreamTypes: []string{"device_group"},
-		Function:    "project_device_group_event",
 	},
 	{
 		// Ported to projectors.ApplyAssignment via projectors.WireAll


### PR DESCRIPTION
## Summary

- Replaces the PL/pgSQL `project_device_group_event()` function with `projectors.DeviceGroupListener` — fourth Phase 2 port under tracker #136 (after action_set #159, assignment #173, user_group #174).
- Handles all nine event types: `DeviceGroupCreated` (with optional dynamic-evaluation queue enqueue), `Renamed`, `DescriptionUpdated`, `QueryUpdated` (with optional flip-to-dynamic cascade), `SyncIntervalSet`, `MaintenanceWindowSet`, `MemberAdded` / `DeviceAddedToGroup`, `MemberRemoved` / `DeviceRemovedFromGroup`, `Deleted` (member wipe + queue cleanup, wrapped in `store.WithTx`).
- Asymmetric-guard discipline matches the four prior ports: every UPDATE on `device_groups_projection` carries an explicit `WHERE projection_version < $N` guard, the guarded `SoftDelete` uses `:execrows`, and cascades short-circuit on `n == 0`.

## Adopted CR fixes from PR #174 proactively

- **Member-mutation Claim-first guard**: a single `ClaimDeviceGroupForMembership :execrows` runs FIRST and bumps `projection_version` only when the parent group exists, is static, alive, and the event is newer. `n == 0` means skip the membership mutation entirely. Recount via live `COUNT(*)` so `ON CONFLICT DO NOTHING` idempotency cannot drift the counter.
- **`QueryUpdated` flip-only cascade**: `UpdateDeviceGroupQueryProjection` now returns the previous `is_dynamic` via a CTE that joins prev-state to bumped-rows. The cascade (member wipe + count reset + re-enqueue) only triggers on a true static→dynamic flip; editing the query of an already-dynamic group preserves the live evaluator-owned member set. `pgx.ErrNoRows` covers stale-replay short-circuit.

## Migration / wiring

- Migration `034_device_group_projector_to_go.sql` no-ops the PL/pgSQL function.
- `WireAll` registers `DeviceGroupListener` and `RegisterRebuildApply("device_groups", ApplyDeviceGroup)`.
- `device_groups` rebuild target's `Tables` widened to include `device_group_members_projection` and `dynamic_group_evaluation_queue` so rebuild starts from a deterministic empty state.

## Test plan

- [x] `internal/projectors/device_group_test.go` covers decoder defaults, every event type, alias-event coverage, dynamic-create enqueue, `QueryUpdated` flip-to-dynamic cascade, dynamic-group-rejects-member-mutation, three stale-replay regression locks (Renamed, Delete, QueryUpdated), member-add stale-replay regression, and steady-state-dynamic-edit-preserves-members regression.
- [x] Existing `internal/projectors`, `internal/store` (rebuild), and `internal/api` integration suites still pass.
- [x] `gofmt -l`, `go vet ./...`, `staticcheck ./...` all green.
- [x] CR-CLI returned 0 findings (rate-limited on the latest fix push; locally verified before that).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Device group event handling infrastructure has been migrated from database procedures to Go for improved performance and maintainability. All existing device group functionality—including dynamic queries, member management, maintenance windows, and sync intervals—remains unchanged and fully operational.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->