### PR TITLE
fix: action_set member events use Claim-then-mutate guard (sibling-sweep from #174)

### DIFF
--- a/internal/projectors/action_set_listener.go
+++ b/internal/projectors/action_set_listener.go
@@ -189,6 +189,25 @@ func applyActionSetMemberAdded(ctx context.Context, q *store.Queries, e store.Pe
 		}
 		return err
 	}
+	// Atomic guard FIRST: bumps projection_version only when the
+	// parent set exists, is alive, and the event is newer. n==0
+	// means skip the membership mutation entirely. Doing the version
+	// check AFTER the INSERT (the prior shape) let stale events
+	// recreate deleted membership rows even when the recount guard
+	// rejected the bump (CR catch on user_group port PR #174;
+	// applied here as a follow-up sibling-sweep).
+	updatedAt := e.OccurredAt
+	n, err := q.ClaimActionSetForMembership(ctx, db.ClaimActionSetForMembershipParams{
+		ID:                payload.SetID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
 	addedAt := e.OccurredAt
 	if err := q.InsertActionSetMember(ctx, db.InsertActionSetMemberParams{
 		SetID:             payload.SetID,
@@ -199,15 +218,7 @@ func applyActionSetMemberAdded(ctx context.Context, q *store.Queries, e store.Pe
 	}); err != nil {
 		return err
 	}
-	updatedAt := e.OccurredAt
-	if _, err := q.RecountActionSetMembers(ctx, db.RecountActionSetMembersParams{
-		SetID:             payload.SetID,
-		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
-	}); err != nil {
-		return err
-	}
-	return nil
+	return q.RecountActionSetMembers(ctx, payload.SetID)
 }
 
 func applyActionSetMemberRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -218,21 +229,25 @@ func applyActionSetMemberRemoved(ctx context.Context, q *store.Queries, e store.
 		}
 		return err
 	}
+	updatedAt := e.OccurredAt
+	n, err := q.ClaimActionSetForMembership(ctx, db.ClaimActionSetForMembershipParams{
+		ID:                payload.SetID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
 	if err := q.DeleteActionSetMember(ctx, db.DeleteActionSetMemberParams{
 		SetID:    payload.SetID,
 		ActionID: payload.ActionID,
 	}); err != nil {
 		return err
 	}
-	updatedAt := e.OccurredAt
-	if _, err := q.RecountActionSetMembers(ctx, db.RecountActionSetMembersParams{
-		SetID:             payload.SetID,
-		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
-	}); err != nil {
-		return err
-	}
-	return nil
+	return q.RecountActionSetMembers(ctx, payload.SetID)
 }
 
 func applyActionSetMemberReordered(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -243,15 +258,12 @@ func applyActionSetMemberReordered(ctx context.Context, q *store.Queries, e stor
 		}
 		return err
 	}
-	// Per-member projection_version guard: a stale reorder must not
-	// roll a fresher position back. n == 0 short-circuits the parent
-	// updated_at bump too — there's no semantic change to surface, and
-	// the bump would otherwise advance the parent's projection_version
-	// to a value the cascade wasn't allowed to write.
-	n, err := q.UpdateActionSetMemberSortOrder(ctx, db.UpdateActionSetMemberSortOrderParams{
-		SetID:             payload.SetID,
-		ActionID:          payload.ActionID,
-		SortOrder:         payload.SortOrder,
+	// Claim the parent first so a stale reorder can't bump the
+	// per-member sort_order against a fresher parent projection_version.
+	updatedAt := e.OccurredAt
+	n, err := q.ClaimActionSetForMembership(ctx, db.ClaimActionSetForMembershipParams{
+		ID:                payload.SetID,
+		UpdatedAt:         &updatedAt,
 		ProjectionVersion: deref(e.SequenceNum),
 	})
 	if err != nil {
@@ -260,10 +272,12 @@ func applyActionSetMemberReordered(ctx context.Context, q *store.Queries, e stor
 	if n == 0 {
 		return nil
 	}
-	updatedAt := e.OccurredAt
-	if _, err := q.TouchActionSetUpdatedAt(ctx, db.TouchActionSetUpdatedAtParams{
-		ID:                payload.SetID,
-		UpdatedAt:         &updatedAt,
+	// Per-member projection_version guard still runs to prevent
+	// reorders applied out of order from clobbering each other.
+	if _, err := q.UpdateActionSetMemberSortOrder(ctx, db.UpdateActionSetMemberSortOrderParams{
+		SetID:             payload.SetID,
+		ActionID:          payload.ActionID,
+		SortOrder:         payload.SortOrder,
 		ProjectionVersion: deref(e.SequenceNum),
 	}); err != nil {
 		return err

--- a/internal/projectors/action_set_test.go
+++ b/internal/projectors/action_set_test.go
@@ -600,6 +600,66 @@ func TestActionSetListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 		"stale ActionSetDeleted must NOT decrement live definitions' member_count")
 }
 
+// TestActionSetListener_StaleMemberAddedDoesNotRecreateMembership locks
+// the Claim-first guard added as a sibling-sweep follow-up to the
+// CR catch on the user_group port (PR #174). A stale
+// ActionSetMemberAdded replayed after a Removed must NOT reinsert
+// the membership row, even though InsertActionSetMember is
+// idempotent (ON CONFLICT DO NOTHING): the version guard runs
+// BEFORE the INSERT.
+func TestActionSetListener_StaleMemberAddedDoesNotRecreateMembership(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+	actionID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data:      map[string]any{"name": "stale-add-set"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"set_id": setID, "action_id": actionID, "sort_order": 0},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberRemoved",
+		Data:      map[string]any{"set_id": setID, "action_id": actionID},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), live.MemberCount)
+
+	older := live.ProjectionVersion - 5
+	staleAt := *live.UpdatedAt
+	listener := projectors.ActionSetListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "action_set",
+		StreamID:    setID,
+		EventType:   "ActionSetMemberAdded",
+		Data:        jsonOrFail(t, map[string]any{"set_id": setID, "action_id": actionID, "sort_order": 0}),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
+	})
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM action_set_members_projection WHERE set_id = $1 AND action_id = $2",
+		setID, actionID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "stale ActionSetMemberAdded must NOT recreate the membership row")
+
+	after, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), after.MemberCount)
+	assert.Equal(t, live.ProjectionVersion, after.ProjectionVersion)
+}
+
 // TestActionSetListener_IgnoresWrongStreamType — defensive.
 func TestActionSetListener_IgnoresWrongStreamType(t *testing.T) {
 	st := testutil.SetupPostgres(t)

--- a/internal/store/generated/action_sets.sql.go
+++ b/internal/store/generated/action_sets.sql.go
@@ -10,6 +10,42 @@ import (
 	"time"
 )
 
+const claimActionSetForMembership = `-- name: ClaimActionSetForMembership :execrows
+UPDATE action_sets_projection
+SET updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+  AND is_deleted = FALSE
+`
+
+type ClaimActionSetForMembershipParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// Atomic guard for the three member-mutation events
+// (ActionSetMemberAdded, ActionSetMemberRemoved, ActionSetMemberReordered).
+// Bumps updated_at + projection_version only when the parent set
+// exists, is not soft-deleted, and the event is newer than the
+// current projection_version.
+//
+// Returns n=1 when the listener may proceed with the membership
+// mutation, n=0 when the event must be skipped. Doing the version
+// check BEFORE any child-row mutation prevents the stale-replay
+// holes CR caught on the user_group port (PR #174): without this
+// guard a stale ActionSetMemberAdded after a Removed would recreate
+// the deleted membership row, and a stale ActionSetMemberRemoved
+// would delete a live one.
+func (q *Queries) ClaimActionSetForMembership(ctx context.Context, arg ClaimActionSetForMembershipParams) (int64, error) {
+	result, err := q.db.Exec(ctx, claimActionSetForMembership, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countActionSets = `-- name: CountActionSets :one
 SELECT COUNT(*) FROM action_sets_projection
 WHERE is_deleted = FALSE
@@ -60,8 +96,8 @@ type DeleteActionSetMemberParams struct {
 	ActionID string `json:"action_id"`
 }
 
-// ActionSetMemberRemoved handler — first half. Plain DELETE — silently
-// no-op on a miss matches the PL/pgSQL projector's behaviour.
+// ActionSetMemberRemoved handler — second half. Plain DELETE —
+// silently no-op on a miss matches the PL/pgSQL projector's behaviour.
 func (q *Queries) DeleteActionSetMember(ctx context.Context, arg DeleteActionSetMemberParams) error {
 	_, err := q.db.Exec(ctx, deleteActionSetMember, arg.SetID, arg.ActionID)
 	return err
@@ -180,7 +216,7 @@ type InsertActionSetMemberParams struct {
 	ProjectionVersion int64      `json:"projection_version"`
 }
 
-// ActionSetMemberAdded handler — first half. ON CONFLICT DO NOTHING
+// ActionSetMemberAdded handler — second half. ON CONFLICT DO NOTHING
 // preserves the PL/pgSQL projector's idempotency under reconciler
 // replays. The composite PK (set_id, action_id) makes this safe.
 func (q *Queries) InsertActionSetMember(ctx context.Context, arg InsertActionSetMemberParams) error {
@@ -378,31 +414,21 @@ func (q *Queries) ListActionsInSet(ctx context.Context, setID string) ([]Actions
 	return items, nil
 }
 
-const recountActionSetMembers = `-- name: RecountActionSetMembers :execrows
+const recountActionSetMembers = `-- name: RecountActionSetMembers :exec
 UPDATE action_sets_projection
-SET member_count      = (SELECT COUNT(*) FROM action_set_members_projection WHERE set_id = $1),
-    updated_at        = $2,
-    projection_version = $3
+SET member_count = (SELECT COUNT(*) FROM action_set_members_projection WHERE set_id = $1)
 WHERE id = $1
-  AND projection_version < $3
 `
 
-type RecountActionSetMembersParams struct {
-	SetID             string     `json:"set_id"`
-	UpdatedAt         *time.Time `json:"updated_at"`
-	ProjectionVersion int64      `json:"projection_version"`
-}
-
-// ActionSetMemberAdded / ActionSetMemberRemoved handler — second half.
-// Recomputes member_count from the live row count, mirroring the
-// PL/pgSQL `(SELECT COUNT(*) ...)` subquery. Guarded so a stale replay
-// doesn't roll member_count backwards or stamp an old version.
-func (q *Queries) RecountActionSetMembers(ctx context.Context, arg RecountActionSetMembersParams) (int64, error) {
-	result, err := q.db.Exec(ctx, recountActionSetMembers, arg.SetID, arg.UpdatedAt, arg.ProjectionVersion)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+// ActionSetMemberAdded / ActionSetMemberRemoved handler — third half.
+// Recomputes member_count from the live row count after the listener
+// has applied a membership mutation. Run in the same transaction as
+// ClaimActionSetForMembership + the INSERT/DELETE so the parent row
+// is never observed with a stale count. No projection_version guard
+// here: the Claim above already stamped the version.
+func (q *Queries) RecountActionSetMembers(ctx context.Context, setID string) error {
+	_, err := q.db.Exec(ctx, recountActionSetMembers, setID)
+	return err
 }
 
 const renameActionSetProjection = `-- name: RenameActionSetProjection :execrows
@@ -464,31 +490,6 @@ func (q *Queries) SoftDeleteActionSetProjection(ctx context.Context, arg SoftDel
 	return result.RowsAffected(), nil
 }
 
-const touchActionSetUpdatedAt = `-- name: TouchActionSetUpdatedAt :execrows
-UPDATE action_sets_projection
-SET updated_at        = $2,
-    projection_version = $3
-WHERE id = $1
-  AND projection_version < $3
-`
-
-type TouchActionSetUpdatedAtParams struct {
-	ID                string     `json:"id"`
-	UpdatedAt         *time.Time `json:"updated_at"`
-	ProjectionVersion int64      `json:"projection_version"`
-}
-
-// ActionSetMemberReordered handler — second half. Bumps updated_at +
-// projection_version on the parent set so listing/cache invalidation
-// sees the change. Guarded for stale-replay safety.
-func (q *Queries) TouchActionSetUpdatedAt(ctx context.Context, arg TouchActionSetUpdatedAtParams) (int64, error) {
-	result, err := q.db.Exec(ctx, touchActionSetUpdatedAt, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
-}
-
 const updateActionSetDescriptionProjection = `-- name: UpdateActionSetDescriptionProjection :execrows
 UPDATE action_sets_projection
 SET description       = $2,
@@ -537,7 +538,7 @@ type UpdateActionSetMemberSortOrderParams struct {
 	ProjectionVersion int64  `json:"projection_version"`
 }
 
-// ActionSetMemberReordered handler — first half. Per-member
+// ActionSetMemberReordered handler — second half. Per-member
 // projection_version guards the row so a stale reorder cannot clobber
 // a fresher position.
 func (q *Queries) UpdateActionSetMemberSortOrder(ctx context.Context, arg UpdateActionSetMemberSortOrderParams) (int64, error) {

--- a/internal/store/queries/action_sets.sql
+++ b/internal/store/queries/action_sets.sql
@@ -95,8 +95,29 @@ SET schedule          = $2,
 WHERE id = $1
   AND projection_version < $4;
 
+-- name: ClaimActionSetForMembership :execrows
+-- Atomic guard for the three member-mutation events
+-- (ActionSetMemberAdded, ActionSetMemberRemoved, ActionSetMemberReordered).
+-- Bumps updated_at + projection_version only when the parent set
+-- exists, is not soft-deleted, and the event is newer than the
+-- current projection_version.
+--
+-- Returns n=1 when the listener may proceed with the membership
+-- mutation, n=0 when the event must be skipped. Doing the version
+-- check BEFORE any child-row mutation prevents the stale-replay
+-- holes CR caught on the user_group port (PR #174): without this
+-- guard a stale ActionSetMemberAdded after a Removed would recreate
+-- the deleted membership row, and a stale ActionSetMemberRemoved
+-- would delete a live one.
+UPDATE action_sets_projection
+SET updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+  AND is_deleted = FALSE;
+
 -- name: InsertActionSetMember :exec
--- ActionSetMemberAdded handler — first half. ON CONFLICT DO NOTHING
+-- ActionSetMemberAdded handler — second half. ON CONFLICT DO NOTHING
 -- preserves the PL/pgSQL projector's idempotency under reconciler
 -- replays. The composite PK (set_id, action_id) makes this safe.
 INSERT INTO action_set_members_projection (
@@ -105,14 +126,14 @@ INSERT INTO action_set_members_projection (
 ON CONFLICT (set_id, action_id) DO NOTHING;
 
 -- name: DeleteActionSetMember :exec
--- ActionSetMemberRemoved handler — first half. Plain DELETE — silently
--- no-op on a miss matches the PL/pgSQL projector's behaviour.
+-- ActionSetMemberRemoved handler — second half. Plain DELETE —
+-- silently no-op on a miss matches the PL/pgSQL projector's behaviour.
 DELETE FROM action_set_members_projection
 WHERE set_id = $1
   AND action_id = $2;
 
 -- name: UpdateActionSetMemberSortOrder :execrows
--- ActionSetMemberReordered handler — first half. Per-member
+-- ActionSetMemberReordered handler — second half. Per-member
 -- projection_version guards the row so a stale reorder cannot clobber
 -- a fresher position.
 UPDATE action_set_members_projection
@@ -122,27 +143,16 @@ WHERE set_id = $1
   AND action_id = $2
   AND projection_version < $4;
 
--- name: RecountActionSetMembers :execrows
--- ActionSetMemberAdded / ActionSetMemberRemoved handler — second half.
--- Recomputes member_count from the live row count, mirroring the
--- PL/pgSQL `(SELECT COUNT(*) ...)` subquery. Guarded so a stale replay
--- doesn't roll member_count backwards or stamp an old version.
+-- name: RecountActionSetMembers :exec
+-- ActionSetMemberAdded / ActionSetMemberRemoved handler — third half.
+-- Recomputes member_count from the live row count after the listener
+-- has applied a membership mutation. Run in the same transaction as
+-- ClaimActionSetForMembership + the INSERT/DELETE so the parent row
+-- is never observed with a stale count. No projection_version guard
+-- here: the Claim above already stamped the version.
 UPDATE action_sets_projection
-SET member_count      = (SELECT COUNT(*) FROM action_set_members_projection WHERE set_id = $1),
-    updated_at        = $2,
-    projection_version = $3
-WHERE id = $1
-  AND projection_version < $3;
-
--- name: TouchActionSetUpdatedAt :execrows
--- ActionSetMemberReordered handler — second half. Bumps updated_at +
--- projection_version on the parent set so listing/cache invalidation
--- sees the change. Guarded for stale-replay safety.
-UPDATE action_sets_projection
-SET updated_at        = $2,
-    projection_version = $3
-WHERE id = $1
-  AND projection_version < $3;
+SET member_count = (SELECT COUNT(*) FROM action_set_members_projection WHERE set_id = $1)
+WHERE id = $1;
 
 -- name: SoftDeleteActionSetProjection :execrows
 -- ActionSetDeleted handler — first half. Returns rows-affected so the


### PR DESCRIPTION
## Summary

Sibling-sweep follow-up from CR's catch on PR #174. The action_set port (merged in PR #159) has the same insert-then-recount stale-replay hole that user_group did. Three vulnerable handlers:

- `ActionSetMemberAdded`: `InsertActionSetMember` ran BEFORE the version guard. A stale Add after a Remove silently re-grants membership on the action set.
- `ActionSetMemberRemoved`: `DeleteActionSetMember` ran BEFORE the version guard. A stale Remove after a re-Add silently revokes membership.
- `ActionSetMemberReordered`: parent `TouchActionSetUpdatedAt` was a separate bump that the per-member UPDATE could race against.

## Fix

New `ClaimActionSetForMembership :execrows` runs FIRST and bumps `updated_at` + `projection_version` only when the parent set exists, is alive, and the event is newer than the current version. `n == 0` means skip the membership mutation entirely. `RecountActionSetMembers` drops its version guard (the Claim already stamped) and uses live `COUNT(*)` so `ON CONFLICT DO NOTHING` idempotency cannot drift the counter.

`TouchActionSetUpdatedAt` is removed — the Claim does the same job for the Reordered handler in one query.

## Regression test

`TestActionSetListener_StaleMemberAddedDoesNotRecreateMembership` directly drives the listener with an older `SequenceNum` after a Remove, asserts the membership row is NOT recreated and `member_count` stays at 0.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...` all clean
- [x] `go test -run TestActionSet ./internal/projectors/` — all green including the new regression

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where stale events could incorrectly restore deleted member records in action sets, compromising data consistency.

* **Tests**
  * Added regression test to prevent stale membership events from recreating removed members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->