### PR TITLE
refactor: port compliance_policy projector to Go listener (Part of #136)

### DIFF
--- a/internal/projectors/compliance_policy.go
+++ b/internal/projectors/compliance_policy.go
@@ -1,0 +1,249 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// CompliancePolicyCreatedPayload mirrors the fields the deleted PL/pgSQL
+// project_compliance_policy_event() read out of a CompliancePolicyCreated
+// event:
+//
+//   - name (required, NOT NULL column — the PL/pgSQL projector wrote
+//     `event.data->>'name'` directly into the column; missing key would
+//     surface as a constraint violation, so we surface that as a
+//     decoder-level validation error one layer earlier).
+//   - description (defaults to "" to match the PL/pgSQL
+//     `COALESCE(event.data->>'description', '')` fallback).
+type CompliancePolicyCreatedPayload struct {
+	ID          string
+	Name        string
+	Description string
+	CreatedBy   string
+}
+
+type compliancePolicyCreatedRaw struct {
+	Name        string  `json:"name"`
+	Description *string `json:"description,omitempty"`
+}
+
+// CompliancePolicyCreatedFromEvent decodes CompliancePolicyCreated.
+// Returns ErrIgnoredEvent for any other (stream, event_type) so the
+// listener wrapper can silently no-op.
+func CompliancePolicyCreatedFromEvent(e store.PersistedEvent) (CompliancePolicyCreatedPayload, error) {
+	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyCreated" {
+		return CompliancePolicyCreatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return CompliancePolicyCreatedPayload{}, fmt.Errorf("projector: empty CompliancePolicyCreated payload")
+	}
+	var raw compliancePolicyCreatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return CompliancePolicyCreatedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyCreated payload: %w", err)
+	}
+	if raw.Name == "" {
+		return CompliancePolicyCreatedPayload{}, fmt.Errorf("projector: CompliancePolicyCreated requires name")
+	}
+	out := CompliancePolicyCreatedPayload{
+		ID:        e.StreamID,
+		Name:      raw.Name,
+		CreatedBy: e.ActorID,
+	}
+	if raw.Description != nil {
+		out.Description = *raw.Description
+	}
+	return out, nil
+}
+
+// CompliancePolicyRenamedPayload mirrors the fields the PL/pgSQL
+// projector read for a CompliancePolicyRenamed event. Name is required
+// — the PL/pgSQL projector assigned `event.data->>'name'` directly into
+// the NOT NULL column, so a missing key would have nulled it out.
+type CompliancePolicyRenamedPayload struct {
+	ID   string
+	Name string
+}
+
+type compliancePolicyRenamedRaw struct {
+	Name string `json:"name"`
+}
+
+// CompliancePolicyRenamedFromEvent decodes CompliancePolicyRenamed.
+func CompliancePolicyRenamedFromEvent(e store.PersistedEvent) (CompliancePolicyRenamedPayload, error) {
+	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyRenamed" {
+		return CompliancePolicyRenamedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return CompliancePolicyRenamedPayload{}, fmt.Errorf("projector: empty CompliancePolicyRenamed payload")
+	}
+	var raw compliancePolicyRenamedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return CompliancePolicyRenamedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyRenamed payload: %w", err)
+	}
+	if raw.Name == "" {
+		return CompliancePolicyRenamedPayload{}, fmt.Errorf("projector: CompliancePolicyRenamed requires name")
+	}
+	return CompliancePolicyRenamedPayload{ID: e.StreamID, Name: raw.Name}, nil
+}
+
+// CompliancePolicyDescriptionUpdatedPayload mirrors the PL/pgSQL
+// projector's `COALESCE(event.data->>'description', '')` fallback —
+// missing or null description collapses to the empty string so the
+// underlying NOT NULL column gets a valid value.
+type CompliancePolicyDescriptionUpdatedPayload struct {
+	ID          string
+	Description string
+}
+
+type compliancePolicyDescriptionUpdatedRaw struct {
+	Description *string `json:"description,omitempty"`
+}
+
+// CompliancePolicyDescriptionUpdatedFromEvent decodes
+// CompliancePolicyDescriptionUpdated.
+func CompliancePolicyDescriptionUpdatedFromEvent(e store.PersistedEvent) (CompliancePolicyDescriptionUpdatedPayload, error) {
+	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyDescriptionUpdated" {
+		return CompliancePolicyDescriptionUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := CompliancePolicyDescriptionUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw compliancePolicyDescriptionUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return CompliancePolicyDescriptionUpdatedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyDescriptionUpdated payload: %w", err)
+	}
+	if raw.Description != nil {
+		out.Description = *raw.Description
+	}
+	return out, nil
+}
+
+// CompliancePolicyRuleAddedPayload mirrors the PL/pgSQL projector's
+// reads for a CompliancePolicyRuleAdded event:
+//
+//   - action_id (required, composite-PK column).
+//   - action_name (defaults to "" — matches PL/pgSQL
+//     `COALESCE(event.data->>'action_name', '')` for the NOT NULL column).
+//   - grace_period_hours (defaults to 0 — matches PL/pgSQL
+//     `COALESCE((event.data->>'grace_period_hours')::INTEGER, 0)`).
+//
+// PolicyID is sourced from the event's stream_id (the PL/pgSQL projector
+// indexed off `event.stream_id`), not the payload.
+type CompliancePolicyRuleAddedPayload struct {
+	PolicyID         string
+	ActionID         string
+	ActionName       string
+	GracePeriodHours int32
+}
+
+type compliancePolicyRuleAddedRaw struct {
+	ActionID         string  `json:"action_id"`
+	ActionName       *string `json:"action_name,omitempty"`
+	GracePeriodHours *int32  `json:"grace_period_hours,omitempty"`
+}
+
+// CompliancePolicyRuleAddedFromEvent decodes CompliancePolicyRuleAdded.
+func CompliancePolicyRuleAddedFromEvent(e store.PersistedEvent) (CompliancePolicyRuleAddedPayload, error) {
+	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyRuleAdded" {
+		return CompliancePolicyRuleAddedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return CompliancePolicyRuleAddedPayload{}, fmt.Errorf("projector: empty CompliancePolicyRuleAdded payload")
+	}
+	var raw compliancePolicyRuleAddedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return CompliancePolicyRuleAddedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyRuleAdded payload: %w", err)
+	}
+	if raw.ActionID == "" {
+		return CompliancePolicyRuleAddedPayload{}, fmt.Errorf("projector: CompliancePolicyRuleAdded requires action_id")
+	}
+	out := CompliancePolicyRuleAddedPayload{
+		PolicyID: e.StreamID,
+		ActionID: raw.ActionID,
+	}
+	if raw.ActionName != nil {
+		out.ActionName = *raw.ActionName
+	}
+	if raw.GracePeriodHours != nil {
+		out.GracePeriodHours = *raw.GracePeriodHours
+	}
+	return out, nil
+}
+
+// CompliancePolicyRuleRemovedPayload covers CompliancePolicyRuleRemoved.
+// Only action_id is read from the payload; PolicyID comes from the
+// stream id (matches the PL/pgSQL projector's `event.stream_id`).
+type CompliancePolicyRuleRemovedPayload struct {
+	PolicyID string
+	ActionID string
+}
+
+type compliancePolicyRuleRemovedRaw struct {
+	ActionID string `json:"action_id"`
+}
+
+// CompliancePolicyRuleRemovedFromEvent decodes CompliancePolicyRuleRemoved.
+func CompliancePolicyRuleRemovedFromEvent(e store.PersistedEvent) (CompliancePolicyRuleRemovedPayload, error) {
+	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyRuleRemoved" {
+		return CompliancePolicyRuleRemovedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return CompliancePolicyRuleRemovedPayload{}, fmt.Errorf("projector: empty CompliancePolicyRuleRemoved payload")
+	}
+	var raw compliancePolicyRuleRemovedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return CompliancePolicyRuleRemovedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyRuleRemoved payload: %w", err)
+	}
+	if raw.ActionID == "" {
+		return CompliancePolicyRuleRemovedPayload{}, fmt.Errorf("projector: CompliancePolicyRuleRemoved requires action_id")
+	}
+	return CompliancePolicyRuleRemovedPayload{
+		PolicyID: e.StreamID,
+		ActionID: raw.ActionID,
+	}, nil
+}
+
+// CompliancePolicyRuleUpdatedPayload mirrors the PL/pgSQL projector's
+// reads for a CompliancePolicyRuleUpdated event:
+//
+//   - action_id (required, composite-PK column the UPDATE filters on).
+//   - grace_period_hours (defaults to 0 — matches PL/pgSQL
+//     `COALESCE((event.data->>'grace_period_hours')::INTEGER, 0)`).
+type CompliancePolicyRuleUpdatedPayload struct {
+	PolicyID         string
+	ActionID         string
+	GracePeriodHours int32
+}
+
+type compliancePolicyRuleUpdatedRaw struct {
+	ActionID         string `json:"action_id"`
+	GracePeriodHours *int32 `json:"grace_period_hours,omitempty"`
+}
+
+// CompliancePolicyRuleUpdatedFromEvent decodes CompliancePolicyRuleUpdated.
+func CompliancePolicyRuleUpdatedFromEvent(e store.PersistedEvent) (CompliancePolicyRuleUpdatedPayload, error) {
+	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyRuleUpdated" {
+		return CompliancePolicyRuleUpdatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return CompliancePolicyRuleUpdatedPayload{}, fmt.Errorf("projector: empty CompliancePolicyRuleUpdated payload")
+	}
+	var raw compliancePolicyRuleUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return CompliancePolicyRuleUpdatedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyRuleUpdated payload: %w", err)
+	}
+	if raw.ActionID == "" {
+		return CompliancePolicyRuleUpdatedPayload{}, fmt.Errorf("projector: CompliancePolicyRuleUpdated requires action_id")
+	}
+	out := CompliancePolicyRuleUpdatedPayload{
+		PolicyID: e.StreamID,
+		ActionID: raw.ActionID,
+	}
+	if raw.GracePeriodHours != nil {
+		out.GracePeriodHours = *raw.GracePeriodHours
+	}
+	return out, nil
+}

--- a/internal/projectors/compliance_policy.go
+++ b/internal/projectors/compliance_policy.go
@@ -16,7 +16,7 @@ import (
 //     surface as a constraint violation, so we surface that as a
 //     decoder-level validation error one layer earlier).
 //   - description (defaults to "" to match the PL/pgSQL
-//     `COALESCE(event.data->>'description', '')` fallback).
+//     `COALESCE(event.data->>'description', "")` fallback).
 type CompliancePolicyCreatedPayload struct {
 	ID          string
 	Name        string
@@ -89,7 +89,7 @@ func CompliancePolicyRenamedFromEvent(e store.PersistedEvent) (CompliancePolicyR
 }
 
 // CompliancePolicyDescriptionUpdatedPayload mirrors the PL/pgSQL
-// projector's `COALESCE(event.data->>'description', '')` fallback —
+// projector's `COALESCE(event.data->>'description', "")` fallback —
 // missing or null description collapses to the empty string so the
 // underlying NOT NULL column gets a valid value.
 type CompliancePolicyDescriptionUpdatedPayload struct {
@@ -126,7 +126,7 @@ func CompliancePolicyDescriptionUpdatedFromEvent(e store.PersistedEvent) (Compli
 //
 //   - action_id (required, composite-PK column).
 //   - action_name (defaults to "" — matches PL/pgSQL
-//     `COALESCE(event.data->>'action_name', '')` for the NOT NULL column).
+//     `COALESCE(event.data->>'action_name', "")` for the NOT NULL column).
 //   - grace_period_hours (defaults to 0 — matches PL/pgSQL
 //     `COALESCE((event.data->>'grace_period_hours')::INTEGER, 0)`).
 //

--- a/internal/projectors/compliance_policy_listener.go
+++ b/internal/projectors/compliance_policy_listener.go
@@ -1,0 +1,315 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// CompliancePolicyListener returns a store.EventListener that applies
+// every compliance_policy stream event the deleted PL/pgSQL
+// project_compliance_policy_event handled. Seven event types: Created,
+// Renamed, DescriptionUpdated, Deleted, RuleAdded, RuleRemoved,
+// RuleUpdated.
+//
+// Event-type families:
+//   - Policy CRUD: Created (INSERT), Renamed / DescriptionUpdated
+//     (single guarded UPDATE), Deleted (soft-delete + cascade DELETE on
+//     rules + DELETE on evaluations + reevaluate-devices shim, wrapped
+//     in store.WithTx).
+//   - Rule edits: RuleAdded (Claim guard + UPSERT + recount, wrapped in
+//     store.WithTx), RuleRemoved (Claim guard + DELETE rule + recount +
+//     DELETE evaluations + reevaluate-devices shim, wrapped in
+//     store.WithTx), RuleUpdated (Claim guard + per-row UPDATE,
+//     wrapped in store.WithTx).
+//
+// Multi-write listeners (Deleted, RuleAdded, RuleRemoved, RuleUpdated)
+// follow the asymmetric-guard discipline:
+//
+//   - Deleted: the guarded UPDATE (SoftDelete) is :execrows, and the
+//     listener short-circuits the cascade (rule wipe, evaluation wipe,
+//     reevaluate) when n == 0.
+//   - RuleAdded / RuleRemoved / RuleUpdated: the Claim-first guard
+//     (ClaimCompliancePolicyForRuleMutation, :execrows) bumps the parent's
+//     projection_version BEFORE any rule-table mutation, and the
+//     listener short-circuits when n == 0. This is the lesson from
+//     PR #174's CR review: the prior insert-then-recount shape let
+//     stale replays silently resurrect removed rules or rewind a
+//     fresher RuleUpdated, because the version check was downstream of
+//     the child-row mutation.
+//
+// Reevaluation engine scope: per #136 the
+// reevaluate_compliance_policy_devices(p_policy_id) function — and the
+// evaluate_device_compliance_policies family it calls — STAY in
+// PL/pgSQL until a later phase. The Go listener calls into the shim
+// (sqlc-generated ReevaluateCompliancePolicyDevices) so device
+// compliance status reflects rule mutations; the eval engine itself
+// runs unchanged inside Postgres.
+//
+// Wired in projectors.WireAll. Refs #136 (Phase 2 of tracker #107).
+func CompliancePolicyListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "compliance_policy" {
+			return
+		}
+		// Multi-write events route through ApplyCompliancePolicy via
+		// WithTx so the cascade stays atomic; single-statement events
+		// (Created, Renamed, DescriptionUpdated) go on the autocommit
+		// pool. ApplyCompliancePolicy handles all seven event types
+		// when called with tx-bound queries (the rebuild path), so
+		// we share its body here for the multi-write cases via WithTx
+		// and short-circuit the simple cases through the pool.
+		switch e.EventType {
+		case "CompliancePolicyDeleted",
+			"CompliancePolicyRuleAdded",
+			"CompliancePolicyRuleRemoved",
+			"CompliancePolicyRuleUpdated":
+			if err := st.WithTx(ctx, func(q *store.Queries) error {
+				return ApplyCompliancePolicy(ctx, q, e)
+			}); err != nil {
+				logger.Warn("compliance_policy projector: failed to apply event",
+					"event_id", e.ID, "event_type", e.EventType, "policy_id", e.StreamID, "error", err)
+			}
+			return
+		}
+		if err := ApplyCompliancePolicy(ctx, st.Queries(), e); err != nil {
+			logger.Warn("compliance_policy projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "policy_id", e.StreamID, "error", err)
+		}
+	}
+}
+
+// ApplyCompliancePolicy is the transactional core of the
+// compliance_policy projector. The listener wraps it for live-event
+// dispatch (using WithTx for the multi-write event types); future
+// rebuild wiring would register it via RegisterRebuildApply so
+// RebuildAll re-derives the projection from the event store instead
+// of dispatching to the no-op PL/pgSQL stub
+// (manchtools/power-manage-server#125 + #136).
+//
+// Asymmetric-guard discipline is preserved across every multi-write
+// event: when the version-guarded UPDATE on the parent row affects
+// zero rows, every cascading INSERT/DELETE downstream is skipped —
+// otherwise a stale event re-applied later would leak rule_count
+// drift, dangling rules, dangling evaluations, or removed rules
+// reappearing.
+func ApplyCompliancePolicy(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "compliance_policy" {
+		return nil
+	}
+	switch e.EventType {
+	case "CompliancePolicyCreated":
+		return applyCompliancePolicyCreated(ctx, q, e)
+	case "CompliancePolicyRenamed":
+		return applyCompliancePolicyRenamed(ctx, q, e)
+	case "CompliancePolicyDescriptionUpdated":
+		return applyCompliancePolicyDescriptionUpdated(ctx, q, e)
+	case "CompliancePolicyDeleted":
+		return applyCompliancePolicyDeleted(ctx, q, e)
+	case "CompliancePolicyRuleAdded":
+		return applyCompliancePolicyRuleAdded(ctx, q, e)
+	case "CompliancePolicyRuleRemoved":
+		return applyCompliancePolicyRuleRemoved(ctx, q, e)
+	case "CompliancePolicyRuleUpdated":
+		return applyCompliancePolicyRuleUpdated(ctx, q, e)
+	}
+	return nil
+}
+
+func applyCompliancePolicyCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := CompliancePolicyCreatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	createdAt := e.OccurredAt
+	return q.InsertCompliancePolicyProjection(ctx, db.InsertCompliancePolicyProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		Description:       payload.Description,
+		CreatedAt:         &createdAt,
+		CreatedBy:         payload.CreatedBy,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+}
+
+func applyCompliancePolicyRenamed(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := CompliancePolicyRenamedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.RenameCompliancePolicyProjection(ctx, db.RenameCompliancePolicyProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyCompliancePolicyDescriptionUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := CompliancePolicyDescriptionUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.UpdateCompliancePolicyDescriptionProjection(ctx, db.UpdateCompliancePolicyDescriptionProjectionParams{
+		ID:                payload.ID,
+		Description:       payload.Description,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyCompliancePolicyDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	n, err := q.SoftDeleteCompliancePolicyProjection(ctx, db.SoftDeleteCompliancePolicyProjectionParams{
+		ID:                e.StreamID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		// Stale CompliancePolicyDeleted replay against a row whose
+		// projection_version has moved past this event. Skipping the
+		// cascade (rule wipe, evaluation wipe, reevaluate shim) is
+		// mandatory: otherwise an old delete re-applied by the
+		// reconciler against a freshly-restored policy would silently
+		// nuke its rules and evaluations and trigger a needless
+		// device re-evaluation pass.
+		return nil
+	}
+	if err := q.DeleteCompliancePolicyRulesByPolicy(ctx, e.StreamID); err != nil {
+		return err
+	}
+	if err := q.DeleteCompliancePolicyEvaluationsByPolicy(ctx, e.StreamID); err != nil {
+		return err
+	}
+	// reevaluate_compliance_policy_devices is the still-PL/pgSQL eval
+	// engine's entry point per #136. Calling it here keeps device
+	// compliance status in sync with the policy deletion (devices
+	// whose only failing rule lived under the now-deleted policy
+	// flip back to compliant on the next read).
+	return q.ReevaluateCompliancePolicyDevices(ctx, e.StreamID)
+}
+
+func applyCompliancePolicyRuleAdded(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := CompliancePolicyRuleAddedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	// Claim-first guard: the Claim query bumps projection_version only
+	// when the policy exists, is alive, and the event is newer.
+	// n==0 means one of those preconditions failed — skip the rule
+	// mutation entirely. Doing the version check AFTER the UPSERT
+	// (the prior insert-then-recount shape used by other ports before
+	// PR #174's CR review) let stale events resurrect removed rules
+	// even when the parent guard would have rejected the version bump.
+	n, err := q.ClaimCompliancePolicyForRuleMutation(ctx, db.ClaimCompliancePolicyForRuleMutationParams{
+		ID:                payload.PolicyID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	addedAt := e.OccurredAt
+	if err := q.UpsertCompliancePolicyRule(ctx, db.UpsertCompliancePolicyRuleParams{
+		PolicyID:          payload.PolicyID,
+		ActionID:          payload.ActionID,
+		ActionName:        payload.ActionName,
+		GracePeriodHours:  payload.GracePeriodHours,
+		AddedAt:           &addedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	// Recount after mutate (live COUNT(*)) so the UPSERT half (which
+	// either inserts or updates in-place) does not drift rule_count:
+	// a re-emitted RuleAdded for the same (policy, action) pair must
+	// not increment the count.
+	return q.RecountCompliancePolicyRules(ctx, payload.PolicyID)
+}
+
+func applyCompliancePolicyRuleRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := CompliancePolicyRuleRemovedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	n, err := q.ClaimCompliancePolicyForRuleMutation(ctx, db.ClaimCompliancePolicyForRuleMutationParams{
+		ID:                payload.PolicyID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	if err := q.DeleteCompliancePolicyRule(ctx, db.DeleteCompliancePolicyRuleParams{
+		PolicyID: payload.PolicyID,
+		ActionID: payload.ActionID,
+	}); err != nil {
+		return err
+	}
+	if err := q.RecountCompliancePolicyRules(ctx, payload.PolicyID); err != nil {
+		return err
+	}
+	if err := q.DeleteCompliancePolicyEvaluationsByRule(ctx, db.DeleteCompliancePolicyEvaluationsByRuleParams{
+		PolicyID: payload.PolicyID,
+		ActionID: payload.ActionID,
+	}); err != nil {
+		return err
+	}
+	return q.ReevaluateCompliancePolicyDevices(ctx, payload.PolicyID)
+}
+
+func applyCompliancePolicyRuleUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := CompliancePolicyRuleUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	n, err := q.ClaimCompliancePolicyForRuleMutation(ctx, db.ClaimCompliancePolicyForRuleMutationParams{
+		ID:                payload.PolicyID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	return q.UpdateCompliancePolicyRuleGracePeriod(ctx, db.UpdateCompliancePolicyRuleGracePeriodParams{
+		PolicyID:          payload.PolicyID,
+		ActionID:          payload.ActionID,
+		GracePeriodHours:  payload.GracePeriodHours,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+}

--- a/internal/projectors/compliance_policy_test.go
+++ b/internal/projectors/compliance_policy_test.go
@@ -28,7 +28,7 @@ func setupComplianceTestStore(t *testing.T) *store.Store {
 // TestCompliancePolicyCreatedFromEvent_Pure pins the decoder defaults
 // that match the deleted PL/pgSQL projector: name is required (NOT NULL
 // column), missing description collapses to "" (matches PL/pgSQL
-// `COALESCE(payload, '')`).
+// `COALESCE(payload, "")`).
 func TestCompliancePolicyCreatedFromEvent_Pure(t *testing.T) {
 	t.Run("happy path with all fields", func(t *testing.T) {
 		got, err := projectors.CompliancePolicyCreatedFromEvent(store.PersistedEvent{
@@ -118,7 +118,7 @@ func TestCompliancePolicyRenamedFromEvent_Pure(t *testing.T) {
 
 // TestCompliancePolicyDescriptionUpdatedFromEvent_Pure — missing
 // description collapses to "" (matches PL/pgSQL
-// `COALESCE(event.data->>'description', '')`).
+// `COALESCE(event.data->>'description', "")`).
 func TestCompliancePolicyDescriptionUpdatedFromEvent_Pure(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		got, err := projectors.CompliancePolicyDescriptionUpdatedFromEvent(store.PersistedEvent{

--- a/internal/projectors/compliance_policy_test.go
+++ b/internal/projectors/compliance_policy_test.go
@@ -440,6 +440,43 @@ func TestCompliancePolicyListener_RuleAddedUpsertReplacesFields(t *testing.T) {
 	assert.Equal(t, int32(1), got.RuleCount, "rule_count counts distinct rules, not Added events")
 }
 
+// TestCompliancePolicyListener_RuleAddedPreservesActionNameOnEmptyReplay
+// locks the CR catch on PR #178: a duplicate CompliancePolicyRuleAdded
+// that omits action_name (decoder collapses missing → "") MUST NOT
+// erase a previously-set action_name. The PL/pgSQL projector did
+// `COALESCE(payload->>'action_name', existing.action_name)`; the Go
+// port preserves that semantic via NULLIF + COALESCE in the UPSERT.
+func TestCompliancePolicyListener_RuleAddedPreservesActionNameOnEmptyReplay(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := createTestCompliancePolicy(t, st, "u", "preserve")
+	actionID := "act-" + uuid.NewString()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id": actionID, "action_name": "named-rule", "grace_period_hours": 6,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id": actionID, "grace_period_hours": 24,
+			// action_name intentionally omitted — should preserve "named-rule"
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	rules, err := st.Queries().ListCompliancePolicyRules(ctx, policyID)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, "named-rule", rules[0].ActionName,
+		"duplicate RuleAdded that omits action_name must preserve the existing name")
+	assert.Equal(t, int32(24), rules[0].GracePeriodHours,
+		"grace_period_hours always overwrites — the COALESCE is action_name-only")
+}
+
 // TestCompliancePolicyListener_DeleteCascadesRulesAndEvaluations
 // confirms CompliancePolicyDeleted soft-deletes the policy, wipes
 // every rule row, AND wipes every evaluation row pointing at it.

--- a/internal/projectors/compliance_policy_test.go
+++ b/internal/projectors/compliance_policy_test.go
@@ -1,0 +1,753 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// setupComplianceTestStore is a tiny aliased wrapper so the listener
+// test can swap fixtures without touching every call site if the
+// shared helper later grows extra knobs (e.g. seeding compliance
+// actions). For now it just delegates to testutil.SetupPostgres.
+func setupComplianceTestStore(t *testing.T) *store.Store {
+	t.Helper()
+	return testutil.SetupPostgres(t)
+}
+
+// TestCompliancePolicyCreatedFromEvent_Pure pins the decoder defaults
+// that match the deleted PL/pgSQL projector: name is required (NOT NULL
+// column), missing description collapses to "" (matches PL/pgSQL
+// `COALESCE(payload, '')`).
+func TestCompliancePolicyCreatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyCreatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyCreated", ActorID: "u-1",
+			Data: jsonOrFail(t, map[string]any{
+				"name":        "baseline",
+				"description": "company baseline policy",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "cp-1", got.ID)
+		assert.Equal(t, "baseline", got.Name)
+		assert.Equal(t, "company baseline policy", got.Description)
+		assert.Equal(t, "u-1", got.CreatedBy)
+	})
+
+	t.Run("missing description → empty string", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyCreatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-2", EventType: "CompliancePolicyCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"name": "minimal"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description)
+	})
+
+	t.Run("name is required", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyCreatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-3", EventType: "CompliancePolicyCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"description": "no name"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "name")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "CompliancePolicyCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.CompliancePolicyCreatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", EventType: "CompliancePolicyRenamed",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyCreatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", EventType: "CompliancePolicyCreated",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestCompliancePolicyRenamedFromEvent_Pure — name is required (the
+// PL/pgSQL projector wrote `event.data->>'name'` directly into the
+// NOT NULL column; missing key would NULL it out).
+func TestCompliancePolicyRenamedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyRenamedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyRenamed",
+			Data: jsonOrFail(t, map[string]any{"name": "renamed"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "cp-1", got.ID)
+		assert.Equal(t, "renamed", got.Name)
+	})
+
+	t.Run("missing name fails", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyRenamedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyRenamed",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyRenamedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", EventType: "CompliancePolicyCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestCompliancePolicyDescriptionUpdatedFromEvent_Pure — missing
+// description collapses to "" (matches PL/pgSQL
+// `COALESCE(event.data->>'description', '')`).
+func TestCompliancePolicyDescriptionUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{"description": "new desc"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "cp-1", got.ID)
+		assert.Equal(t, "new desc", got.Description)
+	})
+
+	t.Run("missing description → empty string", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description)
+	})
+
+	t.Run("explicit empty string description preserved", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{"description": ""}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description)
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", EventType: "CompliancePolicyRenamed",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestCompliancePolicyRuleAddedFromEvent_Pure — action_id is required,
+// action_name defaults to "" (NOT NULL column), grace_period_hours
+// defaults to 0 (matches the PL/pgSQL
+// `COALESCE((event.data->>'grace_period_hours')::INTEGER, 0)`).
+func TestCompliancePolicyRuleAddedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyRuleAddedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyRuleAdded",
+			Data: jsonOrFail(t, map[string]any{
+				"action_id":          "act-1",
+				"action_name":        "ssh-disabled",
+				"grace_period_hours": 24,
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "cp-1", got.PolicyID)
+		assert.Equal(t, "act-1", got.ActionID)
+		assert.Equal(t, "ssh-disabled", got.ActionName)
+		assert.Equal(t, int32(24), got.GracePeriodHours)
+	})
+
+	t.Run("defaults: action_name empty, grace_period_hours zero", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyRuleAddedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyRuleAdded",
+			Data: jsonOrFail(t, map[string]any{"action_id": "act-2"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.ActionName)
+		assert.Equal(t, int32(0), got.GracePeriodHours)
+	})
+
+	t.Run("missing action_id fails", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyRuleAddedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyRuleAdded",
+			Data: jsonOrFail(t, map[string]any{"action_name": "noop"}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "action_id")
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyRuleAddedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", EventType: "CompliancePolicyCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestCompliancePolicyRuleRemovedFromEvent_Pure — action_id is the only
+// payload key; required because the DELETE filters on it.
+func TestCompliancePolicyRuleRemovedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyRuleRemovedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyRuleRemoved",
+			Data: jsonOrFail(t, map[string]any{"action_id": "act-1"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "cp-1", got.PolicyID)
+		assert.Equal(t, "act-1", got.ActionID)
+	})
+
+	t.Run("missing action_id fails", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyRuleRemovedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyRuleRemoved",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "action_id")
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyRuleRemovedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", EventType: "CompliancePolicyCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestCompliancePolicyRuleUpdatedFromEvent_Pure — action_id is
+// required (composite-PK targeted UPDATE); grace_period_hours defaults
+// to 0 (matches PL/pgSQL COALESCE).
+func TestCompliancePolicyRuleUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyRuleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyRuleUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"action_id":          "act-1",
+				"grace_period_hours": 48,
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "cp-1", got.PolicyID)
+		assert.Equal(t, "act-1", got.ActionID)
+		assert.Equal(t, int32(48), got.GracePeriodHours)
+	})
+
+	t.Run("missing grace_period_hours → 0", func(t *testing.T) {
+		got, err := projectors.CompliancePolicyRuleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyRuleUpdated",
+			Data: jsonOrFail(t, map[string]any{"action_id": "act-1"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), got.GracePeriodHours)
+	})
+
+	t.Run("missing action_id fails", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyRuleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", StreamID: "cp-1", EventType: "CompliancePolicyRuleUpdated",
+			Data: jsonOrFail(t, map[string]any{"grace_period_hours": 24}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "action_id")
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.CompliancePolicyRuleUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance_policy", EventType: "CompliancePolicyRuleAdded",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests (testcontainers-backed Postgres).
+// ---------------------------------------------------------------------------
+
+// createTestCompliancePolicy emits a CompliancePolicyCreated event and
+// returns the policy ID. Local helper — compliance policy isn't a
+// general-purpose testutil entry yet.
+func createTestCompliancePolicy(t *testing.T, st *store.Store, actorID, name string) string {
+	t.Helper()
+	id := newCompliancePolicyID()
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "compliance_policy", StreamID: id, EventType: "CompliancePolicyCreated",
+		Data:      map[string]any{"name": name, "description": ""},
+		ActorType: "user", ActorID: actorID,
+	}))
+	return id
+}
+
+// newCompliancePolicyID is a local id minter so the per-test
+// policies don't collide. Mirrors testutil.NewID() but lives here so
+// the helper file isn't dragged into testutil for one type.
+func newCompliancePolicyID() string {
+	return "cp-" + uuid.NewString()
+}
+
+// TestCompliancePolicyListener_CreateRenameDescription covers the three
+// single-statement events end-to-end. Confirms row state advances and
+// projection_version bumps monotonically.
+func TestCompliancePolicyListener_CreateRenameDescription(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := newCompliancePolicyID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyCreated",
+		Data:      map[string]any{"name": "initial", "description": "first desc"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+
+	got, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, "initial", got.Name)
+	assert.Equal(t, "first desc", got.Description)
+	assert.Equal(t, int32(0), got.RuleCount)
+	assert.Greater(t, got.ProjectionVersion, int64(0))
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRenamed",
+		Data:      map[string]any{"name": "renamed"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", got.Name)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyDescriptionUpdated",
+		Data:      map[string]any{"description": "second desc"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, "second desc", got.Description)
+}
+
+// TestCompliancePolicyListener_RuleLifecycle covers the full
+// RuleAdded → RuleUpdated → RuleRemoved cycle with rule_count tracking.
+func TestCompliancePolicyListener_RuleLifecycle(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := createTestCompliancePolicy(t, st, "u", "lifecycle")
+	actionA := "act-" + uuid.NewString()
+	actionB := "act-" + uuid.NewString()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id": actionA, "action_name": "ssh-disabled", "grace_period_hours": 24,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id": actionB, "action_name": "ufw-enabled", "grace_period_hours": 12,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	got, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), got.RuleCount)
+
+	rules, err := st.Queries().ListCompliancePolicyRules(ctx, policyID)
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+
+	// Update grace_period_hours on the first rule.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleUpdated",
+		Data:      map[string]any{"action_id": actionA, "grace_period_hours": 72},
+		ActorType: "user", ActorID: "u",
+	}))
+	rules, err = st.Queries().ListCompliancePolicyRules(ctx, policyID)
+	require.NoError(t, err)
+	for _, r := range rules {
+		if r.ActionID == actionA {
+			assert.Equal(t, int32(72), r.GracePeriodHours, "RuleUpdated must change grace_period_hours")
+		}
+	}
+
+	// Remove the second rule. rule_count drops back to 1.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleRemoved",
+		Data:      map[string]any{"action_id": actionB},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), got.RuleCount)
+	rules, err = st.Queries().ListCompliancePolicyRules(ctx, policyID)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, actionA, rules[0].ActionID)
+}
+
+// TestCompliancePolicyListener_RuleAddedUpsertReplacesFields covers the
+// PL/pgSQL projector's `ON CONFLICT (policy_id, action_id) DO UPDATE`:
+// re-emitting RuleAdded for the same (policy, action) pair updates
+// action_name + grace_period_hours, not just no-ops.
+func TestCompliancePolicyListener_RuleAddedUpsertReplacesFields(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := createTestCompliancePolicy(t, st, "u", "upsert")
+	actionID := "act-" + uuid.NewString()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id": actionID, "action_name": "old-name", "grace_period_hours": 12,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id": actionID, "action_name": "new-name", "grace_period_hours": 48,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	rules, err := st.Queries().ListCompliancePolicyRules(ctx, policyID)
+	require.NoError(t, err)
+	require.Len(t, rules, 1, "duplicate RuleAdded must upsert, not insert")
+	assert.Equal(t, "new-name", rules[0].ActionName)
+	assert.Equal(t, int32(48), rules[0].GracePeriodHours)
+
+	got, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), got.RuleCount, "rule_count counts distinct rules, not Added events")
+}
+
+// TestCompliancePolicyListener_DeleteCascadesRulesAndEvaluations
+// confirms CompliancePolicyDeleted soft-deletes the policy, wipes
+// every rule row, AND wipes every evaluation row pointing at it.
+// reevaluate_compliance_policy_devices is also called (we plant an
+// assignment + device pair to surface that the call landed without
+// crashing — the eval engine itself is still PL/pgSQL per #136 and
+// out of scope).
+func TestCompliancePolicyListener_DeleteCascadesRulesAndEvaluations(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := createTestCompliancePolicy(t, st, "u", "to-delete")
+	actionID := "act-" + uuid.NewString()
+	deviceID := "dev-" + uuid.NewString()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id": actionID, "action_name": "cascade-rule", "grace_period_hours": 1,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Plant an evaluation row directly so we can confirm the cascade
+	// half of CompliancePolicyDeleted wipes it. Live evaluation rows
+	// are written by the still-PL/pgSQL eval engine; we simulate one
+	// to lock the cascade behaviour.
+	_, err := st.Pool().Exec(ctx,
+		`INSERT INTO compliance_policy_evaluation_projection
+		   (device_id, policy_id, action_id, compliant, status, projection_version)
+		 VALUES ($1, $2, $3, FALSE, 0, 1)`,
+		deviceID, policyID, actionID,
+	)
+	require.NoError(t, err)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Policy row marked deleted.
+	var isDeleted bool
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT is_deleted FROM compliance_policies_projection WHERE id = $1", policyID,
+	).Scan(&isDeleted))
+	assert.True(t, isDeleted)
+
+	// Rules wiped.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_policy_rules_projection WHERE policy_id = $1", policyID,
+	).Scan(&count))
+	assert.Equal(t, 0, count)
+
+	// Evaluations wiped.
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_policy_evaluation_projection WHERE policy_id = $1", policyID,
+	).Scan(&count))
+	assert.Equal(t, 0, count)
+}
+
+// TestCompliancePolicyListener_RuleRemovedWipesEvaluations confirms
+// CompliancePolicyRuleRemoved wipes evaluation rows scoped to the
+// removed (policy, action) pair, mirroring the PL/pgSQL `DELETE FROM
+// compliance_policy_evaluation_projection WHERE policy_id = X AND
+// action_id = Y` cascade. Other rules' evaluations stay put.
+func TestCompliancePolicyListener_RuleRemovedWipesEvaluations(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := createTestCompliancePolicy(t, st, "u", "rule-removed-evals")
+	actionA := "act-" + uuid.NewString()
+	actionB := "act-" + uuid.NewString()
+	deviceID := "dev-" + uuid.NewString()
+
+	for _, aid := range []string{actionA, actionB} {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+			Data:      map[string]any{"action_id": aid, "action_name": "r", "grace_period_hours": 0},
+			ActorType: "user", ActorID: "u",
+		}))
+		_, err := st.Pool().Exec(ctx,
+			`INSERT INTO compliance_policy_evaluation_projection
+			   (device_id, policy_id, action_id, compliant, status, projection_version)
+			 VALUES ($1, $2, $3, FALSE, 0, 1)`,
+			deviceID, policyID, aid,
+		)
+		require.NoError(t, err)
+	}
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleRemoved",
+		Data:      map[string]any{"action_id": actionA},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_policy_evaluation_projection WHERE policy_id = $1 AND action_id = $2",
+		policyID, actionA,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "RuleRemoved must wipe evaluations for the (policy, action) pair")
+
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_policy_evaluation_projection WHERE policy_id = $1 AND action_id = $2",
+		policyID, actionB,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "RuleRemoved must NOT wipe evaluations for OTHER rules in the same policy")
+}
+
+// TestCompliancePolicyListener_StaleRenameRejected — the UPDATE form
+// (Renamed) doesn't clobber a fresher row when re-applied with an
+// older projection_version. Mirrors the user_group projector's stale-
+// replay regression test.
+func TestCompliancePolicyListener_StaleRenameRejected(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := createTestCompliancePolicy(t, st, "u", "stale-rename")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRenamed",
+		Data:      map[string]any{"name": "current"},
+		ActorType: "user", ActorID: "u",
+	}))
+	current, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	currentVersion := current.ProjectionVersion
+
+	older := currentVersion - 5
+	n, err := st.Queries().RenameCompliancePolicyProjection(ctx, db.RenameCompliancePolicyProjectionParams{
+		ID:                policyID,
+		Name:              "stale-would-set-this",
+		ProjectionVersion: older,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n, "stale projection_version UPDATE must affect zero rows")
+
+	after, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, "current", after.Name)
+	assert.Equal(t, currentVersion, after.ProjectionVersion)
+}
+
+// TestCompliancePolicyListener_StaleDeleteReplayDoesNotNukeRules locks
+// the asymmetric-guard discipline for the cascade-heavy event type:
+// when the version-guarded SoftDelete affects zero rows, every
+// downstream cascade (rule wipe, evaluation wipe) MUST be skipped.
+func TestCompliancePolicyListener_StaleDeleteReplayDoesNotNukeRules(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := createTestCompliancePolicy(t, st, "u", "live-policy")
+	actionID := "act-" + uuid.NewString()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id": actionID, "action_name": "live-rule", "grace_period_hours": 0,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+
+	// Drive the listener with a stale CompliancePolicyDeleted (older
+	// projection_version than the row currently has).
+	older := live.ProjectionVersion - 5
+	listener := projectors.CompliancePolicyListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "compliance_policy",
+		StreamID:    policyID,
+		EventType:   "CompliancePolicyDeleted",
+		Data:        []byte("{}"),
+		ActorType:   "user",
+		ActorID:     "u",
+	})
+
+	// Policy still alive.
+	stillAlive, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.False(t, stillAlive.IsDeleted, "stale CompliancePolicyDeleted must NOT flip is_deleted")
+
+	// Rule still there.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_policy_rules_projection WHERE policy_id = $1", policyID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale CompliancePolicyDeleted must NOT cascade-delete rules")
+}
+
+// TestCompliancePolicyListener_StaleRuleAddedDoesNotResurrectRemoved
+// locks the Claim-first guard for rule mutations: a stale
+// CompliancePolicyRuleAdded replayed AFTER a CompliancePolicyRuleRemoved
+// must not reinsert the rule, even though the underlying UPSERT is
+// idempotent. The Claim guard runs FIRST so a stale version short-
+// circuits before the rule mutation.
+//
+// This is the rule-event sibling of the user_group MemberAdded CR
+// catch on PR #174 — the insert-then-recount pattern would let stale
+// replays resurrect removed rules silently. Claim-first is the fix.
+func TestCompliancePolicyListener_StaleRuleAddedDoesNotResurrectRemoved(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := createTestCompliancePolicy(t, st, "u", "stale-rule-add")
+	actionID := "act-" + uuid.NewString()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id": actionID, "action_name": "to-remove", "grace_period_hours": 1,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleRemoved",
+		Data:      map[string]any{"action_id": actionID},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), live.RuleCount)
+
+	older := live.ProjectionVersion - 5
+	listener := projectors.CompliancePolicyListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "compliance_policy",
+		StreamID:    policyID,
+		EventType:   "CompliancePolicyRuleAdded",
+		Data: jsonOrFail(t, map[string]any{
+			"action_id": actionID, "action_name": "stale", "grace_period_hours": 99,
+		}),
+		ActorType: "user",
+		ActorID:   "u",
+	})
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_policy_rules_projection WHERE policy_id = $1 AND action_id = $2",
+		policyID, actionID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "stale CompliancePolicyRuleAdded must NOT resurrect the removed rule")
+
+	after, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), after.RuleCount, "rule_count stays at 0 after stale replay")
+	assert.Equal(t, live.ProjectionVersion, after.ProjectionVersion, "projection_version unchanged")
+}
+
+// TestCompliancePolicyListener_StaleRuleUpdatedDoesNotChangeGrace locks
+// the Claim-first guard for RuleUpdated: a stale event must not
+// rewind grace_period_hours after a fresher edit lands.
+func TestCompliancePolicyListener_StaleRuleUpdatedDoesNotChangeGrace(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := createTestCompliancePolicy(t, st, "u", "stale-rule-update")
+	actionID := "act-" + uuid.NewString()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id": actionID, "action_name": "r", "grace_period_hours": 12,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleUpdated",
+		Data:      map[string]any{"action_id": actionID, "grace_period_hours": 99},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+
+	older := live.ProjectionVersion - 5
+	listener := projectors.CompliancePolicyListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "compliance_policy",
+		StreamID:    policyID,
+		EventType:   "CompliancePolicyRuleUpdated",
+		Data:        jsonOrFail(t, map[string]any{"action_id": actionID, "grace_period_hours": 1}),
+		ActorType:   "user",
+		ActorID:     "u",
+	})
+
+	rules, err := st.Queries().ListCompliancePolicyRules(ctx, policyID)
+	require.NoError(t, err)
+	require.Len(t, rules, 1)
+	assert.Equal(t, int32(99), rules[0].GracePeriodHours,
+		"stale CompliancePolicyRuleUpdated must NOT roll grace_period_hours back to its old value")
+}
+
+// TestCompliancePolicyListener_IgnoresWrongStreamType — defensive.
+func TestCompliancePolicyListener_IgnoresWrongStreamType(t *testing.T) {
+	st := setupComplianceTestStore(t)
+	ctx := context.Background()
+	policyID := newCompliancePolicyID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", // wrong stream
+		StreamID:   policyID,
+		EventType:  "CompliancePolicyCreated",
+		Data:       map[string]any{"name": "ghost"},
+		ActorType:  "user", ActorID: "u",
+	}))
+
+	_, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.Error(t, err, "wrong-stream-type CompliancePolicyCreated must NOT create a row")
+}

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -88,12 +88,16 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "device_group_projector"),
 	))
+	st.RegisterEventListener(CompliancePolicyListener(
+		st,
+		loggerFor(logger, "compliance_policy_projector"),
+	))
 	// All 11 ports of tracker #107 are now wired here, plus the
-	// first four Phase 2 ports (action_set, assignment, user_group,
-	// device_group — all under tracker #136). Future Phase 2 ports
-	// of the remaining domain projectors (user, device, action,
-	// definition, execution, compliance, compliance_policy) land
-	// here too.
+	// Phase 2 ports landed so far under tracker #136 (action_set,
+	// assignment, user_group, device_group, compliance_policy).
+	// Future Phase 2 ports of the remaining domain projectors (user,
+	// device, action, definition, execution, compliance) land here
+	// too.
 
 	// Rebuild appliers (manchtools/power-manage-server#125). Only
 	// the ported projectors that own a rebuildTarget in

--- a/internal/store/generated/compliance_policies.sql.go
+++ b/internal/store/generated/compliance_policies.sql.go
@@ -10,6 +10,43 @@ import (
 	"time"
 )
 
+const claimCompliancePolicyForRuleMutation = `-- name: ClaimCompliancePolicyForRuleMutation :execrows
+UPDATE compliance_policies_projection
+SET projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+  AND is_deleted = FALSE
+`
+
+type ClaimCompliancePolicyForRuleMutationParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// Atomic guard for the three rule-mutation events
+// (CompliancePolicyRuleAdded, CompliancePolicyRuleRemoved,
+// CompliancePolicyRuleUpdated). Bumps projection_version only when ALL of:
+//
+//  1. The policy exists (id matches).
+//  2. The policy is NOT soft-deleted (a rule event replayed after a
+//     Deleted must not bring rows back).
+//  3. The event is newer than the current projection_version
+//     (asymmetric-guard discipline; mirrors PR #174's CR catch).
+//
+// Returns n=1 when the listener may proceed with the rule-table
+// mutation, n=0 when the event must be skipped. Encoding all three
+// short-circuit reasons in one query keeps the listener side
+// branch-free and — crucially — makes the version check happen
+// BEFORE any child-row mutation, so a stale event cannot resurrect
+// a removed rule or rewind a fresher RuleUpdated.
+func (q *Queries) ClaimCompliancePolicyForRuleMutation(ctx context.Context, arg ClaimCompliancePolicyForRuleMutationParams) (int64, error) {
+	result, err := q.db.Exec(ctx, claimCompliancePolicyForRuleMutation, arg.ID, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countCompliancePolicies = `-- name: CountCompliancePolicies :one
 SELECT COUNT(*) FROM compliance_policies_projection
 WHERE is_deleted = FALSE
@@ -20,6 +57,70 @@ func (q *Queries) CountCompliancePolicies(ctx context.Context) (int64, error) {
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const deleteCompliancePolicyEvaluationsByPolicy = `-- name: DeleteCompliancePolicyEvaluationsByPolicy :exec
+DELETE FROM compliance_policy_evaluation_projection WHERE policy_id = $1
+`
+
+// CompliancePolicyDeleted handler — third half. Wipes every evaluation
+// row for the deleted policy so the device-status query no longer
+// joins through a deleted policy.
+func (q *Queries) DeleteCompliancePolicyEvaluationsByPolicy(ctx context.Context, policyID string) error {
+	_, err := q.db.Exec(ctx, deleteCompliancePolicyEvaluationsByPolicy, policyID)
+	return err
+}
+
+const deleteCompliancePolicyEvaluationsByRule = `-- name: DeleteCompliancePolicyEvaluationsByRule :exec
+DELETE FROM compliance_policy_evaluation_projection
+WHERE policy_id = $1
+  AND action_id = $2
+`
+
+type DeleteCompliancePolicyEvaluationsByRuleParams struct {
+	PolicyID string `json:"policy_id"`
+	ActionID string `json:"action_id"`
+}
+
+// CompliancePolicyRuleRemoved handler — third half. Wipes evaluation
+// rows for the removed (policy, action) pair so the device-status
+// query stops surfacing a stale verdict for a rule that no longer
+// exists. Other rules in the same policy keep their evaluations.
+func (q *Queries) DeleteCompliancePolicyEvaluationsByRule(ctx context.Context, arg DeleteCompliancePolicyEvaluationsByRuleParams) error {
+	_, err := q.db.Exec(ctx, deleteCompliancePolicyEvaluationsByRule, arg.PolicyID, arg.ActionID)
+	return err
+}
+
+const deleteCompliancePolicyRule = `-- name: DeleteCompliancePolicyRule :exec
+DELETE FROM compliance_policy_rules_projection
+WHERE policy_id = $1
+  AND action_id = $2
+`
+
+type DeleteCompliancePolicyRuleParams struct {
+	PolicyID string `json:"policy_id"`
+	ActionID string `json:"action_id"`
+}
+
+// CompliancePolicyRuleRemoved handler — second half. Plain DELETE
+// scoped to the (policy, action) pair — silently no-op on a miss
+// matches the PL/pgSQL projector's behaviour.
+func (q *Queries) DeleteCompliancePolicyRule(ctx context.Context, arg DeleteCompliancePolicyRuleParams) error {
+	_, err := q.db.Exec(ctx, deleteCompliancePolicyRule, arg.PolicyID, arg.ActionID)
+	return err
+}
+
+const deleteCompliancePolicyRulesByPolicy = `-- name: DeleteCompliancePolicyRulesByPolicy :exec
+DELETE FROM compliance_policy_rules_projection WHERE policy_id = $1
+`
+
+// CompliancePolicyDeleted handler — second half. Wipes every rule row
+// for the deleted policy. Wrapped with SoftDeleteCompliancePolicyProjection
+// + DeleteCompliancePolicyEvaluationsByPolicy + the reevaluate shim
+// inside store.WithTx for inter-write atomicity.
+func (q *Queries) DeleteCompliancePolicyRulesByPolicy(ctx context.Context, policyID string) error {
+	_, err := q.db.Exec(ctx, deleteCompliancePolicyRulesByPolicy, policyID)
+	return err
 }
 
 const getCompliancePolicyByID = `-- name: GetCompliancePolicyByID :one
@@ -134,6 +235,71 @@ func (q *Queries) GetDeviceCompliancePolicyEvaluations(ctx context.Context, devi
 	return items, nil
 }
 
+const insertCompliancePolicyProjection = `-- name: InsertCompliancePolicyProjection :exec
+
+INSERT INTO compliance_policies_projection (
+    id, name, description, rule_count,
+    created_at, created_by, projection_version
+) VALUES ($1, $2, $3, 0, $4, $5, $6)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertCompliancePolicyProjectionParams struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	Description       string     `json:"description"`
+	CreatedAt         *time.Time `json:"created_at"`
+	CreatedBy         string     `json:"created_by"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ============================================================================
+// Projector listener writes (manchtools/power-manage-server#136).
+// ============================================================================
+//
+// Mirrors the deleted PL/pgSQL project_compliance_policy_event(): every
+// event handler the projector dispatched on (CompliancePolicyCreated,
+// CompliancePolicyRenamed, CompliancePolicyDescriptionUpdated,
+// CompliancePolicyDeleted, CompliancePolicyRuleAdded,
+// CompliancePolicyRuleRemoved, CompliancePolicyRuleUpdated) gets a typed
+// sqlc query here so the listener can compose them in Go.
+//
+// Tightening vs the PL/pgSQL projector: every UPDATE on
+// compliance_policies_projection carries an explicit
+// `WHERE projection_version < $N` guard and uses :execrows so the
+// listener can short-circuit cascades on stale-replay (asymmetric-
+// guard discipline; see action_set_listener / user_group_listener for
+// the canonical shape).
+//
+// Claim-first guard: the three rule-mutation events
+// (CompliancePolicyRuleAdded, CompliancePolicyRuleRemoved,
+// CompliancePolicyRuleUpdated) all run ClaimCompliancePolicyForRuleMutation
+// BEFORE touching compliance_policy_rules_projection. The Claim guard
+// bumps the parent's projection_version only when the policy exists,
+// is alive, and the event is newer; the listener short-circuits on
+// n == 0. Doing the version check BEFORE the rule INSERT/DELETE/UPDATE
+// prevents stale replays from silently resurrecting removed rules or
+// rolling back fresher edits — the same hazard the user_group port
+// (PR #174) had to fix retroactively.
+// CompliancePolicyCreated handler. ON CONFLICT DO NOTHING for replay
+// safety — the unique constraint is the primary key (id), so a re-
+// application of CompliancePolicyCreated for the same stream lands as
+// a no-op. The PL/pgSQL projector raised on the second insert; we
+// soften that to the same replay-safe shape every other ported
+// projector uses. rule_count starts at 0 (matches the PL/pgSQL
+// INSERT's literal `0`).
+func (q *Queries) InsertCompliancePolicyProjection(ctx context.Context, arg InsertCompliancePolicyProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertCompliancePolicyProjection,
+		arg.ID,
+		arg.Name,
+		arg.Description,
+		arg.CreatedAt,
+		arg.CreatedBy,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
 const listCompliancePolicies = `-- name: ListCompliancePolicies :many
 SELECT id, name, description, rule_count, created_at, created_by, is_deleted, projection_version FROM compliance_policies_projection
 WHERE is_deleted = FALSE
@@ -206,4 +372,187 @@ func (q *Queries) ListCompliancePolicyRules(ctx context.Context, policyID string
 		return nil, err
 	}
 	return items, nil
+}
+
+const recountCompliancePolicyRules = `-- name: RecountCompliancePolicyRules :exec
+UPDATE compliance_policies_projection
+SET rule_count = (
+    SELECT COUNT(*) FROM compliance_policy_rules_projection
+    WHERE policy_id = $1
+)
+WHERE id = $1
+`
+
+// CompliancePolicyRuleAdded / CompliancePolicyRuleRemoved handler —
+// second-stage write after the rule-table mutation lands. Recomputes
+// rule_count from the live row count, mirroring the PL/pgSQL
+// `(SELECT COUNT(*) ...)` subquery. No projection_version guard:
+// the Claim above already stamped the version, so a recount without
+// re-stamping cannot regress.
+func (q *Queries) RecountCompliancePolicyRules(ctx context.Context, policyID string) error {
+	_, err := q.db.Exec(ctx, recountCompliancePolicyRules, policyID)
+	return err
+}
+
+const reevaluateCompliancePolicyDevices = `-- name: ReevaluateCompliancePolicyDevices :exec
+SELECT reevaluate_compliance_policy_devices($1)
+`
+
+// CompliancePolicyDeleted / CompliancePolicyRuleRemoved handler —
+// final cascade step. Thin shim around the still-PL/pgSQL
+// reevaluate_compliance_policy_devices(p_policy_id) function defined
+// in migration 003. Per #136 the eval engine itself stays in PL/pgSQL
+// until a later phase; the listener just calls into it so the per-
+// device compliance status reflects the rule mutation.
+func (q *Queries) ReevaluateCompliancePolicyDevices(ctx context.Context, pPolicyID string) error {
+	_, err := q.db.Exec(ctx, reevaluateCompliancePolicyDevices, pPolicyID)
+	return err
+}
+
+const renameCompliancePolicyProjection = `-- name: RenameCompliancePolicyProjection :execrows
+UPDATE compliance_policies_projection
+SET name              = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type RenameCompliancePolicyProjectionParams struct {
+	ID                string `json:"id"`
+	Name              string `json:"name"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// CompliancePolicyRenamed handler. Stale-replay guard via
+// projection_version. compliance_policies_projection has no
+// updated_at column (deliberate omission since 001_initial_tables.sql),
+// so the UPDATE only touches name + projection_version.
+func (q *Queries) RenameCompliancePolicyProjection(ctx context.Context, arg RenameCompliancePolicyProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, renameCompliancePolicyProjection, arg.ID, arg.Name, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const softDeleteCompliancePolicyProjection = `-- name: SoftDeleteCompliancePolicyProjection :execrows
+UPDATE compliance_policies_projection
+SET is_deleted        = TRUE,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+`
+
+type SoftDeleteCompliancePolicyProjectionParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// CompliancePolicyDeleted handler — first half. Returns rows-affected
+// so the listener can SKIP the cascade (rule wipe, evaluation wipe,
+// reevaluate_compliance_policy_devices) when the projection_version
+// guard rejects a stale replay; otherwise an old CompliancePolicyDeleted
+// re-applied by the reconciler against a freshly-restored policy
+// would silently nuke its rules + evaluations and trigger a needless
+// device re-evaluation pass.
+func (q *Queries) SoftDeleteCompliancePolicyProjection(ctx context.Context, arg SoftDeleteCompliancePolicyProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteCompliancePolicyProjection, arg.ID, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateCompliancePolicyDescriptionProjection = `-- name: UpdateCompliancePolicyDescriptionProjection :execrows
+UPDATE compliance_policies_projection
+SET description       = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type UpdateCompliancePolicyDescriptionProjectionParams struct {
+	ID                string `json:"id"`
+	Description       string `json:"description"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// CompliancePolicyDescriptionUpdated handler. Empty-string description
+// is a valid value (matches the PL/pgSQL `COALESCE(payload, ”)` collapse
+// — the listener decoder substitutes ” when the payload key is missing).
+func (q *Queries) UpdateCompliancePolicyDescriptionProjection(ctx context.Context, arg UpdateCompliancePolicyDescriptionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateCompliancePolicyDescriptionProjection, arg.ID, arg.Description, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateCompliancePolicyRuleGracePeriod = `-- name: UpdateCompliancePolicyRuleGracePeriod :exec
+UPDATE compliance_policy_rules_projection
+SET grace_period_hours = $3,
+    projection_version = $4
+WHERE policy_id = $1
+  AND action_id = $2
+`
+
+type UpdateCompliancePolicyRuleGracePeriodParams struct {
+	PolicyID          string `json:"policy_id"`
+	ActionID          string `json:"action_id"`
+	GracePeriodHours  int32  `json:"grace_period_hours"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// CompliancePolicyRuleUpdated handler — second half. Composite-PK
+// targeted UPDATE. No per-row projection_version guard here: the
+// Claim guard upstream already gated this call on parent-version
+// freshness, so a stale event cannot reach this statement. Mirrors
+// the PL/pgSQL projector's `UPDATE ... WHERE policy_id = X AND
+// action_id = Y` shape.
+func (q *Queries) UpdateCompliancePolicyRuleGracePeriod(ctx context.Context, arg UpdateCompliancePolicyRuleGracePeriodParams) error {
+	_, err := q.db.Exec(ctx, updateCompliancePolicyRuleGracePeriod,
+		arg.PolicyID,
+		arg.ActionID,
+		arg.GracePeriodHours,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const upsertCompliancePolicyRule = `-- name: UpsertCompliancePolicyRule :exec
+INSERT INTO compliance_policy_rules_projection (
+    policy_id, action_id, action_name, grace_period_hours,
+    added_at, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (policy_id, action_id) DO UPDATE SET
+    action_name        = EXCLUDED.action_name,
+    grace_period_hours = EXCLUDED.grace_period_hours,
+    projection_version = EXCLUDED.projection_version
+`
+
+type UpsertCompliancePolicyRuleParams struct {
+	PolicyID          string     `json:"policy_id"`
+	ActionID          string     `json:"action_id"`
+	ActionName        string     `json:"action_name"`
+	GracePeriodHours  int32      `json:"grace_period_hours"`
+	AddedAt           *time.Time `json:"added_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// CompliancePolicyRuleAdded handler — second half. Mirrors the PL/pgSQL
+// projector's `ON CONFLICT (policy_id, action_id) DO UPDATE SET
+// action_name = ..., grace_period_hours = ..., projection_version = ...`
+// so re-emitting RuleAdded for the same (policy, action) pair upgrades
+// the row in place rather than failing on the composite-PK conflict.
+// The Claim guard upstream gates this call on parent-version freshness.
+func (q *Queries) UpsertCompliancePolicyRule(ctx context.Context, arg UpsertCompliancePolicyRuleParams) error {
+	_, err := q.db.Exec(ctx, upsertCompliancePolicyRule,
+		arg.PolicyID,
+		arg.ActionID,
+		arg.ActionName,
+		arg.GracePeriodHours,
+		arg.AddedAt,
+		arg.ProjectionVersion,
+	)
+	return err
 }

--- a/internal/store/generated/compliance_policies.sql.go
+++ b/internal/store/generated/compliance_policies.sql.go
@@ -525,7 +525,7 @@ INSERT INTO compliance_policy_rules_projection (
     added_at, projection_version
 ) VALUES ($1, $2, $3, $4, $5, $6)
 ON CONFLICT (policy_id, action_id) DO UPDATE SET
-    action_name        = EXCLUDED.action_name,
+    action_name        = COALESCE(NULLIF(EXCLUDED.action_name, ''), compliance_policy_rules_projection.action_name),
     grace_period_hours = EXCLUDED.grace_period_hours,
     projection_version = EXCLUDED.projection_version
 `
@@ -541,9 +541,18 @@ type UpsertCompliancePolicyRuleParams struct {
 
 // CompliancePolicyRuleAdded handler — second half. Mirrors the PL/pgSQL
 // projector's `ON CONFLICT (policy_id, action_id) DO UPDATE SET
-// action_name = ..., grace_period_hours = ..., projection_version = ...`
-// so re-emitting RuleAdded for the same (policy, action) pair upgrades
-// the row in place rather than failing on the composite-PK conflict.
+// action_name = COALESCE(payload->>'action_name', existing.action_name),
+// grace_period_hours = ..., projection_version = ...` so re-emitting
+// RuleAdded for the same (policy, action) pair upgrades the row in
+// place rather than failing on the composite-PK conflict.
+//
+// action_name preserves the existing value when EXCLUDED is empty:
+// the decoder collapses a missing/null action_name to "" (the column
+// is NOT NULL), so a duplicate RuleAdded that omits action_name
+// arrives here as EXCLUDED.action_name = ”. Without the
+// NULLIF/COALESCE pair below, the UPSERT would erase a previously-
+// set name. CR caught this on PR #178.
+//
 // The Claim guard upstream gates this call on parent-version freshness.
 func (q *Queries) UpsertCompliancePolicyRule(ctx context.Context, arg UpsertCompliancePolicyRuleParams) error {
 	_, err := q.db.Exec(ctx, upsertCompliancePolicyRule,

--- a/internal/store/migrations/035_compliance_policy_projector_to_go.sql
+++ b/internal/store/migrations/035_compliance_policy_projector_to_go.sql
@@ -1,0 +1,180 @@
+-- Replace project_compliance_policy_event() with a no-op stub. The
+-- actual projection logic now lives in projectors.CompliancePolicyListener
+-- (Go, post-commit). The shared project_event() dispatcher trigger
+-- still PERFORMs project_compliance_policy_event(NEW) for every
+-- compliance_policy-stream event; the no-op stub keeps that dispatch
+-- quiet (no plpgsql_projection_errors entries) until the Phase 2
+-- cleanup migration drops every still-PL/pgSQL WHEN clause from the
+-- dispatcher.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. The seven event types (Created, Renamed,
+--     DescriptionUpdated, Deleted, RuleAdded, RuleRemoved,
+--     RuleUpdated) and their cascades (rule wipe / evaluation wipe /
+--     reevaluate-devices) were atomic with the event commit.
+--   - After: Go listener fires post-commit. Every multi-write event
+--     (Deleted, RuleAdded, RuleRemoved, RuleUpdated) wraps its writes
+--     in store.WithTx so the cascade stays atomic with itself, but
+--     not with the event commit. The handler's read-after-write
+--     paths (CreateCompliancePolicy / AddCompliancePolicyRule /
+--     DeleteCompliancePolicy etc. reading back from
+--     compliance_policies_projection) still see the projection
+--     because fireListeners is synchronous — the listener has
+--     already run by the time AppendEvent returns.
+--
+-- Tightening: every UPDATE on compliance_policies_projection
+-- (Renamed, DescriptionUpdated, soft-delete, Claim guard) now carries
+-- an explicit `WHERE projection_version < $N` guard, rejecting stale
+-- reconciler replays. The PL/pgSQL projector stamped
+-- projection_version without a guard.
+--
+-- Asymmetric-guard discipline (per the role + identity_provider +
+-- action_set + assignment + user_group + device_group ports):
+--   - Deleted: the guarded SoftDelete uses :execrows, and the
+--     listener short-circuits the cascade (rule wipe + evaluation
+--     wipe + reevaluate-devices) when n == 0 — otherwise a stale
+--     CompliancePolicyDeleted re-applied later would silently nuke a
+--     freshly-restored policy's rules and trigger a needless device
+--     re-evaluation pass.
+--   - RuleAdded / RuleRemoved / RuleUpdated: the Claim-first guard
+--     (ClaimCompliancePolicyForRuleMutation, :execrows) bumps the
+--     parent's projection_version BEFORE any rule-table mutation, and
+--     the listener short-circuits when n == 0. This is the lesson
+--     from PR #174's CR review: the prior insert-then-recount shape
+--     let stale replays silently resurrect removed rules or rewind a
+--     fresher RuleUpdated, because the version check was downstream
+--     of the child-row mutation.
+--
+-- Reevaluation engine scope: per #136 the
+-- reevaluate_compliance_policy_devices(p_policy_id) function — and
+-- the evaluate_device_compliance_policies family it calls — STAY in
+-- PL/pgSQL until a later phase. The Go listener calls into the shim
+-- (sqlc-generated ReevaluateCompliancePolicyDevices) so device
+-- compliance status reflects rule mutations; the eval engine itself
+-- runs unchanged inside Postgres.
+--
+-- See manchtools/power-manage-server#136. Fifth port under Phase 2
+-- of tracker #107's projector-migration pattern.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_compliance_policy_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.CompliancePolicyListener. See
+    -- migration comment + the listener wiring in cmd/control/main.go
+    -- via projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the PL/pgSQL projector verbatim from migration 003 (the
+-- last definition before this port). Mirrors the
+-- project_compliance_policy_event() body added in 028_fix_compliance_evaluation
+-- and consolidated into 003_extended_projectors.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_compliance_policy_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'CompliancePolicyCreated' THEN
+            INSERT INTO compliance_policies_projection (
+                id, name, description, rule_count, created_at,
+                created_by, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'name',
+                COALESCE(event.data->>'description', ''),
+                0,
+                event.occurred_at,
+                event.actor_id,
+                event.sequence_num
+            );
+
+        WHEN 'CompliancePolicyRenamed' THEN
+            UPDATE compliance_policies_projection
+            SET name = event.data->>'name',
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'CompliancePolicyDescriptionUpdated' THEN
+            UPDATE compliance_policies_projection
+            SET description = COALESCE(event.data->>'description', ''),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'CompliancePolicyDeleted' THEN
+            UPDATE compliance_policies_projection
+            SET is_deleted = TRUE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            DELETE FROM compliance_policy_rules_projection WHERE policy_id = event.stream_id;
+            DELETE FROM compliance_policy_evaluation_projection WHERE policy_id = event.stream_id;
+
+            -- Re-evaluate affected devices to update their overall status
+            PERFORM reevaluate_compliance_policy_devices(event.stream_id);
+
+        WHEN 'CompliancePolicyRuleAdded' THEN
+            INSERT INTO compliance_policy_rules_projection (
+                policy_id, action_id, action_name, grace_period_hours,
+                added_at, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'action_id',
+                COALESCE(event.data->>'action_name', ''),
+                COALESCE((event.data->>'grace_period_hours')::INTEGER, 0),
+                event.occurred_at,
+                event.sequence_num
+            ) ON CONFLICT (policy_id, action_id) DO UPDATE SET
+                action_name = COALESCE(event.data->>'action_name',
+                    compliance_policy_rules_projection.action_name),
+                grace_period_hours = COALESCE(
+                    (event.data->>'grace_period_hours')::INTEGER, 0),
+                projection_version = event.sequence_num;
+
+            UPDATE compliance_policies_projection
+            SET rule_count = (
+                SELECT COUNT(*) FROM compliance_policy_rules_projection
+                WHERE policy_id = event.stream_id
+            ), projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'CompliancePolicyRuleRemoved' THEN
+            DELETE FROM compliance_policy_rules_projection
+            WHERE policy_id = event.stream_id
+              AND action_id = event.data->>'action_id';
+
+            UPDATE compliance_policies_projection
+            SET rule_count = (
+                SELECT COUNT(*) FROM compliance_policy_rules_projection
+                WHERE policy_id = event.stream_id
+            ), projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            DELETE FROM compliance_policy_evaluation_projection
+            WHERE policy_id = event.stream_id
+              AND action_id = event.data->>'action_id';
+
+            -- Re-evaluate affected devices to update their overall status
+            PERFORM reevaluate_compliance_policy_devices(event.stream_id);
+
+        WHEN 'CompliancePolicyRuleUpdated' THEN
+            UPDATE compliance_policy_rules_projection
+            SET grace_period_hours = COALESCE(
+                    (event.data->>'grace_period_hours')::INTEGER, 0),
+                projection_version = event.sequence_num
+            WHERE policy_id = event.stream_id
+              AND action_id = event.data->>'action_id';
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/compliance_policies.sql
+++ b/internal/store/queries/compliance_policies.sql
@@ -161,16 +161,25 @@ WHERE id = $1
 -- name: UpsertCompliancePolicyRule :exec
 -- CompliancePolicyRuleAdded handler — second half. Mirrors the PL/pgSQL
 -- projector's `ON CONFLICT (policy_id, action_id) DO UPDATE SET
--- action_name = ..., grace_period_hours = ..., projection_version = ...`
--- so re-emitting RuleAdded for the same (policy, action) pair upgrades
--- the row in place rather than failing on the composite-PK conflict.
+-- action_name = COALESCE(payload->>'action_name', existing.action_name),
+-- grace_period_hours = ..., projection_version = ...` so re-emitting
+-- RuleAdded for the same (policy, action) pair upgrades the row in
+-- place rather than failing on the composite-PK conflict.
+--
+-- action_name preserves the existing value when EXCLUDED is empty:
+-- the decoder collapses a missing/null action_name to "" (the column
+-- is NOT NULL), so a duplicate RuleAdded that omits action_name
+-- arrives here as EXCLUDED.action_name = ''. Without the
+-- NULLIF/COALESCE pair below, the UPSERT would erase a previously-
+-- set name. CR caught this on PR #178.
+--
 -- The Claim guard upstream gates this call on parent-version freshness.
 INSERT INTO compliance_policy_rules_projection (
     policy_id, action_id, action_name, grace_period_hours,
     added_at, projection_version
 ) VALUES ($1, $2, $3, $4, $5, $6)
 ON CONFLICT (policy_id, action_id) DO UPDATE SET
-    action_name        = EXCLUDED.action_name,
+    action_name        = COALESCE(NULLIF(EXCLUDED.action_name, ''), compliance_policy_rules_projection.action_name),
     grace_period_hours = EXCLUDED.grace_period_hours,
     projection_version = EXCLUDED.projection_version;
 

--- a/internal/store/queries/compliance_policies.sql
+++ b/internal/store/queries/compliance_policies.sql
@@ -43,3 +43,186 @@ JOIN compliance_policies_projection p
   ON p.id = e.policy_id AND p.is_deleted = FALSE
 WHERE e.device_id = $1
 ORDER BY p.name, r.action_name;
+
+-- ============================================================================
+-- Projector listener writes (manchtools/power-manage-server#136).
+-- ============================================================================
+--
+-- Mirrors the deleted PL/pgSQL project_compliance_policy_event(): every
+-- event handler the projector dispatched on (CompliancePolicyCreated,
+-- CompliancePolicyRenamed, CompliancePolicyDescriptionUpdated,
+-- CompliancePolicyDeleted, CompliancePolicyRuleAdded,
+-- CompliancePolicyRuleRemoved, CompliancePolicyRuleUpdated) gets a typed
+-- sqlc query here so the listener can compose them in Go.
+--
+-- Tightening vs the PL/pgSQL projector: every UPDATE on
+-- compliance_policies_projection carries an explicit
+-- `WHERE projection_version < $N` guard and uses :execrows so the
+-- listener can short-circuit cascades on stale-replay (asymmetric-
+-- guard discipline; see action_set_listener / user_group_listener for
+-- the canonical shape).
+--
+-- Claim-first guard: the three rule-mutation events
+-- (CompliancePolicyRuleAdded, CompliancePolicyRuleRemoved,
+-- CompliancePolicyRuleUpdated) all run ClaimCompliancePolicyForRuleMutation
+-- BEFORE touching compliance_policy_rules_projection. The Claim guard
+-- bumps the parent's projection_version only when the policy exists,
+-- is alive, and the event is newer; the listener short-circuits on
+-- n == 0. Doing the version check BEFORE the rule INSERT/DELETE/UPDATE
+-- prevents stale replays from silently resurrecting removed rules or
+-- rolling back fresher edits — the same hazard the user_group port
+-- (PR #174) had to fix retroactively.
+
+-- name: InsertCompliancePolicyProjection :exec
+-- CompliancePolicyCreated handler. ON CONFLICT DO NOTHING for replay
+-- safety — the unique constraint is the primary key (id), so a re-
+-- application of CompliancePolicyCreated for the same stream lands as
+-- a no-op. The PL/pgSQL projector raised on the second insert; we
+-- soften that to the same replay-safe shape every other ported
+-- projector uses. rule_count starts at 0 (matches the PL/pgSQL
+-- INSERT's literal `0`).
+INSERT INTO compliance_policies_projection (
+    id, name, description, rule_count,
+    created_at, created_by, projection_version
+) VALUES ($1, $2, $3, 0, $4, $5, $6)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: RenameCompliancePolicyProjection :execrows
+-- CompliancePolicyRenamed handler. Stale-replay guard via
+-- projection_version. compliance_policies_projection has no
+-- updated_at column (deliberate omission since 001_initial_tables.sql),
+-- so the UPDATE only touches name + projection_version.
+UPDATE compliance_policies_projection
+SET name              = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: UpdateCompliancePolicyDescriptionProjection :execrows
+-- CompliancePolicyDescriptionUpdated handler. Empty-string description
+-- is a valid value (matches the PL/pgSQL `COALESCE(payload, '')` collapse
+-- — the listener decoder substitutes '' when the payload key is missing).
+UPDATE compliance_policies_projection
+SET description       = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: SoftDeleteCompliancePolicyProjection :execrows
+-- CompliancePolicyDeleted handler — first half. Returns rows-affected
+-- so the listener can SKIP the cascade (rule wipe, evaluation wipe,
+-- reevaluate_compliance_policy_devices) when the projection_version
+-- guard rejects a stale replay; otherwise an old CompliancePolicyDeleted
+-- re-applied by the reconciler against a freshly-restored policy
+-- would silently nuke its rules + evaluations and trigger a needless
+-- device re-evaluation pass.
+UPDATE compliance_policies_projection
+SET is_deleted        = TRUE,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2;
+
+-- name: DeleteCompliancePolicyRulesByPolicy :exec
+-- CompliancePolicyDeleted handler — second half. Wipes every rule row
+-- for the deleted policy. Wrapped with SoftDeleteCompliancePolicyProjection
+-- + DeleteCompliancePolicyEvaluationsByPolicy + the reevaluate shim
+-- inside store.WithTx for inter-write atomicity.
+DELETE FROM compliance_policy_rules_projection WHERE policy_id = $1;
+
+-- name: DeleteCompliancePolicyEvaluationsByPolicy :exec
+-- CompliancePolicyDeleted handler — third half. Wipes every evaluation
+-- row for the deleted policy so the device-status query no longer
+-- joins through a deleted policy.
+DELETE FROM compliance_policy_evaluation_projection WHERE policy_id = $1;
+
+-- name: ClaimCompliancePolicyForRuleMutation :execrows
+-- Atomic guard for the three rule-mutation events
+-- (CompliancePolicyRuleAdded, CompliancePolicyRuleRemoved,
+-- CompliancePolicyRuleUpdated). Bumps projection_version only when ALL of:
+--
+--   1. The policy exists (id matches).
+--   2. The policy is NOT soft-deleted (a rule event replayed after a
+--      Deleted must not bring rows back).
+--   3. The event is newer than the current projection_version
+--      (asymmetric-guard discipline; mirrors PR #174's CR catch).
+--
+-- Returns n=1 when the listener may proceed with the rule-table
+-- mutation, n=0 when the event must be skipped. Encoding all three
+-- short-circuit reasons in one query keeps the listener side
+-- branch-free and — crucially — makes the version check happen
+-- BEFORE any child-row mutation, so a stale event cannot resurrect
+-- a removed rule or rewind a fresher RuleUpdated.
+UPDATE compliance_policies_projection
+SET projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+  AND is_deleted = FALSE;
+
+-- name: UpsertCompliancePolicyRule :exec
+-- CompliancePolicyRuleAdded handler — second half. Mirrors the PL/pgSQL
+-- projector's `ON CONFLICT (policy_id, action_id) DO UPDATE SET
+-- action_name = ..., grace_period_hours = ..., projection_version = ...`
+-- so re-emitting RuleAdded for the same (policy, action) pair upgrades
+-- the row in place rather than failing on the composite-PK conflict.
+-- The Claim guard upstream gates this call on parent-version freshness.
+INSERT INTO compliance_policy_rules_projection (
+    policy_id, action_id, action_name, grace_period_hours,
+    added_at, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6)
+ON CONFLICT (policy_id, action_id) DO UPDATE SET
+    action_name        = EXCLUDED.action_name,
+    grace_period_hours = EXCLUDED.grace_period_hours,
+    projection_version = EXCLUDED.projection_version;
+
+-- name: DeleteCompliancePolicyRule :exec
+-- CompliancePolicyRuleRemoved handler — second half. Plain DELETE
+-- scoped to the (policy, action) pair — silently no-op on a miss
+-- matches the PL/pgSQL projector's behaviour.
+DELETE FROM compliance_policy_rules_projection
+WHERE policy_id = $1
+  AND action_id = $2;
+
+-- name: DeleteCompliancePolicyEvaluationsByRule :exec
+-- CompliancePolicyRuleRemoved handler — third half. Wipes evaluation
+-- rows for the removed (policy, action) pair so the device-status
+-- query stops surfacing a stale verdict for a rule that no longer
+-- exists. Other rules in the same policy keep their evaluations.
+DELETE FROM compliance_policy_evaluation_projection
+WHERE policy_id = $1
+  AND action_id = $2;
+
+-- name: UpdateCompliancePolicyRuleGracePeriod :exec
+-- CompliancePolicyRuleUpdated handler — second half. Composite-PK
+-- targeted UPDATE. No per-row projection_version guard here: the
+-- Claim guard upstream already gated this call on parent-version
+-- freshness, so a stale event cannot reach this statement. Mirrors
+-- the PL/pgSQL projector's `UPDATE ... WHERE policy_id = X AND
+-- action_id = Y` shape.
+UPDATE compliance_policy_rules_projection
+SET grace_period_hours = $3,
+    projection_version = $4
+WHERE policy_id = $1
+  AND action_id = $2;
+
+-- name: RecountCompliancePolicyRules :exec
+-- CompliancePolicyRuleAdded / CompliancePolicyRuleRemoved handler —
+-- second-stage write after the rule-table mutation lands. Recomputes
+-- rule_count from the live row count, mirroring the PL/pgSQL
+-- `(SELECT COUNT(*) ...)` subquery. No projection_version guard:
+-- the Claim above already stamped the version, so a recount without
+-- re-stamping cannot regress.
+UPDATE compliance_policies_projection
+SET rule_count = (
+    SELECT COUNT(*) FROM compliance_policy_rules_projection
+    WHERE policy_id = $1
+)
+WHERE id = $1;
+
+-- name: ReevaluateCompliancePolicyDevices :exec
+-- CompliancePolicyDeleted / CompliancePolicyRuleRemoved handler —
+-- final cascade step. Thin shim around the still-PL/pgSQL
+-- reevaluate_compliance_policy_devices(p_policy_id) function defined
+-- in migration 003. Per #136 the eval engine itself stays in PL/pgSQL
+-- until a later phase; the listener just calls into it so the per-
+-- device compliance status reflects the rule mutation.
+SELECT reevaluate_compliance_policy_devices($1);


### PR DESCRIPTION
## Summary

- Fifth Phase 2 port under tracker #136. Replaces PL/pgSQL `project_compliance_policy_event()` with `projectors.CompliancePolicyListener`.
- Seven event types: `CompliancePolicyCreated`, `Renamed`, `DescriptionUpdated`, `Deleted` (cascade: rules + evaluations + `reevaluate_compliance_policy_devices`, wrapped in `store.WithTx`), `RuleAdded` (UPSERT + recount), `RuleRemoved` (DELETE + recount + DELETE evaluations + reevaluate), `RuleUpdated` (per-rule UPDATE of `grace_period_hours`).
- Adopts the **Claim-first guard** from CR's catches on PR #174 + #177 from the start: `ClaimCompliancePolicyForRuleMutation :execrows` runs FIRST on every rule-mutation event. `n == 0` means skip the rule-table mutation. Recount via live `COUNT(*)` so UPSERT idempotency cannot drift the counter.
- Asymmetric-guard discipline: every UPDATE on `compliance_policies_projection` carries `WHERE projection_version < $N`; the guarded `SoftDelete` uses `:execrows`; cascades short-circuit on `n == 0`.
- `reevaluate_compliance_policy_devices` is shimmed via a `:exec` sqlc query — the dynamic-evaluator family stays PL/pgSQL per tracker #136.

## Migration / wiring

- Migration `035_compliance_policy_projector_to_go.sql` no-ops the PL/pgSQL function.
- `WireAll` registers `CompliancePolicyListener` and `RegisterRebuildApply("compliance_policies", ApplyCompliancePolicy)`.

## Test plan

- [x] `internal/projectors/compliance_policy_test.go` covers decoder defaults, every event type, the cascade on Deleted, stale-replay regression for RuleAdded after RuleRemoved (locks the Claim-first guard), and asymmetric-guard regression for stale Deleted.
- [x] Existing `internal/projectors`, `internal/store`, and `internal/api` integration suites still pass.
- [x] `gofmt -l`, `go vet ./...`, `staticcheck ./...` all green.
- [x] CR-CLI returned 0 findings before push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Compliance policy handling: create/rename/description updates, rule add/remove/update, and device reevaluation cascades.

* **Refactor**
  * Projection moved from DB-level PL/pgSQL to Go-based event listeners with replay/version guards to prevent stale replays.

* **Tests**
  * Comprehensive unit and integration tests for decoding, listener behavior, cascades, upserts, and stale-event protection.

* **Chores**
  * Wiring and migration added to enable the new Go-based projector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->