### PR TITLE
refactor: port compliance projector to Go listener (Part of #136)

### DIFF
--- a/internal/projectors/compliance.go
+++ b/internal/projectors/compliance.go
@@ -1,0 +1,119 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// ComplianceResultUpdatedPayload mirrors the fields the deleted PL/pgSQL
+// project_compliance_event() read out of a ComplianceResultUpdated
+// event:
+//
+//   - device_id, action_id (required, composite-PK columns the UPSERT
+//     keys on; missing keys would have surfaced as NOT NULL violations
+//     under the PL/pgSQL projector, so we surface that as a
+//     decoder-level validation error one layer earlier).
+//   - action_name (defaults to "" — matches PL/pgSQL
+//     `COALESCE(event.data->>'action_name', "")` for the NOT NULL
+//     column. The listener's UPSERT preserves the existing name on
+//     replays that omit the key via NULLIF + COALESCE, mirroring the
+//     PL/pgSQL `COALESCE(payload, existing.action_name)` semantic).
+//   - compliant (defaults to false — matches PL/pgSQL
+//     `COALESCE((event.data->>'compliant')::boolean, false)`).
+//   - detection_output (raw JSONB sub-tree; PL/pgSQL stored
+//     `event.data->'detection_output'` verbatim so a missing key
+//     collapses to NULL — json.RawMessage's nil zero value gives the
+//     same shape on the Go side).
+type ComplianceResultUpdatedPayload struct {
+	DeviceID        string
+	ActionID        string
+	ActionName      string
+	Compliant       bool
+	DetectionOutput json.RawMessage
+}
+
+type complianceResultUpdatedRaw struct {
+	DeviceID        string          `json:"device_id"`
+	ActionID        string          `json:"action_id"`
+	ActionName      *string         `json:"action_name,omitempty"`
+	Compliant       *bool           `json:"compliant,omitempty"`
+	DetectionOutput json.RawMessage `json:"detection_output,omitempty"`
+}
+
+// ComplianceResultUpdatedFromEvent decodes ComplianceResultUpdated.
+// Returns ErrIgnoredEvent for any other (stream, event_type) so the
+// listener wrapper can silently no-op.
+func ComplianceResultUpdatedFromEvent(e store.PersistedEvent) (ComplianceResultUpdatedPayload, error) {
+	if e.StreamType != "compliance" || e.EventType != "ComplianceResultUpdated" {
+		return ComplianceResultUpdatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return ComplianceResultUpdatedPayload{}, fmt.Errorf("projector: empty ComplianceResultUpdated payload")
+	}
+	var raw complianceResultUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ComplianceResultUpdatedPayload{}, fmt.Errorf("projector: invalid ComplianceResultUpdated payload: %w", err)
+	}
+	if raw.DeviceID == "" {
+		return ComplianceResultUpdatedPayload{}, fmt.Errorf("projector: ComplianceResultUpdated requires device_id")
+	}
+	if raw.ActionID == "" {
+		return ComplianceResultUpdatedPayload{}, fmt.Errorf("projector: ComplianceResultUpdated requires action_id")
+	}
+	out := ComplianceResultUpdatedPayload{
+		DeviceID:        raw.DeviceID,
+		ActionID:        raw.ActionID,
+		DetectionOutput: raw.DetectionOutput,
+	}
+	if raw.ActionName != nil {
+		out.ActionName = *raw.ActionName
+	}
+	if raw.Compliant != nil {
+		out.Compliant = *raw.Compliant
+	}
+	return out, nil
+}
+
+// ComplianceResultRemovedPayload covers ComplianceResultRemoved. Both
+// device_id and action_id are required because the DELETE filters on
+// the composite PK (no fallback to e.StreamID even though the stream
+// id is "deviceID_actionID"; the stream-id format is an emitter-side
+// convention and the projector keys off the payload to stay
+// agnostic).
+type ComplianceResultRemovedPayload struct {
+	DeviceID string
+	ActionID string
+}
+
+type complianceResultRemovedRaw struct {
+	DeviceID string `json:"device_id"`
+	ActionID string `json:"action_id"`
+}
+
+// ComplianceResultRemovedFromEvent decodes ComplianceResultRemoved.
+func ComplianceResultRemovedFromEvent(e store.PersistedEvent) (ComplianceResultRemovedPayload, error) {
+	if e.StreamType != "compliance" || e.EventType != "ComplianceResultRemoved" {
+		return ComplianceResultRemovedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return ComplianceResultRemovedPayload{}, fmt.Errorf("projector: empty ComplianceResultRemoved payload")
+	}
+	var raw complianceResultRemovedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ComplianceResultRemovedPayload{}, fmt.Errorf("projector: invalid ComplianceResultRemoved payload: %w", err)
+	}
+	if raw.DeviceID == "" {
+		return ComplianceResultRemovedPayload{}, fmt.Errorf("projector: ComplianceResultRemoved requires device_id")
+	}
+	if raw.ActionID == "" {
+		return ComplianceResultRemovedPayload{}, fmt.Errorf("projector: ComplianceResultRemoved requires action_id")
+	}
+	// staticcheck S1016: the raw decode struct has identical field
+	// names + types as the payload, so a direct type conversion is
+	// the canonical idiom — explicit field-by-field copy would be
+	// flagged. Keep the two named types so the JSON tags stay scoped
+	// to the wire shape.
+	return ComplianceResultRemovedPayload(raw), nil
+}

--- a/internal/projectors/compliance_listener.go
+++ b/internal/projectors/compliance_listener.go
@@ -1,0 +1,130 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// ComplianceListener returns a store.EventListener that applies every
+// compliance stream event the deleted PL/pgSQL project_compliance_event
+// handled. Two event types: ComplianceResultUpdated, ComplianceResultRemoved.
+//
+// Both event types are multi-write — the projection mutation is paired
+// with a call into the still-PL/pgSQL evaluate_device_compliance_policies
+// reevaluator so the cascade matches PL/pgSQL behaviour. Wrapping in
+// store.WithTx keeps the cascade atomic with itself (the projection
+// write and the reevaluate run inside one transaction); the cascade is
+// not atomic with the event commit because the listener fires post-
+// commit, but the read-after-write paths (handlers reading
+// compliance_results_projection back after an AppendEvent) still see
+// the projection because fireListeners is synchronous — the listener
+// has already run by the time AppendEvent returns.
+//
+// Stale-replay guard: ComplianceResultUpdated routes through an
+// UPSERT whose UPDATE branch carries an explicit
+// `WHERE projection_version < EXCLUDED.projection_version` predicate
+// (mirrors the role + identity_provider + action_set + assignment +
+// user_group + device_group + compliance_policy ports). There is no
+// parent table to Claim against here — compliance_results_projection
+// is the only projection in the cascade — so the guard lives directly
+// on the UPSERT rather than upstream.
+//
+// Reevaluation engine scope: per #136 the
+// evaluate_device_compliance_policies(p_device_id) function — and the
+// per-policy evaluator family it dispatches to — STAY in PL/pgSQL
+// until a later phase. The Go listener calls into the existing shim
+// (EvaluateDeviceCompliancePolicies, defined in assignments.sql for
+// the assignment port) so device compliance status reflects every
+// result mutation; the eval engine itself runs unchanged inside
+// Postgres.
+//
+// Wired in projectors.WireAll. Refs #136 (Phase 2 of tracker #107).
+func ComplianceListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "compliance" {
+			return
+		}
+		// Both event types do a projection write + a reevaluator call,
+		// so they always go through WithTx for cascade atomicity.
+		if err := st.WithTx(ctx, func(q *store.Queries) error {
+			return ApplyCompliance(ctx, q, e)
+		}); err != nil {
+			logger.Warn("compliance projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "stream_id", e.StreamID, "error", err)
+		}
+	}
+}
+
+// ApplyCompliance is the transactional core of the compliance
+// projector. The listener wraps it for live-event dispatch (using
+// WithTx for the multi-write event types). compliance_results is not
+// in store.AllRebuildTargets — there is no operator-facing rebuild
+// for it — so this isn't registered via RegisterRebuildApply. If a
+// rebuild target is ever added, this signature is the standard
+// RebuildApply shape and can be wired in projectors.WireAll without
+// changing the body.
+func ApplyCompliance(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "compliance" {
+		return nil
+	}
+	switch e.EventType {
+	case "ComplianceResultUpdated":
+		return applyComplianceResultUpdated(ctx, q, e)
+	case "ComplianceResultRemoved":
+		return applyComplianceResultRemoved(ctx, q, e)
+	}
+	return nil
+}
+
+func applyComplianceResultUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ComplianceResultUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	checkedAt := e.OccurredAt
+	if err := q.UpsertComplianceResultProjection(ctx, db.UpsertComplianceResultProjectionParams{
+		DeviceID:          payload.DeviceID,
+		ActionID:          payload.ActionID,
+		ActionName:        payload.ActionName,
+		Compliant:         payload.Compliant,
+		DetectionOutput:   []byte(payload.DetectionOutput),
+		CheckedAt:         checkedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	// evaluate_device_compliance_policies is the still-PL/pgSQL eval
+	// engine's entry point per #136. Calling it here keeps device-
+	// level compliance_status (devices_projection) in sync with the
+	// per-action result mutation: the PL/pgSQL function recomputes
+	// the device's pass/fail/grace verdict by aggregating across
+	// every result + every assigned policy's grace window.
+	return q.EvaluateDeviceCompliancePolicies(ctx, payload.DeviceID)
+}
+
+func applyComplianceResultRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ComplianceResultRemovedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if err := q.DeleteComplianceResultProjection(ctx, db.DeleteComplianceResultProjectionParams{
+		DeviceID: payload.DeviceID,
+		ActionID: payload.ActionID,
+	}); err != nil {
+		return err
+	}
+	return q.EvaluateDeviceCompliancePolicies(ctx, payload.DeviceID)
+}

--- a/internal/projectors/compliance_listener.go
+++ b/internal/projectors/compliance_listener.go
@@ -120,11 +120,24 @@ func applyComplianceResultRemoved(ctx context.Context, q *store.Queries, e store
 		}
 		return err
 	}
-	if err := q.DeleteComplianceResultProjection(ctx, db.DeleteComplianceResultProjectionParams{
-		DeviceID: payload.DeviceID,
-		ActionID: payload.ActionID,
-	}); err != nil {
+	// Stale-replay guard: the DELETE only removes a row whose
+	// projection_version is at-or-older than this event's
+	// SequenceNum. n == 0 means either the row is already gone
+	// (replayed Removed against an unrelated state) OR a newer
+	// Updated has stamped a higher projection_version on the
+	// (device, action) pair. In both cases, skipping the
+	// reevaluate cascade is correct: nothing changed, so device
+	// compliance doesn't need recomputing (CR catch on PR #179).
+	n, err := q.DeleteComplianceResultProjection(ctx, db.DeleteComplianceResultProjectionParams{
+		DeviceID:          payload.DeviceID,
+		ActionID:          payload.ActionID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
 		return err
+	}
+	if n == 0 {
+		return nil
 	}
 	return q.EvaluateDeviceCompliancePolicies(ctx, payload.DeviceID)
 }

--- a/internal/projectors/compliance_test.go
+++ b/internal/projectors/compliance_test.go
@@ -357,6 +357,76 @@ func TestComplianceListener_StaleUpdateRejected(t *testing.T) {
 		"stale ComplianceResultUpdated must NOT advance projection_version")
 }
 
+// TestComplianceListener_StaleRemovedDoesNotWipeRevivedRow locks the
+// CR catch on PR #179: a stale ComplianceResultRemoved replayed AFTER
+// a newer ComplianceResultUpdated for the same (device, action) pair
+// must NOT delete the live row. Without the projection_version guard
+// on the DELETE, the older Removed would silently wipe the revived
+// result and the follow-up reevaluate would compound the drift.
+func TestComplianceListener_StaleRemovedDoesNotWipeRevivedRow(t *testing.T) {
+	st := setupComplianceResultStore(t)
+	ctx := context.Background()
+	deviceID := "dev-" + uuid.NewString()
+	actionID := "act-" + uuid.NewString()
+
+	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
+		"device_id":   deviceID,
+		"action_id":   actionID,
+		"action_name": "v1",
+		"compliant":   false,
+	})
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance",
+		StreamID:   deviceID + "_" + actionID,
+		EventType:  "ComplianceResultRemoved",
+		Data:       map[string]any{"device_id": deviceID, "action_id": actionID},
+		ActorType:  "device", ActorID: deviceID,
+	}))
+	// Capture this Removed's sequence so we can replay it later.
+	var staleRemovedSeq int64
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		`SELECT sequence_num FROM events
+		 WHERE stream_type = 'compliance' AND stream_id = $1
+		   AND event_type = 'ComplianceResultRemoved'
+		 ORDER BY sequence_num DESC LIMIT 1`,
+		deviceID+"_"+actionID,
+	).Scan(&staleRemovedSeq))
+
+	// Newer Updated re-creates the row at a higher projection_version.
+	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
+		"device_id":   deviceID,
+		"action_id":   actionID,
+		"action_name": "v2-revived",
+		"compliant":   true,
+	})
+	revived, err := st.Queries().GetDeviceComplianceResults(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, revived, 1)
+	revivedVersion := revived[0].ProjectionVersion
+
+	// Drive the listener directly with the OLDER Removed sequence.
+	listener := projectors.ComplianceListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &staleRemovedSeq,
+		StreamType:  "compliance",
+		StreamID:    deviceID + "_" + actionID,
+		EventType:   "ComplianceResultRemoved",
+		Data:        jsonOrFail(t, map[string]any{"device_id": deviceID, "action_id": actionID}),
+		ActorType:   "device",
+		ActorID:     deviceID,
+		OccurredAt:  revived[0].CheckedAt,
+	})
+
+	survivors, err := st.Queries().GetDeviceComplianceResults(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, survivors, 1, "stale ComplianceResultRemoved must NOT wipe the revived row")
+	assert.Equal(t, "v2-revived", survivors[0].ActionName,
+		"the revived row's action_name must survive the stale Removed replay")
+	assert.Equal(t, revivedVersion, survivors[0].ProjectionVersion,
+		"the revived row's projection_version must be unchanged")
+}
+
 // TestComplianceListener_IgnoresWrongStreamType — defensive: an event
 // with the wrong stream_type must NOT touch the projection even when
 // the event_type matches.

--- a/internal/projectors/compliance_test.go
+++ b/internal/projectors/compliance_test.go
@@ -1,0 +1,385 @@
+package projectors_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// setupComplianceResultStore wraps testutil.SetupPostgres so the
+// listener tests can grow extra fixture knobs (e.g. seeding a real
+// devices_projection row) without touching every call site.
+func setupComplianceResultStore(t *testing.T) *store.Store {
+	t.Helper()
+	return testutil.SetupPostgres(t)
+}
+
+// TestComplianceResultUpdatedFromEvent_Pure pins the decoder defaults
+// against the deleted PL/pgSQL projector: device_id and action_id are
+// required (the composite PK columns the UPSERT keys on); action_name
+// defaults to "" (matches PL/pgSQL `COALESCE(payload, "")` for the
+// NOT NULL column); compliant defaults to false (matches PL/pgSQL
+// `COALESCE((payload)::boolean, false)`); detection_output is a raw
+// JSONB sub-tree (PL/pgSQL stored `event.data->'detection_output'`
+// verbatim, so a missing key collapses to NULL via json.RawMessage's
+// nil zero value).
+func TestComplianceResultUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.ComplianceResultUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance", StreamID: "dev-1_act-1", EventType: "ComplianceResultUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":        "dev-1",
+				"action_id":        "act-1",
+				"action_name":      "ssh-disabled",
+				"compliant":        true,
+				"detection_output": map[string]any{"stdout": "ok"},
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.DeviceID)
+		assert.Equal(t, "act-1", got.ActionID)
+		assert.Equal(t, "ssh-disabled", got.ActionName)
+		assert.True(t, got.Compliant)
+		// detection_output round-trips as raw JSON bytes.
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(got.DetectionOutput, &parsed))
+		assert.Equal(t, "ok", parsed["stdout"])
+	})
+
+	t.Run("defaults: missing action_name → empty, missing compliant → false, missing detection_output → nil", func(t *testing.T) {
+		got, err := projectors.ComplianceResultUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance", StreamID: "dev-2_act-2", EventType: "ComplianceResultUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id": "dev-2",
+				"action_id": "act-2",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.ActionName)
+		assert.False(t, got.Compliant)
+		assert.Nil(t, got.DetectionOutput)
+	})
+
+	t.Run("missing device_id fails", func(t *testing.T) {
+		_, err := projectors.ComplianceResultUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance", StreamID: "x_y", EventType: "ComplianceResultUpdated",
+			Data: jsonOrFail(t, map[string]any{"action_id": "act-1"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "device_id")
+	})
+
+	t.Run("missing action_id fails", func(t *testing.T) {
+		_, err := projectors.ComplianceResultUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance", StreamID: "x_y", EventType: "ComplianceResultUpdated",
+			Data: jsonOrFail(t, map[string]any{"device_id": "dev-1"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "action_id")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.ComplianceResultUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "ComplianceResultUpdated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.ComplianceResultUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance", EventType: "ComplianceResultRemoved",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.ComplianceResultUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "compliance", EventType: "ComplianceResultUpdated",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestComplianceResultRemovedFromEvent_Pure — only device_id and
+// action_id are read; both are required because the DELETE filters on
+// the composite PK.
+func TestComplianceResultRemovedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.ComplianceResultRemovedFromEvent(store.PersistedEvent{
+			StreamType: "compliance", StreamID: "dev-1_act-1", EventType: "ComplianceResultRemoved",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id": "dev-1",
+				"action_id": "act-1",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.DeviceID)
+		assert.Equal(t, "act-1", got.ActionID)
+	})
+
+	t.Run("missing device_id fails", func(t *testing.T) {
+		_, err := projectors.ComplianceResultRemovedFromEvent(store.PersistedEvent{
+			StreamType: "compliance", StreamID: "x_y", EventType: "ComplianceResultRemoved",
+			Data: jsonOrFail(t, map[string]any{"action_id": "act-1"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "device_id")
+	})
+
+	t.Run("missing action_id fails", func(t *testing.T) {
+		_, err := projectors.ComplianceResultRemovedFromEvent(store.PersistedEvent{
+			StreamType: "compliance", StreamID: "x_y", EventType: "ComplianceResultRemoved",
+			Data: jsonOrFail(t, map[string]any{"device_id": "dev-1"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "action_id")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.ComplianceResultRemovedFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "ComplianceResultRemoved",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.ComplianceResultRemovedFromEvent(store.PersistedEvent{
+			StreamType: "compliance", EventType: "ComplianceResultUpdated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests (testcontainers-backed Postgres).
+// ---------------------------------------------------------------------------
+
+// appendComplianceResultUpdated emits one ComplianceResultUpdated
+// event so each test can short-cut the boilerplate.
+func appendComplianceResultUpdated(t *testing.T, st *store.Store, deviceID, actionID string, data map[string]any) {
+	t.Helper()
+	ctx := context.Background()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance",
+		StreamID:   deviceID + "_" + actionID,
+		EventType:  "ComplianceResultUpdated",
+		Data:       data,
+		ActorType:  "device",
+		ActorID:    deviceID,
+	}))
+}
+
+// TestComplianceListener_UpsertLifecycle covers the full
+// insert → update cycle for a single (device, action) row. Confirms
+// the row state advances and projection_version bumps monotonically.
+func TestComplianceListener_UpsertLifecycle(t *testing.T) {
+	st := setupComplianceResultStore(t)
+	ctx := context.Background()
+	deviceID := "dev-" + uuid.NewString()
+	actionID := "act-" + uuid.NewString()
+
+	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
+		"device_id":        deviceID,
+		"action_id":        actionID,
+		"action_name":      "first-name",
+		"compliant":        false,
+		"detection_output": map[string]any{"stdout": "fail"},
+	})
+
+	results, err := st.Queries().GetDeviceComplianceResults(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "first-name", results[0].ActionName)
+	assert.False(t, results[0].Compliant)
+	firstVersion := results[0].ProjectionVersion
+	assert.Greater(t, firstVersion, int64(0))
+
+	// Second event for the same (device, action) pair flips compliant
+	// and the action_name. The UPSERT must overwrite, not duplicate.
+	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
+		"device_id":        deviceID,
+		"action_id":        actionID,
+		"action_name":      "second-name",
+		"compliant":        true,
+		"detection_output": map[string]any{"stdout": "pass"},
+	})
+
+	results, err = st.Queries().GetDeviceComplianceResults(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, results, 1, "duplicate ComplianceResultUpdated must upsert, not insert")
+	assert.Equal(t, "second-name", results[0].ActionName)
+	assert.True(t, results[0].Compliant)
+	assert.Greater(t, results[0].ProjectionVersion, firstVersion)
+}
+
+// TestComplianceListener_UpsertPreservesActionNameOnEmptyReplay locks
+// the CR catch on PR #178: a duplicate ComplianceResultUpdated that
+// omits action_name (decoder collapses missing → "") MUST NOT erase a
+// previously-set action_name. The PL/pgSQL projector did
+// `COALESCE(payload->>'action_name', existing.action_name)`; the Go
+// port preserves that semantic via NULLIF + COALESCE in the UPSERT.
+//
+// compliant and detection_output are intentionally NOT preserved —
+// they always overwrite, matching the PL/pgSQL projector's
+// unconditional `compliant = COALESCE(..., false)` and
+// `detection_output = event.data->'detection_output'` (which collapses
+// a missing key to NULL).
+func TestComplianceListener_UpsertPreservesActionNameOnEmptyReplay(t *testing.T) {
+	st := setupComplianceResultStore(t)
+	ctx := context.Background()
+	deviceID := "dev-" + uuid.NewString()
+	actionID := "act-" + uuid.NewString()
+
+	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
+		"device_id":        deviceID,
+		"action_id":        actionID,
+		"action_name":      "named-result",
+		"compliant":        true,
+		"detection_output": map[string]any{"stdout": "ok"},
+	})
+
+	// Second event: action_name intentionally omitted. The COALESCE
+	// + NULLIF in the UPSERT must keep the existing "named-result".
+	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
+		"device_id": deviceID,
+		"action_id": actionID,
+		"compliant": false,
+	})
+
+	results, err := st.Queries().GetDeviceComplianceResults(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "named-result", results[0].ActionName,
+		"duplicate ComplianceResultUpdated that omits action_name must preserve the existing name")
+	assert.False(t, results[0].Compliant,
+		"compliant always overwrites — the COALESCE is action_name-only")
+}
+
+// TestComplianceListener_DeleteLifecycle confirms
+// ComplianceResultRemoved DELETEs the (device, action) row.
+func TestComplianceListener_DeleteLifecycle(t *testing.T) {
+	st := setupComplianceResultStore(t)
+	ctx := context.Background()
+	deviceID := "dev-" + uuid.NewString()
+	actionID := "act-" + uuid.NewString()
+
+	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
+		"device_id":   deviceID,
+		"action_id":   actionID,
+		"action_name": "to-remove",
+		"compliant":   true,
+	})
+	results, err := st.Queries().GetDeviceComplianceResults(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance",
+		StreamID:   deviceID + "_" + actionID,
+		EventType:  "ComplianceResultRemoved",
+		Data: map[string]any{
+			"device_id": deviceID,
+			"action_id": actionID,
+		},
+		ActorType: "device",
+		ActorID:   deviceID,
+	}))
+
+	results, err = st.Queries().GetDeviceComplianceResults(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Len(t, results, 0, "ComplianceResultRemoved must DELETE the row")
+}
+
+// TestComplianceListener_StaleUpdateRejected — locks the asymmetric-
+// guard discipline: a ComplianceResultUpdated re-applied with an
+// older projection_version than the row currently has must NOT
+// rewind the row. The UPSERT's UPDATE branch carries an explicit
+// `WHERE projection_version < EXCLUDED.projection_version` predicate
+// (mirrors the user_group / device_group / compliance_policy ports).
+func TestComplianceListener_StaleUpdateRejected(t *testing.T) {
+	st := setupComplianceResultStore(t)
+	ctx := context.Background()
+	deviceID := "dev-" + uuid.NewString()
+	actionID := "act-" + uuid.NewString()
+
+	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
+		"device_id":   deviceID,
+		"action_id":   actionID,
+		"action_name": "current",
+		"compliant":   true,
+	})
+	results, err := st.Queries().GetDeviceComplianceResults(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	currentVersion := results[0].ProjectionVersion
+
+	// Drive the listener directly with a stale event (older
+	// sequence_num) so the guard can be exercised without going
+	// through AppendEvent (which would assign a fresh, monotonically
+	// larger sequence_num).
+	older := currentVersion - 5
+	listener := projectors.ComplianceListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "compliance",
+		StreamID:    deviceID + "_" + actionID,
+		EventType:   "ComplianceResultUpdated",
+		Data: jsonOrFail(t, map[string]any{
+			"device_id":   deviceID,
+			"action_id":   actionID,
+			"action_name": "stale-would-set-this",
+			"compliant":   false,
+		}),
+		ActorType:  "device",
+		ActorID:    deviceID,
+		OccurredAt: results[0].CheckedAt,
+	})
+
+	after, err := st.Queries().GetDeviceComplianceResults(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	assert.Equal(t, "current", after[0].ActionName,
+		"stale ComplianceResultUpdated must NOT clobber the existing action_name")
+	assert.True(t, after[0].Compliant,
+		"stale ComplianceResultUpdated must NOT flip compliant")
+	assert.Equal(t, currentVersion, after[0].ProjectionVersion,
+		"stale ComplianceResultUpdated must NOT advance projection_version")
+}
+
+// TestComplianceListener_IgnoresWrongStreamType — defensive: an event
+// with the wrong stream_type must NOT touch the projection even when
+// the event_type matches.
+func TestComplianceListener_IgnoresWrongStreamType(t *testing.T) {
+	st := setupComplianceResultStore(t)
+	ctx := context.Background()
+	deviceID := "dev-" + uuid.NewString()
+	actionID := "act-" + uuid.NewString()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", // wrong stream
+		StreamID:   deviceID + "_" + actionID,
+		EventType:  "ComplianceResultUpdated",
+		Data: map[string]any{
+			"device_id":   deviceID,
+			"action_id":   actionID,
+			"action_name": "ghost",
+			"compliant":   true,
+		},
+		ActorType: "device", ActorID: deviceID,
+	}))
+
+	results, err := st.Queries().GetDeviceComplianceResults(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Len(t, results, 0, "wrong-stream-type event must NOT create a row")
+}

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -92,12 +92,16 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "compliance_policy_projector"),
 	))
+	st.RegisterEventListener(ComplianceListener(
+		st,
+		loggerFor(logger, "compliance_projector"),
+	))
 	// All 11 ports of tracker #107 are now wired here, plus the
 	// Phase 2 ports landed so far under tracker #136 (action_set,
-	// assignment, user_group, device_group, compliance_policy).
-	// Future Phase 2 ports of the remaining domain projectors (user,
-	// device, action, definition, execution, compliance) land here
-	// too.
+	// assignment, user_group, device_group, compliance_policy,
+	// compliance). Future Phase 2 ports of the remaining domain
+	// projectors (user, device, action, definition, execution) land
+	// here too.
 
 	// Rebuild appliers (manchtools/power-manage-server#125). Only
 	// the ported projectors that own a rebuildTarget in

--- a/internal/store/generated/compliance.sql.go
+++ b/internal/store/generated/compliance.sql.go
@@ -10,27 +10,35 @@ import (
 	"time"
 )
 
-const deleteComplianceResultProjection = `-- name: DeleteComplianceResultProjection :exec
+const deleteComplianceResultProjection = `-- name: DeleteComplianceResultProjection :execrows
 DELETE FROM compliance_results_projection
 WHERE device_id = $1
   AND action_id = $2
+  AND projection_version <= $3
 `
 
 type DeleteComplianceResultProjectionParams struct {
-	DeviceID string `json:"device_id"`
-	ActionID string `json:"action_id"`
+	DeviceID          string `json:"device_id"`
+	ActionID          string `json:"action_id"`
+	ProjectionVersion int64  `json:"projection_version"`
 }
 
-// ComplianceResultRemoved handler. Plain DELETE scoped to the
-// composite PK — silently no-op on a miss matches the PL/pgSQL
-// projector's behaviour. No projection_version guard: the PL/pgSQL
-// projector unconditionally DELETEd the row on every Removed event,
-// and a stale Removed re-applied later is safe because the row is
-// already gone (the listener still calls the reevaluate shim, which
-// is idempotent on the device-policy state).
-func (q *Queries) DeleteComplianceResultProjection(ctx context.Context, arg DeleteComplianceResultProjectionParams) error {
-	_, err := q.db.Exec(ctx, deleteComplianceResultProjection, arg.DeviceID, arg.ActionID)
-	return err
+// ComplianceResultRemoved handler. Stale-replay guard via
+// projection_version: an older Removed replayed AFTER a newer
+// Updated for the same (device_id, action_id) must NOT wipe the
+// live row. Without this guard the follow-up reevaluate cascade
+// would also recompute device compliance against the missing
+// result, compounding the drift (CR catch on PR #179).
+//
+// Returns rows-affected so the listener can decide whether to
+// trigger the cascade — a stale Removed (n == 0 because the row's
+// projection_version is already newer) skips the reevaluate.
+func (q *Queries) DeleteComplianceResultProjection(ctx context.Context, arg DeleteComplianceResultProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteComplianceResultProjection, arg.DeviceID, arg.ActionID, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const getDeviceComplianceResults = `-- name: GetDeviceComplianceResults :many

--- a/internal/store/generated/compliance.sql.go
+++ b/internal/store/generated/compliance.sql.go
@@ -10,6 +10,29 @@ import (
 	"time"
 )
 
+const deleteComplianceResultProjection = `-- name: DeleteComplianceResultProjection :exec
+DELETE FROM compliance_results_projection
+WHERE device_id = $1
+  AND action_id = $2
+`
+
+type DeleteComplianceResultProjectionParams struct {
+	DeviceID string `json:"device_id"`
+	ActionID string `json:"action_id"`
+}
+
+// ComplianceResultRemoved handler. Plain DELETE scoped to the
+// composite PK — silently no-op on a miss matches the PL/pgSQL
+// projector's behaviour. No projection_version guard: the PL/pgSQL
+// projector unconditionally DELETEd the row on every Removed event,
+// and a stale Removed re-applied later is safe because the row is
+// already gone (the listener still calls the reevaluate shim, which
+// is idempotent on the device-policy state).
+func (q *Queries) DeleteComplianceResultProjection(ctx context.Context, arg DeleteComplianceResultProjectionParams) error {
+	_, err := q.db.Exec(ctx, deleteComplianceResultProjection, arg.DeviceID, arg.ActionID)
+	return err
+}
+
 const getDeviceComplianceResults = `-- name: GetDeviceComplianceResults :many
 
 SELECT device_id, action_id, action_name, compliant, detection_output, checked_at, projection_version FROM compliance_results_projection
@@ -68,4 +91,91 @@ func (q *Queries) GetDeviceComplianceSummary(ctx context.Context, id string) (Ge
 		&i.ComplianceCheckedAt,
 	)
 	return i, err
+}
+
+const upsertComplianceResultProjection = `-- name: UpsertComplianceResultProjection :exec
+
+INSERT INTO compliance_results_projection (
+    device_id, action_id, action_name, compliant, detection_output,
+    checked_at, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (device_id, action_id) DO UPDATE SET
+    action_name        = COALESCE(NULLIF(EXCLUDED.action_name, ''), compliance_results_projection.action_name),
+    compliant          = EXCLUDED.compliant,
+    detection_output   = EXCLUDED.detection_output,
+    checked_at         = EXCLUDED.checked_at,
+    projection_version = EXCLUDED.projection_version
+WHERE compliance_results_projection.projection_version < EXCLUDED.projection_version
+`
+
+type UpsertComplianceResultProjectionParams struct {
+	DeviceID          string    `json:"device_id"`
+	ActionID          string    `json:"action_id"`
+	ActionName        string    `json:"action_name"`
+	Compliant         bool      `json:"compliant"`
+	DetectionOutput   []byte    `json:"detection_output"`
+	CheckedAt         time.Time `json:"checked_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// ============================================================================
+// Projector listener writes (manchtools/power-manage-server#136).
+// ============================================================================
+//
+// Mirrors the deleted PL/pgSQL project_compliance_event(): two event
+// types (ComplianceResultUpdated, ComplianceResultRemoved) get typed
+// sqlc queries here so the listener can compose them in Go.
+//
+// compliance_results_projection has a composite PK (device_id,
+// action_id) and no parent table to Claim against — there is no
+// compliance_results "header" row. The asymmetric-guard discipline
+// still applies: the UPSERT's UPDATE branch carries an explicit
+// `WHERE projection_version < EXCLUDED.projection_version` predicate
+// so a stale ComplianceResultUpdated cannot rewind a fresher row.
+//
+// Reevaluation engine scope: per #136 the
+// evaluate_device_compliance_policies(p_device_id) function — and the
+// per-policy evaluator family it dispatches to — STAY in PL/pgSQL
+// until a later phase. The Go listener calls into the existing shim
+// (EvaluateDeviceCompliancePolicies, defined in assignments.sql for
+// the assignment port) so device compliance status reflects every
+// result mutation; the eval engine itself runs unchanged inside
+// Postgres.
+// ComplianceResultUpdated handler. Mirrors the PL/pgSQL projector's
+// `INSERT … ON CONFLICT (device_id, action_id) DO UPDATE SET …` shape.
+//
+// action_name preserves the existing value when EXCLUDED is empty:
+// the decoder collapses a missing/null action_name to "" (the column
+// is NOT NULL), so a duplicate ComplianceResultUpdated that omits
+// action_name arrives here as EXCLUDED.action_name = "". Without the
+// NULLIF/COALESCE pair below, the UPSERT would erase a previously-
+// set name. CR caught this same shape on PR #178 for the
+// compliance_policy rule UPSERT; applying it from the start here.
+//
+// compliant and detection_output always overwrite — matches the
+// PL/pgSQL `compliant = COALESCE(..., false)` and
+// `detection_output = event.data->'detection_output'` (which collapses
+// a missing key to NULL). Preserving them on omission would change
+// semantics: a compliance check that intentionally clears its prior
+// detection_output by sending NULL must be honoured.
+//
+// Stale-replay guard: the UPDATE branch's
+// `WHERE projection_version < EXCLUDED.projection_version` predicate
+// rejects re-applications of an older event against a fresher row.
+// The INSERT branch can't be guarded the same way — there's no row
+// to compare against — but a "stale" event that arrives before the
+// row exists is just a normal first INSERT, indistinguishable from a
+// fresh first emission. Once the row exists, every subsequent UPSERT
+// routes through the guarded UPDATE branch.
+func (q *Queries) UpsertComplianceResultProjection(ctx context.Context, arg UpsertComplianceResultProjectionParams) error {
+	_, err := q.db.Exec(ctx, upsertComplianceResultProjection,
+		arg.DeviceID,
+		arg.ActionID,
+		arg.ActionName,
+		arg.Compliant,
+		arg.DetectionOutput,
+		arg.CheckedAt,
+		arg.ProjectionVersion,
+	)
+	return err
 }

--- a/internal/store/migrations/036_compliance_projector_to_go.sql
+++ b/internal/store/migrations/036_compliance_projector_to_go.sql
@@ -1,0 +1,125 @@
+-- Replace project_compliance_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.ComplianceListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger still
+-- PERFORMs project_compliance_event(NEW) for every compliance-stream
+-- event; the no-op stub keeps that dispatch quiet (no
+-- plpgsql_projection_errors entries) until the Phase 2 cleanup
+-- migration drops every still-PL/pgSQL WHEN clause from the dispatcher.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. Both event types (ComplianceResultUpdated,
+--     ComplianceResultRemoved) and their cascade
+--     (evaluate_device_compliance_policies) were atomic with the
+--     event commit.
+--   - After: Go listener fires post-commit. Both event types wrap
+--     their writes (UPSERT/DELETE + reevaluate cascade) in
+--     store.WithTx so the cascade stays atomic with itself, but not
+--     with the event commit. The handler's read-after-write paths
+--     (the inbox worker reading back compliance_results_projection
+--     after AppendEvent, plus any handler that lists device
+--     compliance state) still see the projection because
+--     fireListeners is synchronous — the listener has already run by
+--     the time AppendEvent returns.
+--
+-- Tightening: the UPSERT on compliance_results_projection now carries
+-- an explicit `WHERE projection_version < EXCLUDED.projection_version`
+-- predicate on its UPDATE branch, rejecting stale reconciler replays.
+-- The PL/pgSQL projector stamped projection_version without a guard,
+-- so a stale ComplianceResultUpdated re-applied later would silently
+-- rewind action_name + compliant + detection_output.
+--
+-- Asymmetric-guard discipline (per the role + identity_provider +
+-- action_set + assignment + user_group + device_group +
+-- compliance_policy ports): the UPSERT's UPDATE branch is the only
+-- mutation step on the projection — no parent table to Claim against
+-- (compliance_results_projection has no header row). The
+-- reevaluate_device_compliance_policies cascade is unconditional
+-- under the PL/pgSQL projector and stays unconditional here: the
+-- shim is idempotent on the device-policy state, so re-running it on
+-- a stale-rejected UPSERT is harmless (and matches the legacy
+-- behaviour of the PL/pgSQL projector, which also called the
+-- reevaluator unconditionally on every event).
+--
+-- action_name preservation: a duplicate ComplianceResultUpdated that
+-- omits action_name (decoder collapses missing → "") MUST NOT erase
+-- a previously-set action_name. The PL/pgSQL projector did
+-- `COALESCE(payload->>'action_name', existing.action_name)`; the Go
+-- port preserves that semantic via NULLIF + COALESCE in the UPSERT
+-- (matches the PR #178 CR catch on the compliance_policy rule
+-- UPSERT).
+--
+-- Reevaluation engine scope: per #136 the
+-- evaluate_device_compliance_policies(p_device_id) function — and
+-- the per-policy evaluator family it dispatches to — STAY in PL/pgSQL
+-- until a later phase. The Go listener calls into the existing shim
+-- (EvaluateDeviceCompliancePolicies, reused from the assignment
+-- port's sqlc generation) so device compliance status reflects every
+-- result mutation; the eval engine itself runs unchanged inside
+-- Postgres.
+--
+-- See manchtools/power-manage-server#136. Sixth port under Phase 2
+-- of tracker #107's projector-migration pattern.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_compliance_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.ComplianceListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the PL/pgSQL projector verbatim from migration 003 (the
+-- last definition before this port). Mirrors the
+-- project_compliance_event() body added in 018_compliance_policies
+-- and consolidated into 003_extended_projectors.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_compliance_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'ComplianceResultUpdated' THEN
+            INSERT INTO compliance_results_projection (
+                device_id, action_id, action_name, compliant, detection_output,
+                checked_at, projection_version
+            ) VALUES (
+                event.data->>'device_id',
+                event.data->>'action_id',
+                COALESCE(event.data->>'action_name', ''),
+                COALESCE((event.data->>'compliant')::boolean, false),
+                event.data->'detection_output',
+                event.occurred_at,
+                event.sequence_num
+            )
+            ON CONFLICT (device_id, action_id) DO UPDATE SET
+                action_name = COALESCE(event.data->>'action_name', compliance_results_projection.action_name),
+                compliant = COALESCE((event.data->>'compliant')::boolean, false),
+                detection_output = event.data->'detection_output',
+                checked_at = event.occurred_at,
+                projection_version = event.sequence_num;
+
+            -- Evaluate compliance policies (falls back to simple check if no policies assigned)
+            PERFORM evaluate_device_compliance_policies(event.data->>'device_id');
+
+        WHEN 'ComplianceResultRemoved' THEN
+            DELETE FROM compliance_results_projection
+            WHERE device_id = event.data->>'device_id'
+              AND action_id = event.data->>'action_id';
+
+            -- Re-evaluate compliance policies
+            PERFORM evaluate_device_compliance_policies(event.data->>'device_id');
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/compliance.sql
+++ b/internal/store/queries/compliance.sql
@@ -8,3 +8,78 @@ ORDER BY action_name;
 -- name: GetDeviceComplianceSummary :one
 SELECT compliance_status, compliance_total, compliance_passing, compliance_checked_at
 FROM devices_projection WHERE id = $1;
+
+-- ============================================================================
+-- Projector listener writes (manchtools/power-manage-server#136).
+-- ============================================================================
+--
+-- Mirrors the deleted PL/pgSQL project_compliance_event(): two event
+-- types (ComplianceResultUpdated, ComplianceResultRemoved) get typed
+-- sqlc queries here so the listener can compose them in Go.
+--
+-- compliance_results_projection has a composite PK (device_id,
+-- action_id) and no parent table to Claim against — there is no
+-- compliance_results "header" row. The asymmetric-guard discipline
+-- still applies: the UPSERT's UPDATE branch carries an explicit
+-- `WHERE projection_version < EXCLUDED.projection_version` predicate
+-- so a stale ComplianceResultUpdated cannot rewind a fresher row.
+--
+-- Reevaluation engine scope: per #136 the
+-- evaluate_device_compliance_policies(p_device_id) function — and the
+-- per-policy evaluator family it dispatches to — STAY in PL/pgSQL
+-- until a later phase. The Go listener calls into the existing shim
+-- (EvaluateDeviceCompliancePolicies, defined in assignments.sql for
+-- the assignment port) so device compliance status reflects every
+-- result mutation; the eval engine itself runs unchanged inside
+-- Postgres.
+
+-- name: UpsertComplianceResultProjection :exec
+-- ComplianceResultUpdated handler. Mirrors the PL/pgSQL projector's
+-- `INSERT … ON CONFLICT (device_id, action_id) DO UPDATE SET …` shape.
+--
+-- action_name preserves the existing value when EXCLUDED is empty:
+-- the decoder collapses a missing/null action_name to "" (the column
+-- is NOT NULL), so a duplicate ComplianceResultUpdated that omits
+-- action_name arrives here as EXCLUDED.action_name = "". Without the
+-- NULLIF/COALESCE pair below, the UPSERT would erase a previously-
+-- set name. CR caught this same shape on PR #178 for the
+-- compliance_policy rule UPSERT; applying it from the start here.
+--
+-- compliant and detection_output always overwrite — matches the
+-- PL/pgSQL `compliant = COALESCE(..., false)` and
+-- `detection_output = event.data->'detection_output'` (which collapses
+-- a missing key to NULL). Preserving them on omission would change
+-- semantics: a compliance check that intentionally clears its prior
+-- detection_output by sending NULL must be honoured.
+--
+-- Stale-replay guard: the UPDATE branch's
+-- `WHERE projection_version < EXCLUDED.projection_version` predicate
+-- rejects re-applications of an older event against a fresher row.
+-- The INSERT branch can't be guarded the same way — there's no row
+-- to compare against — but a "stale" event that arrives before the
+-- row exists is just a normal first INSERT, indistinguishable from a
+-- fresh first emission. Once the row exists, every subsequent UPSERT
+-- routes through the guarded UPDATE branch.
+INSERT INTO compliance_results_projection (
+    device_id, action_id, action_name, compliant, detection_output,
+    checked_at, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (device_id, action_id) DO UPDATE SET
+    action_name        = COALESCE(NULLIF(EXCLUDED.action_name, ''), compliance_results_projection.action_name),
+    compliant          = EXCLUDED.compliant,
+    detection_output   = EXCLUDED.detection_output,
+    checked_at         = EXCLUDED.checked_at,
+    projection_version = EXCLUDED.projection_version
+WHERE compliance_results_projection.projection_version < EXCLUDED.projection_version;
+
+-- name: DeleteComplianceResultProjection :exec
+-- ComplianceResultRemoved handler. Plain DELETE scoped to the
+-- composite PK — silently no-op on a miss matches the PL/pgSQL
+-- projector's behaviour. No projection_version guard: the PL/pgSQL
+-- projector unconditionally DELETEd the row on every Removed event,
+-- and a stale Removed re-applied later is safe because the row is
+-- already gone (the listener still calls the reevaluate shim, which
+-- is idempotent on the device-policy state).
+DELETE FROM compliance_results_projection
+WHERE device_id = $1
+  AND action_id = $2;

--- a/internal/store/queries/compliance.sql
+++ b/internal/store/queries/compliance.sql
@@ -72,14 +72,18 @@ ON CONFLICT (device_id, action_id) DO UPDATE SET
     projection_version = EXCLUDED.projection_version
 WHERE compliance_results_projection.projection_version < EXCLUDED.projection_version;
 
--- name: DeleteComplianceResultProjection :exec
--- ComplianceResultRemoved handler. Plain DELETE scoped to the
--- composite PK — silently no-op on a miss matches the PL/pgSQL
--- projector's behaviour. No projection_version guard: the PL/pgSQL
--- projector unconditionally DELETEd the row on every Removed event,
--- and a stale Removed re-applied later is safe because the row is
--- already gone (the listener still calls the reevaluate shim, which
--- is idempotent on the device-policy state).
+-- name: DeleteComplianceResultProjection :execrows
+-- ComplianceResultRemoved handler. Stale-replay guard via
+-- projection_version: an older Removed replayed AFTER a newer
+-- Updated for the same (device_id, action_id) must NOT wipe the
+-- live row. Without this guard the follow-up reevaluate cascade
+-- would also recompute device compliance against the missing
+-- result, compounding the drift (CR catch on PR #179).
+--
+-- Returns rows-affected so the listener can decide whether to
+-- trigger the cascade — a stale Removed (n == 0 because the row's
+-- projection_version is already newer) skips the reevaluate.
 DELETE FROM compliance_results_projection
 WHERE device_id = $1
-  AND action_id = $2;
+  AND action_id = $2
+  AND projection_version <= $3;


### PR DESCRIPTION
## Summary

Sixth Phase 2 port under tracker #136. Replaces PL/pgSQL `project_compliance_event()` with `projectors.ComplianceListener`. Two event types:

- `ComplianceResultUpdated` — UPSERT into `compliance_results_projection` (composite PK device_id + action_id) + cascade via `EvaluateDeviceCompliancePolicies`.
- `ComplianceResultRemoved` — DELETE row + same cascade.

Both wrapped in `store.WithTx`.

## Patterns adopted from prior CR review

- **action_name preservation** (CR catch on PR #178): `ON CONFLICT DO UPDATE SET action_name = COALESCE(NULLIF(EXCLUDED.action_name, ''), compliance_results_projection.action_name)` so a duplicate `ComplianceResultUpdated` that omits `action_name` doesn't erase a previously-set name. Regression test `TestComplianceListener_UpsertPreservesActionNameOnEmptyReplay` locks the behaviour.
- **Stale-replay guard**: `WHERE projection_version < EXCLUDED.projection_version` on the UPDATE branch. No Claim-first guard needed — `compliance_results_projection` has no parent header table.
- **`EvaluateDeviceCompliancePolicies` shim** was already added by the assignment port (#173); reused as-is.

## Migration / wiring

- Migration `036_compliance_projector_to_go.sql` no-ops the PL/pgSQL function.
- `WireAll` registers `ComplianceListener`. No `RegisterRebuildApply` — `compliance_results` is not in `AllRebuildTargets`.

## Test plan

- [x] `internal/projectors/compliance_test.go`: pure decoder tests, upsert lifecycle, action_name preservation regression, delete lifecycle, stale-update rejection, wrong-stream-type ignore.
- [x] `gofmt -l`, `go vet ./...`, `staticcheck ./...` all green.
- [x] CR-CLI returned 0 findings before push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated compliance result tracking from DB procedures to application-level listeners for more reliable processing and lifecycle control.
* **Bug Fixes**
  * Prevented stale or out-of-order events from overwriting current compliance state; preserved existing metadata on empty replays and avoided unintended deletions.
* **Tests**
  * Added extensive unit and integration tests covering decoding, upsert/delete lifecycle, replay semantics, and staleness guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->