### PR TITLE
refactor: port action + definition projectors to Go listener (Part of #136)

### DIFF
--- a/internal/projectors/action.go
+++ b/internal/projectors/action.go
@@ -1,0 +1,223 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// defaultActionParams mirrors the column default on actions_projection
+// (`'{}'::JSONB`) and the PL/pgSQL projector's
+// `COALESCE(event.data->'params', '{}')` fallback. Stored as a byte
+// slice so the listener can pass it straight to the JSONB column
+// without a marshal step.
+var defaultActionParams = []byte(`{}`)
+
+// defaultActionTimeoutSeconds mirrors the PL/pgSQL projector's
+// `COALESCE((event.data->>'timeout_seconds')::INTEGER, 300)` fallback.
+const defaultActionTimeoutSeconds int32 = 300
+
+// ActionCreatedPayload mirrors the fields the deleted PL/pgSQL
+// project_action_event() read out of an ActionCreated event.
+//
+//   - name (required)
+//   - description (defaults to "" — column is nullable but the
+//     PL/pgSQL projector wrote `event.data->>'description'` directly,
+//     which yields NULL on absence; we surface that as the empty
+//     pointer)
+//   - action_type (required, integer; PL/pgSQL COALESCEd to 0 — we
+//     surface a missing key as 0 to match)
+//   - desired_state (defaults to 0)
+//   - params (defaults to `{}` JSONB)
+//   - timeout_seconds (defaults to 300)
+//   - is_system (defaults to false)
+//   - schedule (no PL/pgSQL default — column is nullable; absent key
+//     stays nil bytes which sqlc maps to NULL)
+type ActionCreatedPayload struct {
+	ID             string
+	Name           string
+	Description    *string
+	ActionType     int32
+	DesiredState   int32
+	Params         []byte
+	TimeoutSeconds int32
+	IsSystem       bool
+	Schedule       []byte
+	CreatedBy      string
+}
+
+type actionCreatedRaw struct {
+	Name           string          `json:"name"`
+	Description    *string         `json:"description,omitempty"`
+	ActionType     *int32          `json:"action_type,omitempty"`
+	DesiredState   *int32          `json:"desired_state,omitempty"`
+	Params         json.RawMessage `json:"params,omitempty"`
+	TimeoutSeconds *int32          `json:"timeout_seconds,omitempty"`
+	IsSystem       *bool           `json:"is_system,omitempty"`
+	Schedule       json.RawMessage `json:"schedule,omitempty"`
+}
+
+// ActionCreatedFromEvent decodes ActionCreated. Returns ErrIgnoredEvent
+// for any other (stream, event_type) so the listener wrapper can
+// silently no-op.
+func ActionCreatedFromEvent(e store.PersistedEvent) (ActionCreatedPayload, error) {
+	if e.StreamType != "action" || e.EventType != "ActionCreated" {
+		return ActionCreatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return ActionCreatedPayload{}, fmt.Errorf("projector: empty ActionCreated payload")
+	}
+	var raw actionCreatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionCreatedPayload{}, fmt.Errorf("projector: invalid ActionCreated payload: %w", err)
+	}
+	if raw.Name == "" {
+		return ActionCreatedPayload{}, fmt.Errorf("projector: ActionCreated requires name")
+	}
+	out := ActionCreatedPayload{
+		ID:             e.StreamID,
+		Name:           raw.Name,
+		Description:    raw.Description,
+		Params:         defaultActionParams,
+		TimeoutSeconds: defaultActionTimeoutSeconds,
+		CreatedBy:      e.ActorID,
+	}
+	if raw.ActionType != nil {
+		out.ActionType = *raw.ActionType
+	}
+	if raw.DesiredState != nil {
+		out.DesiredState = *raw.DesiredState
+	}
+	if len(raw.Params) > 0 {
+		out.Params = []byte(raw.Params)
+	}
+	if raw.TimeoutSeconds != nil {
+		out.TimeoutSeconds = *raw.TimeoutSeconds
+	}
+	if raw.IsSystem != nil {
+		out.IsSystem = *raw.IsSystem
+	}
+	if len(raw.Schedule) > 0 {
+		out.Schedule = []byte(raw.Schedule)
+	}
+	return out, nil
+}
+
+// ActionRenamedPayload covers the single mutable field the PL/pgSQL
+// projector wrote on an ActionRenamed event. Empty Name is treated as
+// a validation error rather than silently no-op'd — the PL/pgSQL
+// projector would have written NULL and broken the NOT NULL column
+// constraint, so emitters that drop the field hit the same error class
+// either way.
+type ActionRenamedPayload struct {
+	ID   string
+	Name string
+}
+
+type actionRenamedRaw struct {
+	Name string `json:"name"`
+}
+
+// ActionRenamedFromEvent decodes ActionRenamed.
+func ActionRenamedFromEvent(e store.PersistedEvent) (ActionRenamedPayload, error) {
+	if e.StreamType != "action" || e.EventType != "ActionRenamed" {
+		return ActionRenamedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return ActionRenamedPayload{}, fmt.Errorf("projector: empty ActionRenamed payload")
+	}
+	var raw actionRenamedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionRenamedPayload{}, fmt.Errorf("projector: invalid ActionRenamed payload: %w", err)
+	}
+	if raw.Name == "" {
+		return ActionRenamedPayload{}, fmt.Errorf("projector: ActionRenamed requires name")
+	}
+	return ActionRenamedPayload{ID: e.StreamID, Name: raw.Name}, nil
+}
+
+// ActionDescriptionUpdatedPayload — the PL/pgSQL projector wrote
+// `event.data->>'description'` directly, which can be NULL. We surface
+// the same shape via *string so an absent key collapses to NULL and an
+// explicit empty string round-trips as "".
+type ActionDescriptionUpdatedPayload struct {
+	ID          string
+	Description *string
+}
+
+type actionDescriptionUpdatedRaw struct {
+	Description *string `json:"description,omitempty"`
+}
+
+// ActionDescriptionUpdatedFromEvent decodes ActionDescriptionUpdated.
+func ActionDescriptionUpdatedFromEvent(e store.PersistedEvent) (ActionDescriptionUpdatedPayload, error) {
+	if e.StreamType != "action" || e.EventType != "ActionDescriptionUpdated" {
+		return ActionDescriptionUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := ActionDescriptionUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw actionDescriptionUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionDescriptionUpdatedPayload{}, fmt.Errorf("projector: invalid ActionDescriptionUpdated payload: %w", err)
+	}
+	out.Description = raw.Description
+	return out, nil
+}
+
+// ActionParamsUpdatedPayload — the PL/pgSQL projector used
+// `COALESCE(event.data->'params', params)` for params/timeout/desired_state/
+// schedule, meaning a missing key preserves the existing column value.
+// We model that with pointer/raw-bytes presence: nil means "preserve",
+// non-nil means "set to this".
+type ActionParamsUpdatedPayload struct {
+	ID             string
+	Params         []byte
+	TimeoutSeconds *int32
+	DesiredState   *int32
+	Schedule       []byte
+}
+
+type actionParamsUpdatedRaw struct {
+	Params         json.RawMessage `json:"params,omitempty"`
+	TimeoutSeconds *int32          `json:"timeout_seconds,omitempty"`
+	DesiredState   *int32          `json:"desired_state,omitempty"`
+	Schedule       json.RawMessage `json:"schedule,omitempty"`
+}
+
+// ActionParamsUpdatedFromEvent decodes ActionParamsUpdated.
+func ActionParamsUpdatedFromEvent(e store.PersistedEvent) (ActionParamsUpdatedPayload, error) {
+	if e.StreamType != "action" || e.EventType != "ActionParamsUpdated" {
+		return ActionParamsUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := ActionParamsUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw actionParamsUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return ActionParamsUpdatedPayload{}, fmt.Errorf("projector: invalid ActionParamsUpdated payload: %w", err)
+	}
+	if len(raw.Params) > 0 {
+		out.Params = []byte(raw.Params)
+	}
+	out.TimeoutSeconds = raw.TimeoutSeconds
+	out.DesiredState = raw.DesiredState
+	if len(raw.Schedule) > 0 {
+		out.Schedule = []byte(raw.Schedule)
+	}
+	return out, nil
+}
+
+// ActionDeletedFromEvent decodes ActionDeleted. The PL/pgSQL projector
+// did not read any payload fields — the cascade derives everything from
+// the stream id and the projection's own state — so this is a stream/
+// event-type validator only.
+func ActionDeletedFromEvent(e store.PersistedEvent) (string, error) {
+	if e.StreamType != "action" || e.EventType != "ActionDeleted" {
+		return "", ErrIgnoredEvent
+	}
+	return e.StreamID, nil
+}

--- a/internal/projectors/action_listener.go
+++ b/internal/projectors/action_listener.go
@@ -1,0 +1,646 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// ActionListener returns a store.EventListener that applies BOTH the
+// action-stream events the deleted PL/pgSQL project_action_event
+// handled (5 ActionXxx + 4 DefinitionXxx for the synthesised-action
+// path) AND the definition-stream events the deleted PL/pgSQL
+// project_definition_event handled (8 DefinitionXxx for the
+// definitions_projection path). One listener owns both because
+// DefinitionCreated dispatches across two projections — synthesise an
+// actions_projection row (when payload carries `action_type`) OR insert
+// a definitions_projection row (otherwise) — and splitting would race
+// the two branches against each other.
+//
+// Event-type families:
+//
+//   - Action CRUD (action stream): Created (INSERT), Renamed (UPDATE +
+//     cross-stream UPDATE on compliance_policy_rules.action_name),
+//     DescriptionUpdated / ParamsUpdated (single guarded UPDATE),
+//     Deleted (soft-delete + 4-table cascade + per-affected-device
+//     reevaluate loop, wrapped in store.WithTx).
+//   - Action-side Definition events (action stream — synthesised
+//     actions only): DefinitionCreated (INSERT into actions_projection
+//     IFF payload carries action_type), DefinitionRenamed /
+//     DescriptionUpdated / Deleted (single guarded UPDATE / soft-delete
+//     on actions_projection — these mirror the action variants for the
+//     synthesised-action row).
+//   - Definition CRUD (definition stream): Created (INSERT into
+//     definitions_projection IFF payload OMITS action_type), Renamed /
+//     DescriptionUpdated / ScheduleUpdated (single guarded UPDATE),
+//     Deleted (soft-delete on definitions_projection).
+//   - Definition-member edits (definition stream): MemberAdded /
+//     MemberRemoved (Claim guard + INSERT|DELETE + recount, wrapped in
+//     store.WithTx), MemberReordered (Claim guard + per-row UPDATE,
+//     wrapped in store.WithTx).
+//
+// Multi-write listeners (ActionDeleted, DefinitionDeleted on the
+// action-stream branch when the row is the synthesised-action variant,
+// DefinitionMemberAdded / MemberRemoved / MemberReordered) follow the
+// asymmetric-guard discipline:
+//
+//   - ActionDeleted: the guarded SoftDelete uses :execrows. When n==0
+//     EVERY downstream cascade is skipped — action_set_member decrement,
+//     compliance_policy_rules delete + recount, compliance_policy_evaluation
+//     delete, compliance_results delete, AND the per-affected-device
+//     reevaluate loop. Otherwise a stale ActionDeleted re-applied later
+//     against a freshly-restored action would silently nuke its
+//     compliance footprint.
+//   - DefinitionMemberAdded / MemberRemoved / MemberReordered: Claim-
+//     first guard against definitions_projection. Mirrors the
+//     user_group / action_set / compliance_policy member ports
+//     (PR #174's CR catch).
+//
+// Compliance reevaluation engine scope: the
+// evaluate_device_compliance_policies(p_device_id) function STAYS in
+// PL/pgSQL until a later phase (per #136). The Go listener calls into
+// the existing shim (q.EvaluateDeviceCompliancePolicies, defined for
+// the assignment port) so device compliance status reflects every
+// action deletion; the eval engine itself runs unchanged inside
+// Postgres.
+//
+// Wired in projectors.WireAll. Refs #136, tracker #107 (Phase 2).
+func ActionListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		// Owns both action and definition stream types — see the
+		// header comment for why splitting breaks DefinitionCreated.
+		if e.StreamType != "action" && e.StreamType != "definition" {
+			return
+		}
+		// Multi-write events route through ApplyAction via WithTx so
+		// the cascade stays atomic; single-statement events go on the
+		// autocommit pool. ApplyAction handles every event type when
+		// called with tx-bound queries (the rebuild path), so we share
+		// its body here for the multi-write cases via WithTx and
+		// short-circuit the simple cases through the pool.
+		needsTx := false
+		switch e.EventType {
+		case "ActionDeleted",
+			"DefinitionMemberAdded",
+			"DefinitionMemberRemoved",
+			"DefinitionMemberReordered":
+			needsTx = true
+		case "DefinitionCreated":
+			// DefinitionCreated on the action stream that carries
+			// action_type is a single INSERT (no cascade). On the
+			// definition stream the same event is also a single INSERT
+			// (definitions_projection). Neither needs tx wrapping.
+			needsTx = false
+		}
+		if needsTx {
+			if err := st.WithTx(ctx, func(q *store.Queries) error {
+				return ApplyAction(ctx, q, e)
+			}); err != nil {
+				logger.Warn("action projector: failed to apply event",
+					"event_id", e.ID, "event_type", e.EventType, "stream_type", e.StreamType, "stream_id", e.StreamID, "error", err)
+			}
+			return
+		}
+		if err := ApplyAction(ctx, st.Queries(), e); err != nil {
+			logger.Warn("action projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "stream_type", e.StreamType, "stream_id", e.StreamID, "error", err)
+		}
+	}
+}
+
+// ApplyAction is the transactional core of the action projector. The
+// listener wraps it for live-event dispatch (using WithTx for the
+// multi-write event types); the rebuild path
+// (manchtools/power-manage-server#125) registers it twice — once for
+// the "actions" target (StreamTypes: ["action", "definition"]) and
+// once for the "definitions" target (StreamTypes: ["definition"]).
+// Both targets share this dispatch body; the per-event StreamType
+// gate inside the function makes the dual-registration safe.
+//
+// Asymmetric-guard discipline is preserved across every multi-write
+// event: when the version-guarded UPDATE on the parent row affects
+// zero rows, every cascading INSERT/DELETE/loop downstream is skipped.
+func ApplyAction(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "action" && e.StreamType != "definition" {
+		return nil
+	}
+	switch {
+	case e.StreamType == "action" && e.EventType == "ActionCreated":
+		return applyActionCreated(ctx, q, e)
+	case e.StreamType == "action" && e.EventType == "ActionRenamed":
+		return applyActionRenamed(ctx, q, e)
+	case e.StreamType == "action" && e.EventType == "ActionDescriptionUpdated":
+		return applyActionDescriptionUpdated(ctx, q, e)
+	case e.StreamType == "action" && e.EventType == "ActionParamsUpdated":
+		return applyActionParamsUpdated(ctx, q, e)
+	case e.StreamType == "action" && e.EventType == "ActionDeleted":
+		return applyActionDeleted(ctx, q, e)
+	case e.EventType == "DefinitionCreated":
+		// Both stream types route through the same handler; the
+		// payload's `action_type` presence picks the branch.
+		return applyDefinitionCreated(ctx, q, e)
+	case e.EventType == "DefinitionRenamed":
+		return applyDefinitionRenamed(ctx, q, e)
+	case e.EventType == "DefinitionDescriptionUpdated":
+		return applyDefinitionDescriptionUpdated(ctx, q, e)
+	case e.EventType == "DefinitionDeleted":
+		return applyDefinitionDeleted(ctx, q, e)
+	case e.StreamType == "definition" && e.EventType == "DefinitionScheduleUpdated":
+		return applyDefinitionScheduleUpdated(ctx, q, e)
+	case e.StreamType == "definition" && e.EventType == "DefinitionMemberAdded":
+		return applyDefinitionMemberAdded(ctx, q, e)
+	case e.StreamType == "definition" && e.EventType == "DefinitionMemberRemoved":
+		return applyDefinitionMemberRemoved(ctx, q, e)
+	case e.StreamType == "definition" && e.EventType == "DefinitionMemberReordered":
+		return applyDefinitionMemberReordered(ctx, q, e)
+	}
+	return nil
+}
+
+// ApplyDefinition is a thin alias to ApplyAction so the rebuild
+// registration for the "definitions" target reads naturally
+// (RegisterRebuildApply("definitions", ApplyDefinition)). Both
+// rebuild targets ("actions" with StreamTypes ["action","definition"]
+// and "definitions" with StreamTypes ["definition"]) share the same
+// body — the per-event StreamType gate inside ApplyAction makes the
+// dual registration safe (a definition event replayed under the
+// "actions" rebuild lands on the synthesised-action branches; the
+// same event replayed under the "definitions" rebuild lands on the
+// definitions_projection branches).
+func ApplyDefinition(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	return ApplyAction(ctx, q, e)
+}
+
+func applyActionCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionCreatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	occurredAt := e.OccurredAt
+	return q.InsertActionProjection(ctx, db.InsertActionProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		Description:       payload.Description,
+		ActionType:        payload.ActionType,
+		DesiredState:      payload.DesiredState,
+		Params:            payload.Params,
+		TimeoutSeconds:    payload.TimeoutSeconds,
+		CreatedAt:         &occurredAt,
+		UpdatedAt:         &occurredAt,
+		CreatedBy:         payload.CreatedBy,
+		ProjectionVersion: deref(e.SequenceNum),
+		IsSystem:          payload.IsSystem,
+		Schedule:          payload.Schedule,
+	})
+}
+
+func applyActionRenamed(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionRenamedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	n, err := q.RenameActionProjection(ctx, db.RenameActionProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		// Stale rename: skip the cross-stream cascade into
+		// compliance_policy_rules.action_name. Otherwise a stale rename
+		// re-applied after a fresher rename would push the old name
+		// into the compliance projection rows.
+		return nil
+	}
+	return q.RenameComplianceRuleActionName(ctx, db.RenameComplianceRuleActionNameParams{
+		ActionID:   payload.ID,
+		ActionName: payload.Name,
+	})
+}
+
+func applyActionDescriptionUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionDescriptionUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateActionDescriptionProjection(ctx, db.UpdateActionDescriptionProjectionParams{
+		ID:                payload.ID,
+		Description:       payload.Description,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyActionParamsUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ActionParamsUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateActionParamsProjection(ctx, db.UpdateActionParamsProjectionParams{
+		ID:                payload.ID,
+		Params:            payload.Params,
+		TimeoutSeconds:    payload.TimeoutSeconds,
+		DesiredState:      payload.DesiredState,
+		Schedule:          payload.Schedule,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyActionDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	streamID, err := ActionDeletedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	n, err := q.SoftDeleteActionProjection(ctx, db.SoftDeleteActionProjectionParams{
+		ID:                streamID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		// Stale ActionDeleted replay: every downstream cascade MUST be
+		// skipped. Otherwise an old delete re-applied by the reconciler
+		// against a freshly-restored action would silently:
+		//   - decrement member_count on every action_set that contains it
+		//   - delete every compliance_policy_rules row referencing it
+		//     (and decrement rule_count on those policies)
+		//   - delete every compliance_policy_evaluation row for it
+		//   - delete every compliance_results row for it
+		//   - trigger a needless reevaluate pass on every device that
+		//     was assigned a policy that used to reference it
+		return nil
+	}
+	// Cascade order matches the PL/pgSQL projector verbatim.
+	if err := q.DecrementActionSetMemberCountByAction(ctx, streamID); err != nil {
+		return err
+	}
+	if err := q.DeleteActionSetMembersByAction(ctx, streamID); err != nil {
+		return err
+	}
+	// Capture affected policies BEFORE deleting their rules — the
+	// follow-up reevaluate loop iterates devices assigned to those
+	// policies and the policy ids would be unrecoverable otherwise.
+	affectedPolicies, err := q.ListCompliancePolicyIDsByAction(ctx, streamID)
+	if err != nil {
+		return err
+	}
+	if len(affectedPolicies) == 0 {
+		// No compliance footprint — done. Matches the PL/pgSQL
+		// projector's `IF v_affected_policies IS NOT NULL THEN ... END IF;`
+		// short-circuit.
+		return nil
+	}
+	if err := q.DecrementCompliancePolicyRuleCountByPolicies(ctx, affectedPolicies); err != nil {
+		return err
+	}
+	if err := q.DeleteCompliancePolicyRulesByAction(ctx, streamID); err != nil {
+		return err
+	}
+	if err := q.DeleteCompliancePolicyEvaluationsByAction(ctx, streamID); err != nil {
+		return err
+	}
+	if err := q.DeleteComplianceResultsByAction(ctx, streamID); err != nil {
+		return err
+	}
+	// Walk every device whose assignment surface includes one of the
+	// affected policies (direct or via device_group) and trigger a
+	// re-evaluation. Mirrors the PL/pgSQL `FOR v_device_id IN ... LOOP
+	// PERFORM evaluate_device_compliance_policies(v_device_id); END
+	// LOOP;` shape.
+	deviceIDs, err := q.ListDeviceIDsForCompliancePolicies(ctx, affectedPolicies)
+	if err != nil {
+		return err
+	}
+	for _, deviceID := range deviceIDs {
+		// Bail out on context cancellation so a SIGTERM mid-deletion
+		// doesn't keep evaluating against an already-cancelled tx.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := q.EvaluateDeviceCompliancePolicies(ctx, deviceID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func applyDefinitionCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DefinitionCreatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	// The event arrives on BOTH stream types via project_event() —
+	// `action` and `definition` — so the listener fires twice. The
+	// payload's action_type discriminator picks which projection gets
+	// the row, and the OTHER stream's invocation no-ops. We mirror that
+	// dispatch here to stay bit-identical with the PL/pgSQL projectors.
+	//
+	// The (StreamType, SynthesisedAction) truth table:
+	//   (action, true)        → INSERT into actions_projection
+	//   (action, false)       → no-op (project_action_event branch)
+	//   (definition, true)    → no-op (project_definition_event branch)
+	//   (definition, false)   → INSERT into definitions_projection
+	if e.StreamType == "action" {
+		if !payload.SynthesisedAction {
+			return nil
+		}
+		occurredAt := e.OccurredAt
+		return q.InsertSynthesisedActionProjection(ctx, db.InsertSynthesisedActionProjectionParams{
+			ID:                payload.ID,
+			Name:              payload.Name,
+			Description:       payload.ActionDescription,
+			ActionType:        payload.ActionType,
+			DesiredState:      payload.DesiredState,
+			Params:            payload.Params,
+			TimeoutSeconds:    payload.TimeoutSeconds,
+			CreatedAt:         &occurredAt,
+			UpdatedAt:         &occurredAt,
+			CreatedBy:         payload.CreatedBy,
+			ProjectionVersion: deref(e.SequenceNum),
+		})
+	}
+	// e.StreamType == "definition"
+	if payload.SynthesisedAction {
+		return nil
+	}
+	occurredAt := e.OccurredAt
+	return q.InsertDefinitionProjection(ctx, db.InsertDefinitionProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		Description:       payload.Description,
+		Schedule:          payload.Schedule,
+		CreatedAt:         &occurredAt,
+		UpdatedAt:         &occurredAt,
+		CreatedBy:         payload.CreatedBy,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+}
+
+func applyDefinitionRenamed(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DefinitionRenamedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	// Action-stream invocation of DefinitionRenamed targets the
+	// synthesised-action row in actions_projection (PL/pgSQL
+	// project_action_event branch). Definition-stream invocation
+	// targets definitions_projection. Both UPDATE paths carry the
+	// projection_version guard; either silently no-ops when the row
+	// doesn't exist (e.g. a synthesised-action rename arriving on the
+	// definition stream lands on the no-target branch).
+	if e.StreamType == "action" {
+		if _, err := q.RenameActionProjection(ctx, db.RenameActionProjectionParams{
+			ID:                payload.ID,
+			Name:              payload.Name,
+			UpdatedAt:         &updatedAt,
+			ProjectionVersion: deref(e.SequenceNum),
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+	if _, err := q.RenameDefinitionProjection(ctx, db.RenameDefinitionProjectionParams{
+		ID:                payload.ID,
+		Name:              payload.Name,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDefinitionDescriptionUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DefinitionDescriptionUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if e.StreamType == "action" {
+		// Action-stream branch writes to actions_projection. The
+		// PL/pgSQL projector wrote `event.data->>'description'`
+		// directly (NULL on absence, "" on explicit empty). The
+		// decoder preserves that distinction in DescriptionPtr so
+		// the absent-vs-explicit-empty difference reaches the column.
+		if _, err := q.UpdateActionDescriptionProjection(ctx, db.UpdateActionDescriptionProjectionParams{
+			ID:                payload.ID,
+			Description:       payload.DescriptionPtr,
+			UpdatedAt:         &updatedAt,
+			ProjectionVersion: deref(e.SequenceNum),
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+	if _, err := q.UpdateDefinitionDescriptionProjection(ctx, db.UpdateDefinitionDescriptionProjectionParams{
+		ID:                payload.ID,
+		Description:       payload.Description,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDefinitionScheduleUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DefinitionScheduleUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateDefinitionScheduleProjection(ctx, db.UpdateDefinitionScheduleProjectionParams{
+		ID:                payload.ID,
+		Schedule:          payload.Schedule,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDefinitionDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	streamID, err := DefinitionDeletedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if e.StreamType == "action" {
+		// Targets the synthesised-action row in actions_projection.
+		// No further cascade — the synthesised action lives only in
+		// actions_projection, with no action_set / compliance_rule
+		// references owned by the synthesis path.
+		if _, err := q.SoftDeleteActionProjection(ctx, db.SoftDeleteActionProjectionParams{
+			ID:                streamID,
+			UpdatedAt:         &updatedAt,
+			ProjectionVersion: deref(e.SequenceNum),
+		}); err != nil {
+			return err
+		}
+		return nil
+	}
+	if _, err := q.SoftDeleteDefinitionProjection(ctx, db.SoftDeleteDefinitionProjectionParams{
+		ID:                streamID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDefinitionMemberAdded(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DefinitionMemberAddedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	// Claim-first guard against definitions_projection. Mirrors the
+	// user_group / action_set / compliance_policy member ports
+	// (PR #174's CR catch). Doing the version check BEFORE the INSERT
+	// closes the stale-replay hole that would otherwise let a stale
+	// MemberAdded recreate a previously-removed membership row, even
+	// though InsertDefinitionMember is idempotent (ON CONFLICT DO
+	// NOTHING).
+	updatedAt := e.OccurredAt
+	n, err := q.ClaimDefinitionForMembership(ctx, db.ClaimDefinitionForMembershipParams{
+		ID:                payload.DefinitionID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	addedAt := e.OccurredAt
+	if err := q.InsertDefinitionMember(ctx, db.InsertDefinitionMemberParams{
+		DefinitionID:      payload.DefinitionID,
+		ActionSetID:       payload.ActionSetID,
+		SortOrder:         payload.SortOrder,
+		AddedAt:           &addedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return q.RecountDefinitionMembers(ctx, payload.DefinitionID)
+}
+
+func applyDefinitionMemberRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DefinitionMemberRemovedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	n, err := q.ClaimDefinitionForMembership(ctx, db.ClaimDefinitionForMembershipParams{
+		ID:                payload.DefinitionID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	if err := q.DeleteDefinitionMember(ctx, db.DeleteDefinitionMemberParams{
+		DefinitionID: payload.DefinitionID,
+		ActionSetID:  payload.ActionSetID,
+	}); err != nil {
+		return err
+	}
+	return q.RecountDefinitionMembers(ctx, payload.DefinitionID)
+}
+
+func applyDefinitionMemberReordered(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DefinitionMemberReorderedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	n, err := q.ClaimDefinitionForMembership(ctx, db.ClaimDefinitionForMembershipParams{
+		ID:                payload.DefinitionID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	// Per-member projection_version guard still runs to prevent
+	// reorders applied out of order from clobbering each other.
+	if _, err := q.UpdateDefinitionMemberSortOrder(ctx, db.UpdateDefinitionMemberSortOrderParams{
+		DefinitionID:      payload.DefinitionID,
+		ActionSetID:       payload.ActionSetID,
+		SortOrder:         payload.SortOrder,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/projectors/action_test.go
+++ b/internal/projectors/action_test.go
@@ -1,0 +1,607 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestActionCreatedFromEvent_Pure pins the decoder defaults that match
+// the deleted PL/pgSQL projector: missing description → nil pointer
+// (NULL on the column); missing action_type / desired_state → 0;
+// missing params → `{}`; missing timeout_seconds → 300; missing
+// is_system → false; missing schedule → nil bytes.
+func TestActionCreatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.ActionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "act-1", EventType: "ActionCreated", ActorID: "u-1",
+			Data: jsonOrFail(t, map[string]any{
+				"name":            "install-curl",
+				"description":     "package install",
+				"action_type":     2,
+				"desired_state":   1,
+				"params":          map[string]any{"package": "curl"},
+				"timeout_seconds": 600,
+				"is_system":       true,
+				"schedule":        map[string]any{"interval_hours": 4},
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "act-1", got.ID)
+		assert.Equal(t, "install-curl", got.Name)
+		require.NotNil(t, got.Description)
+		assert.Equal(t, "package install", *got.Description)
+		assert.Equal(t, int32(2), got.ActionType)
+		assert.Equal(t, int32(1), got.DesiredState)
+		assert.JSONEq(t, `{"package":"curl"}`, string(got.Params))
+		assert.Equal(t, int32(600), got.TimeoutSeconds)
+		assert.True(t, got.IsSystem)
+		assert.JSONEq(t, `{"interval_hours":4}`, string(got.Schedule))
+		assert.Equal(t, "u-1", got.CreatedBy)
+	})
+
+	t.Run("defaults: params={}, timeout=300, action_type=0, is_system=false", func(t *testing.T) {
+		got, err := projectors.ActionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "act-2", EventType: "ActionCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"name": "minimal"}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.Description)
+		assert.Equal(t, int32(0), got.ActionType)
+		assert.Equal(t, int32(0), got.DesiredState)
+		assert.JSONEq(t, `{}`, string(got.Params))
+		assert.Equal(t, int32(300), got.TimeoutSeconds)
+		assert.False(t, got.IsSystem)
+		assert.Nil(t, got.Schedule)
+	})
+
+	t.Run("name is required", func(t *testing.T) {
+		_, err := projectors.ActionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "act-3", EventType: "ActionCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"description": "no name"}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "name")
+	})
+
+	t.Run("wrong stream/event → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.ActionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "definition", EventType: "ActionCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.ActionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action", EventType: "ActionRenamed",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.ActionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action", EventType: "ActionCreated",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestActionRenamedFromEvent_Pure — name is required.
+func TestActionRenamedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.ActionRenamedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "act-1", EventType: "ActionRenamed",
+			Data: jsonOrFail(t, map[string]any{"name": "renamed"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "renamed", got.Name)
+	})
+	t.Run("missing name fails", func(t *testing.T) {
+		_, err := projectors.ActionRenamedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "act-1", EventType: "ActionRenamed",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+	})
+	t.Run("wrong event → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.ActionRenamedFromEvent(store.PersistedEvent{
+			StreamType: "action", EventType: "ActionCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestActionDescriptionUpdatedFromEvent_Pure — *string preserves the
+// absent-vs-empty distinction (nil vs &"") so the nullable column gets
+// the correct value.
+func TestActionDescriptionUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("explicit description", func(t *testing.T) {
+		got, err := projectors.ActionDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "act-1", EventType: "ActionDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{"description": "new"}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Description)
+		assert.Equal(t, "new", *got.Description)
+	})
+	t.Run("missing description → nil pointer (NULL)", func(t *testing.T) {
+		got, err := projectors.ActionDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "act-1", EventType: "ActionDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.Description)
+	})
+	t.Run("explicit empty string round-trips as &\"\"", func(t *testing.T) {
+		got, err := projectors.ActionDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "act-1", EventType: "ActionDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{"description": ""}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Description)
+		assert.Equal(t, "", *got.Description)
+	})
+}
+
+// TestActionParamsUpdatedFromEvent_Pure — every field is optional and
+// nil means "preserve the existing column value". The PL/pgSQL projector
+// did `COALESCE(payload, existing)` per-field; the decoder surfaces
+// absence as nil pointers / empty bytes so the SQL COALESCE picks
+// `existing`.
+func TestActionParamsUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("all fields present", func(t *testing.T) {
+		got, err := projectors.ActionParamsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "act-1", EventType: "ActionParamsUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"params":          map[string]any{"k": "v"},
+				"timeout_seconds": 99,
+				"desired_state":   2,
+				"schedule":        map[string]any{"cron": "0 * * * *"},
+			}),
+		})
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"k":"v"}`, string(got.Params))
+		require.NotNil(t, got.TimeoutSeconds)
+		assert.Equal(t, int32(99), *got.TimeoutSeconds)
+		require.NotNil(t, got.DesiredState)
+		assert.Equal(t, int32(2), *got.DesiredState)
+		assert.JSONEq(t, `{"cron":"0 * * * *"}`, string(got.Schedule))
+	})
+	t.Run("all fields missing → all nil/empty (preserve existing)", func(t *testing.T) {
+		got, err := projectors.ActionParamsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "act-1", EventType: "ActionParamsUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.Params)
+		assert.Nil(t, got.TimeoutSeconds)
+		assert.Nil(t, got.DesiredState)
+		assert.Nil(t, got.Schedule)
+	})
+}
+
+// TestActionDeletedFromEvent_Pure — payload-less validator.
+func TestActionDeletedFromEvent_Pure(t *testing.T) {
+	id, err := projectors.ActionDeletedFromEvent(store.PersistedEvent{
+		StreamType: "action", StreamID: "act-1", EventType: "ActionDeleted",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "act-1", id)
+	_, err = projectors.ActionDeletedFromEvent(store.PersistedEvent{
+		StreamType: "definition", EventType: "ActionDeleted",
+	})
+	assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+}
+
+// TestActionListener_FullLifecycle covers the four single-statement
+// action events end-to-end.
+func TestActionListener_FullLifecycle(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	actionID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionCreated",
+		Data: map[string]any{
+			"name":            "initial",
+			"description":     "first",
+			"action_type":     1,
+			"params":          map[string]any{"k": "v"},
+			"timeout_seconds": 120,
+		},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err := st.Queries().GetActionByID(ctx, actionID)
+	require.NoError(t, err)
+	assert.Equal(t, "initial", got.Name)
+	require.NotNil(t, got.Description)
+	assert.Equal(t, "first", *got.Description)
+	assert.Equal(t, int32(1), got.ActionType)
+	assert.Equal(t, int32(120), got.TimeoutSeconds)
+	assert.Greater(t, got.ProjectionVersion, int64(0))
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionRenamed",
+		Data:      map[string]any{"name": "renamed"},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetActionByID(ctx, actionID)
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", got.Name)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionParamsUpdated",
+		Data: map[string]any{
+			"timeout_seconds": 30,
+			// params + desired_state + schedule omitted: must be preserved.
+		},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	got, err = st.Queries().GetActionByID(ctx, actionID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(30), got.TimeoutSeconds, "timeout updated")
+	assert.JSONEq(t, `{"k":"v"}`, string(got.Params),
+		"params NOT in payload must be preserved (PL/pgSQL COALESCE semantic)")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u-1",
+	}))
+	_, err = st.Queries().GetActionByID(ctx, actionID)
+	require.Error(t, err, "GetActionByID filters out is_deleted=TRUE rows")
+}
+
+// TestActionListener_RenameCascadesIntoComplianceRule confirms the
+// cross-stream cascade: ActionRenamed updates compliance_policy_rules
+// .action_name as a denormalised projection mirror.
+func TestActionListener_RenameCascadesIntoComplianceRule(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	actionID := testutil.NewID()
+	policyID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionCreated",
+		Data:      map[string]any{"name": "before-rename"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyCreated",
+		Data:      map[string]any{"name": "p1", "description": ""},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id":          actionID,
+			"action_name":        "before-rename",
+			"grace_period_hours": 0,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionRenamed",
+		Data:      map[string]any{"name": "after-rename"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	var actionName string
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		`SELECT action_name FROM compliance_policy_rules_projection
+		 WHERE policy_id = $1 AND action_id = $2`, policyID, actionID,
+	).Scan(&actionName))
+	assert.Equal(t, "after-rename", actionName,
+		"ActionRenamed must cascade into compliance_policy_rules.action_name")
+}
+
+// TestActionListener_DeletedCascadesAcrossEverything covers the full
+// 4-table cascade: action_set decrement + member wipe, compliance rule
+// delete + per-policy rule_count decrement, evaluation wipe, results
+// wipe.
+func TestActionListener_DeletedCascadesAcrossEverything(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	actionID := testutil.NewID()
+	setID := testutil.NewID()
+	policyID := testutil.NewID()
+	deviceID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionCreated",
+		Data:      map[string]any{"name": "doomed"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data:      map[string]any{"name": "set-with-doomed"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"action_id": actionID},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyCreated",
+		Data:      map[string]any{"name": "p1", "description": ""},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id":          actionID,
+			"action_name":        "doomed",
+			"grace_period_hours": 0,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	// Plant a compliance result + an evaluation row directly so we
+	// don't have to drive the full eval engine to exercise the wipes.
+	_, err := st.Pool().Exec(ctx,
+		`INSERT INTO compliance_results_projection (device_id, action_id, action_name, compliant, checked_at)
+		 VALUES ($1, $2, $3, TRUE, NOW())`,
+		deviceID, actionID, "doomed",
+	)
+	require.NoError(t, err)
+	_, err = st.Pool().Exec(ctx,
+		`INSERT INTO compliance_policy_evaluation_projection (device_id, policy_id, action_id, compliant, checked_at)
+		 VALUES ($1, $2, $3, TRUE, NOW())`,
+		deviceID, policyID, actionID,
+	)
+	require.NoError(t, err)
+
+	// Verify pre-state: parent action_set has member_count == 1, policy
+	// has rule_count == 1.
+	beforeSet, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), beforeSet.MemberCount)
+	beforePolicy, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), beforePolicy.RuleCount)
+
+	// Delete the action.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// action_set member wiped + member_count decremented.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM action_set_members_projection WHERE action_id = $1", actionID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "action_set members for deleted action wiped")
+	afterSet, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), afterSet.MemberCount, "parent action_set member_count decremented")
+
+	// Compliance rules wiped + per-policy rule_count decremented.
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_policy_rules_projection WHERE action_id = $1", actionID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "compliance rules for deleted action wiped")
+	afterPolicy, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), afterPolicy.RuleCount, "policy rule_count decremented")
+
+	// Evaluation + result rows wiped.
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_policy_evaluation_projection WHERE action_id = $1", actionID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "evaluation rows for deleted action wiped")
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_results_projection WHERE action_id = $1", actionID,
+	).Scan(&count))
+	assert.Equal(t, 0, count, "result rows for deleted action wiped")
+}
+
+// TestActionListener_StaleDeleteReplayDoesNotNukeCascade locks the
+// asymmetric-guard discipline for the most cascade-heavy event type:
+// when the version-guarded SoftDelete affects zero rows, every
+// downstream cascade (action_set member decrement, compliance rule
+// delete + recount, evaluation delete, results delete) MUST be
+// skipped.
+func TestActionListener_StaleDeleteReplayDoesNotNukeCascade(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	actionID := testutil.NewID()
+	setID := testutil.NewID()
+	policyID := testutil.NewID()
+	deviceID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionCreated",
+		Data:      map[string]any{"name": "live"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data:      map[string]any{"name": "live-set"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"action_id": actionID},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyCreated",
+		Data:      map[string]any{"name": "live-policy"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
+		Data: map[string]any{
+			"action_id":   actionID,
+			"action_name": "live",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	_, err := st.Pool().Exec(ctx,
+		`INSERT INTO compliance_results_projection (device_id, action_id, action_name, compliant, checked_at)
+		 VALUES ($1, $2, $3, TRUE, NOW())`,
+		deviceID, actionID, "live",
+	)
+	require.NoError(t, err)
+
+	live, err := st.Queries().GetActionByID(ctx, actionID)
+	require.NoError(t, err)
+
+	// Drive the listener directly with a stale ActionDeleted (older
+	// projection_version than the row currently has).
+	older := live.ProjectionVersion - 5
+	staleAt := *live.UpdatedAt
+	listener := projectors.ActionListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "action",
+		StreamID:    actionID,
+		EventType:   "ActionDeleted",
+		Data:        []byte("{}"),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
+	})
+
+	// Action still alive.
+	stillAlive, err := st.Queries().GetActionByID(ctx, actionID)
+	require.NoError(t, err)
+	assert.False(t, stillAlive.IsDeleted, "stale ActionDeleted must NOT flip is_deleted")
+
+	// action_set member NOT wiped, member_count NOT decremented.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM action_set_members_projection WHERE action_id = $1", actionID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale ActionDeleted must NOT cascade-delete action_set members")
+	afterSet, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), afterSet.MemberCount,
+		"stale ActionDeleted must NOT decrement live action_set member_count")
+
+	// Compliance rule NOT wiped, rule_count NOT decremented.
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_policy_rules_projection WHERE action_id = $1", actionID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale ActionDeleted must NOT cascade-delete compliance rules")
+	afterPolicy, err := st.Queries().GetCompliancePolicyByID(ctx, policyID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), afterPolicy.RuleCount,
+		"stale ActionDeleted must NOT decrement live policy rule_count")
+
+	// Compliance results NOT wiped.
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM compliance_results_projection WHERE action_id = $1", actionID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale ActionDeleted must NOT cascade-delete compliance results")
+}
+
+// TestActionListener_ActionSetMemberCountDecrementsOnDelete is a
+// focused regression for the action_set decrement step — covered by
+// the cascade test above but kept as a dedicated probe.
+func TestActionListener_ActionSetMemberCountDecrementsOnDelete(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	actionID := testutil.NewID()
+	setID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionCreated",
+		Data:      map[string]any{"name": "to-delete"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data:      map[string]any{"name": "container"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data:      map[string]any{"action_id": actionID},
+		ActorType: "user", ActorID: "u",
+	}))
+	pre, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), pre.MemberCount)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	post, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), post.MemberCount,
+		"ActionDeleted must decrement member_count on every parent set")
+}
+
+// TestActionListener_StaleRenamedReplayRejected — UPDATE form on the
+// action stream doesn't clobber a fresher row when re-applied with an
+// older projection_version.
+func TestActionListener_StaleRenamedReplayRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	actionID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionCreated",
+		Data:      map[string]any{"name": "first"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: actionID, EventType: "ActionRenamed",
+		Data:      map[string]any{"name": "current"},
+		ActorType: "user", ActorID: "u",
+	}))
+	current, err := st.Queries().GetActionByID(ctx, actionID)
+	require.NoError(t, err)
+	currentVersion := current.ProjectionVersion
+
+	older := currentVersion - 5
+	updatedAt := current.UpdatedAt
+	n, err := st.Queries().RenameActionProjection(ctx, db.RenameActionProjectionParams{
+		ID:                actionID,
+		Name:              "stale",
+		UpdatedAt:         updatedAt,
+		ProjectionVersion: older,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+
+	after, err := st.Queries().GetActionByID(ctx, actionID)
+	require.NoError(t, err)
+	assert.Equal(t, "current", after.Name)
+}
+
+// TestActionListener_IgnoresOtherStreamTypes — defensive.
+func TestActionListener_IgnoresOtherStreamTypes(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	id := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", // wrong
+		StreamID:   id,
+		EventType:  "ActionCreated",
+		Data:       map[string]any{"name": "ghost"},
+		ActorType:  "user", ActorID: "u",
+	}))
+
+	_, err := st.Queries().GetActionByID(ctx, id)
+	require.Error(t, err, "wrong-stream ActionCreated must NOT create a row")
+}

--- a/internal/projectors/definition.go
+++ b/internal/projectors/definition.go
@@ -1,0 +1,339 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// defaultDefinitionSchedule mirrors the column default added in
+// migration 012 (`{"interval_hours": 8}`) and the PL/pgSQL projector's
+// COALESCE fallback for the missing schedule key.
+var defaultDefinitionSchedule = []byte(`{"interval_hours": 8}`)
+
+// DefinitionCreatedPayload covers BOTH branches the deleted PL/pgSQL
+// projector pair handled:
+//
+//   - When the payload carries an `action_type` key, project_action_event
+//     synthesises an actions_projection row (compliance-policy bootstrap)
+//     and project_definition_event no-ops on the definitions_projection
+//     side. SynthesisedAction == true.
+//   - Otherwise project_definition_event inserts a definitions_projection
+//     row and project_action_event no-ops. SynthesisedAction == false.
+//
+// SynthesisedAction is the dispatch key the listener uses to pick the
+// right branch — keeping the routing decision in the decoder lets the
+// listener stay branch-shape-symmetric with the other ports.
+type DefinitionCreatedPayload struct {
+	ID                string
+	Name              string
+	Description       string
+	Schedule          []byte
+	CreatedBy         string
+	SynthesisedAction bool
+	ActionType        int32
+	DesiredState      int32
+	Params            []byte
+	TimeoutSeconds    int32
+	ActionDescription *string
+}
+
+type definitionCreatedRaw struct {
+	Name           string          `json:"name"`
+	Description    *string         `json:"description,omitempty"`
+	Schedule       json.RawMessage `json:"schedule,omitempty"`
+	ActionType     *int32          `json:"action_type,omitempty"`
+	DesiredState   *int32          `json:"desired_state,omitempty"`
+	Params         json.RawMessage `json:"params,omitempty"`
+	TimeoutSeconds *int32          `json:"timeout_seconds,omitempty"`
+}
+
+// DefinitionCreatedFromEvent decodes DefinitionCreated for BOTH
+// streams (the action stream's synthesised-action branch reuses this
+// decoder via the listener dispatch in action_listener.go). The
+// SynthesisedAction flag mirrors the PL/pgSQL projector's
+// `IF event.data ? 'action_type'` discriminator: presence (not value)
+// of the key picks the actions_projection branch; absence picks the
+// definitions_projection branch.
+//
+// The two branches need different field sets:
+//   - definitions_projection branch: name, description (defaults to "" —
+//     NOT NULL column), schedule (defaults to '{"interval_hours": 8}').
+//   - actions_projection synthesis branch: name, description (nullable
+//     in actions_projection), action_type, desired_state, params
+//     (defaults to '{}'), timeout_seconds (defaults to 300). schedule
+//     is intentionally NOT written by the synthesis branch — the
+//     PL/pgSQL projector's INSERT into actions_projection on this branch
+//     omitted the schedule column entirely, leaving it at the column
+//     default (NULL since the actions schedule column is nullable).
+func DefinitionCreatedFromEvent(e store.PersistedEvent) (DefinitionCreatedPayload, error) {
+	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != "DefinitionCreated" {
+		return DefinitionCreatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DefinitionCreatedPayload{}, fmt.Errorf("projector: empty DefinitionCreated payload")
+	}
+	// Discriminate on key presence (not value) using a generic decode —
+	// the PL/pgSQL `event.data ? 'action_type'` test treats an explicit
+	// JSON null AS present. Mirror that here so a synthesised-action
+	// event with `"action_type": null` lands on the synthesis branch.
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(e.Data, &probe); err != nil {
+		return DefinitionCreatedPayload{}, fmt.Errorf("projector: invalid DefinitionCreated payload: %w", err)
+	}
+	_, hasActionType := probe["action_type"]
+
+	var raw definitionCreatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DefinitionCreatedPayload{}, fmt.Errorf("projector: invalid DefinitionCreated payload: %w", err)
+	}
+	if raw.Name == "" {
+		return DefinitionCreatedPayload{}, fmt.Errorf("projector: DefinitionCreated requires name")
+	}
+	out := DefinitionCreatedPayload{
+		ID:                e.StreamID,
+		Name:              raw.Name,
+		Schedule:          defaultDefinitionSchedule,
+		CreatedBy:         e.ActorID,
+		SynthesisedAction: hasActionType,
+		Params:            defaultActionParams,
+		TimeoutSeconds:    defaultActionTimeoutSeconds,
+		ActionDescription: raw.Description,
+	}
+	if raw.Description != nil {
+		out.Description = *raw.Description
+	}
+	if len(raw.Schedule) > 0 {
+		out.Schedule = []byte(raw.Schedule)
+	}
+	if raw.ActionType != nil {
+		out.ActionType = *raw.ActionType
+	}
+	if raw.DesiredState != nil {
+		out.DesiredState = *raw.DesiredState
+	}
+	if len(raw.Params) > 0 {
+		out.Params = []byte(raw.Params)
+	}
+	if raw.TimeoutSeconds != nil {
+		out.TimeoutSeconds = *raw.TimeoutSeconds
+	}
+	return out, nil
+}
+
+// DefinitionRenamedPayload — single mutable field. Empty Name is a
+// validation error (see ActionRenamed for the same rationale).
+type DefinitionRenamedPayload struct {
+	ID   string
+	Name string
+}
+
+type definitionRenamedRaw struct {
+	Name string `json:"name"`
+}
+
+// DefinitionRenamedFromEvent decodes DefinitionRenamed for BOTH
+// streams (action-stream synthesised-action rename + definition-stream
+// rename).
+func DefinitionRenamedFromEvent(e store.PersistedEvent) (DefinitionRenamedPayload, error) {
+	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != "DefinitionRenamed" {
+		return DefinitionRenamedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DefinitionRenamedPayload{}, fmt.Errorf("projector: empty DefinitionRenamed payload")
+	}
+	var raw definitionRenamedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DefinitionRenamedPayload{}, fmt.Errorf("projector: invalid DefinitionRenamed payload: %w", err)
+	}
+	if raw.Name == "" {
+		return DefinitionRenamedPayload{}, fmt.Errorf("projector: DefinitionRenamed requires name")
+	}
+	return DefinitionRenamedPayload{ID: e.StreamID, Name: raw.Name}, nil
+}
+
+// DefinitionDescriptionUpdatedPayload exposes both shapes the
+// PL/pgSQL projector pair needed:
+//
+//   - definitions_projection branch: `COALESCE(payload, "")` — missing
+//     key OR explicit empty string both collapse to "" (the column is
+//     NOT NULL). Description carries that value.
+//   - actions_projection branch (synthesised-action rename — fires when
+//     the same DefinitionDescriptionUpdated arrives on the action
+//     stream): `event.data->>'description'` direct — absence is NULL,
+//     explicit empty is "". DescriptionPtr carries that value (nil on
+//     absence, &"" on explicit empty, &"x" on explicit value).
+//
+// Listener picks DescriptionPtr for the action-stream branch and
+// Description for the definition-stream branch so each projection
+// keeps its original semantic.
+type DefinitionDescriptionUpdatedPayload struct {
+	ID             string
+	Description    string
+	DescriptionPtr *string
+}
+
+type definitionDescriptionUpdatedRaw struct {
+	Description *string `json:"description,omitempty"`
+}
+
+// DefinitionDescriptionUpdatedFromEvent decodes DefinitionDescriptionUpdated
+// for BOTH streams (the action stream's synthesised-action branch
+// reuses this decoder via the listener dispatch in action_listener.go).
+// The decoder accepts both stream types because the PL/pgSQL pair
+// shared the event-name with different write semantics.
+func DefinitionDescriptionUpdatedFromEvent(e store.PersistedEvent) (DefinitionDescriptionUpdatedPayload, error) {
+	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != "DefinitionDescriptionUpdated" {
+		return DefinitionDescriptionUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := DefinitionDescriptionUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw definitionDescriptionUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DefinitionDescriptionUpdatedPayload{}, fmt.Errorf("projector: invalid DefinitionDescriptionUpdated payload: %w", err)
+	}
+	out.DescriptionPtr = raw.Description
+	if raw.Description != nil {
+		out.Description = *raw.Description
+	}
+	return out, nil
+}
+
+// DefinitionScheduleUpdatedPayload — missing schedule key falls back to
+// the column default `{"interval_hours": 8}` (mirrors the PL/pgSQL
+// COALESCE against the JSONB default).
+type DefinitionScheduleUpdatedPayload struct {
+	ID       string
+	Schedule []byte
+}
+
+type definitionScheduleUpdatedRaw struct {
+	Schedule json.RawMessage `json:"schedule,omitempty"`
+}
+
+// DefinitionScheduleUpdatedFromEvent decodes DefinitionScheduleUpdated.
+func DefinitionScheduleUpdatedFromEvent(e store.PersistedEvent) (DefinitionScheduleUpdatedPayload, error) {
+	if e.StreamType != "definition" || e.EventType != "DefinitionScheduleUpdated" {
+		return DefinitionScheduleUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := DefinitionScheduleUpdatedPayload{
+		ID:       e.StreamID,
+		Schedule: defaultDefinitionSchedule,
+	}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw definitionScheduleUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DefinitionScheduleUpdatedPayload{}, fmt.Errorf("projector: invalid DefinitionScheduleUpdated payload: %w", err)
+	}
+	if len(raw.Schedule) > 0 {
+		out.Schedule = []byte(raw.Schedule)
+	}
+	return out, nil
+}
+
+// DefinitionMemberAddedPayload — sort_order defaults to 0 (matches
+// PL/pgSQL `COALESCE((payload)::INTEGER, 0)`).
+type DefinitionMemberAddedPayload struct {
+	DefinitionID string
+	ActionSetID  string
+	SortOrder    int32
+}
+
+type definitionMemberRaw struct {
+	ActionSetID string `json:"action_set_id"`
+	SortOrder   *int32 `json:"sort_order,omitempty"`
+}
+
+// DefinitionMemberAddedFromEvent decodes DefinitionMemberAdded.
+func DefinitionMemberAddedFromEvent(e store.PersistedEvent) (DefinitionMemberAddedPayload, error) {
+	if e.StreamType != "definition" || e.EventType != "DefinitionMemberAdded" {
+		return DefinitionMemberAddedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DefinitionMemberAddedPayload{}, fmt.Errorf("projector: empty DefinitionMemberAdded payload")
+	}
+	var raw definitionMemberRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DefinitionMemberAddedPayload{}, fmt.Errorf("projector: invalid DefinitionMemberAdded payload: %w", err)
+	}
+	if raw.ActionSetID == "" {
+		return DefinitionMemberAddedPayload{}, fmt.Errorf("projector: DefinitionMemberAdded requires action_set_id")
+	}
+	out := DefinitionMemberAddedPayload{DefinitionID: e.StreamID, ActionSetID: raw.ActionSetID}
+	if raw.SortOrder != nil {
+		out.SortOrder = *raw.SortOrder
+	}
+	return out, nil
+}
+
+// DefinitionMemberRemovedPayload — only action_set_id matters; the
+// definition id comes from the stream.
+type DefinitionMemberRemovedPayload struct {
+	DefinitionID string
+	ActionSetID  string
+}
+
+type definitionMemberRemovedRaw struct {
+	ActionSetID string `json:"action_set_id"`
+}
+
+// DefinitionMemberRemovedFromEvent decodes DefinitionMemberRemoved.
+func DefinitionMemberRemovedFromEvent(e store.PersistedEvent) (DefinitionMemberRemovedPayload, error) {
+	if e.StreamType != "definition" || e.EventType != "DefinitionMemberRemoved" {
+		return DefinitionMemberRemovedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DefinitionMemberRemovedPayload{}, fmt.Errorf("projector: empty DefinitionMemberRemoved payload")
+	}
+	var raw definitionMemberRemovedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DefinitionMemberRemovedPayload{}, fmt.Errorf("projector: invalid DefinitionMemberRemoved payload: %w", err)
+	}
+	if raw.ActionSetID == "" {
+		return DefinitionMemberRemovedPayload{}, fmt.Errorf("projector: DefinitionMemberRemoved requires action_set_id")
+	}
+	return DefinitionMemberRemovedPayload{DefinitionID: e.StreamID, ActionSetID: raw.ActionSetID}, nil
+}
+
+// DefinitionMemberReorderedPayload — same shape as DefinitionMemberAdded.
+type DefinitionMemberReorderedPayload = DefinitionMemberAddedPayload
+
+// DefinitionMemberReorderedFromEvent decodes DefinitionMemberReordered.
+func DefinitionMemberReorderedFromEvent(e store.PersistedEvent) (DefinitionMemberReorderedPayload, error) {
+	if e.StreamType != "definition" || e.EventType != "DefinitionMemberReordered" {
+		return DefinitionMemberReorderedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DefinitionMemberReorderedPayload{}, fmt.Errorf("projector: empty DefinitionMemberReordered payload")
+	}
+	var raw definitionMemberRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DefinitionMemberReorderedPayload{}, fmt.Errorf("projector: invalid DefinitionMemberReordered payload: %w", err)
+	}
+	if raw.ActionSetID == "" {
+		return DefinitionMemberReorderedPayload{}, fmt.Errorf("projector: DefinitionMemberReordered requires action_set_id")
+	}
+	out := DefinitionMemberReorderedPayload{DefinitionID: e.StreamID, ActionSetID: raw.ActionSetID}
+	if raw.SortOrder != nil {
+		out.SortOrder = *raw.SortOrder
+	}
+	return out, nil
+}
+
+// DefinitionDeletedFromEvent — payload-less; only validates the
+// (stream, event_type) pair. The cascade derives everything from the
+// stream id. Accepts both stream types because the action-stream
+// invocation soft-deletes the synthesised-action row in
+// actions_projection while the definition-stream invocation soft-
+// deletes the definitions_projection row.
+func DefinitionDeletedFromEvent(e store.PersistedEvent) (string, error) {
+	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != "DefinitionDeleted" {
+		return "", ErrIgnoredEvent
+	}
+	return e.StreamID, nil
+}

--- a/internal/projectors/definition_test.go
+++ b/internal/projectors/definition_test.go
@@ -1,0 +1,470 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestDefinitionCreatedFromEvent_Pure pins the SynthesisedAction
+// discriminator: presence of `action_type` (not value) flips it.
+func TestDefinitionCreatedFromEvent_Pure(t *testing.T) {
+	t.Run("definition branch — no action_type → SynthesisedAction=false", func(t *testing.T) {
+		got, err := projectors.DefinitionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "definition", StreamID: "def-1", EventType: "DefinitionCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{
+				"name":        "weekly",
+				"description": "weekly maintenance",
+				"schedule":    map[string]any{"interval_hours": 24},
+			}),
+		})
+		require.NoError(t, err)
+		assert.False(t, got.SynthesisedAction)
+		assert.Equal(t, "def-1", got.ID)
+		assert.Equal(t, "weekly", got.Name)
+		assert.Equal(t, "weekly maintenance", got.Description)
+		assert.JSONEq(t, `{"interval_hours":24}`, string(got.Schedule))
+		assert.Equal(t, "u", got.CreatedBy)
+	})
+
+	t.Run("synthesis branch — action_type present → SynthesisedAction=true", func(t *testing.T) {
+		got, err := projectors.DefinitionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "definition", StreamID: "def-2", EventType: "DefinitionCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{
+				"name":        "synth",
+				"action_type": 5,
+				"params":      map[string]any{"x": 1},
+			}),
+		})
+		require.NoError(t, err)
+		assert.True(t, got.SynthesisedAction,
+			"presence of action_type triggers the synthesis branch")
+		assert.Equal(t, int32(5), got.ActionType)
+		assert.JSONEq(t, `{"x":1}`, string(got.Params))
+	})
+
+	t.Run("synthesis branch — explicit null action_type also counts as present", func(t *testing.T) {
+		// PL/pgSQL `event.data ? 'action_type'` returns TRUE even when
+		// the value is JSON null. Mirror that here so a synthesised-
+		// action event with `"action_type": null` lands on the
+		// synthesis branch.
+		got, err := projectors.DefinitionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "definition", StreamID: "def-3", EventType: "DefinitionCreated", ActorID: "u",
+			Data: []byte(`{"name":"nullsynth","action_type":null}`),
+		})
+		require.NoError(t, err)
+		assert.True(t, got.SynthesisedAction,
+			"null-valued action_type counts as 'present' under PL/pgSQL ? operator semantics")
+	})
+
+	t.Run("defaults: description='', schedule={interval_hours:8}, params={}, timeout=300", func(t *testing.T) {
+		got, err := projectors.DefinitionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "definition", StreamID: "def-4", EventType: "DefinitionCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"name": "minimal"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description)
+		assert.JSONEq(t, `{"interval_hours":8}`, string(got.Schedule))
+		assert.JSONEq(t, `{}`, string(got.Params))
+		assert.Equal(t, int32(300), got.TimeoutSeconds)
+	})
+
+	t.Run("name is required", func(t *testing.T) {
+		_, err := projectors.DefinitionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "definition", StreamID: "def-5", EventType: "DefinitionCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"description": "no name"}),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("accepts both stream types (action AND definition)", func(t *testing.T) {
+		// The action stream invocation is how the synthesised-action
+		// branch receives the event — the listener dispatches to it
+		// from action_listener.go.
+		_, err := projectors.DefinitionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "action", StreamID: "x", EventType: "DefinitionCreated", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{"name": "x"}),
+		})
+		require.NoError(t, err)
+		_, err = projectors.DefinitionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "DefinitionCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.DefinitionCreatedFromEvent(store.PersistedEvent{
+			StreamType: "definition", EventType: "DefinitionCreated",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDefinitionRenamedFromEvent_Pure — name is required.
+func TestDefinitionRenamedFromEvent_Pure(t *testing.T) {
+	got, err := projectors.DefinitionRenamedFromEvent(store.PersistedEvent{
+		StreamType: "definition", StreamID: "def-1", EventType: "DefinitionRenamed",
+		Data: jsonOrFail(t, map[string]any{"name": "renamed"}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "renamed", got.Name)
+
+	_, err = projectors.DefinitionRenamedFromEvent(store.PersistedEvent{
+		StreamType: "definition", StreamID: "def-1", EventType: "DefinitionRenamed",
+		Data: jsonOrFail(t, map[string]any{}),
+	})
+	require.Error(t, err)
+}
+
+// TestDefinitionDescriptionUpdatedFromEvent_Pure — exposes BOTH the
+// definition-stream collapse (Description string) AND the action-stream
+// pass-through (DescriptionPtr *string).
+func TestDefinitionDescriptionUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("explicit description set", func(t *testing.T) {
+		got, err := projectors.DefinitionDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "definition", StreamID: "def-1", EventType: "DefinitionDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{"description": "new"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "new", got.Description)
+		require.NotNil(t, got.DescriptionPtr)
+		assert.Equal(t, "new", *got.DescriptionPtr)
+	})
+
+	t.Run("missing description: Description='' AND DescriptionPtr=nil", func(t *testing.T) {
+		got, err := projectors.DefinitionDescriptionUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "definition", StreamID: "def-1", EventType: "DefinitionDescriptionUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Description,
+			"definition stream collapses missing → '' (matches PL/pgSQL COALESCE)")
+		assert.Nil(t, got.DescriptionPtr,
+			"action stream sees nil pointer → NULL (matches direct pass-through)")
+	})
+}
+
+// TestDefinitionScheduleUpdatedFromEvent_Pure — missing → column default.
+func TestDefinitionScheduleUpdatedFromEvent_Pure(t *testing.T) {
+	got, err := projectors.DefinitionScheduleUpdatedFromEvent(store.PersistedEvent{
+		StreamType: "definition", StreamID: "def-1", EventType: "DefinitionScheduleUpdated",
+		Data: jsonOrFail(t, map[string]any{}),
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"interval_hours":8}`, string(got.Schedule))
+}
+
+// TestDefinitionMemberAddedFromEvent_Pure — sort_order defaults 0.
+func TestDefinitionMemberAddedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.DefinitionMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "definition", StreamID: "def-1", EventType: "DefinitionMemberAdded",
+			Data: jsonOrFail(t, map[string]any{"action_set_id": "as-1", "sort_order": 7}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "def-1", got.DefinitionID)
+		assert.Equal(t, "as-1", got.ActionSetID)
+		assert.Equal(t, int32(7), got.SortOrder)
+	})
+	t.Run("sort_order missing → 0", func(t *testing.T) {
+		got, err := projectors.DefinitionMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "definition", StreamID: "def-1", EventType: "DefinitionMemberAdded",
+			Data: jsonOrFail(t, map[string]any{"action_set_id": "as-1"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), got.SortOrder)
+	})
+	t.Run("missing action_set_id is a validation error", func(t *testing.T) {
+		_, err := projectors.DefinitionMemberAddedFromEvent(store.PersistedEvent{
+			StreamType: "definition", StreamID: "def-1", EventType: "DefinitionMemberAdded",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+	})
+}
+
+// TestDefinitionMemberRemovedFromEvent_Pure
+func TestDefinitionMemberRemovedFromEvent_Pure(t *testing.T) {
+	got, err := projectors.DefinitionMemberRemovedFromEvent(store.PersistedEvent{
+		StreamType: "definition", StreamID: "def-1", EventType: "DefinitionMemberRemoved",
+		Data: jsonOrFail(t, map[string]any{"action_set_id": "as-9"}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "as-9", got.ActionSetID)
+}
+
+// TestDefinitionMemberReorderedFromEvent_Pure
+func TestDefinitionMemberReorderedFromEvent_Pure(t *testing.T) {
+	got, err := projectors.DefinitionMemberReorderedFromEvent(store.PersistedEvent{
+		StreamType: "definition", StreamID: "def-1", EventType: "DefinitionMemberReordered",
+		Data: jsonOrFail(t, map[string]any{"action_set_id": "as-1", "sort_order": 3}),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), got.SortOrder)
+}
+
+// TestDefinitionDeletedFromEvent_Pure — payload-less.
+func TestDefinitionDeletedFromEvent_Pure(t *testing.T) {
+	id, err := projectors.DefinitionDeletedFromEvent(store.PersistedEvent{
+		StreamType: "definition", StreamID: "def-1", EventType: "DefinitionDeleted",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "def-1", id)
+	_, err = projectors.DefinitionDeletedFromEvent(store.PersistedEvent{
+		StreamType: "user", EventType: "DefinitionDeleted",
+	})
+	assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+}
+
+// TestDefinitionListener_FullLifecycle_NoActionType covers the
+// definition-stream branch end-to-end (action_type omitted, so the
+// definitions_projection branch fires).
+func TestDefinitionListener_FullLifecycle_NoActionType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	defID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionCreated",
+		Data: map[string]any{
+			"name":        "weekly",
+			"description": "first",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err := st.Queries().GetDefinitionByID(ctx, defID)
+	require.NoError(t, err)
+	assert.Equal(t, "weekly", got.Name)
+	assert.Equal(t, "first", got.Description)
+	assert.JSONEq(t, `{"interval_hours":8}`, string(got.Schedule),
+		"missing schedule defaults to column default")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionRenamed",
+		Data:      map[string]any{"name": "biweekly"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetDefinitionByID(ctx, defID)
+	require.NoError(t, err)
+	assert.Equal(t, "biweekly", got.Name)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionDescriptionUpdated",
+		Data:      map[string]any{"description": "updated"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetDefinitionByID(ctx, defID)
+	require.NoError(t, err)
+	assert.Equal(t, "updated", got.Description)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionScheduleUpdated",
+		Data:      map[string]any{"schedule": map[string]any{"cron": "0 6 * * MON"}},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetDefinitionByID(ctx, defID)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"cron":"0 6 * * MON"}`, string(got.Schedule))
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+	_, err = st.Queries().GetDefinitionByID(ctx, defID)
+	require.Error(t, err, "soft-deleted definition is filtered out by GetDefinitionByID")
+}
+
+// TestDefinitionListener_SynthesisedActionBranch covers the action-
+// stream branch: a DefinitionCreated event arriving on the action
+// stream with an action_type payload INSERTs into actions_projection
+// (compliance-policy bootstrap), and the same event arriving on the
+// definition stream no-ops.
+func TestDefinitionListener_SynthesisedActionBranch(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	id := testutil.NewID()
+
+	// Real production flow synthesises one event per stream — both
+	// stream types receive the same DefinitionCreated payload through
+	// project_event() dispatch. Mirror that here by calling
+	// AppendEvent twice with different StreamType, sharing the same
+	// id (the payload is identical).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action", StreamID: id, EventType: "DefinitionCreated",
+		Data: map[string]any{
+			"name":        "synth-action",
+			"description": "compliance-policy backed",
+			"action_type": 3,
+			"params":      map[string]any{"k": "v"},
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: id, EventType: "DefinitionCreated",
+		Data: map[string]any{
+			"name":        "synth-action",
+			"description": "compliance-policy backed",
+			"action_type": 3,
+			"params":      map[string]any{"k": "v"},
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// actions_projection has the synthesised row.
+	got, err := st.Queries().GetActionByID(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, "synth-action", got.Name)
+	assert.Equal(t, int32(3), got.ActionType)
+	assert.JSONEq(t, `{"k":"v"}`, string(got.Params))
+
+	// definitions_projection MUST NOT have a row (synthesis branch
+	// is the action-stream side; definition stream no-ops).
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM definitions_projection WHERE id = $1", id,
+	).Scan(&count))
+	assert.Equal(t, 0, count,
+		"DefinitionCreated with action_type must NOT insert into definitions_projection")
+}
+
+// TestDefinitionListener_MemberAddRemoveRecounts covers the
+// MemberAdded → MemberRemoved cycle and asserts member_count tracks
+// the live row count after each.
+func TestDefinitionListener_MemberAddRemoveRecounts(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	defID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionCreated",
+		Data:      map[string]any{"name": "with-members"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionMemberAdded",
+		Data:      map[string]any{"action_set_id": "as-A", "sort_order": 0},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionMemberAdded",
+		Data:      map[string]any{"action_set_id": "as-B", "sort_order": 1},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err := st.Queries().GetDefinitionByID(ctx, defID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), got.MemberCount)
+
+	// Idempotent re-add: ON CONFLICT DO NOTHING + recount keeps
+	// member_count stable.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionMemberAdded",
+		Data:      map[string]any{"action_set_id": "as-A", "sort_order": 99},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetDefinitionByID(ctx, defID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), got.MemberCount, "repeat-add must not double-count")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionMemberRemoved",
+		Data:      map[string]any{"action_set_id": "as-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetDefinitionByID(ctx, defID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), got.MemberCount)
+}
+
+// TestDefinitionListener_StaleMemberAddedDoesNotRecreateMembership
+// locks the Claim-first guard for DefinitionMember events: a stale
+// MemberAdded replayed after a Removed must NOT reinsert the
+// membership row, even though InsertDefinitionMember is idempotent
+// (ON CONFLICT DO NOTHING).
+func TestDefinitionListener_StaleMemberAddedDoesNotRecreateMembership(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	defID := testutil.NewID()
+	actionSetID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionCreated",
+		Data:      map[string]any{"name": "stale-add"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionMemberAdded",
+		Data:      map[string]any{"action_set_id": actionSetID, "sort_order": 0},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "definition", StreamID: defID, EventType: "DefinitionMemberRemoved",
+		Data:      map[string]any{"action_set_id": actionSetID},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetDefinitionByID(ctx, defID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), live.MemberCount)
+
+	// Drive the listener directly with a stale MemberAdded.
+	older := live.ProjectionVersion - 5
+	staleAt := *live.UpdatedAt
+	listener := projectors.ActionListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "definition",
+		StreamID:    defID,
+		EventType:   "DefinitionMemberAdded",
+		Data:        jsonOrFail(t, map[string]any{"action_set_id": actionSetID, "sort_order": 0}),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
+	})
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM definition_members_projection WHERE definition_id = $1 AND action_set_id = $2",
+		defID, actionSetID,
+	).Scan(&count))
+	assert.Equal(t, 0, count,
+		"stale DefinitionMemberAdded must NOT recreate the membership row")
+	after, err := st.Queries().GetDefinitionByID(ctx, defID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), after.MemberCount)
+	assert.Equal(t, live.ProjectionVersion, after.ProjectionVersion)
+}
+
+// TestDefinitionListener_IgnoresOtherStreamTypes — defensive: an event
+// whose stream type is neither "action" nor "definition" must be
+// dropped on the floor.
+func TestDefinitionListener_IgnoresOtherStreamTypes(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	id := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", // wrong
+		StreamID:   id,
+		EventType:  "DefinitionCreated",
+		Data:       map[string]any{"name": "ghost"},
+		ActorType:  "user", ActorID: "u",
+	}))
+
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM definitions_projection WHERE id = $1", id,
+	).Scan(&count))
+	assert.Equal(t, 0, count)
+}

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -96,12 +96,21 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "compliance_projector"),
 	))
+	st.RegisterEventListener(ActionListener(
+		st,
+		loggerFor(logger, "action_projector"),
+	))
 	// All 11 ports of tracker #107 are now wired here, plus the
 	// Phase 2 ports landed so far under tracker #136 (action_set,
 	// assignment, user_group, device_group, compliance_policy,
-	// compliance). Future Phase 2 ports of the remaining domain
-	// projectors (user, device, action, definition, execution) land
-	// here too.
+	// compliance, action+definition). One ActionListener handles
+	// both the action and definition stream types because
+	// DefinitionCreated dispatches across two projections —
+	// synthesise an actions_projection row (when payload carries
+	// `action_type`) OR insert a definitions_projection row
+	// (otherwise) — and splitting would race the two branches.
+	// Future Phase 2 ports of the remaining domain projectors (user,
+	// device, execution) land here too.
 
 	// Rebuild appliers (manchtools/power-manage-server#125). Only
 	// the ported projectors that own a rebuildTarget in
@@ -117,6 +126,14 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 	st.RegisterRebuildApply("assignments", ApplyAssignment)
 	st.RegisterRebuildApply("user_groups", ApplyUserGroup)
 	st.RegisterRebuildApply("device_groups", ApplyDeviceGroup)
+	// One Apply body, two rebuild targets: the "actions" target
+	// rebuilds actions_projection from BOTH action and definition
+	// streams (the synthesised-action path). The "definitions"
+	// target rebuilds definitions_projection from definition events
+	// only. The per-event StreamType gate inside ApplyAction makes
+	// the dual registration safe.
+	st.RegisterRebuildApply("actions", ApplyAction)
+	st.RegisterRebuildApply("definitions", ApplyDefinition)
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/actions.sql.go
+++ b/internal/store/generated/actions.sql.go
@@ -74,6 +74,85 @@ func (q *Queries) CountExecutionsForWarm(ctx context.Context) (int64, error) {
 	return count, err
 }
 
+const decrementActionSetMemberCountByAction = `-- name: DecrementActionSetMemberCountByAction :exec
+UPDATE action_sets_projection
+SET member_count = member_count - 1
+WHERE id IN (
+    SELECT set_id FROM action_set_members_projection WHERE action_id = $1
+)
+`
+
+// ActionDeleted handler — second half. Mirrors the PL/pgSQL subquery
+// `UPDATE action_sets_projection SET member_count = member_count - 1
+// WHERE id IN (SELECT set_id FROM action_set_members_projection WHERE
+// action_id = ...)`. Runs BEFORE DeleteActionSetMembersByAction —
+// once those member rows are gone the subquery returns empty and the
+// recount no-ops.
+func (q *Queries) DecrementActionSetMemberCountByAction(ctx context.Context, actionID string) error {
+	_, err := q.db.Exec(ctx, decrementActionSetMemberCountByAction, actionID)
+	return err
+}
+
+const decrementCompliancePolicyRuleCountByPolicies = `-- name: DecrementCompliancePolicyRuleCountByPolicies :exec
+UPDATE compliance_policies_projection
+SET rule_count = rule_count - 1
+WHERE id = ANY($1::TEXT[])
+`
+
+// ActionDeleted handler — fifth half. Decrements rule_count on every
+// policy whose rule set referenced the deleted action. Runs BEFORE
+// DeleteCompliancePolicyRulesByAction so the row count drops by
+// exactly one per matching rule (mirrors PL/pgSQL `UPDATE ... SET
+// rule_count = rule_count - 1 WHERE id = ANY(v_affected_policies)`).
+func (q *Queries) DecrementCompliancePolicyRuleCountByPolicies(ctx context.Context, dollar_1 []string) error {
+	_, err := q.db.Exec(ctx, decrementCompliancePolicyRuleCountByPolicies, dollar_1)
+	return err
+}
+
+const deleteActionSetMembersByAction = `-- name: DeleteActionSetMembersByAction :exec
+DELETE FROM action_set_members_projection WHERE action_id = $1
+`
+
+// ActionDeleted handler — third half. Removes every action_set member
+// row for the deleted action.
+func (q *Queries) DeleteActionSetMembersByAction(ctx context.Context, actionID string) error {
+	_, err := q.db.Exec(ctx, deleteActionSetMembersByAction, actionID)
+	return err
+}
+
+const deleteCompliancePolicyEvaluationsByAction = `-- name: DeleteCompliancePolicyEvaluationsByAction :exec
+DELETE FROM compliance_policy_evaluation_projection WHERE action_id = $1
+`
+
+// ActionDeleted handler — seventh half. Wipes every evaluation row
+// referencing the deleted action across every policy.
+func (q *Queries) DeleteCompliancePolicyEvaluationsByAction(ctx context.Context, actionID string) error {
+	_, err := q.db.Exec(ctx, deleteCompliancePolicyEvaluationsByAction, actionID)
+	return err
+}
+
+const deleteCompliancePolicyRulesByAction = `-- name: DeleteCompliancePolicyRulesByAction :exec
+DELETE FROM compliance_policy_rules_projection WHERE action_id = $1
+`
+
+// ActionDeleted handler — sixth half. Wipes every rule row referencing
+// the deleted action across every policy.
+func (q *Queries) DeleteCompliancePolicyRulesByAction(ctx context.Context, actionID string) error {
+	_, err := q.db.Exec(ctx, deleteCompliancePolicyRulesByAction, actionID)
+	return err
+}
+
+const deleteComplianceResultsByAction = `-- name: DeleteComplianceResultsByAction :exec
+DELETE FROM compliance_results_projection WHERE action_id = $1
+`
+
+// ActionDeleted handler — eighth half. Wipes every per-device
+// compliance result for the deleted action.
+func (q *Queries) DeleteComplianceResultsByAction(ctx context.Context, actionID string) error {
+	_, err := q.db.Exec(ctx, deleteComplianceResultsByAction, actionID)
+	return err
+}
+
 const getActionByID = `-- name: GetActionByID :one
 
 SELECT id, name, description, action_type, params, timeout_seconds, created_at, created_by, is_deleted, projection_version, signature, params_canonical, desired_state, is_system, updated_at, schedule FROM actions_projection
@@ -201,6 +280,120 @@ func (q *Queries) GetExecutionByID(ctx context.Context, id string) (ExecutionsPr
 	return i, err
 }
 
+const insertActionProjection = `-- name: InsertActionProjection :exec
+
+INSERT INTO actions_projection (
+    id, name, description, action_type, desired_state,
+    params, timeout_seconds, created_at, updated_at, created_by, projection_version,
+    is_system, schedule
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertActionProjectionParams struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	Description       *string    `json:"description"`
+	ActionType        int32      `json:"action_type"`
+	DesiredState      int32      `json:"desired_state"`
+	Params            []byte     `json:"params"`
+	TimeoutSeconds    int32      `json:"timeout_seconds"`
+	CreatedAt         *time.Time `json:"created_at"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	CreatedBy         string     `json:"created_by"`
+	ProjectionVersion int64      `json:"projection_version"`
+	IsSystem          bool       `json:"is_system"`
+	Schedule          []byte     `json:"schedule"`
+}
+
+// ============================================================================
+// Projector listener writes (manchtools/power-manage-server#136).
+// ============================================================================
+//
+// Mirrors the deleted PL/pgSQL project_action_event(). The projector
+// handled both action-stream events (ActionCreated, ActionRenamed,
+// ActionDescriptionUpdated, ActionParamsUpdated, ActionDeleted) AND
+// definition-stream events that synthesise actions_projection rows
+// (DefinitionCreated/Renamed/DescriptionUpdated/Deleted IFF the
+// payload carries `action_type` — compliance-policy bootstrap path).
+//
+// Tightening vs the PL/pgSQL projector: every UPDATE on
+// actions_projection carries an explicit `WHERE projection_version < $N`
+// guard and uses :execrows so the listener can short-circuit cascades
+// on stale-replay (asymmetric-guard discipline; see role_listener /
+// action_set_listener for the canonical shape).
+//
+// The ActionDeleted cascade is the most complex of any Phase 2 port:
+// the SoftDelete is :execrows and gates FOUR downstream writes
+// (action_set_member decrement, compliance_policy_rules delete with
+// per-policy rule_count decrement, compliance_policy_evaluation
+// delete, compliance_results delete) PLUS a per-affected-device
+// reevaluate loop. Skipping every step on n==0 is mandatory — see the
+// listener for the discipline narrative.
+// ActionCreated handler. ON CONFLICT DO NOTHING for replay safety.
+func (q *Queries) InsertActionProjection(ctx context.Context, arg InsertActionProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertActionProjection,
+		arg.ID,
+		arg.Name,
+		arg.Description,
+		arg.ActionType,
+		arg.DesiredState,
+		arg.Params,
+		arg.TimeoutSeconds,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+		arg.CreatedBy,
+		arg.ProjectionVersion,
+		arg.IsSystem,
+		arg.Schedule,
+	)
+	return err
+}
+
+const insertSynthesisedActionProjection = `-- name: InsertSynthesisedActionProjection :exec
+INSERT INTO actions_projection (
+    id, name, description, action_type, desired_state,
+    params, timeout_seconds, created_at, updated_at, created_by, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertSynthesisedActionProjectionParams struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	Description       *string    `json:"description"`
+	ActionType        int32      `json:"action_type"`
+	DesiredState      int32      `json:"desired_state"`
+	Params            []byte     `json:"params"`
+	TimeoutSeconds    int32      `json:"timeout_seconds"`
+	CreatedAt         *time.Time `json:"created_at"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	CreatedBy         string     `json:"created_by"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// DefinitionCreated handler — actions_projection branch (compliance-
+// policy synthesised action). Mirrors the PL/pgSQL projector's
+// INSERT into actions_projection that omits is_system + schedule (those
+// columns are left at their column defaults: is_system=FALSE,
+// schedule=NULL). ON CONFLICT DO NOTHING for replay safety.
+func (q *Queries) InsertSynthesisedActionProjection(ctx context.Context, arg InsertSynthesisedActionProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertSynthesisedActionProjection,
+		arg.ID,
+		arg.Name,
+		arg.Description,
+		arg.ActionType,
+		arg.DesiredState,
+		arg.Params,
+		arg.TimeoutSeconds,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+		arg.CreatedBy,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
 const listActions = `-- name: ListActions :many
 SELECT id, name, description, action_type, params, timeout_seconds, created_at, created_by, is_deleted, projection_version, signature, params_canonical, desired_state, is_system, updated_at, schedule FROM actions_projection
 WHERE is_deleted = FALSE AND is_system = FALSE
@@ -254,6 +447,84 @@ func (q *Queries) ListActions(ctx context.Context, arg ListActionsParams) ([]Act
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listCompliancePolicyIDsByAction = `-- name: ListCompliancePolicyIDsByAction :many
+SELECT DISTINCT policy_id
+FROM compliance_policy_rules_projection
+WHERE action_id = $1
+`
+
+// ActionDeleted handler — fourth half (preflight for the compliance
+// cascade). Mirrors the PL/pgSQL `SELECT ARRAY_AGG(DISTINCT policy_id)
+// ... INTO v_affected_policies FROM compliance_policy_rules_projection
+// WHERE action_id = ...`. Listener short-circuits the rest of the
+// cascade when this returns empty (matches the PL/pgSQL `IF
+// v_affected_policies IS NOT NULL THEN ... END IF;` guard).
+func (q *Queries) ListCompliancePolicyIDsByAction(ctx context.Context, actionID string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listCompliancePolicyIDsByAction, actionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var policy_id string
+		if err := rows.Scan(&policy_id); err != nil {
+			return nil, err
+		}
+		items = append(items, policy_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listDeviceIDsForCompliancePolicies = `-- name: ListDeviceIDsForCompliancePolicies :many
+SELECT DISTINCT a.target_id AS device_id
+FROM assignments_projection a
+WHERE a.source_type = 'compliance_policy'
+  AND a.source_id = ANY($1::TEXT[])
+  AND a.target_type = 'device'
+  AND a.is_deleted = FALSE
+UNION
+SELECT DISTINCT dgm.device_id
+FROM assignments_projection a
+JOIN device_group_members_projection dgm ON dgm.group_id = a.target_id
+WHERE a.source_type = 'compliance_policy'
+  AND a.source_id = ANY($1::TEXT[])
+  AND a.target_type = 'device_group'
+  AND a.is_deleted = FALSE
+`
+
+// ActionDeleted handler — final cascade preflight. Mirrors the
+// PL/pgSQL `FOR v_device_id IN SELECT DISTINCT a.target_id ... UNION
+// SELECT DISTINCT dgm.device_id ... LOOP PERFORM
+// evaluate_device_compliance_policies(v_device_id); END LOOP`. Returns
+// every device that was assigned at least one of the affected policies
+// either directly or through a device_group. The listener iterates
+// the returned ids and calls EvaluateDeviceCompliancePolicies (the
+// existing shim from assignments.sql) for each so device-level
+// compliance status reflects the action's deletion.
+func (q *Queries) ListDeviceIDsForCompliancePolicies(ctx context.Context, dollar_1 []string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listDeviceIDsForCompliancePolicies, dollar_1)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var device_id string
+		if err := rows.Scan(&device_id); err != nil {
+			return nil, err
+		}
+		items = append(items, device_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -541,6 +812,172 @@ func (q *Queries) ListStaleExecutions(ctx context.Context) ([]ListStaleExecution
 		return nil, err
 	}
 	return items, nil
+}
+
+const renameActionProjection = `-- name: RenameActionProjection :execrows
+UPDATE actions_projection
+SET name              = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type RenameActionProjectionParams struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ActionRenamed handler — first half. Stale-replay guard via
+// projection_version. Returns rows-affected so the listener can
+// short-circuit the cross-stream rename cascade
+// (RenameComplianceRuleActionName) when the guard rejects a stale
+// replay.
+func (q *Queries) RenameActionProjection(ctx context.Context, arg RenameActionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, renameActionProjection,
+		arg.ID,
+		arg.Name,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const renameComplianceRuleActionName = `-- name: RenameComplianceRuleActionName :exec
+UPDATE compliance_policy_rules_projection
+SET action_name = $2
+WHERE action_id = $1
+`
+
+type RenameComplianceRuleActionNameParams struct {
+	ActionID   string `json:"action_id"`
+	ActionName string `json:"action_name"`
+}
+
+// ActionRenamed handler — second half. Cross-stream cascade into the
+// compliance_policy_rules_projection. Mirrors the PL/pgSQL projector's
+// `UPDATE compliance_policy_rules_projection SET action_name = ...
+// WHERE action_id = ...`. No projection_version guard here: the rules
+// table's projection_version is owned by the compliance_policy
+// projector, and this denormalised name column is updated unconditionally
+// by the action projector (legacy behaviour preserved). The cascade is
+// gated upstream by RenameActionProjection's :execrows short-circuit.
+func (q *Queries) RenameComplianceRuleActionName(ctx context.Context, arg RenameComplianceRuleActionNameParams) error {
+	_, err := q.db.Exec(ctx, renameComplianceRuleActionName, arg.ActionID, arg.ActionName)
+	return err
+}
+
+const softDeleteActionProjection = `-- name: SoftDeleteActionProjection :execrows
+UPDATE actions_projection
+SET is_deleted        = TRUE,
+    updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type SoftDeleteActionProjectionParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ActionDeleted handler — first half. Returns rows-affected so the
+// listener can SKIP the cascade (action_set_member decrement +
+// compliance_policy_rules delete + compliance_policy_evaluation delete
+// + compliance_results delete + per-device reevaluate loop) when the
+// projection_version guard rejects a stale replay; otherwise an old
+// ActionDeleted re-applied by the reconciler against a freshly-restored
+// action would silently nuke its compliance footprint and trigger a
+// needless device re-evaluation pass.
+func (q *Queries) SoftDeleteActionProjection(ctx context.Context, arg SoftDeleteActionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteActionProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateActionDescriptionProjection = `-- name: UpdateActionDescriptionProjection :execrows
+UPDATE actions_projection
+SET description       = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateActionDescriptionProjectionParams struct {
+	ID                string     `json:"id"`
+	Description       *string    `json:"description"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ActionDescriptionUpdated handler. NULL-able description column: the
+// PL/pgSQL projector wrote `event.data->>'description'` directly, so
+// absence becomes NULL and explicit empty string becomes "". The
+// listener decoder preserves that distinction via *string.
+func (q *Queries) UpdateActionDescriptionProjection(ctx context.Context, arg UpdateActionDescriptionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateActionDescriptionProjection,
+		arg.ID,
+		arg.Description,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateActionParamsProjection = `-- name: UpdateActionParamsProjection :execrows
+UPDATE actions_projection
+SET params            = COALESCE($1::JSONB, params),
+    timeout_seconds   = COALESCE($2::INTEGER, timeout_seconds),
+    desired_state     = COALESCE($3::INTEGER, desired_state),
+    schedule          = COALESCE($4::JSONB, schedule),
+    updated_at        = $5,
+    projection_version = $6
+WHERE id = $7
+  AND projection_version < $6
+`
+
+type UpdateActionParamsProjectionParams struct {
+	Params            []byte     `json:"params"`
+	TimeoutSeconds    *int32     `json:"timeout_seconds"`
+	DesiredState      *int32     `json:"desired_state"`
+	Schedule          []byte     `json:"schedule"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+	ID                string     `json:"id"`
+}
+
+// ActionParamsUpdated handler. Mirrors the PL/pgSQL projector's
+// `COALESCE(event.data->'params', params)` per-field preservation:
+// every NULL parameter preserves the existing column value via
+// COALESCE, every non-NULL parameter overwrites. The decoder surfaces
+// absence as NULL and presence as the new value, so this query is the
+// direct PL/pgSQL translation.
+func (q *Queries) UpdateActionParamsProjection(ctx context.Context, arg UpdateActionParamsProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateActionParamsProjection,
+		arg.Params,
+		arg.TimeoutSeconds,
+		arg.DesiredState,
+		arg.Schedule,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const updateActionSignature = `-- name: UpdateActionSignature :exec

--- a/internal/store/generated/definitions.sql.go
+++ b/internal/store/generated/definitions.sql.go
@@ -10,6 +10,42 @@ import (
 	"time"
 )
 
+const claimDefinitionForMembership = `-- name: ClaimDefinitionForMembership :execrows
+UPDATE definitions_projection
+SET updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+  AND is_deleted = FALSE
+`
+
+type ClaimDefinitionForMembershipParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// Atomic guard for the three member-mutation events
+// (DefinitionMemberAdded, DefinitionMemberRemoved, DefinitionMemberReordered).
+// Bumps updated_at + projection_version only when the parent
+// definition exists, is not soft-deleted, and the event is newer than
+// the current projection_version.
+//
+// Returns n=1 when the listener may proceed with the membership
+// mutation, n=0 when the event must be skipped. Doing the version
+// check BEFORE any child-row mutation prevents the stale-replay holes
+// CR caught on the user_group port (PR #174): without this guard a
+// stale DefinitionMemberAdded after a Removed would recreate the
+// removed membership row, and a stale Removed would delete a live
+// one.
+func (q *Queries) ClaimDefinitionForMembership(ctx context.Context, arg ClaimDefinitionForMembershipParams) (int64, error) {
+	result, err := q.db.Exec(ctx, claimDefinitionForMembership, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countDefinitions = `-- name: CountDefinitions :one
 SELECT COUNT(*) FROM definitions_projection
 WHERE is_deleted = FALSE
@@ -20,6 +56,24 @@ func (q *Queries) CountDefinitions(ctx context.Context) (int64, error) {
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const deleteDefinitionMember = `-- name: DeleteDefinitionMember :exec
+DELETE FROM definition_members_projection
+WHERE definition_id = $1
+  AND action_set_id = $2
+`
+
+type DeleteDefinitionMemberParams struct {
+	DefinitionID string `json:"definition_id"`
+	ActionSetID  string `json:"action_set_id"`
+}
+
+// DefinitionMemberRemoved handler — second half. Plain DELETE —
+// silently no-op on a miss matches the PL/pgSQL projector's behaviour.
+func (q *Queries) DeleteDefinitionMember(ctx context.Context, arg DeleteDefinitionMemberParams) error {
+	_, err := q.db.Exec(ctx, deleteDefinitionMember, arg.DefinitionID, arg.ActionSetID)
+	return err
 }
 
 const getDefinitionByID = `-- name: GetDefinitionByID :one
@@ -91,6 +145,114 @@ func (q *Queries) GetDefinitionMember(ctx context.Context, arg GetDefinitionMemb
 		&i.ProjectionVersion,
 	)
 	return i, err
+}
+
+const insertDefinitionMember = `-- name: InsertDefinitionMember :exec
+INSERT INTO definition_members_projection (
+    definition_id, action_set_id, sort_order, added_at, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (definition_id, action_set_id) DO NOTHING
+`
+
+type InsertDefinitionMemberParams struct {
+	DefinitionID      string     `json:"definition_id"`
+	ActionSetID       string     `json:"action_set_id"`
+	SortOrder         int32      `json:"sort_order"`
+	AddedAt           *time.Time `json:"added_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// DefinitionMemberAdded handler — second half. ON CONFLICT DO NOTHING
+// preserves the PL/pgSQL projector's idempotency under reconciler
+// replays. The composite PK (definition_id, action_set_id) makes this
+// safe.
+func (q *Queries) InsertDefinitionMember(ctx context.Context, arg InsertDefinitionMemberParams) error {
+	_, err := q.db.Exec(ctx, insertDefinitionMember,
+		arg.DefinitionID,
+		arg.ActionSetID,
+		arg.SortOrder,
+		arg.AddedAt,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const insertDefinitionProjection = `-- name: InsertDefinitionProjection :exec
+
+INSERT INTO definitions_projection (
+    id, name, description, schedule,
+    created_at, updated_at, created_by, projection_version
+) VALUES (
+    $1,
+    $2,
+    $3,
+    $4,
+    $5,
+    $6,
+    $7,
+    $8
+)
+ON CONFLICT (id) DO NOTHING
+`
+
+type InsertDefinitionProjectionParams struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	Description       string     `json:"description"`
+	Schedule          []byte     `json:"schedule"`
+	CreatedAt         *time.Time `json:"created_at"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	CreatedBy         string     `json:"created_by"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ============================================================================
+// Projector listener writes (manchtools/power-manage-server#136).
+// ============================================================================
+//
+// Mirrors the deleted PL/pgSQL project_definition_event(). Eight event
+// types: Created, Renamed, DescriptionUpdated, ScheduleUpdated,
+// MemberAdded, MemberRemoved, MemberReordered, Deleted. The Created
+// event is shared with project_action_event — when the payload carries
+// `action_type` the action projector synthesises an actions_projection
+// row and the definition projector no-ops; otherwise the definition
+// projector inserts a definitions_projection row and the action
+// projector no-ops. The Go listener (action_listener.go) owns BOTH
+// stream types so the dispatch is single-pass.
+//
+// Tightening vs the PL/pgSQL projector: every UPDATE on
+// definitions_projection carries an explicit `WHERE projection_version < $N`
+// guard and uses :execrows so the listener can short-circuit cascades
+// on stale-replay (asymmetric-guard discipline; see role_listener /
+// action_set_listener for the canonical shape).
+//
+// Claim-first guard: the three member-mutation events
+// (DefinitionMemberAdded, DefinitionMemberRemoved, DefinitionMemberReordered)
+// all run ClaimDefinitionForMembership BEFORE touching
+// definition_members_projection. The Claim guard bumps
+// definitions_projection.projection_version only when the definition
+// exists, is alive, and the event is newer; the listener short-circuits
+// on n == 0. Doing the version check BEFORE the membership INSERT/
+// DELETE/UPDATE prevents stale replays from silently resurrecting
+// removed members or rolling back fresher reorders — the same hazard
+// the user_group port (PR #174) had to fix retroactively.
+// DefinitionCreated handler — definitions_projection branch (taken
+// when the payload OMITS action_type). ON CONFLICT DO NOTHING for
+// replay safety. Schedule defaults to '{"interval_hours": 8}' (column
+// default mirrors the PL/pgSQL COALESCE fallback for the missing
+// payload key).
+func (q *Queries) InsertDefinitionProjection(ctx context.Context, arg InsertDefinitionProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertDefinitionProjection,
+		arg.ID,
+		arg.Name,
+		arg.Description,
+		arg.Schedule,
+		arg.CreatedAt,
+		arg.UpdatedAt,
+		arg.CreatedBy,
+		arg.ProjectionVersion,
+	)
+	return err
 }
 
 const listActionSetsInDefinition = `-- name: ListActionSetsInDefinition :many
@@ -219,4 +381,176 @@ func (q *Queries) ListDefinitions(ctx context.Context, arg ListDefinitionsParams
 		return nil, err
 	}
 	return items, nil
+}
+
+const recountDefinitionMembers = `-- name: RecountDefinitionMembers :exec
+UPDATE definitions_projection
+SET member_count = (SELECT COUNT(*) FROM definition_members_projection WHERE definition_id = $1)
+WHERE id = $1
+`
+
+// DefinitionMemberAdded / DefinitionMemberRemoved handler — third half.
+// Recomputes member_count from the live row count after the listener
+// has applied a membership mutation. Run in the same transaction as
+// ClaimDefinitionForMembership + the INSERT/DELETE so the parent row
+// is never observed with a stale count. No projection_version guard
+// here: the Claim above already stamped the version.
+func (q *Queries) RecountDefinitionMembers(ctx context.Context, definitionID string) error {
+	_, err := q.db.Exec(ctx, recountDefinitionMembers, definitionID)
+	return err
+}
+
+const renameDefinitionProjection = `-- name: RenameDefinitionProjection :execrows
+UPDATE definitions_projection
+SET name              = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type RenameDefinitionProjectionParams struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// DefinitionRenamed handler. Stale-replay guard via projection_version.
+func (q *Queries) RenameDefinitionProjection(ctx context.Context, arg RenameDefinitionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, renameDefinitionProjection,
+		arg.ID,
+		arg.Name,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const softDeleteDefinitionProjection = `-- name: SoftDeleteDefinitionProjection :execrows
+UPDATE definitions_projection
+SET is_deleted        = TRUE,
+    updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type SoftDeleteDefinitionProjectionParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// DefinitionDeleted handler — definitions_projection branch (taken on
+// the definition stream). Stale-replay guard via projection_version;
+// :execrows lets the listener detect and skip downstream cascades —
+// though there is no cross-table cascade for DefinitionDeleted today
+// (the PL/pgSQL projector left definition_members orphaned by
+// design), so n==0 just short-circuits to a no-op.
+func (q *Queries) SoftDeleteDefinitionProjection(ctx context.Context, arg SoftDeleteDefinitionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteDefinitionProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDefinitionDescriptionProjection = `-- name: UpdateDefinitionDescriptionProjection :execrows
+UPDATE definitions_projection
+SET description       = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateDefinitionDescriptionProjectionParams struct {
+	ID                string     `json:"id"`
+	Description       string     `json:"description"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// DefinitionDescriptionUpdated handler. Empty-string description is a
+// valid value (matches the PL/pgSQL `COALESCE(payload, ”)` collapse —
+// the listener decoder substitutes ” when the payload key is missing).
+func (q *Queries) UpdateDefinitionDescriptionProjection(ctx context.Context, arg UpdateDefinitionDescriptionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDefinitionDescriptionProjection,
+		arg.ID,
+		arg.Description,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDefinitionMemberSortOrder = `-- name: UpdateDefinitionMemberSortOrder :execrows
+UPDATE definition_members_projection
+SET sort_order        = $3,
+    projection_version = $4
+WHERE definition_id = $1
+  AND action_set_id = $2
+  AND projection_version < $4
+`
+
+type UpdateDefinitionMemberSortOrderParams struct {
+	DefinitionID      string `json:"definition_id"`
+	ActionSetID       string `json:"action_set_id"`
+	SortOrder         int32  `json:"sort_order"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// DefinitionMemberReordered handler — second half. Per-member
+// projection_version guards the row so a stale reorder cannot clobber
+// a fresher position.
+func (q *Queries) UpdateDefinitionMemberSortOrder(ctx context.Context, arg UpdateDefinitionMemberSortOrderParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDefinitionMemberSortOrder,
+		arg.DefinitionID,
+		arg.ActionSetID,
+		arg.SortOrder,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDefinitionScheduleProjection = `-- name: UpdateDefinitionScheduleProjection :execrows
+UPDATE definitions_projection
+SET schedule          = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateDefinitionScheduleProjectionParams struct {
+	ID                string     `json:"id"`
+	Schedule          []byte     `json:"schedule"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// DefinitionScheduleUpdated handler. Decoder defaults a missing
+// schedule key to the column default '{"interval_hours": 8}' so this
+// query always receives a non-NULL JSONB blob.
+func (q *Queries) UpdateDefinitionScheduleProjection(ctx context.Context, arg UpdateDefinitionScheduleProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDefinitionScheduleProjection,
+		arg.ID,
+		arg.Schedule,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/internal/store/migrations/037_action_definition_projector_to_go.sql
+++ b/internal/store/migrations/037_action_definition_projector_to_go.sql
@@ -1,0 +1,371 @@
+-- Replace project_action_event() AND project_definition_event() with
+-- no-op stubs. The actual projection logic now lives in
+-- projectors.ActionListener (Go, post-commit). One Go listener owns
+-- BOTH stream types because DefinitionCreated dispatches across two
+-- projections — synthesise an actions_projection row (when payload
+-- carries `action_type`) OR insert a definitions_projection row
+-- (otherwise) — and splitting would race the two branches against
+-- each other.
+--
+-- The shared project_event() dispatcher trigger still PERFORMs
+-- project_action_event(NEW) for every action-stream event AND
+-- project_definition_event(NEW) for every definition-stream event;
+-- the no-op stubs keep those dispatches quiet (no
+-- plpgsql_projection_errors entries) until the Phase 2 cleanup
+-- migration drops every still-PL/pgSQL WHEN clause from the
+-- dispatcher.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector pair ran inside the AppendEvent
+--     transaction. Every event type — 5 ActionXxx + 8 DefinitionXxx
+--     — and their cascades (action_set member decrement, compliance
+--     cascade through 4 tables, per-affected-device reevaluate loop,
+--     cross-stream rename of compliance_policy_rules.action_name)
+--     were atomic with the event commit.
+--   - After: Go listener fires post-commit. Every multi-write event
+--     (ActionDeleted, DefinitionMemberAdded/Removed/Reordered) wraps
+--     its writes in store.WithTx so the cascade stays atomic with
+--     itself, but not with the event commit. The handler's read-
+--     after-write paths (CreateAction / RenameAction / DeleteAction
+--     etc. reading back from actions_projection) still see the
+--     projection because fireListeners is synchronous — the listener
+--     has already run by the time AppendEvent returns.
+--
+-- Tightening: every UPDATE on actions_projection AND
+-- definitions_projection now carries an explicit
+-- `WHERE projection_version < $N` guard, rejecting stale reconciler
+-- replays. The PL/pgSQL projector pair stamped projection_version
+-- without a guard, so a stale ActionParamsUpdated re-applied later
+-- would silently rewind params + timeout + desired_state + schedule.
+--
+-- Asymmetric-guard discipline (per the role + identity_provider +
+-- action_set + assignment + user_group + device_group +
+-- compliance_policy + compliance ports):
+--   - ActionDeleted: the guarded SoftDelete uses :execrows. When n==0
+--     EVERY downstream cascade is skipped — action_set member
+--     decrement, compliance_policy_rules delete + per-policy
+--     rule_count decrement, compliance_policy_evaluation delete,
+--     compliance_results delete, AND the per-affected-device
+--     reevaluate loop. Otherwise an old delete re-applied by the
+--     reconciler against a freshly-restored action would silently
+--     nuke its compliance footprint and trigger a needless device
+--     re-evaluation pass.
+--   - ActionRenamed: the guarded Rename UPDATE is :execrows. When
+--     n==0 the cross-stream cascade into
+--     compliance_policy_rules.action_name is skipped — otherwise a
+--     stale rename re-applied after a fresher rename would push the
+--     old name into the compliance projection rows.
+--   - DefinitionMemberAdded / DefinitionMemberRemoved /
+--     DefinitionMemberReordered: the Claim-first guard
+--     (ClaimDefinitionForMembership, :execrows) bumps the parent's
+--     projection_version BEFORE any membership-table mutation, and the
+--     listener short-circuits when n == 0. This is the lesson from
+--     PR #174's CR review: the prior insert-then-recount shape let
+--     stale replays silently resurrect removed members or rewind a
+--     fresher Reorder, because the version check was downstream of
+--     the child-row mutation.
+--
+-- Compliance reevaluation engine scope: per #136 the
+-- evaluate_device_compliance_policies(p_device_id) function — and the
+-- per-policy evaluator family it dispatches to — STAY in PL/pgSQL
+-- until a later phase. The Go listener calls into the existing shim
+-- (EvaluateDeviceCompliancePolicies, reused from the assignment
+-- port's sqlc generation) so device compliance status reflects every
+-- action deletion; the eval engine itself runs unchanged inside
+-- Postgres.
+--
+-- Tracker #136 explicitly required these two functions to be ported
+-- TOGETHER in one PR because the DefinitionCreated branch
+-- synthesises actions_projection rows (cross-stream effect); a split
+-- port would let the action-stream invocation observe a partially-
+-- ported state where the definition-stream sibling still wrote to
+-- definitions_projection.
+--
+-- See manchtools/power-manage-server#136. Seventh port under Phase 2
+-- of tracker #107's projector-migration pattern.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_action_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.ActionListener (the listener owns
+    -- BOTH stream types). See migration comment + the listener wiring
+    -- in cmd/control/main.go via projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_definition_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.ActionListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the PL/pgSQL projector for actions verbatim from migration
+-- 002_core_projectors (the last definition before this port). Handles
+-- 5 ActionXxx events plus 4 DefinitionXxx events for the synthesised-
+-- action path.
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_action_event(event events) RETURNS void AS $$
+DECLARE
+    v_device_id TEXT;
+    v_affected_policies TEXT[];
+BEGIN
+    CASE event.event_type
+        WHEN 'ActionCreated' THEN
+            INSERT INTO actions_projection (
+                id, name, description, action_type, desired_state,
+                params, timeout_seconds, created_at, updated_at, created_by, projection_version,
+                is_system, schedule
+            ) VALUES (
+                event.stream_id,
+                event.data->>'name',
+                event.data->>'description',
+                COALESCE((event.data->>'action_type')::INTEGER, 0),
+                COALESCE((event.data->>'desired_state')::INTEGER, 0),
+                COALESCE(event.data->'params', '{}'),
+                COALESCE((event.data->>'timeout_seconds')::INTEGER, 300),
+                event.occurred_at,
+                event.occurred_at,
+                event.actor_id,
+                event.sequence_num,
+                COALESCE((event.data->>'is_system')::BOOLEAN, FALSE),
+                event.data->'schedule'
+            );
+
+        WHEN 'ActionRenamed' THEN
+            UPDATE actions_projection
+            SET name = event.data->>'name',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            -- Cascade rename to compliance policy rules that reference this action.
+            UPDATE compliance_policy_rules_projection
+            SET action_name = event.data->>'name'
+            WHERE action_id = event.stream_id;
+
+        WHEN 'ActionDescriptionUpdated' THEN
+            UPDATE actions_projection
+            SET description = event.data->>'description',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ActionParamsUpdated' THEN
+            UPDATE actions_projection
+            SET params = COALESCE(event.data->'params', params),
+                timeout_seconds = COALESCE((event.data->>'timeout_seconds')::INTEGER, timeout_seconds),
+                desired_state = COALESCE((event.data->>'desired_state')::INTEGER, desired_state),
+                schedule = COALESCE(event.data->'schedule', schedule),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'ActionDeleted' THEN
+            UPDATE actions_projection
+            SET is_deleted = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            UPDATE action_sets_projection
+            SET member_count = member_count - 1
+            WHERE id IN (
+                SELECT set_id FROM action_set_members_projection WHERE action_id = event.stream_id
+            );
+
+            DELETE FROM action_set_members_projection WHERE action_id = event.stream_id;
+
+            -- Clean up compliance data for this action.
+            -- Collect affected policy IDs before deleting rules.
+            SELECT ARRAY_AGG(DISTINCT policy_id)
+            INTO v_affected_policies
+            FROM compliance_policy_rules_projection
+            WHERE action_id = event.stream_id;
+
+            IF v_affected_policies IS NOT NULL THEN
+                UPDATE compliance_policies_projection
+                SET rule_count = rule_count - 1
+                WHERE id = ANY(v_affected_policies);
+
+                DELETE FROM compliance_policy_rules_projection WHERE action_id = event.stream_id;
+                DELETE FROM compliance_policy_evaluation_projection WHERE action_id = event.stream_id;
+                DELETE FROM compliance_results_projection WHERE action_id = event.stream_id;
+
+                -- Re-evaluate compliance for all devices affected by these policies
+                FOR v_device_id IN
+                    SELECT DISTINCT a.target_id
+                    FROM assignments_projection a
+                    WHERE a.source_type = 'compliance_policy'
+                      AND a.source_id = ANY(v_affected_policies)
+                      AND a.target_type = 'device'
+                      AND a.is_deleted = FALSE
+                    UNION
+                    SELECT DISTINCT dgm.device_id
+                    FROM assignments_projection a
+                    JOIN device_group_members_projection dgm ON dgm.group_id = a.target_id
+                    WHERE a.source_type = 'compliance_policy'
+                      AND a.source_id = ANY(v_affected_policies)
+                      AND a.target_type = 'device_group'
+                      AND a.is_deleted = FALSE
+                LOOP
+                    PERFORM evaluate_device_compliance_policies(v_device_id);
+                END LOOP;
+            END IF;
+
+        WHEN 'DefinitionCreated' THEN
+            IF event.data ? 'action_type' THEN
+                INSERT INTO actions_projection (
+                    id, name, description, action_type, desired_state,
+                    params, timeout_seconds, created_at, updated_at, created_by, projection_version
+                ) VALUES (
+                    event.stream_id,
+                    event.data->>'name',
+                    event.data->>'description',
+                    COALESCE((event.data->>'action_type')::INTEGER, 0),
+                    COALESCE((event.data->>'desired_state')::INTEGER, 0),
+                    COALESCE(event.data->'params', '{}'),
+                    COALESCE((event.data->>'timeout_seconds')::INTEGER, 300),
+                    event.occurred_at,
+                    event.occurred_at,
+                    event.actor_id,
+                    event.sequence_num
+                );
+            END IF;
+
+        WHEN 'DefinitionRenamed' THEN
+            UPDATE actions_projection
+            SET name = event.data->>'name',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DefinitionDescriptionUpdated' THEN
+            UPDATE actions_projection
+            SET description = event.data->>'description',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DefinitionDeleted' THEN
+            UPDATE actions_projection
+            SET is_deleted = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- Restore the PL/pgSQL projector for definitions verbatim from
+-- migration 012_action_set_definition_schedule (the latest definition,
+-- which adds the schedule column and DefinitionScheduleUpdated handler).
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_definition_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'DefinitionCreated' THEN
+            IF NOT (event.data ? 'action_type') THEN
+                INSERT INTO definitions_projection (
+                    id, name, description, schedule, created_at, updated_at, created_by, projection_version
+                ) VALUES (
+                    event.stream_id,
+                    event.data->>'name',
+                    COALESCE(event.data->>'description', ''),
+                    COALESCE((event.data->'schedule')::JSONB, '{"interval_hours": 8}'::JSONB),
+                    event.occurred_at,
+                    event.occurred_at,
+                    event.actor_id,
+                    event.sequence_num
+                );
+            END IF;
+
+        WHEN 'DefinitionRenamed' THEN
+            UPDATE definitions_projection
+            SET name = event.data->>'name',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DefinitionDescriptionUpdated' THEN
+            UPDATE definitions_projection
+            SET description = COALESCE(event.data->>'description', ''),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DefinitionScheduleUpdated' THEN
+            UPDATE definitions_projection
+            SET schedule = COALESCE((event.data->'schedule')::JSONB, '{"interval_hours": 8}'::JSONB),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DefinitionMemberAdded' THEN
+            INSERT INTO definition_members_projection (
+                definition_id, action_set_id, sort_order, added_at, projection_version
+            ) VALUES (
+                event.stream_id,
+                event.data->>'action_set_id',
+                COALESCE((event.data->>'sort_order')::INTEGER, 0),
+                event.occurred_at,
+                event.sequence_num
+            ) ON CONFLICT (definition_id, action_set_id) DO NOTHING;
+
+            UPDATE definitions_projection
+            SET member_count = (SELECT COUNT(*) FROM definition_members_projection WHERE definition_id = event.stream_id),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DefinitionMemberRemoved' THEN
+            DELETE FROM definition_members_projection
+            WHERE definition_id = event.stream_id AND action_set_id = event.data->>'action_set_id';
+
+            UPDATE definitions_projection
+            SET member_count = (SELECT COUNT(*) FROM definition_members_projection WHERE definition_id = event.stream_id),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DefinitionMemberReordered' THEN
+            UPDATE definition_members_projection
+            SET sort_order = COALESCE((event.data->>'sort_order')::INTEGER, 0),
+                projection_version = event.sequence_num
+            WHERE definition_id = event.stream_id AND action_set_id = event.data->>'action_set_id';
+
+            UPDATE definitions_projection
+            SET updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DefinitionDeleted' THEN
+            UPDATE definitions_projection
+            SET is_deleted = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/actions.sql
+++ b/internal/store/queries/actions.sql
@@ -35,6 +35,202 @@ UPDATE actions_projection
 SET signature = $2, params_canonical = $3
 WHERE id = $1;
 
+-- ============================================================================
+-- Projector listener writes (manchtools/power-manage-server#136).
+-- ============================================================================
+--
+-- Mirrors the deleted PL/pgSQL project_action_event(). The projector
+-- handled both action-stream events (ActionCreated, ActionRenamed,
+-- ActionDescriptionUpdated, ActionParamsUpdated, ActionDeleted) AND
+-- definition-stream events that synthesise actions_projection rows
+-- (DefinitionCreated/Renamed/DescriptionUpdated/Deleted IFF the
+-- payload carries `action_type` — compliance-policy bootstrap path).
+--
+-- Tightening vs the PL/pgSQL projector: every UPDATE on
+-- actions_projection carries an explicit `WHERE projection_version < $N`
+-- guard and uses :execrows so the listener can short-circuit cascades
+-- on stale-replay (asymmetric-guard discipline; see role_listener /
+-- action_set_listener for the canonical shape).
+--
+-- The ActionDeleted cascade is the most complex of any Phase 2 port:
+-- the SoftDelete is :execrows and gates FOUR downstream writes
+-- (action_set_member decrement, compliance_policy_rules delete with
+-- per-policy rule_count decrement, compliance_policy_evaluation
+-- delete, compliance_results delete) PLUS a per-affected-device
+-- reevaluate loop. Skipping every step on n==0 is mandatory — see the
+-- listener for the discipline narrative.
+
+-- name: InsertActionProjection :exec
+-- ActionCreated handler. ON CONFLICT DO NOTHING for replay safety.
+INSERT INTO actions_projection (
+    id, name, description, action_type, desired_state,
+    params, timeout_seconds, created_at, updated_at, created_by, projection_version,
+    is_system, schedule
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: InsertSynthesisedActionProjection :exec
+-- DefinitionCreated handler — actions_projection branch (compliance-
+-- policy synthesised action). Mirrors the PL/pgSQL projector's
+-- INSERT into actions_projection that omits is_system + schedule (those
+-- columns are left at their column defaults: is_system=FALSE,
+-- schedule=NULL). ON CONFLICT DO NOTHING for replay safety.
+INSERT INTO actions_projection (
+    id, name, description, action_type, desired_state,
+    params, timeout_seconds, created_at, updated_at, created_by, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: RenameActionProjection :execrows
+-- ActionRenamed handler — first half. Stale-replay guard via
+-- projection_version. Returns rows-affected so the listener can
+-- short-circuit the cross-stream rename cascade
+-- (RenameComplianceRuleActionName) when the guard rejects a stale
+-- replay.
+UPDATE actions_projection
+SET name              = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: RenameComplianceRuleActionName :exec
+-- ActionRenamed handler — second half. Cross-stream cascade into the
+-- compliance_policy_rules_projection. Mirrors the PL/pgSQL projector's
+-- `UPDATE compliance_policy_rules_projection SET action_name = ...
+-- WHERE action_id = ...`. No projection_version guard here: the rules
+-- table's projection_version is owned by the compliance_policy
+-- projector, and this denormalised name column is updated unconditionally
+-- by the action projector (legacy behaviour preserved). The cascade is
+-- gated upstream by RenameActionProjection's :execrows short-circuit.
+UPDATE compliance_policy_rules_projection
+SET action_name = $2
+WHERE action_id = $1;
+
+-- name: UpdateActionDescriptionProjection :execrows
+-- ActionDescriptionUpdated handler. NULL-able description column: the
+-- PL/pgSQL projector wrote `event.data->>'description'` directly, so
+-- absence becomes NULL and explicit empty string becomes "". The
+-- listener decoder preserves that distinction via *string.
+UPDATE actions_projection
+SET description       = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: UpdateActionParamsProjection :execrows
+-- ActionParamsUpdated handler. Mirrors the PL/pgSQL projector's
+-- `COALESCE(event.data->'params', params)` per-field preservation:
+-- every NULL parameter preserves the existing column value via
+-- COALESCE, every non-NULL parameter overwrites. The decoder surfaces
+-- absence as NULL and presence as the new value, so this query is the
+-- direct PL/pgSQL translation.
+UPDATE actions_projection
+SET params            = COALESCE(sqlc.narg('params')::JSONB, params),
+    timeout_seconds   = COALESCE(sqlc.narg('timeout_seconds')::INTEGER, timeout_seconds),
+    desired_state     = COALESCE(sqlc.narg('desired_state')::INTEGER, desired_state),
+    schedule          = COALESCE(sqlc.narg('schedule')::JSONB, schedule),
+    updated_at        = sqlc.arg('updated_at'),
+    projection_version = sqlc.arg('projection_version')
+WHERE id = sqlc.arg('id')
+  AND projection_version < sqlc.arg('projection_version');
+
+-- name: SoftDeleteActionProjection :execrows
+-- ActionDeleted handler — first half. Returns rows-affected so the
+-- listener can SKIP the cascade (action_set_member decrement +
+-- compliance_policy_rules delete + compliance_policy_evaluation delete
+-- + compliance_results delete + per-device reevaluate loop) when the
+-- projection_version guard rejects a stale replay; otherwise an old
+-- ActionDeleted re-applied by the reconciler against a freshly-restored
+-- action would silently nuke its compliance footprint and trigger a
+-- needless device re-evaluation pass.
+UPDATE actions_projection
+SET is_deleted        = TRUE,
+    updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: DecrementActionSetMemberCountByAction :exec
+-- ActionDeleted handler — second half. Mirrors the PL/pgSQL subquery
+-- `UPDATE action_sets_projection SET member_count = member_count - 1
+-- WHERE id IN (SELECT set_id FROM action_set_members_projection WHERE
+-- action_id = ...)`. Runs BEFORE DeleteActionSetMembersByAction —
+-- once those member rows are gone the subquery returns empty and the
+-- recount no-ops.
+UPDATE action_sets_projection
+SET member_count = member_count - 1
+WHERE id IN (
+    SELECT set_id FROM action_set_members_projection WHERE action_id = $1
+);
+
+-- name: DeleteActionSetMembersByAction :exec
+-- ActionDeleted handler — third half. Removes every action_set member
+-- row for the deleted action.
+DELETE FROM action_set_members_projection WHERE action_id = $1;
+
+-- name: ListCompliancePolicyIDsByAction :many
+-- ActionDeleted handler — fourth half (preflight for the compliance
+-- cascade). Mirrors the PL/pgSQL `SELECT ARRAY_AGG(DISTINCT policy_id)
+-- ... INTO v_affected_policies FROM compliance_policy_rules_projection
+-- WHERE action_id = ...`. Listener short-circuits the rest of the
+-- cascade when this returns empty (matches the PL/pgSQL `IF
+-- v_affected_policies IS NOT NULL THEN ... END IF;` guard).
+SELECT DISTINCT policy_id
+FROM compliance_policy_rules_projection
+WHERE action_id = $1;
+
+-- name: DecrementCompliancePolicyRuleCountByPolicies :exec
+-- ActionDeleted handler — fifth half. Decrements rule_count on every
+-- policy whose rule set referenced the deleted action. Runs BEFORE
+-- DeleteCompliancePolicyRulesByAction so the row count drops by
+-- exactly one per matching rule (mirrors PL/pgSQL `UPDATE ... SET
+-- rule_count = rule_count - 1 WHERE id = ANY(v_affected_policies)`).
+UPDATE compliance_policies_projection
+SET rule_count = rule_count - 1
+WHERE id = ANY($1::TEXT[]);
+
+-- name: DeleteCompliancePolicyRulesByAction :exec
+-- ActionDeleted handler — sixth half. Wipes every rule row referencing
+-- the deleted action across every policy.
+DELETE FROM compliance_policy_rules_projection WHERE action_id = $1;
+
+-- name: DeleteCompliancePolicyEvaluationsByAction :exec
+-- ActionDeleted handler — seventh half. Wipes every evaluation row
+-- referencing the deleted action across every policy.
+DELETE FROM compliance_policy_evaluation_projection WHERE action_id = $1;
+
+-- name: DeleteComplianceResultsByAction :exec
+-- ActionDeleted handler — eighth half. Wipes every per-device
+-- compliance result for the deleted action.
+DELETE FROM compliance_results_projection WHERE action_id = $1;
+
+-- name: ListDeviceIDsForCompliancePolicies :many
+-- ActionDeleted handler — final cascade preflight. Mirrors the
+-- PL/pgSQL `FOR v_device_id IN SELECT DISTINCT a.target_id ... UNION
+-- SELECT DISTINCT dgm.device_id ... LOOP PERFORM
+-- evaluate_device_compliance_policies(v_device_id); END LOOP`. Returns
+-- every device that was assigned at least one of the affected policies
+-- either directly or through a device_group. The listener iterates
+-- the returned ids and calls EvaluateDeviceCompliancePolicies (the
+-- existing shim from assignments.sql) for each so device-level
+-- compliance status reflects the action's deletion.
+SELECT DISTINCT a.target_id AS device_id
+FROM assignments_projection a
+WHERE a.source_type = 'compliance_policy'
+  AND a.source_id = ANY($1::TEXT[])
+  AND a.target_type = 'device'
+  AND a.is_deleted = FALSE
+UNION
+SELECT DISTINCT dgm.device_id
+FROM assignments_projection a
+JOIN device_group_members_projection dgm ON dgm.group_id = a.target_id
+WHERE a.source_type = 'compliance_policy'
+  AND a.source_id = ANY($1::TEXT[])
+  AND a.target_type = 'device_group'
+  AND a.is_deleted = FALSE;
+
 -- Executions queries
 
 -- name: GetExecutionByID :one

--- a/internal/store/queries/definitions.sql
+++ b/internal/store/queries/definitions.sql
@@ -37,3 +37,160 @@ SELECT s.* FROM action_sets_projection s
 JOIN definition_members_projection m ON s.id = m.action_set_id
 WHERE m.definition_id = $1 AND s.is_deleted = FALSE
 ORDER BY m.sort_order ASC;
+
+-- ============================================================================
+-- Projector listener writes (manchtools/power-manage-server#136).
+-- ============================================================================
+--
+-- Mirrors the deleted PL/pgSQL project_definition_event(). Eight event
+-- types: Created, Renamed, DescriptionUpdated, ScheduleUpdated,
+-- MemberAdded, MemberRemoved, MemberReordered, Deleted. The Created
+-- event is shared with project_action_event — when the payload carries
+-- `action_type` the action projector synthesises an actions_projection
+-- row and the definition projector no-ops; otherwise the definition
+-- projector inserts a definitions_projection row and the action
+-- projector no-ops. The Go listener (action_listener.go) owns BOTH
+-- stream types so the dispatch is single-pass.
+--
+-- Tightening vs the PL/pgSQL projector: every UPDATE on
+-- definitions_projection carries an explicit `WHERE projection_version < $N`
+-- guard and uses :execrows so the listener can short-circuit cascades
+-- on stale-replay (asymmetric-guard discipline; see role_listener /
+-- action_set_listener for the canonical shape).
+--
+-- Claim-first guard: the three member-mutation events
+-- (DefinitionMemberAdded, DefinitionMemberRemoved, DefinitionMemberReordered)
+-- all run ClaimDefinitionForMembership BEFORE touching
+-- definition_members_projection. The Claim guard bumps
+-- definitions_projection.projection_version only when the definition
+-- exists, is alive, and the event is newer; the listener short-circuits
+-- on n == 0. Doing the version check BEFORE the membership INSERT/
+-- DELETE/UPDATE prevents stale replays from silently resurrecting
+-- removed members or rolling back fresher reorders — the same hazard
+-- the user_group port (PR #174) had to fix retroactively.
+
+-- name: InsertDefinitionProjection :exec
+-- DefinitionCreated handler — definitions_projection branch (taken
+-- when the payload OMITS action_type). ON CONFLICT DO NOTHING for
+-- replay safety. Schedule defaults to '{"interval_hours": 8}' (column
+-- default mirrors the PL/pgSQL COALESCE fallback for the missing
+-- payload key).
+INSERT INTO definitions_projection (
+    id, name, description, schedule,
+    created_at, updated_at, created_by, projection_version
+) VALUES (
+    sqlc.arg('id'),
+    sqlc.arg('name'),
+    sqlc.arg('description'),
+    sqlc.arg('schedule'),
+    sqlc.arg('created_at'),
+    sqlc.arg('updated_at'),
+    sqlc.arg('created_by'),
+    sqlc.arg('projection_version')
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- name: RenameDefinitionProjection :execrows
+-- DefinitionRenamed handler. Stale-replay guard via projection_version.
+UPDATE definitions_projection
+SET name              = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: UpdateDefinitionDescriptionProjection :execrows
+-- DefinitionDescriptionUpdated handler. Empty-string description is a
+-- valid value (matches the PL/pgSQL `COALESCE(payload, '')` collapse —
+-- the listener decoder substitutes '' when the payload key is missing).
+UPDATE definitions_projection
+SET description       = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: UpdateDefinitionScheduleProjection :execrows
+-- DefinitionScheduleUpdated handler. Decoder defaults a missing
+-- schedule key to the column default '{"interval_hours": 8}' so this
+-- query always receives a non-NULL JSONB blob.
+UPDATE definitions_projection
+SET schedule          = $2,
+    updated_at        = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: ClaimDefinitionForMembership :execrows
+-- Atomic guard for the three member-mutation events
+-- (DefinitionMemberAdded, DefinitionMemberRemoved, DefinitionMemberReordered).
+-- Bumps updated_at + projection_version only when the parent
+-- definition exists, is not soft-deleted, and the event is newer than
+-- the current projection_version.
+--
+-- Returns n=1 when the listener may proceed with the membership
+-- mutation, n=0 when the event must be skipped. Doing the version
+-- check BEFORE any child-row mutation prevents the stale-replay holes
+-- CR caught on the user_group port (PR #174): without this guard a
+-- stale DefinitionMemberAdded after a Removed would recreate the
+-- removed membership row, and a stale Removed would delete a live
+-- one.
+UPDATE definitions_projection
+SET updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+  AND is_deleted = FALSE;
+
+-- name: InsertDefinitionMember :exec
+-- DefinitionMemberAdded handler — second half. ON CONFLICT DO NOTHING
+-- preserves the PL/pgSQL projector's idempotency under reconciler
+-- replays. The composite PK (definition_id, action_set_id) makes this
+-- safe.
+INSERT INTO definition_members_projection (
+    definition_id, action_set_id, sort_order, added_at, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (definition_id, action_set_id) DO NOTHING;
+
+-- name: DeleteDefinitionMember :exec
+-- DefinitionMemberRemoved handler — second half. Plain DELETE —
+-- silently no-op on a miss matches the PL/pgSQL projector's behaviour.
+DELETE FROM definition_members_projection
+WHERE definition_id = $1
+  AND action_set_id = $2;
+
+-- name: UpdateDefinitionMemberSortOrder :execrows
+-- DefinitionMemberReordered handler — second half. Per-member
+-- projection_version guards the row so a stale reorder cannot clobber
+-- a fresher position.
+UPDATE definition_members_projection
+SET sort_order        = $3,
+    projection_version = $4
+WHERE definition_id = $1
+  AND action_set_id = $2
+  AND projection_version < $4;
+
+-- name: RecountDefinitionMembers :exec
+-- DefinitionMemberAdded / DefinitionMemberRemoved handler — third half.
+-- Recomputes member_count from the live row count after the listener
+-- has applied a membership mutation. Run in the same transaction as
+-- ClaimDefinitionForMembership + the INSERT/DELETE so the parent row
+-- is never observed with a stale count. No projection_version guard
+-- here: the Claim above already stamped the version.
+UPDATE definitions_projection
+SET member_count = (SELECT COUNT(*) FROM definition_members_projection WHERE definition_id = $1)
+WHERE id = $1;
+
+-- name: SoftDeleteDefinitionProjection :execrows
+-- DefinitionDeleted handler — definitions_projection branch (taken on
+-- the definition stream). Stale-replay guard via projection_version;
+-- :execrows lets the listener detect and skip downstream cascades —
+-- though there is no cross-table cascade for DefinitionDeleted today
+-- (the PL/pgSQL projector left definition_members orphaned by
+-- design), so n==0 just short-circuits to a no-op.
+UPDATE definitions_projection
+SET is_deleted        = TRUE,
+    updated_at        = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -128,14 +128,23 @@ var AllRebuildTargets = []rebuildTarget{
 		Function:    "project_device_event",
 	},
 	{
+		// Ported to projectors.ApplyAction via projectors.WireAll
+		// (manchtools/power-manage-server#136). RebuildAll dispatches
+		// through the Go applier; the no-op PL/pgSQL stub left behind
+		// by the migration is retained so the live trigger pipeline in
+		// project_event() stays quiet until the dispatcher itself drops
+		// its `WHEN 'action'` / `WHEN 'definition'` clauses in the
+		// Phase 2 cleanup.
+		//
 		// Same combined ('action' + 'definition') filter as the
 		// original rebuild_actions_projection — the action projector
 		// owns both because some definition events synthesise action
-		// rows (compliance-policy definitions specifically).
+		// rows (compliance-policy definitions specifically). The
+		// per-event StreamType gate inside ApplyAction picks the
+		// correct branch for each event during replay.
 		Name:        "actions",
 		Tables:      []string{"actions_projection"},
 		StreamTypes: []string{"action", "definition"},
-		Function:    "project_action_event",
 	},
 	{
 		Name:        "executions",
@@ -167,11 +176,22 @@ var AllRebuildTargets = []rebuildTarget{
 		StreamTypes: []string{"action_set"},
 	},
 	{
+		// Ported to projectors.ApplyDefinition (a thin alias to
+		// ApplyAction) via projectors.WireAll
+		// (manchtools/power-manage-server#136). RebuildAll dispatches
+		// through the Go applier; the no-op PL/pgSQL stub left behind
+		// by the migration is retained so the live trigger pipeline in
+		// project_event() stays quiet until the dispatcher itself drops
+		// its `WHEN 'definition'` clause in the Phase 2 cleanup.
+		//
+		// `TRUNCATE definitions_projection CASCADE` matches the legacy
+		// rebuild_definitions_projection() blast radius — the cascade
+		// wipes definition_members_projection (FK reference), which
+		// the applier then re-derives from DefinitionMember* events.
 		Name:        "definitions",
 		Tables:      []string{"definitions_projection"},
 		Cascade:     true,
 		StreamTypes: []string{"definition"},
-		Function:    "project_definition_event",
 	},
 	{
 		// Ported to projectors.ApplyDeviceGroup via projectors.WireAll


### PR DESCRIPTION
## Summary

Seventh Phase 2 port. Replaces both `project_action_event()` and `project_definition_event()` with a single `projectors.ActionListener` that owns both `action` and `definition` stream types — paired per tracker #136 because Definition events with `action_type` synthesise rows in `actions_projection` (cross-stream effect).

13 event types total:
- **action stream**: `ActionCreated`, `ActionRenamed`, `ActionDescriptionUpdated`, `ActionParamsUpdated`, `ActionDeleted`
- **definition stream**: `DefinitionCreated` (synthesises action when `action_type` present; creates definition row otherwise), `DefinitionRenamed`, `DefinitionDescriptionUpdated`, `DefinitionScheduleUpdated`, `DefinitionMemberAdded`, `DefinitionMemberRemoved`, `DefinitionMemberReordered`, `DefinitionDeleted`

## Patterns adopted from prior Phase 2 CR review

- **Asymmetric guards**: every UPDATE on `actions_projection` + `definitions_projection` carries `WHERE projection_version < $N`; guarded `SoftDelete` uses `:execrows`.
- **ActionDeleted's 8-step cascade** short-circuits ALL steps on `n == 0` (action_set decrement, member wipe, policy rule_count decrement, rule wipe, evaluation wipe, results wipe, per-device reevaluate loop). Tightening over PL/pgSQL.
- **ActionRenamed cross-stream cascade** into `compliance_policy_rules.action_name` also short-circuits on `n == 0`.
- **DefinitionMember{Added,Removed,Reordered}** use Claim-first guard (`ClaimDefinitionForMembership`) so parent's projection_version bumps BEFORE any membership-table mutation.
- **DefinitionCreated key-presence discriminator** probes via `map[string]json.RawMessage` so JSON-null `action_type` counts as present (matches PL/pgSQL `?` operator semantics) — covered by a dedicated test.
- **`ctx.Err()` check at top of device reevaluate loop** so SIGTERM mid-cascade exits gracefully (CR-CLI catch).

## Migration / wiring

- Migration `037_action_definition_projector_to_go.sql` no-ops both PL/pgSQL functions.
- `WireAll` registers `ActionListener` once (covers both stream types).
- Both `actions` and `definitions` rebuild targets dispatch via the Go applier.

## Test plan

- [x] 8 pure decoder tests (action) + 7 integration tests including full lifecycle, ActionRenamed→compliance_policy_rules cascade, full 4-table delete cascade, **stale-replay regression for ActionDeleted** locking the cascade short-circuit.
- [x] 8 pure decoder tests (definition) + 5 integration tests covering both DefinitionCreated branches (with/without action_type), member lifecycle, **stale-replay regression for DefinitionMemberAdded after Removed** locking the Claim-first guard.
- [x] `gofmt -l`, `go vet ./...`, `staticcheck ./...` all green.
- [x] CR-CLI returned 0 findings before push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated action and definition projection logic to new processing architecture.
  * Added comprehensive test coverage for projection handling and event lifecycle management.
  * Updated database queries to support new projection processing flow while maintaining existing behavior and consistency guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->