### PR TITLE
refactor: port device projector to Go listener (Part of #136)

### DIFF
--- a/internal/projectors/device.go
+++ b/internal/projectors/device.go
@@ -1,0 +1,416 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// defaultDeviceLabels mirrors the PL/pgSQL projector's
+// `COALESCE(event.data->'labels', '{}')` fallback for
+// DeviceRegistered. Held as raw bytes so the listener can pass it
+// straight to the JSONB column without an extra marshal.
+var defaultDeviceLabels = []byte(`{}`)
+
+// DeviceRegisteredPayload mirrors the fields the deleted PL/pgSQL
+// project_device_event() read out of a DeviceRegistered event:
+//
+//   - hostname (defaults to "" — matches PL/pgSQL
+//     `COALESCE(payload, "")` for the NOT NULL column).
+//   - cert_fingerprint (nullable — the UPSERT writes whatever the
+//     payload contains. The PL/pgSQL projector wrote NULL when the
+//     payload omitted the key, and the column's UNIQUE constraint
+//     allows multiple NULLs, so omission is a documented permissive
+//     path used by enrollment flows that haven't issued a cert yet.
+//     Mirror that here as a *string so omission lands as SQL NULL).
+//   - cert_not_after (nullable timestamp).
+//   - registration_token_id (nullable).
+//   - labels (defaults to `{}` JSONB — matches PL/pgSQL fallback).
+//   - assigned_user_id (nullable; when present, the listener cascades
+//     to an INSERT into device_assigned_users_projection).
+type DeviceRegisteredPayload struct {
+	ID                  string
+	Hostname            string
+	CertFingerprint     *string
+	CertNotAfter        *time.Time
+	RegistrationTokenID *string
+	Labels              []byte
+	AssignedUserID      *string
+}
+
+type deviceRegisteredRaw struct {
+	Hostname            *string         `json:"hostname,omitempty"`
+	CertFingerprint     *string         `json:"cert_fingerprint,omitempty"`
+	CertNotAfter        *time.Time      `json:"cert_not_after,omitempty"`
+	RegistrationTokenID *string         `json:"registration_token_id,omitempty"`
+	Labels              json.RawMessage `json:"labels,omitempty"`
+	AssignedUserID      *string         `json:"assigned_user_id,omitempty"`
+}
+
+// DeviceRegisteredFromEvent decodes DeviceRegistered. Returns
+// ErrIgnoredEvent for any other (stream, event_type) so the listener
+// wrapper can silently no-op.
+func DeviceRegisteredFromEvent(e store.PersistedEvent) (DeviceRegisteredPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceRegistered" {
+		return DeviceRegisteredPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DeviceRegisteredPayload{}, fmt.Errorf("projector: empty DeviceRegistered payload")
+	}
+	var raw deviceRegisteredRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceRegisteredPayload{}, fmt.Errorf("projector: invalid DeviceRegistered payload: %w", err)
+	}
+	out := DeviceRegisteredPayload{
+		ID:                  e.StreamID,
+		CertFingerprint:     raw.CertFingerprint,
+		CertNotAfter:        raw.CertNotAfter,
+		RegistrationTokenID: raw.RegistrationTokenID,
+		AssignedUserID:      raw.AssignedUserID,
+		Labels:              defaultDeviceLabels,
+	}
+	if raw.Hostname != nil {
+		out.Hostname = *raw.Hostname
+	}
+	if len(raw.Labels) > 0 {
+		// Preserve wire bytes verbatim so the listener writes the same
+		// JSONB the emitter sent (matches the PL/pgSQL projector's
+		// `event.data->'labels'`).
+		out.Labels = []byte(raw.Labels)
+	}
+	return out, nil
+}
+
+// DeviceSeenPayload mirrors the PL/pgSQL projector's COALESCE-on-
+// missing semantics for DeviceSeen:
+//
+//   - agent_version: COALESCE(payload, agent_version) — when missing,
+//     the existing column value is preserved. Decoder leaves the
+//     pointer nil; the listener uses COALESCE in SQL so we don't need
+//     to read the row first.
+//   - hostname: COALESCE(NULLIF(payload, ""), hostname) — empty string
+//     OR missing key both fall back to the existing value. Decoder
+//     leaves nil for missing; explicit empty string also collapses to
+//     nil so the SQL COALESCE does the right thing.
+type DeviceSeenPayload struct {
+	ID           string
+	AgentVersion *string
+	Hostname     *string
+}
+
+type deviceSeenRaw struct {
+	AgentVersion *string `json:"agent_version,omitempty"`
+	Hostname     *string `json:"hostname,omitempty"`
+}
+
+// DeviceSeenFromEvent decodes DeviceSeen. Empty payload is valid (a
+// pure heartbeat-style ping that only refreshes last_seen_at).
+func DeviceSeenFromEvent(e store.PersistedEvent) (DeviceSeenPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceSeen" {
+		return DeviceSeenPayload{}, ErrIgnoredEvent
+	}
+	out := DeviceSeenPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw deviceSeenRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceSeenPayload{}, fmt.Errorf("projector: invalid DeviceSeen payload: %w", err)
+	}
+	out.AgentVersion = raw.AgentVersion
+	// NULLIF(payload, '') collapse: an explicit empty hostname must
+	// fall back to the existing column value. Drop the pointer so the
+	// SQL COALESCE preserves the prior row state.
+	if raw.Hostname != nil && *raw.Hostname == "" {
+		out.Hostname = nil
+	} else {
+		out.Hostname = raw.Hostname
+	}
+	return out, nil
+}
+
+// DeviceHeartbeatPayload mirrors the PL/pgSQL projector's
+// COALESCE-on-missing for DeviceHeartbeat: agent_version preserved
+// when the payload omits it.
+type DeviceHeartbeatPayload struct {
+	ID           string
+	AgentVersion *string
+}
+
+type deviceHeartbeatRaw struct {
+	AgentVersion *string `json:"agent_version,omitempty"`
+}
+
+// DeviceHeartbeatFromEvent decodes DeviceHeartbeat. Empty payload is
+// a valid bare ping.
+func DeviceHeartbeatFromEvent(e store.PersistedEvent) (DeviceHeartbeatPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceHeartbeat" {
+		return DeviceHeartbeatPayload{}, ErrIgnoredEvent
+	}
+	out := DeviceHeartbeatPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw deviceHeartbeatRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceHeartbeatPayload{}, fmt.Errorf("projector: invalid DeviceHeartbeat payload: %w", err)
+	}
+	out.AgentVersion = raw.AgentVersion
+	return out, nil
+}
+
+// DeviceCertRenewedPayload mirrors the PL/pgSQL projector's
+// DeviceCertRenewed handling: cert_fingerprint is required,
+// cert_not_after is optional (when omitted the existing column value
+// is preserved via SQL COALESCE).
+type DeviceCertRenewedPayload struct {
+	ID              string
+	CertFingerprint string
+	CertNotAfter    *time.Time
+}
+
+type deviceCertRenewedRaw struct {
+	CertFingerprint *string    `json:"cert_fingerprint,omitempty"`
+	CertNotAfter    *time.Time `json:"cert_not_after,omitempty"`
+}
+
+// DeviceCertRenewedFromEvent decodes DeviceCertRenewed.
+func DeviceCertRenewedFromEvent(e store.PersistedEvent) (DeviceCertRenewedPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceCertRenewed" {
+		return DeviceCertRenewedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DeviceCertRenewedPayload{}, fmt.Errorf("projector: empty DeviceCertRenewed payload")
+	}
+	var raw deviceCertRenewedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceCertRenewedPayload{}, fmt.Errorf("projector: invalid DeviceCertRenewed payload: %w", err)
+	}
+	if raw.CertFingerprint == nil || *raw.CertFingerprint == "" {
+		return DeviceCertRenewedPayload{}, fmt.Errorf("projector: DeviceCertRenewed requires cert_fingerprint")
+	}
+	return DeviceCertRenewedPayload{
+		ID:              e.StreamID,
+		CertFingerprint: *raw.CertFingerprint,
+		CertNotAfter:    raw.CertNotAfter,
+	}, nil
+}
+
+// DeviceLabelsUpdatedPayload mirrors the PL/pgSQL projector's
+// `COALESCE(event.data->'labels', labels)` for DeviceLabelsUpdated:
+// missing key preserves the existing labels JSONB, present key
+// REPLACES the entire blob.
+type DeviceLabelsUpdatedPayload struct {
+	ID     string
+	Labels []byte
+}
+
+type deviceLabelsUpdatedRaw struct {
+	Labels json.RawMessage `json:"labels,omitempty"`
+}
+
+// DeviceLabelsUpdatedFromEvent decodes DeviceLabelsUpdated. Empty
+// labels => nil byte slice; the SQL COALESCE will preserve the
+// existing row value.
+func DeviceLabelsUpdatedFromEvent(e store.PersistedEvent) (DeviceLabelsUpdatedPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceLabelsUpdated" {
+		return DeviceLabelsUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := DeviceLabelsUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw deviceLabelsUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceLabelsUpdatedPayload{}, fmt.Errorf("projector: invalid DeviceLabelsUpdated payload: %w", err)
+	}
+	if len(raw.Labels) > 0 {
+		out.Labels = []byte(raw.Labels)
+	}
+	return out, nil
+}
+
+// DeviceLabelSetPayload mirrors the PL/pgSQL projector's JSONB merge
+// for DeviceLabelSet: `labels || jsonb_build_object(key, value)`.
+// Both key and value are required strings.
+type DeviceLabelSetPayload struct {
+	ID    string
+	Key   string
+	Value string
+}
+
+type deviceLabelSetRaw struct {
+	Key   *string `json:"key,omitempty"`
+	Value *string `json:"value,omitempty"`
+}
+
+// DeviceLabelSetFromEvent decodes DeviceLabelSet.
+func DeviceLabelSetFromEvent(e store.PersistedEvent) (DeviceLabelSetPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceLabelSet" {
+		return DeviceLabelSetPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DeviceLabelSetPayload{}, fmt.Errorf("projector: empty DeviceLabelSet payload")
+	}
+	var raw deviceLabelSetRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceLabelSetPayload{}, fmt.Errorf("projector: invalid DeviceLabelSet payload: %w", err)
+	}
+	if raw.Key == nil || *raw.Key == "" {
+		return DeviceLabelSetPayload{}, fmt.Errorf("projector: DeviceLabelSet requires key")
+	}
+	out := DeviceLabelSetPayload{ID: e.StreamID, Key: *raw.Key}
+	if raw.Value != nil {
+		out.Value = *raw.Value
+	}
+	return out, nil
+}
+
+// DeviceLabelRemovedPayload mirrors the PL/pgSQL projector's
+// `labels - (event.data->>'key')` for DeviceLabelRemoved.
+type DeviceLabelRemovedPayload struct {
+	ID  string
+	Key string
+}
+
+type deviceLabelRemovedRaw struct {
+	Key *string `json:"key,omitempty"`
+}
+
+// DeviceLabelRemovedFromEvent decodes DeviceLabelRemoved.
+func DeviceLabelRemovedFromEvent(e store.PersistedEvent) (DeviceLabelRemovedPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceLabelRemoved" {
+		return DeviceLabelRemovedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return DeviceLabelRemovedPayload{}, fmt.Errorf("projector: empty DeviceLabelRemoved payload")
+	}
+	var raw deviceLabelRemovedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceLabelRemovedPayload{}, fmt.Errorf("projector: invalid DeviceLabelRemoved payload: %w", err)
+	}
+	if raw.Key == nil || *raw.Key == "" {
+		return DeviceLabelRemovedPayload{}, fmt.Errorf("projector: DeviceLabelRemoved requires key")
+	}
+	return DeviceLabelRemovedPayload{ID: e.StreamID, Key: *raw.Key}, nil
+}
+
+// DeviceUserAssignmentPayload covers DeviceAssigned and
+// DeviceUnassigned. user_id is required because the underlying
+// composite PK column would otherwise be NULL — surfacing as a
+// Postgres constraint violation under the PL/pgSQL projector. We
+// surface the missing-field case as a decoder validation error so
+// the listener log makes the failure obvious.
+type DeviceUserAssignmentPayload struct {
+	DeviceID string
+	UserID   string
+}
+
+type deviceUserAssignmentRaw struct {
+	UserID *string `json:"user_id,omitempty"`
+}
+
+// DeviceAssignedFromEvent decodes DeviceAssigned.
+func DeviceAssignedFromEvent(e store.PersistedEvent) (DeviceUserAssignmentPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceAssigned" {
+		return DeviceUserAssignmentPayload{}, ErrIgnoredEvent
+	}
+	return decodeDeviceUserAssignment(e)
+}
+
+// DeviceUnassignedFromEvent decodes DeviceUnassigned.
+func DeviceUnassignedFromEvent(e store.PersistedEvent) (DeviceUserAssignmentPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceUnassigned" {
+		return DeviceUserAssignmentPayload{}, ErrIgnoredEvent
+	}
+	return decodeDeviceUserAssignment(e)
+}
+
+func decodeDeviceUserAssignment(e store.PersistedEvent) (DeviceUserAssignmentPayload, error) {
+	if len(e.Data) == 0 {
+		return DeviceUserAssignmentPayload{}, fmt.Errorf("projector: empty %s payload", e.EventType)
+	}
+	var raw deviceUserAssignmentRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceUserAssignmentPayload{}, fmt.Errorf("projector: invalid %s payload: %w", e.EventType, err)
+	}
+	if raw.UserID == nil || *raw.UserID == "" {
+		return DeviceUserAssignmentPayload{}, fmt.Errorf("projector: %s requires user_id", e.EventType)
+	}
+	return DeviceUserAssignmentPayload{DeviceID: e.StreamID, UserID: *raw.UserID}, nil
+}
+
+// DeviceGroupAssignmentPayload covers DeviceGroupAssigned and
+// DeviceGroupUnassigned. group_id is required for the same reason
+// user_id is on DeviceAssigned: composite-PK column.
+type DeviceGroupAssignmentPayload struct {
+	DeviceID string
+	GroupID  string
+}
+
+type deviceGroupAssignmentRaw struct {
+	GroupID *string `json:"group_id,omitempty"`
+}
+
+// DeviceGroupAssignedFromEvent decodes DeviceGroupAssigned.
+func DeviceGroupAssignedFromEvent(e store.PersistedEvent) (DeviceGroupAssignmentPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceGroupAssigned" {
+		return DeviceGroupAssignmentPayload{}, ErrIgnoredEvent
+	}
+	return decodeDeviceGroupAssignment(e)
+}
+
+// DeviceGroupUnassignedFromEvent decodes DeviceGroupUnassigned.
+func DeviceGroupUnassignedFromEvent(e store.PersistedEvent) (DeviceGroupAssignmentPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceGroupUnassigned" {
+		return DeviceGroupAssignmentPayload{}, ErrIgnoredEvent
+	}
+	return decodeDeviceGroupAssignment(e)
+}
+
+func decodeDeviceGroupAssignment(e store.PersistedEvent) (DeviceGroupAssignmentPayload, error) {
+	if len(e.Data) == 0 {
+		return DeviceGroupAssignmentPayload{}, fmt.Errorf("projector: empty %s payload", e.EventType)
+	}
+	var raw deviceGroupAssignmentRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceGroupAssignmentPayload{}, fmt.Errorf("projector: invalid %s payload: %w", e.EventType, err)
+	}
+	if raw.GroupID == nil || *raw.GroupID == "" {
+		return DeviceGroupAssignmentPayload{}, fmt.Errorf("projector: %s requires group_id", e.EventType)
+	}
+	return DeviceGroupAssignmentPayload{DeviceID: e.StreamID, GroupID: *raw.GroupID}, nil
+}
+
+// DeviceSyncIntervalSetPayload mirrors the PL/pgSQL projector's
+// `COALESCE((event.data->>'sync_interval_minutes')::INTEGER, 0)`:
+// missing key collapses to 0.
+type DeviceSyncIntervalSetPayload struct {
+	ID                  string
+	SyncIntervalMinutes int32
+}
+
+type deviceSyncIntervalSetRaw struct {
+	SyncIntervalMinutes *int32 `json:"sync_interval_minutes,omitempty"`
+}
+
+// DeviceSyncIntervalSetFromEvent decodes DeviceSyncIntervalSet.
+func DeviceSyncIntervalSetFromEvent(e store.PersistedEvent) (DeviceSyncIntervalSetPayload, error) {
+	if e.StreamType != "device" || e.EventType != "DeviceSyncIntervalSet" {
+		return DeviceSyncIntervalSetPayload{}, ErrIgnoredEvent
+	}
+	out := DeviceSyncIntervalSetPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw deviceSyncIntervalSetRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return DeviceSyncIntervalSetPayload{}, fmt.Errorf("projector: invalid DeviceSyncIntervalSet payload: %w", err)
+	}
+	if raw.SyncIntervalMinutes != nil {
+		out.SyncIntervalMinutes = *raw.SyncIntervalMinutes
+	}
+	return out, nil
+}

--- a/internal/projectors/device_listener.go
+++ b/internal/projectors/device_listener.go
@@ -1,0 +1,390 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// DeviceListener returns a store.EventListener that applies every
+// device stream event the deleted PL/pgSQL project_device_event
+// handled. Thirteen event types: DeviceRegistered, DeviceSeen,
+// DeviceHeartbeat, DeviceCertRenewed, DeviceLabelsUpdated,
+// DeviceLabelSet, DeviceLabelRemoved, DeviceDeleted, DeviceAssigned,
+// DeviceUnassigned, DeviceGroupAssigned, DeviceGroupUnassigned,
+// DeviceSyncIntervalSet.
+//
+// Event-type families:
+//   - Single-statement events (Seen, Heartbeat, CertRenewed,
+//     LabelsUpdated, LabelSet, LabelRemoved, Assigned, Unassigned,
+//     GroupAssigned, GroupUnassigned, SyncIntervalSet) run on the
+//     autocommit pool — one guarded UPDATE/INSERT/DELETE each.
+//   - Multi-write events (DeviceRegistered when assigned_user_id is
+//     present; DeviceDeleted with its assigned-user + assigned-group
+//     wipes) wrap the cascade in store.WithTx so the writes are
+//     atomic with each other (not with the event commit, which
+//     already happened — fireListeners is post-commit).
+//
+// Asymmetric-guard discipline (per the role + identity_provider +
+// action_set + assignment + user_group + device_group +
+// compliance_policy + compliance + action+definition + execution
+// ports): every UPDATE on devices_projection carries a
+// `WHERE projection_version < $N` guard via :execrows, and the
+// listener short-circuits cascades when n == 0. The DELETEs on
+// device_assigned_users_projection and device_assigned_groups_projection
+// carry a `WHERE projection_version <= $N` guard so a stale Unassigned
+// replayed after a re-Assign cannot wipe the live row (CR catch on
+// PR #179, applied here to the assignment-table junction tables).
+//
+// Wired in projectors.WireAll. Refs #136 (Phase 2 of tracker #107).
+func DeviceListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "device" {
+			return
+		}
+		// Multi-write events route through ApplyDevice via WithTx so
+		// the cascade stays atomic; single-statement events go on the
+		// autocommit pool. ApplyDevice handles all event types when
+		// called with tx-bound queries (the rebuild path).
+		switch e.EventType {
+		case "DeviceRegistered", "DeviceDeleted":
+			if err := st.WithTx(ctx, func(q *store.Queries) error {
+				return ApplyDevice(ctx, q, e)
+			}); err != nil {
+				logger.Warn("device projector: failed to apply event",
+					"event_id", e.ID, "event_type", e.EventType, "device_id", e.StreamID, "error", err)
+			}
+			return
+		}
+		if err := ApplyDevice(ctx, st.Queries(), e); err != nil {
+			logger.Warn("device projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "device_id", e.StreamID, "error", err)
+		}
+	}
+}
+
+// ApplyDevice is the transactional core of the device projector.
+// The listener wraps it for live-event dispatch (using WithTx for
+// the multi-write event types); the rebuild path
+// (manchtools/power-manage-server#125) registers it via
+// RegisterRebuildApply so RebuildAll re-derives the projection from
+// the event store instead of dispatching to the no-op PL/pgSQL stub.
+//
+// Asymmetric-guard discipline is preserved across every multi-write
+// event: when the version-guarded write on the parent row affects
+// zero rows, every cascading INSERT/DELETE downstream is skipped —
+// otherwise a stale event re-applied later would leak orphan
+// junction rows or wipe a freshly-restored device's assignments.
+func ApplyDevice(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "device" {
+		return nil
+	}
+	switch e.EventType {
+	case "DeviceRegistered":
+		return applyDeviceRegistered(ctx, q, e)
+	case "DeviceSeen":
+		return applyDeviceSeen(ctx, q, e)
+	case "DeviceHeartbeat":
+		return applyDeviceHeartbeat(ctx, q, e)
+	case "DeviceCertRenewed":
+		return applyDeviceCertRenewed(ctx, q, e)
+	case "DeviceLabelsUpdated":
+		return applyDeviceLabelsUpdated(ctx, q, e)
+	case "DeviceLabelSet":
+		return applyDeviceLabelSet(ctx, q, e)
+	case "DeviceLabelRemoved":
+		return applyDeviceLabelRemoved(ctx, q, e)
+	case "DeviceDeleted":
+		return applyDeviceDeleted(ctx, q, e)
+	case "DeviceAssigned":
+		return applyDeviceAssigned(ctx, q, e)
+	case "DeviceUnassigned":
+		return applyDeviceUnassigned(ctx, q, e)
+	case "DeviceGroupAssigned":
+		return applyDeviceGroupAssigned(ctx, q, e)
+	case "DeviceGroupUnassigned":
+		return applyDeviceGroupUnassigned(ctx, q, e)
+	case "DeviceSyncIntervalSet":
+		return applyDeviceSyncIntervalSet(ctx, q, e)
+	}
+	return nil
+}
+
+func applyDeviceRegistered(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceRegisteredFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	occurredAt := e.OccurredAt
+	if err := q.UpsertDeviceProjection(ctx, db.UpsertDeviceProjectionParams{
+		ID:                  payload.ID,
+		Hostname:            payload.Hostname,
+		CertFingerprint:     payload.CertFingerprint,
+		CertNotAfter:        payload.CertNotAfter,
+		RegisteredAt:        &occurredAt,
+		RegistrationTokenID: payload.RegistrationTokenID,
+		Labels:              payload.Labels,
+		ProjectionVersion:   deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	if payload.AssignedUserID == nil || *payload.AssignedUserID == "" {
+		return nil
+	}
+	// Auto-assign cascade — token owner gets the device assignment.
+	// Wrapped in the same WithTx as the upsert (the listener routes
+	// DeviceRegistered through WithTx unconditionally) so the two
+	// writes commit together.
+	return q.InsertDeviceAssignedUserOnRegister(ctx, db.InsertDeviceAssignedUserOnRegisterParams{
+		DeviceID:          payload.ID,
+		UserID:            *payload.AssignedUserID,
+		AssignedAt:        occurredAt,
+		AssignedBy:        e.ActorID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+}
+
+func applyDeviceSeen(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceSeenFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	occurredAt := e.OccurredAt
+	if _, err := q.UpdateDeviceSeenProjection(ctx, db.UpdateDeviceSeenProjectionParams{
+		ID:                payload.ID,
+		LastSeenAt:        &occurredAt,
+		AgentVersion:      payload.AgentVersion,
+		Hostname:          payload.Hostname,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceHeartbeat(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceHeartbeatFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	occurredAt := e.OccurredAt
+	if _, err := q.UpdateDeviceHeartbeatProjection(ctx, db.UpdateDeviceHeartbeatProjectionParams{
+		ID:                payload.ID,
+		LastSeenAt:        &occurredAt,
+		AgentVersion:      payload.AgentVersion,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceCertRenewed(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceCertRenewedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	certFingerprint := payload.CertFingerprint
+	if _, err := q.UpdateDeviceCertRenewedProjection(ctx, db.UpdateDeviceCertRenewedProjectionParams{
+		ID:                payload.ID,
+		CertFingerprint:   &certFingerprint,
+		CertNotAfter:      payload.CertNotAfter,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceLabelsUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceLabelsUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.UpdateDeviceLabelsProjection(ctx, db.UpdateDeviceLabelsProjectionParams{
+		ID:                payload.ID,
+		Labels:            payload.Labels,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceLabelSet(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceLabelSetFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.SetDeviceLabelKey(ctx, db.SetDeviceLabelKeyParams{
+		ID:                payload.ID,
+		Key:               payload.Key,
+		Value:             payload.Value,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceLabelRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceLabelRemovedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.RemoveDeviceLabelKey(ctx, db.RemoveDeviceLabelKeyParams{
+		ID:                payload.ID,
+		Key:               payload.Key,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	n, err := q.SoftDeleteDeviceProjection(ctx, db.SoftDeleteDeviceProjectionParams{
+		ID:                e.StreamID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		// Stale DeviceDeleted replay against a row whose
+		// projection_version has moved past this event. Skipping the
+		// cascade (assigned-user wipe + assigned-group wipe) is
+		// mandatory: otherwise an old delete re-applied by the
+		// reconciler against a freshly-restored device would silently
+		// nuke its assignments.
+		return nil
+	}
+	if err := q.DeleteDeviceAssignedUsersByDevice(ctx, e.StreamID); err != nil {
+		return err
+	}
+	return q.DeleteDeviceAssignedGroupsByDevice(ctx, e.StreamID)
+}
+
+func applyDeviceAssigned(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceAssignedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	return q.InsertDeviceAssignedUser(ctx, db.InsertDeviceAssignedUserParams{
+		DeviceID:          payload.DeviceID,
+		UserID:            payload.UserID,
+		AssignedAt:        e.OccurredAt,
+		AssignedBy:        e.ActorID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+}
+
+func applyDeviceUnassigned(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceUnassignedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	// Stale-replay DELETE protection: the SQL guard
+	// `WHERE projection_version <= $N` rejects a stale Unassigned
+	// replayed after a re-Assign — the live row's projection_version
+	// was bumped by the re-Assign INSERT, so the stale Unassigned's
+	// older sequence_num fails the guard. n == 0 here is silent (no
+	// cascade to short-circuit), but the :execrows shape gives us
+	// a hook to grow observability later if needed.
+	if _, err := q.DeleteDeviceAssignedUser(ctx, db.DeleteDeviceAssignedUserParams{
+		DeviceID:          payload.DeviceID,
+		UserID:            payload.UserID,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceGroupAssigned(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceGroupAssignedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	return q.InsertDeviceAssignedGroup(ctx, db.InsertDeviceAssignedGroupParams{
+		DeviceID:          payload.DeviceID,
+		GroupID:           payload.GroupID,
+		AssignedAt:        e.OccurredAt,
+		AssignedBy:        e.ActorID,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+}
+
+func applyDeviceGroupUnassigned(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceGroupUnassignedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	// Same stale-replay guard as DeviceUnassigned (assignment-table
+	// DELETE protection from PR #179 CR catch).
+	if _, err := q.DeleteDeviceAssignedGroup(ctx, db.DeleteDeviceAssignedGroupParams{
+		DeviceID:          payload.DeviceID,
+		GroupID:           payload.GroupID,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyDeviceSyncIntervalSet(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := DeviceSyncIntervalSetFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.UpdateDeviceSyncIntervalProjection(ctx, db.UpdateDeviceSyncIntervalProjectionParams{
+		ID:                  payload.ID,
+		SyncIntervalMinutes: payload.SyncIntervalMinutes,
+		ProjectionVersion:   deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/projectors/device_test.go
+++ b/internal/projectors/device_test.go
@@ -1,0 +1,783 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// ============================================================================
+// Pure decoder tests — pin the field defaults that match the deleted
+// PL/pgSQL project_device_event() COALESCE / NULL semantics.
+// ============================================================================
+
+// TestDeviceRegisteredFromEvent_Pure pins the decoder defaults: missing
+// hostname → "" (matches PL/pgSQL `COALESCE(payload, "")`); missing
+// labels → "{}"; missing cert_fingerprint stays nil so the column lands
+// as SQL NULL (matches PL/pgSQL permissive behaviour); assigned_user_id
+// is nullable.
+func TestDeviceRegisteredFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.DeviceRegisteredFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceRegistered", ActorID: "u-1",
+			Data: jsonOrFail(t, map[string]any{
+				"hostname":              "host-1",
+				"cert_fingerprint":      "abc123",
+				"registration_token_id": "tok-1",
+				"labels":                map[string]any{"env": "prod"},
+				"assigned_user_id":      "user-A",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.ID)
+		assert.Equal(t, "host-1", got.Hostname)
+		require.NotNil(t, got.CertFingerprint)
+		assert.Equal(t, "abc123", *got.CertFingerprint)
+		require.NotNil(t, got.RegistrationTokenID)
+		assert.Equal(t, "tok-1", *got.RegistrationTokenID)
+		assert.Contains(t, string(got.Labels), "prod")
+		require.NotNil(t, got.AssignedUserID)
+		assert.Equal(t, "user-A", *got.AssignedUserID)
+	})
+
+	t.Run("defaults: missing hostname → '', missing labels → '{}', missing cert/assigned → nil", func(t *testing.T) {
+		got, err := projectors.DeviceRegisteredFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-2", EventType: "DeviceRegistered",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Hostname)
+		assert.JSONEq(t, "{}", string(got.Labels))
+		assert.Nil(t, got.CertFingerprint)
+		assert.Nil(t, got.AssignedUserID)
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceRegisteredFromEvent(store.PersistedEvent{
+			StreamType: "device_group", EventType: "DeviceRegistered",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.DeviceRegisteredFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceSeen",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.DeviceRegisteredFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceRegistered",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceSeenFromEvent_Pure — empty payload is valid (heartbeat
+// ping); explicit empty hostname collapses to nil so the SQL COALESCE
+// preserves the existing column value (matches PL/pgSQL NULLIF).
+func TestDeviceSeenFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		v := "2.0.0"
+		h := "new-host"
+		got, err := projectors.DeviceSeenFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceSeen",
+			Data: jsonOrFail(t, map[string]any{"agent_version": v, "hostname": h}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.AgentVersion)
+		assert.Equal(t, v, *got.AgentVersion)
+		require.NotNil(t, got.Hostname)
+		assert.Equal(t, h, *got.Hostname)
+	})
+
+	t.Run("empty payload is a valid bare ping", func(t *testing.T) {
+		got, err := projectors.DeviceSeenFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceSeen",
+			Data: nil,
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.AgentVersion)
+		assert.Nil(t, got.Hostname)
+	})
+
+	t.Run("explicit empty hostname collapses to nil (NULLIF)", func(t *testing.T) {
+		got, err := projectors.DeviceSeenFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceSeen",
+			Data: jsonOrFail(t, map[string]any{"hostname": ""}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.Hostname, "explicit empty hostname must drop to nil so SQL COALESCE preserves the existing value")
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceSeenFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceHeartbeat",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceHeartbeatFromEvent_Pure — empty payload valid; missing
+// agent_version stays nil so SQL COALESCE preserves existing.
+func TestDeviceHeartbeatFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		v := "1.5.0"
+		got, err := projectors.DeviceHeartbeatFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceHeartbeat",
+			Data: jsonOrFail(t, map[string]any{"agent_version": v}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.AgentVersion)
+		assert.Equal(t, v, *got.AgentVersion)
+	})
+
+	t.Run("empty payload valid", func(t *testing.T) {
+		got, err := projectors.DeviceHeartbeatFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceHeartbeat",
+			Data: nil,
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.AgentVersion)
+	})
+
+	t.Run("wrong stream type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceHeartbeatFromEvent(store.PersistedEvent{
+			StreamType: "device_group", EventType: "DeviceHeartbeat",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceCertRenewedFromEvent_Pure — cert_fingerprint required;
+// cert_not_after optional (nil means SQL COALESCE preserves existing).
+func TestDeviceCertRenewedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.DeviceCertRenewedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceCertRenewed",
+			Data: jsonOrFail(t, map[string]any{
+				"cert_fingerprint": "newfp",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "newfp", got.CertFingerprint)
+		assert.Nil(t, got.CertNotAfter)
+	})
+
+	t.Run("missing cert_fingerprint fails", func(t *testing.T) {
+		_, err := projectors.DeviceCertRenewedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceCertRenewed",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "cert_fingerprint")
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceCertRenewedFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceSeen",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceLabelsUpdatedFromEvent_Pure — missing labels stays nil so
+// the SQL COALESCE preserves the existing column value.
+func TestDeviceLabelsUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("explicit labels", func(t *testing.T) {
+		got, err := projectors.DeviceLabelsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceLabelsUpdated",
+			Data: jsonOrFail(t, map[string]any{"labels": map[string]any{"env": "prod"}}),
+		})
+		require.NoError(t, err)
+		assert.Contains(t, string(got.Labels), "prod")
+	})
+
+	t.Run("missing labels stays nil", func(t *testing.T) {
+		got, err := projectors.DeviceLabelsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceLabelsUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.Labels)
+	})
+
+	t.Run("wrong stream type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceLabelsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "device_group", EventType: "DeviceLabelsUpdated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceLabelSetFromEvent_Pure — key required; value defaults to "".
+func TestDeviceLabelSetFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.DeviceLabelSetFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceLabelSet",
+			Data: jsonOrFail(t, map[string]any{"key": "env", "value": "prod"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "env", got.Key)
+		assert.Equal(t, "prod", got.Value)
+	})
+
+	t.Run("missing key fails", func(t *testing.T) {
+		_, err := projectors.DeviceLabelSetFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceLabelSet",
+			Data: jsonOrFail(t, map[string]any{"value": "prod"}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "key")
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceLabelSetFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceLabelRemoved",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceLabelRemovedFromEvent_Pure — key required.
+func TestDeviceLabelRemovedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.DeviceLabelRemovedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceLabelRemoved",
+			Data: jsonOrFail(t, map[string]any{"key": "env"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "env", got.Key)
+	})
+
+	t.Run("missing key fails", func(t *testing.T) {
+		_, err := projectors.DeviceLabelRemovedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceLabelRemoved",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "key")
+	})
+}
+
+// TestDeviceAssignedFromEvent_Pure — user_id required.
+func TestDeviceAssignedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.DeviceAssignedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceAssigned",
+			Data: jsonOrFail(t, map[string]any{"user_id": "user-X"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.DeviceID)
+		assert.Equal(t, "user-X", got.UserID)
+	})
+
+	t.Run("missing user_id fails", func(t *testing.T) {
+		_, err := projectors.DeviceAssignedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceAssigned",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user_id")
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.DeviceAssignedFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "DeviceUnassigned",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestDeviceUnassignedFromEvent_Pure — user_id required.
+func TestDeviceUnassignedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.DeviceUnassignedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceUnassigned",
+			Data: jsonOrFail(t, map[string]any{"user_id": "user-X"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "user-X", got.UserID)
+	})
+
+	t.Run("missing user_id fails", func(t *testing.T) {
+		_, err := projectors.DeviceUnassignedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceUnassigned",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "user_id")
+	})
+}
+
+// TestDeviceGroupAssignedFromEvent_Pure — group_id required.
+func TestDeviceGroupAssignedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.DeviceGroupAssignedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceGroupAssigned",
+			Data: jsonOrFail(t, map[string]any{"group_id": "grp-X"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "dev-1", got.DeviceID)
+		assert.Equal(t, "grp-X", got.GroupID)
+	})
+
+	t.Run("missing group_id fails", func(t *testing.T) {
+		_, err := projectors.DeviceGroupAssignedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceGroupAssigned",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "group_id")
+	})
+}
+
+// TestDeviceGroupUnassignedFromEvent_Pure — group_id required.
+func TestDeviceGroupUnassignedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.DeviceGroupUnassignedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceGroupUnassigned",
+			Data: jsonOrFail(t, map[string]any{"group_id": "grp-X"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "grp-X", got.GroupID)
+	})
+
+	t.Run("missing group_id fails", func(t *testing.T) {
+		_, err := projectors.DeviceGroupUnassignedFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceGroupUnassigned",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "group_id")
+	})
+}
+
+// TestDeviceSyncIntervalSetFromEvent_Pure — missing key collapses to 0.
+func TestDeviceSyncIntervalSetFromEvent_Pure(t *testing.T) {
+	t.Run("explicit value", func(t *testing.T) {
+		got, err := projectors.DeviceSyncIntervalSetFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceSyncIntervalSet",
+			Data: jsonOrFail(t, map[string]any{"sync_interval_minutes": 15}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(15), got.SyncIntervalMinutes)
+	})
+
+	t.Run("missing key → 0", func(t *testing.T) {
+		got, err := projectors.DeviceSyncIntervalSetFromEvent(store.PersistedEvent{
+			StreamType: "device", StreamID: "dev-1", EventType: "DeviceSyncIntervalSet",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), got.SyncIntervalMinutes)
+	})
+}
+
+// ============================================================================
+// Integration tests — drive the listener via st.AppendEvent and verify
+// the projection lands as expected. Use testutil.SetupPostgres which
+// wires projectors.WireAll.
+// ============================================================================
+
+// registerDeviceForTest emits a DeviceRegistered event for the given
+// device id with a unique cert_fingerprint and returns it. Used as the
+// fixture seed for every lifecycle test below.
+func registerDeviceForTest(t *testing.T, st *store.Store, ctx context.Context, deviceID, hostname string) {
+	t.Helper()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceRegistered",
+		Data: map[string]any{
+			"hostname":         hostname,
+			"cert_fingerprint": "fp-" + deviceID,
+		},
+		ActorType: "user", ActorID: "u-1",
+	}))
+}
+
+// TestDeviceListener_FullLifecycle drives every event type in order
+// against a single device and asserts the projection lands in the
+// right state at every step.
+func TestDeviceListener_FullLifecycle(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := testutil.NewID()
+
+	// 1. Registered.
+	registerDeviceForTest(t, st, ctx, deviceID, "lifecycle")
+	got, err := st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+	assert.Equal(t, "lifecycle", got.Hostname)
+	require.NotNil(t, got.CertFingerprint)
+	assert.Equal(t, "fp-"+deviceID, *got.CertFingerprint)
+	assert.False(t, got.IsDeleted)
+
+	// 2. Seen — refreshes last_seen_at + agent_version.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceSeen",
+		Data:      map[string]any{"agent_version": "2.0.0"},
+		ActorType: "agent", ActorID: deviceID,
+	}))
+	got, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", got.AgentVersion)
+
+	// 3. Heartbeat — bumps version.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceHeartbeat",
+		Data:      map[string]any{"agent_version": "2.0.1"},
+		ActorType: "agent", ActorID: deviceID,
+	}))
+	got, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.1", got.AgentVersion)
+
+	// 4. CertRenewed — overwrites fingerprint.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceCertRenewed",
+		Data:      map[string]any{"cert_fingerprint": "renewed-fp"},
+		ActorType: "agent", ActorID: deviceID,
+	}))
+	got, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+	require.NotNil(t, got.CertFingerprint)
+	assert.Equal(t, "renewed-fp", *got.CertFingerprint)
+
+	// 5. LabelsUpdated — REPLACES the entire labels JSONB.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceLabelsUpdated",
+		Data:      map[string]any{"labels": map[string]any{"env": "prod", "region": "eu"}},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+	assert.Contains(t, string(got.Labels), "prod")
+	assert.Contains(t, string(got.Labels), "eu")
+
+	// 6. LabelSet — JSONB merge keeps existing labels and adds the new key.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceLabelSet",
+		Data:      map[string]any{"key": "tier", "value": "gold"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+	assert.Contains(t, string(got.Labels), "gold", "DeviceLabelSet must merge new key into labels")
+	assert.Contains(t, string(got.Labels), "prod", "DeviceLabelSet must preserve existing keys")
+
+	// 7. LabelRemoved — drops the key from labels.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceLabelRemoved",
+		Data:      map[string]any{"key": "env"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+	assert.NotContains(t, string(got.Labels), `"env"`, "DeviceLabelRemoved must drop the named key")
+	assert.Contains(t, string(got.Labels), "gold", "DeviceLabelRemoved must preserve other keys")
+
+	// 8. SyncIntervalSet — stamps the per-device override.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceSyncIntervalSet",
+		Data:      map[string]any{"sync_interval_minutes": 30},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+	assert.Equal(t, int32(30), got.SyncIntervalMinutes)
+
+	// 9. Assigned — INSERT into device_assigned_users_projection.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceAssigned",
+		Data:      map[string]any{"user_id": "user-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	users, err := st.Queries().ListDeviceAssignedUserIDs(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Contains(t, users, "user-A")
+
+	// 10. GroupAssigned — INSERT into device_assigned_groups_projection.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceGroupAssigned",
+		Data:      map[string]any{"group_id": "grp-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	groups, err := st.Queries().ListDeviceAssignedGroupIDs(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Contains(t, groups, "grp-A")
+
+	// 11. Unassigned — DELETE from device_assigned_users_projection.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceUnassigned",
+		Data:      map[string]any{"user_id": "user-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	users, err = st.Queries().ListDeviceAssignedUserIDs(ctx, deviceID)
+	require.NoError(t, err)
+	assert.NotContains(t, users, "user-A")
+
+	// 12. GroupUnassigned — DELETE from device_assigned_groups_projection.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceGroupUnassigned",
+		Data:      map[string]any{"group_id": "grp-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+	groups, err = st.Queries().ListDeviceAssignedGroupIDs(ctx, deviceID)
+	require.NoError(t, err)
+	assert.NotContains(t, groups, "grp-A")
+
+	// Re-add an assignment so we can prove DeviceDeleted's cascade
+	// wipes both junction tables.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceAssigned",
+		Data:      map[string]any{"user_id": "user-B"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceGroupAssigned",
+		Data:      map[string]any{"group_id": "grp-B"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// 13. Deleted — soft-delete + cascade wipe.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	_, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.Error(t, err, "GetDeviceByID filters is_deleted=FALSE; deleted device is gone from this query")
+
+	users, err = st.Queries().ListDeviceAssignedUserIDs(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Empty(t, users, "DeviceDeleted cascade must wipe assigned-user rows")
+
+	groups, err = st.Queries().ListDeviceAssignedGroupIDs(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Empty(t, groups, "DeviceDeleted cascade must wipe assigned-group rows")
+}
+
+// TestDeviceListener_RegisterRevivesSoftDeleted locks the PL/pgSQL
+// projector's revival semantic: a DeviceRegistered against a
+// previously soft-deleted device id flips is_deleted=FALSE via
+// ON CONFLICT (id) DO UPDATE.
+func TestDeviceListener_RegisterRevivesSoftDeleted(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := testutil.NewID()
+
+	registerDeviceForTest(t, st, ctx, deviceID, "live")
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Confirm soft-deleted (not visible via filtered query).
+	_, err := st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.Error(t, err)
+
+	// Re-register the same id.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceRegistered",
+		Data: map[string]any{
+			"hostname":         "revived",
+			"cert_fingerprint": "fp-revived-" + deviceID,
+		},
+		ActorType: "user", ActorID: "u-1",
+	}))
+
+	got, err := st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err, "DeviceRegistered ON CONFLICT (id) DO UPDATE must revive the soft-deleted row")
+	assert.False(t, got.IsDeleted, "is_deleted must be flipped to FALSE on revival")
+	assert.Equal(t, "revived", got.Hostname)
+}
+
+// TestDeviceListener_RegisterAutoAssignsTokenOwner locks the
+// DeviceRegistered cascade: when the payload carries assigned_user_id,
+// the listener inserts a row into device_assigned_users_projection
+// inside the same transaction.
+func TestDeviceListener_RegisterAutoAssignsTokenOwner(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceRegistered",
+		Data: map[string]any{
+			"hostname":         "auto-assigned",
+			"cert_fingerprint": "fp-aa-" + deviceID,
+			"assigned_user_id": "owner-X",
+		},
+		ActorType: "user", ActorID: "tok-owner",
+	}))
+
+	users, err := st.Queries().ListDeviceAssignedUserIDs(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Contains(t, users, "owner-X", "DeviceRegistered with assigned_user_id must auto-insert the assignment")
+}
+
+// TestDeviceListener_StaleDeleteReplayDoesNotNukeAssignments locks the
+// asymmetric-guard discipline for the cascade-heavy DeviceDeleted: when
+// the version-guarded SoftDelete affects zero rows, the cascade
+// (assigned-user wipe + assigned-group wipe) MUST be skipped. Otherwise
+// an old DeviceDeleted re-applied later would silently nuke a
+// freshly-restored device's assignments.
+func TestDeviceListener_StaleDeleteReplayDoesNotNukeAssignments(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := testutil.NewID()
+
+	registerDeviceForTest(t, st, ctx, deviceID, "live")
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceAssigned",
+		Data:      map[string]any{"user_id": "user-stay"},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceGroupAssigned",
+		Data:      map[string]any{"group_id": "grp-stay"},
+		ActorType: "user", ActorID: "u",
+	}))
+	live, err := st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+
+	// Drive the listener with a stale DeviceDeleted (older
+	// projection_version than the row currently has).
+	older := live.ProjectionVersion - 5
+	staleAt := *live.RegisteredAt
+	listener := projectors.DeviceListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "device",
+		StreamID:    deviceID,
+		EventType:   "DeviceDeleted",
+		Data:        []byte("{}"),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
+	})
+
+	// Device still alive.
+	stillAlive, err := st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+	assert.False(t, stillAlive.IsDeleted, "stale DeviceDeleted must NOT flip is_deleted")
+
+	// Assignments still there — cascade was short-circuited by the
+	// SoftDelete returning n == 0.
+	users, err := st.Queries().ListDeviceAssignedUserIDs(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Contains(t, users, "user-stay", "stale DeviceDeleted must NOT cascade-wipe assigned-user rows")
+	groups, err := st.Queries().ListDeviceAssignedGroupIDs(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Contains(t, groups, "grp-stay", "stale DeviceDeleted must NOT cascade-wipe assigned-group rows")
+}
+
+// TestDeviceListener_StaleUnassignedAfterReAssignDoesNotWipeRow locks
+// the assignment-table DELETE guard (CR catch on PR #179 pattern,
+// applied to the device-assignment junction tables). A stale
+// DeviceUnassigned replayed AFTER a re-Assign must NOT delete the
+// live row, even though the user_id matches: the live row's
+// projection_version was bumped by the re-Assign INSERT, so the
+// stale Unassigned's older sequence_num fails the SQL guard
+// `WHERE projection_version <= $N`.
+func TestDeviceListener_StaleUnassignedAfterReAssignDoesNotWipeRow(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := testutil.NewID()
+	userID := "u-stale"
+
+	registerDeviceForTest(t, st, ctx, deviceID, "live")
+
+	// First Assign — establishes a baseline projection_version on the row.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceAssigned",
+		Data:      map[string]any{"user_id": userID},
+		ActorType: "user", ActorID: "u",
+	}))
+	// Capture the seq_num that would belong to a "would-be Unassigned"
+	// emitted right now (before the re-Assign bumps it). We do this by
+	// reading the assignment row's projection_version + 1 — this
+	// mirrors the gap a stale event from the past carries.
+	var firstAssignVer int64
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT projection_version FROM device_assigned_users_projection WHERE device_id = $1 AND user_id = $2",
+		deviceID, userID,
+	).Scan(&firstAssignVer))
+
+	// Real Unassigned + Re-Assign — the second Assign bumps the
+	// projection_version of the live row past the stale-event mark.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceUnassigned",
+		Data:      map[string]any{"user_id": userID},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceAssigned",
+		Data:      map[string]any{"user_id": userID},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	users, err := st.Queries().ListDeviceAssignedUserIDs(ctx, deviceID)
+	require.NoError(t, err)
+	require.Contains(t, users, userID, "re-Assign must restore the assignment")
+
+	// Now drive the listener with a STALE Unassigned whose sequence_num
+	// is the one the original Unassigned would have carried — older
+	// than the re-Assign that bumped projection_version. The DELETE
+	// guard `WHERE projection_version <= $N` must reject this and
+	// leave the live row intact.
+	stale := firstAssignVer
+	staleAt := *getDeviceRegisteredAt(t, st, ctx, deviceID)
+	listener := projectors.DeviceListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &stale,
+		StreamType:  "device",
+		StreamID:    deviceID,
+		EventType:   "DeviceUnassigned",
+		Data:        jsonOrFail(t, map[string]any{"user_id": userID}),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
+	})
+
+	users, err = st.Queries().ListDeviceAssignedUserIDs(ctx, deviceID)
+	require.NoError(t, err)
+	assert.Contains(t, users, userID,
+		"stale DeviceUnassigned replayed after a re-Assign must NOT wipe the live row")
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+// deviceLookup builds a GetDeviceByIDParams with no user filter (the
+// admin-style read path that all tests in this file want).
+func deviceLookup(id string) db.GetDeviceByIDParams {
+	return db.GetDeviceByIDParams{ID: id}
+}
+
+// getDeviceRegisteredAt fetches the device's registered_at timestamp
+// directly so stale-event tests can construct a PersistedEvent whose
+// OccurredAt sits at a plausible point in the row's history.
+func getDeviceRegisteredAt(t *testing.T, st *store.Store, ctx context.Context, deviceID string) *time.Time {
+	t.Helper()
+	got, err := st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	require.NoError(t, err)
+	return got.RegisteredAt
+}

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -104,17 +104,21 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "execution_projector"),
 	))
+	st.RegisterEventListener(DeviceListener(
+		st,
+		loggerFor(logger, "device_projector"),
+	))
 	// All 11 ports of tracker #107 are now wired here, plus the
 	// Phase 2 ports landed so far under tracker #136 (action_set,
 	// assignment, user_group, device_group, compliance_policy,
-	// compliance, action+definition, execution). One ActionListener
-	// handles both the action and definition stream types because
-	// DefinitionCreated dispatches across two projections —
-	// synthesise an actions_projection row (when payload carries
-	// `action_type`) OR insert a definitions_projection row
-	// (otherwise) — and splitting would race the two branches.
-	// Future Phase 2 ports of the remaining domain projectors (user,
-	// device) land here too.
+	// compliance, action+definition, execution, device). One
+	// ActionListener handles both the action and definition stream
+	// types because DefinitionCreated dispatches across two
+	// projections — synthesise an actions_projection row (when
+	// payload carries `action_type`) OR insert a definitions_projection
+	// row (otherwise) — and splitting would race the two branches.
+	// Future Phase 2 ports of the remaining domain projector (user)
+	// land here too.
 
 	// Rebuild appliers (manchtools/power-manage-server#125). Only
 	// the ported projectors that own a rebuildTarget in
@@ -139,6 +143,7 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 	st.RegisterRebuildApply("actions", ApplyAction)
 	st.RegisterRebuildApply("definitions", ApplyDefinition)
 	st.RegisterRebuildApply("executions", ApplyExecution)
+	st.RegisterRebuildApply("devices", ApplyDevice)
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/devices.sql.go
+++ b/internal/store/generated/devices.sql.go
@@ -60,6 +60,81 @@ func (q *Queries) CountDevicesOnline(ctx context.Context, filterUserID *string) 
 	return count, err
 }
 
+const deleteDeviceAssignedGroup = `-- name: DeleteDeviceAssignedGroup :execrows
+DELETE FROM device_assigned_groups_projection
+WHERE device_id = $1
+  AND group_id = $2
+  AND projection_version <= $3
+`
+
+type DeleteDeviceAssignedGroupParams struct {
+	DeviceID          string `json:"device_id"`
+	GroupID           string `json:"group_id"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// DeviceGroupUnassigned handler. Same stale-replay guard as
+// DeleteDeviceAssignedUser.
+func (q *Queries) DeleteDeviceAssignedGroup(ctx context.Context, arg DeleteDeviceAssignedGroupParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteDeviceAssignedGroup, arg.DeviceID, arg.GroupID, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const deleteDeviceAssignedGroupsByDevice = `-- name: DeleteDeviceAssignedGroupsByDevice :exec
+DELETE FROM device_assigned_groups_projection WHERE device_id = $1
+`
+
+// DeviceDeleted handler — third half. Same shape as the assigned-user
+// wipe, scoped to the assigned-groups junction table.
+func (q *Queries) DeleteDeviceAssignedGroupsByDevice(ctx context.Context, deviceID string) error {
+	_, err := q.db.Exec(ctx, deleteDeviceAssignedGroupsByDevice, deviceID)
+	return err
+}
+
+const deleteDeviceAssignedUser = `-- name: DeleteDeviceAssignedUser :execrows
+DELETE FROM device_assigned_users_projection
+WHERE device_id = $1
+  AND user_id = $2
+  AND projection_version <= $3
+`
+
+type DeleteDeviceAssignedUserParams struct {
+	DeviceID          string `json:"device_id"`
+	UserID            string `json:"user_id"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// DeviceUnassigned handler. Stale-replay DELETE protection: the guard
+// `WHERE projection_version <= $N` ensures a stale Unassigned replayed
+// after a re-Assign cannot wipe the live row — the live row's
+// projection_version was bumped by the re-Assign INSERT, so the
+// stale Unassigned's older sequence_num fails the guard. The :execrows
+// count gives the listener a hook to log/observe stale rejections
+// (CR catch on PR #179 pattern, applied to assignment-table DELETEs).
+func (q *Queries) DeleteDeviceAssignedUser(ctx context.Context, arg DeleteDeviceAssignedUserParams) (int64, error) {
+	result, err := q.db.Exec(ctx, deleteDeviceAssignedUser, arg.DeviceID, arg.UserID, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const deleteDeviceAssignedUsersByDevice = `-- name: DeleteDeviceAssignedUsersByDevice :exec
+DELETE FROM device_assigned_users_projection WHERE device_id = $1
+`
+
+// DeviceDeleted handler — second half. Wipes every assigned-user row
+// for the deleted device. Wrapped with SoftDeleteDeviceProjection +
+// DeleteDeviceAssignedGroupsByDevice inside store.WithTx for
+// inter-write atomicity.
+func (q *Queries) DeleteDeviceAssignedUsersByDevice(ctx context.Context, deviceID string) error {
+	_, err := q.db.Exec(ctx, deleteDeviceAssignedUsersByDevice, deviceID)
+	return err
+}
+
 const getDeviceByFingerprint = `-- name: GetDeviceByFingerprint :one
 SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, labels, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
 WHERE cert_fingerprint = $1 AND is_deleted = FALSE
@@ -260,6 +335,92 @@ func (q *Queries) GetDevicesWithLabel(ctx context.Context, arg GetDevicesWithLab
 		return nil, err
 	}
 	return items, nil
+}
+
+const insertDeviceAssignedGroup = `-- name: InsertDeviceAssignedGroup :exec
+INSERT INTO device_assigned_groups_projection (
+    device_id, group_id, assigned_at, assigned_by, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (device_id, group_id) DO NOTHING
+`
+
+type InsertDeviceAssignedGroupParams struct {
+	DeviceID          string    `json:"device_id"`
+	GroupID           string    `json:"group_id"`
+	AssignedAt        time.Time `json:"assigned_at"`
+	AssignedBy        string    `json:"assigned_by"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// DeviceGroupAssigned handler. ON CONFLICT DO NOTHING matches the
+// PL/pgSQL projector's idempotency.
+func (q *Queries) InsertDeviceAssignedGroup(ctx context.Context, arg InsertDeviceAssignedGroupParams) error {
+	_, err := q.db.Exec(ctx, insertDeviceAssignedGroup,
+		arg.DeviceID,
+		arg.GroupID,
+		arg.AssignedAt,
+		arg.AssignedBy,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const insertDeviceAssignedUser = `-- name: InsertDeviceAssignedUser :exec
+INSERT INTO device_assigned_users_projection (
+    device_id, user_id, assigned_at, assigned_by, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (device_id, user_id) DO NOTHING
+`
+
+type InsertDeviceAssignedUserParams struct {
+	DeviceID          string    `json:"device_id"`
+	UserID            string    `json:"user_id"`
+	AssignedAt        time.Time `json:"assigned_at"`
+	AssignedBy        string    `json:"assigned_by"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// DeviceAssigned handler. ON CONFLICT DO NOTHING matches the PL/pgSQL
+// projector's idempotency.
+func (q *Queries) InsertDeviceAssignedUser(ctx context.Context, arg InsertDeviceAssignedUserParams) error {
+	_, err := q.db.Exec(ctx, insertDeviceAssignedUser,
+		arg.DeviceID,
+		arg.UserID,
+		arg.AssignedAt,
+		arg.AssignedBy,
+		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const insertDeviceAssignedUserOnRegister = `-- name: InsertDeviceAssignedUserOnRegister :exec
+INSERT INTO device_assigned_users_projection (
+    device_id, user_id, assigned_at, assigned_by, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (device_id, user_id) DO NOTHING
+`
+
+type InsertDeviceAssignedUserOnRegisterParams struct {
+	DeviceID          string    `json:"device_id"`
+	UserID            string    `json:"user_id"`
+	AssignedAt        time.Time `json:"assigned_at"`
+	AssignedBy        string    `json:"assigned_by"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// DeviceRegistered cascade — auto-assign the device to the token owner
+// when the payload carries `assigned_user_id`. ON CONFLICT DO NOTHING
+// mirrors the PL/pgSQL projector's idempotency. Wrapped with
+// UpsertDeviceProjection in store.WithTx for cascade atomicity.
+func (q *Queries) InsertDeviceAssignedUserOnRegister(ctx context.Context, arg InsertDeviceAssignedUserOnRegisterParams) error {
+	_, err := q.db.Exec(ctx, insertDeviceAssignedUserOnRegister,
+		arg.DeviceID,
+		arg.UserID,
+		arg.AssignedAt,
+		arg.AssignedBy,
+		arg.ProjectionVersion,
+	)
+	return err
 }
 
 const isDeviceDeleted = `-- name: IsDeviceDeleted :one
@@ -609,4 +770,318 @@ func (q *Queries) ListDevicesOnline(ctx context.Context, arg ListDevicesOnlinePa
 		return nil, err
 	}
 	return items, nil
+}
+
+const removeDeviceLabelKey = `-- name: RemoveDeviceLabelKey :execrows
+UPDATE devices_projection
+SET labels             = labels - $3::TEXT,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+`
+
+type RemoveDeviceLabelKeyParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+	Key               string `json:"key"`
+}
+
+// DeviceLabelRemoved handler. JSONB minus operator drops the key from
+// the labels object. Stale-replay guard via projection_version.
+func (q *Queries) RemoveDeviceLabelKey(ctx context.Context, arg RemoveDeviceLabelKeyParams) (int64, error) {
+	result, err := q.db.Exec(ctx, removeDeviceLabelKey, arg.ID, arg.ProjectionVersion, arg.Key)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const setDeviceLabelKey = `-- name: SetDeviceLabelKey :execrows
+UPDATE devices_projection
+SET labels             = COALESCE(labels, '{}'::JSONB) || jsonb_build_object($3::TEXT, $4::TEXT),
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+`
+
+type SetDeviceLabelKeyParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+	Key               string `json:"key"`
+	Value             string `json:"value"`
+}
+
+// DeviceLabelSet handler. Mirrors the PL/pgSQL JSONB merge:
+// `labels || jsonb_build_object(key, value)`. The first COALESCE on
+// labels handles the (theoretical) NULL case for legacy rows — matches
+// PL/pgSQL's `COALESCE(labels, '{}'::jsonb) || ...`. Stale-replay guard
+// via projection_version.
+func (q *Queries) SetDeviceLabelKey(ctx context.Context, arg SetDeviceLabelKeyParams) (int64, error) {
+	result, err := q.db.Exec(ctx, setDeviceLabelKey,
+		arg.ID,
+		arg.ProjectionVersion,
+		arg.Key,
+		arg.Value,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const softDeleteDeviceProjection = `-- name: SoftDeleteDeviceProjection :execrows
+UPDATE devices_projection
+SET is_deleted         = TRUE,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+`
+
+type SoftDeleteDeviceProjectionParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// DeviceDeleted handler — first half. Returns rows-affected so the
+// listener can SKIP the cascade (assigned-user wipe + assigned-group
+// wipe) when the projection_version guard rejects a stale replay.
+// Otherwise an old DeviceDeleted re-applied by the reconciler would
+// silently nuke a freshly-restored device's assignments.
+func (q *Queries) SoftDeleteDeviceProjection(ctx context.Context, arg SoftDeleteDeviceProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteDeviceProjection, arg.ID, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDeviceCertRenewedProjection = `-- name: UpdateDeviceCertRenewedProjection :execrows
+UPDATE devices_projection
+SET cert_fingerprint   = $2,
+    cert_not_after     = COALESCE($4::TIMESTAMPTZ, cert_not_after),
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type UpdateDeviceCertRenewedProjectionParams struct {
+	ID                string     `json:"id"`
+	CertFingerprint   *string    `json:"cert_fingerprint"`
+	ProjectionVersion int64      `json:"projection_version"`
+	CertNotAfter      *time.Time `json:"cert_not_after"`
+}
+
+// DeviceCertRenewed handler. cert_not_after preserved when the payload
+// omits the key (mirrors PL/pgSQL `COALESCE(payload, cert_not_after)`).
+// Stale-replay guard via projection_version.
+func (q *Queries) UpdateDeviceCertRenewedProjection(ctx context.Context, arg UpdateDeviceCertRenewedProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDeviceCertRenewedProjection,
+		arg.ID,
+		arg.CertFingerprint,
+		arg.ProjectionVersion,
+		arg.CertNotAfter,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDeviceHeartbeatProjection = `-- name: UpdateDeviceHeartbeatProjection :execrows
+UPDATE devices_projection
+SET last_seen_at       = $2,
+    agent_version      = COALESCE($4::TEXT, agent_version),
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type UpdateDeviceHeartbeatProjectionParams struct {
+	ID                string     `json:"id"`
+	LastSeenAt        *time.Time `json:"last_seen_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+	AgentVersion      *string    `json:"agent_version"`
+}
+
+// DeviceHeartbeat handler. agent_version preserved when the payload
+// omits the key. Stale-replay guard via projection_version.
+func (q *Queries) UpdateDeviceHeartbeatProjection(ctx context.Context, arg UpdateDeviceHeartbeatProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDeviceHeartbeatProjection,
+		arg.ID,
+		arg.LastSeenAt,
+		arg.ProjectionVersion,
+		arg.AgentVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDeviceLabelsProjection = `-- name: UpdateDeviceLabelsProjection :execrows
+UPDATE devices_projection
+SET labels             = COALESCE($3::JSONB, labels),
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+`
+
+type UpdateDeviceLabelsProjectionParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+	Labels            []byte `json:"labels"`
+}
+
+// DeviceLabelsUpdated handler. The decoder leaves a missing labels key
+// as a nil byte slice; the SQL COALESCE preserves the existing column
+// value in that case (matches PL/pgSQL `COALESCE(payload, labels)`).
+// The :: JSONB cast is required so PostgreSQL can resolve the parameter
+// type when the value is NULL.
+// Stale-replay guard via projection_version.
+func (q *Queries) UpdateDeviceLabelsProjection(ctx context.Context, arg UpdateDeviceLabelsProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDeviceLabelsProjection, arg.ID, arg.ProjectionVersion, arg.Labels)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDeviceSeenProjection = `-- name: UpdateDeviceSeenProjection :execrows
+UPDATE devices_projection
+SET last_seen_at        = $2,
+    agent_version       = COALESCE($4::TEXT, agent_version),
+    hostname            = COALESCE($5::TEXT, hostname),
+    projection_version  = $3,
+    is_deleted          = FALSE
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type UpdateDeviceSeenProjectionParams struct {
+	ID                string     `json:"id"`
+	LastSeenAt        *time.Time `json:"last_seen_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+	AgentVersion      *string    `json:"agent_version"`
+	Hostname          *string    `json:"hostname"`
+}
+
+// DeviceSeen handler. COALESCE preserves the existing column value when
+// the payload omits the key (matches PL/pgSQL's
+// `COALESCE(payload, agent_version)` and
+// `COALESCE(NULLIF(payload, ”), hostname)` collapses). The decoder
+// leaves a missing/empty hostname as nil so the SQL COALESCE picks the
+// existing value; same for agent_version. is_deleted=FALSE revives a
+// soft-deleted row when the agent comes back online — mirrors the
+// PL/pgSQL projector. Stale-replay guard via projection_version.
+func (q *Queries) UpdateDeviceSeenProjection(ctx context.Context, arg UpdateDeviceSeenProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDeviceSeenProjection,
+		arg.ID,
+		arg.LastSeenAt,
+		arg.ProjectionVersion,
+		arg.AgentVersion,
+		arg.Hostname,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateDeviceSyncIntervalProjection = `-- name: UpdateDeviceSyncIntervalProjection :execrows
+UPDATE devices_projection
+SET sync_interval_minutes = $2,
+    projection_version    = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type UpdateDeviceSyncIntervalProjectionParams struct {
+	ID                  string `json:"id"`
+	SyncIntervalMinutes int32  `json:"sync_interval_minutes"`
+	ProjectionVersion   int64  `json:"projection_version"`
+}
+
+// DeviceSyncIntervalSet handler. The decoder defaults a missing
+// sync_interval_minutes key to 0 (matches the PL/pgSQL COALESCE).
+// Stale-replay guard via projection_version.
+func (q *Queries) UpdateDeviceSyncIntervalProjection(ctx context.Context, arg UpdateDeviceSyncIntervalProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateDeviceSyncIntervalProjection, arg.ID, arg.SyncIntervalMinutes, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const upsertDeviceProjection = `-- name: UpsertDeviceProjection :exec
+
+INSERT INTO devices_projection (
+    id, hostname, cert_fingerprint, cert_not_after,
+    registered_at, last_seen_at, registration_token_id,
+    labels, projection_version
+) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8)
+ON CONFLICT (id) DO UPDATE SET
+    hostname              = EXCLUDED.hostname,
+    cert_fingerprint      = EXCLUDED.cert_fingerprint,
+    cert_not_after        = EXCLUDED.cert_not_after,
+    registered_at         = EXCLUDED.registered_at,
+    last_seen_at          = EXCLUDED.last_seen_at,
+    registration_token_id = EXCLUDED.registration_token_id,
+    labels                = EXCLUDED.labels,
+    projection_version    = EXCLUDED.projection_version,
+    is_deleted            = FALSE
+`
+
+type UpsertDeviceProjectionParams struct {
+	ID                  string     `json:"id"`
+	Hostname            string     `json:"hostname"`
+	CertFingerprint     *string    `json:"cert_fingerprint"`
+	CertNotAfter        *time.Time `json:"cert_not_after"`
+	RegisteredAt        *time.Time `json:"registered_at"`
+	RegistrationTokenID *string    `json:"registration_token_id"`
+	Labels              []byte     `json:"labels"`
+	ProjectionVersion   int64      `json:"projection_version"`
+}
+
+// ============================================================================
+// Projector listener writes (manchtools/power-manage-server#136).
+// ============================================================================
+//
+// Mirrors the deleted PL/pgSQL project_device_event(): every event handler
+// the projector dispatched on (DeviceRegistered, DeviceSeen,
+// DeviceHeartbeat, DeviceCertRenewed, DeviceLabelsUpdated, DeviceLabelSet,
+// DeviceLabelRemoved, DeviceDeleted, DeviceAssigned, DeviceUnassigned,
+// DeviceGroupAssigned, DeviceGroupUnassigned, DeviceSyncIntervalSet) gets a
+// typed sqlc query here so the listener can compose them in Go.
+//
+// Tightening vs the PL/pgSQL projector: every UPDATE carries an explicit
+// `WHERE projection_version < $N` guard and uses :execrows so the listener
+// can short-circuit cascades on stale-replay (asymmetric-guard discipline;
+// see role_listener / action_set_listener / device_group_listener for the
+// canonical shape). The PL/pgSQL projector stamped projection_version
+// without a guard — an out-of-order event re-applied later would silently
+// rewind row state.
+//
+// DELETEs on the assignment tables (DeviceUnassigned / DeviceGroupUnassigned)
+// carry a `WHERE projection_version <= $N` guard via :execrows so a stale
+// Unassigned replayed after a re-Assign cannot wipe the live row (CR catch
+// on PR #179).
+// DeviceRegistered handler. ON CONFLICT (id) DO UPDATE re-activates a
+// soft-deleted row by flipping is_deleted=FALSE — mirrors the PL/pgSQL
+// projector's revival semantic (an operator re-enrolling a previously
+// deleted device id gets the row back, preserving the event-sourced
+// timeline). projection_version is unconditionally bumped here because
+// DeviceRegistered is the stream's birthing event; replay safety for
+// subsequent events lives on their per-event guarded UPDATEs.
+func (q *Queries) UpsertDeviceProjection(ctx context.Context, arg UpsertDeviceProjectionParams) error {
+	_, err := q.db.Exec(ctx, upsertDeviceProjection,
+		arg.ID,
+		arg.Hostname,
+		arg.CertFingerprint,
+		arg.CertNotAfter,
+		arg.RegisteredAt,
+		arg.RegistrationTokenID,
+		arg.Labels,
+		arg.ProjectionVersion,
+	)
+	return err
 }

--- a/internal/store/migrations/039_device_projector_to_go.sql
+++ b/internal/store/migrations/039_device_projector_to_go.sql
@@ -1,0 +1,204 @@
+-- Replace project_device_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.DeviceListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger still
+-- PERFORMs project_device_event(NEW) for every device-stream event;
+-- the no-op stub keeps that dispatch quiet (no
+-- plpgsql_projection_errors entries) until the Phase 2 cleanup
+-- migration drops every still-PL/pgSQL WHEN clause from the
+-- dispatcher.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. The thirteen event types (Registered, Seen,
+--     Heartbeat, CertRenewed, LabelsUpdated, LabelSet, LabelRemoved,
+--     Deleted, Assigned, Unassigned, GroupAssigned, GroupUnassigned,
+--     SyncIntervalSet) and their cascades (Registered's auto-assign,
+--     Deleted's assignment-table wipe) were atomic with the event
+--     commit.
+--   - After: Go listener fires post-commit. Every multi-write event
+--     (DeviceRegistered when assigned_user_id is present;
+--     DeviceDeleted with its two assignment-table wipes) wraps its
+--     writes in store.WithTx so the cascade stays atomic with itself,
+--     but not with the event commit. The handler's read-after-write
+--     paths (RegisterDevice / DeleteDevice / etc. reading back from
+--     devices_projection) still see the projection because
+--     fireListeners is synchronous — the listener has already run by
+--     the time AppendEvent returns.
+--
+-- Tightening: every UPDATE on devices_projection (Seen, Heartbeat,
+-- CertRenewed, LabelsUpdated, LabelSet, LabelRemoved,
+-- SyncIntervalSet, soft-delete) now carries an explicit
+-- `WHERE projection_version < $N` guard, rejecting stale reconciler
+-- replays. The PL/pgSQL projector stamped projection_version without
+-- a guard.
+--
+-- Asymmetric-guard discipline (per the role + identity_provider +
+-- action_set + assignment + user_group + device_group +
+-- compliance_policy + compliance + action+definition + execution
+-- ports): the guarded SoftDelete uses :execrows, and the listener
+-- short-circuits the cascade (assigned-user wipe + assigned-group
+-- wipe) when n == 0 — otherwise a stale DeviceDeleted re-applied
+-- later would silently nuke a freshly-restored device's assignments.
+--
+-- Stale-replay DELETE protection on the assignment junction tables:
+-- DeviceUnassigned and DeviceGroupUnassigned both carry a
+-- `WHERE projection_version <= $N` guard via :execrows so a stale
+-- Unassigned replayed after a re-Assign cannot wipe the live row.
+-- The live row's projection_version was bumped by the re-Assign
+-- INSERT, so the stale Unassigned's older sequence_num fails the
+-- guard. CR catch on PR #179 pattern, applied here to the
+-- device_assigned_users / device_assigned_groups projections.
+--
+-- DeviceRegistered's UPSERT preserves the PL/pgSQL projector's
+-- soft-delete revival semantic: ON CONFLICT (id) DO UPDATE flips
+-- is_deleted=FALSE so an operator re-enrolling a previously-deleted
+-- device id gets the row back, with the event-sourced timeline
+-- preserved.
+--
+-- See manchtools/power-manage-server#136. Ninth port under Phase 2
+-- of tracker #107's projector-migration pattern.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_device_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.DeviceListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the PL/pgSQL projector verbatim from migration 002 (the
+-- last definition before this port — multi-user assignment support
+-- with junction tables, the body that was in place when this port
+-- ran).
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_device_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'DeviceRegistered' THEN
+            INSERT INTO devices_projection (
+                id, hostname, cert_fingerprint, cert_not_after,
+                registered_at, last_seen_at, registration_token_id,
+                labels, projection_version
+            ) VALUES (
+                event.stream_id,
+                COALESCE(event.data->>'hostname', ''),
+                event.data->>'cert_fingerprint',
+                CASE WHEN event.data->>'cert_not_after' IS NOT NULL
+                     THEN (event.data->>'cert_not_after')::TIMESTAMPTZ
+                     ELSE NULL END,
+                event.occurred_at,
+                event.occurred_at,
+                event.data->>'registration_token_id',
+                COALESCE(event.data->'labels', '{}'),
+                event.sequence_num
+            )
+            ON CONFLICT (id) DO UPDATE SET
+                hostname = EXCLUDED.hostname,
+                cert_fingerprint = EXCLUDED.cert_fingerprint,
+                cert_not_after = EXCLUDED.cert_not_after,
+                registered_at = EXCLUDED.registered_at,
+                last_seen_at = EXCLUDED.last_seen_at,
+                registration_token_id = EXCLUDED.registration_token_id,
+                labels = EXCLUDED.labels,
+                projection_version = EXCLUDED.projection_version,
+                is_deleted = FALSE;
+
+            -- Auto-assign device to token owner if present
+            IF event.data->>'assigned_user_id' IS NOT NULL THEN
+                INSERT INTO device_assigned_users_projection (device_id, user_id, assigned_at, assigned_by, projection_version)
+                VALUES (event.stream_id, event.data->>'assigned_user_id', event.occurred_at, event.actor_id, event.sequence_num)
+                ON CONFLICT (device_id, user_id) DO NOTHING;
+            END IF;
+
+        WHEN 'DeviceSeen' THEN
+            UPDATE devices_projection
+            SET last_seen_at = event.occurred_at,
+                agent_version = COALESCE(event.data->>'agent_version', agent_version),
+                hostname = COALESCE(NULLIF(event.data->>'hostname', ''), hostname),
+                projection_version = event.sequence_num,
+                is_deleted = FALSE
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceHeartbeat' THEN
+            UPDATE devices_projection
+            SET last_seen_at = event.occurred_at,
+                agent_version = COALESCE(event.data->>'agent_version', agent_version),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceCertRenewed' THEN
+            UPDATE devices_projection
+            SET cert_fingerprint = event.data->>'cert_fingerprint',
+                cert_not_after = CASE WHEN event.data->>'cert_not_after' IS NOT NULL
+                                      THEN (event.data->>'cert_not_after')::TIMESTAMPTZ
+                                      ELSE cert_not_after END,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceLabelsUpdated' THEN
+            UPDATE devices_projection
+            SET labels = COALESCE(event.data->'labels', labels),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceLabelSet' THEN
+            UPDATE devices_projection
+            SET labels = COALESCE(labels, '{}'::jsonb) || jsonb_build_object(event.data->>'key', event.data->>'value'),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceLabelRemoved' THEN
+            UPDATE devices_projection
+            SET labels = labels - (event.data->>'key'),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'DeviceDeleted' THEN
+            UPDATE devices_projection
+            SET is_deleted = TRUE,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+            -- Clean up assignments when device is deleted
+            DELETE FROM device_assigned_users_projection WHERE device_id = event.stream_id;
+            DELETE FROM device_assigned_groups_projection WHERE device_id = event.stream_id;
+
+        WHEN 'DeviceAssigned' THEN
+            INSERT INTO device_assigned_users_projection (device_id, user_id, assigned_at, assigned_by, projection_version)
+            VALUES (event.stream_id, event.data->>'user_id', event.occurred_at, event.actor_id, event.sequence_num)
+            ON CONFLICT (device_id, user_id) DO NOTHING;
+
+        WHEN 'DeviceUnassigned' THEN
+            DELETE FROM device_assigned_users_projection
+            WHERE device_id = event.stream_id AND user_id = event.data->>'user_id';
+
+        WHEN 'DeviceGroupAssigned' THEN
+            INSERT INTO device_assigned_groups_projection (device_id, group_id, assigned_at, assigned_by, projection_version)
+            VALUES (event.stream_id, event.data->>'group_id', event.occurred_at, event.actor_id, event.sequence_num)
+            ON CONFLICT (device_id, group_id) DO NOTHING;
+
+        WHEN 'DeviceGroupUnassigned' THEN
+            DELETE FROM device_assigned_groups_projection
+            WHERE device_id = event.stream_id AND group_id = event.data->>'group_id';
+
+        WHEN 'DeviceSyncIntervalSet' THEN
+            UPDATE devices_projection
+            SET sync_interval_minutes = COALESCE((event.data->>'sync_interval_minutes')::INTEGER, 0),
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/devices.sql
+++ b/internal/store/queries/devices.sql
@@ -147,3 +147,205 @@ SELECT group_id FROM device_assigned_groups_projection WHERE device_id = $1;
 -- ≈ 100 sequential round-trips per RPC).
 SELECT id, hostname FROM devices_projection
 WHERE id = ANY($1::TEXT[]) AND is_deleted = FALSE;
+
+-- ============================================================================
+-- Projector listener writes (manchtools/power-manage-server#136).
+-- ============================================================================
+--
+-- Mirrors the deleted PL/pgSQL project_device_event(): every event handler
+-- the projector dispatched on (DeviceRegistered, DeviceSeen,
+-- DeviceHeartbeat, DeviceCertRenewed, DeviceLabelsUpdated, DeviceLabelSet,
+-- DeviceLabelRemoved, DeviceDeleted, DeviceAssigned, DeviceUnassigned,
+-- DeviceGroupAssigned, DeviceGroupUnassigned, DeviceSyncIntervalSet) gets a
+-- typed sqlc query here so the listener can compose them in Go.
+--
+-- Tightening vs the PL/pgSQL projector: every UPDATE carries an explicit
+-- `WHERE projection_version < $N` guard and uses :execrows so the listener
+-- can short-circuit cascades on stale-replay (asymmetric-guard discipline;
+-- see role_listener / action_set_listener / device_group_listener for the
+-- canonical shape). The PL/pgSQL projector stamped projection_version
+-- without a guard — an out-of-order event re-applied later would silently
+-- rewind row state.
+--
+-- DELETEs on the assignment tables (DeviceUnassigned / DeviceGroupUnassigned)
+-- carry a `WHERE projection_version <= $N` guard via :execrows so a stale
+-- Unassigned replayed after a re-Assign cannot wipe the live row (CR catch
+-- on PR #179).
+
+-- name: UpsertDeviceProjection :exec
+-- DeviceRegistered handler. ON CONFLICT (id) DO UPDATE re-activates a
+-- soft-deleted row by flipping is_deleted=FALSE — mirrors the PL/pgSQL
+-- projector's revival semantic (an operator re-enrolling a previously
+-- deleted device id gets the row back, preserving the event-sourced
+-- timeline). projection_version is unconditionally bumped here because
+-- DeviceRegistered is the stream's birthing event; replay safety for
+-- subsequent events lives on their per-event guarded UPDATEs.
+INSERT INTO devices_projection (
+    id, hostname, cert_fingerprint, cert_not_after,
+    registered_at, last_seen_at, registration_token_id,
+    labels, projection_version
+) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8)
+ON CONFLICT (id) DO UPDATE SET
+    hostname              = EXCLUDED.hostname,
+    cert_fingerprint      = EXCLUDED.cert_fingerprint,
+    cert_not_after        = EXCLUDED.cert_not_after,
+    registered_at         = EXCLUDED.registered_at,
+    last_seen_at          = EXCLUDED.last_seen_at,
+    registration_token_id = EXCLUDED.registration_token_id,
+    labels                = EXCLUDED.labels,
+    projection_version    = EXCLUDED.projection_version,
+    is_deleted            = FALSE;
+
+-- name: InsertDeviceAssignedUserOnRegister :exec
+-- DeviceRegistered cascade — auto-assign the device to the token owner
+-- when the payload carries `assigned_user_id`. ON CONFLICT DO NOTHING
+-- mirrors the PL/pgSQL projector's idempotency. Wrapped with
+-- UpsertDeviceProjection in store.WithTx for cascade atomicity.
+INSERT INTO device_assigned_users_projection (
+    device_id, user_id, assigned_at, assigned_by, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (device_id, user_id) DO NOTHING;
+
+-- name: UpdateDeviceSeenProjection :execrows
+-- DeviceSeen handler. COALESCE preserves the existing column value when
+-- the payload omits the key (matches PL/pgSQL's
+-- `COALESCE(payload, agent_version)` and
+-- `COALESCE(NULLIF(payload, ''), hostname)` collapses). The decoder
+-- leaves a missing/empty hostname as nil so the SQL COALESCE picks the
+-- existing value; same for agent_version. is_deleted=FALSE revives a
+-- soft-deleted row when the agent comes back online — mirrors the
+-- PL/pgSQL projector. Stale-replay guard via projection_version.
+UPDATE devices_projection
+SET last_seen_at        = $2,
+    agent_version       = COALESCE(sqlc.narg('agent_version')::TEXT, agent_version),
+    hostname            = COALESCE(sqlc.narg('hostname')::TEXT, hostname),
+    projection_version  = $3,
+    is_deleted          = FALSE
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: UpdateDeviceHeartbeatProjection :execrows
+-- DeviceHeartbeat handler. agent_version preserved when the payload
+-- omits the key. Stale-replay guard via projection_version.
+UPDATE devices_projection
+SET last_seen_at       = $2,
+    agent_version      = COALESCE(sqlc.narg('agent_version')::TEXT, agent_version),
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: UpdateDeviceCertRenewedProjection :execrows
+-- DeviceCertRenewed handler. cert_not_after preserved when the payload
+-- omits the key (mirrors PL/pgSQL `COALESCE(payload, cert_not_after)`).
+-- Stale-replay guard via projection_version.
+UPDATE devices_projection
+SET cert_fingerprint   = $2,
+    cert_not_after     = COALESCE(sqlc.narg('cert_not_after')::TIMESTAMPTZ, cert_not_after),
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: UpdateDeviceLabelsProjection :execrows
+-- DeviceLabelsUpdated handler. The decoder leaves a missing labels key
+-- as a nil byte slice; the SQL COALESCE preserves the existing column
+-- value in that case (matches PL/pgSQL `COALESCE(payload, labels)`).
+-- The :: JSONB cast is required so PostgreSQL can resolve the parameter
+-- type when the value is NULL.
+-- Stale-replay guard via projection_version.
+UPDATE devices_projection
+SET labels             = COALESCE(sqlc.narg('labels')::JSONB, labels),
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2;
+
+-- name: SetDeviceLabelKey :execrows
+-- DeviceLabelSet handler. Mirrors the PL/pgSQL JSONB merge:
+-- `labels || jsonb_build_object(key, value)`. The first COALESCE on
+-- labels handles the (theoretical) NULL case for legacy rows — matches
+-- PL/pgSQL's `COALESCE(labels, '{}'::jsonb) || ...`. Stale-replay guard
+-- via projection_version.
+UPDATE devices_projection
+SET labels             = COALESCE(labels, '{}'::JSONB) || jsonb_build_object(@key::TEXT, @value::TEXT),
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2;
+
+-- name: RemoveDeviceLabelKey :execrows
+-- DeviceLabelRemoved handler. JSONB minus operator drops the key from
+-- the labels object. Stale-replay guard via projection_version.
+UPDATE devices_projection
+SET labels             = labels - @key::TEXT,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2;
+
+-- name: SoftDeleteDeviceProjection :execrows
+-- DeviceDeleted handler — first half. Returns rows-affected so the
+-- listener can SKIP the cascade (assigned-user wipe + assigned-group
+-- wipe) when the projection_version guard rejects a stale replay.
+-- Otherwise an old DeviceDeleted re-applied by the reconciler would
+-- silently nuke a freshly-restored device's assignments.
+UPDATE devices_projection
+SET is_deleted         = TRUE,
+    projection_version = $2
+WHERE id = $1
+  AND projection_version < $2;
+
+-- name: DeleteDeviceAssignedUsersByDevice :exec
+-- DeviceDeleted handler — second half. Wipes every assigned-user row
+-- for the deleted device. Wrapped with SoftDeleteDeviceProjection +
+-- DeleteDeviceAssignedGroupsByDevice inside store.WithTx for
+-- inter-write atomicity.
+DELETE FROM device_assigned_users_projection WHERE device_id = $1;
+
+-- name: DeleteDeviceAssignedGroupsByDevice :exec
+-- DeviceDeleted handler — third half. Same shape as the assigned-user
+-- wipe, scoped to the assigned-groups junction table.
+DELETE FROM device_assigned_groups_projection WHERE device_id = $1;
+
+-- name: InsertDeviceAssignedUser :exec
+-- DeviceAssigned handler. ON CONFLICT DO NOTHING matches the PL/pgSQL
+-- projector's idempotency.
+INSERT INTO device_assigned_users_projection (
+    device_id, user_id, assigned_at, assigned_by, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (device_id, user_id) DO NOTHING;
+
+-- name: DeleteDeviceAssignedUser :execrows
+-- DeviceUnassigned handler. Stale-replay DELETE protection: the guard
+-- `WHERE projection_version <= $N` ensures a stale Unassigned replayed
+-- after a re-Assign cannot wipe the live row — the live row's
+-- projection_version was bumped by the re-Assign INSERT, so the
+-- stale Unassigned's older sequence_num fails the guard. The :execrows
+-- count gives the listener a hook to log/observe stale rejections
+-- (CR catch on PR #179 pattern, applied to assignment-table DELETEs).
+DELETE FROM device_assigned_users_projection
+WHERE device_id = $1
+  AND user_id = $2
+  AND projection_version <= $3;
+
+-- name: InsertDeviceAssignedGroup :exec
+-- DeviceGroupAssigned handler. ON CONFLICT DO NOTHING matches the
+-- PL/pgSQL projector's idempotency.
+INSERT INTO device_assigned_groups_projection (
+    device_id, group_id, assigned_at, assigned_by, projection_version
+) VALUES ($1, $2, $3, $4, $5)
+ON CONFLICT (device_id, group_id) DO NOTHING;
+
+-- name: DeleteDeviceAssignedGroup :execrows
+-- DeviceGroupUnassigned handler. Same stale-replay guard as
+-- DeleteDeviceAssignedUser.
+DELETE FROM device_assigned_groups_projection
+WHERE device_id = $1
+  AND group_id = $2
+  AND projection_version <= $3;
+
+-- name: UpdateDeviceSyncIntervalProjection :execrows
+-- DeviceSyncIntervalSet handler. The decoder defaults a missing
+-- sync_interval_minutes key to 0 (matches the PL/pgSQL COALESCE).
+-- Stale-replay guard via projection_version.
+UPDATE devices_projection
+SET sync_interval_minutes = $2,
+    projection_version    = $3
+WHERE id = $1
+  AND projection_version < $3;

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -121,11 +121,16 @@ var AllRebuildTargets = []rebuildTarget{
 		StreamTypes: []string{"token"},
 	},
 	{
+		// Ported to projectors.ApplyDevice via projectors.WireAll
+		// (manchtools/power-manage-server#136). RebuildAll dispatches
+		// through the Go applier; the no-op PL/pgSQL stub left behind
+		// by the migration is retained so the live trigger pipeline in
+		// project_event() stays quiet until the dispatcher itself drops
+		// its `WHEN 'device'` clause in the Phase 2 cleanup.
 		Name:        "devices",
 		Tables:      []string{"devices_projection"},
 		Cascade:     true,
 		StreamTypes: []string{"device"},
-		Function:    "project_device_event",
 	},
 	{
 		// Ported to projectors.ApplyAction via projectors.WireAll


### PR DESCRIPTION
## Summary

Tenth Phase 2 port. Replaces `project_device_event()` with `projectors.DeviceListener`. 13 event types covering device lifecycle:

- `DeviceRegistered` (UPSERT with `is_deleted=FALSE` revival; optional auto-assign user when token carries `assigned_user_id`)
- `DeviceSeen`, `DeviceHeartbeat`, `DeviceCertRenewed` (UPDATE)
- `DeviceLabelsUpdated` (whole JSONB replace)
- `DeviceLabelSet` (JSONB merge: `labels || jsonb_build_object(k, v)`)
- `DeviceLabelRemoved` (JSONB key minus)
- `DeviceDeleted` (soft-delete + cascade DELETE `device_assigned_users` + `device_assigned_groups`, wrapped in `store.WithTx`)
- `DeviceAssigned`, `DeviceUnassigned` (junction-table I/D)
- `DeviceGroupAssigned`, `DeviceGroupUnassigned` (junction-table I/D)
- `DeviceSyncIntervalSet` (UPDATE)

## Patterns adopted from prior CR review

- **Asymmetric guards** on every UPDATE: `WHERE projection_version < $N` + `:execrows`.
- **DeviceDeleted cascade** short-circuits both junction-table DELETEs on `n == 0` (stale-replay safety).
- **Junction-table DELETEs** (Unassigned, GroupUnassigned) carry `WHERE projection_version <= $N` + `:execrows` so a stale Unassigned replayed after a re-Assign doesn't wipe the live row (sibling fix to PR #179 stale-Remove guard).
- **DeviceSeen's hostname COALESCE-NULLIF** semantic: decoder collapses explicit `""` to nil so SQL COALESCE preserves existing column value.

## Migration / wiring

- Migration `039_device_projector_to_go.sql` no-ops the PL/pgSQL function.
- `WireAll` registers `DeviceListener` and `RegisterRebuildApply("devices", ApplyDevice)` so RebuildAll dispatches via the Go applier.

## Test plan

- [x] Pure decoder tests for every event type.
- [x] Integration tests: full lifecycle (register → seen → heartbeat → certRenewed → labelsUpdated → labelSet → labelRemoved → assigned → groupAssigned → unassigned → groupUnassigned → deleted), register-revives-soft-deleted, register-auto-assigns-token-owner, **stale DeviceDeleted does not nuke assignments**, **stale DeviceUnassigned after re-Assign does not wipe live row**.
- [x] `gofmt -l`, `go vet ./...`, `staticcheck ./...` all green.
- [x] CR-CLI returned 0 findings before push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal device projection infrastructure with improved stability and performance for device registration, state tracking, label management, and user/group assignments. Updated event processing to include stricter validation and replay protection mechanisms for data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->