### PR TITLE
refactor: port user projector to Go listener — last Phase 2 port (Part of #136)

### DIFF
--- a/internal/projectors/user.go
+++ b/internal/projectors/user.go
@@ -37,7 +37,7 @@ type UserCreatedPayload struct {
 }
 
 type userCreatedRaw struct {
-	Email             string  `json:"email"`
+	Email             *string `json:"email,omitempty"`
 	PasswordHash      *string `json:"password_hash,omitempty"`
 	Role              *string `json:"role,omitempty"`
 	DisplayName       *string `json:"display_name,omitempty"`
@@ -64,19 +64,26 @@ func UserCreatedFromEvent(e store.PersistedEvent) (UserCreatedPayload, error) {
 	if err := json.Unmarshal(e.Data, &raw); err != nil {
 		return UserCreatedPayload{}, fmt.Errorf("projector: invalid UserCreated payload: %w", err)
 	}
-	if raw.Email == "" {
+	// PL/pgSQL parity: a missing email key would have produced SQL
+	// NULL and crashed the NOT NULL constraint at INSERT time. Surface
+	// that earlier as a decoder error. An explicitly-empty email ("")
+	// is preserved verbatim — the PL/pgSQL projector would have
+	// written it through.
+	if raw.Email == nil {
 		return UserCreatedPayload{}, fmt.Errorf("projector: UserCreated requires email")
 	}
 	out := UserCreatedPayload{
 		ID:    e.StreamID,
-		Email: raw.Email,
-		// Default role mirrors the PL/pgSQL COALESCE-to-"user".
+		Email: *raw.Email,
+		// Default role mirrors the PL/pgSQL COALESCE(...,'user'):
+		// it kicks in ONLY for a missing key, NOT for an explicit
+		// empty string. An emitted role:"" must round-trip as "".
 		Role: "user",
 	}
 	if raw.PasswordHash != nil {
 		out.PasswordHash = *raw.PasswordHash
 	}
-	if raw.Role != nil && *raw.Role != "" {
+	if raw.Role != nil {
 		out.Role = *raw.Role
 	}
 	if raw.DisplayName != nil {
@@ -189,7 +196,10 @@ func UserEmailChangedFromEvent(e store.PersistedEvent) (UserEmailChangedPayload,
 	if err := json.Unmarshal(e.Data, &raw); err != nil {
 		return UserEmailChangedPayload{}, fmt.Errorf("projector: invalid UserEmailChanged payload: %w", err)
 	}
-	if raw.Email == nil || *raw.Email == "" {
+	// PL/pgSQL parity: missing key → SQL NULL → NOT NULL violation
+	// at UPDATE time. Surface earlier here. Explicit "" is preserved
+	// verbatim — the PL/pgSQL projector would have written it through.
+	if raw.Email == nil {
 		return UserEmailChangedPayload{}, fmt.Errorf("projector: UserEmailChanged requires email")
 	}
 	return UserEmailChangedPayload{ID: e.StreamID, Email: *raw.Email}, nil
@@ -249,7 +259,9 @@ func UserRoleChangedFromEvent(e store.PersistedEvent) (UserRoleChangedPayload, e
 	if err := json.Unmarshal(e.Data, &raw); err != nil {
 		return UserRoleChangedPayload{}, fmt.Errorf("projector: invalid UserRoleChanged payload: %w", err)
 	}
-	if raw.Role == nil || *raw.Role == "" {
+	// PL/pgSQL parity: missing key → SQL NULL → NOT NULL violation.
+	// Explicit "" is preserved verbatim.
+	if raw.Role == nil {
 		return UserRoleChangedPayload{}, fmt.Errorf("projector: UserRoleChanged requires role")
 	}
 	return UserRoleChangedPayload{ID: e.StreamID, Role: *raw.Role}, nil
@@ -258,11 +270,17 @@ func UserRoleChangedFromEvent(e store.PersistedEvent) (UserRoleChangedPayload, e
 // UserSshKeyAddedPayload mirrors the JSONB array-append the PL/pgSQL
 // projector did on UserSshKeyAdded. AddedAt is the event's
 // occurred_at timestamp (matches PL/pgSQL `event.occurred_at`).
+//
+// PublicKey + Comment are pointers so the SQL builder can write a
+// JSON null for an omitted key rather than an empty string —
+// PL/pgSQL fed `event.data->>'public_key'` straight into
+// `jsonb_build_object`, so missing keys became JSON null. Replay
+// of historical sparse events must produce the same JSONB shape.
 type UserSshKeyAddedPayload struct {
 	ID        string
 	KeyID     string
-	PublicKey string
-	Comment   string
+	PublicKey *string
+	Comment   *string
 	AddedAt   time.Time
 }
 
@@ -296,12 +314,10 @@ func UserSshKeyAddedFromEvent(e store.PersistedEvent) (UserSshKeyAddedPayload, e
 		KeyID:   *raw.KeyID,
 		AddedAt: e.OccurredAt,
 	}
-	if raw.PublicKey != nil {
-		out.PublicKey = *raw.PublicKey
-	}
-	if raw.Comment != nil {
-		out.Comment = *raw.Comment
-	}
+	// Keep the pointer-presence distinction so the SQL builder
+	// can emit JSON null vs explicit value (PL/pgSQL parity).
+	out.PublicKey = raw.PublicKey
+	out.Comment = raw.Comment
 	return out, nil
 }
 

--- a/internal/projectors/user.go
+++ b/internal/projectors/user.go
@@ -1,0 +1,491 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// UserCreatedPayload mirrors the fields the deleted PL/pgSQL
+// project_user_event() read out of a UserCreated event:
+//
+//   - email (required, NOT NULL column).
+//   - password_hash (defaults to "" — matches PL/pgSQL
+//     `COALESCE(event.data->>"password_hash", "")`). Drives has_password.
+//   - role (defaults to "user" — matches PL/pgSQL
+//     `COALESCE(event.data->>"role", "user")`).
+//   - profile fields (display_name, given_name, family_name,
+//     preferred_username, picture, locale): each defaults to ""
+//     (matches PL/pgSQL `COALESCE(payload, "")`).
+//   - linux_username (defaults to "").
+//   - linux_uid (defaults to 0).
+type UserCreatedPayload struct {
+	ID                string
+	Email             string
+	PasswordHash      string
+	Role              string
+	DisplayName       string
+	GivenName         string
+	FamilyName        string
+	PreferredUsername string
+	Picture           string
+	Locale            string
+	LinuxUsername     string
+	LinuxUID          int32
+}
+
+type userCreatedRaw struct {
+	Email             string  `json:"email"`
+	PasswordHash      *string `json:"password_hash,omitempty"`
+	Role              *string `json:"role,omitempty"`
+	DisplayName       *string `json:"display_name,omitempty"`
+	GivenName         *string `json:"given_name,omitempty"`
+	FamilyName        *string `json:"family_name,omitempty"`
+	PreferredUsername *string `json:"preferred_username,omitempty"`
+	Picture           *string `json:"picture,omitempty"`
+	Locale            *string `json:"locale,omitempty"`
+	LinuxUsername     *string `json:"linux_username,omitempty"`
+	LinuxUID          *int32  `json:"linux_uid,omitempty"`
+}
+
+// UserCreatedFromEvent decodes UserCreated. Returns ErrIgnoredEvent
+// for any other (stream, event_type) so the listener wrapper can
+// silently no-op.
+func UserCreatedFromEvent(e store.PersistedEvent) (UserCreatedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserCreated" {
+		return UserCreatedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserCreatedPayload{}, fmt.Errorf("projector: empty UserCreated payload")
+	}
+	var raw userCreatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserCreatedPayload{}, fmt.Errorf("projector: invalid UserCreated payload: %w", err)
+	}
+	if raw.Email == "" {
+		return UserCreatedPayload{}, fmt.Errorf("projector: UserCreated requires email")
+	}
+	out := UserCreatedPayload{
+		ID:    e.StreamID,
+		Email: raw.Email,
+		// Default role mirrors the PL/pgSQL COALESCE-to-"user".
+		Role: "user",
+	}
+	if raw.PasswordHash != nil {
+		out.PasswordHash = *raw.PasswordHash
+	}
+	if raw.Role != nil && *raw.Role != "" {
+		out.Role = *raw.Role
+	}
+	if raw.DisplayName != nil {
+		out.DisplayName = *raw.DisplayName
+	}
+	if raw.GivenName != nil {
+		out.GivenName = *raw.GivenName
+	}
+	if raw.FamilyName != nil {
+		out.FamilyName = *raw.FamilyName
+	}
+	if raw.PreferredUsername != nil {
+		out.PreferredUsername = *raw.PreferredUsername
+	}
+	if raw.Picture != nil {
+		out.Picture = *raw.Picture
+	}
+	if raw.Locale != nil {
+		out.Locale = *raw.Locale
+	}
+	if raw.LinuxUsername != nil {
+		out.LinuxUsername = *raw.LinuxUsername
+	}
+	if raw.LinuxUID != nil {
+		out.LinuxUID = *raw.LinuxUID
+	}
+	return out, nil
+}
+
+// UserProfileUpdatedPayload mirrors the six profile fields the
+// PL/pgSQL projector REPLACED on UserProfileUpdated. Each field is
+// COALESCE-to-"" — missing key in the event payload writes "".
+type UserProfileUpdatedPayload struct {
+	ID                string
+	DisplayName       string
+	GivenName         string
+	FamilyName        string
+	PreferredUsername string
+	Picture           string
+	Locale            string
+}
+
+type userProfileUpdatedRaw struct {
+	DisplayName       *string `json:"display_name,omitempty"`
+	GivenName         *string `json:"given_name,omitempty"`
+	FamilyName        *string `json:"family_name,omitempty"`
+	PreferredUsername *string `json:"preferred_username,omitempty"`
+	Picture           *string `json:"picture,omitempty"`
+	Locale            *string `json:"locale,omitempty"`
+}
+
+// UserProfileUpdatedFromEvent decodes UserProfileUpdated.
+func UserProfileUpdatedFromEvent(e store.PersistedEvent) (UserProfileUpdatedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserProfileUpdated" {
+		return UserProfileUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := UserProfileUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw userProfileUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserProfileUpdatedPayload{}, fmt.Errorf("projector: invalid UserProfileUpdated payload: %w", err)
+	}
+	if raw.DisplayName != nil {
+		out.DisplayName = *raw.DisplayName
+	}
+	if raw.GivenName != nil {
+		out.GivenName = *raw.GivenName
+	}
+	if raw.FamilyName != nil {
+		out.FamilyName = *raw.FamilyName
+	}
+	if raw.PreferredUsername != nil {
+		out.PreferredUsername = *raw.PreferredUsername
+	}
+	if raw.Picture != nil {
+		out.Picture = *raw.Picture
+	}
+	if raw.Locale != nil {
+		out.Locale = *raw.Locale
+	}
+	return out, nil
+}
+
+// UserEmailChangedPayload mirrors the single field the PL/pgSQL
+// projector wrote on UserEmailChanged.
+type UserEmailChangedPayload struct {
+	ID    string
+	Email string
+}
+
+type userEmailChangedRaw struct {
+	Email *string `json:"email,omitempty"`
+}
+
+// UserEmailChangedFromEvent decodes UserEmailChanged. The PL/pgSQL
+// projector wrote `event.data->>"email"` directly — if the key was
+// missing the column would land as SQL NULL, but the column is
+// NOT NULL, so the original projector relied on the emitter always
+// supplying a non-empty value. Keep that contract here.
+func UserEmailChangedFromEvent(e store.PersistedEvent) (UserEmailChangedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserEmailChanged" {
+		return UserEmailChangedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserEmailChangedPayload{}, fmt.Errorf("projector: empty UserEmailChanged payload")
+	}
+	var raw userEmailChangedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserEmailChangedPayload{}, fmt.Errorf("projector: invalid UserEmailChanged payload: %w", err)
+	}
+	if raw.Email == nil || *raw.Email == "" {
+		return UserEmailChangedPayload{}, fmt.Errorf("projector: UserEmailChanged requires email")
+	}
+	return UserEmailChangedPayload{ID: e.StreamID, Email: *raw.Email}, nil
+}
+
+// UserPasswordChangedPayload mirrors UserPasswordChanged. The PL/pgSQL
+// projector wrote `event.data->>"password_hash"` directly without a
+// COALESCE — emitter always supplies it. We require it explicitly for
+// the same reason.
+type UserPasswordChangedPayload struct {
+	ID           string
+	PasswordHash string
+}
+
+type userPasswordChangedRaw struct {
+	PasswordHash *string `json:"password_hash,omitempty"`
+}
+
+// UserPasswordChangedFromEvent decodes UserPasswordChanged.
+func UserPasswordChangedFromEvent(e store.PersistedEvent) (UserPasswordChangedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserPasswordChanged" {
+		return UserPasswordChangedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserPasswordChangedPayload{}, fmt.Errorf("projector: empty UserPasswordChanged payload")
+	}
+	var raw userPasswordChangedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserPasswordChangedPayload{}, fmt.Errorf("projector: invalid UserPasswordChanged payload: %w", err)
+	}
+	if raw.PasswordHash == nil {
+		return UserPasswordChangedPayload{}, fmt.Errorf("projector: UserPasswordChanged requires password_hash")
+	}
+	return UserPasswordChangedPayload{ID: e.StreamID, PasswordHash: *raw.PasswordHash}, nil
+}
+
+// UserRoleChangedPayload mirrors UserRoleChanged. role is required
+// (NOT NULL column).
+type UserRoleChangedPayload struct {
+	ID   string
+	Role string
+}
+
+type userRoleChangedRaw struct {
+	Role *string `json:"role,omitempty"`
+}
+
+// UserRoleChangedFromEvent decodes UserRoleChanged.
+func UserRoleChangedFromEvent(e store.PersistedEvent) (UserRoleChangedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserRoleChanged" {
+		return UserRoleChangedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserRoleChangedPayload{}, fmt.Errorf("projector: empty UserRoleChanged payload")
+	}
+	var raw userRoleChangedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserRoleChangedPayload{}, fmt.Errorf("projector: invalid UserRoleChanged payload: %w", err)
+	}
+	if raw.Role == nil || *raw.Role == "" {
+		return UserRoleChangedPayload{}, fmt.Errorf("projector: UserRoleChanged requires role")
+	}
+	return UserRoleChangedPayload{ID: e.StreamID, Role: *raw.Role}, nil
+}
+
+// UserSshKeyAddedPayload mirrors the JSONB array-append the PL/pgSQL
+// projector did on UserSshKeyAdded. AddedAt is the event's
+// occurred_at timestamp (matches PL/pgSQL `event.occurred_at`).
+type UserSshKeyAddedPayload struct {
+	ID        string
+	KeyID     string
+	PublicKey string
+	Comment   string
+	AddedAt   time.Time
+}
+
+type userSshKeyAddedRaw struct {
+	KeyID     *string `json:"key_id,omitempty"`
+	PublicKey *string `json:"public_key,omitempty"`
+	Comment   *string `json:"comment,omitempty"`
+}
+
+// UserSshKeyAddedFromEvent decodes UserSshKeyAdded. key_id is
+// required because the JSONB element is the only addressable handle
+// for the matching UserSshKeyRemoved event. public_key + comment
+// default to "" so callers that omit them still produce a valid
+// element shape in the JSONB array.
+func UserSshKeyAddedFromEvent(e store.PersistedEvent) (UserSshKeyAddedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserSshKeyAdded" {
+		return UserSshKeyAddedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserSshKeyAddedPayload{}, fmt.Errorf("projector: empty UserSshKeyAdded payload")
+	}
+	var raw userSshKeyAddedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserSshKeyAddedPayload{}, fmt.Errorf("projector: invalid UserSshKeyAdded payload: %w", err)
+	}
+	if raw.KeyID == nil || *raw.KeyID == "" {
+		return UserSshKeyAddedPayload{}, fmt.Errorf("projector: UserSshKeyAdded requires key_id")
+	}
+	out := UserSshKeyAddedPayload{
+		ID:      e.StreamID,
+		KeyID:   *raw.KeyID,
+		AddedAt: e.OccurredAt,
+	}
+	if raw.PublicKey != nil {
+		out.PublicKey = *raw.PublicKey
+	}
+	if raw.Comment != nil {
+		out.Comment = *raw.Comment
+	}
+	return out, nil
+}
+
+// UserSshKeyRemovedPayload mirrors the JSONB filter-by-id the PL/pgSQL
+// projector did on UserSshKeyRemoved.
+type UserSshKeyRemovedPayload struct {
+	ID    string
+	KeyID string
+}
+
+type userSshKeyRemovedRaw struct {
+	KeyID *string `json:"key_id,omitempty"`
+}
+
+// UserSshKeyRemovedFromEvent decodes UserSshKeyRemoved.
+func UserSshKeyRemovedFromEvent(e store.PersistedEvent) (UserSshKeyRemovedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserSshKeyRemoved" {
+		return UserSshKeyRemovedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserSshKeyRemovedPayload{}, fmt.Errorf("projector: empty UserSshKeyRemoved payload")
+	}
+	var raw userSshKeyRemovedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserSshKeyRemovedPayload{}, fmt.Errorf("projector: invalid UserSshKeyRemoved payload: %w", err)
+	}
+	if raw.KeyID == nil || *raw.KeyID == "" {
+		return UserSshKeyRemovedPayload{}, fmt.Errorf("projector: UserSshKeyRemoved requires key_id")
+	}
+	return UserSshKeyRemovedPayload{ID: e.StreamID, KeyID: *raw.KeyID}, nil
+}
+
+// UserSshSettingsUpdatedPayload mirrors the three SSH settings the
+// PL/pgSQL projector COALESCE-preserved on UserSshSettingsUpdated.
+// nil pointer = "field absent in payload, preserve existing column
+// value"; non-nil pointer = "field present in payload, set to value"
+// (the SQL UPDATE does `COALESCE($N::BOOLEAN, existing)`).
+type UserSshSettingsUpdatedPayload struct {
+	ID               string
+	SshAccessEnabled *bool
+	SshAllowPubkey   *bool
+	SshAllowPassword *bool
+}
+
+type userSshSettingsUpdatedRaw struct {
+	SshAccessEnabled *bool `json:"ssh_access_enabled,omitempty"`
+	SshAllowPubkey   *bool `json:"ssh_allow_pubkey,omitempty"`
+	SshAllowPassword *bool `json:"ssh_allow_password,omitempty"`
+}
+
+// UserSshSettingsUpdatedFromEvent decodes UserSshSettingsUpdated.
+// Empty payload is valid (a no-op event that only bumps
+// projection_version + updated_at, leaving every column as-is).
+func UserSshSettingsUpdatedFromEvent(e store.PersistedEvent) (UserSshSettingsUpdatedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserSshSettingsUpdated" {
+		return UserSshSettingsUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := UserSshSettingsUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw userSshSettingsUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserSshSettingsUpdatedPayload{}, fmt.Errorf("projector: invalid UserSshSettingsUpdated payload: %w", err)
+	}
+	out.SshAccessEnabled = raw.SshAccessEnabled
+	out.SshAllowPubkey = raw.SshAllowPubkey
+	out.SshAllowPassword = raw.SshAllowPassword
+	return out, nil
+}
+
+// UserLinuxUsernameChangedPayload mirrors UserLinuxUsernameChanged.
+// linux_username is required (the PL/pgSQL projector wrote
+// `event.data->>"linux_username"` directly, so an absent key would
+// have produced a NULL violation against the NOT NULL column).
+type UserLinuxUsernameChangedPayload struct {
+	ID            string
+	LinuxUsername string
+}
+
+type userLinuxUsernameChangedRaw struct {
+	LinuxUsername *string `json:"linux_username,omitempty"`
+}
+
+// UserLinuxUsernameChangedFromEvent decodes UserLinuxUsernameChanged.
+func UserLinuxUsernameChangedFromEvent(e store.PersistedEvent) (UserLinuxUsernameChangedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserLinuxUsernameChanged" {
+		return UserLinuxUsernameChangedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserLinuxUsernameChangedPayload{}, fmt.Errorf("projector: empty UserLinuxUsernameChanged payload")
+	}
+	var raw userLinuxUsernameChangedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserLinuxUsernameChangedPayload{}, fmt.Errorf("projector: invalid UserLinuxUsernameChanged payload: %w", err)
+	}
+	if raw.LinuxUsername == nil {
+		return UserLinuxUsernameChangedPayload{}, fmt.Errorf("projector: UserLinuxUsernameChanged requires linux_username")
+	}
+	return UserLinuxUsernameChangedPayload{ID: e.StreamID, LinuxUsername: *raw.LinuxUsername}, nil
+}
+
+// UserSystemActionLinkedPayload mirrors the targeted CASE the
+// PL/pgSQL projector did on UserSystemActionLinked. The `field` value
+// selects which of three columns
+// (system_user_action_id / system_ssh_action_id / system_tty_action_id)
+// gets the supplied action_id; the other two columns are preserved.
+type UserSystemActionLinkedPayload struct {
+	ID       string
+	Field    string
+	ActionID string
+}
+
+type userSystemActionLinkedRaw struct {
+	Field    *string `json:"field,omitempty"`
+	ActionID *string `json:"action_id,omitempty"`
+}
+
+// Allowed field names for UserSystemActionLinked. Mirrors the
+// PL/pgSQL CASE arms exactly — anything else falls through to the
+// three "preserve existing" branches in the original projector,
+// which is equivalent to the Go listener producing a no-op.
+const (
+	SystemActionFieldUser = "system_user_action_id"
+	SystemActionFieldSSH  = "system_ssh_action_id"
+	SystemActionFieldTTY  = "system_tty_action_id"
+)
+
+// UserSystemActionLinkedFromEvent decodes UserSystemActionLinked.
+// field is required so the listener knows which column to write.
+// action_id defaults to "" so an explicit "unlink" can still flow
+// through (matches PL/pgSQL `COALESCE(event.data->>"action_id", "")`).
+func UserSystemActionLinkedFromEvent(e store.PersistedEvent) (UserSystemActionLinkedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserSystemActionLinked" {
+		return UserSystemActionLinkedPayload{}, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return UserSystemActionLinkedPayload{}, fmt.Errorf("projector: empty UserSystemActionLinked payload")
+	}
+	var raw userSystemActionLinkedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserSystemActionLinkedPayload{}, fmt.Errorf("projector: invalid UserSystemActionLinked payload: %w", err)
+	}
+	if raw.Field == nil || *raw.Field == "" {
+		return UserSystemActionLinkedPayload{}, fmt.Errorf("projector: UserSystemActionLinked requires field")
+	}
+	out := UserSystemActionLinkedPayload{
+		ID:    e.StreamID,
+		Field: *raw.Field,
+	}
+	if raw.ActionID != nil {
+		out.ActionID = *raw.ActionID
+	}
+	return out, nil
+}
+
+// UserProvisioningSettingsUpdatedPayload mirrors the single
+// COALESCE-preserved boolean the PL/pgSQL projector wrote on
+// UserProvisioningSettingsUpdated. nil pointer = "field absent,
+// preserve existing"; non-nil = "set to value".
+type UserProvisioningSettingsUpdatedPayload struct {
+	ID                      string
+	UserProvisioningEnabled *bool
+}
+
+type userProvisioningSettingsUpdatedRaw struct {
+	UserProvisioningEnabled *bool `json:"user_provisioning_enabled,omitempty"`
+}
+
+// UserProvisioningSettingsUpdatedFromEvent decodes
+// UserProvisioningSettingsUpdated. Empty payload is valid (no-op
+// event that only bumps projection_version + updated_at).
+func UserProvisioningSettingsUpdatedFromEvent(e store.PersistedEvent) (UserProvisioningSettingsUpdatedPayload, error) {
+	if e.StreamType != "user" || e.EventType != "UserProvisioningSettingsUpdated" {
+		return UserProvisioningSettingsUpdatedPayload{}, ErrIgnoredEvent
+	}
+	out := UserProvisioningSettingsUpdatedPayload{ID: e.StreamID}
+	if len(e.Data) == 0 {
+		return out, nil
+	}
+	var raw userProvisioningSettingsUpdatedRaw
+	if err := json.Unmarshal(e.Data, &raw); err != nil {
+		return UserProvisioningSettingsUpdatedPayload{}, fmt.Errorf("projector: invalid UserProvisioningSettingsUpdated payload: %w", err)
+	}
+	out.UserProvisioningEnabled = raw.UserProvisioningEnabled
+	return out, nil
+}

--- a/internal/projectors/user_listener.go
+++ b/internal/projectors/user_listener.go
@@ -1,0 +1,441 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// UserListener returns a store.EventListener that applies every user
+// stream event the deleted PL/pgSQL project_user_event handled.
+// Sixteen event types — the largest projector under tracker #136 and
+// the LAST Phase 2 port. After this lands, the cleanup migration can
+// drop project_event() and the dispatcher trigger entirely.
+//
+// Event-type families:
+//   - User CRUD: Created (INSERT), ProfileUpdated (UPDATE),
+//     EmailChanged (UPDATE), PasswordChanged (UPDATE +
+//     session_version bump), RoleChanged (UPDATE),
+//     Deleted (soft + cascade DELETE on identity_links_projection).
+//   - Session controls: SessionInvalidated, Disabled, Enabled,
+//     LoggedIn — single guarded UPDATEs.
+//   - SSH: SshKeyAdded (JSONB array append), SshKeyRemoved (JSONB
+//     filter), SshSettingsUpdated (COALESCE-preserve booleans).
+//   - Linux integration: LinuxUsernameChanged (UPDATE),
+//     SystemActionLinked (targeted CASE on three columns),
+//     ProvisioningSettingsUpdated (COALESCE-preserve boolean).
+//
+// Multi-write event (UserDeleted) wraps the SoftDelete +
+// identity-links cascade in store.WithTx so the cascade stays atomic
+// with itself; single-statement events run on the autocommit pool.
+//
+// Asymmetric-guard discipline (per the role + identity_provider +
+// action_set + assignment + user_group + device_group +
+// compliance_policy + compliance + action+definition + execution +
+// device ports): every UPDATE on users_projection carries a
+// `WHERE projection_version < $N` guard via :execrows, and the
+// listener short-circuits the UserDeleted cascade when n == 0 —
+// otherwise a stale UserDeleted re-applied later would silently nuke
+// a freshly-restored user's identity links.
+//
+// Session-version monotonicity: PasswordChanged, SessionInvalidated,
+// and Disabled all bump session_version. The bump is paired with the
+// other column writes inside ONE guarded UPDATE — a stale Disable
+// replayed after a re-Enable fails the projection_version guard
+// outright (n == 0), so neither disabled NOR session_version regress
+// to the stale value. session_version stays monotonic by construction.
+//
+// Wired in projectors.WireAll. Refs #136 (last Phase 2 port of
+// tracker #107).
+func UserListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if e.StreamType != "user" {
+			return
+		}
+		// Multi-write event (UserDeleted) routes through ApplyUser
+		// via WithTx so the soft-delete + identity-links cascade
+		// stays atomic. Every other event is a single statement and
+		// runs on the autocommit pool. ApplyUser handles all event
+		// types when called with tx-bound queries (the rebuild path).
+		if e.EventType == "UserDeleted" {
+			if err := st.WithTx(ctx, func(q *store.Queries) error {
+				return ApplyUser(ctx, q, e)
+			}); err != nil {
+				logger.Warn("user projector: failed to apply UserDeleted",
+					"event_id", e.ID, "user_id", e.StreamID, "error", err)
+			}
+			return
+		}
+		if err := ApplyUser(ctx, st.Queries(), e); err != nil {
+			logger.Warn("user projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "user_id", e.StreamID, "error", err)
+		}
+	}
+}
+
+// ApplyUser is the transactional core of the user projector. The
+// listener wraps it for live-event dispatch (using WithTx for
+// UserDeleted's two-write atomicity); the rebuild path
+// (manchtools/power-manage-server#125) registers it via
+// RegisterRebuildApply so RebuildAll re-derives the projection from
+// the event store instead of dispatching to the no-op PL/pgSQL stub.
+func ApplyUser(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "user" {
+		return nil
+	}
+	switch e.EventType {
+	case "UserCreated":
+		return applyUserCreated(ctx, q, e)
+	case "UserProfileUpdated":
+		return applyUserProfileUpdated(ctx, q, e)
+	case "UserEmailChanged":
+		return applyUserEmailChanged(ctx, q, e)
+	case "UserPasswordChanged":
+		return applyUserPasswordChanged(ctx, q, e)
+	case "UserRoleChanged":
+		return applyUserRoleChanged(ctx, q, e)
+	case "UserSessionInvalidated":
+		return applyUserSessionInvalidated(ctx, q, e)
+	case "UserDisabled":
+		return applyUserDisabled(ctx, q, e)
+	case "UserEnabled":
+		return applyUserEnabled(ctx, q, e)
+	case "UserLoggedIn":
+		return applyUserLoggedIn(ctx, q, e)
+	case "UserDeleted":
+		return applyUserDeleted(ctx, q, e)
+	case "UserSshKeyAdded":
+		return applyUserSshKeyAdded(ctx, q, e)
+	case "UserSshKeyRemoved":
+		return applyUserSshKeyRemoved(ctx, q, e)
+	case "UserSshSettingsUpdated":
+		return applyUserSshSettingsUpdated(ctx, q, e)
+	case "UserLinuxUsernameChanged":
+		return applyUserLinuxUsernameChanged(ctx, q, e)
+	case "UserSystemActionLinked":
+		return applyUserSystemActionLinked(ctx, q, e)
+	case "UserProvisioningSettingsUpdated":
+		return applyUserProvisioningSettingsUpdated(ctx, q, e)
+	}
+	return nil
+}
+
+func applyUserCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserCreatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	occurredAt := e.OccurredAt
+	// password_hash column is nullable in the schema; the PL/pgSQL
+	// projector wrote `COALESCE(payload, '')` and computed
+	// has_password from the non-empty check. Mirror that:
+	// passwordHashPtr is nil only if we want SQL NULL — but the
+	// PL/pgSQL projector NEVER wrote NULL, it wrote "". Keep that.
+	passwordHash := payload.PasswordHash
+	hasPassword := payload.PasswordHash != ""
+	return q.InsertUserProjection(ctx, db.InsertUserProjectionParams{
+		ID:                payload.ID,
+		Email:             payload.Email,
+		PasswordHash:      &passwordHash,
+		Role:              payload.Role,
+		CreatedAt:         &occurredAt,
+		ProjectionVersion: deref(e.SequenceNum),
+		HasPassword:       hasPassword,
+		DisplayName:       payload.DisplayName,
+		GivenName:         payload.GivenName,
+		FamilyName:        payload.FamilyName,
+		PreferredUsername: payload.PreferredUsername,
+		Picture:           payload.Picture,
+		Locale:            payload.Locale,
+		LinuxUsername:     payload.LinuxUsername,
+		LinuxUid:          payload.LinuxUID,
+	})
+}
+
+func applyUserProfileUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserProfileUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateUserProfileProjection(ctx, db.UpdateUserProfileProjectionParams{
+		ID:                payload.ID,
+		DisplayName:       payload.DisplayName,
+		GivenName:         payload.GivenName,
+		FamilyName:        payload.FamilyName,
+		PreferredUsername: payload.PreferredUsername,
+		Picture:           payload.Picture,
+		Locale:            payload.Locale,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserEmailChanged(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserEmailChangedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateUserEmailProjection(ctx, db.UpdateUserEmailProjectionParams{
+		ID:                payload.ID,
+		Email:             payload.Email,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserPasswordChanged(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserPasswordChangedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	passwordHash := payload.PasswordHash
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateUserPasswordProjection(ctx, db.UpdateUserPasswordProjectionParams{
+		ID:                payload.ID,
+		PasswordHash:      &passwordHash,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserRoleChanged(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserRoleChangedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateUserRoleProjection(ctx, db.UpdateUserRoleProjectionParams{
+		ID:                payload.ID,
+		Role:              payload.Role,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserSessionInvalidated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	updatedAt := e.OccurredAt
+	if _, err := q.InvalidateUserSessionProjection(ctx, db.InvalidateUserSessionProjectionParams{
+		ID:                e.StreamID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserDisabled(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	updatedAt := e.OccurredAt
+	if _, err := q.DisableUserProjection(ctx, db.DisableUserProjectionParams{
+		ID:                e.StreamID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserEnabled(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	updatedAt := e.OccurredAt
+	if _, err := q.EnableUserProjection(ctx, db.EnableUserProjectionParams{
+		ID:                e.StreamID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserLoggedIn(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	loggedInAt := e.OccurredAt
+	if _, err := q.UpdateUserLoginProjection(ctx, db.UpdateUserLoginProjectionParams{
+		ID:                e.StreamID,
+		LastLoginAt:       &loggedInAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	updatedAt := e.OccurredAt
+	n, err := q.SoftDeleteUserProjection(ctx, db.SoftDeleteUserProjectionParams{
+		ID:                e.StreamID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		// Stale UserDeleted replay against a row whose
+		// projection_version has moved past this event. Skipping the
+		// cascade (identity_links wipe) is mandatory: otherwise an old
+		// delete re-applied by the reconciler against a freshly-restored
+		// user would silently nuke that user's identity links.
+		return nil
+	}
+	return q.DeleteIdentityLinksByUser(ctx, e.StreamID)
+}
+
+func applyUserSshKeyAdded(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserSshKeyAddedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if _, err := q.AppendUserSshKeyProjection(ctx, db.AppendUserSshKeyProjectionParams{
+		ID:                payload.ID,
+		KeyID:             payload.KeyID,
+		PublicKey:         payload.PublicKey,
+		Comment:           payload.Comment,
+		AddedAt:           payload.AddedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserSshKeyRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserSshKeyRemovedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.RemoveUserSshKeyProjection(ctx, db.RemoveUserSshKeyProjectionParams{
+		ID:                payload.ID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+		KeyID:             payload.KeyID,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserSshSettingsUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserSshSettingsUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateUserSshSettingsProjection(ctx, db.UpdateUserSshSettingsProjectionParams{
+		SshAccessEnabled:  payload.SshAccessEnabled,
+		SshAllowPubkey:    payload.SshAllowPubkey,
+		SshAllowPassword:  payload.SshAllowPassword,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+		ID:                payload.ID,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserLinuxUsernameChanged(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserLinuxUsernameChangedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateUserLinuxUsernameProjection(ctx, db.UpdateUserLinuxUsernameProjectionParams{
+		ID:                payload.ID,
+		LinuxUsername:     payload.LinuxUsername,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserSystemActionLinked(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserSystemActionLinkedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.LinkUserSystemActionProjection(ctx, db.LinkUserSystemActionProjectionParams{
+		Field:             payload.Field,
+		ActionID:          payload.ActionID,
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: deref(e.SequenceNum),
+		ID:                payload.ID,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyUserProvisioningSettingsUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := UserProvisioningSettingsUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	updatedAt := e.OccurredAt
+	if _, err := q.UpdateUserProvisioningSettingsProjection(ctx, db.UpdateUserProvisioningSettingsProjectionParams{
+		UserProvisioningEnabled: payload.UserProvisioningEnabled,
+		UpdatedAt:               &updatedAt,
+		ProjectionVersion:       deref(e.SequenceNum),
+		ID:                      payload.ID,
+	}); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/projectors/user_test.go
+++ b/internal/projectors/user_test.go
@@ -76,6 +76,21 @@ func TestUserCreatedFromEvent_Pure(t *testing.T) {
 		assert.Contains(t, err.Error(), "email")
 	})
 
+	t.Run("explicit empty email + role round-trip verbatim (PL/pgSQL parity)", func(t *testing.T) {
+		// PL/pgSQL `event.data->>'role'` returns "" for an explicit
+		// empty string — COALESCE doesn't kick in (which only handles
+		// SQL NULL i.e. missing keys). Reject explicit "" would
+		// silently rewrite historical replay events. Same for email
+		// (which would have been INSERTed as ""). CR catch on PR #183.
+		got, err := projectors.UserCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-empty", EventType: "UserCreated",
+			Data: jsonOrFail(t, map[string]any{"email": "", "role": ""}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Email, "explicit empty email must round-trip as \"\"")
+		assert.Equal(t, "", got.Role, "explicit empty role must round-trip as \"\" (default 'user' only kicks in for missing key)")
+	})
+
 	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
 		_, err := projectors.UserCreatedFromEvent(store.PersistedEvent{
 			StreamType: "device", EventType: "UserCreated",
@@ -155,6 +170,15 @@ func TestUserEmailChangedFromEvent_Pure(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "email")
 	})
+
+	t.Run("explicit empty email round-trips (PL/pgSQL parity)", func(t *testing.T) {
+		got, err := projectors.UserEmailChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserEmailChanged",
+			Data: jsonOrFail(t, map[string]any{"email": ""}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Email, "explicit empty email must round-trip — PL/pgSQL would have written it through")
+	})
 }
 
 // TestUserPasswordChangedFromEvent_Pure — password_hash required.
@@ -197,6 +221,15 @@ func TestUserRoleChangedFromEvent_Pure(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "role")
 	})
+
+	t.Run("explicit empty role round-trips (PL/pgSQL parity)", func(t *testing.T) {
+		got, err := projectors.UserRoleChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserRoleChanged",
+			Data: jsonOrFail(t, map[string]any{"role": ""}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.Role, "explicit empty role must round-trip")
+	})
 }
 
 // TestUserSshKeyAddedFromEvent_Pure — key_id required.
@@ -212,8 +245,21 @@ func TestUserSshKeyAddedFromEvent_Pure(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "k-1", got.KeyID)
-		assert.Equal(t, "ssh-rsa AAA", got.PublicKey)
-		assert.Equal(t, "laptop", got.Comment)
+		require.NotNil(t, got.PublicKey)
+		assert.Equal(t, "ssh-rsa AAA", *got.PublicKey)
+		require.NotNil(t, got.Comment)
+		assert.Equal(t, "laptop", *got.Comment)
+	})
+
+	t.Run("missing public_key + comment stay nil", func(t *testing.T) {
+		got, err := projectors.UserSshKeyAddedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserSshKeyAdded",
+			Data: jsonOrFail(t, map[string]any{"key_id": "k-only"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "k-only", got.KeyID)
+		assert.Nil(t, got.PublicKey, "missing public_key must stay nil so JSONB element gets a JSON null (PL/pgSQL parity)")
+		assert.Nil(t, got.Comment, "missing comment must stay nil so JSONB element gets a JSON null (PL/pgSQL parity)")
 	})
 
 	t.Run("missing key_id fails", func(t *testing.T) {

--- a/internal/projectors/user_test.go
+++ b/internal/projectors/user_test.go
@@ -1,0 +1,777 @@
+package projectors_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// ============================================================================
+// Pure decoder tests — pin the field defaults that match the deleted
+// PL/pgSQL project_user_event() COALESCE / NULL semantics.
+// ============================================================================
+
+// TestUserCreatedFromEvent_Pure pins the decoder defaults: missing
+// password_hash → "" (drives has_password=false), missing role → "user"
+// (matches PL/pgSQL `COALESCE(role, "user")`), profile fields each
+// default to "", linux_uid → 0.
+func TestUserCreatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.UserCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserCreated", ActorID: "actor",
+			Data: jsonOrFail(t, map[string]any{
+				"email":              "a@b.com",
+				"password_hash":      "hash-1",
+				"role":               "admin",
+				"display_name":       "Alice",
+				"given_name":         "Al",
+				"family_name":        "Ice",
+				"preferred_username": "alice",
+				"picture":            "http://x/pic.jpg",
+				"locale":             "en-US",
+				"linux_username":     "alice",
+				"linux_uid":          1001,
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "u-1", got.ID)
+		assert.Equal(t, "a@b.com", got.Email)
+		assert.Equal(t, "hash-1", got.PasswordHash)
+		assert.Equal(t, "admin", got.Role)
+		assert.Equal(t, "Alice", got.DisplayName)
+		assert.Equal(t, "alice", got.PreferredUsername)
+		assert.Equal(t, "alice", got.LinuxUsername)
+		assert.Equal(t, int32(1001), got.LinuxUID)
+	})
+
+	t.Run("defaults: missing password_hash → '', role → 'user', profile → '', linux_uid → 0", func(t *testing.T) {
+		got, err := projectors.UserCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-2", EventType: "UserCreated",
+			Data: jsonOrFail(t, map[string]any{"email": "x@y.com"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.PasswordHash)
+		assert.Equal(t, "user", got.Role, "missing role must default to 'user'")
+		assert.Equal(t, "", got.DisplayName)
+		assert.Equal(t, "", got.LinuxUsername)
+		assert.Equal(t, int32(0), got.LinuxUID)
+	})
+
+	t.Run("missing email fails", func(t *testing.T) {
+		_, err := projectors.UserCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-3", EventType: "UserCreated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "email")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.UserCreatedFromEvent(store.PersistedEvent{
+			StreamType: "device", EventType: "UserCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.UserCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "UserDisabled",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("malformed payload bytes is a validation error", func(t *testing.T) {
+		_, err := projectors.UserCreatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "UserCreated",
+			Data: []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestUserProfileUpdatedFromEvent_Pure — every profile field defaults
+// to "" when missing (matches PL/pgSQL COALESCE-to-"").
+func TestUserProfileUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.UserProfileUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserProfileUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"display_name":       "Bob",
+				"given_name":         "Bob",
+				"family_name":        "Smith",
+				"preferred_username": "bobby",
+				"picture":            "p",
+				"locale":             "de",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "Bob", got.DisplayName)
+		assert.Equal(t, "Smith", got.FamilyName)
+		assert.Equal(t, "de", got.Locale)
+	})
+
+	t.Run("missing keys default to ''", func(t *testing.T) {
+		got, err := projectors.UserProfileUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserProfileUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.DisplayName)
+		assert.Equal(t, "", got.Locale)
+	})
+
+	t.Run("wrong event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.UserProfileUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "UserCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestUserEmailChangedFromEvent_Pure — email is required.
+func TestUserEmailChangedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.UserEmailChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserEmailChanged",
+			Data: jsonOrFail(t, map[string]any{"email": "new@e.com"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "new@e.com", got.Email)
+	})
+
+	t.Run("missing email fails", func(t *testing.T) {
+		_, err := projectors.UserEmailChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserEmailChanged",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "email")
+	})
+}
+
+// TestUserPasswordChangedFromEvent_Pure — password_hash required.
+func TestUserPasswordChangedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.UserPasswordChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserPasswordChanged",
+			Data: jsonOrFail(t, map[string]any{"password_hash": "h"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "h", got.PasswordHash)
+	})
+
+	t.Run("missing password_hash fails", func(t *testing.T) {
+		_, err := projectors.UserPasswordChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserPasswordChanged",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "password_hash")
+	})
+}
+
+// TestUserRoleChangedFromEvent_Pure — role is required.
+func TestUserRoleChangedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.UserRoleChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserRoleChanged",
+			Data: jsonOrFail(t, map[string]any{"role": "admin"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "admin", got.Role)
+	})
+
+	t.Run("missing role fails", func(t *testing.T) {
+		_, err := projectors.UserRoleChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserRoleChanged",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "role")
+	})
+}
+
+// TestUserSshKeyAddedFromEvent_Pure — key_id required.
+func TestUserSshKeyAddedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.UserSshKeyAddedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserSshKeyAdded",
+			Data: jsonOrFail(t, map[string]any{
+				"key_id":     "k-1",
+				"public_key": "ssh-rsa AAA",
+				"comment":    "laptop",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "k-1", got.KeyID)
+		assert.Equal(t, "ssh-rsa AAA", got.PublicKey)
+		assert.Equal(t, "laptop", got.Comment)
+	})
+
+	t.Run("missing key_id fails", func(t *testing.T) {
+		_, err := projectors.UserSshKeyAddedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserSshKeyAdded",
+			Data: jsonOrFail(t, map[string]any{"public_key": "p"}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "key_id")
+	})
+}
+
+// TestUserSshKeyRemovedFromEvent_Pure — key_id required.
+func TestUserSshKeyRemovedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.UserSshKeyRemovedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserSshKeyRemoved",
+			Data: jsonOrFail(t, map[string]any{"key_id": "k-1"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "k-1", got.KeyID)
+	})
+
+	t.Run("missing key_id fails", func(t *testing.T) {
+		_, err := projectors.UserSshKeyRemovedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserSshKeyRemoved",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "key_id")
+	})
+}
+
+// TestUserSshSettingsUpdatedFromEvent_Pure — every boolean is
+// COALESCE-preserved (nil pointer = "preserve existing"; non-nil =
+// "set"). Empty payload is valid.
+func TestUserSshSettingsUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("explicit values present", func(t *testing.T) {
+		got, err := projectors.UserSshSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserSshSettingsUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"ssh_access_enabled": true,
+				"ssh_allow_pubkey":   false,
+				"ssh_allow_password": true,
+			}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.SshAccessEnabled)
+		assert.True(t, *got.SshAccessEnabled)
+		require.NotNil(t, got.SshAllowPubkey)
+		assert.False(t, *got.SshAllowPubkey)
+		require.NotNil(t, got.SshAllowPassword)
+		assert.True(t, *got.SshAllowPassword)
+	})
+
+	t.Run("missing keys stay nil for SQL COALESCE preserve", func(t *testing.T) {
+		got, err := projectors.UserSshSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserSshSettingsUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.SshAccessEnabled, "missing key must stay nil so SQL COALESCE preserves the existing column")
+		assert.Nil(t, got.SshAllowPubkey)
+		assert.Nil(t, got.SshAllowPassword)
+	})
+}
+
+// TestUserLinuxUsernameChangedFromEvent_Pure — linux_username
+// required (NOT NULL column in the projection schema).
+func TestUserLinuxUsernameChangedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.UserLinuxUsernameChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserLinuxUsernameChanged",
+			Data: jsonOrFail(t, map[string]any{"linux_username": "newname"}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "newname", got.LinuxUsername)
+	})
+
+	t.Run("missing key fails", func(t *testing.T) {
+		_, err := projectors.UserLinuxUsernameChangedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserLinuxUsernameChanged",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "linux_username")
+	})
+}
+
+// TestUserSystemActionLinkedFromEvent_Pure — field required;
+// action_id defaults to "".
+func TestUserSystemActionLinkedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with action_id", func(t *testing.T) {
+		got, err := projectors.UserSystemActionLinkedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserSystemActionLinked",
+			Data: jsonOrFail(t, map[string]any{
+				"field":     projectors.SystemActionFieldTTY,
+				"action_id": "act-tty-1",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, projectors.SystemActionFieldTTY, got.Field)
+		assert.Equal(t, "act-tty-1", got.ActionID)
+	})
+
+	t.Run("missing field fails", func(t *testing.T) {
+		_, err := projectors.UserSystemActionLinkedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserSystemActionLinked",
+			Data: jsonOrFail(t, map[string]any{"action_id": "x"}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field")
+	})
+
+	t.Run("explicit unlink: empty action_id ok", func(t *testing.T) {
+		got, err := projectors.UserSystemActionLinkedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserSystemActionLinked",
+			Data: jsonOrFail(t, map[string]any{
+				"field": projectors.SystemActionFieldUser,
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "", got.ActionID, "missing action_id must default to '' (matches PL/pgSQL COALESCE)")
+	})
+}
+
+// TestUserProvisioningSettingsUpdatedFromEvent_Pure — same
+// COALESCE-preserve shape as SSH settings.
+func TestUserProvisioningSettingsUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("explicit value", func(t *testing.T) {
+		got, err := projectors.UserProvisioningSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserProvisioningSettingsUpdated",
+			Data: jsonOrFail(t, map[string]any{"user_provisioning_enabled": true}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.UserProvisioningEnabled)
+		assert.True(t, *got.UserProvisioningEnabled)
+	})
+
+	t.Run("missing key stays nil for COALESCE preserve", func(t *testing.T) {
+		got, err := projectors.UserProvisioningSettingsUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "user", StreamID: "u-1", EventType: "UserProvisioningSettingsUpdated",
+			Data: jsonOrFail(t, map[string]any{}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.UserProvisioningEnabled)
+	})
+}
+
+// ============================================================================
+// Integration tests — drive the listener via st.AppendEvent and verify
+// the projection lands as expected. Use testutil.SetupPostgres which
+// wires projectors.WireAll.
+// ============================================================================
+
+// createUserViaEvent emits a UserCreated event for the given user id
+// and returns nothing — the seed for every lifecycle test below.
+func createUserViaEvent(t *testing.T, st *store.Store, ctx context.Context, userID, email string) {
+	t.Helper()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserCreated",
+		Data: map[string]any{
+			"email":         email,
+			"password_hash": "hash-seed",
+			"role":          "user",
+		},
+		ActorType: "system", ActorID: "test",
+	}))
+}
+
+// TestUserListener_FullLifecycle drives every event type in sequence
+// against a single user and asserts the projection lands in the right
+// state at every step.
+func TestUserListener_FullLifecycle(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.NewID()
+
+	// 1. Created.
+	createUserViaEvent(t, st, ctx, userID, "alice@e.com")
+	got, err := st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, "alice@e.com", got.Email)
+	assert.True(t, got.HasPassword, "non-empty password_hash must set has_password=true")
+	assert.Equal(t, "user", got.Role)
+	assert.False(t, got.Disabled)
+	assert.Equal(t, int32(0), got.SessionVersion)
+	originalSessionVersion := got.SessionVersion
+
+	// 2. ProfileUpdated — REPLACES the six profile fields.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserProfileUpdated",
+		Data: map[string]any{
+			"display_name":       "Alice",
+			"given_name":         "Al",
+			"family_name":        "Ice",
+			"preferred_username": "alice",
+			"picture":            "p",
+			"locale":             "en-US",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", got.DisplayName)
+	assert.Equal(t, "alice", got.PreferredUsername)
+	assert.Equal(t, "en-US", got.Locale)
+
+	// 3. EmailChanged.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserEmailChanged",
+		Data:      map[string]any{"email": "alice2@e.com"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, "alice2@e.com", got.Email)
+
+	// 4. PasswordChanged — must bump session_version.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserPasswordChanged",
+		Data:      map[string]any{"password_hash": "newhash"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	require.NotNil(t, got.PasswordHash)
+	assert.Equal(t, "newhash", *got.PasswordHash)
+	assert.Greater(t, got.SessionVersion, originalSessionVersion,
+		"UserPasswordChanged must bump session_version monotonically")
+	afterPasswordSessionVersion := got.SessionVersion
+
+	// 5. RoleChanged.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserRoleChanged",
+		Data:      map[string]any{"role": "admin"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, "admin", got.Role)
+
+	// 6. Disabled — must bump session_version and flip disabled=true.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserDisabled",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.True(t, got.Disabled)
+	assert.Greater(t, got.SessionVersion, afterPasswordSessionVersion,
+		"UserDisabled must bump session_version monotonically")
+
+	// 7. Enabled — flip disabled=false (no session_version bump).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserEnabled",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.False(t, got.Disabled)
+
+	// 8. SshKeyAdded.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserSshKeyAdded",
+		Data: map[string]any{
+			"key_id":     "k-1",
+			"public_key": "ssh-rsa AAA",
+			"comment":    "laptop",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.Contains(t, string(got.SshPublicKeys), "k-1")
+	assert.Contains(t, string(got.SshPublicKeys), "ssh-rsa AAA")
+
+	// 9. SshKeyRemoved — drops the matching element.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserSshKeyRemoved",
+		Data:      map[string]any{"key_id": "k-1"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.NotContains(t, string(got.SshPublicKeys), "k-1")
+
+	// 10. SshSettingsUpdated — explicit values.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserSshSettingsUpdated",
+		Data: map[string]any{
+			"ssh_access_enabled": true,
+			"ssh_allow_pubkey":   true,
+			"ssh_allow_password": false,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.True(t, got.SshAccessEnabled)
+	assert.True(t, got.SshAllowPubkey)
+	assert.False(t, got.SshAllowPassword)
+
+	// 11. LinuxUsernameChanged.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserLinuxUsernameChanged",
+		Data:      map[string]any{"linux_username": "alice2"},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, "alice2", got.LinuxUsername)
+
+	// 12. SystemActionLinked — TTY arm only.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserSystemActionLinked",
+		Data: map[string]any{
+			"field":     projectors.SystemActionFieldTTY,
+			"action_id": "act-tty-1",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, "act-tty-1", got.SystemTtyActionID)
+	assert.Equal(t, "", got.SystemUserActionID, "non-targeted column must be preserved as ''")
+	assert.Equal(t, "", got.SystemSshActionID, "non-targeted column must be preserved as ''")
+
+	// 13. SessionInvalidated — bumps session_version.
+	priorSV := got.SessionVersion
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserSessionInvalidated",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.Greater(t, got.SessionVersion, priorSV,
+		"UserSessionInvalidated must bump session_version monotonically")
+
+	// 14. LoggedIn — stamps last_login_at.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserLoggedIn",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	require.NotNil(t, got.LastLoginAt)
+
+	// 15. ProvisioningSettingsUpdated.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserProvisioningSettingsUpdated",
+		Data:      map[string]any{"user_provisioning_enabled": true},
+		ActorType: "user", ActorID: "u",
+	}))
+	got, err = st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.True(t, got.UserProvisioningEnabled)
+
+	// 16. Deleted — soft-delete (GetUserByID filters is_deleted=FALSE
+	// so the row vanishes from this query).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserDeleted",
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+	_, err = st.Queries().GetUserByID(ctx, userID)
+	require.Error(t, err, "GetUserByID filters is_deleted=FALSE; deleted user is gone from this query")
+}
+
+// TestUserListener_SshKeyFilterIsolatesByID locks the JSONB filter
+// semantics: add A → add B → remove A — only B remains.
+func TestUserListener_SshKeyFilterIsolatesByID(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.NewID()
+	createUserViaEvent(t, st, ctx, userID, "ssh@e.com")
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserSshKeyAdded",
+		Data: map[string]any{
+			"key_id": "key-A", "public_key": "AAA", "comment": "a",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserSshKeyAdded",
+		Data: map[string]any{
+			"key_id": "key-B", "public_key": "BBB", "comment": "b",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserSshKeyRemoved",
+		Data:      map[string]any{"key_id": "key-A"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	got, err := st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.NotContains(t, string(got.SshPublicKeys), "key-A",
+		"UserSshKeyRemoved must drop the matching element")
+	assert.Contains(t, string(got.SshPublicKeys), "key-B",
+		"UserSshKeyRemoved must NOT touch other elements")
+}
+
+// TestUserListener_StaleDeleteReplayDoesNotNukeIdentityLinks locks
+// the asymmetric-guard discipline for the cascade-heavy UserDeleted:
+// when the version-guarded SoftDelete affects zero rows, the cascade
+// (identity_links wipe) MUST be skipped. Otherwise an old UserDeleted
+// re-applied later would silently nuke a freshly-restored user's
+// identity links.
+func TestUserListener_StaleDeleteReplayDoesNotNukeIdentityLinks(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.NewID()
+
+	// Need an IdP to satisfy identity_links_projection.provider_id FK.
+	idpID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: idpID,
+		EventType: "IdentityProviderCreated",
+		Data: map[string]any{
+			"name": "test", "slug": "test-" + testutil.NewID(),
+			"client_id": "c", "issuer_url": "https://x.example.com",
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	createUserViaEvent(t, st, ctx, userID, "stale-del@e.com")
+	// Bump projection_version with a profile update so the row's
+	// projection_version is non-zero — gives us room to send an older
+	// stale event.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserProfileUpdated",
+		Data:      map[string]any{"display_name": "Stale"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	live, err := st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+
+	// Plant an identity_link that a stale replay would wrongly nuke.
+	_, err = st.Pool().Exec(ctx,
+		"INSERT INTO identity_links_projection (id, user_id, provider_id, external_id) VALUES ($1, $2, $3, $4)",
+		"link-"+testutil.NewID(), userID, idpID, "ext-stale",
+	)
+	require.NoError(t, err)
+
+	// Drive the listener with a stale UserDeleted.
+	older := live.ProjectionVersion - 5
+	staleAt := *live.CreatedAt
+	listener := projectors.UserListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &older,
+		StreamType:  "user",
+		StreamID:    userID,
+		EventType:   "UserDeleted",
+		Data:        []byte("{}"),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  staleAt,
+	})
+
+	// User still alive.
+	stillAlive, err := st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.False(t, stillAlive.IsDeleted, "stale UserDeleted must NOT flip is_deleted")
+
+	// Identity link still there — cascade was short-circuited by the
+	// SoftDelete returning n == 0.
+	count := 0
+	require.NoError(t, st.Pool().QueryRow(ctx,
+		"SELECT count(*) FROM identity_links_projection WHERE user_id = $1", userID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "stale UserDeleted must NOT cascade-delete identity_links")
+}
+
+// TestUserListener_StaleDisableAfterReEnableKeepsSessionMonotonic
+// locks the session_version monotonic property: a stale UserDisabled
+// replayed AFTER a re-Enable must NOT regress session_version. The
+// guarded UPDATE rejects the stale event outright (n == 0), so
+// neither disabled NOR session_version change.
+func TestUserListener_StaleDisableAfterReEnableKeepsSessionMonotonic(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.NewID()
+	createUserViaEvent(t, st, ctx, userID, "stale-disable@e.com")
+
+	// First Disable — bumps session_version. Capture what we see right
+	// after that so we know the projection_version that the would-be
+	// stale event carries.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserDisabled",
+		Data: map[string]any{}, ActorType: "user", ActorID: "u",
+	}))
+	afterFirstDisable, err := st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	staleVer := afterFirstDisable.ProjectionVersion
+
+	// Real Enable + re-Disable + re-Enable to push session_version up
+	// and the projection_version past the staleVer mark.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserEnabled",
+		Data: map[string]any{}, ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserDisabled",
+		Data: map[string]any{}, ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserEnabled",
+		Data: map[string]any{}, ActorType: "user", ActorID: "u",
+	}))
+
+	live, err := st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	require.False(t, live.Disabled, "user must be re-enabled before stale-replay test")
+	liveSV := live.SessionVersion
+	liveDisabled := live.Disabled
+
+	// Now drive the listener with a STALE UserDisabled whose
+	// projection_version sits below the live row's. The guarded
+	// UPDATE must reject it: neither disabled nor session_version
+	// changes.
+	listener := projectors.UserListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID:          uuid.New(),
+		SequenceNum: &staleVer,
+		StreamType:  "user",
+		StreamID:    userID,
+		EventType:   "UserDisabled",
+		Data:        []byte("{}"),
+		ActorType:   "user",
+		ActorID:     "u",
+		OccurredAt:  *afterFirstDisable.CreatedAt,
+	})
+
+	after, err := st.Queries().GetUserByID(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, liveDisabled, after.Disabled,
+		"stale UserDisabled must NOT regress disabled flag")
+	assert.Equal(t, liveSV, after.SessionVersion,
+		"stale UserDisabled must NOT regress session_version (monotonic)")
+}
+
+// TestUserListener_IgnoresWrongStreamType — defensive: a non-user
+// event must not crash the listener.
+func TestUserListener_IgnoresWrongStreamType(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	listener := projectors.UserListener(st, slog.Default())
+	// Should be a no-op (no panic, no DB call).
+	listener(ctx, store.PersistedEvent{
+		StreamType: "device", StreamID: "d-1", EventType: "DeviceRegistered",
+	})
+}

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -108,17 +108,21 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "device_projector"),
 	))
-	// All 11 ports of tracker #107 are now wired here, plus the
-	// Phase 2 ports landed so far under tracker #136 (action_set,
-	// assignment, user_group, device_group, compliance_policy,
-	// compliance, action+definition, execution, device). One
-	// ActionListener handles both the action and definition stream
+	st.RegisterEventListener(UserListener(
+		st,
+		loggerFor(logger, "user_projector"),
+	))
+	// All 11 ports of tracker #107 are now wired here, plus every
+	// Phase 2 port under tracker #136 (action_set, assignment,
+	// user_group, device_group, compliance_policy, compliance,
+	// action+definition, execution, device, user). With UserListener
+	// landed, every domain projector lives in Go — the cleanup
+	// migration can drop project_event() and the dispatcher trigger.
+	// One ActionListener handles both the action and definition stream
 	// types because DefinitionCreated dispatches across two
 	// projections — synthesise an actions_projection row (when
 	// payload carries `action_type`) OR insert a definitions_projection
 	// row (otherwise) — and splitting would race the two branches.
-	// Future Phase 2 ports of the remaining domain projector (user)
-	// land here too.
 
 	// Rebuild appliers (manchtools/power-manage-server#125). Only
 	// the ported projectors that own a rebuildTarget in
@@ -144,6 +148,7 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 	st.RegisterRebuildApply("definitions", ApplyDefinition)
 	st.RegisterRebuildApply("executions", ApplyExecution)
 	st.RegisterRebuildApply("devices", ApplyDevice)
+	st.RegisterRebuildApply("users", ApplyUser)
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/users.sql.go
+++ b/internal/store/generated/users.sql.go
@@ -7,7 +7,51 @@ package generated
 
 import (
 	"context"
+	"time"
 )
+
+const appendUserSshKeyProjection = `-- name: AppendUserSshKeyProjection :execrows
+UPDATE users_projection
+SET ssh_public_keys = ssh_public_keys || jsonb_build_array(
+        jsonb_build_object(
+            'id', $1::TEXT,
+            'public_key', $2::TEXT,
+            'comment', $3::TEXT,
+            'added_at', $4::TIMESTAMPTZ
+        )
+    ),
+    updated_at         = $4::TIMESTAMPTZ,
+    projection_version = $5
+WHERE id = $6
+  AND projection_version < $5
+`
+
+type AppendUserSshKeyProjectionParams struct {
+	KeyID             string    `json:"key_id"`
+	PublicKey         string    `json:"public_key"`
+	Comment           string    `json:"comment"`
+	AddedAt           time.Time `json:"added_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+	ID                string    `json:"id"`
+}
+
+// UserSshKeyAdded handler. Mirrors the PL/pgSQL JSONB array-append
+// exactly: builds a single-element array and concatenates.
+// Stale-replay guard via projection_version.
+func (q *Queries) AppendUserSshKeyProjection(ctx context.Context, arg AppendUserSshKeyProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, appendUserSshKeyProjection,
+		arg.KeyID,
+		arg.PublicKey,
+		arg.Comment,
+		arg.AddedAt,
+		arg.ProjectionVersion,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
 
 const countUsers = `-- name: CountUsers :one
 SELECT COUNT(*) FROM users_projection
@@ -19,6 +63,73 @@ func (q *Queries) CountUsers(ctx context.Context) (int64, error) {
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const deleteIdentityLinksByUser = `-- name: DeleteIdentityLinksByUser :exec
+DELETE FROM identity_links_projection WHERE user_id = $1
+`
+
+// UserDeleted handler — second half. Cascades the delete to
+// identity_links_projection. Wrapped with SoftDeleteUserProjection
+// in store.WithTx for inter-write atomicity.
+func (q *Queries) DeleteIdentityLinksByUser(ctx context.Context, userID string) error {
+	_, err := q.db.Exec(ctx, deleteIdentityLinksByUser, userID)
+	return err
+}
+
+const disableUserProjection = `-- name: DisableUserProjection :execrows
+UPDATE users_projection
+SET disabled           = TRUE,
+    session_version    = session_version + 1,
+    updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type DisableUserProjectionParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// UserDisabled handler. The session_version + 1 increment is paired
+// with the disabled flag flip inside one guarded UPDATE — a stale
+// Disable replayed after a re-Enable fails the projection_version
+// guard outright (n == 0), so neither disabled NOR session_version
+// regress to the stale value.
+func (q *Queries) DisableUserProjection(ctx context.Context, arg DisableUserProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, disableUserProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const enableUserProjection = `-- name: EnableUserProjection :execrows
+UPDATE users_projection
+SET disabled           = FALSE,
+    updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type EnableUserProjectionParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// UserEnabled handler. Note: no session_version bump on enable
+// (matches PL/pgSQL — only Disable, PasswordChanged, and
+// SessionInvalidated bump it).
+func (q *Queries) EnableUserProjection(ctx context.Context, arg EnableUserProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, enableUserProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const getNextLinuxUID = `-- name: GetNextLinuxUID :one
@@ -132,6 +243,138 @@ func (q *Queries) GetUserSessionInfo(ctx context.Context, id string) (GetUserSes
 	var i GetUserSessionInfoRow
 	err := row.Scan(&i.Disabled, &i.SessionVersion, &i.IsDeleted)
 	return i, err
+}
+
+const insertUserProjection = `-- name: InsertUserProjection :exec
+INSERT INTO users_projection (
+    id, email, password_hash, role,
+    created_at, updated_at, projection_version, session_version, has_password,
+    display_name, given_name, family_name, preferred_username, picture, locale,
+    linux_username, linux_uid
+) VALUES (
+    $1, $2, $3, $4,
+    $5, $5, $6, 0, $7,
+    $8, $9, $10, $11, $12, $13,
+    $14, $15
+)
+`
+
+type InsertUserProjectionParams struct {
+	ID                string     `json:"id"`
+	Email             string     `json:"email"`
+	PasswordHash      *string    `json:"password_hash"`
+	Role              string     `json:"role"`
+	CreatedAt         *time.Time `json:"created_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+	HasPassword       bool       `json:"has_password"`
+	DisplayName       string     `json:"display_name"`
+	GivenName         string     `json:"given_name"`
+	FamilyName        string     `json:"family_name"`
+	PreferredUsername string     `json:"preferred_username"`
+	Picture           string     `json:"picture"`
+	Locale            string     `json:"locale"`
+	LinuxUsername     string     `json:"linux_username"`
+	LinuxUid          int32      `json:"linux_uid"`
+}
+
+// UserCreated handler. Mirrors the PL/pgSQL projector's INSERT with
+// has_password derived from password_hash being non-empty. No
+// ON CONFLICT clause: a duplicate UserCreated must surface as an
+// error so the listener log catches the bug (the reconciler does not
+// replay UserCreated against an existing user).
+func (q *Queries) InsertUserProjection(ctx context.Context, arg InsertUserProjectionParams) error {
+	_, err := q.db.Exec(ctx, insertUserProjection,
+		arg.ID,
+		arg.Email,
+		arg.PasswordHash,
+		arg.Role,
+		arg.CreatedAt,
+		arg.ProjectionVersion,
+		arg.HasPassword,
+		arg.DisplayName,
+		arg.GivenName,
+		arg.FamilyName,
+		arg.PreferredUsername,
+		arg.Picture,
+		arg.Locale,
+		arg.LinuxUsername,
+		arg.LinuxUid,
+	)
+	return err
+}
+
+const invalidateUserSessionProjection = `-- name: InvalidateUserSessionProjection :execrows
+UPDATE users_projection
+SET session_version    = session_version + 1,
+    updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type InvalidateUserSessionProjectionParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// UserSessionInvalidated handler. Same monotonic-bump rationale as
+// UpdateUserPasswordProjection: the guarded UPDATE rejects a stale
+// replay outright so session_version stays monotonic.
+func (q *Queries) InvalidateUserSessionProjection(ctx context.Context, arg InvalidateUserSessionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, invalidateUserSessionProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const linkUserSystemActionProjection = `-- name: LinkUserSystemActionProjection :execrows
+UPDATE users_projection
+SET system_user_action_id = CASE
+        WHEN $1::TEXT = 'system_user_action_id' THEN $2::TEXT
+        ELSE system_user_action_id
+    END,
+    system_ssh_action_id = CASE
+        WHEN $1::TEXT = 'system_ssh_action_id' THEN $2::TEXT
+        ELSE system_ssh_action_id
+    END,
+    system_tty_action_id = CASE
+        WHEN $1::TEXT = 'system_tty_action_id' THEN $2::TEXT
+        ELSE system_tty_action_id
+    END,
+    updated_at         = $3,
+    projection_version = $4
+WHERE id = $5
+  AND projection_version < $4
+`
+
+type LinkUserSystemActionProjectionParams struct {
+	Field             string     `json:"field"`
+	ActionID          string     `json:"action_id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+	ID                string     `json:"id"`
+}
+
+// UserSystemActionLinked handler. Mirrors the PL/pgSQL targeted CASE
+// exactly: only the column matching `field` gets the supplied
+// action_id; the other two columns are preserved. The CASE arms are
+// in SQL (not Go) so the column-write decision atomically lines up
+// with the projection_version guard.
+// Stale-replay guard via projection_version.
+func (q *Queries) LinkUserSystemActionProjection(ctx context.Context, arg LinkUserSystemActionProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, linkUserSystemActionProjection,
+		arg.Field,
+		arg.ActionID,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const listAllNonDeletedUsers = `-- name: ListAllNonDeletedUsers :many
@@ -311,4 +554,340 @@ func (q *Queries) ListUsers(ctx context.Context, arg ListUsersParams) ([]UsersPr
 		return nil, err
 	}
 	return items, nil
+}
+
+const removeUserSshKeyProjection = `-- name: RemoveUserSshKeyProjection :execrows
+UPDATE users_projection
+SET ssh_public_keys = COALESCE((
+        SELECT jsonb_agg(e.value)
+        FROM jsonb_array_elements(ssh_public_keys) AS e(value)
+        WHERE e.value->>'id' != $4::TEXT
+    ), '[]'::JSONB),
+    updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type RemoveUserSshKeyProjectionParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+	KeyID             string     `json:"key_id"`
+}
+
+// UserSshKeyRemoved handler. Mirrors the PL/pgSQL JSONB filter-by-id
+// via subquery exactly — the array filter happens in SQL so we
+// don't read-modify-write the JSONB blob through Go.
+// Stale-replay guard via projection_version.
+func (q *Queries) RemoveUserSshKeyProjection(ctx context.Context, arg RemoveUserSshKeyProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, removeUserSshKeyProjection,
+		arg.ID,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+		arg.KeyID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const softDeleteUserProjection = `-- name: SoftDeleteUserProjection :execrows
+UPDATE users_projection
+SET is_deleted         = TRUE,
+    updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type SoftDeleteUserProjectionParams struct {
+	ID                string     `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// UserDeleted handler — first half. Returns rows-affected so the
+// listener can SHORT-CIRCUIT the cascade DELETE on
+// identity_links_projection when the projection_version guard
+// rejects a stale replay. Otherwise an old UserDeleted re-applied by
+// the reconciler would silently nuke a freshly-restored user's
+// identity links (multi-write asymmetric-guard discipline, CR catch
+// on PR #101 pattern).
+func (q *Queries) SoftDeleteUserProjection(ctx context.Context, arg SoftDeleteUserProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, softDeleteUserProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateUserEmailProjection = `-- name: UpdateUserEmailProjection :execrows
+UPDATE users_projection
+SET email              = $2,
+    updated_at         = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateUserEmailProjectionParams struct {
+	ID                string     `json:"id"`
+	Email             string     `json:"email"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// UserEmailChanged handler. Stale-replay guard via projection_version.
+func (q *Queries) UpdateUserEmailProjection(ctx context.Context, arg UpdateUserEmailProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateUserEmailProjection,
+		arg.ID,
+		arg.Email,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateUserLinuxUsernameProjection = `-- name: UpdateUserLinuxUsernameProjection :execrows
+UPDATE users_projection
+SET linux_username     = $2,
+    updated_at         = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateUserLinuxUsernameProjectionParams struct {
+	ID                string     `json:"id"`
+	LinuxUsername     string     `json:"linux_username"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// UserLinuxUsernameChanged handler. Stale-replay guard via
+// projection_version.
+func (q *Queries) UpdateUserLinuxUsernameProjection(ctx context.Context, arg UpdateUserLinuxUsernameProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateUserLinuxUsernameProjection,
+		arg.ID,
+		arg.LinuxUsername,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateUserLoginProjection = `-- name: UpdateUserLoginProjection :execrows
+UPDATE users_projection
+SET last_login_at      = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+`
+
+type UpdateUserLoginProjectionParams struct {
+	ID                string     `json:"id"`
+	LastLoginAt       *time.Time `json:"last_login_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// UserLoggedIn handler. PL/pgSQL only stamped last_login_at and
+// projection_version (no updated_at touch). Preserve that exactly.
+func (q *Queries) UpdateUserLoginProjection(ctx context.Context, arg UpdateUserLoginProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateUserLoginProjection, arg.ID, arg.LastLoginAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateUserPasswordProjection = `-- name: UpdateUserPasswordProjection :execrows
+UPDATE users_projection
+SET password_hash      = $2,
+    has_password       = TRUE,
+    session_version    = session_version + 1,
+    updated_at         = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateUserPasswordProjectionParams struct {
+	ID                string     `json:"id"`
+	PasswordHash      *string    `json:"password_hash"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// UserPasswordChanged handler. Bumps session_version monotonically as
+// part of the same guarded UPDATE so a stale replay (whose
+// projection_version fails the guard) cannot reset session_version
+// to a stale value — neither password_hash NOR session_version
+// changes when n == 0.
+func (q *Queries) UpdateUserPasswordProjection(ctx context.Context, arg UpdateUserPasswordProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateUserPasswordProjection,
+		arg.ID,
+		arg.PasswordHash,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateUserProfileProjection = `-- name: UpdateUserProfileProjection :execrows
+UPDATE users_projection
+SET display_name       = $2,
+    given_name         = $3,
+    family_name        = $4,
+    preferred_username = $5,
+    picture            = $6,
+    locale             = $7,
+    updated_at         = $8,
+    projection_version = $9
+WHERE id = $1
+  AND projection_version < $9
+`
+
+type UpdateUserProfileProjectionParams struct {
+	ID                string     `json:"id"`
+	DisplayName       string     `json:"display_name"`
+	GivenName         string     `json:"given_name"`
+	FamilyName        string     `json:"family_name"`
+	PreferredUsername string     `json:"preferred_username"`
+	Picture           string     `json:"picture"`
+	Locale            string     `json:"locale"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// UserProfileUpdated handler. Each profile field is a plain string —
+// the decoder expanded missing keys to "" already (matches PL/pgSQL
+// COALESCE-to-""). Stale-replay guard via projection_version.
+func (q *Queries) UpdateUserProfileProjection(ctx context.Context, arg UpdateUserProfileProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateUserProfileProjection,
+		arg.ID,
+		arg.DisplayName,
+		arg.GivenName,
+		arg.FamilyName,
+		arg.PreferredUsername,
+		arg.Picture,
+		arg.Locale,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateUserProvisioningSettingsProjection = `-- name: UpdateUserProvisioningSettingsProjection :execrows
+UPDATE users_projection
+SET user_provisioning_enabled = COALESCE($1::BOOLEAN, user_provisioning_enabled),
+    updated_at                = $2,
+    projection_version        = $3
+WHERE id = $4
+  AND projection_version < $3
+`
+
+type UpdateUserProvisioningSettingsProjectionParams struct {
+	UserProvisioningEnabled *bool      `json:"user_provisioning_enabled"`
+	UpdatedAt               *time.Time `json:"updated_at"`
+	ProjectionVersion       int64      `json:"projection_version"`
+	ID                      string     `json:"id"`
+}
+
+// UserProvisioningSettingsUpdated handler. The single boolean is
+// COALESCE-preserved via sqlc.narg — nil pointer = SQL NULL =
+// preserve existing column. Stale-replay guard via
+// projection_version.
+func (q *Queries) UpdateUserProvisioningSettingsProjection(ctx context.Context, arg UpdateUserProvisioningSettingsProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateUserProvisioningSettingsProjection,
+		arg.UserProvisioningEnabled,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateUserRoleProjection = `-- name: UpdateUserRoleProjection :execrows
+UPDATE users_projection
+SET role               = $2,
+    updated_at         = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateUserRoleProjectionParams struct {
+	ID                string     `json:"id"`
+	Role              string     `json:"role"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// UserRoleChanged handler. Stale-replay guard via projection_version.
+func (q *Queries) UpdateUserRoleProjection(ctx context.Context, arg UpdateUserRoleProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateUserRoleProjection,
+		arg.ID,
+		arg.Role,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const updateUserSshSettingsProjection = `-- name: UpdateUserSshSettingsProjection :execrows
+UPDATE users_projection
+SET ssh_access_enabled = COALESCE($1::BOOLEAN, ssh_access_enabled),
+    ssh_allow_pubkey   = COALESCE($2::BOOLEAN, ssh_allow_pubkey),
+    ssh_allow_password = COALESCE($3::BOOLEAN, ssh_allow_password),
+    updated_at         = $4,
+    projection_version = $5
+WHERE id = $6
+  AND projection_version < $5
+`
+
+type UpdateUserSshSettingsProjectionParams struct {
+	SshAccessEnabled  *bool      `json:"ssh_access_enabled"`
+	SshAllowPubkey    *bool      `json:"ssh_allow_pubkey"`
+	SshAllowPassword  *bool      `json:"ssh_allow_password"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+	ID                string     `json:"id"`
+}
+
+// UserSshSettingsUpdated handler. Each boolean is COALESCE-preserved
+// via sqlc.narg — nil pointer = SQL NULL = preserve existing column.
+// Stale-replay guard via projection_version.
+func (q *Queries) UpdateUserSshSettingsProjection(ctx context.Context, arg UpdateUserSshSettingsProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateUserSshSettingsProjection,
+		arg.SshAccessEnabled,
+		arg.SshAllowPubkey,
+		arg.SshAllowPassword,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }

--- a/internal/store/generated/users.sql.go
+++ b/internal/store/generated/users.sql.go
@@ -28,8 +28,8 @@ WHERE id = $6
 
 type AppendUserSshKeyProjectionParams struct {
 	KeyID             string    `json:"key_id"`
-	PublicKey         string    `json:"public_key"`
-	Comment           string    `json:"comment"`
+	PublicKey         *string   `json:"public_key"`
+	Comment           *string   `json:"comment"`
 	AddedAt           time.Time `json:"added_at"`
 	ProjectionVersion int64     `json:"projection_version"`
 	ID                string    `json:"id"`
@@ -37,6 +37,10 @@ type AppendUserSshKeyProjectionParams struct {
 
 // UserSshKeyAdded handler. Mirrors the PL/pgSQL JSONB array-append
 // exactly: builds a single-element array and concatenates.
+// public_key + comment use sqlc.narg so an omitted-key payload
+// writes JSON null into the JSONB element (PL/pgSQL parity:
+// `event.data->>'public_key'` returned NULL for missing keys, and
+// jsonb_build_object preserves NULL as a JSON null entry).
 // Stale-replay guard via projection_version.
 func (q *Queries) AppendUserSshKeyProjection(ctx context.Context, arg AppendUserSshKeyProjectionParams) (int64, error) {
 	result, err := q.db.Exec(ctx, appendUserSshKeyProjection,

--- a/internal/store/migration_029_test.go
+++ b/internal/store/migration_029_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
@@ -41,54 +40,19 @@ func TestMigration029_TableRenamedAndCommented(t *testing.T) {
 	assert.Contains(t, *comment, "Go projectors",
 		"COMMENT must call out that Go projectors do NOT write here, so an empty table is not 'no projector errors'")
 
-	// End-to-end behavioural assertion. Pinning the rename + COMMENT
-	// catches schema drift but a future edit could still drop a CASE
-	// arm or leave a stale `INSERT INTO projection_errors` somewhere
-	// in project_event() and these checks would pass while the
-	// operator trap silently regressed. Force a PL/pgSQL projector
-	// to raise (duplicate users_projection PK on a second
-	// UserCreated event for the same stream_id) and verify the row
-	// lands in the renamed table — proves the trigger body was
-	// actually rewritten.
-	t.Run("trigger writes failures to the renamed table", func(t *testing.T) {
-		userID := testutil.NewID()
-		require.NoError(t, st.AppendEvent(ctx, store.Event{
-			StreamType: "user",
-			StreamID:   userID,
-			EventType:  "UserCreated",
-			Data: map[string]any{
-				"email":         testutil.NewID() + "@test.example",
-				"password_hash": "h",
-				"role":          "admin",
-			},
-			ActorType: "system",
-			ActorID:   "test",
-		}))
-
-		// Second UserCreated for the same stream_id: the PL/pgSQL
-		// projector tries an INSERT into users_projection and the
-		// PRIMARY KEY violation propagates to project_event()'s
-		// EXCEPTION handler, which writes a row to the renamed
-		// table.
-		require.NoError(t, st.AppendEvent(ctx, store.Event{
-			StreamType: "user",
-			StreamID:   userID,
-			EventType:  "UserCreated",
-			Data: map[string]any{
-				"email":         testutil.NewID() + "@test.example",
-				"password_hash": "h",
-				"role":          "admin",
-			},
-			ActorType: "system",
-			ActorID:   "test",
-		}))
-
-		var n int
-		require.NoError(t, st.Pool().QueryRow(ctx,
-			`SELECT COUNT(*) FROM plpgsql_projection_errors
-			  WHERE stream_type = 'user' AND event_type = 'UserCreated'`,
-		).Scan(&n))
-		assert.GreaterOrEqual(t, n, 1,
-			"project_event() must route PL/pgSQL projector failures to plpgsql_projection_errors after migration 029 — finding zero means a stale INSERT INTO projection_errors slipped past the rewrite")
-	})
+	// End-to-end behavioural assertion historically forced a PL/pgSQL
+	// projector to raise (duplicate users_projection PK on a second
+	// UserCreated event) so the row landed in plpgsql_projection_errors
+	// and we could verify project_event()'s EXCEPTION handler wrote to
+	// the renamed table.
+	//
+	// Removed in #136 along with the user projector port: every
+	// domain projector now lives in Go, every project_<X>_event()
+	// PL/pgSQL function is a no-op stub, so there is no remaining
+	// reproducer that lands in plpgsql_projection_errors via the
+	// dispatcher. Go-listener errors go through slog.Warn, not the
+	// renamed table. The schema-level rename + COMMENT checks above
+	// still pin the operator-trap fix from migration 029; the
+	// follow-up Phase 2 cleanup drops project_event() and this
+	// table-rename concern entirely.
 }

--- a/internal/store/migrations/040_user_projector_to_go.sql
+++ b/internal/store/migrations/040_user_projector_to_go.sql
@@ -1,0 +1,247 @@
+-- Replace project_user_event() with a no-op stub. The actual
+-- projection logic now lives in projectors.UserListener (Go,
+-- post-commit). The shared project_event() dispatcher trigger still
+-- PERFORMs project_user_event(NEW) for every user-stream event;
+-- the no-op stub keeps that dispatch quiet (no
+-- plpgsql_projection_errors entries) until the Phase 2 cleanup
+-- migration drops every still-PL/pgSQL WHEN clause from the
+-- dispatcher.
+--
+-- This is the LAST Phase 2 port under tracker #136. After this lands,
+-- every domain projector lives in Go and the next migration can drop
+-- project_event() and the dispatcher trigger entirely.
+--
+-- Behavioural delta:
+--   - Before: PL/pgSQL projector ran inside the AppendEvent
+--     transaction. The sixteen event types (Created, ProfileUpdated,
+--     EmailChanged, PasswordChanged, RoleChanged, SessionInvalidated,
+--     Disabled, Enabled, LoggedIn, Deleted, SshKeyAdded, SshKeyRemoved,
+--     SshSettingsUpdated, LinuxUsernameChanged, SystemActionLinked,
+--     ProvisioningSettingsUpdated) and the UserDeleted cascade on
+--     identity_links_projection were atomic with the event commit.
+--   - After: Go listener fires post-commit. The multi-write event
+--     (UserDeleted, with its identity_links wipe) wraps its writes
+--     in store.WithTx so the cascade stays atomic with itself, but
+--     not with the event commit. The handler's read-after-write
+--     paths (CreateUser / DisableUser / etc. reading back from
+--     users_projection) still see the projection because
+--     fireListeners is synchronous — the listener has already run by
+--     the time AppendEvent returns.
+--
+-- Tightening: every UPDATE on users_projection now carries an
+-- explicit `WHERE projection_version < $N` guard, rejecting stale
+-- reconciler replays. The PL/pgSQL projector stamped
+-- projection_version without a guard.
+--
+-- Asymmetric-guard discipline (per the role + identity_provider +
+-- action_set + assignment + user_group + device_group +
+-- compliance_policy + compliance + action+definition + execution +
+-- device ports): the guarded SoftDelete uses :execrows, and the
+-- listener short-circuits the cascade (identity_links wipe) when
+-- n == 0 — otherwise a stale UserDeleted re-applied later would
+-- silently nuke a freshly-restored user's identity links.
+--
+-- Session-version monotonicity: PasswordChanged, SessionInvalidated,
+-- and Disabled all bump session_version. The bump is paired with the
+-- other column writes inside ONE guarded UPDATE — a stale Disable
+-- replayed after a re-Enable fails the projection_version guard
+-- outright (n == 0), so neither disabled NOR session_version regress
+-- to the stale value. session_version stays monotonic by construction.
+--
+-- See manchtools/power-manage-server#136. LAST Phase 2 port under
+-- tracker #107's projector-migration pattern.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_event(event events) RETURNS void AS $$
+BEGIN
+    -- No-op: ported to projectors.UserListener. See migration
+    -- comment + the listener wiring in cmd/control/main.go via
+    -- projectors.WireAll.
+    NULL;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- Restore the PL/pgSQL projector verbatim from migration 007 (the
+-- last definition before this port — UserSystemActionLinked extended
+-- to handle system_tty_action_id, the body that was in place when
+-- this port ran).
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION project_user_event(event events) RETURNS void AS $$
+BEGIN
+    CASE event.event_type
+        WHEN 'UserCreated' THEN
+            INSERT INTO users_projection (
+                id, email, password_hash, role, created_at, updated_at, projection_version, session_version, has_password,
+                display_name, given_name, family_name, preferred_username, picture, locale,
+                linux_username, linux_uid
+            ) VALUES (
+                event.stream_id,
+                event.data->>'email',
+                COALESCE(event.data->>'password_hash', ''),
+                COALESCE(event.data->>'role', 'user'),
+                event.occurred_at,
+                event.occurred_at,
+                event.sequence_num,
+                0,
+                COALESCE(NULLIF(event.data->>'password_hash', ''), NULL) IS NOT NULL,
+                COALESCE(event.data->>'display_name', ''),
+                COALESCE(event.data->>'given_name', ''),
+                COALESCE(event.data->>'family_name', ''),
+                COALESCE(event.data->>'preferred_username', ''),
+                COALESCE(event.data->>'picture', ''),
+                COALESCE(event.data->>'locale', ''),
+                COALESCE(event.data->>'linux_username', ''),
+                COALESCE((event.data->>'linux_uid')::INTEGER, 0)
+            );
+
+        WHEN 'UserProfileUpdated' THEN
+            UPDATE users_projection
+            SET display_name = COALESCE(event.data->>'display_name', ''),
+                given_name = COALESCE(event.data->>'given_name', ''),
+                family_name = COALESCE(event.data->>'family_name', ''),
+                preferred_username = COALESCE(event.data->>'preferred_username', ''),
+                picture = COALESCE(event.data->>'picture', ''),
+                locale = COALESCE(event.data->>'locale', ''),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserEmailChanged' THEN
+            UPDATE users_projection
+            SET email = event.data->>'email',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserPasswordChanged' THEN
+            UPDATE users_projection
+            SET password_hash = event.data->>'password_hash',
+                has_password = TRUE,
+                session_version = session_version + 1,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserRoleChanged' THEN
+            UPDATE users_projection
+            SET role = event.data->>'role',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserSessionInvalidated' THEN
+            UPDATE users_projection
+            SET session_version = session_version + 1,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserDisabled' THEN
+            UPDATE users_projection
+            SET disabled = TRUE,
+                session_version = session_version + 1,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserEnabled' THEN
+            UPDATE users_projection
+            SET disabled = FALSE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserLoggedIn' THEN
+            UPDATE users_projection
+            SET last_login_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserDeleted' THEN
+            DELETE FROM identity_links_projection WHERE user_id = event.stream_id;
+
+            UPDATE users_projection
+            SET is_deleted = TRUE,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserSshKeyAdded' THEN
+            UPDATE users_projection
+            SET ssh_public_keys = ssh_public_keys || jsonb_build_array(
+                jsonb_build_object(
+                    'id', event.data->>'key_id',
+                    'public_key', event.data->>'public_key',
+                    'comment', event.data->>'comment',
+                    'added_at', event.occurred_at
+                )
+            ),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserSshKeyRemoved' THEN
+            UPDATE users_projection
+            SET ssh_public_keys = (
+                SELECT COALESCE(jsonb_agg(elem), '[]'::jsonb)
+                FROM jsonb_array_elements(ssh_public_keys) AS elem
+                WHERE elem->>'id' != event.data->>'key_id'
+            ),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserSshSettingsUpdated' THEN
+            UPDATE users_projection
+            SET ssh_access_enabled = COALESCE((event.data->>'ssh_access_enabled')::BOOLEAN, ssh_access_enabled),
+                ssh_allow_pubkey = COALESCE((event.data->>'ssh_allow_pubkey')::BOOLEAN, ssh_allow_pubkey),
+                ssh_allow_password = COALESCE((event.data->>'ssh_allow_password')::BOOLEAN, ssh_allow_password),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserLinuxUsernameChanged' THEN
+            UPDATE users_projection
+            SET linux_username = event.data->>'linux_username',
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserSystemActionLinked' THEN
+            UPDATE users_projection
+            SET system_user_action_id = CASE
+                    WHEN event.data->>'field' = 'system_user_action_id' THEN COALESCE(event.data->>'action_id', '')
+                    ELSE system_user_action_id
+                END,
+                system_ssh_action_id = CASE
+                    WHEN event.data->>'field' = 'system_ssh_action_id' THEN COALESCE(event.data->>'action_id', '')
+                    ELSE system_ssh_action_id
+                END,
+                system_tty_action_id = CASE
+                    WHEN event.data->>'field' = 'system_tty_action_id' THEN COALESCE(event.data->>'action_id', '')
+                    ELSE system_tty_action_id
+                END,
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        WHEN 'UserProvisioningSettingsUpdated' THEN
+            UPDATE users_projection
+            SET user_provisioning_enabled = COALESCE((event.data->>'user_provisioning_enabled')::BOOLEAN, user_provisioning_enabled),
+                updated_at = event.occurred_at,
+                projection_version = event.sequence_num
+            WHERE id = event.stream_id;
+
+        ELSE
+            NULL;
+    END CASE;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/users.sql
+++ b/internal/store/queries/users.sql
@@ -169,20 +169,24 @@ DELETE FROM identity_links_projection WHERE user_id = $1;
 -- name: AppendUserSshKeyProjection :execrows
 -- UserSshKeyAdded handler. Mirrors the PL/pgSQL JSONB array-append
 -- exactly: builds a single-element array and concatenates.
+-- public_key + comment use sqlc.narg so an omitted-key payload
+-- writes JSON null into the JSONB element (PL/pgSQL parity:
+-- `event.data->>'public_key'` returned NULL for missing keys, and
+-- jsonb_build_object preserves NULL as a JSON null entry).
 -- Stale-replay guard via projection_version.
 UPDATE users_projection
 SET ssh_public_keys = ssh_public_keys || jsonb_build_array(
         jsonb_build_object(
-            'id', @key_id::TEXT,
-            'public_key', @public_key::TEXT,
-            'comment', @comment::TEXT,
-            'added_at', @added_at::TIMESTAMPTZ
+            'id', sqlc.arg(key_id)::TEXT,
+            'public_key', sqlc.narg(public_key)::TEXT,
+            'comment', sqlc.narg(comment)::TEXT,
+            'added_at', sqlc.arg(added_at)::TIMESTAMPTZ
         )
     ),
-    updated_at         = @added_at::TIMESTAMPTZ,
-    projection_version = @projection_version
-WHERE id = @id
-  AND projection_version < @projection_version;
+    updated_at         = sqlc.arg(added_at)::TIMESTAMPTZ,
+    projection_version = sqlc.arg(projection_version)
+WHERE id = sqlc.arg(id)
+  AND projection_version < sqlc.arg(projection_version);
 
 -- name: RemoveUserSshKeyProjection :execrows
 -- UserSshKeyRemoved handler. Mirrors the PL/pgSQL JSONB filter-by-id

--- a/internal/store/queries/users.sql
+++ b/internal/store/queries/users.sql
@@ -32,3 +32,230 @@ SELECT nextval('linux_uid_seq')::INTEGER;
 SELECT * FROM users_projection
 WHERE is_deleted = FALSE
 ORDER BY created_at;
+
+-- name: InsertUserProjection :exec
+-- UserCreated handler. Mirrors the PL/pgSQL projector's INSERT with
+-- has_password derived from password_hash being non-empty. No
+-- ON CONFLICT clause: a duplicate UserCreated must surface as an
+-- error so the listener log catches the bug (the reconciler does not
+-- replay UserCreated against an existing user).
+INSERT INTO users_projection (
+    id, email, password_hash, role,
+    created_at, updated_at, projection_version, session_version, has_password,
+    display_name, given_name, family_name, preferred_username, picture, locale,
+    linux_username, linux_uid
+) VALUES (
+    $1, $2, $3, $4,
+    $5, $5, $6, 0, $7,
+    $8, $9, $10, $11, $12, $13,
+    $14, $15
+);
+
+-- name: UpdateUserProfileProjection :execrows
+-- UserProfileUpdated handler. Each profile field is a plain string —
+-- the decoder expanded missing keys to "" already (matches PL/pgSQL
+-- COALESCE-to-""). Stale-replay guard via projection_version.
+UPDATE users_projection
+SET display_name       = $2,
+    given_name         = $3,
+    family_name        = $4,
+    preferred_username = $5,
+    picture            = $6,
+    locale             = $7,
+    updated_at         = $8,
+    projection_version = $9
+WHERE id = $1
+  AND projection_version < $9;
+
+-- name: UpdateUserEmailProjection :execrows
+-- UserEmailChanged handler. Stale-replay guard via projection_version.
+UPDATE users_projection
+SET email              = $2,
+    updated_at         = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: UpdateUserPasswordProjection :execrows
+-- UserPasswordChanged handler. Bumps session_version monotonically as
+-- part of the same guarded UPDATE so a stale replay (whose
+-- projection_version fails the guard) cannot reset session_version
+-- to a stale value — neither password_hash NOR session_version
+-- changes when n == 0.
+UPDATE users_projection
+SET password_hash      = $2,
+    has_password       = TRUE,
+    session_version    = session_version + 1,
+    updated_at         = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: UpdateUserRoleProjection :execrows
+-- UserRoleChanged handler. Stale-replay guard via projection_version.
+UPDATE users_projection
+SET role               = $2,
+    updated_at         = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: InvalidateUserSessionProjection :execrows
+-- UserSessionInvalidated handler. Same monotonic-bump rationale as
+-- UpdateUserPasswordProjection: the guarded UPDATE rejects a stale
+-- replay outright so session_version stays monotonic.
+UPDATE users_projection
+SET session_version    = session_version + 1,
+    updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: DisableUserProjection :execrows
+-- UserDisabled handler. The session_version + 1 increment is paired
+-- with the disabled flag flip inside one guarded UPDATE — a stale
+-- Disable replayed after a re-Enable fails the projection_version
+-- guard outright (n == 0), so neither disabled NOR session_version
+-- regress to the stale value.
+UPDATE users_projection
+SET disabled           = TRUE,
+    session_version    = session_version + 1,
+    updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: EnableUserProjection :execrows
+-- UserEnabled handler. Note: no session_version bump on enable
+-- (matches PL/pgSQL — only Disable, PasswordChanged, and
+-- SessionInvalidated bump it).
+UPDATE users_projection
+SET disabled           = FALSE,
+    updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: UpdateUserLoginProjection :execrows
+-- UserLoggedIn handler. PL/pgSQL only stamped last_login_at and
+-- projection_version (no updated_at touch). Preserve that exactly.
+UPDATE users_projection
+SET last_login_at      = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: SoftDeleteUserProjection :execrows
+-- UserDeleted handler — first half. Returns rows-affected so the
+-- listener can SHORT-CIRCUIT the cascade DELETE on
+-- identity_links_projection when the projection_version guard
+-- rejects a stale replay. Otherwise an old UserDeleted re-applied by
+-- the reconciler would silently nuke a freshly-restored user's
+-- identity links (multi-write asymmetric-guard discipline, CR catch
+-- on PR #101 pattern).
+UPDATE users_projection
+SET is_deleted         = TRUE,
+    updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: DeleteIdentityLinksByUser :exec
+-- UserDeleted handler — second half. Cascades the delete to
+-- identity_links_projection. Wrapped with SoftDeleteUserProjection
+-- in store.WithTx for inter-write atomicity.
+DELETE FROM identity_links_projection WHERE user_id = $1;
+
+-- name: AppendUserSshKeyProjection :execrows
+-- UserSshKeyAdded handler. Mirrors the PL/pgSQL JSONB array-append
+-- exactly: builds a single-element array and concatenates.
+-- Stale-replay guard via projection_version.
+UPDATE users_projection
+SET ssh_public_keys = ssh_public_keys || jsonb_build_array(
+        jsonb_build_object(
+            'id', @key_id::TEXT,
+            'public_key', @public_key::TEXT,
+            'comment', @comment::TEXT,
+            'added_at', @added_at::TIMESTAMPTZ
+        )
+    ),
+    updated_at         = @added_at::TIMESTAMPTZ,
+    projection_version = @projection_version
+WHERE id = @id
+  AND projection_version < @projection_version;
+
+-- name: RemoveUserSshKeyProjection :execrows
+-- UserSshKeyRemoved handler. Mirrors the PL/pgSQL JSONB filter-by-id
+-- via subquery exactly — the array filter happens in SQL so we
+-- don't read-modify-write the JSONB blob through Go.
+-- Stale-replay guard via projection_version.
+UPDATE users_projection
+SET ssh_public_keys = COALESCE((
+        SELECT jsonb_agg(e.value)
+        FROM jsonb_array_elements(ssh_public_keys) AS e(value)
+        WHERE e.value->>'id' != @key_id::TEXT
+    ), '[]'::JSONB),
+    updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3;
+
+-- name: UpdateUserSshSettingsProjection :execrows
+-- UserSshSettingsUpdated handler. Each boolean is COALESCE-preserved
+-- via sqlc.narg — nil pointer = SQL NULL = preserve existing column.
+-- Stale-replay guard via projection_version.
+UPDATE users_projection
+SET ssh_access_enabled = COALESCE(sqlc.narg('ssh_access_enabled')::BOOLEAN, ssh_access_enabled),
+    ssh_allow_pubkey   = COALESCE(sqlc.narg('ssh_allow_pubkey')::BOOLEAN, ssh_allow_pubkey),
+    ssh_allow_password = COALESCE(sqlc.narg('ssh_allow_password')::BOOLEAN, ssh_allow_password),
+    updated_at         = sqlc.arg('updated_at'),
+    projection_version = sqlc.arg('projection_version')
+WHERE id = sqlc.arg('id')
+  AND projection_version < sqlc.arg('projection_version');
+
+-- name: UpdateUserLinuxUsernameProjection :execrows
+-- UserLinuxUsernameChanged handler. Stale-replay guard via
+-- projection_version.
+UPDATE users_projection
+SET linux_username     = $2,
+    updated_at         = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
+-- name: LinkUserSystemActionProjection :execrows
+-- UserSystemActionLinked handler. Mirrors the PL/pgSQL targeted CASE
+-- exactly: only the column matching `field` gets the supplied
+-- action_id; the other two columns are preserved. The CASE arms are
+-- in SQL (not Go) so the column-write decision atomically lines up
+-- with the projection_version guard.
+-- Stale-replay guard via projection_version.
+UPDATE users_projection
+SET system_user_action_id = CASE
+        WHEN @field::TEXT = 'system_user_action_id' THEN @action_id::TEXT
+        ELSE system_user_action_id
+    END,
+    system_ssh_action_id = CASE
+        WHEN @field::TEXT = 'system_ssh_action_id' THEN @action_id::TEXT
+        ELSE system_ssh_action_id
+    END,
+    system_tty_action_id = CASE
+        WHEN @field::TEXT = 'system_tty_action_id' THEN @action_id::TEXT
+        ELSE system_tty_action_id
+    END,
+    updated_at         = @updated_at,
+    projection_version = @projection_version
+WHERE id = @id
+  AND projection_version < @projection_version;
+
+-- name: UpdateUserProvisioningSettingsProjection :execrows
+-- UserProvisioningSettingsUpdated handler. The single boolean is
+-- COALESCE-preserved via sqlc.narg — nil pointer = SQL NULL =
+-- preserve existing column. Stale-replay guard via
+-- projection_version.
+UPDATE users_projection
+SET user_provisioning_enabled = COALESCE(sqlc.narg('user_provisioning_enabled')::BOOLEAN, user_provisioning_enabled),
+    updated_at                = sqlc.arg('updated_at'),
+    projection_version        = sqlc.arg('projection_version')
+WHERE id = sqlc.arg('id')
+  AND projection_version < sqlc.arg('projection_version');

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -108,11 +108,17 @@ type rebuildTarget struct {
 // stay stale.
 var AllRebuildTargets = []rebuildTarget{
 	{
+		// Ported to projectors.ApplyUser via projectors.WireAll
+		// (manchtools/power-manage-server#136). RebuildAll dispatches
+		// through the Go applier; the no-op PL/pgSQL stub left behind
+		// by migration 040 is retained so the live trigger pipeline in
+		// project_event() stays quiet until the dispatcher itself drops
+		// its `WHEN 'user'` clause in the Phase 2 cleanup. This was the
+		// LAST domain projector still on PL/pgSQL.
 		Name:        "users",
 		Tables:      []string{"users_projection"},
 		Cascade:     true,
 		StreamTypes: []string{"user"},
-		Function:    "project_user_event",
 	},
 	{
 		// Ported to projectors.ApplyToken via projectors.WireAll.


### PR DESCRIPTION
## Summary

**Last Phase 2 port under tracker #136.** After this lands, the cleanup migration can drop `project_event()` and the dispatcher trigger entirely (every domain projector will be Go).

Replaces `project_user_event()` with `projectors.UserListener`. 16 event types — biggest single-stream projector under #136:

- `UserCreated` (full row INSERT with all profile + linux fields)
- `UserProfileUpdated` (display_name + given_name + family_name + preferred_username + picture + locale)
- `UserEmailChanged`, `UserPasswordChanged` (bumps session_version), `UserRoleChanged`
- `UserSessionInvalidated`, `UserDisabled` (bumps session_version), `UserEnabled`, `UserLoggedIn`
- `UserDeleted` (cascade DELETE identity_links + soft-delete, wrapped in `store.WithTx`)
- `UserSshKeyAdded` (JSONB array append), `UserSshKeyRemoved` (JSONB array filter via subquery), `UserSshSettingsUpdated` (3 COALESCE-preserve booleans)
- `UserLinuxUsernameChanged`
- `UserSystemActionLinked` (targeted CASE on `field` name)
- `UserProvisioningSettingsUpdated` (COALESCE-preserve)

## Patterns adopted from prior CR review

- **Asymmetric guards** on every UPDATE: `WHERE projection_version < $N` + `:execrows`.
- **UserDeleted cascade** short-circuits the `identity_links` DELETE on `n == 0` (stale-replay safety).
- **session_version bumps are structurally monotonic** — they live inside the same guarded UPDATE as projection_version, so a stale Disable replayed after re-Enable is rejected entirely (neither `disabled` nor `session_version` flip).
- **COALESCE-preserve fields** use `sqlc.narg()` so the decoder's `*bool` flows through as SQL NULL when the payload omits the key.

## Migration / wiring

- Migration `040_user_projector_to_go.sql` no-ops the PL/pgSQL function.
- `WireAll` registers `UserListener` and `RegisterRebuildApply("users", ApplyUser)`.

## Note on issue #135 (compound UserCreatedWithRoles event)

Per user direction (2026-05-09), the `UserCreatedWithRoles` compound event proposed in #135 is intentionally NOT in this port. It ships as a separate 2026.07 enhancement that adds one more case to this Go projector. The current `UserCreated` + N×`UserRoleAssigned` shape is what production event stores already contain, so backward compat is automatic.

## Test removal

`migration_029_test.go`'s "trigger writes failures to the renamed table" subtest is removed because every domain projector is now Go — no remaining reproducer writes to `plpgsql_projection_errors` via the dispatcher. Schema-level rename + COMMENT checks remain to pin migration 029's operator-trap fix.

## Test plan

- [x] Pure decoder tests for every event type.
- [x] Integration tests: full lifecycle (16 events), SSH-key isolation (add A → add B → remove A → only B remains), **stale-replay regression for UserDeleted** (cascade short-circuit), **stale-replay regression for UserDisabled after re-Enable** (session_version monotonicity).
- [x] `gofmt -l`, `go vet ./...`, `staticcheck ./...` all green.
- [x] CR-CLI returned 0 findings before push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved user event processing powering reliable account lifecycle updates: profile, email, password, role, SSH key management, Linux username, system-action links, session and provisioning controls, soft-deletes, and last-login handling.

* **Refactor**
  * Moved user projection handling to the Go-based projector for safer, clearer projection application and replay protection.

* **Tests**
  * Added comprehensive unit and integration tests covering decoders, full user lifecycle, SSH key behaviors, and stale-replay protections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/183)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->