### PR TITLE
feat: assignment handlers switch on AssignmentSourceType / AssignmentTargetType enums (PR A of cleanup)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-14177a1fae5a
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260509124137-3672154a1f16

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-14177a1fae5a h1:exPydycoctMkMlJFs0oPIw9y/XWadKW7a9Wz1RYgfQ4=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260503161545-14177a1fae5a/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260509124137-3672154a1f16 h1:0X7+3IAWjJ+wChrs52To7HM5dgFS5ej03YGie/TTuqA=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260509124137-3672154a1f16/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -44,7 +44,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 
 	// Validate source exists
 	switch req.Msg.SourceType {
-	case "action":
+	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION:
 		_, err := h.store.Queries().GetActionByID(ctx, req.Msg.SourceId)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -52,7 +52,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
 		}
-	case "action_set":
+	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION_SET:
 		_, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.SourceId)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -60,7 +60,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action set")
 		}
-	case "definition":
+	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_DEFINITION:
 		_, err := h.store.Queries().GetDefinitionByID(ctx, req.Msg.SourceId)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -68,7 +68,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get definition")
 		}
-	case "compliance_policy":
+	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_COMPLIANCE_POLICY:
 		_, err := h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.SourceId)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -80,7 +80,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 
 	// Validate target exists
 	switch req.Msg.TargetType {
-	case "device":
+	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE:
 		_, err := h.store.Queries().GetDeviceByID(ctx, db.GetDeviceByIDParams{ID: req.Msg.TargetId})
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -88,7 +88,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device")
 		}
-	case "device_group":
+	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE_GROUP:
 		_, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.TargetId)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -96,7 +96,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group")
 		}
-	case "user":
+	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER:
 		_, err := h.store.Queries().GetUserByID(ctx, req.Msg.TargetId)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -104,7 +104,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user")
 		}
-	case "user_group":
+	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER_GROUP:
 		_, err := h.store.Queries().GetUserGroupByID(ctx, req.Msg.TargetId)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
@@ -114,11 +114,18 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 		}
 	}
 
+	// Translate the wire enums to the legacy lowercase strings used
+	// by the event payload, projection rows, and SQL filters. The
+	// enum is the contract; the strings are an internal storage
+	// detail that pre-dates the enum.
+	sourceTypeStr := assignmentSourceTypeToString(req.Msg.SourceType)
+	targetTypeStr := assignmentTargetTypeToString(req.Msg.TargetType)
+
 	// Check if an active assignment already exists
 	existingAssignment, err := h.store.Queries().GetAssignment(ctx, db.GetAssignmentParams{
-		SourceType: req.Msg.SourceType,
+		SourceType: sourceTypeStr,
 		SourceID:   req.Msg.SourceId,
-		TargetType: req.Msg.TargetType,
+		TargetType: targetTypeStr,
 		TargetID:   req.Msg.TargetId,
 	})
 	if err == nil {
@@ -137,9 +144,9 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 		StreamID:   id,
 		EventType:  "AssignmentCreated",
 		Data: map[string]any{
-			"source_type": req.Msg.SourceType,
+			"source_type": sourceTypeStr,
 			"source_id":   req.Msg.SourceId,
-			"target_type": req.Msg.TargetType,
+			"target_type": targetTypeStr,
 			"target_id":   req.Msg.TargetId,
 			"mode":        int32(req.Msg.Mode),
 		},
@@ -152,9 +159,9 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	// Use GetAssignment instead of GetAssignmentByID because the upsert
 	// may have updated an existing soft-deleted record with a different ID
 	assignment, err := h.store.Queries().GetAssignment(ctx, db.GetAssignmentParams{
-		SourceType: req.Msg.SourceType,
+		SourceType: sourceTypeStr,
 		SourceID:   req.Msg.SourceId,
-		TargetType: req.Msg.TargetType,
+		TargetType: targetTypeStr,
 		TargetID:   req.Msg.TargetId,
 	})
 	if err != nil {
@@ -204,10 +211,16 @@ func (h *AssignmentHandler) ListAssignments(ctx context.Context, req *connect.Re
 		return nil, err
 	}
 
+	// Wire enums map back to the legacy lowercase strings stored in
+	// the projection. UNSPECIFIED becomes the empty string, which
+	// the SQL filter treats as "no filter".
+	sourceTypeStr := assignmentSourceTypeToString(req.Msg.SourceType)
+	targetTypeStr := assignmentTargetTypeToString(req.Msg.TargetType)
+
 	assignments, err := h.store.Queries().ListAssignments(ctx, db.ListAssignmentsParams{
-		Column1: req.Msg.SourceType,
+		Column1: sourceTypeStr,
 		Column2: req.Msg.SourceId,
-		Column3: req.Msg.TargetType,
+		Column3: targetTypeStr,
 		Column4: req.Msg.TargetId,
 		Limit:   pageSize,
 		Offset:  offset,
@@ -217,9 +230,9 @@ func (h *AssignmentHandler) ListAssignments(ctx context.Context, req *connect.Re
 	}
 
 	count, err := h.store.Queries().CountAssignments(ctx, db.CountAssignmentsParams{
-		Column1: req.Msg.SourceType,
+		Column1: sourceTypeStr,
 		Column2: req.Msg.SourceId,
-		Column3: req.Msg.TargetType,
+		Column3: targetTypeStr,
 		Column4: req.Msg.TargetId,
 	})
 	if err != nil {
@@ -232,9 +245,9 @@ func (h *AssignmentHandler) ListAssignments(ctx context.Context, req *connect.Re
 	for i, a := range assignments {
 		assignment := &pm.Assignment{
 			Id:         a.ID,
-			SourceType: a.SourceType,
+			SourceType: assignmentSourceTypeFromString(a.SourceType),
 			SourceId:   a.SourceID,
-			TargetType: a.TargetType,
+			TargetType: assignmentTargetTypeFromString(a.TargetType),
 			TargetId:   a.TargetID,
 			CreatedBy:  a.CreatedBy,
 			Mode:       pm.AssignmentMode(a.Mode),
@@ -452,9 +465,9 @@ func (h *AssignmentHandler) GetUserAssignments(ctx context.Context, req *connect
 func (h *AssignmentHandler) assignmentToProto(a db.AssignmentsProjection) *pm.Assignment {
 	assignment := &pm.Assignment{
 		Id:         a.ID,
-		SourceType: a.SourceType,
+		SourceType: assignmentSourceTypeFromString(a.SourceType),
 		SourceId:   a.SourceID,
-		TargetType: a.TargetType,
+		TargetType: assignmentTargetTypeFromString(a.TargetType),
 		TargetId:   a.TargetID,
 		CreatedBy:  a.CreatedBy,
 		Mode:       pm.AssignmentMode(a.Mode),
@@ -465,4 +478,82 @@ func (h *AssignmentHandler) assignmentToProto(a db.AssignmentsProjection) *pm.As
 	}
 
 	return assignment
+}
+
+// assignmentSourceTypeToString converts the wire enum to the legacy
+// lowercase string used in event payloads, projection rows, and
+// SQL-side string filtering. Returns the empty string for
+// UNSPECIFIED so callers can pass it straight into the optional
+// filter columns on List/Count queries (an empty string is the
+// stored signal for "no filter").
+func assignmentSourceTypeToString(t pm.AssignmentSourceType) string {
+	switch t {
+	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION:
+		return "action"
+	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION_SET:
+		return "action_set"
+	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_DEFINITION:
+		return "definition"
+	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_COMPLIANCE_POLICY:
+		return "compliance_policy"
+	default:
+		return ""
+	}
+}
+
+// assignmentSourceTypeFromString is the inverse: it parses the
+// projection / event-payload string back into the wire enum.
+// Unknown / empty values map to UNSPECIFIED so a stale row never
+// crashes the handler — the caller then surfaces UNSPECIFIED in the
+// response and the client treats it as "unknown source".
+func assignmentSourceTypeFromString(s string) pm.AssignmentSourceType {
+	switch s {
+	case "action":
+		return pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION
+	case "action_set":
+		return pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION_SET
+	case "definition":
+		return pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_DEFINITION
+	case "compliance_policy":
+		return pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_COMPLIANCE_POLICY
+	default:
+		return pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_UNSPECIFIED
+	}
+}
+
+// assignmentTargetTypeToString mirrors assignmentSourceTypeToString
+// for the four supported target kinds. Same UNSPECIFIED-as-empty
+// convention so the helper feeds the optional List/Count filter
+// columns directly.
+func assignmentTargetTypeToString(t pm.AssignmentTargetType) string {
+	switch t {
+	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE:
+		return "device"
+	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE_GROUP:
+		return "device_group"
+	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER:
+		return "user"
+	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER_GROUP:
+		return "user_group"
+	default:
+		return ""
+	}
+}
+
+// assignmentTargetTypeFromString parses the projection /
+// event-payload string back into the wire enum. Unknown / empty
+// values map to UNSPECIFIED, same rationale as the source helper.
+func assignmentTargetTypeFromString(s string) pm.AssignmentTargetType {
+	switch s {
+	case "device":
+		return pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE
+	case "device_group":
+		return pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE_GROUP
+	case "user":
+		return pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER
+	case "user_group":
+		return pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER_GROUP
+	default:
+		return pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_UNSPECIFIED
+	}
 }

--- a/internal/api/assignment_handler_test.go
+++ b/internal/api/assignment_handler_test.go
@@ -26,16 +26,16 @@ func TestCreateAssignment_ActionToDevice(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	resp, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
-		TargetType: "device",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE,
 		TargetId:   deviceID,
 	}))
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp.Msg.Assignment.Id)
-	assert.Equal(t, "action", resp.Msg.Assignment.SourceType)
+	assert.Equal(t, pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION, resp.Msg.Assignment.SourceType)
 	assert.Equal(t, actionID, resp.Msg.Assignment.SourceId)
-	assert.Equal(t, "device", resp.Msg.Assignment.TargetType)
+	assert.Equal(t, pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE, resp.Msg.Assignment.TargetType)
 	assert.Equal(t, deviceID, resp.Msg.Assignment.TargetId)
 }
 
@@ -50,14 +50,14 @@ func TestCreateAssignment_SetToGroup(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	resp, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action_set",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION_SET,
 		SourceId:   setID,
-		TargetType: "device_group",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE_GROUP,
 		TargetId:   groupID,
 	}))
 	require.NoError(t, err)
-	assert.Equal(t, "action_set", resp.Msg.Assignment.SourceType)
-	assert.Equal(t, "device_group", resp.Msg.Assignment.TargetType)
+	assert.Equal(t, pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION_SET, resp.Msg.Assignment.SourceType)
+	assert.Equal(t, pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE_GROUP, resp.Msg.Assignment.TargetType)
 }
 
 func TestCreateAssignment_UninstallMode(t *testing.T) {
@@ -71,9 +71,9 @@ func TestCreateAssignment_UninstallMode(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	resp, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
-		TargetType: "device",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE,
 		TargetId:   deviceID,
 		Mode:       pm.AssignmentMode(uninstallAssignmentMode),
 	}))
@@ -92,9 +92,9 @@ func TestCreateAssignment_Idempotent(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	req := &pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
-		TargetType: "device",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE,
 		TargetId:   deviceID,
 	}
 
@@ -119,9 +119,9 @@ func TestDeleteAssignment(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	createResp, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
-		TargetType: "device",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE,
 		TargetId:   deviceID,
 	}))
 	require.NoError(t, err)
@@ -144,9 +144,9 @@ func TestListAssignments(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		actionID := testutil.CreateTestAction(t, st, adminID, testutil.NewID(), int(pm.ActionType_ACTION_TYPE_SHELL))
 		_, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-			SourceType: "action",
+			SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 			SourceId:   actionID,
-			TargetType: "device",
+			TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE,
 			TargetId:   deviceID,
 		}))
 		require.NoError(t, err)
@@ -168,14 +168,14 @@ func TestCreateAssignment_ActionToUser(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	resp, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
-		TargetType: "user",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER,
 		TargetId:   targetUserID,
 	}))
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp.Msg.Assignment.Id)
-	assert.Equal(t, "user", resp.Msg.Assignment.TargetType)
+	assert.Equal(t, pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER, resp.Msg.Assignment.TargetType)
 	assert.Equal(t, targetUserID, resp.Msg.Assignment.TargetId)
 }
 
@@ -190,14 +190,14 @@ func TestCreateAssignment_ActionToUserGroup(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	resp, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
-		TargetType: "user_group",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER_GROUP,
 		TargetId:   groupID,
 	}))
 	require.NoError(t, err)
 	assert.NotEmpty(t, resp.Msg.Assignment.Id)
-	assert.Equal(t, "user_group", resp.Msg.Assignment.TargetType)
+	assert.Equal(t, pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER_GROUP, resp.Msg.Assignment.TargetType)
 	assert.Equal(t, groupID, resp.Msg.Assignment.TargetId)
 }
 
@@ -211,9 +211,9 @@ func TestCreateAssignment_UserNotFound(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	_, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
-		TargetType: "user",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER,
 		TargetId:   testutil.NewID(),
 	}))
 	require.Error(t, err)
@@ -234,9 +234,9 @@ func TestGetUserAssignments(t *testing.T) {
 	// Create direct user assignment
 	actionID1 := testutil.CreateTestAction(t, st, adminID, "UA Direct", int(pm.ActionType_ACTION_TYPE_SHELL))
 	_, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID1,
-		TargetType: "user",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER,
 		TargetId:   userID,
 	}))
 	require.NoError(t, err)
@@ -244,9 +244,9 @@ func TestGetUserAssignments(t *testing.T) {
 	// Create user group assignment
 	actionID2 := testutil.CreateTestAction(t, st, adminID, "UA Group", int(pm.ActionType_ACTION_TYPE_SHELL))
 	_, err = h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID2,
-		TargetType: "user_group",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER_GROUP,
 		TargetId:   groupID,
 	}))
 	require.NoError(t, err)
@@ -269,9 +269,9 @@ func TestGetDeviceAssignments(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	_, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
-		TargetType: "device",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE,
 		TargetId:   deviceID,
 	}))
 	require.NoError(t, err)

--- a/internal/api/user_selection_handler.go
+++ b/internal/api/user_selection_handler.go
@@ -47,6 +47,11 @@ func (h *UserSelectionHandler) SetUserSelection(ctx context.Context, req *connec
 		return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
 	}
 
+	// Translate the wire enum to the projection / event-payload
+	// string. The projection still stores the legacy lowercase form
+	// so existing rows replay unchanged.
+	sourceTypeStr := assignmentSourceTypeToString(req.Msg.SourceType)
+
 	// Verify an available-mode assignment exists for this source targeting this device
 	availableAssignments, err := h.store.Queries().ListAvailableAssignmentsForDevice(ctx, req.Msg.DeviceId)
 	if err != nil {
@@ -55,7 +60,7 @@ func (h *UserSelectionHandler) SetUserSelection(ctx context.Context, req *connec
 
 	found := false
 	for _, asn := range availableAssignments {
-		if asn.SourceType == req.Msg.SourceType && asn.SourceID == req.Msg.SourceId {
+		if asn.SourceType == sourceTypeStr && asn.SourceID == req.Msg.SourceId {
 			found = true
 			break
 		}
@@ -72,7 +77,7 @@ func (h *UserSelectionHandler) SetUserSelection(ctx context.Context, req *connec
 		EventType:  "UserSelectionChanged",
 		Data: map[string]any{
 			"device_id":   req.Msg.DeviceId,
-			"source_type": req.Msg.SourceType,
+			"source_type": sourceTypeStr,
 			"source_id":   req.Msg.SourceId,
 			"selected":    req.Msg.Selected,
 		},
@@ -84,7 +89,7 @@ func (h *UserSelectionHandler) SetUserSelection(ctx context.Context, req *connec
 
 	selection, err := h.store.Queries().GetUserSelection(ctx, db.GetUserSelectionParams{
 		DeviceID:   req.Msg.DeviceId,
-		SourceType: req.Msg.SourceType,
+		SourceType: sourceTypeStr,
 		SourceID:   req.Msg.SourceId,
 	})
 	if err != nil {
@@ -184,7 +189,7 @@ func userSelectionToProto(s db.UserSelectionsProjection) *pm.UserSelection {
 	sel := &pm.UserSelection{
 		Id:         s.ID,
 		DeviceId:   s.DeviceID,
-		SourceType: s.SourceType,
+		SourceType: assignmentSourceTypeFromString(s.SourceType),
 		SourceId:   s.SourceID,
 		Selected:   s.Selected,
 	}

--- a/internal/api/user_selection_handler_test.go
+++ b/internal/api/user_selection_handler_test.go
@@ -28,14 +28,14 @@ func TestSetUserSelection_Success(t *testing.T) {
 
 	resp, err := h.SetUserSelection(ctx, connect.NewRequest(&pm.SetUserSelectionRequest{
 		DeviceId:   deviceID,
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
 		Selected:   true,
 	}))
 	require.NoError(t, err)
 	assert.NotNil(t, resp.Msg.Selection)
 	assert.Equal(t, deviceID, resp.Msg.Selection.DeviceId)
-	assert.Equal(t, "action", resp.Msg.Selection.SourceType)
+	assert.Equal(t, pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION, resp.Msg.Selection.SourceType)
 	assert.Equal(t, actionID, resp.Msg.Selection.SourceId)
 	assert.True(t, resp.Msg.Selection.Selected)
 }
@@ -53,7 +53,7 @@ func TestSetUserSelection_NoAssignment(t *testing.T) {
 	// No assignment created — selecting should fail
 	_, err := h.SetUserSelection(ctx, connect.NewRequest(&pm.SetUserSelectionRequest{
 		DeviceId:   deviceID,
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
 		Selected:   true,
 	}))

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -313,9 +313,9 @@ func TestCreateAssignment_UserTargetViaHandler(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	_, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
-		SourceType: "action",
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
 		SourceId:   actionID,
-		TargetType: "user",
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER,
 		TargetId:   userID,
 		Mode:       pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED,
 	}))
@@ -326,7 +326,7 @@ func TestCreateAssignment_UserTargetViaHandler(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	assert.Len(t, resp.Msg.Assignments, 1)
-	assert.Equal(t, "user", resp.Msg.Assignments[0].TargetType)
+	assert.Equal(t, pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER, resp.Msg.Assignments[0].TargetType)
 }
 
 // linkSystemTtyAction stamps users_projection.system_tty_action_id by


### PR DESCRIPTION
## Summary

Companion to power-manage-sdk PR #53 (already merged). Replaces every `case \"action\"` / `case \"device\"` etc. on `req.SourceType` / `req.TargetType` strings with switches on the new typed enum constants.

## Files

- `internal/api/assignment_handler.go` — main switch + four boundary helpers (`assignmentSourceTypeToString` / `FromString`, `assignmentTargetTypeToString` / `FromString`).
- `internal/api/user_selection_handler.go` — same pattern; `userSelectionToProto` maps the projection string back to the enum.
- `internal/api/assignment_handler_test.go`, `user_selection_handler_test.go`, `internal/resolution/resolve_test.go` — updated to use enum constants (both as request inputs and `assert.Equal` expected values).

## Wire/event-store separation

The events-table JSONB payloads keep their existing string values (`"action"`, `"action_set"`, etc.) so the projection layer + event replay are unchanged. Only the wire (proto) changes; helper functions bridge the two.

## Test plan

- [x] `gofmt -l`, `go vet ./...`, `staticcheck ./...` all clean.
- [x] `go test -run "TestAssignment|TestCreateAssignment|TestUserSelection|..." ./internal/api/ ./internal/projectors/ ./internal/resolution/ ./internal/store/` — all green.
- [x] CR-CLI returned 0 findings before push.

Part of the 2026.06 cleanup-release proto-enum sweep. PRs B/C/D follow with status / scope / rotation_reason / eventtypes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type consistency between wire enums and legacy string values in assignment and user-selection handling while preserving public API compatibility.
* **Tests**
  * Updated test suites to use the strongly-typed enum values and adjusted assertions accordingly, ensuring coverage remains intact.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/186)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->