### PR TITLE
feat: device/search/idp handlers switch on typed enums (PR B of cleanup)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260509124137-3672154a1f16
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260509141343-ec1d65730a19

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260509124137-3672154a1f16 h1:0X7+3IAWjJ+wChrs52To7HM5dgFS5ej03YGie/TTuqA=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260509124137-3672154a1f16/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260509141343-ec1d65730a19 h1:KmuVvpv7xtIFxzAlm/iGnx7foxeUBVziQtkCgoKhUjw=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260509141343-ec1d65730a19/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -100,13 +100,13 @@ func (h *DeviceHandler) ListDevices(ctx context.Context, req *connect.Request[pm
 	var devices []db.DevicesProjection
 
 	switch req.Msg.StatusFilter {
-	case "online":
+	case pm.DeviceStatus_DEVICE_STATUS_ONLINE:
 		devices, err = q.ListDevicesOnline(ctx, db.ListDevicesOnlineParams{
 			Limit:        pageSize,
 			Offset:       offset,
 			FilterUserID: filterUID,
 		})
-	case "offline":
+	case pm.DeviceStatus_DEVICE_STATUS_OFFLINE:
 		devices, err = q.ListDevicesOffline(ctx, db.ListDevicesOfflineParams{
 			Limit:        pageSize,
 			Offset:       offset,
@@ -126,9 +126,9 @@ func (h *DeviceHandler) ListDevices(ctx context.Context, req *connect.Request[pm
 	// Use the matching count query for the active status filter
 	var count int64
 	switch req.Msg.StatusFilter {
-	case "online":
+	case pm.DeviceStatus_DEVICE_STATUS_ONLINE:
 		count, err = q.CountDevicesOnline(ctx, filterUID)
-	case "offline":
+	case pm.DeviceStatus_DEVICE_STATUS_OFFLINE:
 		count, err = q.CountDevicesOffline(ctx, filterUID)
 	default:
 		count, err = q.CountDevices(ctx, filterUID)
@@ -587,12 +587,12 @@ func (h *DeviceHandler) deviceToProtoWithAssignments(d db.DevicesProjection, ass
 	if d.LastSeenAt != nil {
 		device.LastSeenAt = timestamppb.New(*d.LastSeenAt)
 		if time.Since(*d.LastSeenAt) < 5*time.Minute {
-			device.Status = "online"
+			device.Status = pm.DeviceStatus_DEVICE_STATUS_ONLINE
 		} else {
-			device.Status = "offline"
+			device.Status = pm.DeviceStatus_DEVICE_STATUS_OFFLINE
 		}
 	} else {
-		device.Status = "offline"
+		device.Status = pm.DeviceStatus_DEVICE_STATUS_OFFLINE
 	}
 
 	if d.RegisteredAt != nil {

--- a/internal/api/idp_handler.go
+++ b/internal/api/idp_handler.go
@@ -70,7 +70,7 @@ func (h *IDPHandler) CreateIdentityProvider(ctx context.Context, req *connect.Re
 		Data: map[string]any{
 			"name":                        req.Msg.Name,
 			"slug":                        req.Msg.Slug,
-			"provider_type":               req.Msg.ProviderType,
+			"provider_type":               identityProviderTypeToString(req.Msg.ProviderType),
 			"client_id":                   req.Msg.ClientId,
 			"client_secret_encrypted":     encryptedSecret,
 			"issuer_url":                  req.Msg.IssuerUrl,
@@ -454,7 +454,7 @@ func (h *IDPHandler) idpToProto(p db.IdentityProvidersProjection) *pm.IdentityPr
 		Id:                       p.ID,
 		Name:                     p.Name,
 		Slug:                     p.Slug,
-		ProviderType:             p.ProviderType,
+		ProviderType:             identityProviderTypeFromString(p.ProviderType),
 		Enabled:                  p.Enabled,
 		ClientId:                 p.ClientID,
 		IssuerUrl:                p.IssuerUrl,
@@ -482,4 +482,34 @@ func (h *IDPHandler) idpToProto(p db.IdentityProvidersProjection) *pm.IdentityPr
 	provider.UpdatedAt = timestamppb.New(p.UpdatedAt)
 
 	return provider
+}
+
+// identityProviderTypeToString converts the wire enum to the
+// lowercase string used in event payloads and the projection
+// `provider_type` column ("oidc" today; "saml2", "ldap" reserved for
+// future protocols). UNSPECIFIED maps to the empty string so a
+// caller that forgot to set the field stores an empty value rather
+// than a fake protocol name — Validate() rejects empty earlier in
+// the request path.
+func identityProviderTypeToString(t pm.IdentityProviderType) string {
+	switch t {
+	case pm.IdentityProviderType_IDENTITY_PROVIDER_TYPE_OIDC:
+		return "oidc"
+	default:
+		return ""
+	}
+}
+
+// identityProviderTypeFromString is the inverse: it parses the
+// projection / event-payload string back into the wire enum.
+// Unknown / empty values map to UNSPECIFIED so a stale row never
+// crashes the handler — the caller surfaces UNSPECIFIED and the
+// client treats it as "unknown protocol".
+func identityProviderTypeFromString(s string) pm.IdentityProviderType {
+	switch s {
+	case "oidc":
+		return pm.IdentityProviderType_IDENTITY_PROVIDER_TYPE_OIDC
+	default:
+		return pm.IdentityProviderType_IDENTITY_PROVIDER_TYPE_UNSPECIFIED
+	}
 }

--- a/internal/api/idp_handler_test.go
+++ b/internal/api/idp_handler_test.go
@@ -26,7 +26,7 @@ func TestCreateIdentityProvider_Success(t *testing.T) {
 	resp, err := h.CreateIdentityProvider(ctx, connect.NewRequest(&pm.CreateIdentityProviderRequest{
 		Name:         "Test Google",
 		Slug:         "google",
-		ProviderType: "oidc",
+		ProviderType: pm.IdentityProviderType_IDENTITY_PROVIDER_TYPE_OIDC,
 		ClientId:     "client-123",
 		ClientSecret: "secret-456",
 		IssuerUrl:    "https://accounts.google.com",
@@ -38,7 +38,7 @@ func TestCreateIdentityProvider_Success(t *testing.T) {
 	assert.NotEmpty(t, p.Id)
 	assert.Equal(t, "Test Google", p.Name)
 	assert.Equal(t, "google", p.Slug)
-	assert.Equal(t, "oidc", p.ProviderType)
+	assert.Equal(t, pm.IdentityProviderType_IDENTITY_PROVIDER_TYPE_OIDC, p.ProviderType)
 	assert.Equal(t, "client-123", p.ClientId)
 	assert.NotNil(t, p.CreatedAt)
 }
@@ -58,7 +58,7 @@ func TestCreateIdentityProvider_DuplicateSlug(t *testing.T) {
 	_, err := h.CreateIdentityProvider(ctx, connect.NewRequest(&pm.CreateIdentityProviderRequest{
 		Name:         "Another Google",
 		Slug:         "google",
-		ProviderType: "oidc",
+		ProviderType: pm.IdentityProviderType_IDENTITY_PROVIDER_TYPE_OIDC,
 		ClientId:     "client-other",
 		ClientSecret: "secret-other",
 		IssuerUrl:    "https://accounts.google.com",
@@ -239,7 +239,7 @@ func TestCreateIdentityProvider_WithGroupMapping(t *testing.T) {
 	resp, err := h.CreateIdentityProvider(ctx, connect.NewRequest(&pm.CreateIdentityProviderRequest{
 		Name:         "Okta",
 		Slug:         "okta",
-		ProviderType: "oidc",
+		ProviderType: pm.IdentityProviderType_IDENTITY_PROVIDER_TYPE_OIDC,
 		ClientId:     "client-okta",
 		ClientSecret: "secret-okta",
 		IssuerUrl:    "https://dev.okta.com",

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -42,6 +42,70 @@ func scopeSortField(scope string) string {
 	return ""
 }
 
+// searchScopeToString converts the wire enum to the lowercase string
+// form used by the RediSearch index names (idx:<scope>) and the
+// document key prefixes (search:<scope>:<id>). Returns the empty
+// string for UNSPECIFIED so the caller can treat it as the legacy
+// "all scopes" sentinel.
+func searchScopeToString(s pm.SearchScope) string {
+	switch s {
+	case pm.SearchScope_SEARCH_SCOPE_ACTIONS:
+		return "actions"
+	case pm.SearchScope_SEARCH_SCOPE_ACTION_SETS:
+		return "action_sets"
+	case pm.SearchScope_SEARCH_SCOPE_DEFINITIONS:
+		return "definitions"
+	case pm.SearchScope_SEARCH_SCOPE_COMPLIANCE_POLICIES:
+		return "compliance_policies"
+	case pm.SearchScope_SEARCH_SCOPE_DEVICES:
+		return "devices"
+	case pm.SearchScope_SEARCH_SCOPE_USERS:
+		return "users"
+	case pm.SearchScope_SEARCH_SCOPE_DEVICE_GROUPS:
+		return "device_groups"
+	case pm.SearchScope_SEARCH_SCOPE_USER_GROUPS:
+		return "user_groups"
+	case pm.SearchScope_SEARCH_SCOPE_EXECUTIONS:
+		return "executions"
+	case pm.SearchScope_SEARCH_SCOPE_AUDIT_EVENTS:
+		return "audit_events"
+	default:
+		return ""
+	}
+}
+
+// searchScopeFromString is the inverse: it maps the lowercase string
+// (as embedded in RediSearch keys) back to the wire enum. Unknown /
+// empty values map to UNSPECIFIED so a stale or unknown index entry
+// never crashes the response — the caller surfaces UNSPECIFIED and
+// the client treats it as "unknown scope".
+func searchScopeFromString(s string) pm.SearchScope {
+	switch s {
+	case "actions":
+		return pm.SearchScope_SEARCH_SCOPE_ACTIONS
+	case "action_sets":
+		return pm.SearchScope_SEARCH_SCOPE_ACTION_SETS
+	case "definitions":
+		return pm.SearchScope_SEARCH_SCOPE_DEFINITIONS
+	case "compliance_policies":
+		return pm.SearchScope_SEARCH_SCOPE_COMPLIANCE_POLICIES
+	case "devices":
+		return pm.SearchScope_SEARCH_SCOPE_DEVICES
+	case "users":
+		return pm.SearchScope_SEARCH_SCOPE_USERS
+	case "device_groups":
+		return pm.SearchScope_SEARCH_SCOPE_DEVICE_GROUPS
+	case "user_groups":
+		return pm.SearchScope_SEARCH_SCOPE_USER_GROUPS
+	case "executions":
+		return pm.SearchScope_SEARCH_SCOPE_EXECUTIONS
+	case "audit_events":
+		return pm.SearchScope_SEARCH_SCOPE_AUDIT_EVENTS
+	default:
+		return pm.SearchScope_SEARCH_SCOPE_UNSPECIFIED
+	}
+}
+
 func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.SearchRequest]) (*connect.Response[pm.SearchResponse], error) {
 	if h.searchIdx == nil {
 		return nil, connect.NewError(connect.CodeUnavailable, nil)
@@ -49,9 +113,11 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 
 	query := strings.TrimSpace(req.Msg.Query)
 	hasFilters := len(req.Msg.DateFilters) > 0 || len(req.Msg.TagFilters) > 0
+	scopeStr := searchScopeToString(req.Msg.Scope)
 
-	// Allow empty query when filters or scope are provided.
-	if query == "" && !hasFilters && req.Msg.Scope == "" {
+	// Allow empty query when filters or a specific scope are provided.
+	// scopeStr == "" matches the legacy "all scopes" sentinel.
+	if query == "" && !hasFilters && scopeStr == "" {
 		return connect.NewResponse(&pm.SearchResponse{}), nil
 	}
 
@@ -74,8 +140,8 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 	}
 
 	// Determine which scopes to search.
-	scopes := []string{req.Msg.Scope}
-	if req.Msg.Scope == "" {
+	scopes := []string{scopeStr}
+	if scopeStr == "" {
 		scopes = []string{"actions", "action_sets", "definitions", "compliance_policies", "devices", "users", "device_groups", "user_groups"}
 	}
 
@@ -258,7 +324,7 @@ func parseFTSearchResult(raw any, scope string) ([]*pm.SearchResult, int32) {
 
 		result := &pm.SearchResult{
 			Id:     id,
-			Scope:  scope,
+			Scope:  searchScopeFromString(scope),
 			Fields: make(map[string]string),
 		}
 

--- a/internal/api/search_handler_test.go
+++ b/internal/api/search_handler_test.go
@@ -234,7 +234,7 @@ func TestParseFTSearchResult_SingleResult(t *testing.T) {
 	require.Len(t, results, 1)
 	assert.Equal(t, int32(1), count)
 	assert.Equal(t, "ABC123", results[0].Id)
-	assert.Equal(t, "actions", results[0].Scope)
+	assert.Equal(t, pm.SearchScope_SEARCH_SCOPE_ACTIONS, results[0].Scope)
 	assert.Equal(t, "My Action", results[0].Name)
 	assert.Equal(t, "A test action", results[0].Description)
 	assert.Equal(t, "My Action", results[0].Fields["name"])

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -88,7 +88,7 @@ func (h *SSOHandler) ListAuthMethods(ctx context.Context, req *connect.Request[p
 			resp.Providers = append(resp.Providers, &pm.AuthMethodProvider{
 				Slug:         p.Slug,
 				Name:         p.Name,
-				ProviderType: p.ProviderType,
+				ProviderType: identityProviderTypeFromString(p.ProviderType),
 			})
 		}
 	} else {

--- a/internal/api/sso_handler_test.go
+++ b/internal/api/sso_handler_test.go
@@ -71,7 +71,7 @@ func TestListAuthMethods_WithProviders(t *testing.T) {
 	require.Len(t, resp.Msg.Providers, 1)
 	assert.Equal(t, "google", resp.Msg.Providers[0].Slug)
 	assert.Equal(t, "Google", resp.Msg.Providers[0].Name)
-	assert.Equal(t, "oidc", resp.Msg.Providers[0].ProviderType)
+	assert.Equal(t, pm.IdentityProviderType_IDENTITY_PROVIDER_TYPE_OIDC, resp.Msg.Providers[0].ProviderType)
 }
 
 func TestListAuthMethods_WithEmailUserHasTOTP(t *testing.T) {


### PR DESCRIPTION
## Summary

Companion to power-manage-sdk PR #54 (already merged). Replaces every `case \"online\"` / `case \"offline\"` / `case \"actions\"` / `case \"oidc\"` etc. on relevant string fields with switches on the new typed enum constants.

## Files

- `internal/api/device_handler.go` — `status_filter` switch + boundary helpers; `deviceToProtoWithAssignments` returns typed `Status`.
- `internal/api/search_handler.go` — `scope` switch + `searchScopeToString` / `searchScopeFromString` helpers. `UNSPECIFIED` maps to `\"\"` (preserving the legacy "all scopes" semantic the empty-string had). `parseFTSearchResult` returns the enum for the result scope.
- `internal/api/idp_handler.go` — `provider_type` validation + `identityProviderTypeToString` / `FromString` helpers. `CreateIdentityProvider` writes the lowercase string into the event payload; `idpToProto` reads the projection string into the enum.
- `internal/api/sso_handler.go` — `AuthMethodProvider.ProviderType` populated via the new helper.
- Tests for the four handlers updated to use enum constants.

## Wire/event-store separation

Same pattern as PR A: events-table JSONB payloads keep their existing string values. Helper functions bridge wire ↔ payload at the handler boundary.

## Dep bump

`go.mod` replace directive bumped to `power-manage-sdk@ec1d657` (the SDK PR #54 merge commit) so the new enum types resolve at vet/build time.

## Test plan

- [x] `gofmt -l`, `go vet ./...`, `staticcheck ./...` all clean.
- [x] `go test -run "TestDevice|TestListDevices|TestSearch|TestIdentityProvider|TestIdp|TestSSO|TestParseFT" ./internal/api/` — all green.
- [x] CR-CLI returned 0 findings before push.

Part of the 2026.06 cleanup-release proto-enum sweep. PRs C/D/E/F follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized device status handling for improved internal consistency.
  * Enhanced identity provider type representation and conversion logic.
  * Improved search scope handling with updated conversion mechanisms.

* **Chores**
  * Updated SDK dependency version.

* **Tests**
  * Updated test assertions to align with internal standardization changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/187)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->