### PR TITLE
feat: rotation_reason + SCIM Op typed enums (PR C of cleanup)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -107,4 +107,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260509141343-ec1d65730a19
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260509150403-fedab9d3ade5

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260509141343-ec1d65730a19 h1:KmuVvpv7xtIFxzAlm/iGnx7foxeUBVziQtkCgoKhUjw=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260509141343-ec1d65730a19/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260509150403-fedab9d3ade5 h1:JXNxuNC7/GL4QhJc9ZQ/j1cGX0ltt3xo1OabaqOgz3A=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260509150403-fedab9d3ade5/go.mod h1:HvI/R+FSMZMC4vwuL0Mnf2gcqXyIGJwEK8D7SLY+vh0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -317,7 +317,7 @@ func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Re
 			"device_path":     req.Msg.DevicePath,
 			"passphrase":      encPassphrase,
 			"rotated_at":      time.Now().Format(time.RFC3339),
-			"rotation_reason": req.Msg.RotationReason,
+			"rotation_reason": rotationReasonToString(req.Msg.RotationReason),
 		},
 		ActorType: "device",
 		ActorID:   req.Msg.DeviceId,
@@ -371,7 +371,7 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 				"username":        r.Username,
 				"password":        encPassword,
 				"rotated_at":      r.RotatedAt,
-				"rotation_reason": r.Reason,
+				"rotation_reason": rotationReasonToString(r.Reason),
 			},
 			ActorType: "device",
 			ActorID:   req.Msg.DeviceId,
@@ -522,4 +522,32 @@ func dbResolvedActionToWireAction(a db.ListResolvedActionsForDeviceRow) *pm.Acti
 	}
 
 	return action
+}
+
+// rotationReasonToString converts the wire enum into the lowercase
+// string the events table and projection columns have always stored
+// ("initial" / "scheduled"). Mirrors the PR-A/B boundary-helper
+// pattern: keep the JSONB shape stable for backward replay while
+// callers move to the typed enum on the wire. UNSPECIFIED maps to the
+// empty string so the projector defaulting logic
+// (LpsPasswordRotatedFromEvent and LuksKeyRotatedFromEvent) sees the
+// same shape an older agent would have produced.
+//
+// No FromString counterpart is exported here because nothing in the
+// api package currently lifts a stored rotation reason back onto the
+// wire — the surface is write-only at this boundary. The gateway's
+// agent-side mirror (rotationReasonFromAgentString in
+// internal/handler/agent.go) covers the other direction at the only
+// site that needs it.
+func rotationReasonToString(r pm.RotationReason) string {
+	switch r {
+	case pm.RotationReason_ROTATION_REASON_INITIAL:
+		return "initial"
+	case pm.RotationReason_ROTATION_REASON_SCHEDULED:
+		return "scheduled"
+	case pm.RotationReason_ROTATION_REASON_AUTH_GRACE:
+		return "auth_grace"
+	default:
+		return ""
+	}
 }

--- a/internal/api/internal_handler_test.go
+++ b/internal/api/internal_handler_test.go
@@ -189,7 +189,7 @@ func TestProxyStoreLuksKey(t *testing.T) {
 		ActionId:       testutil.NewID(),
 		DevicePath:     "/dev/sda1",
 		Passphrase:     "super-secret-key",
-		RotationReason: "initial",
+		RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL,
 	}))
 	require.NoError(t, err)
 	assert.True(t, resp.Msg.Success)
@@ -246,7 +246,7 @@ func TestProxyStoreLpsPasswords(t *testing.T) {
 				Username:  "admin",
 				Password:  "new-pass-123",
 				RotatedAt: "2026-03-31T12:00:00Z",
-				Reason:    "scheduled",
+				Reason:    pm.RotationReason_ROTATION_REASON_SCHEDULED,
 			},
 		},
 	}))

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -558,7 +558,7 @@ func (h *AgentHandler) proxyLpsRotations(ctx context.Context, deviceID, resultID
 			Username:  r.Username,
 			Password:  r.Password,
 			RotatedAt: r.RotatedAt,
-			Reason:    r.Reason,
+			Reason:    rotationReasonFromAgentString(r.Reason),
 		}
 	}
 	if err := h.controlProxy.StoreLpsPasswords(ctx, deviceID, resultID, protoRotations); err != nil {
@@ -776,4 +776,26 @@ func (h *AgentHandler) SyncActions(ctx context.Context, req *connect.Request[pm.
 		"sync_interval_minutes", resp.SyncIntervalMinutes)
 
 	return connect.NewResponse(resp), nil
+}
+
+// rotationReasonFromAgentString maps the lowercase string the agent
+// puts into the lps.rotations metadata JSON ("initial" / "scheduled")
+// to the wire enum the gateway forwards to control. Unknown values
+// (including the empty string an older agent might emit) collapse to
+// UNSPECIFIED — the projector defaults UNSPECIFIED-equivalent rows to
+// "scheduled" downstream, matching the historical PL/pgSQL COALESCE
+// behaviour. Inverse of api.rotationReasonToString in
+// server/internal/api/internal_handler.go; kept here in handler so
+// the gateway package does not gain an api dependency.
+func rotationReasonFromAgentString(s string) pm.RotationReason {
+	switch s {
+	case "initial":
+		return pm.RotationReason_ROTATION_REASON_INITIAL
+	case "scheduled":
+		return pm.RotationReason_ROTATION_REASON_SCHEDULED
+	case "auth_grace":
+		return pm.RotationReason_ROTATION_REASON_AUTH_GRACE
+	default:
+		return pm.RotationReason_ROTATION_REASON_UNSPECIFIED
+	}
 }

--- a/internal/handler/control_proxy.go
+++ b/internal/handler/control_proxy.go
@@ -67,7 +67,7 @@ func (p *ControlProxy) GetLuksKey(ctx context.Context, deviceID, actionID string
 }
 
 // StoreLuksKey encrypts and stores a new LUKS key via the control server.
-func (p *ControlProxy) StoreLuksKey(ctx context.Context, deviceID, actionID, devicePath, passphrase, reason string) (*pm.StoreLuksKeyResponse, error) {
+func (p *ControlProxy) StoreLuksKey(ctx context.Context, deviceID, actionID, devicePath, passphrase string, reason pm.RotationReason) (*pm.StoreLuksKeyResponse, error) {
 	resp, err := p.client.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
 		DeviceId:       deviceID,
 		ActionId:       actionID,

--- a/internal/scim/groups.go
+++ b/internal/scim/groups.go
@@ -517,14 +517,23 @@ func (h *Handler) patchGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, op := range patch.Operations {
-		switch strings.ToLower(op.Op) {
-		case "add":
+		// Pre-validate per RFC 7644 §3.5.2 — `op` must be one of
+		// add | remove | replace. Reject up front so unknown verbs
+		// never silently fall through to a per-op switch default
+		// elsewhere in the codebase.
+		if !op.Op.IsValid() {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("unsupported patch op: %s", op.Op))
+			return
+		}
+		switch op.Op.Normalize() {
+		case SCIMPatchOpAdd:
 			h.handleGroupPatchAdd(ctx, provider, groupID, op)
-		case "remove":
+		case SCIMPatchOpRemove:
 			h.handleGroupPatchRemove(ctx, provider, groupID, op)
-		case "replace":
+		case SCIMPatchOpReplace:
 			h.handleGroupPatchReplace(ctx, provider, groupID, mapping, op)
 		default:
+			// Unreachable: IsValid above guards this switch.
 			writeError(w, http.StatusBadRequest, fmt.Sprintf("unsupported patch op: %s", op.Op))
 			return
 		}

--- a/internal/scim/scim.go
+++ b/internal/scim/scim.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 )
 
 // SCIM schema URIs.
@@ -111,11 +112,50 @@ type SCIMMember struct {
 	Ref     string `json:"$ref,omitempty"`
 }
 
+// SCIMPatchOpType is the typed `op` value of a SCIM PATCH operation.
+// SCIM PATCH (RFC 7644 §3.5.2) defines exactly three verbs — add,
+// remove, replace — and identity providers occasionally vary case.
+// A typed alias plus the canonical-form constants below keep callers
+// off raw string literals while leaving the JSON wire format
+// unchanged (lowercase per the RFC).
+type SCIMPatchOpType string
+
+const (
+	// SCIMPatchOpAdd appends a value to a multi-valued attribute, or
+	// sets an attribute that has no current value.
+	SCIMPatchOpAdd SCIMPatchOpType = "add"
+	// SCIMPatchOpRemove deletes the addressed value(s) from the target
+	// attribute. Path is required (RFC 7644 §3.5.2.2).
+	SCIMPatchOpRemove SCIMPatchOpType = "remove"
+	// SCIMPatchOpReplace overwrites the target with the supplied value;
+	// behaves like add when no current value exists.
+	SCIMPatchOpReplace SCIMPatchOpType = "replace"
+)
+
+// IsValid reports whether the op is one of the three RFC 7644 verbs
+// after lowercasing. Used at the request boundary to reject unknown
+// ops with HTTP 400 instead of silently no-op-ing them inside the
+// per-op switch.
+func (o SCIMPatchOpType) IsValid() bool {
+	switch SCIMPatchOpType(strings.ToLower(string(o))) {
+	case SCIMPatchOpAdd, SCIMPatchOpRemove, SCIMPatchOpReplace:
+		return true
+	default:
+		return false
+	}
+}
+
+// Normalize returns the lowercase canonical form so callers can switch
+// on the constants without sprinkling strings.ToLower at every site.
+func (o SCIMPatchOpType) Normalize() SCIMPatchOpType {
+	return SCIMPatchOpType(strings.ToLower(string(o)))
+}
+
 // SCIMPatchOp represents a single SCIM PATCH operation.
 type SCIMPatchOp struct {
-	Op    string `json:"op"`
-	Path  string `json:"path,omitempty"`
-	Value any    `json:"value,omitempty"`
+	Op    SCIMPatchOpType `json:"op"`
+	Path  string          `json:"path,omitempty"`
+	Value any             `json:"value,omitempty"`
 }
 
 // SCIMPatchRequest represents a SCIM PATCH request body.

--- a/internal/scim/users.go
+++ b/internal/scim/users.go
@@ -623,8 +623,18 @@ func (h *Handler) patchUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, op := range patch.Operations {
-		switch strings.ToLower(op.Op) {
-		case "replace":
+		// Pre-validate per RFC 7644 §3.5.2 so the user patch path
+		// rejects unknown verbs with a 400 even though add/remove
+		// fall through to the catch-all default below — they are
+		// not implemented for users today, but they ARE valid SCIM
+		// ops, and a 400 with the precise error is the right
+		// response (vs. a 501 for the implementation gap).
+		if !op.Op.IsValid() {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("unsupported patch op: %s", op.Op))
+			return
+		}
+		switch op.Op.Normalize() {
+		case SCIMPatchOpReplace:
 			if err := h.handleUserPatchReplace(ctx, provider, userID, existingUser, op); err != nil {
 				h.logger.Error("failed to apply SCIM patch op", "op", op.Op, "path", op.Path, "error", err)
 				writeError(w, http.StatusInternalServerError, "failed to apply patch operation")
@@ -775,7 +785,7 @@ func (h *Handler) handleUserPatchReplace(ctx context.Context, provider db.Identi
 		}
 		for key, val := range valueMap {
 			subOp := SCIMPatchOp{
-				Op:    "replace",
+				Op:    SCIMPatchOpReplace,
 				Path:  key,
 				Value: val,
 			}
@@ -1153,7 +1163,7 @@ func extractNameFromPatchOps(ops []SCIMPatchOp) *SCIMName {
 	found := false
 
 	for _, op := range ops {
-		if strings.ToLower(op.Op) != "replace" {
+		if op.Op.Normalize() != SCIMPatchOpReplace {
 			continue
 		}
 		path := strings.ToLower(op.Path)


### PR DESCRIPTION
## Summary

Companion to power-manage-sdk PR #55 (already merged). Two unrelated small enum clusters bundled per user direction.

## RotationReason wire wiring

- `internal/handler/control_proxy.go`: `StoreLuksKey` reason param retyped to `pm.RotationReason`.
- `internal/handler/agent.go`: added `rotationReasonFromAgentString` helper (handles "initial", "scheduled", "auth_grace"); LPS rotations metadata-string is converted to enum at the gateway boundary before forwarding.
- `internal/api/internal_handler.go`: added `rotationReasonToString` helper; `ProxyStoreLuksKey` and `ProxyStoreLpsPasswords` convert the enum back to the lowercase string the events table has always stored.
- `internal/api/internal_handler_test.go`: enum constants in tests.

## SCIM Op typing

- `internal/scim/scim.go`: `SCIMPatchOpType` alias + `SCIMPatchOpAdd/Remove/Replace` constants, `IsValid()` and `Normalize()` methods. `SCIMPatchOp.Op` retyped from `string` to `SCIMPatchOpType`.
- `internal/scim/groups.go`: group PATCH validates `op.Op.IsValid()` (returns 400 on unknown verbs per RFC 7644 §3.5.2) and switches on the typed constants.
- `internal/scim/users.go`: same `IsValid` pre-check on user PATCH; `extractNameFromPatchOps` switched to `op.Op.Normalize() == SCIMPatchOpReplace`.

## Deps

- `power-manage-sdk` bumped to `fedab9d` (the PR #55 merge commit).
- Companion **agent PR** (incoming) emits `pb.RotationReason_*` constants.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...` clean.
- [x] `go test -run "TestStoreLuksKey|TestLuksKey|TestLpsPassword|TestSCIM" ./internal/...` — all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SCIM PATCH operation validation with better error handling for unsupported operations.
  * Enhanced rotation reason serialization for consistency across key rotation and password management.

* **Refactor**
  * Updated rotation reason handling to use typed enum values for better consistency.
  * Standardized SCIM operation handling with improved type safety and validation.

* **Chores**
  * Updated SDK dependency to latest pinned version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/188)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->