### PR TITLE
refactor: internal/eventtypes package for compile-time-checked event-type constants (PR D of cleanup)

### DIFF
--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -18,6 +18,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
@@ -452,7 +453,7 @@ func (h *ActionHandler) CreateAction(ctx context.Context, req *connect.Request[p
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action",
 		StreamID:   id,
-		EventType:  "ActionCreated",
+		EventType:  string(eventtypes.ActionCreated),
 		Data:       eventData,
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -562,7 +563,7 @@ func (h *ActionHandler) RenameAction(ctx context.Context, req *connect.Request[p
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action",
 		StreamID:   req.Msg.Id,
-		EventType:  "ActionRenamed",
+		EventType:  string(eventtypes.ActionRenamed),
 		Data: map[string]any{
 			"name": req.Msg.Name,
 		},
@@ -604,7 +605,7 @@ func (h *ActionHandler) UpdateActionDescription(ctx context.Context, req *connec
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action",
 		StreamID:   req.Msg.Id,
-		EventType:  "ActionDescriptionUpdated",
+		EventType:  string(eventtypes.ActionDescriptionUpdated),
 		Data: map[string]any{
 			"description": req.Msg.Description,
 		},
@@ -691,7 +692,7 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action",
 		StreamID:   req.Msg.Id,
-		EventType:  "ActionParamsUpdated",
+		EventType:  string(eventtypes.ActionParamsUpdated),
 		Data:       eventData,
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -777,7 +778,7 @@ func (h *ActionHandler) rollbackUnsignedCreate(ctx context.Context, userID, acti
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action",
 		StreamID:   actionID,
-		EventType:  "ActionDeleted",
+		EventType:  string(eventtypes.ActionDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userID,
@@ -801,7 +802,7 @@ func (h *ActionHandler) DeleteAction(ctx context.Context, req *connect.Request[p
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action",
 		StreamID:   req.Msg.Id,
-		EventType:  "ActionDeleted",
+		EventType:  string(eventtypes.ActionDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -994,9 +995,9 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 	// the caller asked for a deferred dispatch. The two events are
 	// projected to status='scheduled' / status='pending' respectively
 	// and the row only diverges from there on the dispatch's outcome.
-	initialEventType := "ExecutionCreated"
+	initialEventType := string(eventtypes.ExecutionCreated)
 	if dispatchDelay > 0 {
-		initialEventType = "ExecutionScheduled"
+		initialEventType = string(eventtypes.ExecutionScheduled)
 	}
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "execution",
@@ -1044,7 +1045,7 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		if failErr := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "execution",
 			StreamID:   id,
-			EventType:  "ExecutionFailed",
+			EventType:  string(eventtypes.ExecutionFailed),
 			Data: map[string]any{
 				"error":        fmt.Sprintf("dispatch enqueue failed: %v", err),
 				"completed_at": nil, // projector falls back to event.occurred_at
@@ -1478,9 +1479,9 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeFailedPrecondition, "instant dispatch unavailable: task queue not configured")
 	}
 
-	initialEventType := "ExecutionCreated"
+	initialEventType := string(eventtypes.ExecutionCreated)
 	if dispatchDelay > 0 {
-		initialEventType = "ExecutionScheduled"
+		initialEventType = string(eventtypes.ExecutionScheduled)
 	}
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "execution",
@@ -1515,7 +1516,7 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 		if failErr := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "execution",
 			StreamID:   id,
-			EventType:  "ExecutionFailed",
+			EventType:  string(eventtypes.ExecutionFailed),
 			Data: map[string]any{
 				"error":        fmt.Sprintf("instant dispatch enqueue failed: %v", err),
 				"completed_at": nil,
@@ -1591,7 +1592,7 @@ func (h *ActionHandler) CancelExecution(ctx context.Context, req *connect.Reques
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "execution",
 		StreamID:   exec.ID,
-		EventType:  "ExecutionCancelled",
+		EventType:  string(eventtypes.ExecutionCancelled),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,

--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -10,6 +10,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -58,7 +59,7 @@ func (h *ActionSetHandler) CreateActionSet(ctx context.Context, req *connect.Req
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   id,
-		EventType:  "ActionSetCreated",
+		EventType:  string(eventtypes.ActionSetCreated),
 		Data:       data,
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -157,7 +158,7 @@ func (h *ActionSetHandler) RenameActionSet(ctx context.Context, req *connect.Req
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.Id,
-		EventType:  "ActionSetRenamed",
+		EventType:  string(eventtypes.ActionSetRenamed),
 		Data: map[string]any{
 			"name": req.Msg.Name,
 		},
@@ -199,7 +200,7 @@ func (h *ActionSetHandler) UpdateActionSetSchedule(ctx context.Context, req *con
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.Id,
-		EventType:  "ActionSetScheduleUpdated",
+		EventType:  string(eventtypes.ActionSetScheduleUpdated),
 		Data:       data,
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -231,7 +232,7 @@ func (h *ActionSetHandler) UpdateActionSetDescription(ctx context.Context, req *
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.Id,
-		EventType:  "ActionSetDescriptionUpdated",
+		EventType:  string(eventtypes.ActionSetDescriptionUpdated),
 		Data: map[string]any{
 			"description": req.Msg.Description,
 		},
@@ -265,7 +266,7 @@ func (h *ActionSetHandler) DeleteActionSet(ctx context.Context, req *connect.Req
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.Id,
-		EventType:  "ActionSetDeleted",
+		EventType:  string(eventtypes.ActionSetDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -307,7 +308,7 @@ func (h *ActionSetHandler) AddActionToSet(ctx context.Context, req *connect.Requ
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.SetId,
-		EventType:  "ActionSetMemberAdded",
+		EventType:  string(eventtypes.ActionSetMemberAdded),
 		Data: map[string]any{
 			"action_id":  req.Msg.ActionId,
 			"sort_order": req.Msg.SortOrder,
@@ -348,7 +349,7 @@ func (h *ActionSetHandler) RemoveActionFromSet(ctx context.Context, req *connect
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.SetId,
-		EventType:  "ActionSetMemberRemoved",
+		EventType:  string(eventtypes.ActionSetMemberRemoved),
 		Data: map[string]any{
 			"action_id": req.Msg.ActionId,
 		},
@@ -388,7 +389,7 @@ func (h *ActionSetHandler) ReorderActionInSet(ctx context.Context, req *connect.
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.SetId,
-		EventType:  "ActionSetMemberReordered",
+		EventType:  string(eventtypes.ActionSetMemberReordered),
 		Data: map[string]any{
 			"action_id":  req.Msg.ActionId,
 			"sort_order": req.Msg.NewOrder,

--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -142,7 +143,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "assignment",
 		StreamID:   id,
-		EventType:  "AssignmentCreated",
+		EventType:  string(eventtypes.AssignmentCreated),
 		Data: map[string]any{
 			"source_type": sourceTypeStr,
 			"source_id":   req.Msg.SourceId,
@@ -193,7 +194,7 @@ func (h *AssignmentHandler) DeleteAssignment(ctx context.Context, req *connect.R
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "assignment",
 		StreamID:   req.Msg.Id,
-		EventType:  "AssignmentDeleted",
+		EventType:  string(eventtypes.AssignmentDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -12,6 +12,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/store/generated"
@@ -110,7 +111,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   user.ID,
-		EventType:  "UserLoggedIn",
+		EventType:  string(eventtypes.UserLoggedIn),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    user.ID,

--- a/internal/api/certificate_handler.go
+++ b/internal/api/certificate_handler.go
@@ -11,6 +11,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -84,7 +85,7 @@ func (h *CertificateHandler) RenewCertificate(ctx context.Context, req *connect.
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   deviceID,
-		EventType:  "DeviceCertRenewed",
+		EventType:  string(eventtypes.DeviceCertRenewed),
 		Data: map[string]any{
 			"cert_fingerprint": newCert.Fingerprint,
 			"cert_not_after":   newCert.NotAfter.Format(time.RFC3339),

--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -46,7 +47,7 @@ func (h *CompliancePolicyHandler) CreateCompliancePolicy(ctx context.Context, re
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "compliance_policy",
 		StreamID:   id,
-		EventType:  "CompliancePolicyCreated",
+		EventType:  string(eventtypes.CompliancePolicyCreated),
 		Data: map[string]any{
 			"name":        req.Msg.Name,
 			"description": req.Msg.Description,
@@ -142,7 +143,7 @@ func (h *CompliancePolicyHandler) RenameCompliancePolicy(ctx context.Context, re
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "compliance_policy",
 		StreamID:   req.Msg.Id,
-		EventType:  "CompliancePolicyRenamed",
+		EventType:  string(eventtypes.CompliancePolicyRenamed),
 		Data: map[string]any{
 			"name": req.Msg.Name,
 		},
@@ -182,7 +183,7 @@ func (h *CompliancePolicyHandler) UpdateCompliancePolicyDescription(ctx context.
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "compliance_policy",
 		StreamID:   req.Msg.Id,
-		EventType:  "CompliancePolicyDescriptionUpdated",
+		EventType:  string(eventtypes.CompliancePolicyDescriptionUpdated),
 		Data: map[string]any{
 			"description": req.Msg.Description,
 		},
@@ -222,7 +223,7 @@ func (h *CompliancePolicyHandler) DeleteCompliancePolicy(ctx context.Context, re
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "compliance_policy",
 		StreamID:   req.Msg.Id,
-		EventType:  "CompliancePolicyDeleted",
+		EventType:  string(eventtypes.CompliancePolicyDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -277,7 +278,7 @@ func (h *CompliancePolicyHandler) AddCompliancePolicyRule(ctx context.Context, r
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "compliance_policy",
 		StreamID:   req.Msg.PolicyId,
-		EventType:  "CompliancePolicyRuleAdded",
+		EventType:  string(eventtypes.CompliancePolicyRuleAdded),
 		Data: map[string]any{
 			"action_id":          req.Msg.ActionId,
 			"action_name":        action.Name,
@@ -324,7 +325,7 @@ func (h *CompliancePolicyHandler) RemoveCompliancePolicyRule(ctx context.Context
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "compliance_policy",
 		StreamID:   req.Msg.PolicyId,
-		EventType:  "CompliancePolicyRuleRemoved",
+		EventType:  string(eventtypes.CompliancePolicyRuleRemoved),
 		Data: map[string]any{
 			"action_id": req.Msg.ActionId,
 		},
@@ -369,7 +370,7 @@ func (h *CompliancePolicyHandler) UpdateCompliancePolicyRule(ctx context.Context
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "compliance_policy",
 		StreamID:   req.Msg.PolicyId,
-		EventType:  "CompliancePolicyRuleUpdated",
+		EventType:  string(eventtypes.CompliancePolicyRuleUpdated),
 		Data: map[string]any{
 			"action_id":          req.Msg.ActionId,
 			"grace_period_hours": req.Msg.GracePeriodHours,

--- a/internal/api/definition_handler.go
+++ b/internal/api/definition_handler.go
@@ -10,6 +10,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -57,7 +58,7 @@ func (h *DefinitionHandler) CreateDefinition(ctx context.Context, req *connect.R
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   id,
-		EventType:  "DefinitionCreated",
+		EventType:  string(eventtypes.DefinitionCreated),
 		Data:       data,
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -154,7 +155,7 @@ func (h *DefinitionHandler) RenameDefinition(ctx context.Context, req *connect.R
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.Id,
-		EventType:  "DefinitionRenamed",
+		EventType:  string(eventtypes.DefinitionRenamed),
 		Data: map[string]any{
 			"name": req.Msg.Name,
 		},
@@ -197,7 +198,7 @@ func (h *DefinitionHandler) UpdateDefinitionSchedule(ctx context.Context, req *c
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.Id,
-		EventType:  "DefinitionScheduleUpdated",
+		EventType:  string(eventtypes.DefinitionScheduleUpdated),
 		Data:       data,
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -229,7 +230,7 @@ func (h *DefinitionHandler) UpdateDefinitionDescription(ctx context.Context, req
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.Id,
-		EventType:  "DefinitionDescriptionUpdated",
+		EventType:  string(eventtypes.DefinitionDescriptionUpdated),
 		Data: map[string]any{
 			"description": req.Msg.Description,
 		},
@@ -263,7 +264,7 @@ func (h *DefinitionHandler) DeleteDefinition(ctx context.Context, req *connect.R
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.Id,
-		EventType:  "DefinitionDeleted",
+		EventType:  string(eventtypes.DefinitionDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -305,7 +306,7 @@ func (h *DefinitionHandler) AddActionSetToDefinition(ctx context.Context, req *c
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.DefinitionId,
-		EventType:  "DefinitionMemberAdded",
+		EventType:  string(eventtypes.DefinitionMemberAdded),
 		Data: map[string]any{
 			"action_set_id": req.Msg.ActionSetId,
 			"sort_order":    req.Msg.SortOrder,
@@ -346,7 +347,7 @@ func (h *DefinitionHandler) RemoveActionSetFromDefinition(ctx context.Context, r
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.DefinitionId,
-		EventType:  "DefinitionMemberRemoved",
+		EventType:  string(eventtypes.DefinitionMemberRemoved),
 		Data: map[string]any{
 			"action_set_id": req.Msg.ActionSetId,
 		},
@@ -386,7 +387,7 @@ func (h *DefinitionHandler) ReorderActionSetInDefinition(ctx context.Context, re
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.DefinitionId,
-		EventType:  "DefinitionMemberReordered",
+		EventType:  string(eventtypes.DefinitionMemberReordered),
 		Data: map[string]any{
 			"action_set_id": req.Msg.ActionSetId,
 			"sort_order":    req.Msg.NewOrder,

--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -12,6 +12,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/go/maintenance"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -62,7 +63,7 @@ func (h *DeviceGroupHandler) CreateDeviceGroup(ctx context.Context, req *connect
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device_group",
 		StreamID:   id,
-		EventType:  "DeviceGroupCreated",
+		EventType:  string(eventtypes.DeviceGroupCreated),
 		Data: map[string]any{
 			"name":          req.Msg.Name,
 			"description":   req.Msg.Description,
@@ -191,7 +192,7 @@ func (h *DeviceGroupHandler) RenameDeviceGroup(ctx context.Context, req *connect
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device_group",
 		StreamID:   req.Msg.Id,
-		EventType:  "DeviceGroupRenamed",
+		EventType:  string(eventtypes.DeviceGroupRenamed),
 		Data: map[string]any{
 			"name": req.Msg.Name,
 		},
@@ -225,7 +226,7 @@ func (h *DeviceGroupHandler) UpdateDeviceGroupDescription(ctx context.Context, r
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device_group",
 		StreamID:   req.Msg.Id,
-		EventType:  "DeviceGroupDescriptionUpdated",
+		EventType:  string(eventtypes.DeviceGroupDescriptionUpdated),
 		Data: map[string]any{
 			"description": req.Msg.Description,
 		},
@@ -259,7 +260,7 @@ func (h *DeviceGroupHandler) DeleteDeviceGroup(ctx context.Context, req *connect
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device_group",
 		StreamID:   req.Msg.Id,
-		EventType:  "DeviceGroupDeleted",
+		EventType:  string(eventtypes.DeviceGroupDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -322,7 +323,7 @@ func (h *DeviceGroupHandler) AddDeviceToGroup(ctx context.Context, req *connect.
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "device_group",
 			StreamID:   req.Msg.GroupId,
-			EventType:  "DeviceGroupMemberAdded",
+			EventType:  string(eventtypes.DeviceGroupMemberAdded),
 			Data: map[string]any{
 				"device_id": deviceID,
 			},
@@ -368,7 +369,7 @@ func (h *DeviceGroupHandler) RemoveDeviceFromGroup(ctx context.Context, req *con
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device_group",
 		StreamID:   req.Msg.GroupId,
-		EventType:  "DeviceGroupMemberRemoved",
+		EventType:  string(eventtypes.DeviceGroupMemberRemoved),
 		Data: map[string]any{
 			"device_id": req.Msg.DeviceId,
 		},
@@ -416,7 +417,7 @@ func (h *DeviceGroupHandler) UpdateDeviceGroupQuery(ctx context.Context, req *co
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device_group",
 		StreamID:   req.Msg.Id,
-		EventType:  "DeviceGroupQueryUpdated",
+		EventType:  string(eventtypes.DeviceGroupQueryUpdated),
 		Data: map[string]any{
 			"is_dynamic":    req.Msg.IsDynamic,
 			"dynamic_query": req.Msg.DynamicQuery,
@@ -539,7 +540,7 @@ func (h *DeviceGroupHandler) SetDeviceGroupSyncInterval(ctx context.Context, req
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device_group",
 		StreamID:   req.Msg.Id,
-		EventType:  "DeviceGroupSyncIntervalSet",
+		EventType:  string(eventtypes.DeviceGroupSyncIntervalSet),
 		Data: map[string]any{
 			"sync_interval_minutes": req.Msg.SyncIntervalMinutes,
 		},
@@ -585,7 +586,7 @@ func (h *DeviceGroupHandler) SetDeviceGroupMaintenanceWindow(ctx context.Context
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device_group",
 		StreamID:   req.Msg.Id,
-		EventType:  "DeviceGroupMaintenanceWindowSet",
+		EventType:  string(eventtypes.DeviceGroupMaintenanceWindowSet),
 		Data: map[string]any{
 			"maintenance_window": maintenanceWindowToMap(req.Msg.MaintenanceWindow),
 		},

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -21,6 +21,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -213,7 +214,7 @@ func (h *DeviceHandler) SetDeviceLabel(ctx context.Context, req *connect.Request
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device",
 		StreamID:   req.Msg.Id,
-		EventType:  "DeviceLabelSet",
+		EventType:  string(eventtypes.DeviceLabelSet),
 		Data: map[string]any{
 			"key":   req.Msg.Key,
 			"value": req.Msg.Value,
@@ -258,7 +259,7 @@ func (h *DeviceHandler) RemoveDeviceLabel(ctx context.Context, req *connect.Requ
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device",
 		StreamID:   req.Msg.Id,
-		EventType:  "DeviceLabelRemoved",
+		EventType:  string(eventtypes.DeviceLabelRemoved),
 		Data: map[string]any{
 			"key": req.Msg.Key,
 		},
@@ -296,7 +297,7 @@ func (h *DeviceHandler) DeleteDevice(ctx context.Context, req *connect.Request[p
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device",
 		StreamID:   req.Msg.Id,
-		EventType:  "DeviceDeleted",
+		EventType:  string(eventtypes.DeviceDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -377,7 +378,7 @@ func (h *DeviceHandler) AssignDevice(ctx context.Context, req *connect.Request[p
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "device",
 			StreamID:   req.Msg.DeviceId,
-			EventType:  "DeviceAssigned",
+			EventType:  string(eventtypes.DeviceAssigned),
 			Data: map[string]any{
 				"user_id": userID,
 			},
@@ -405,7 +406,7 @@ func (h *DeviceHandler) AssignDevice(ctx context.Context, req *connect.Request[p
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "device",
 			StreamID:   req.Msg.DeviceId,
-			EventType:  "DeviceGroupAssigned",
+			EventType:  string(eventtypes.DeviceGroupAssigned),
 			Data: map[string]any{
 				"group_id": groupID,
 			},
@@ -478,7 +479,7 @@ func (h *DeviceHandler) UnassignDevice(ctx context.Context, req *connect.Request
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "device",
 			StreamID:   req.Msg.DeviceId,
-			EventType:  "DeviceUnassigned",
+			EventType:  string(eventtypes.DeviceUnassigned),
 			Data: map[string]any{
 				"user_id": req.Msg.UserId,
 			},
@@ -492,7 +493,7 @@ func (h *DeviceHandler) UnassignDevice(ctx context.Context, req *connect.Request
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "device",
 			StreamID:   req.Msg.DeviceId,
-			EventType:  "DeviceGroupUnassigned",
+			EventType:  string(eventtypes.DeviceGroupUnassigned),
 			Data: map[string]any{
 				"group_id": req.Msg.GroupId,
 			},
@@ -535,7 +536,7 @@ func (h *DeviceHandler) SetDeviceSyncInterval(ctx context.Context, req *connect.
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device",
 		StreamID:   req.Msg.Id,
-		EventType:  "DeviceSyncIntervalSet",
+		EventType:  string(eventtypes.DeviceSyncIntervalSet),
 		Data: map[string]any{
 			"sync_interval_minutes": req.Msg.SyncIntervalMinutes,
 		},
@@ -983,7 +984,7 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "luks_key",
 		StreamID:   luksStreamID,
-		EventType:  "LuksDeviceKeyRevocationRequested",
+		EventType:  string(eventtypes.LuksDeviceKeyRevocationRequested),
 		Data: map[string]any{
 			"device_id":    req.Msg.DeviceId,
 			"action_id":    req.Msg.ActionId,
@@ -1009,7 +1010,7 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 		if failErr := h.store.AppendEvent(ctx, store.Event{
 			StreamType: "luks_key",
 			StreamID:   luksStreamID,
-			EventType:  "LuksDeviceKeyRevocationFailed",
+			EventType:  string(eventtypes.LuksDeviceKeyRevocationFailed),
 			Data: map[string]any{
 				"device_id": req.Msg.DeviceId,
 				"action_id": req.Msg.ActionId,
@@ -1034,7 +1035,7 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "luks_key",
 		StreamID:   luksStreamID,
-		EventType:  "LuksDeviceKeyRevocationDispatched",
+		EventType:  string(eventtypes.LuksDeviceKeyRevocationDispatched),
 		Data: map[string]any{
 			"device_id":     req.Msg.DeviceId,
 			"action_id":     req.Msg.ActionId,

--- a/internal/api/identity_link_handler.go
+++ b/internal/api/identity_link_handler.go
@@ -9,6 +9,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -89,7 +90,7 @@ func (h *IdentityLinkHandler) UnlinkIdentity(ctx context.Context, req *connect.R
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   link.ID,
-		EventType:  "IdentityUnlinked",
+		EventType:  string(eventtypes.IdentityUnlinked),
 		Data: map[string]any{
 			"user_id":     link.UserID,
 			"provider_id": link.ProviderID,

--- a/internal/api/idp_handler.go
+++ b/internal/api/idp_handler.go
@@ -16,6 +16,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -66,7 +67,7 @@ func (h *IDPHandler) CreateIdentityProvider(ctx context.Context, req *connect.Re
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   id,
-		EventType:  "IdentityProviderCreated",
+		EventType:  string(eventtypes.IdentityProviderCreated),
 		Data: map[string]any{
 			"name":                        req.Msg.Name,
 			"slug":                        req.Msg.Slug,
@@ -208,7 +209,7 @@ func (h *IDPHandler) UpdateIdentityProvider(ctx context.Context, req *connect.Re
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   req.Msg.Id,
-		EventType:  "IdentityProviderUpdated",
+		EventType:  string(eventtypes.IdentityProviderUpdated),
 		Data:       data,
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -249,7 +250,7 @@ func (h *IDPHandler) DeleteIdentityProvider(ctx context.Context, req *connect.Re
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   providerID,
-		EventType:  "IdentityProviderDeleted",
+		EventType:  string(eventtypes.IdentityProviderDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -262,7 +263,7 @@ func (h *IDPHandler) DeleteIdentityProvider(ctx context.Context, req *connect.Re
 		if err := h.store.AppendEvent(ctx, store.Event{
 			StreamType: "identity_provider",
 			StreamID:   link.ID,
-			EventType:  "IdentityUnlinked",
+			EventType:  string(eventtypes.IdentityUnlinked),
 			Data:       map[string]any{},
 			ActorType:  "user",
 			ActorID:    userCtx.ID,
@@ -290,7 +291,7 @@ func (h *IDPHandler) DeleteIdentityProvider(ctx context.Context, req *connect.Re
 			if err := h.store.AppendEvent(ctx, store.Event{
 				StreamType: "user",
 				StreamID:   link.UserID,
-				EventType:  "UserDeleted",
+				EventType:  string(eventtypes.UserDeleted),
 				Data:       map[string]any{},
 				ActorType:  "user",
 				ActorID:    userCtx.ID,
@@ -345,7 +346,7 @@ func (h *IDPHandler) EnableSCIM(ctx context.Context, req *connect.Request[pm.Ena
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   req.Msg.Id,
-		EventType:  "IdentityProviderSCIMEnabled",
+		EventType:  string(eventtypes.IdentityProviderSCIMEnabled),
 		Data: map[string]any{
 			"scim_token_hash": hashStr,
 		},
@@ -386,7 +387,7 @@ func (h *IDPHandler) DisableSCIM(ctx context.Context, req *connect.Request[pm.Di
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   req.Msg.Id,
-		EventType:  "IdentityProviderSCIMDisabled",
+		EventType:  string(eventtypes.IdentityProviderSCIMDisabled),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -432,7 +433,7 @@ func (h *IDPHandler) RotateSCIMToken(ctx context.Context, req *connect.Request[p
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   req.Msg.Id,
-		EventType:  "IdentityProviderSCIMTokenRotated",
+		EventType:  string(eventtypes.IdentityProviderSCIMTokenRotated),
 		Data: map[string]any{
 			"scim_token_hash": hashStr,
 		},

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -299,12 +299,13 @@ func (h *InternalHandler) ProxyGetLuksKey(ctx context.Context, req *connect.Requ
 // ProxyStoreLuksKey encrypts and stores a new LUKS key.
 func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Request[pm.InternalStoreLuksKeyRequest]) (*connect.Response[pm.StoreLuksKeyResponse], error) {
 	if req.Msg.DeviceId == "" || req.Msg.ActionId == "" || req.Msg.Passphrase == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("device_id, action_id, and passphrase are required"))
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id, action_id, and passphrase are required")
 	}
 
 	encPassphrase, err := h.encryptor.Encrypt(req.Msg.Passphrase)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, errors.New("failed to encrypt passphrase"))
+		h.logger.Error("failed to encrypt LUKS passphrase", "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to encrypt passphrase")
 	}
 
 	luksStreamID := ulid.Make().String()
@@ -323,7 +324,8 @@ func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Re
 		ActorType: "device",
 		ActorID:   req.Msg.DeviceId,
 	}); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to store LUKS key: %w", err))
+		h.logger.Error("failed to store LUKS key event", "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to store LUKS key")
 	}
 
 	return connect.NewResponse(&pm.StoreLuksKeyResponse{
@@ -334,7 +336,7 @@ func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Re
 // ProxyStoreLpsPasswords encrypts and stores LPS password rotation entries.
 func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *connect.Request[pm.InternalStoreLpsPasswordsRequest]) (*connect.Response[pm.InternalStoreLpsPasswordsResponse], error) {
 	if req.Msg.DeviceId == "" || req.Msg.ActionId == "" {
-		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("device_id and action_id are required"))
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id and action_id are required")
 	}
 
 	// Persistence MUST fail-closed. LPS rotation is irreversible:
@@ -357,8 +359,8 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 	for _, r := range req.Msg.Rotations {
 		encPassword, err := h.encryptor.Encrypt(r.Password)
 		if err != nil {
-			h.logger.Error("failed to encrypt LPS password", "error", err)
-			return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to encrypt password for user %s", r.Username))
+			h.logger.Error("failed to encrypt LPS password", "error", err, "username", r.Username)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to encrypt password")
 		}
 
 		lpsStreamID := ulid.Make().String()

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/resolution"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -310,7 +311,7 @@ func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Re
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "luks_key",
 		StreamID:   luksStreamID,
-		EventType:  "LuksKeyRotated",
+		EventType:  string(eventtypes.LuksKeyRotated),
 		Data: map[string]any{
 			"device_id":       req.Msg.DeviceId,
 			"action_id":       req.Msg.ActionId,
@@ -364,7 +365,7 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 		if err := h.store.AppendEvent(ctx, store.Event{
 			StreamType: "lps_password",
 			StreamID:   lpsStreamID,
-			EventType:  "LpsPasswordRotated",
+			EventType:  string(eventtypes.LpsPasswordRotated),
 			Data: map[string]any{
 				"device_id":       req.Msg.DeviceId,
 				"action_id":       req.Msg.ActionId,

--- a/internal/api/registration_handler.go
+++ b/internal/api/registration_handler.go
@@ -16,6 +16,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -236,7 +237,7 @@ func (h *RegistrationHandler) Register(ctx context.Context, req *connect.Request
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   deviceID,
-		EventType:  "DeviceRegistered",
+		EventType:  string(eventtypes.DeviceRegistered),
 		Data:       eventData,
 		ActorType:  "system",
 		ActorID:    "registration",

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -13,6 +13,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -71,7 +72,7 @@ func (h *RoleHandler) CreateRole(ctx context.Context, req *connect.Request[pm.Cr
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "role",
 		StreamID:   id,
-		EventType:  "RoleCreated",
+		EventType:  string(eventtypes.RoleCreated),
 		Data: map[string]any{
 			"name":        req.Msg.Name,
 			"description": req.Msg.Description,
@@ -187,7 +188,7 @@ func (h *RoleHandler) UpdateRole(ctx context.Context, req *connect.Request[pm.Up
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "role",
 		StreamID:   req.Msg.RoleId,
-		EventType:  "RoleUpdated",
+		EventType:  string(eventtypes.RoleUpdated),
 		Data: map[string]any{
 			"name":        req.Msg.Name,
 			"description": req.Msg.Description,
@@ -251,7 +252,7 @@ func (h *RoleHandler) DeleteRole(ctx context.Context, req *connect.Request[pm.De
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "role",
 		StreamID:   req.Msg.Id,
-		EventType:  "RoleDeleted",
+		EventType:  string(eventtypes.RoleDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -317,7 +318,7 @@ func (h *RoleHandler) AssignRoleToUser(ctx context.Context, req *connect.Request
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "user_role",
 			StreamID:   streamID,
-			EventType:  "UserRoleAssigned",
+			EventType:  string(eventtypes.UserRoleAssigned),
 			Data: map[string]any{
 				"user_id": req.Msg.UserId,
 				"role_id": roleID,
@@ -384,7 +385,7 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "user_role",
 			StreamID:   streamID,
-			EventType:  "UserRoleRevoked",
+			EventType:  string(eventtypes.UserRoleRevoked),
 			Data: map[string]any{
 				"user_id": req.Msg.UserId,
 				"role_id": req.Msg.RoleId,
@@ -430,7 +431,7 @@ func (h *RoleHandler) bumpUserSessionVersion(ctx context.Context, userID, actorI
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   userID,
-		EventType:  "UserSessionInvalidated",
+		EventType:  string(eventtypes.UserSessionInvalidated),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    actorID,

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -74,14 +75,14 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// user_handler.go). Other user events (SSH keys, password,
 	// session invalidation, system-action linking) don't surface
 	// in search results today, so they classify as SearchOpNone.
-	case "UserCreatedWithRoles",
-		"UserEmailChanged",
-		"UserProfileUpdated",
-		"UserLinuxUsernameChanged",
-		"UserDisabled":
+	case string(eventtypes.UserCreatedWithRoles),
+		string(eventtypes.UserEmailChanged),
+		string(eventtypes.UserProfileUpdated),
+		string(eventtypes.UserLinuxUsernameChanged),
+		string(eventtypes.UserDisabled):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeUser, ID: e.StreamID}}
 
-	case "UserDeleted":
+	case string(eventtypes.UserDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeUser, ID: e.StreamID}}
 
 	// ---------------------------------------------------------
@@ -91,13 +92,13 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// denormalised fields per DeviceHandler.enqueueDeviceReindex.
 	// Cert renewal / assignment / unassignment do not change any
 	// of those fields → SearchOpNone.
-	case "DeviceRegistered",
-		"DeviceLabelSet",
-		"DeviceLabelRemoved",
-		"DeviceSyncIntervalSet":
+	case string(eventtypes.DeviceRegistered),
+		string(eventtypes.DeviceLabelSet),
+		string(eventtypes.DeviceLabelRemoved),
+		string(eventtypes.DeviceSyncIntervalSet):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeDevice, ID: e.StreamID}}
 
-	case "DeviceDeleted":
+	case string(eventtypes.DeviceDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeDevice, ID: e.StreamID}}
 
 	// ---------------------------------------------------------
@@ -108,17 +109,17 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// per DeviceGroupHandler.enqueueDeviceGroupReindex. Member-add /
 	// member-remove events update member_count; the row reload picks
 	// that up.
-	case "DeviceGroupCreated",
-		"DeviceGroupRenamed",
-		"DeviceGroupDescriptionUpdated",
-		"DeviceGroupQueryUpdated",
-		"DeviceGroupSyncIntervalSet",
-		"DeviceGroupMaintenanceWindowSet",
-		"DeviceGroupMemberAdded",
-		"DeviceGroupMemberRemoved":
+	case string(eventtypes.DeviceGroupCreated),
+		string(eventtypes.DeviceGroupRenamed),
+		string(eventtypes.DeviceGroupDescriptionUpdated),
+		string(eventtypes.DeviceGroupQueryUpdated),
+		string(eventtypes.DeviceGroupSyncIntervalSet),
+		string(eventtypes.DeviceGroupMaintenanceWindowSet),
+		string(eventtypes.DeviceGroupMemberAdded),
+		string(eventtypes.DeviceGroupMemberRemoved):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeDeviceGroup, ID: e.StreamID}}
 
-	case "DeviceGroupDeleted":
+	case string(eventtypes.DeviceGroupDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeDeviceGroup, ID: e.StreamID}}
 
 	// DeviceAddedToGroup / DeviceRemovedFromGroup / DeviceGroupAssigned
@@ -133,13 +134,13 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// Group-stream events (Created, Updated, QueryUpdated,
 	// MaintenanceWindowSet) carry the group ID directly in StreamID
 	// — these reindex against e.StreamID.
-	case "UserGroupCreated",
-		"UserGroupUpdated",
-		"UserGroupQueryUpdated",
-		"UserGroupMaintenanceWindowSet":
+	case string(eventtypes.UserGroupCreated),
+		string(eventtypes.UserGroupUpdated),
+		string(eventtypes.UserGroupQueryUpdated),
+		string(eventtypes.UserGroupMaintenanceWindowSet):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeUserGroup, ID: e.StreamID}}
 
-	case "UserGroupDeleted":
+	case string(eventtypes.UserGroupDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeUserGroup, ID: e.StreamID}}
 
 	// Member / role events use a COMPOSITE StreamID:
@@ -150,10 +151,10 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// listener (#77) — the user_id / role_id suffixes are irrelevant
 	// to the search payload (member_count + role list are already
 	// denormalised on the projection row by the projector).
-	case "UserGroupMemberAdded",
-		"UserGroupMemberRemoved",
-		"UserGroupRoleAssigned",
-		"UserGroupRoleRevoked":
+	case string(eventtypes.UserGroupMemberAdded),
+		string(eventtypes.UserGroupMemberRemoved),
+		string(eventtypes.UserGroupRoleAssigned),
+		string(eventtypes.UserGroupRoleRevoked):
 		groupID, _, _ := strings.Cut(e.StreamID, ":")
 		if groupID == "" {
 			return nil
@@ -167,14 +168,14 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// flags all live in the search row per the DispatchAction
 	// handler's existing inline enqueue. Every execution lifecycle
 	// event mutates one of those fields, so each one reindexes.
-	case "ExecutionCreated",
-		"ExecutionScheduled",
-		"ExecutionDispatched",
-		"ExecutionStarted",
-		"ExecutionCompleted",
-		"ExecutionFailed",
-		"ExecutionCancelled",
-		"ExecutionTimedOut":
+	case string(eventtypes.ExecutionCreated),
+		string(eventtypes.ExecutionScheduled),
+		string(eventtypes.ExecutionDispatched),
+		string(eventtypes.ExecutionStarted),
+		string(eventtypes.ExecutionCompleted),
+		string(eventtypes.ExecutionFailed),
+		string(eventtypes.ExecutionCancelled),
+		string(eventtypes.ExecutionTimedOut):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeExecution, ID: e.StreamID}}
 
 	// ---------------------------------------------------------
@@ -191,31 +192,31 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// follow-up PR) extends SearchAffected with member-edge variants
 	// and removes those calls. Splitting keeps this PR's diff small
 	// and CR-reviewable.
-	case "ActionSetCreated",
-		"ActionSetRenamed",
-		"ActionSetDescriptionUpdated",
-		"ActionSetScheduleUpdated",
-		"ActionSetMemberAdded",
-		"ActionSetMemberRemoved",
-		"ActionSetMemberReordered":
+	case string(eventtypes.ActionSetCreated),
+		string(eventtypes.ActionSetRenamed),
+		string(eventtypes.ActionSetDescriptionUpdated),
+		string(eventtypes.ActionSetScheduleUpdated),
+		string(eventtypes.ActionSetMemberAdded),
+		string(eventtypes.ActionSetMemberRemoved),
+		string(eventtypes.ActionSetMemberReordered):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeActionSet, ID: e.StreamID}}
 
-	case "ActionSetDeleted":
+	case string(eventtypes.ActionSetDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeActionSet, ID: e.StreamID}}
 
 	// ---------------------------------------------------------
 	// Definition scope (same shape as ActionSet)
 	// ---------------------------------------------------------
-	case "DefinitionCreated",
-		"DefinitionRenamed",
-		"DefinitionDescriptionUpdated",
-		"DefinitionScheduleUpdated",
-		"DefinitionMemberAdded",
-		"DefinitionMemberRemoved",
-		"DefinitionMemberReordered":
+	case string(eventtypes.DefinitionCreated),
+		string(eventtypes.DefinitionRenamed),
+		string(eventtypes.DefinitionDescriptionUpdated),
+		string(eventtypes.DefinitionScheduleUpdated),
+		string(eventtypes.DefinitionMemberAdded),
+		string(eventtypes.DefinitionMemberRemoved),
+		string(eventtypes.DefinitionMemberReordered):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeDefinition, ID: e.StreamID}}
 
-	case "DefinitionDeleted":
+	case string(eventtypes.DefinitionDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeDefinition, ID: e.StreamID}}
 
 	// ---------------------------------------------------------
@@ -225,13 +226,13 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// from action.params) all live on the search row. ParamsUpdated
 	// triggers a reindex because the isCompliance derivation can
 	// flip when params change.
-	case "ActionCreated",
-		"ActionRenamed",
-		"ActionDescriptionUpdated",
-		"ActionParamsUpdated":
+	case string(eventtypes.ActionCreated),
+		string(eventtypes.ActionRenamed),
+		string(eventtypes.ActionDescriptionUpdated),
+		string(eventtypes.ActionParamsUpdated):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeAction, ID: e.StreamID}}
 
-	case "ActionDeleted":
+	case string(eventtypes.ActionDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeAction, ID: e.StreamID}}
 
 	// ---------------------------------------------------------
@@ -241,15 +242,15 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// contributes denormalised action names ("ActionNames" field) so
 	// a search hit ranks/highlights by the policy's referenced
 	// actions. Rule mutations therefore reindex the policy too.
-	case "CompliancePolicyCreated",
-		"CompliancePolicyRenamed",
-		"CompliancePolicyDescriptionUpdated",
-		"CompliancePolicyRuleAdded",
-		"CompliancePolicyRuleRemoved",
-		"CompliancePolicyRuleUpdated":
+	case string(eventtypes.CompliancePolicyCreated),
+		string(eventtypes.CompliancePolicyRenamed),
+		string(eventtypes.CompliancePolicyDescriptionUpdated),
+		string(eventtypes.CompliancePolicyRuleAdded),
+		string(eventtypes.CompliancePolicyRuleRemoved),
+		string(eventtypes.CompliancePolicyRuleUpdated):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeCompliancePolicy, ID: e.StreamID}}
 
-	case "CompliancePolicyDeleted":
+	case string(eventtypes.CompliancePolicyDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeCompliancePolicy, ID: e.StreamID}}
 	}
 

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -9,6 +9,7 @@ import (
 	"connectrpc.com/connect"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -48,7 +49,7 @@ func (h *SettingsHandler) UpdateServerSettings(ctx context.Context, req *connect
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "server_settings",
 		StreamID:   "global",
-		EventType:  "ServerSettingUpdated",
+		EventType:  string(eventtypes.ServerSettingUpdated),
 		Data: map[string]any{
 			"user_provisioning_enabled": req.Msg.UserProvisioningEnabled,
 			"ssh_access_for_all":        req.Msg.SshAccessForAll,
@@ -117,7 +118,7 @@ func (h *SettingsHandler) enableProvisioningForAllUsers(ctx context.Context) err
 		if err := h.store.AppendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   u.ID,
-			EventType:  "UserProvisioningSettingsUpdated",
+			EventType:  string(eventtypes.UserProvisioningSettingsUpdated),
 			Data:       map[string]any{"user_provisioning_enabled": true},
 			ActorType:  "system",
 			ActorID:    "system",
@@ -148,7 +149,7 @@ func (h *SettingsHandler) enableSshAccessForAllUsers(ctx context.Context) error 
 		if err := h.store.AppendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   u.ID,
-			EventType:  "UserSshSettingsUpdated",
+			EventType:  string(eventtypes.UserSshSettingsUpdated),
 			Data: map[string]any{
 				"ssh_access_enabled": true,
 				"ssh_allow_pubkey":   u.SshAllowPubkey,

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -13,6 +13,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/idp"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -296,7 +297,7 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   linkResult.UserID,
-		EventType:  "UserProfileUpdated",
+		EventType:  string(eventtypes.UserProfileUpdated),
 		Data: map[string]any{
 			"display_name":       claims.Name,
 			"given_name":         claims.GivenName,
@@ -342,7 +343,7 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   user.ID,
-		EventType:  "UserLoggedIn",
+		EventType:  string(eventtypes.UserLoggedIn),
 		Data: map[string]any{
 			"provider": provider.Slug,
 		},

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -11,6 +11,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -506,7 +507,7 @@ func (m *SystemActionManager) createSystemAction(ctx context.Context, name strin
 	if err := m.store.AppendEvent(ctx, store.Event{
 		StreamType: "action",
 		StreamID:   id,
-		EventType:  "ActionCreated",
+		EventType:  string(eventtypes.ActionCreated),
 		Data: map[string]any{
 			"name":            name,
 			"description":     "System-managed action",
@@ -532,7 +533,7 @@ func (m *SystemActionManager) assignActionToUser(ctx context.Context, actionID, 
 	return m.store.AppendEvent(ctx, store.Event{
 		StreamType: "assignment",
 		StreamID:   assignmentID,
-		EventType:  "AssignmentCreated",
+		EventType:  string(eventtypes.AssignmentCreated),
 		Data: map[string]any{
 			"source_type": "action",
 			"source_id":   actionID,
@@ -556,7 +557,7 @@ func (m *SystemActionManager) updateSystemAction(ctx context.Context, actionID s
 	return m.store.AppendEvent(ctx, store.Event{
 		StreamType: "action",
 		StreamID:   actionID,
-		EventType:  "ActionParamsUpdated",
+		EventType:  string(eventtypes.ActionParamsUpdated),
 		Data: map[string]any{
 			"params":        params,
 			"desired_state": desiredState,
@@ -571,7 +572,7 @@ func (m *SystemActionManager) deleteSystemAction(ctx context.Context, actionID s
 	return m.store.AppendEvent(ctx, store.Event{
 		StreamType: "action",
 		StreamID:   actionID,
-		EventType:  "ActionDeleted",
+		EventType:  string(eventtypes.ActionDeleted),
 		Data:       map[string]any{},
 		ActorType:  "system",
 		ActorID:    "system",
@@ -584,7 +585,7 @@ func (m *SystemActionManager) linkSystemAction(ctx context.Context, userID, fiel
 	return m.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   userID,
-		EventType:  "UserSystemActionLinked",
+		EventType:  string(eventtypes.UserSystemActionLinked),
 		Data: map[string]any{
 			"field":     field,
 			"action_id": actionID,

--- a/internal/api/system_actions_listener.go
+++ b/internal/api/system_actions_listener.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -42,20 +43,20 @@ func AffectedFromEvent(e store.PersistedEvent) (SyncOp, []string) {
 	// must be re-evaluated. The user_id source varies: for `user`
 	// stream events it's the StreamID; for `user_role` it's in the
 	// event Data payload.
-	case "UserCreatedWithRoles",
-		"UserDisabled",
-		"UserEnabled",
-		"UserLinuxUsernameChanged",
-		"UserProvisioningSettingsUpdated",
-		"UserSshSettingsUpdated",
-		"UserProfileUpdated",
-		"UserSshKeyAdded",
-		"UserSshKeyRemoved",
-		"UserEmailChanged":
+	case string(eventtypes.UserCreatedWithRoles),
+		string(eventtypes.UserDisabled),
+		string(eventtypes.UserEnabled),
+		string(eventtypes.UserLinuxUsernameChanged),
+		string(eventtypes.UserProvisioningSettingsUpdated),
+		string(eventtypes.UserSshSettingsUpdated),
+		string(eventtypes.UserProfileUpdated),
+		string(eventtypes.UserSshKeyAdded),
+		string(eventtypes.UserSshKeyRemoved),
+		string(eventtypes.UserEmailChanged):
 		// stream_type=user, stream_id=user_id
 		return SyncOpSyncUser, []string{e.StreamID}
 
-	case "UserRoleAssigned", "UserRoleRevoked":
+	case string(eventtypes.UserRoleAssigned), string(eventtypes.UserRoleRevoked):
 		// stream_type=user_role, stream_id=user_id:role_id; user_id
 		// also lives in event.data["user_id"] for clarity. Prefer the
 		// data payload (cleaner contract); fall back to splitting the
@@ -72,7 +73,7 @@ func AffectedFromEvent(e store.PersistedEvent) (SyncOp, []string) {
 		}
 		return SyncOpNone, nil
 
-	case "UserGroupMemberAdded", "UserGroupMemberRemoved":
+	case string(eventtypes.UserGroupMemberAdded), string(eventtypes.UserGroupMemberRemoved):
 		// stream_type=user_group; event.data carries user_id of the
 		// added/removed member. StreamID format is mixed across
 		// emitters: SCIM (internal/scim/groups.go), the API user-
@@ -104,13 +105,13 @@ func AffectedFromEvent(e store.PersistedEvent) (SyncOp, []string) {
 
 	// Fan-out events — affect every holder / member / user. Route to
 	// the full sweep instead of materialising the affected set.
-	case "RoleUpdated",
-		"RoleDeleted",
-		"UserGroupRoleAssigned",
-		"UserGroupRoleRevoked",
-		"UserGroupDeleted",
-		"UserGroupQueryUpdated",
-		"ServerSettingUpdated":
+	case string(eventtypes.RoleUpdated),
+		string(eventtypes.RoleDeleted),
+		string(eventtypes.UserGroupRoleAssigned),
+		string(eventtypes.UserGroupRoleRevoked),
+		string(eventtypes.UserGroupDeleted),
+		string(eventtypes.UserGroupQueryUpdated),
+		string(eventtypes.ServerSettingUpdated):
 		return SyncOpSyncAll, nil
 
 	default:

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	sdkterminal "github.com/manchtools/power-manage/sdk/go/sys/terminal"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/store/generated"
@@ -157,7 +158,7 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   req.Msg.DeviceId,
-		EventType:  "TerminalSessionStarted",
+		EventType:  string(eventtypes.TerminalSessionStarted),
 		Data: map[string]any{
 			"session_id": sessionID,
 			"tty_user":   ttyUser,
@@ -401,7 +402,7 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   session.DeviceID,
-		EventType:  "TerminalSessionStopped",
+		EventType:  string(eventtypes.TerminalSessionStopped),
 		Data: map[string]any{
 			"session_id": session.SessionID,
 			"reason":     "user_stopped",
@@ -603,7 +604,7 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   session.DeviceID,
-		EventType:  "TerminalSessionTerminated",
+		EventType:  string(eventtypes.TerminalSessionTerminated),
 		Data: map[string]any{
 			"session_id": session.SessionID,
 			"reason":     req.Msg.Reason,

--- a/internal/api/token_handler.go
+++ b/internal/api/token_handler.go
@@ -15,6 +15,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -95,7 +96,7 @@ func (h *TokenHandler) CreateToken(ctx context.Context, req *connect.Request[pm.
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "token",
 		StreamID:   id,
-		EventType:  "TokenCreated",
+		EventType:  string(eventtypes.TokenCreated),
 		Data:       eventData,
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -187,7 +188,7 @@ func (h *TokenHandler) RenameToken(ctx context.Context, req *connect.Request[pm.
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "token",
 		StreamID:   req.Msg.Id,
-		EventType:  "TokenRenamed",
+		EventType:  string(eventtypes.TokenRenamed),
 		Data: map[string]any{
 			"name": req.Msg.Name,
 		},
@@ -262,7 +263,7 @@ func (h *TokenHandler) DeleteToken(ctx context.Context, req *connect.Request[pm.
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "token",
 		StreamID:   req.Msg.Id,
-		EventType:  "TokenDeleted",
+		EventType:  string(eventtypes.TokenDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/auth/totp"
 	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
@@ -78,7 +79,7 @@ func (h *TOTPHandler) SetupTOTP(ctx context.Context, req *connect.Request[pm.Set
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "totp",
 		StreamID:   userCtx.ID,
-		EventType:  "TOTPSetupInitiated",
+		EventType:  string(eventtypes.TOTPSetupInitiated),
 		Data: map[string]any{
 			"secret_encrypted":  encryptedSecret,
 			"backup_codes_hash": hashes,
@@ -134,7 +135,7 @@ func (h *TOTPHandler) VerifyTOTP(ctx context.Context, req *connect.Request[pm.Ve
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "totp",
 		StreamID:   userCtx.ID,
-		EventType:  "TOTPVerified",
+		EventType:  string(eventtypes.TOTPVerified),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -178,7 +179,7 @@ func (h *TOTPHandler) DisableTOTP(ctx context.Context, req *connect.Request[pm.D
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "totp",
 		StreamID:   userCtx.ID,
-		EventType:  "TOTPDisabled",
+		EventType:  string(eventtypes.TOTPDisabled),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -215,7 +216,7 @@ func (h *TOTPHandler) AdminDisableUserTOTP(ctx context.Context, req *connect.Req
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "totp",
 		StreamID:   targetUserID,
-		EventType:  "TOTPDisabled",
+		EventType:  string(eventtypes.TOTPDisabled),
 		Data:       map[string]any{"admin": true},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -288,7 +289,7 @@ func (h *TOTPHandler) RegenerateBackupCodes(ctx context.Context, req *connect.Re
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "totp",
 		StreamID:   userCtx.ID,
-		EventType:  "TOTPBackupCodesRegenerated",
+		EventType:  string(eventtypes.TOTPBackupCodesRegenerated),
 		Data: map[string]any{
 			"backup_codes_hash": hashes,
 		},
@@ -351,7 +352,7 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 			if err := h.store.AppendEvent(ctx, store.Event{
 				StreamType: "totp",
 				StreamID:   claims.UserID,
-				EventType:  "TOTPBackupCodeUsed",
+				EventType:  string(eventtypes.TOTPBackupCodeUsed),
 				Data:       map[string]any{"index": idx},
 				ActorType:  "user",
 				ActorID:    claims.UserID,
@@ -407,7 +408,7 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   claims.UserID,
-		EventType:  "UserLoggedIn",
+		EventType:  string(eventtypes.UserLoggedIn),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    claims.UserID,

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -14,6 +14,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/go/maintenance"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -75,7 +76,7 @@ func (h *UserGroupHandler) CreateUserGroup(ctx context.Context, req *connect.Req
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_group",
 		StreamID:   id,
-		EventType:  "UserGroupCreated",
+		EventType:  string(eventtypes.UserGroupCreated),
 		Data: map[string]any{
 			"name":          req.Msg.Name,
 			"description":   req.Msg.Description,
@@ -191,7 +192,7 @@ func (h *UserGroupHandler) UpdateUserGroup(ctx context.Context, req *connect.Req
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_group",
 		StreamID:   req.Msg.GroupId,
-		EventType:  "UserGroupUpdated",
+		EventType:  string(eventtypes.UserGroupUpdated),
 		Data: map[string]any{
 			"name":        req.Msg.Name,
 			"description": req.Msg.Description,
@@ -242,7 +243,7 @@ func (h *UserGroupHandler) SetUserGroupMaintenanceWindow(ctx context.Context, re
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_group",
 		StreamID:   req.Msg.Id,
-		EventType:  "UserGroupMaintenanceWindowSet",
+		EventType:  string(eventtypes.UserGroupMaintenanceWindowSet),
 		Data: map[string]any{
 			"maintenance_window": maintenanceWindowToMap(req.Msg.MaintenanceWindow),
 		},
@@ -289,7 +290,7 @@ func (h *UserGroupHandler) DeleteUserGroup(ctx context.Context, req *connect.Req
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_group",
 		StreamID:   req.Msg.Id,
-		EventType:  "UserGroupDeleted",
+		EventType:  string(eventtypes.UserGroupDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -367,7 +368,7 @@ func (h *UserGroupHandler) AddUserToGroup(ctx context.Context, req *connect.Requ
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "user_group",
 			StreamID:   streamID,
-			EventType:  "UserGroupMemberAdded",
+			EventType:  string(eventtypes.UserGroupMemberAdded),
 			Data: map[string]any{
 				"group_id": req.Msg.GroupId,
 				"user_id":  userID,
@@ -429,7 +430,7 @@ func (h *UserGroupHandler) RemoveUserFromGroup(ctx context.Context, req *connect
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_group",
 		StreamID:   streamID,
-		EventType:  "UserGroupMemberRemoved",
+		EventType:  string(eventtypes.UserGroupMemberRemoved),
 		Data: map[string]any{
 			"group_id": req.Msg.GroupId,
 			"user_id":  req.Msg.UserId,
@@ -507,7 +508,7 @@ func (h *UserGroupHandler) AssignRoleToUserGroup(ctx context.Context, req *conne
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "user_group",
 			StreamID:   streamID,
-			EventType:  "UserGroupRoleAssigned",
+			EventType:  string(eventtypes.UserGroupRoleAssigned),
 			Data: map[string]any{
 				"group_id": req.Msg.GroupId,
 				"role_id":  roleID,
@@ -553,7 +554,7 @@ func (h *UserGroupHandler) RevokeRoleFromUserGroup(ctx context.Context, req *con
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_group",
 		StreamID:   streamID,
-		EventType:  "UserGroupRoleRevoked",
+		EventType:  string(eventtypes.UserGroupRoleRevoked),
 		Data: map[string]any{
 			"group_id": req.Msg.GroupId,
 			"role_id":  req.Msg.RoleId,
@@ -628,7 +629,7 @@ func (h *UserGroupHandler) UpdateUserGroupQuery(ctx context.Context, req *connec
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_group",
 		StreamID:   req.Msg.Id,
-		EventType:  "UserGroupQueryUpdated",
+		EventType:  string(eventtypes.UserGroupQueryUpdated),
 		Data: map[string]any{
 			"is_dynamic":    req.Msg.IsDynamic,
 			"dynamic_query": req.Msg.DynamicQuery,
@@ -762,7 +763,7 @@ func (h *UserGroupHandler) bumpUserSessionVersion(ctx context.Context, userID, a
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   userID,
-		EventType:  "UserSessionInvalidated",
+		EventType:  string(eventtypes.UserSessionInvalidated),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    actorID,

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -14,6 +14,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -132,7 +133,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   id,
-		EventType:  "UserCreatedWithRoles",
+		EventType:  string(eventtypes.UserCreatedWithRoles),
 		Data: map[string]any{
 			"email":              req.Msg.Email,
 			"password_hash":      passwordHash,
@@ -173,7 +174,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 			if err := h.store.AppendEvent(ctx, store.Event{
 				StreamType: "user",
 				StreamID:   id,
-				EventType:  "UserProvisioningSettingsUpdated",
+				EventType:  string(eventtypes.UserProvisioningSettingsUpdated),
 				Data:       map[string]any{"user_provisioning_enabled": true},
 				ActorType:  "system",
 				ActorID:    "auto",
@@ -185,7 +186,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 			if err := h.store.AppendEvent(ctx, store.Event{
 				StreamType: "user",
 				StreamID:   id,
-				EventType:  "UserSshSettingsUpdated",
+				EventType:  string(eventtypes.UserSshSettingsUpdated),
 				Data: map[string]any{
 					"ssh_access_enabled": true,
 					"ssh_allow_pubkey":   true,
@@ -327,7 +328,7 @@ func (h *UserHandler) UpdateUserEmail(ctx context.Context, req *connect.Request[
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   req.Msg.Id,
-		EventType:  "UserEmailChanged",
+		EventType:  string(eventtypes.UserEmailChanged),
 		Data: map[string]any{
 			"email": req.Msg.Email,
 		},
@@ -392,7 +393,7 @@ func (h *UserHandler) UpdateUserPassword(ctx context.Context, req *connect.Reque
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   req.Msg.Id,
-		EventType:  "UserPasswordChanged",
+		EventType:  string(eventtypes.UserPasswordChanged),
 		Data: map[string]any{
 			"password_hash": passwordHash,
 		},
@@ -479,7 +480,7 @@ func (h *UserHandler) DeleteUser(ctx context.Context, req *connect.Request[pm.De
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   req.Msg.Id,
-		EventType:  "UserDeleted",
+		EventType:  string(eventtypes.UserDeleted),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userCtx.ID,
@@ -521,7 +522,7 @@ func (h *UserHandler) UpdateUserProfile(ctx context.Context, req *connect.Reques
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   req.Msg.Id,
-		EventType:  "UserProfileUpdated",
+		EventType:  string(eventtypes.UserProfileUpdated),
 		Data: map[string]any{
 			"display_name":       req.Msg.DisplayName,
 			"given_name":         req.Msg.GivenName,
@@ -622,7 +623,7 @@ func (h *UserHandler) SetUserProvisioningEnabled(ctx context.Context, req *conne
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   req.Msg.UserId,
-		EventType:  "UserProvisioningSettingsUpdated",
+		EventType:  string(eventtypes.UserProvisioningSettingsUpdated),
 		Data: map[string]any{
 			"user_provisioning_enabled": req.Msg.Enabled,
 		},
@@ -673,7 +674,7 @@ func (h *UserHandler) UpdateUserLinuxUsername(ctx context.Context, req *connect.
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   req.Msg.UserId,
-		EventType:  "UserLinuxUsernameChanged",
+		EventType:  string(eventtypes.UserLinuxUsernameChanged),
 		Data: map[string]any{
 			"linux_username": username,
 		},
@@ -719,7 +720,7 @@ func (h *UserHandler) AddUserSshKey(ctx context.Context, req *connect.Request[pm
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   req.Msg.UserId,
-		EventType:  "UserSshKeyAdded",
+		EventType:  string(eventtypes.UserSshKeyAdded),
 		Data: map[string]any{
 			"key_id":     keyID,
 			"public_key": req.Msg.PublicKey,
@@ -763,7 +764,7 @@ func (h *UserHandler) RemoveUserSshKey(ctx context.Context, req *connect.Request
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   req.Msg.UserId,
-		EventType:  "UserSshKeyRemoved",
+		EventType:  string(eventtypes.UserSshKeyRemoved),
 		Data: map[string]any{
 			"key_id": req.Msg.KeyId,
 		},
@@ -797,7 +798,7 @@ func (h *UserHandler) UpdateUserSshSettings(ctx context.Context, req *connect.Re
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   req.Msg.UserId,
-		EventType:  "UserSshSettingsUpdated",
+		EventType:  string(eventtypes.UserSshSettingsUpdated),
 		Data: map[string]any{
 			"ssh_access_enabled": req.Msg.SshAccessEnabled,
 			"ssh_allow_pubkey":   req.Msg.SshAllowPubkey,

--- a/internal/api/user_selection_handler.go
+++ b/internal/api/user_selection_handler.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -74,7 +75,7 @@ func (h *UserSelectionHandler) SetUserSelection(ctx context.Context, req *connec
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_selection",
 		StreamID:   id,
-		EventType:  "UserSelectionChanged",
+		EventType:  string(eventtypes.UserSelectionChanged),
 		Data: map[string]any{
 			"device_id":   req.Msg.DeviceId,
 			"source_type": sourceTypeStr,

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -16,6 +16,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
@@ -105,7 +106,7 @@ func (w *InboxWorker) handleDeviceHello(ctx context.Context, t *asynq.Task) erro
 	if err := w.store.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   payload.DeviceID,
-		EventType:  "DeviceHeartbeat",
+		EventType:  string(eventtypes.DeviceHeartbeat),
 		Data: map[string]any{
 			"agent_version": payload.AgentVersion,
 			"hostname":      payload.Hostname,
@@ -166,7 +167,7 @@ func (w *InboxWorker) handleDeviceHeartbeat(ctx context.Context, t *asynq.Task) 
 	return w.store.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   payload.DeviceID,
-		EventType:  "DeviceHeartbeat",
+		EventType:  string(eventtypes.DeviceHeartbeat),
 		Data:       data,
 		ActorType:  "device",
 		ActorID:    payload.DeviceID,
@@ -275,7 +276,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		if err := w.store.AppendEvent(ctx, store.Event{
 			StreamType: "execution",
 			StreamID:   executionID,
-			EventType:  "ExecutionCreated",
+			EventType:  string(eventtypes.ExecutionCreated),
 			Data:       createdData,
 			ActorType:  "device",
 			ActorID:    deviceID,
@@ -374,7 +375,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 				if err := w.store.AppendEvent(ctx, store.Event{
 					StreamType: "compliance",
 					StreamID:   deviceID + "_" + actionID,
-					EventType:  "ComplianceResultUpdated",
+					EventType:  string(eventtypes.ComplianceResultUpdated),
 					Data:       complianceData,
 					ActorType:  "device",
 					ActorID:    deviceID,
@@ -398,7 +399,7 @@ func (w *InboxWorker) handleExecutionOutputChunk(ctx context.Context, t *asynq.T
 	return w.store.AppendEvent(ctx, store.Event{
 		StreamType: "execution",
 		StreamID:   payload.ExecutionID,
-		EventType:  "OutputChunk",
+		EventType:  string(eventtypes.OutputChunk),
 		Data: map[string]any{
 			"stream":   payload.Stream,
 			"data":     payload.Data,
@@ -506,7 +507,7 @@ func (w *InboxWorker) handleSecurityAlert(ctx context.Context, t *asynq.Task) er
 	return w.store.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   payload.DeviceID,
-		EventType:  "SecurityAlert",
+		EventType:  string(eventtypes.SecurityAlert),
 		Data: map[string]any{
 			"alert_type": payload.AlertType,
 			"message":    payload.Message,
@@ -583,7 +584,7 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 		return w.store.AppendEvent(ctx, store.Event{
 			StreamType: "luks_key",
 			StreamID:   luksStreamID,
-			EventType:  "LuksDeviceKeyRevoked",
+			EventType:  string(eventtypes.LuksDeviceKeyRevoked),
 			Data: map[string]any{
 				"device_id":  payload.DeviceID,
 				"action_id":  payload.ActionID,
@@ -597,7 +598,7 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 	return w.store.AppendEvent(ctx, store.Event{
 		StreamType: "luks_key",
 		StreamID:   luksStreamID,
-		EventType:  "LuksDeviceKeyRevocationFailed",
+		EventType:  string(eventtypes.LuksDeviceKeyRevocationFailed),
 		Data: map[string]any{
 			"device_id": payload.DeviceID,
 			"action_id": payload.ActionID,
@@ -663,7 +664,7 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 						if appendErr := w.store.AppendEvent(ctx, store.Event{
 							StreamType: "execution",
 							StreamID:   exec.ID,
-							EventType:  "ExecutionFailed",
+							EventType:  string(eventtypes.ExecutionFailed),
 							Data: map[string]any{
 								"error":        "action was deleted before the device came online",
 								"duration_ms":  int64(0),
@@ -726,7 +727,7 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 		dispatchEvt := store.Event{
 			StreamType: "execution",
 			StreamID:   exec.ID,
-			EventType:  "ExecutionDispatched",
+			EventType:  string(eventtypes.ExecutionDispatched),
 			Data: map[string]any{
 				"device_id": deviceID,
 			},

--- a/internal/eventtypes/types.go
+++ b/internal/eventtypes/types.go
@@ -1,0 +1,257 @@
+// Package eventtypes is the single source of truth for event-type
+// string identifiers stored in the events table. Constants here catch
+// typos at compile time that would otherwise silently mis-dispatch
+// (a bare `case "UserCrated":` matches no event, projects nothing,
+// and never errors). Every emit site and every listener switch in the
+// server should reference a constant from this package instead of a
+// bare string literal.
+//
+// The constants intentionally retain the exact wire-string values the
+// server has always written into events.event_type — the events table
+// schema does not change, the JSON-encoded event_type column stays a
+// plain string, and historical events stay readable.
+package eventtypes
+
+// EventType is the typed wrapper for an event-type identifier. Stored
+// as the bare string in the events table; the type alias only
+// constrains where a string literal can be passed at the Go layer.
+// Convert with string(eventtypes.X) at the boundary with store.Event,
+// where the field is intentionally still a plain string (matching the
+// JSONB column).
+type EventType string
+
+const (
+	// action stream
+	ActionCreated            EventType = "ActionCreated"
+	ActionRenamed            EventType = "ActionRenamed"
+	ActionDescriptionUpdated EventType = "ActionDescriptionUpdated"
+	ActionParamsUpdated      EventType = "ActionParamsUpdated"
+	ActionDeleted            EventType = "ActionDeleted"
+
+	// definition stream
+	DefinitionCreated            EventType = "DefinitionCreated"
+	DefinitionRenamed            EventType = "DefinitionRenamed"
+	DefinitionDescriptionUpdated EventType = "DefinitionDescriptionUpdated"
+	DefinitionScheduleUpdated    EventType = "DefinitionScheduleUpdated"
+	DefinitionDeleted            EventType = "DefinitionDeleted"
+	DefinitionMemberAdded        EventType = "DefinitionMemberAdded"
+	DefinitionMemberRemoved      EventType = "DefinitionMemberRemoved"
+	DefinitionMemberReordered    EventType = "DefinitionMemberReordered"
+
+	// action_set stream
+	ActionSetCreated            EventType = "ActionSetCreated"
+	ActionSetRenamed            EventType = "ActionSetRenamed"
+	ActionSetDescriptionUpdated EventType = "ActionSetDescriptionUpdated"
+	ActionSetScheduleUpdated    EventType = "ActionSetScheduleUpdated"
+	ActionSetDeleted            EventType = "ActionSetDeleted"
+	ActionSetMemberAdded        EventType = "ActionSetMemberAdded"
+	ActionSetMemberRemoved      EventType = "ActionSetMemberRemoved"
+	ActionSetMemberReordered    EventType = "ActionSetMemberReordered"
+
+	// assignment stream
+	AssignmentCreated          EventType = "AssignmentCreated"
+	AssignmentDeleted          EventType = "AssignmentDeleted"
+	AssignmentModeChanged      EventType = "AssignmentModeChanged"
+	AssignmentSortOrderChanged EventType = "AssignmentSortOrderChanged"
+
+	// compliance stream
+	ComplianceResultUpdated EventType = "ComplianceResultUpdated"
+	ComplianceResultRemoved EventType = "ComplianceResultRemoved"
+
+	// compliance_policy stream
+	CompliancePolicyCreated            EventType = "CompliancePolicyCreated"
+	CompliancePolicyRenamed            EventType = "CompliancePolicyRenamed"
+	CompliancePolicyDescriptionUpdated EventType = "CompliancePolicyDescriptionUpdated"
+	CompliancePolicyDeleted            EventType = "CompliancePolicyDeleted"
+	CompliancePolicyRuleAdded          EventType = "CompliancePolicyRuleAdded"
+	CompliancePolicyRuleRemoved        EventType = "CompliancePolicyRuleRemoved"
+	CompliancePolicyRuleUpdated        EventType = "CompliancePolicyRuleUpdated"
+
+	// device stream
+	DeviceRegistered      EventType = "DeviceRegistered"
+	DeviceSeen            EventType = "DeviceSeen"
+	DeviceHeartbeat       EventType = "DeviceHeartbeat"
+	DeviceCertRenewed     EventType = "DeviceCertRenewed"
+	DeviceLabelsUpdated   EventType = "DeviceLabelsUpdated"
+	DeviceLabelSet        EventType = "DeviceLabelSet"
+	DeviceLabelRemoved    EventType = "DeviceLabelRemoved"
+	DeviceDeleted         EventType = "DeviceDeleted"
+	DeviceAssigned        EventType = "DeviceAssigned"
+	DeviceUnassigned      EventType = "DeviceUnassigned"
+	DeviceGroupAssigned   EventType = "DeviceGroupAssigned"
+	DeviceGroupUnassigned EventType = "DeviceGroupUnassigned"
+	DeviceSyncIntervalSet EventType = "DeviceSyncIntervalSet"
+
+	// device_group stream
+	DeviceGroupCreated              EventType = "DeviceGroupCreated"
+	DeviceGroupRenamed              EventType = "DeviceGroupRenamed"
+	DeviceGroupDescriptionUpdated   EventType = "DeviceGroupDescriptionUpdated"
+	DeviceGroupQueryUpdated         EventType = "DeviceGroupQueryUpdated"
+	DeviceGroupSyncIntervalSet      EventType = "DeviceGroupSyncIntervalSet"
+	DeviceGroupMaintenanceWindowSet EventType = "DeviceGroupMaintenanceWindowSet"
+	DeviceGroupMemberAdded          EventType = "DeviceGroupMemberAdded"
+	DeviceGroupMemberRemoved        EventType = "DeviceGroupMemberRemoved"
+	DeviceGroupDeleted              EventType = "DeviceGroupDeleted"
+	// Legacy device-group membership aliases — emitted by older versions
+	// before the *MemberAdded / *MemberRemoved naming. The device_group
+	// listener still recognises them so historical events replay
+	// correctly during a rebuild.
+	DeviceAddedToGroup     EventType = "DeviceAddedToGroup"
+	DeviceRemovedFromGroup EventType = "DeviceRemovedFromGroup"
+
+	// execution stream
+	ExecutionCreated    EventType = "ExecutionCreated"
+	ExecutionScheduled  EventType = "ExecutionScheduled"
+	ExecutionDispatched EventType = "ExecutionDispatched"
+	ExecutionStarted    EventType = "ExecutionStarted"
+	ExecutionCompleted  EventType = "ExecutionCompleted"
+	ExecutionFailed     EventType = "ExecutionFailed"
+	ExecutionTimedOut   EventType = "ExecutionTimedOut"
+	ExecutionSkipped    EventType = "ExecutionSkipped"
+	ExecutionCancelled  EventType = "ExecutionCancelled"
+	// OutputChunk is emitted on the execution stream for streaming
+	// terminal/output payloads (LoadOutputChunks reads them back).
+	OutputChunk EventType = "OutputChunk"
+
+	// identity_provider stream
+	IdentityProviderCreated          EventType = "IdentityProviderCreated"
+	IdentityProviderUpdated          EventType = "IdentityProviderUpdated"
+	IdentityProviderDeleted          EventType = "IdentityProviderDeleted"
+	IdentityProviderSCIMEnabled      EventType = "IdentityProviderSCIMEnabled"
+	IdentityProviderSCIMDisabled     EventType = "IdentityProviderSCIMDisabled"
+	IdentityProviderSCIMTokenRotated EventType = "IdentityProviderSCIMTokenRotated"
+	IdentityLinked                   EventType = "IdentityLinked"
+	IdentityLinkLoginUpdated         EventType = "IdentityLinkLoginUpdated"
+	IdentityUnlinked                 EventType = "IdentityUnlinked"
+
+	// lps_password stream
+	LpsPasswordRotated EventType = "LpsPasswordRotated"
+
+	// luks_key stream
+	LuksKeyRotated                    EventType = "LuksKeyRotated"
+	LuksDeviceKeyRevocationRequested  EventType = "LuksDeviceKeyRevocationRequested"
+	LuksDeviceKeyRevocationDispatched EventType = "LuksDeviceKeyRevocationDispatched"
+	LuksDeviceKeyRevoked              EventType = "LuksDeviceKeyRevoked"
+	LuksDeviceKeyRevocationFailed     EventType = "LuksDeviceKeyRevocationFailed"
+
+	// role stream
+	RoleCreated EventType = "RoleCreated"
+	RoleUpdated EventType = "RoleUpdated"
+	RoleDeleted EventType = "RoleDeleted"
+
+	// scim_group_mapping stream
+	SCIMGroupMapped         EventType = "SCIMGroupMapped"
+	SCIMGroupUnmapped       EventType = "SCIMGroupUnmapped"
+	SCIMGroupMappingUpdated EventType = "SCIMGroupMappingUpdated"
+
+	// security_alert stream
+	SecurityAlert             EventType = "SecurityAlert"
+	SecurityAlertAcknowledged EventType = "SecurityAlertAcknowledged"
+
+	// server_settings stream
+	ServerSettingUpdated EventType = "ServerSettingUpdated"
+
+	// terminal_session stream
+	TerminalSessionStarted    EventType = "TerminalSessionStarted"
+	TerminalSessionStopped    EventType = "TerminalSessionStopped"
+	TerminalSessionTerminated EventType = "TerminalSessionTerminated"
+
+	// token stream
+	TokenCreated  EventType = "TokenCreated"
+	TokenRenamed  EventType = "TokenRenamed"
+	TokenUsed     EventType = "TokenUsed"
+	TokenDisabled EventType = "TokenDisabled"
+	TokenEnabled  EventType = "TokenEnabled"
+	TokenDeleted  EventType = "TokenDeleted"
+
+	// totp stream
+	TOTPSetupInitiated         EventType = "TOTPSetupInitiated"
+	TOTPVerified               EventType = "TOTPVerified"
+	TOTPDisabled               EventType = "TOTPDisabled"
+	TOTPBackupCodeUsed         EventType = "TOTPBackupCodeUsed"
+	TOTPBackupCodesRegenerated EventType = "TOTPBackupCodesRegenerated"
+
+	// user stream
+	UserCreatedWithRoles            EventType = "UserCreatedWithRoles"
+	UserProfileUpdated              EventType = "UserProfileUpdated"
+	UserEmailChanged                EventType = "UserEmailChanged"
+	UserPasswordChanged             EventType = "UserPasswordChanged"
+	UserRoleChanged                 EventType = "UserRoleChanged"
+	UserSessionInvalidated          EventType = "UserSessionInvalidated"
+	UserDisabled                    EventType = "UserDisabled"
+	UserEnabled                     EventType = "UserEnabled"
+	UserLoggedIn                    EventType = "UserLoggedIn"
+	UserDeleted                     EventType = "UserDeleted"
+	UserSshKeyAdded                 EventType = "UserSshKeyAdded"
+	UserSshKeyRemoved               EventType = "UserSshKeyRemoved"
+	UserSshSettingsUpdated          EventType = "UserSshSettingsUpdated"
+	UserLinuxUsernameChanged        EventType = "UserLinuxUsernameChanged"
+	UserSystemActionLinked          EventType = "UserSystemActionLinked"
+	UserProvisioningSettingsUpdated EventType = "UserProvisioningSettingsUpdated"
+
+	// user_role stream
+	UserRoleAssigned EventType = "UserRoleAssigned"
+	UserRoleRevoked  EventType = "UserRoleRevoked"
+
+	// user_group stream
+	UserGroupCreated              EventType = "UserGroupCreated"
+	UserGroupUpdated              EventType = "UserGroupUpdated"
+	UserGroupQueryUpdated         EventType = "UserGroupQueryUpdated"
+	UserGroupMaintenanceWindowSet EventType = "UserGroupMaintenanceWindowSet"
+	UserGroupDeleted              EventType = "UserGroupDeleted"
+	UserGroupMemberAdded          EventType = "UserGroupMemberAdded"
+	UserGroupMemberRemoved        EventType = "UserGroupMemberRemoved"
+	UserGroupRoleAssigned         EventType = "UserGroupRoleAssigned"
+	UserGroupRoleRevoked          EventType = "UserGroupRoleRevoked"
+	UserGroupMembersRebuilt       EventType = "UserGroupMembersRebuilt"
+
+	// user_selection stream
+	UserSelectionChanged EventType = "UserSelectionChanged"
+)
+
+// All returns every defined event type. Useful for tests that want to
+// enumerate over the full set (e.g. uniqueness checks, future parity
+// checks against listener switch coverage).
+func All() []EventType {
+	return []EventType{
+		ActionCreated, ActionRenamed, ActionDescriptionUpdated, ActionParamsUpdated, ActionDeleted,
+		DefinitionCreated, DefinitionRenamed, DefinitionDescriptionUpdated, DefinitionScheduleUpdated, DefinitionDeleted,
+		DefinitionMemberAdded, DefinitionMemberRemoved, DefinitionMemberReordered,
+		ActionSetCreated, ActionSetRenamed, ActionSetDescriptionUpdated, ActionSetScheduleUpdated,
+		ActionSetDeleted, ActionSetMemberAdded, ActionSetMemberRemoved, ActionSetMemberReordered,
+		AssignmentCreated, AssignmentDeleted, AssignmentModeChanged, AssignmentSortOrderChanged,
+		ComplianceResultUpdated, ComplianceResultRemoved,
+		CompliancePolicyCreated, CompliancePolicyRenamed, CompliancePolicyDescriptionUpdated, CompliancePolicyDeleted,
+		CompliancePolicyRuleAdded, CompliancePolicyRuleRemoved, CompliancePolicyRuleUpdated,
+		DeviceRegistered, DeviceSeen, DeviceHeartbeat, DeviceCertRenewed, DeviceLabelsUpdated,
+		DeviceLabelSet, DeviceLabelRemoved, DeviceDeleted, DeviceAssigned, DeviceUnassigned,
+		DeviceGroupAssigned, DeviceGroupUnassigned, DeviceSyncIntervalSet,
+		DeviceGroupCreated, DeviceGroupRenamed, DeviceGroupDescriptionUpdated, DeviceGroupQueryUpdated,
+		DeviceGroupSyncIntervalSet, DeviceGroupMaintenanceWindowSet, DeviceGroupMemberAdded,
+		DeviceGroupMemberRemoved, DeviceGroupDeleted, DeviceAddedToGroup, DeviceRemovedFromGroup,
+		ExecutionCreated, ExecutionScheduled, ExecutionDispatched, ExecutionStarted, ExecutionCompleted,
+		ExecutionFailed, ExecutionTimedOut, ExecutionSkipped, ExecutionCancelled, OutputChunk,
+		IdentityProviderCreated, IdentityProviderUpdated, IdentityProviderDeleted, IdentityProviderSCIMEnabled,
+		IdentityProviderSCIMDisabled, IdentityProviderSCIMTokenRotated, IdentityLinked,
+		IdentityLinkLoginUpdated, IdentityUnlinked,
+		LpsPasswordRotated,
+		LuksKeyRotated, LuksDeviceKeyRevocationRequested, LuksDeviceKeyRevocationDispatched,
+		LuksDeviceKeyRevoked, LuksDeviceKeyRevocationFailed,
+		RoleCreated, RoleUpdated, RoleDeleted,
+		SCIMGroupMapped, SCIMGroupUnmapped, SCIMGroupMappingUpdated,
+		SecurityAlert, SecurityAlertAcknowledged,
+		ServerSettingUpdated,
+		TerminalSessionStarted, TerminalSessionStopped, TerminalSessionTerminated,
+		TokenCreated, TokenRenamed, TokenUsed, TokenDisabled, TokenEnabled, TokenDeleted,
+		TOTPSetupInitiated, TOTPVerified, TOTPDisabled, TOTPBackupCodeUsed, TOTPBackupCodesRegenerated,
+		UserCreatedWithRoles, UserProfileUpdated, UserEmailChanged, UserPasswordChanged, UserRoleChanged,
+		UserSessionInvalidated, UserDisabled, UserEnabled, UserLoggedIn, UserDeleted,
+		UserSshKeyAdded, UserSshKeyRemoved, UserSshSettingsUpdated, UserLinuxUsernameChanged,
+		UserSystemActionLinked, UserProvisioningSettingsUpdated,
+		UserRoleAssigned, UserRoleRevoked,
+		UserGroupCreated, UserGroupUpdated, UserGroupQueryUpdated, UserGroupMaintenanceWindowSet,
+		UserGroupDeleted, UserGroupMemberAdded, UserGroupMemberRemoved, UserGroupRoleAssigned,
+		UserGroupRoleRevoked, UserGroupMembersRebuilt,
+		UserSelectionChanged,
+	}
+}

--- a/internal/eventtypes/types_test.go
+++ b/internal/eventtypes/types_test.go
@@ -1,0 +1,47 @@
+package eventtypes
+
+import (
+	"regexp"
+	"testing"
+)
+
+// TestAll_NoDuplicates ensures the All() slice has no duplicate values.
+// A duplicate would mean two constants share a wire string and a typo
+// or copy-paste mistake during a future addition would silently
+// shadow an existing event.
+func TestAll_NoDuplicates(t *testing.T) {
+	seen := make(map[EventType]bool, len(All()))
+	for _, et := range All() {
+		if seen[et] {
+			t.Errorf("duplicate event type in All(): %q", et)
+		}
+		seen[et] = true
+	}
+}
+
+// TestAll_NonEmpty ensures every constant has a non-empty wire string.
+// An empty event type would never match in any switch and would also
+// fail the events table CHECK constraint.
+func TestAll_NonEmpty(t *testing.T) {
+	for i, et := range All() {
+		if et == "" {
+			t.Errorf("All()[%d] is empty", i)
+		}
+	}
+}
+
+// TestAll_MatchesPattern ensures every constant follows PascalCase
+// (the project convention for event-type identifiers). This catches
+// accidental snake_case or kebab-case slips at refactor time.
+func TestAll_MatchesPattern(t *testing.T) {
+	// Allow PascalCase with embedded uppercase runs (TOTPVerified,
+	// SCIMGroupMapped, IdentityProviderSCIMEnabled). Identifiers must
+	// start with an uppercase letter and contain only ASCII letters
+	// and digits.
+	pattern := regexp.MustCompile(`^[A-Z][A-Za-z0-9]+$`)
+	for _, et := range All() {
+		if !pattern.MatchString(string(et)) {
+			t.Errorf("event type %q does not match PascalCase pattern", et)
+		}
+	}
+}

--- a/internal/idp/linker.go
+++ b/internal/idp/linker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
@@ -103,7 +104,7 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProviders
 			if err := l.appender.AppendEvent(ctx, EventInput{
 				StreamType: "identity_provider",
 				StreamID:   link.ID,
-				EventType:  "IdentityUnlinked",
+				EventType:  string(eventtypes.IdentityUnlinked),
 				Data:       map[string]any{},
 				ActorType:  "system",
 				ActorID:    "sso",
@@ -118,7 +119,7 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProviders
 			err = l.appender.AppendEvent(ctx, EventInput{
 				StreamType: "identity_provider",
 				StreamID:   link.ID,
-				EventType:  "IdentityLinkLoginUpdated",
+				EventType:  string(eventtypes.IdentityLinkLoginUpdated),
 				Data: map[string]any{
 					"provider_id":    provider.ID,
 					"external_id":    claims.Subject,
@@ -153,7 +154,7 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProviders
 			err = l.appender.AppendEvent(ctx, EventInput{
 				StreamType: "identity_provider",
 				StreamID:   linkID,
-				EventType:  "IdentityLinked",
+				EventType:  string(eventtypes.IdentityLinked),
 				Data: map[string]any{
 					"user_id":        user.ID,
 					"provider_id":    provider.ID,
@@ -209,7 +210,7 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProviders
 		err = l.appender.AppendEvent(ctx, EventInput{
 			StreamType: "user",
 			StreamID:   userID,
-			EventType:  "UserCreatedWithRoles",
+			EventType:  string(eventtypes.UserCreatedWithRoles),
 			Data: map[string]any{
 				"email":              claims.Email,
 				"role":               "user",
@@ -236,7 +237,7 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProviders
 				if err := l.appender.AppendEvent(ctx, EventInput{
 					StreamType: "user",
 					StreamID:   userID,
-					EventType:  "UserProvisioningSettingsUpdated",
+					EventType:  string(eventtypes.UserProvisioningSettingsUpdated),
 					Data:       map[string]any{"user_provisioning_enabled": true},
 					ActorType:  "system",
 					ActorID:    "sso",
@@ -248,7 +249,7 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProviders
 				if err := l.appender.AppendEvent(ctx, EventInput{
 					StreamType: "user",
 					StreamID:   userID,
-					EventType:  "UserSshSettingsUpdated",
+					EventType:  string(eventtypes.UserSshSettingsUpdated),
 					Data: map[string]any{
 						"ssh_access_enabled": true,
 						"ssh_allow_pubkey":   true,
@@ -269,7 +270,7 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProviders
 		err = l.appender.AppendEvent(ctx, EventInput{
 			StreamType: "identity_provider",
 			StreamID:   linkID,
-			EventType:  "IdentityLinked",
+			EventType:  string(eventtypes.IdentityLinked),
 			Data: map[string]any{
 				"user_id":        userID,
 				"provider_id":    provider.ID,
@@ -323,7 +324,7 @@ func (l *Linker) SyncGroupMemberships(ctx context.Context, userID string, extern
 			if err := l.appender.AppendEvent(ctx, EventInput{
 				StreamType: "user_group",
 				StreamID:   groupID,
-				EventType:  "UserGroupMemberAdded",
+				EventType:  string(eventtypes.UserGroupMemberAdded),
 				Data: map[string]any{
 					"group_id": groupID,
 					"user_id":  userID,
@@ -338,7 +339,7 @@ func (l *Linker) SyncGroupMemberships(ctx context.Context, userID string, extern
 			if err := l.appender.AppendEvent(ctx, EventInput{
 				StreamType: "user_group",
 				StreamID:   groupID,
-				EventType:  "UserGroupMemberRemoved",
+				EventType:  string(eventtypes.UserGroupMemberRemoved),
 				Data: map[string]any{
 					"group_id": groupID,
 					"user_id":  userID,

--- a/internal/projectors/action.go
+++ b/internal/projectors/action.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -62,7 +63,7 @@ type actionCreatedRaw struct {
 // for any other (stream, event_type) so the listener wrapper can
 // silently no-op.
 func ActionCreatedFromEvent(e store.PersistedEvent) (ActionCreatedPayload, error) {
-	if e.StreamType != "action" || e.EventType != "ActionCreated" {
+	if e.StreamType != "action" || e.EventType != string(eventtypes.ActionCreated) {
 		return ActionCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -121,7 +122,7 @@ type actionRenamedRaw struct {
 
 // ActionRenamedFromEvent decodes ActionRenamed.
 func ActionRenamedFromEvent(e store.PersistedEvent) (ActionRenamedPayload, error) {
-	if e.StreamType != "action" || e.EventType != "ActionRenamed" {
+	if e.StreamType != "action" || e.EventType != string(eventtypes.ActionRenamed) {
 		return ActionRenamedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -152,7 +153,7 @@ type actionDescriptionUpdatedRaw struct {
 
 // ActionDescriptionUpdatedFromEvent decodes ActionDescriptionUpdated.
 func ActionDescriptionUpdatedFromEvent(e store.PersistedEvent) (ActionDescriptionUpdatedPayload, error) {
-	if e.StreamType != "action" || e.EventType != "ActionDescriptionUpdated" {
+	if e.StreamType != "action" || e.EventType != string(eventtypes.ActionDescriptionUpdated) {
 		return ActionDescriptionUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := ActionDescriptionUpdatedPayload{ID: e.StreamID}
@@ -189,7 +190,7 @@ type actionParamsUpdatedRaw struct {
 
 // ActionParamsUpdatedFromEvent decodes ActionParamsUpdated.
 func ActionParamsUpdatedFromEvent(e store.PersistedEvent) (ActionParamsUpdatedPayload, error) {
-	if e.StreamType != "action" || e.EventType != "ActionParamsUpdated" {
+	if e.StreamType != "action" || e.EventType != string(eventtypes.ActionParamsUpdated) {
 		return ActionParamsUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := ActionParamsUpdatedPayload{ID: e.StreamID}
@@ -216,7 +217,7 @@ func ActionParamsUpdatedFromEvent(e store.PersistedEvent) (ActionParamsUpdatedPa
 // the stream id and the projection's own state — so this is a stream/
 // event-type validator only.
 func ActionDeletedFromEvent(e store.PersistedEvent) (string, error) {
-	if e.StreamType != "action" || e.EventType != "ActionDeleted" {
+	if e.StreamType != "action" || e.EventType != string(eventtypes.ActionDeleted) {
 		return "", ErrIgnoredEvent
 	}
 	return e.StreamID, nil

--- a/internal/projectors/action_listener.go
+++ b/internal/projectors/action_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -86,12 +87,12 @@ func ActionListener(st *store.Store, logger *slog.Logger) store.EventListener {
 		// short-circuit the simple cases through the pool.
 		needsTx := false
 		switch e.EventType {
-		case "ActionDeleted",
-			"DefinitionMemberAdded",
-			"DefinitionMemberRemoved",
-			"DefinitionMemberReordered":
+		case string(eventtypes.ActionDeleted),
+			string(eventtypes.DefinitionMemberAdded),
+			string(eventtypes.DefinitionMemberRemoved),
+			string(eventtypes.DefinitionMemberReordered):
 			needsTx = true
-		case "DefinitionCreated":
+		case string(eventtypes.DefinitionCreated):
 			// DefinitionCreated on the action stream that carries
 			// action_type is a single INSERT (no cascade). On the
 			// definition stream the same event is also a single INSERT
@@ -131,33 +132,33 @@ func ApplyAction(ctx context.Context, q *store.Queries, e store.PersistedEvent) 
 		return nil
 	}
 	switch {
-	case e.StreamType == "action" && e.EventType == "ActionCreated":
+	case e.StreamType == "action" && e.EventType == string(eventtypes.ActionCreated):
 		return applyActionCreated(ctx, q, e)
-	case e.StreamType == "action" && e.EventType == "ActionRenamed":
+	case e.StreamType == "action" && e.EventType == string(eventtypes.ActionRenamed):
 		return applyActionRenamed(ctx, q, e)
-	case e.StreamType == "action" && e.EventType == "ActionDescriptionUpdated":
+	case e.StreamType == "action" && e.EventType == string(eventtypes.ActionDescriptionUpdated):
 		return applyActionDescriptionUpdated(ctx, q, e)
-	case e.StreamType == "action" && e.EventType == "ActionParamsUpdated":
+	case e.StreamType == "action" && e.EventType == string(eventtypes.ActionParamsUpdated):
 		return applyActionParamsUpdated(ctx, q, e)
-	case e.StreamType == "action" && e.EventType == "ActionDeleted":
+	case e.StreamType == "action" && e.EventType == string(eventtypes.ActionDeleted):
 		return applyActionDeleted(ctx, q, e)
-	case e.EventType == "DefinitionCreated":
+	case e.EventType == string(eventtypes.DefinitionCreated):
 		// Both stream types route through the same handler; the
 		// payload's `action_type` presence picks the branch.
 		return applyDefinitionCreated(ctx, q, e)
-	case e.EventType == "DefinitionRenamed":
+	case e.EventType == string(eventtypes.DefinitionRenamed):
 		return applyDefinitionRenamed(ctx, q, e)
-	case e.EventType == "DefinitionDescriptionUpdated":
+	case e.EventType == string(eventtypes.DefinitionDescriptionUpdated):
 		return applyDefinitionDescriptionUpdated(ctx, q, e)
-	case e.EventType == "DefinitionDeleted":
+	case e.EventType == string(eventtypes.DefinitionDeleted):
 		return applyDefinitionDeleted(ctx, q, e)
-	case e.StreamType == "definition" && e.EventType == "DefinitionScheduleUpdated":
+	case e.StreamType == "definition" && e.EventType == string(eventtypes.DefinitionScheduleUpdated):
 		return applyDefinitionScheduleUpdated(ctx, q, e)
-	case e.StreamType == "definition" && e.EventType == "DefinitionMemberAdded":
+	case e.StreamType == "definition" && e.EventType == string(eventtypes.DefinitionMemberAdded):
 		return applyDefinitionMemberAdded(ctx, q, e)
-	case e.StreamType == "definition" && e.EventType == "DefinitionMemberRemoved":
+	case e.StreamType == "definition" && e.EventType == string(eventtypes.DefinitionMemberRemoved):
 		return applyDefinitionMemberRemoved(ctx, q, e)
-	case e.StreamType == "definition" && e.EventType == "DefinitionMemberReordered":
+	case e.StreamType == "definition" && e.EventType == string(eventtypes.DefinitionMemberReordered):
 		return applyDefinitionMemberReordered(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/action_set.go
+++ b/internal/projectors/action_set.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -40,7 +41,7 @@ type actionSetCreatedRaw struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func ActionSetCreatedFromEvent(e store.PersistedEvent) (ActionSetCreatedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != "ActionSetCreated" {
+	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetCreated) {
 		return ActionSetCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -88,7 +89,7 @@ type actionSetRenamedRaw struct {
 
 // ActionSetRenamedFromEvent decodes ActionSetRenamed.
 func ActionSetRenamedFromEvent(e store.PersistedEvent) (ActionSetRenamedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != "ActionSetRenamed" {
+	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetRenamed) {
 		return ActionSetRenamedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -122,7 +123,7 @@ type actionSetDescriptionUpdatedRaw struct {
 // Description == "", matching the PL/pgSQL COALESCE-to-empty-string
 // behaviour.
 func ActionSetDescriptionUpdatedFromEvent(e store.PersistedEvent) (ActionSetDescriptionUpdatedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != "ActionSetDescriptionUpdated" {
+	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetDescriptionUpdated) {
 		return ActionSetDescriptionUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := ActionSetDescriptionUpdatedPayload{ID: e.StreamID}
@@ -153,7 +154,7 @@ type actionSetScheduleUpdatedRaw struct {
 
 // ActionSetScheduleUpdatedFromEvent decodes ActionSetScheduleUpdated.
 func ActionSetScheduleUpdatedFromEvent(e store.PersistedEvent) (ActionSetScheduleUpdatedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != "ActionSetScheduleUpdated" {
+	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetScheduleUpdated) {
 		return ActionSetScheduleUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := ActionSetScheduleUpdatedPayload{
@@ -189,7 +190,7 @@ type actionSetMemberRaw struct {
 
 // ActionSetMemberAddedFromEvent decodes ActionSetMemberAdded.
 func ActionSetMemberAddedFromEvent(e store.PersistedEvent) (ActionSetMemberAddedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != "ActionSetMemberAdded" {
+	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetMemberAdded) {
 		return ActionSetMemberAddedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -222,7 +223,7 @@ type actionSetMemberRemovedRaw struct {
 
 // ActionSetMemberRemovedFromEvent decodes ActionSetMemberRemoved.
 func ActionSetMemberRemovedFromEvent(e store.PersistedEvent) (ActionSetMemberRemovedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != "ActionSetMemberRemoved" {
+	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetMemberRemoved) {
 		return ActionSetMemberRemovedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -246,7 +247,7 @@ type ActionSetMemberReorderedPayload = ActionSetMemberAddedPayload
 // Same field set as ActionSetMemberAdded plus the same default-zero
 // behaviour for sort_order.
 func ActionSetMemberReorderedFromEvent(e store.PersistedEvent) (ActionSetMemberReorderedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != "ActionSetMemberReordered" {
+	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetMemberReordered) {
 		return ActionSetMemberReorderedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/action_set_listener.go
+++ b/internal/projectors/action_set_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -46,10 +47,10 @@ func ActionSetListener(st *store.Store, logger *slog.Logger) store.EventListener
 		// so we share its body here for the multi-write cases via
 		// WithTx and short-circuit the simple cases through the pool.
 		switch e.EventType {
-		case "ActionSetMemberAdded",
-			"ActionSetMemberRemoved",
-			"ActionSetMemberReordered",
-			"ActionSetDeleted":
+		case string(eventtypes.ActionSetMemberAdded),
+			string(eventtypes.ActionSetMemberRemoved),
+			string(eventtypes.ActionSetMemberReordered),
+			string(eventtypes.ActionSetDeleted):
 			if err := st.WithTx(ctx, func(q *store.Queries) error {
 				return ApplyActionSet(ctx, q, e)
 			}); err != nil {
@@ -82,21 +83,21 @@ func ApplyActionSet(ctx context.Context, q *store.Queries, e store.PersistedEven
 		return nil
 	}
 	switch e.EventType {
-	case "ActionSetCreated":
+	case string(eventtypes.ActionSetCreated):
 		return applyActionSetCreated(ctx, q, e)
-	case "ActionSetRenamed":
+	case string(eventtypes.ActionSetRenamed):
 		return applyActionSetRenamed(ctx, q, e)
-	case "ActionSetDescriptionUpdated":
+	case string(eventtypes.ActionSetDescriptionUpdated):
 		return applyActionSetDescriptionUpdated(ctx, q, e)
-	case "ActionSetScheduleUpdated":
+	case string(eventtypes.ActionSetScheduleUpdated):
 		return applyActionSetScheduleUpdated(ctx, q, e)
-	case "ActionSetMemberAdded":
+	case string(eventtypes.ActionSetMemberAdded):
 		return applyActionSetMemberAdded(ctx, q, e)
-	case "ActionSetMemberRemoved":
+	case string(eventtypes.ActionSetMemberRemoved):
 		return applyActionSetMemberRemoved(ctx, q, e)
-	case "ActionSetMemberReordered":
+	case string(eventtypes.ActionSetMemberReordered):
 		return applyActionSetMemberReordered(ctx, q, e)
-	case "ActionSetDeleted":
+	case string(eventtypes.ActionSetDeleted):
 		return applyActionSetDeleted(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/assignment.go
+++ b/internal/projectors/assignment.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -47,7 +48,7 @@ type assignmentCreatedRaw struct {
 // failure surface in the listener log instead of producing a half-
 // applied row.
 func AssignmentCreatedFromEvent(e store.PersistedEvent) (AssignmentCreatedPayload, error) {
-	if e.StreamType != "assignment" || e.EventType != "AssignmentCreated" {
+	if e.StreamType != "assignment" || e.EventType != string(eventtypes.AssignmentCreated) {
 		return AssignmentCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -104,7 +105,7 @@ type assignmentModeChangedRaw struct {
 
 // AssignmentModeChangedFromEvent decodes AssignmentModeChanged.
 func AssignmentModeChangedFromEvent(e store.PersistedEvent) (AssignmentModeChangedPayload, error) {
-	if e.StreamType != "assignment" || e.EventType != "AssignmentModeChanged" {
+	if e.StreamType != "assignment" || e.EventType != string(eventtypes.AssignmentModeChanged) {
 		return AssignmentModeChangedPayload{}, ErrIgnoredEvent
 	}
 	out := AssignmentModeChangedPayload{ID: e.StreamID}
@@ -139,7 +140,7 @@ type assignmentSortOrderChangedRaw struct {
 // AssignmentSortOrderChangedFromEvent decodes
 // AssignmentSortOrderChanged.
 func AssignmentSortOrderChangedFromEvent(e store.PersistedEvent) (AssignmentSortOrderChangedPayload, error) {
-	if e.StreamType != "assignment" || e.EventType != "AssignmentSortOrderChanged" {
+	if e.StreamType != "assignment" || e.EventType != string(eventtypes.AssignmentSortOrderChanged) {
 		return AssignmentSortOrderChangedPayload{}, ErrIgnoredEvent
 	}
 	out := AssignmentSortOrderChangedPayload{ID: e.StreamID}

--- a/internal/projectors/assignment_listener.go
+++ b/internal/projectors/assignment_listener.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -55,7 +56,7 @@ func AssignmentListener(st *store.Store, logger *slog.Logger) store.EventListene
 		// projection consistent if the function raises mid-cascade).
 		// Single-statement events go on the autocommit pool.
 		switch e.EventType {
-		case "AssignmentCreated", "AssignmentDeleted":
+		case string(eventtypes.AssignmentCreated), string(eventtypes.AssignmentDeleted):
 			if err := st.WithTx(ctx, func(q *store.Queries) error {
 				return ApplyAssignment(ctx, q, e)
 			}); err != nil {
@@ -89,13 +90,13 @@ func ApplyAssignment(ctx context.Context, q *store.Queries, e store.PersistedEve
 		return nil
 	}
 	switch e.EventType {
-	case "AssignmentCreated":
+	case string(eventtypes.AssignmentCreated):
 		return applyAssignmentCreated(ctx, q, e)
-	case "AssignmentModeChanged":
+	case string(eventtypes.AssignmentModeChanged):
 		return applyAssignmentModeChanged(ctx, q, e)
-	case "AssignmentSortOrderChanged":
+	case string(eventtypes.AssignmentSortOrderChanged):
 		return applyAssignmentSortOrderChanged(ctx, q, e)
-	case "AssignmentDeleted":
+	case string(eventtypes.AssignmentDeleted):
 		return applyAssignmentDeleted(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/compliance.go
+++ b/internal/projectors/compliance.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -46,7 +47,7 @@ type complianceResultUpdatedRaw struct {
 // Returns ErrIgnoredEvent for any other (stream, event_type) so the
 // listener wrapper can silently no-op.
 func ComplianceResultUpdatedFromEvent(e store.PersistedEvent) (ComplianceResultUpdatedPayload, error) {
-	if e.StreamType != "compliance" || e.EventType != "ComplianceResultUpdated" {
+	if e.StreamType != "compliance" || e.EventType != string(eventtypes.ComplianceResultUpdated) {
 		return ComplianceResultUpdatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -94,7 +95,7 @@ type complianceResultRemovedRaw struct {
 
 // ComplianceResultRemovedFromEvent decodes ComplianceResultRemoved.
 func ComplianceResultRemovedFromEvent(e store.PersistedEvent) (ComplianceResultRemovedPayload, error) {
-	if e.StreamType != "compliance" || e.EventType != "ComplianceResultRemoved" {
+	if e.StreamType != "compliance" || e.EventType != string(eventtypes.ComplianceResultRemoved) {
 		return ComplianceResultRemovedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/compliance_listener.go
+++ b/internal/projectors/compliance_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -75,9 +76,9 @@ func ApplyCompliance(ctx context.Context, q *store.Queries, e store.PersistedEve
 		return nil
 	}
 	switch e.EventType {
-	case "ComplianceResultUpdated":
+	case string(eventtypes.ComplianceResultUpdated):
 		return applyComplianceResultUpdated(ctx, q, e)
-	case "ComplianceResultRemoved":
+	case string(eventtypes.ComplianceResultRemoved):
 		return applyComplianceResultRemoved(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/compliance_policy.go
+++ b/internal/projectors/compliance_policy.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -33,7 +34,7 @@ type compliancePolicyCreatedRaw struct {
 // Returns ErrIgnoredEvent for any other (stream, event_type) so the
 // listener wrapper can silently no-op.
 func CompliancePolicyCreatedFromEvent(e store.PersistedEvent) (CompliancePolicyCreatedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyCreated" {
+	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyCreated) {
 		return CompliancePolicyCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -72,7 +73,7 @@ type compliancePolicyRenamedRaw struct {
 
 // CompliancePolicyRenamedFromEvent decodes CompliancePolicyRenamed.
 func CompliancePolicyRenamedFromEvent(e store.PersistedEvent) (CompliancePolicyRenamedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyRenamed" {
+	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyRenamed) {
 		return CompliancePolicyRenamedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -104,7 +105,7 @@ type compliancePolicyDescriptionUpdatedRaw struct {
 // CompliancePolicyDescriptionUpdatedFromEvent decodes
 // CompliancePolicyDescriptionUpdated.
 func CompliancePolicyDescriptionUpdatedFromEvent(e store.PersistedEvent) (CompliancePolicyDescriptionUpdatedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyDescriptionUpdated" {
+	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyDescriptionUpdated) {
 		return CompliancePolicyDescriptionUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := CompliancePolicyDescriptionUpdatedPayload{ID: e.StreamID}
@@ -147,7 +148,7 @@ type compliancePolicyRuleAddedRaw struct {
 
 // CompliancePolicyRuleAddedFromEvent decodes CompliancePolicyRuleAdded.
 func CompliancePolicyRuleAddedFromEvent(e store.PersistedEvent) (CompliancePolicyRuleAddedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyRuleAdded" {
+	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyRuleAdded) {
 		return CompliancePolicyRuleAddedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -187,7 +188,7 @@ type compliancePolicyRuleRemovedRaw struct {
 
 // CompliancePolicyRuleRemovedFromEvent decodes CompliancePolicyRuleRemoved.
 func CompliancePolicyRuleRemovedFromEvent(e store.PersistedEvent) (CompliancePolicyRuleRemovedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyRuleRemoved" {
+	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyRuleRemoved) {
 		return CompliancePolicyRuleRemovedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -225,7 +226,7 @@ type compliancePolicyRuleUpdatedRaw struct {
 
 // CompliancePolicyRuleUpdatedFromEvent decodes CompliancePolicyRuleUpdated.
 func CompliancePolicyRuleUpdatedFromEvent(e store.PersistedEvent) (CompliancePolicyRuleUpdatedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != "CompliancePolicyRuleUpdated" {
+	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyRuleUpdated) {
 		return CompliancePolicyRuleUpdatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/compliance_policy_listener.go
+++ b/internal/projectors/compliance_policy_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -66,10 +67,10 @@ func CompliancePolicyListener(st *store.Store, logger *slog.Logger) store.EventL
 		// we share its body here for the multi-write cases via WithTx
 		// and short-circuit the simple cases through the pool.
 		switch e.EventType {
-		case "CompliancePolicyDeleted",
-			"CompliancePolicyRuleAdded",
-			"CompliancePolicyRuleRemoved",
-			"CompliancePolicyRuleUpdated":
+		case string(eventtypes.CompliancePolicyDeleted),
+			string(eventtypes.CompliancePolicyRuleAdded),
+			string(eventtypes.CompliancePolicyRuleRemoved),
+			string(eventtypes.CompliancePolicyRuleUpdated):
 			if err := st.WithTx(ctx, func(q *store.Queries) error {
 				return ApplyCompliancePolicy(ctx, q, e)
 			}); err != nil {
@@ -104,19 +105,19 @@ func ApplyCompliancePolicy(ctx context.Context, q *store.Queries, e store.Persis
 		return nil
 	}
 	switch e.EventType {
-	case "CompliancePolicyCreated":
+	case string(eventtypes.CompliancePolicyCreated):
 		return applyCompliancePolicyCreated(ctx, q, e)
-	case "CompliancePolicyRenamed":
+	case string(eventtypes.CompliancePolicyRenamed):
 		return applyCompliancePolicyRenamed(ctx, q, e)
-	case "CompliancePolicyDescriptionUpdated":
+	case string(eventtypes.CompliancePolicyDescriptionUpdated):
 		return applyCompliancePolicyDescriptionUpdated(ctx, q, e)
-	case "CompliancePolicyDeleted":
+	case string(eventtypes.CompliancePolicyDeleted):
 		return applyCompliancePolicyDeleted(ctx, q, e)
-	case "CompliancePolicyRuleAdded":
+	case string(eventtypes.CompliancePolicyRuleAdded):
 		return applyCompliancePolicyRuleAdded(ctx, q, e)
-	case "CompliancePolicyRuleRemoved":
+	case string(eventtypes.CompliancePolicyRuleRemoved):
 		return applyCompliancePolicyRuleRemoved(ctx, q, e)
-	case "CompliancePolicyRuleUpdated":
+	case string(eventtypes.CompliancePolicyRuleUpdated):
 		return applyCompliancePolicyRuleUpdated(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/definition.go
+++ b/internal/projectors/definition.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -68,7 +69,7 @@ type definitionCreatedRaw struct {
 //     omitted the schedule column entirely, leaving it at the column
 //     default (NULL since the actions schedule column is nullable).
 func DefinitionCreatedFromEvent(e store.PersistedEvent) (DefinitionCreatedPayload, error) {
-	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != "DefinitionCreated" {
+	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != string(eventtypes.DefinitionCreated) {
 		return DefinitionCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -137,7 +138,7 @@ type definitionRenamedRaw struct {
 // streams (action-stream synthesised-action rename + definition-stream
 // rename).
 func DefinitionRenamedFromEvent(e store.PersistedEvent) (DefinitionRenamedPayload, error) {
-	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != "DefinitionRenamed" {
+	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != string(eventtypes.DefinitionRenamed) {
 		return DefinitionRenamedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -184,7 +185,7 @@ type definitionDescriptionUpdatedRaw struct {
 // The decoder accepts both stream types because the PL/pgSQL pair
 // shared the event-name with different write semantics.
 func DefinitionDescriptionUpdatedFromEvent(e store.PersistedEvent) (DefinitionDescriptionUpdatedPayload, error) {
-	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != "DefinitionDescriptionUpdated" {
+	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != string(eventtypes.DefinitionDescriptionUpdated) {
 		return DefinitionDescriptionUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := DefinitionDescriptionUpdatedPayload{ID: e.StreamID}
@@ -216,7 +217,7 @@ type definitionScheduleUpdatedRaw struct {
 
 // DefinitionScheduleUpdatedFromEvent decodes DefinitionScheduleUpdated.
 func DefinitionScheduleUpdatedFromEvent(e store.PersistedEvent) (DefinitionScheduleUpdatedPayload, error) {
-	if e.StreamType != "definition" || e.EventType != "DefinitionScheduleUpdated" {
+	if e.StreamType != "definition" || e.EventType != string(eventtypes.DefinitionScheduleUpdated) {
 		return DefinitionScheduleUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := DefinitionScheduleUpdatedPayload{
@@ -251,7 +252,7 @@ type definitionMemberRaw struct {
 
 // DefinitionMemberAddedFromEvent decodes DefinitionMemberAdded.
 func DefinitionMemberAddedFromEvent(e store.PersistedEvent) (DefinitionMemberAddedPayload, error) {
-	if e.StreamType != "definition" || e.EventType != "DefinitionMemberAdded" {
+	if e.StreamType != "definition" || e.EventType != string(eventtypes.DefinitionMemberAdded) {
 		return DefinitionMemberAddedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -284,7 +285,7 @@ type definitionMemberRemovedRaw struct {
 
 // DefinitionMemberRemovedFromEvent decodes DefinitionMemberRemoved.
 func DefinitionMemberRemovedFromEvent(e store.PersistedEvent) (DefinitionMemberRemovedPayload, error) {
-	if e.StreamType != "definition" || e.EventType != "DefinitionMemberRemoved" {
+	if e.StreamType != "definition" || e.EventType != string(eventtypes.DefinitionMemberRemoved) {
 		return DefinitionMemberRemovedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -305,7 +306,7 @@ type DefinitionMemberReorderedPayload = DefinitionMemberAddedPayload
 
 // DefinitionMemberReorderedFromEvent decodes DefinitionMemberReordered.
 func DefinitionMemberReorderedFromEvent(e store.PersistedEvent) (DefinitionMemberReorderedPayload, error) {
-	if e.StreamType != "definition" || e.EventType != "DefinitionMemberReordered" {
+	if e.StreamType != "definition" || e.EventType != string(eventtypes.DefinitionMemberReordered) {
 		return DefinitionMemberReorderedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -332,7 +333,7 @@ func DefinitionMemberReorderedFromEvent(e store.PersistedEvent) (DefinitionMembe
 // actions_projection while the definition-stream invocation soft-
 // deletes the definitions_projection row.
 func DefinitionDeletedFromEvent(e store.PersistedEvent) (string, error) {
-	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != "DefinitionDeleted" {
+	if (e.StreamType != "definition" && e.StreamType != "action") || e.EventType != string(eventtypes.DefinitionDeleted) {
 		return "", ErrIgnoredEvent
 	}
 	return e.StreamID, nil

--- a/internal/projectors/device.go
+++ b/internal/projectors/device.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -53,7 +54,7 @@ type deviceRegisteredRaw struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func DeviceRegisteredFromEvent(e store.PersistedEvent) (DeviceRegisteredPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceRegistered" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceRegistered) {
 		return DeviceRegisteredPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -108,7 +109,7 @@ type deviceSeenRaw struct {
 // DeviceSeenFromEvent decodes DeviceSeen. Empty payload is valid (a
 // pure heartbeat-style ping that only refreshes last_seen_at).
 func DeviceSeenFromEvent(e store.PersistedEvent) (DeviceSeenPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceSeen" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceSeen) {
 		return DeviceSeenPayload{}, ErrIgnoredEvent
 	}
 	out := DeviceSeenPayload{ID: e.StreamID}
@@ -146,7 +147,7 @@ type deviceHeartbeatRaw struct {
 // DeviceHeartbeatFromEvent decodes DeviceHeartbeat. Empty payload is
 // a valid bare ping.
 func DeviceHeartbeatFromEvent(e store.PersistedEvent) (DeviceHeartbeatPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceHeartbeat" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceHeartbeat) {
 		return DeviceHeartbeatPayload{}, ErrIgnoredEvent
 	}
 	out := DeviceHeartbeatPayload{ID: e.StreamID}
@@ -178,7 +179,7 @@ type deviceCertRenewedRaw struct {
 
 // DeviceCertRenewedFromEvent decodes DeviceCertRenewed.
 func DeviceCertRenewedFromEvent(e store.PersistedEvent) (DeviceCertRenewedPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceCertRenewed" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceCertRenewed) {
 		return DeviceCertRenewedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -215,7 +216,7 @@ type deviceLabelsUpdatedRaw struct {
 // labels => nil byte slice; the SQL COALESCE will preserve the
 // existing row value.
 func DeviceLabelsUpdatedFromEvent(e store.PersistedEvent) (DeviceLabelsUpdatedPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceLabelsUpdated" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceLabelsUpdated) {
 		return DeviceLabelsUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := DeviceLabelsUpdatedPayload{ID: e.StreamID}
@@ -248,7 +249,7 @@ type deviceLabelSetRaw struct {
 
 // DeviceLabelSetFromEvent decodes DeviceLabelSet.
 func DeviceLabelSetFromEvent(e store.PersistedEvent) (DeviceLabelSetPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceLabelSet" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceLabelSet) {
 		return DeviceLabelSetPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -281,7 +282,7 @@ type deviceLabelRemovedRaw struct {
 
 // DeviceLabelRemovedFromEvent decodes DeviceLabelRemoved.
 func DeviceLabelRemovedFromEvent(e store.PersistedEvent) (DeviceLabelRemovedPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceLabelRemoved" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceLabelRemoved) {
 		return DeviceLabelRemovedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -314,7 +315,7 @@ type deviceUserAssignmentRaw struct {
 
 // DeviceAssignedFromEvent decodes DeviceAssigned.
 func DeviceAssignedFromEvent(e store.PersistedEvent) (DeviceUserAssignmentPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceAssigned" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceAssigned) {
 		return DeviceUserAssignmentPayload{}, ErrIgnoredEvent
 	}
 	return decodeDeviceUserAssignment(e)
@@ -322,7 +323,7 @@ func DeviceAssignedFromEvent(e store.PersistedEvent) (DeviceUserAssignmentPayloa
 
 // DeviceUnassignedFromEvent decodes DeviceUnassigned.
 func DeviceUnassignedFromEvent(e store.PersistedEvent) (DeviceUserAssignmentPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceUnassigned" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceUnassigned) {
 		return DeviceUserAssignmentPayload{}, ErrIgnoredEvent
 	}
 	return decodeDeviceUserAssignment(e)
@@ -356,7 +357,7 @@ type deviceGroupAssignmentRaw struct {
 
 // DeviceGroupAssignedFromEvent decodes DeviceGroupAssigned.
 func DeviceGroupAssignedFromEvent(e store.PersistedEvent) (DeviceGroupAssignmentPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceGroupAssigned" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceGroupAssigned) {
 		return DeviceGroupAssignmentPayload{}, ErrIgnoredEvent
 	}
 	return decodeDeviceGroupAssignment(e)
@@ -364,7 +365,7 @@ func DeviceGroupAssignedFromEvent(e store.PersistedEvent) (DeviceGroupAssignment
 
 // DeviceGroupUnassignedFromEvent decodes DeviceGroupUnassigned.
 func DeviceGroupUnassignedFromEvent(e store.PersistedEvent) (DeviceGroupAssignmentPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceGroupUnassigned" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceGroupUnassigned) {
 		return DeviceGroupAssignmentPayload{}, ErrIgnoredEvent
 	}
 	return decodeDeviceGroupAssignment(e)
@@ -398,7 +399,7 @@ type deviceSyncIntervalSetRaw struct {
 
 // DeviceSyncIntervalSetFromEvent decodes DeviceSyncIntervalSet.
 func DeviceSyncIntervalSetFromEvent(e store.PersistedEvent) (DeviceSyncIntervalSetPayload, error) {
-	if e.StreamType != "device" || e.EventType != "DeviceSyncIntervalSet" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceSyncIntervalSet) {
 		return DeviceSyncIntervalSetPayload{}, ErrIgnoredEvent
 	}
 	out := DeviceSyncIntervalSetPayload{ID: e.StreamID}

--- a/internal/projectors/device_group.go
+++ b/internal/projectors/device_group.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -48,7 +49,7 @@ type deviceGroupCreatedRaw struct {
 // otherwise fail the INSERT, surfacing as a Postgres constraint
 // violation rather than a projector-level validation error.
 func DeviceGroupCreatedFromEvent(e store.PersistedEvent) (DeviceGroupCreatedPayload, error) {
-	if e.StreamType != "device_group" || e.EventType != "DeviceGroupCreated" {
+	if e.StreamType != "device_group" || e.EventType != string(eventtypes.DeviceGroupCreated) {
 		return DeviceGroupCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -93,7 +94,7 @@ type deviceGroupRenamedRaw struct {
 
 // DeviceGroupRenamedFromEvent decodes DeviceGroupRenamed.
 func DeviceGroupRenamedFromEvent(e store.PersistedEvent) (DeviceGroupRenamedPayload, error) {
-	if e.StreamType != "device_group" || e.EventType != "DeviceGroupRenamed" {
+	if e.StreamType != "device_group" || e.EventType != string(eventtypes.DeviceGroupRenamed) {
 		return DeviceGroupRenamedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -127,7 +128,7 @@ type deviceGroupDescriptionUpdatedRaw struct {
 // Description == "", matching the PL/pgSQL COALESCE-to-empty-string
 // behaviour.
 func DeviceGroupDescriptionUpdatedFromEvent(e store.PersistedEvent) (DeviceGroupDescriptionUpdatedPayload, error) {
-	if e.StreamType != "device_group" || e.EventType != "DeviceGroupDescriptionUpdated" {
+	if e.StreamType != "device_group" || e.EventType != string(eventtypes.DeviceGroupDescriptionUpdated) {
 		return DeviceGroupDescriptionUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := DeviceGroupDescriptionUpdatedPayload{ID: e.StreamID}
@@ -161,7 +162,7 @@ type deviceGroupQueryUpdatedRaw struct {
 
 // DeviceGroupQueryUpdatedFromEvent decodes DeviceGroupQueryUpdated.
 func DeviceGroupQueryUpdatedFromEvent(e store.PersistedEvent) (DeviceGroupQueryUpdatedPayload, error) {
-	if e.StreamType != "device_group" || e.EventType != "DeviceGroupQueryUpdated" {
+	if e.StreamType != "device_group" || e.EventType != string(eventtypes.DeviceGroupQueryUpdated) {
 		return DeviceGroupQueryUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := DeviceGroupQueryUpdatedPayload{ID: e.StreamID}
@@ -193,7 +194,7 @@ type deviceGroupSyncIntervalSetRaw struct {
 
 // DeviceGroupSyncIntervalSetFromEvent decodes DeviceGroupSyncIntervalSet.
 func DeviceGroupSyncIntervalSetFromEvent(e store.PersistedEvent) (DeviceGroupSyncIntervalSetPayload, error) {
-	if e.StreamType != "device_group" || e.EventType != "DeviceGroupSyncIntervalSet" {
+	if e.StreamType != "device_group" || e.EventType != string(eventtypes.DeviceGroupSyncIntervalSet) {
 		return DeviceGroupSyncIntervalSetPayload{}, ErrIgnoredEvent
 	}
 	out := DeviceGroupSyncIntervalSetPayload{ID: e.StreamID}
@@ -227,7 +228,7 @@ type deviceGroupMaintenanceWindowSetRaw struct {
 // DeviceGroupMaintenanceWindowSetFromEvent decodes
 // DeviceGroupMaintenanceWindowSet.
 func DeviceGroupMaintenanceWindowSetFromEvent(e store.PersistedEvent) (DeviceGroupMaintenanceWindowSetPayload, error) {
-	if e.StreamType != "device_group" || e.EventType != "DeviceGroupMaintenanceWindowSet" {
+	if e.StreamType != "device_group" || e.EventType != string(eventtypes.DeviceGroupMaintenanceWindowSet) {
 		return DeviceGroupMaintenanceWindowSetPayload{}, ErrIgnoredEvent
 	}
 	out := DeviceGroupMaintenanceWindowSetPayload{
@@ -276,7 +277,7 @@ func DeviceGroupMemberAddedFromEvent(e store.PersistedEvent) (DeviceGroupMemberP
 	if e.StreamType != "device_group" {
 		return DeviceGroupMemberPayload{}, ErrIgnoredEvent
 	}
-	if e.EventType != "DeviceGroupMemberAdded" && e.EventType != "DeviceAddedToGroup" {
+	if e.EventType != string(eventtypes.DeviceGroupMemberAdded) && e.EventType != string(eventtypes.DeviceAddedToGroup) {
 		return DeviceGroupMemberPayload{}, ErrIgnoredEvent
 	}
 	return decodeDeviceGroupMember(e)
@@ -289,7 +290,7 @@ func DeviceGroupMemberRemovedFromEvent(e store.PersistedEvent) (DeviceGroupMembe
 	if e.StreamType != "device_group" {
 		return DeviceGroupMemberPayload{}, ErrIgnoredEvent
 	}
-	if e.EventType != "DeviceGroupMemberRemoved" && e.EventType != "DeviceRemovedFromGroup" {
+	if e.EventType != string(eventtypes.DeviceGroupMemberRemoved) && e.EventType != string(eventtypes.DeviceRemovedFromGroup) {
 		return DeviceGroupMemberPayload{}, ErrIgnoredEvent
 	}
 	return decodeDeviceGroupMember(e)

--- a/internal/projectors/device_group_listener.go
+++ b/internal/projectors/device_group_listener.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -74,13 +75,13 @@ func DeviceGroupListener(st *store.Store, logger *slog.Logger) store.EventListen
 		// so we share its body here for the multi-write cases via
 		// WithTx and short-circuit the simple cases through the pool.
 		switch e.EventType {
-		case "DeviceGroupCreated",
-			"DeviceGroupQueryUpdated",
-			"DeviceGroupDeleted",
-			"DeviceGroupMemberAdded",
-			"DeviceAddedToGroup",
-			"DeviceGroupMemberRemoved",
-			"DeviceRemovedFromGroup":
+		case string(eventtypes.DeviceGroupCreated),
+			string(eventtypes.DeviceGroupQueryUpdated),
+			string(eventtypes.DeviceGroupDeleted),
+			string(eventtypes.DeviceGroupMemberAdded),
+			string(eventtypes.DeviceAddedToGroup),
+			string(eventtypes.DeviceGroupMemberRemoved),
+			string(eventtypes.DeviceRemovedFromGroup):
 			if err := st.WithTx(ctx, func(q *store.Queries) error {
 				return ApplyDeviceGroup(ctx, q, e)
 			}); err != nil {
@@ -113,23 +114,23 @@ func ApplyDeviceGroup(ctx context.Context, q *store.Queries, e store.PersistedEv
 		return nil
 	}
 	switch e.EventType {
-	case "DeviceGroupCreated":
+	case string(eventtypes.DeviceGroupCreated):
 		return applyDeviceGroupCreated(ctx, q, e)
-	case "DeviceGroupRenamed":
+	case string(eventtypes.DeviceGroupRenamed):
 		return applyDeviceGroupRenamed(ctx, q, e)
-	case "DeviceGroupDescriptionUpdated":
+	case string(eventtypes.DeviceGroupDescriptionUpdated):
 		return applyDeviceGroupDescriptionUpdated(ctx, q, e)
-	case "DeviceGroupQueryUpdated":
+	case string(eventtypes.DeviceGroupQueryUpdated):
 		return applyDeviceGroupQueryUpdated(ctx, q, e)
-	case "DeviceGroupSyncIntervalSet":
+	case string(eventtypes.DeviceGroupSyncIntervalSet):
 		return applyDeviceGroupSyncIntervalSet(ctx, q, e)
-	case "DeviceGroupMaintenanceWindowSet":
+	case string(eventtypes.DeviceGroupMaintenanceWindowSet):
 		return applyDeviceGroupMaintenanceWindowSet(ctx, q, e)
-	case "DeviceGroupMemberAdded", "DeviceAddedToGroup":
+	case string(eventtypes.DeviceGroupMemberAdded), string(eventtypes.DeviceAddedToGroup):
 		return applyDeviceGroupMemberAdded(ctx, q, e)
-	case "DeviceGroupMemberRemoved", "DeviceRemovedFromGroup":
+	case string(eventtypes.DeviceGroupMemberRemoved), string(eventtypes.DeviceRemovedFromGroup):
 		return applyDeviceGroupMemberRemoved(ctx, q, e)
-	case "DeviceGroupDeleted":
+	case string(eventtypes.DeviceGroupDeleted):
 		return applyDeviceGroupDeleted(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/device_listener.go
+++ b/internal/projectors/device_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -53,7 +54,7 @@ func DeviceListener(st *store.Store, logger *slog.Logger) store.EventListener {
 		// autocommit pool. ApplyDevice handles all event types when
 		// called with tx-bound queries (the rebuild path).
 		switch e.EventType {
-		case "DeviceRegistered", "DeviceDeleted":
+		case string(eventtypes.DeviceRegistered), string(eventtypes.DeviceDeleted):
 			if err := st.WithTx(ctx, func(q *store.Queries) error {
 				return ApplyDevice(ctx, q, e)
 			}); err != nil {
@@ -86,31 +87,31 @@ func ApplyDevice(ctx context.Context, q *store.Queries, e store.PersistedEvent) 
 		return nil
 	}
 	switch e.EventType {
-	case "DeviceRegistered":
+	case string(eventtypes.DeviceRegistered):
 		return applyDeviceRegistered(ctx, q, e)
-	case "DeviceSeen":
+	case string(eventtypes.DeviceSeen):
 		return applyDeviceSeen(ctx, q, e)
-	case "DeviceHeartbeat":
+	case string(eventtypes.DeviceHeartbeat):
 		return applyDeviceHeartbeat(ctx, q, e)
-	case "DeviceCertRenewed":
+	case string(eventtypes.DeviceCertRenewed):
 		return applyDeviceCertRenewed(ctx, q, e)
-	case "DeviceLabelsUpdated":
+	case string(eventtypes.DeviceLabelsUpdated):
 		return applyDeviceLabelsUpdated(ctx, q, e)
-	case "DeviceLabelSet":
+	case string(eventtypes.DeviceLabelSet):
 		return applyDeviceLabelSet(ctx, q, e)
-	case "DeviceLabelRemoved":
+	case string(eventtypes.DeviceLabelRemoved):
 		return applyDeviceLabelRemoved(ctx, q, e)
-	case "DeviceDeleted":
+	case string(eventtypes.DeviceDeleted):
 		return applyDeviceDeleted(ctx, q, e)
-	case "DeviceAssigned":
+	case string(eventtypes.DeviceAssigned):
 		return applyDeviceAssigned(ctx, q, e)
-	case "DeviceUnassigned":
+	case string(eventtypes.DeviceUnassigned):
 		return applyDeviceUnassigned(ctx, q, e)
-	case "DeviceGroupAssigned":
+	case string(eventtypes.DeviceGroupAssigned):
 		return applyDeviceGroupAssigned(ctx, q, e)
-	case "DeviceGroupUnassigned":
+	case string(eventtypes.DeviceGroupUnassigned):
 		return applyDeviceGroupUnassigned(ctx, q, e)
-	case "DeviceSyncIntervalSet":
+	case string(eventtypes.DeviceSyncIntervalSet):
 		return applyDeviceSyncIntervalSet(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/execution.go
+++ b/internal/projectors/execution.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -63,7 +64,7 @@ type executionCreatedRaw struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func ExecutionCreatedFromEvent(e store.PersistedEvent) (ExecutionCreatedPayload, error) {
-	if e.StreamType != "execution" || e.EventType != "ExecutionCreated" {
+	if e.StreamType != "execution" || e.EventType != string(eventtypes.ExecutionCreated) {
 		return ExecutionCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -142,7 +143,7 @@ type executionScheduledRaw struct {
 // emitter that builds this event populates it unconditionally
 // (action_handler.go RunAt branch); a missing key is an emitter bug.
 func ExecutionScheduledFromEvent(e store.PersistedEvent) (ExecutionScheduledPayload, error) {
-	if e.StreamType != "execution" || e.EventType != "ExecutionScheduled" {
+	if e.StreamType != "execution" || e.EventType != string(eventtypes.ExecutionScheduled) {
 		return ExecutionScheduledPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -219,7 +220,7 @@ type executionTerminalRaw struct {
 
 // ExecutionCompletedFromEvent decodes ExecutionCompleted.
 func ExecutionCompletedFromEvent(e store.PersistedEvent) (ExecutionTerminalPayload, error) {
-	if e.StreamType != "execution" || e.EventType != "ExecutionCompleted" {
+	if e.StreamType != "execution" || e.EventType != string(eventtypes.ExecutionCompleted) {
 		return ExecutionTerminalPayload{}, ErrIgnoredEvent
 	}
 	return decodeTerminal(e, "ExecutionCompleted")
@@ -227,7 +228,7 @@ func ExecutionCompletedFromEvent(e store.PersistedEvent) (ExecutionTerminalPaylo
 
 // ExecutionFailedFromEvent decodes ExecutionFailed.
 func ExecutionFailedFromEvent(e store.PersistedEvent) (ExecutionTerminalPayload, error) {
-	if e.StreamType != "execution" || e.EventType != "ExecutionFailed" {
+	if e.StreamType != "execution" || e.EventType != string(eventtypes.ExecutionFailed) {
 		return ExecutionTerminalPayload{}, ErrIgnoredEvent
 	}
 	return decodeTerminal(e, "ExecutionFailed")
@@ -291,7 +292,7 @@ type executionTimedOutRaw struct {
 
 // ExecutionTimedOutFromEvent decodes ExecutionTimedOut.
 func ExecutionTimedOutFromEvent(e store.PersistedEvent) (ExecutionTimedOutPayload, error) {
-	if e.StreamType != "execution" || e.EventType != "ExecutionTimedOut" {
+	if e.StreamType != "execution" || e.EventType != string(eventtypes.ExecutionTimedOut) {
 		return ExecutionTimedOutPayload{}, ErrIgnoredEvent
 	}
 	out := ExecutionTimedOutPayload{
@@ -334,7 +335,7 @@ type executionReasonRaw struct {
 
 // ExecutionSkippedFromEvent decodes ExecutionSkipped.
 func ExecutionSkippedFromEvent(e store.PersistedEvent) (ExecutionReasonPayload, error) {
-	if e.StreamType != "execution" || e.EventType != "ExecutionSkipped" {
+	if e.StreamType != "execution" || e.EventType != string(eventtypes.ExecutionSkipped) {
 		return ExecutionReasonPayload{}, ErrIgnoredEvent
 	}
 	return decodeReason(e, "ExecutionSkipped")
@@ -342,7 +343,7 @@ func ExecutionSkippedFromEvent(e store.PersistedEvent) (ExecutionReasonPayload, 
 
 // ExecutionCancelledFromEvent decodes ExecutionCancelled.
 func ExecutionCancelledFromEvent(e store.PersistedEvent) (ExecutionReasonPayload, error) {
-	if e.StreamType != "execution" || e.EventType != "ExecutionCancelled" {
+	if e.StreamType != "execution" || e.EventType != string(eventtypes.ExecutionCancelled) {
 		return ExecutionReasonPayload{}, ErrIgnoredEvent
 	}
 	return decodeReason(e, "ExecutionCancelled")

--- a/internal/projectors/execution_listener.go
+++ b/internal/projectors/execution_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -60,23 +61,23 @@ func ApplyExecution(ctx context.Context, q *store.Queries, e store.PersistedEven
 		return nil
 	}
 	switch e.EventType {
-	case "ExecutionCreated":
+	case string(eventtypes.ExecutionCreated):
 		return applyExecutionCreated(ctx, q, e)
-	case "ExecutionScheduled":
+	case string(eventtypes.ExecutionScheduled):
 		return applyExecutionScheduled(ctx, q, e)
-	case "ExecutionDispatched":
+	case string(eventtypes.ExecutionDispatched):
 		return applyExecutionDispatched(ctx, q, e)
-	case "ExecutionStarted":
+	case string(eventtypes.ExecutionStarted):
 		return applyExecutionStarted(ctx, q, e)
-	case "ExecutionCompleted":
+	case string(eventtypes.ExecutionCompleted):
 		return applyExecutionCompleted(ctx, q, e)
-	case "ExecutionFailed":
+	case string(eventtypes.ExecutionFailed):
 		return applyExecutionFailed(ctx, q, e)
-	case "ExecutionTimedOut":
+	case string(eventtypes.ExecutionTimedOut):
 		return applyExecutionTimedOut(ctx, q, e)
-	case "ExecutionSkipped":
+	case string(eventtypes.ExecutionSkipped):
 		return applyExecutionSkipped(ctx, q, e)
-	case "ExecutionCancelled":
+	case string(eventtypes.ExecutionCancelled):
 		return applyExecutionCancelled(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/identity_provider.go
+++ b/internal/projectors/identity_provider.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -129,7 +130,7 @@ type idpCreatedRaw struct {
 // IdentityProviderCreatedFromEvent decodes IdentityProviderCreated.
 // Returns ErrIgnoredEvent for any other (stream, event_type).
 func IdentityProviderCreatedFromEvent(e store.PersistedEvent) (IdentityProviderCreatedPayload, error) {
-	if e.StreamType != "identity_provider" || e.EventType != "IdentityProviderCreated" {
+	if e.StreamType != "identity_provider" || e.EventType != string(eventtypes.IdentityProviderCreated) {
 		return IdentityProviderCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -222,7 +223,7 @@ type idpUpdatedRaw struct {
 // (client_id, client_secret_encrypted, issuer_url) to match the
 // PL/pgSQL projector's `COALESCE(NULLIF(payload, ""), existing)`.
 func IdentityProviderUpdatedFromEvent(e store.PersistedEvent) (IdentityProviderUpdatedPayload, error) {
-	if e.StreamType != "identity_provider" || e.EventType != "IdentityProviderUpdated" {
+	if e.StreamType != "identity_provider" || e.EventType != string(eventtypes.IdentityProviderUpdated) {
 		return IdentityProviderUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := IdentityProviderUpdatedPayload{ID: e.StreamID}
@@ -256,7 +257,7 @@ func IdentityProviderUpdatedFromEvent(e store.PersistedEvent) (IdentityProviderU
 // IdentityLinkedFromEvent decodes IdentityLinked. user_id, provider_id
 // and external_id are required (composite key on the projection).
 func IdentityLinkedFromEvent(e store.PersistedEvent) (IdentityLinkPayload, error) {
-	if e.StreamType != "identity_provider" || e.EventType != "IdentityLinked" {
+	if e.StreamType != "identity_provider" || e.EventType != string(eventtypes.IdentityLinked) {
 		return IdentityLinkPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -296,7 +297,7 @@ func IdentityLinkedFromEvent(e store.PersistedEvent) (IdentityLinkPayload, error
 // provider_id + external_id are the lookup key; external_email and
 // external_name are NULLIF-semantic (empty preserves existing).
 func IdentityLinkLoginUpdatedFromEvent(e store.PersistedEvent) (IdentityLinkPayload, error) {
-	if e.StreamType != "identity_provider" || e.EventType != "IdentityLinkLoginUpdated" {
+	if e.StreamType != "identity_provider" || e.EventType != string(eventtypes.IdentityLinkLoginUpdated) {
 		return IdentityLinkPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/identity_provider_listener.go
+++ b/internal/projectors/identity_provider_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -37,23 +38,23 @@ func IdentityProviderListener(st *store.Store, logger *slog.Logger) store.EventL
 			return
 		}
 		switch e.EventType {
-		case "IdentityProviderCreated":
+		case string(eventtypes.IdentityProviderCreated):
 			applyIdentityProviderCreated(ctx, st, logger, e)
-		case "IdentityProviderUpdated":
+		case string(eventtypes.IdentityProviderUpdated):
 			applyIdentityProviderUpdated(ctx, st, logger, e)
-		case "IdentityProviderDeleted":
+		case string(eventtypes.IdentityProviderDeleted):
 			applyIdentityProviderDeleted(ctx, st, logger, e)
-		case "IdentityProviderSCIMEnabled":
+		case string(eventtypes.IdentityProviderSCIMEnabled):
 			applyIdentityProviderSCIMEnabled(ctx, st, logger, e)
-		case "IdentityProviderSCIMDisabled":
+		case string(eventtypes.IdentityProviderSCIMDisabled):
 			applyIdentityProviderSCIMDisabled(ctx, st, logger, e)
-		case "IdentityProviderSCIMTokenRotated":
+		case string(eventtypes.IdentityProviderSCIMTokenRotated):
 			applyIdentityProviderSCIMTokenRotated(ctx, st, logger, e)
-		case "IdentityLinked":
+		case string(eventtypes.IdentityLinked):
 			applyIdentityLinked(ctx, st, logger, e)
-		case "IdentityLinkLoginUpdated":
+		case string(eventtypes.IdentityLinkLoginUpdated):
 			applyIdentityLinkLoginUpdated(ctx, st, logger, e)
-		case "IdentityUnlinked":
+		case string(eventtypes.IdentityUnlinked):
 			applyIdentityUnlinked(ctx, st, logger, e)
 		}
 	}

--- a/internal/projectors/lps_password.go
+++ b/internal/projectors/lps_password.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -55,7 +56,7 @@ func (p LpsPasswordRotatedPayload) LogValue() slog.Value {
 // Reuse from a handler that wants to mirror the projection state in
 // memory while the listener writes to the DB.
 func LpsPasswordRotatedFromEvent(e store.PersistedEvent) (LpsPasswordRotatedPayload, error) {
-	if e.StreamType != "lps_password" || e.EventType != "LpsPasswordRotated" {
+	if e.StreamType != "lps_password" || e.EventType != string(eventtypes.LpsPasswordRotated) {
 		return LpsPasswordRotatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/lps_password_listener.go
+++ b/internal/projectors/lps_password_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -43,7 +44,7 @@ func LpsPasswordListener(st *store.Store, logger *slog.Logger) store.EventListen
 		if e.StreamType != "lps_password" {
 			return
 		}
-		if e.EventType != "LpsPasswordRotated" {
+		if e.EventType != string(eventtypes.LpsPasswordRotated) {
 			return
 		}
 

--- a/internal/projectors/luks_key.go
+++ b/internal/projectors/luks_key.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -61,7 +62,7 @@ type LuksRevocationPayload struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func LuksKeyRotatedFromEvent(e store.PersistedEvent) (LuksKeyRotatedPayload, error) {
-	if e.StreamType != "luks_key" || e.EventType != "LuksKeyRotated" {
+	if e.StreamType != "luks_key" || e.EventType != string(eventtypes.LuksKeyRotated) {
 		return LuksKeyRotatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -95,7 +96,7 @@ func LuksKeyRotatedFromEvent(e store.PersistedEvent) (LuksKeyRotatedPayload, err
 // payload. Status is hardcoded "dispatched" so the listener doesn't
 // need a per-event mapping table.
 func LuksRevocationDispatchedFromEvent(e store.PersistedEvent) (LuksRevocationPayload, error) {
-	if e.StreamType != "luks_key" || e.EventType != "LuksDeviceKeyRevocationDispatched" {
+	if e.StreamType != "luks_key" || e.EventType != string(eventtypes.LuksDeviceKeyRevocationDispatched) {
 		return LuksRevocationPayload{}, ErrIgnoredEvent
 	}
 	return decodeLuksRevocation(e, "dispatched", "dispatched_at", false)
@@ -105,7 +106,7 @@ func LuksRevocationDispatchedFromEvent(e store.PersistedEvent) (LuksRevocationPa
 // "success" — note the event type vs column-value mismatch is
 // intentional and matches the PL/pgSQL projector verbatim.
 func LuksRevokedFromEvent(e store.PersistedEvent) (LuksRevocationPayload, error) {
-	if e.StreamType != "luks_key" || e.EventType != "LuksDeviceKeyRevoked" {
+	if e.StreamType != "luks_key" || e.EventType != string(eventtypes.LuksDeviceKeyRevoked) {
 		return LuksRevocationPayload{}, ErrIgnoredEvent
 	}
 	return decodeLuksRevocation(e, "success", "revoked_at", false)
@@ -114,7 +115,7 @@ func LuksRevokedFromEvent(e store.PersistedEvent) (LuksRevocationPayload, error)
 // LuksRevocationFailedFromEvent decodes LuksDeviceKeyRevocationFailed
 // — only this variant requires an error string in the payload.
 func LuksRevocationFailedFromEvent(e store.PersistedEvent) (LuksRevocationPayload, error) {
-	if e.StreamType != "luks_key" || e.EventType != "LuksDeviceKeyRevocationFailed" {
+	if e.StreamType != "luks_key" || e.EventType != string(eventtypes.LuksDeviceKeyRevocationFailed) {
 		return LuksRevocationPayload{}, ErrIgnoredEvent
 	}
 	return decodeLuksRevocation(e, "failed", "failed_at", true)

--- a/internal/projectors/luks_key_listener.go
+++ b/internal/projectors/luks_key_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -39,13 +40,13 @@ func LuksKeyListener(st *store.Store, logger *slog.Logger) store.EventListener {
 		}
 
 		switch e.EventType {
-		case "LuksKeyRotated":
+		case string(eventtypes.LuksKeyRotated):
 			applyLuksKeyRotated(ctx, st, logger, e)
-		case "LuksDeviceKeyRevocationDispatched":
+		case string(eventtypes.LuksDeviceKeyRevocationDispatched):
 			applyLuksRevocation(ctx, st, logger, e, LuksRevocationDispatchedFromEvent)
-		case "LuksDeviceKeyRevoked":
+		case string(eventtypes.LuksDeviceKeyRevoked):
 			applyLuksRevocation(ctx, st, logger, e, LuksRevokedFromEvent)
-		case "LuksDeviceKeyRevocationFailed":
+		case string(eventtypes.LuksDeviceKeyRevocationFailed):
 			applyLuksRevocation(ctx, st, logger, e, LuksRevocationFailedFromEvent)
 		}
 		// Every other event_type (incl. LuksDeviceKeyRevocationRequested)

--- a/internal/projectors/role.go
+++ b/internal/projectors/role.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -59,7 +60,7 @@ type roleCreatedRaw struct {
 // Defaults match the PL/pgSQL projector: missing description → "";
 // missing permissions → empty slice; missing is_system → false.
 func RoleCreatedFromEvent(e store.PersistedEvent) (RoleCreatedPayload, error) {
-	if e.StreamType != "role" || e.EventType != "RoleCreated" {
+	if e.StreamType != "role" || e.EventType != string(eventtypes.RoleCreated) {
 		return RoleCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -109,7 +110,7 @@ type roleUpdatedRaw struct {
 // PL/pgSQL `NULLIF(name, "")` semantics — a UI that sends "" for
 // the name field doesn't blank the role.
 func RoleUpdatedFromEvent(e store.PersistedEvent) (RoleUpdatedPayload, error) {
-	if e.StreamType != "role" || e.EventType != "RoleUpdated" {
+	if e.StreamType != "role" || e.EventType != string(eventtypes.RoleUpdated) {
 		return RoleUpdatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/role_listener.go
+++ b/internal/projectors/role_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -38,7 +39,7 @@ func RoleListener(st *store.Store, logger *slog.Logger) store.EventListener {
 		// tx-bound queries (the rebuild path), so we share its body
 		// for RoleDeleted via WithTx and short-circuit the simple
 		// cases through the pool.
-		if e.EventType == "RoleDeleted" {
+		if e.EventType == string(eventtypes.RoleDeleted) {
 			err := st.WithTx(ctx, func(q *store.Queries) error {
 				return ApplyRole(ctx, q, e)
 			})
@@ -71,11 +72,11 @@ func ApplyRole(ctx context.Context, q *store.Queries, e store.PersistedEvent) er
 		return nil
 	}
 	switch e.EventType {
-	case "RoleCreated":
+	case string(eventtypes.RoleCreated):
 		return applyRoleCreated(ctx, q, e)
-	case "RoleUpdated":
+	case string(eventtypes.RoleUpdated):
 		return applyRoleUpdated(ctx, q, e)
-	case "RoleDeleted":
+	case string(eventtypes.RoleDeleted):
 		return applyRoleDeleted(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/scim_group_mapping.go
+++ b/internal/projectors/scim_group_mapping.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -35,7 +36,7 @@ type SCIMGroupMappingUpdatedPayload struct {
 
 // SCIMGroupMappedFromEvent decodes SCIMGroupMapped.
 func SCIMGroupMappedFromEvent(e store.PersistedEvent) (SCIMGroupMappedPayload, error) {
-	if e.StreamType != "scim_group_mapping" || e.EventType != "SCIMGroupMapped" {
+	if e.StreamType != "scim_group_mapping" || e.EventType != string(eventtypes.SCIMGroupMapped) {
 		return SCIMGroupMappedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -72,7 +73,7 @@ func SCIMGroupMappedFromEvent(e store.PersistedEvent) (SCIMGroupMappedPayload, e
 
 // SCIMGroupUnmappedFromEvent decodes SCIMGroupUnmapped.
 func SCIMGroupUnmappedFromEvent(e store.PersistedEvent) (SCIMGroupUnmappedPayload, error) {
-	if e.StreamType != "scim_group_mapping" || e.EventType != "SCIMGroupUnmapped" {
+	if e.StreamType != "scim_group_mapping" || e.EventType != string(eventtypes.SCIMGroupUnmapped) {
 		return SCIMGroupUnmappedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -98,7 +99,7 @@ func SCIMGroupUnmappedFromEvent(e store.PersistedEvent) (SCIMGroupUnmappedPayloa
 // Only scim_display_name is updatable; pointer field preserves
 // "missing → no update" via COALESCE.
 func SCIMGroupMappingUpdatedFromEvent(e store.PersistedEvent) (SCIMGroupMappingUpdatedPayload, error) {
-	if e.StreamType != "scim_group_mapping" || e.EventType != "SCIMGroupMappingUpdated" {
+	if e.StreamType != "scim_group_mapping" || e.EventType != string(eventtypes.SCIMGroupMappingUpdated) {
 		return SCIMGroupMappingUpdatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/scim_group_mapping_listener.go
+++ b/internal/projectors/scim_group_mapping_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -28,11 +29,11 @@ func SCIMGroupMappingListener(st *store.Store, logger *slog.Logger) store.EventL
 			return
 		}
 		switch e.EventType {
-		case "SCIMGroupMapped":
+		case string(eventtypes.SCIMGroupMapped):
 			applySCIMGroupMapped(ctx, st, logger, e)
-		case "SCIMGroupUnmapped":
+		case string(eventtypes.SCIMGroupUnmapped):
 			applySCIMGroupUnmapped(ctx, st, logger, e)
-		case "SCIMGroupMappingUpdated":
+		case string(eventtypes.SCIMGroupMappingUpdated):
 			applySCIMGroupMappingUpdated(ctx, st, logger, e)
 		}
 	}

--- a/internal/projectors/security_alert.go
+++ b/internal/projectors/security_alert.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -46,7 +47,7 @@ var ErrIgnoredEvent = errors.New("projector: event ignored")
 // wants to render the alert immediately while the listener writes
 // to the DB asynchronously.
 func SecurityAlertProjectionFromEvent(e store.PersistedEvent) (db.InsertSecurityAlertProjectionParams, error) {
-	if e.StreamType != "device" || e.EventType != "SecurityAlert" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.SecurityAlert) {
 		return db.InsertSecurityAlertProjectionParams{}, ErrIgnoredEvent
 	}
 
@@ -84,7 +85,7 @@ func SecurityAlertProjectionFromEvent(e store.PersistedEvent) (db.InsertSecurity
 // silently full-scanning and matching nothing — matches the deleted
 // PL/pgSQL projector's `(event.data->>'alert_id')::uuid` behaviour.
 func SecurityAlertAckParamsFromEvent(e store.PersistedEvent) (db.AcknowledgeSecurityAlertProjectionParams, error) {
-	if e.StreamType != "device" || e.EventType != "SecurityAlertAcknowledged" {
+	if e.StreamType != "device" || e.EventType != string(eventtypes.SecurityAlertAcknowledged) {
 		return db.AcknowledgeSecurityAlertProjectionParams{}, ErrIgnoredEvent
 	}
 

--- a/internal/projectors/security_alert_listener.go
+++ b/internal/projectors/security_alert_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -49,7 +50,7 @@ func SecurityAlertListener(st *store.Store, logger *slog.Logger) store.EventList
 			return
 		}
 		switch e.EventType {
-		case "SecurityAlert":
+		case string(eventtypes.SecurityAlert):
 			params, err := SecurityAlertProjectionFromEvent(e)
 			if err != nil {
 				if errors.Is(err, ErrIgnoredEvent) {
@@ -64,7 +65,7 @@ func SecurityAlertListener(st *store.Store, logger *slog.Logger) store.EventList
 					"event_id", e.ID, "device_id", e.StreamID, "error", err)
 			}
 
-		case "SecurityAlertAcknowledged":
+		case string(eventtypes.SecurityAlertAcknowledged):
 			params, err := SecurityAlertAckParamsFromEvent(e)
 			if err != nil {
 				if errors.Is(err, ErrIgnoredEvent) {

--- a/internal/projectors/server_settings.go
+++ b/internal/projectors/server_settings.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -41,7 +42,7 @@ type ServerSettingsUpdate struct {
 // would have applied `COALESCE(NULL, existing)` to every field,
 // which is a no-op UPDATE. We preserve that behavior.
 func ServerSettingsUpdatedFromEvent(e store.PersistedEvent) (ServerSettingsUpdatedPayload, error) {
-	if e.StreamType != "server_settings" || e.EventType != "ServerSettingUpdated" {
+	if e.StreamType != "server_settings" || e.EventType != string(eventtypes.ServerSettingUpdated) {
 		return ServerSettingsUpdatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/server_settings_listener.go
+++ b/internal/projectors/server_settings_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -27,7 +28,7 @@ func ServerSettingsListener(st *store.Store, logger *slog.Logger) store.EventLis
 		if e.StreamType != "server_settings" {
 			return
 		}
-		if e.EventType != "ServerSettingUpdated" {
+		if e.EventType != string(eventtypes.ServerSettingUpdated) {
 			return
 		}
 

--- a/internal/projectors/token.go
+++ b/internal/projectors/token.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -43,7 +44,7 @@ type tokenCreatedRaw struct {
 // missing max_uses → 0; missing expires_at → nil (stays NULL); missing
 // owner_id → nil. value_hash is required (UNIQUE NOT NULL).
 func TokenCreatedFromEvent(e store.PersistedEvent) (TokenCreatedPayload, error) {
-	if e.StreamType != "token" || e.EventType != "TokenCreated" {
+	if e.StreamType != "token" || e.EventType != string(eventtypes.TokenCreated) {
 		return TokenCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -88,7 +89,7 @@ func TokenCreatedFromEvent(e store.PersistedEvent) (TokenCreatedPayload, error) 
 // the rename handler always supplies it; an empty payload would be
 // a programmer error.
 func TokenRenamedFromEvent(e store.PersistedEvent) (TokenRenamedPayload, error) {
-	if e.StreamType != "token" || e.EventType != "TokenRenamed" {
+	if e.StreamType != "token" || e.EventType != string(eventtypes.TokenRenamed) {
 		return TokenRenamedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/token_listener.go
+++ b/internal/projectors/token_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -48,23 +49,23 @@ func ApplyToken(ctx context.Context, q *store.Queries, e store.PersistedEvent) e
 	}
 	ver := deref(e.SequenceNum)
 	switch e.EventType {
-	case "TokenCreated":
+	case string(eventtypes.TokenCreated):
 		return applyTokenCreated(ctx, q, e)
-	case "TokenRenamed":
+	case string(eventtypes.TokenRenamed):
 		return applyTokenRenamed(ctx, q, e)
-	case "TokenUsed":
+	case string(eventtypes.TokenUsed):
 		return q.IncrementTokenUseProjection(ctx, db.IncrementTokenUseProjectionParams{
 			ID: e.StreamID, ProjectionVersion: ver,
 		})
-	case "TokenDisabled":
+	case string(eventtypes.TokenDisabled):
 		return q.SetTokenDisabledProjection(ctx, db.SetTokenDisabledProjectionParams{
 			ID: e.StreamID, Disabled: true, ProjectionVersion: ver,
 		})
-	case "TokenEnabled":
+	case string(eventtypes.TokenEnabled):
 		return q.SetTokenDisabledProjection(ctx, db.SetTokenDisabledProjectionParams{
 			ID: e.StreamID, Disabled: false, ProjectionVersion: ver,
 		})
-	case "TokenDeleted":
+	case string(eventtypes.TokenDeleted):
 		return q.SoftDeleteTokenProjection(ctx, db.SoftDeleteTokenProjectionParams{
 			ID: e.StreamID, ProjectionVersion: ver,
 		})

--- a/internal/projectors/totp_listener.go
+++ b/internal/projectors/totp_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -55,7 +56,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 		userID := e.StreamID
 
 		switch e.EventType {
-		case "TOTPSetupInitiated":
+		case string(eventtypes.TOTPSetupInitiated):
 			if err := q.UpsertTotpProjection(ctx, db.UpsertTotpProjectionParams{
 				UserID:            userID,
 				SecretEncrypted:   payload.SecretEncrypted,
@@ -67,7 +68,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 					"event_id", e.ID, "user_id", userID, "error", err)
 			}
 
-		case "TOTPVerified":
+		case string(eventtypes.TOTPVerified):
 			if err := q.VerifyTotpProjection(ctx, db.VerifyTotpProjectionParams{
 				UserID:            userID,
 				UpdatedAt:         updatedAt,
@@ -86,7 +87,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 					"event_id", e.ID, "user_id", userID, "error", err)
 			}
 
-		case "TOTPDisabled":
+		case string(eventtypes.TOTPDisabled):
 			if err := q.DeleteTotpProjection(ctx, userID); err != nil {
 				logger.Warn("totp projector: failed to delete totp_projection row",
 					"event_id", e.ID, "user_id", userID, "error", err)
@@ -101,7 +102,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 					"event_id", e.ID, "user_id", userID, "error", err)
 			}
 
-		case "TOTPBackupCodeUsed":
+		case string(eventtypes.TOTPBackupCodeUsed):
 			if payload.Index == nil {
 				logger.Warn("totp projector: TOTPBackupCodeUsed missing index field",
 					"event_id", e.ID, "user_id", userID)
@@ -120,7 +121,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 					"event_id", e.ID, "user_id", userID, "index", *payload.Index, "error", err)
 			}
 
-		case "TOTPBackupCodesRegenerated":
+		case string(eventtypes.TOTPBackupCodesRegenerated):
 			if err := q.RegenerateTotpBackupCodes(ctx, db.RegenerateTotpBackupCodesParams{
 				UserID:            userID,
 				BackupCodesHash:   payload.BackupCodesHash,

--- a/internal/projectors/user.go
+++ b/internal/projectors/user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -76,7 +77,7 @@ type userCreatedWithRolesRaw struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func UserCreatedWithRolesFromEvent(e store.PersistedEvent) (UserCreatedWithRolesPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserCreatedWithRoles" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserCreatedWithRoles) {
 		return UserCreatedWithRolesPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -163,7 +164,7 @@ type userProfileUpdatedRaw struct {
 
 // UserProfileUpdatedFromEvent decodes UserProfileUpdated.
 func UserProfileUpdatedFromEvent(e store.PersistedEvent) (UserProfileUpdatedPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserProfileUpdated" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserProfileUpdated) {
 		return UserProfileUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := UserProfileUpdatedPayload{ID: e.StreamID}
@@ -212,7 +213,7 @@ type userEmailChangedRaw struct {
 // NOT NULL, so the original projector relied on the emitter always
 // supplying a non-empty value. Keep that contract here.
 func UserEmailChangedFromEvent(e store.PersistedEvent) (UserEmailChangedPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserEmailChanged" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserEmailChanged) {
 		return UserEmailChangedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -246,7 +247,7 @@ type userPasswordChangedRaw struct {
 
 // UserPasswordChangedFromEvent decodes UserPasswordChanged.
 func UserPasswordChangedFromEvent(e store.PersistedEvent) (UserPasswordChangedPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserPasswordChanged" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserPasswordChanged) {
 		return UserPasswordChangedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -275,7 +276,7 @@ type userRoleChangedRaw struct {
 
 // UserRoleChangedFromEvent decodes UserRoleChanged.
 func UserRoleChangedFromEvent(e store.PersistedEvent) (UserRoleChangedPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserRoleChanged" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserRoleChanged) {
 		return UserRoleChangedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -322,7 +323,7 @@ type userSshKeyAddedRaw struct {
 // default to "" so callers that omit them still produce a valid
 // element shape in the JSONB array.
 func UserSshKeyAddedFromEvent(e store.PersistedEvent) (UserSshKeyAddedPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserSshKeyAdded" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserSshKeyAdded) {
 		return UserSshKeyAddedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -360,7 +361,7 @@ type userSshKeyRemovedRaw struct {
 
 // UserSshKeyRemovedFromEvent decodes UserSshKeyRemoved.
 func UserSshKeyRemovedFromEvent(e store.PersistedEvent) (UserSshKeyRemovedPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserSshKeyRemoved" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserSshKeyRemoved) {
 		return UserSshKeyRemovedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -398,7 +399,7 @@ type userSshSettingsUpdatedRaw struct {
 // Empty payload is valid (a no-op event that only bumps
 // projection_version + updated_at, leaving every column as-is).
 func UserSshSettingsUpdatedFromEvent(e store.PersistedEvent) (UserSshSettingsUpdatedPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserSshSettingsUpdated" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserSshSettingsUpdated) {
 		return UserSshSettingsUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := UserSshSettingsUpdatedPayload{ID: e.StreamID}
@@ -430,7 +431,7 @@ type userLinuxUsernameChangedRaw struct {
 
 // UserLinuxUsernameChangedFromEvent decodes UserLinuxUsernameChanged.
 func UserLinuxUsernameChangedFromEvent(e store.PersistedEvent) (UserLinuxUsernameChangedPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserLinuxUsernameChanged" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserLinuxUsernameChanged) {
 		return UserLinuxUsernameChangedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -477,7 +478,7 @@ const (
 // action_id defaults to "" so an explicit "unlink" can still flow
 // through (matches PL/pgSQL `COALESCE(event.data->>"action_id", "")`).
 func UserSystemActionLinkedFromEvent(e store.PersistedEvent) (UserSystemActionLinkedPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserSystemActionLinked" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserSystemActionLinked) {
 		return UserSystemActionLinkedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -517,7 +518,7 @@ type userProvisioningSettingsUpdatedRaw struct {
 // UserProvisioningSettingsUpdated. Empty payload is valid (no-op
 // event that only bumps projection_version + updated_at).
 func UserProvisioningSettingsUpdatedFromEvent(e store.PersistedEvent) (UserProvisioningSettingsUpdatedPayload, error) {
-	if e.StreamType != "user" || e.EventType != "UserProvisioningSettingsUpdated" {
+	if e.StreamType != "user" || e.EventType != string(eventtypes.UserProvisioningSettingsUpdated) {
 		return UserProvisioningSettingsUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := UserProvisioningSettingsUpdatedPayload{ID: e.StreamID}

--- a/internal/projectors/user_group.go
+++ b/internal/projectors/user_group.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -48,7 +49,7 @@ type userGroupCreatedRaw struct {
 // otherwise fail the INSERT, surfacing as a Postgres constraint
 // violation rather than a projector-level validation error.
 func UserGroupCreatedFromEvent(e store.PersistedEvent) (UserGroupCreatedPayload, error) {
-	if e.StreamType != "user_group" || e.EventType != "UserGroupCreated" {
+	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupCreated) {
 		return UserGroupCreatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -101,7 +102,7 @@ type userGroupUpdatedRaw struct {
 // Description signals "update" vs "preserve": non-nil = update with
 // the value (incl. empty string); nil = preserve.
 func UserGroupUpdatedFromEvent(e store.PersistedEvent) (UserGroupUpdatedPayload, error) {
-	if e.StreamType != "user_group" || e.EventType != "UserGroupUpdated" {
+	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupUpdated) {
 		return UserGroupUpdatedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -138,7 +139,7 @@ type userGroupQueryUpdatedRaw struct {
 
 // UserGroupQueryUpdatedFromEvent decodes UserGroupQueryUpdated.
 func UserGroupQueryUpdatedFromEvent(e store.PersistedEvent) (UserGroupQueryUpdatedPayload, error) {
-	if e.StreamType != "user_group" || e.EventType != "UserGroupQueryUpdated" {
+	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupQueryUpdated) {
 		return UserGroupQueryUpdatedPayload{}, ErrIgnoredEvent
 	}
 	out := UserGroupQueryUpdatedPayload{ID: e.StreamID}
@@ -173,7 +174,7 @@ type userGroupMaintenanceWindowSetRaw struct {
 // UserGroupMaintenanceWindowSetFromEvent decodes
 // UserGroupMaintenanceWindowSet.
 func UserGroupMaintenanceWindowSetFromEvent(e store.PersistedEvent) (UserGroupMaintenanceWindowSetPayload, error) {
-	if e.StreamType != "user_group" || e.EventType != "UserGroupMaintenanceWindowSet" {
+	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupMaintenanceWindowSet) {
 		return UserGroupMaintenanceWindowSetPayload{}, ErrIgnoredEvent
 	}
 	out := UserGroupMaintenanceWindowSetPayload{
@@ -217,7 +218,7 @@ type userGroupMemberRaw struct {
 
 // UserGroupMemberAddedFromEvent decodes UserGroupMemberAdded.
 func UserGroupMemberAddedFromEvent(e store.PersistedEvent) (UserGroupMemberPayload, error) {
-	if e.StreamType != "user_group" || e.EventType != "UserGroupMemberAdded" {
+	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupMemberAdded) {
 		return UserGroupMemberPayload{}, ErrIgnoredEvent
 	}
 	return decodeUserGroupMember(e, "UserGroupMemberAdded")
@@ -225,7 +226,7 @@ func UserGroupMemberAddedFromEvent(e store.PersistedEvent) (UserGroupMemberPaylo
 
 // UserGroupMemberRemovedFromEvent decodes UserGroupMemberRemoved.
 func UserGroupMemberRemovedFromEvent(e store.PersistedEvent) (UserGroupMemberPayload, error) {
-	if e.StreamType != "user_group" || e.EventType != "UserGroupMemberRemoved" {
+	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupMemberRemoved) {
 		return UserGroupMemberPayload{}, ErrIgnoredEvent
 	}
 	return decodeUserGroupMember(e, "UserGroupMemberRemoved")
@@ -264,7 +265,7 @@ type userGroupRoleRaw struct {
 
 // UserGroupRoleAssignedFromEvent decodes UserGroupRoleAssigned.
 func UserGroupRoleAssignedFromEvent(e store.PersistedEvent) (UserGroupRolePayload, error) {
-	if e.StreamType != "user_group" || e.EventType != "UserGroupRoleAssigned" {
+	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupRoleAssigned) {
 		return UserGroupRolePayload{}, ErrIgnoredEvent
 	}
 	return decodeUserGroupRole(e, "UserGroupRoleAssigned")
@@ -272,7 +273,7 @@ func UserGroupRoleAssignedFromEvent(e store.PersistedEvent) (UserGroupRolePayloa
 
 // UserGroupRoleRevokedFromEvent decodes UserGroupRoleRevoked.
 func UserGroupRoleRevokedFromEvent(e store.PersistedEvent) (UserGroupRolePayload, error) {
-	if e.StreamType != "user_group" || e.EventType != "UserGroupRoleRevoked" {
+	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupRoleRevoked) {
 		return UserGroupRolePayload{}, ErrIgnoredEvent
 	}
 	return decodeUserGroupRole(e, "UserGroupRoleRevoked")
@@ -314,7 +315,7 @@ type userGroupMembersRebuiltRaw struct {
 
 // UserGroupMembersRebuiltFromEvent decodes UserGroupMembersRebuilt.
 func UserGroupMembersRebuiltFromEvent(e store.PersistedEvent) (UserGroupMembersRebuiltPayload, error) {
-	if e.StreamType != "user_group" || e.EventType != "UserGroupMembersRebuilt" {
+	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupMembersRebuilt) {
 		return UserGroupMembersRebuiltPayload{}, ErrIgnoredEvent
 	}
 	out := UserGroupMembersRebuiltPayload{GroupID: e.StreamID, UserIDs: []string{}}

--- a/internal/projectors/user_group_listener.go
+++ b/internal/projectors/user_group_listener.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -75,14 +76,14 @@ func UserGroupListener(st *store.Store, logger *slog.Logger) store.EventListener
 		// so we share its body here for the multi-write cases via
 		// WithTx and short-circuit the simple cases through the pool.
 		switch e.EventType {
-		case "UserGroupCreated",
-			"UserGroupQueryUpdated",
-			"UserGroupDeleted",
-			"UserGroupMemberAdded",
-			"UserGroupMemberRemoved",
-			"UserGroupMembersRebuilt",
-			"UserGroupRoleAssigned",
-			"UserGroupRoleRevoked":
+		case string(eventtypes.UserGroupCreated),
+			string(eventtypes.UserGroupQueryUpdated),
+			string(eventtypes.UserGroupDeleted),
+			string(eventtypes.UserGroupMemberAdded),
+			string(eventtypes.UserGroupMemberRemoved),
+			string(eventtypes.UserGroupMembersRebuilt),
+			string(eventtypes.UserGroupRoleAssigned),
+			string(eventtypes.UserGroupRoleRevoked):
 			if err := st.WithTx(ctx, func(q *store.Queries) error {
 				return ApplyUserGroup(ctx, q, e)
 			}); err != nil {
@@ -116,25 +117,25 @@ func ApplyUserGroup(ctx context.Context, q *store.Queries, e store.PersistedEven
 		return nil
 	}
 	switch e.EventType {
-	case "UserGroupCreated":
+	case string(eventtypes.UserGroupCreated):
 		return applyUserGroupCreated(ctx, q, e)
-	case "UserGroupUpdated":
+	case string(eventtypes.UserGroupUpdated):
 		return applyUserGroupUpdated(ctx, q, e)
-	case "UserGroupQueryUpdated":
+	case string(eventtypes.UserGroupQueryUpdated):
 		return applyUserGroupQueryUpdated(ctx, q, e)
-	case "UserGroupMaintenanceWindowSet":
+	case string(eventtypes.UserGroupMaintenanceWindowSet):
 		return applyUserGroupMaintenanceWindowSet(ctx, q, e)
-	case "UserGroupDeleted":
+	case string(eventtypes.UserGroupDeleted):
 		return applyUserGroupDeleted(ctx, q, e)
-	case "UserGroupMemberAdded":
+	case string(eventtypes.UserGroupMemberAdded):
 		return applyUserGroupMemberAdded(ctx, q, e)
-	case "UserGroupMemberRemoved":
+	case string(eventtypes.UserGroupMemberRemoved):
 		return applyUserGroupMemberRemoved(ctx, q, e)
-	case "UserGroupRoleAssigned":
+	case string(eventtypes.UserGroupRoleAssigned):
 		return applyUserGroupRoleAssigned(ctx, q, e)
-	case "UserGroupRoleRevoked":
+	case string(eventtypes.UserGroupRoleRevoked):
 		return applyUserGroupRoleRevoked(ctx, q, e)
-	case "UserGroupMembersRebuilt":
+	case string(eventtypes.UserGroupMembersRebuilt):
 		return applyUserGroupMembersRebuilt(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/user_listener.go
+++ b/internal/projectors/user_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -69,7 +70,7 @@ func UserListener(st *store.Store, logger *slog.Logger) store.EventListener {
 		// is a single statement and runs on the autocommit pool.
 		// ApplyUser handles all event types when called with
 		// tx-bound queries (the rebuild path).
-		if e.EventType == "UserCreatedWithRoles" || e.EventType == "UserDeleted" {
+		if e.EventType == string(eventtypes.UserCreatedWithRoles) || e.EventType == string(eventtypes.UserDeleted) {
 			if err := st.WithTx(ctx, func(q *store.Queries) error {
 				return ApplyUser(ctx, q, e)
 			}); err != nil {
@@ -97,37 +98,37 @@ func ApplyUser(ctx context.Context, q *store.Queries, e store.PersistedEvent) er
 		return nil
 	}
 	switch e.EventType {
-	case "UserCreatedWithRoles":
+	case string(eventtypes.UserCreatedWithRoles):
 		return applyUserCreatedWithRoles(ctx, q, e)
-	case "UserProfileUpdated":
+	case string(eventtypes.UserProfileUpdated):
 		return applyUserProfileUpdated(ctx, q, e)
-	case "UserEmailChanged":
+	case string(eventtypes.UserEmailChanged):
 		return applyUserEmailChanged(ctx, q, e)
-	case "UserPasswordChanged":
+	case string(eventtypes.UserPasswordChanged):
 		return applyUserPasswordChanged(ctx, q, e)
-	case "UserRoleChanged":
+	case string(eventtypes.UserRoleChanged):
 		return applyUserRoleChanged(ctx, q, e)
-	case "UserSessionInvalidated":
+	case string(eventtypes.UserSessionInvalidated):
 		return applyUserSessionInvalidated(ctx, q, e)
-	case "UserDisabled":
+	case string(eventtypes.UserDisabled):
 		return applyUserDisabled(ctx, q, e)
-	case "UserEnabled":
+	case string(eventtypes.UserEnabled):
 		return applyUserEnabled(ctx, q, e)
-	case "UserLoggedIn":
+	case string(eventtypes.UserLoggedIn):
 		return applyUserLoggedIn(ctx, q, e)
-	case "UserDeleted":
+	case string(eventtypes.UserDeleted):
 		return applyUserDeleted(ctx, q, e)
-	case "UserSshKeyAdded":
+	case string(eventtypes.UserSshKeyAdded):
 		return applyUserSshKeyAdded(ctx, q, e)
-	case "UserSshKeyRemoved":
+	case string(eventtypes.UserSshKeyRemoved):
 		return applyUserSshKeyRemoved(ctx, q, e)
-	case "UserSshSettingsUpdated":
+	case string(eventtypes.UserSshSettingsUpdated):
 		return applyUserSshSettingsUpdated(ctx, q, e)
-	case "UserLinuxUsernameChanged":
+	case string(eventtypes.UserLinuxUsernameChanged):
 		return applyUserLinuxUsernameChanged(ctx, q, e)
-	case "UserSystemActionLinked":
+	case string(eventtypes.UserSystemActionLinked):
 		return applyUserSystemActionLinked(ctx, q, e)
-	case "UserProvisioningSettingsUpdated":
+	case string(eventtypes.UserProvisioningSettingsUpdated):
 		return applyUserProvisioningSettingsUpdated(ctx, q, e)
 	}
 	return nil

--- a/internal/projectors/user_role.go
+++ b/internal/projectors/user_role.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -27,7 +28,7 @@ type UserRoleRevokedPayload struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func UserRoleAssignedFromEvent(e store.PersistedEvent) (UserRoleAssignedPayload, error) {
-	if e.StreamType != "user_role" || e.EventType != "UserRoleAssigned" {
+	if e.StreamType != "user_role" || e.EventType != string(eventtypes.UserRoleAssigned) {
 		return UserRoleAssignedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {
@@ -50,7 +51,7 @@ func UserRoleAssignedFromEvent(e store.PersistedEvent) (UserRoleAssignedPayload,
 // UserRoleRevokedFromEvent decodes UserRoleRevoked. Same validation
 // shape as UserRoleAssigned — both composite-key fields required.
 func UserRoleRevokedFromEvent(e store.PersistedEvent) (UserRoleRevokedPayload, error) {
-	if e.StreamType != "user_role" || e.EventType != "UserRoleRevoked" {
+	if e.StreamType != "user_role" || e.EventType != string(eventtypes.UserRoleRevoked) {
 		return UserRoleRevokedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/user_role_listener.go
+++ b/internal/projectors/user_role_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -27,9 +28,9 @@ func UserRoleListener(st *store.Store, logger *slog.Logger) store.EventListener 
 			return
 		}
 		switch e.EventType {
-		case "UserRoleAssigned":
+		case string(eventtypes.UserRoleAssigned):
 			applyUserRoleAssigned(ctx, st, logger, e)
-		case "UserRoleRevoked":
+		case string(eventtypes.UserRoleRevoked):
 			applyUserRoleRevoked(ctx, st, logger, e)
 		}
 	}

--- a/internal/projectors/user_selection.go
+++ b/internal/projectors/user_selection.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -28,7 +29,7 @@ type UserSelectionChangedPayload struct {
 
 // UserSelectionChangedFromEvent decodes UserSelectionChanged.
 func UserSelectionChangedFromEvent(e store.PersistedEvent) (UserSelectionChangedPayload, error) {
-	if e.StreamType != "user_selection" || e.EventType != "UserSelectionChanged" {
+	if e.StreamType != "user_selection" || e.EventType != string(eventtypes.UserSelectionChanged) {
 		return UserSelectionChangedPayload{}, ErrIgnoredEvent
 	}
 	if len(e.Data) == 0 {

--- a/internal/projectors/user_selection_listener.go
+++ b/internal/projectors/user_selection_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -41,7 +42,7 @@ func ApplyUserSelection(ctx context.Context, q *store.Queries, e store.Persisted
 	if e.StreamType != "user_selection" {
 		return nil
 	}
-	if e.EventType != "UserSelectionChanged" {
+	if e.EventType != string(eventtypes.UserSelectionChanged) {
 		return nil
 	}
 	payload, err := UserSelectionChangedFromEvent(e)

--- a/internal/scim/groups.go
+++ b/internal/scim/groups.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -187,7 +188,7 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 			h.appendEvent(ctx, store.Event{
 				StreamType: "scim_group_mapping",
 				StreamID:   existing.ID,
-				EventType:  "SCIMGroupMappingUpdated",
+				EventType:  string(eventtypes.SCIMGroupMappingUpdated),
 				Data: map[string]any{
 					"provider_id":       provider.ID,
 					"scim_group_id":     scimGroupID,
@@ -199,7 +200,7 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 			h.appendEvent(ctx, store.Event{
 				StreamType: "user_group",
 				StreamID:   existing.UserGroupID,
-				EventType:  "UserGroupUpdated",
+				EventType:  string(eventtypes.UserGroupUpdated),
 				Data: map[string]any{
 					"name": scimGroup.DisplayName,
 				},
@@ -225,7 +226,7 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 			h.appendEvent(ctx, store.Event{
 				StreamType: "scim_group_mapping",
 				StreamID:   existing.ID,
-				EventType:  "SCIMGroupUnmapped",
+				EventType:  string(eventtypes.SCIMGroupUnmapped),
 				Data: map[string]any{
 					"provider_id":   provider.ID,
 					"scim_group_id": existing.ScimGroupID,
@@ -251,7 +252,7 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user_group",
 		StreamID:   userGroupID,
-		EventType:  "UserGroupCreated",
+		EventType:  string(eventtypes.UserGroupCreated),
 		Data: map[string]any{
 			"name":        scimGroup.DisplayName,
 			"description": fmt.Sprintf("SCIM-provisioned group from %s", provider.Name),
@@ -270,7 +271,7 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "scim_group_mapping",
 		StreamID:   mappingID,
-		EventType:  "SCIMGroupMapped",
+		EventType:  string(eventtypes.SCIMGroupMapped),
 		Data: map[string]any{
 			"provider_id":       provider.ID,
 			"scim_group_id":     scimGroupID,
@@ -295,7 +296,7 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 		h.appendEvent(ctx, store.Event{
 			StreamType: "user_group",
 			StreamID:   streamID,
-			EventType:  "UserGroupMemberAdded",
+			EventType:  string(eventtypes.UserGroupMemberAdded),
 			Data: map[string]any{
 				"group_id": userGroupID,
 				"user_id":  member.Value,
@@ -427,7 +428,7 @@ func (h *Handler) replaceGroup(w http.ResponseWriter, r *http.Request) {
 		h.appendEvent(ctx, store.Event{
 			StreamType: "scim_group_mapping",
 			StreamID:   mapping.ID,
-			EventType:  "SCIMGroupMappingUpdated",
+			EventType:  string(eventtypes.SCIMGroupMappingUpdated),
 			Data: map[string]any{
 				"provider_id":       provider.ID,
 				"scim_group_id":     mapping.ScimGroupID,
@@ -440,7 +441,7 @@ func (h *Handler) replaceGroup(w http.ResponseWriter, r *http.Request) {
 		h.appendEvent(ctx, store.Event{
 			StreamType: "user_group",
 			StreamID:   groupID,
-			EventType:  "UserGroupUpdated",
+			EventType:  string(eventtypes.UserGroupUpdated),
 			Data: map[string]any{
 				"name": scimGroup.DisplayName,
 			},
@@ -571,7 +572,7 @@ func (h *Handler) handleGroupPatchAdd(ctx context.Context, provider db.IdentityP
 		h.appendEvent(ctx, store.Event{
 			StreamType: "user_group",
 			StreamID:   streamID,
-			EventType:  "UserGroupMemberAdded",
+			EventType:  string(eventtypes.UserGroupMemberAdded),
 			Data: map[string]any{
 				"group_id": groupID,
 				"user_id":  userID,
@@ -595,7 +596,7 @@ func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider db.Identi
 			h.appendEvent(ctx, store.Event{
 				StreamType: "user_group",
 				StreamID:   streamID,
-				EventType:  "UserGroupMemberRemoved",
+				EventType:  string(eventtypes.UserGroupMemberRemoved),
 				Data: map[string]any{
 					"group_id": groupID,
 					"user_id":  userID,
@@ -615,7 +616,7 @@ func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider db.Identi
 			h.appendEvent(ctx, store.Event{
 				StreamType: "user_group",
 				StreamID:   streamID,
-				EventType:  "UserGroupMemberRemoved",
+				EventType:  string(eventtypes.UserGroupMemberRemoved),
 				Data: map[string]any{
 					"group_id": groupID,
 					"user_id":  userID,
@@ -641,7 +642,7 @@ func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider db.Ident
 		h.appendEvent(ctx, store.Event{
 			StreamType: "scim_group_mapping",
 			StreamID:   mapping.ID,
-			EventType:  "SCIMGroupMappingUpdated",
+			EventType:  string(eventtypes.SCIMGroupMappingUpdated),
 			Data: map[string]any{
 				"provider_id":       provider.ID,
 				"scim_group_id":     mapping.ScimGroupID,
@@ -654,7 +655,7 @@ func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider db.Ident
 		h.appendEvent(ctx, store.Event{
 			StreamType: "user_group",
 			StreamID:   groupID,
-			EventType:  "UserGroupUpdated",
+			EventType:  string(eventtypes.UserGroupUpdated),
 			Data: map[string]any{
 				"name": name,
 			},
@@ -689,7 +690,7 @@ func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider db.Ident
 				h.appendEvent(ctx, store.Event{
 					StreamType: "user_group",
 					StreamID:   streamID,
-					EventType:  "UserGroupMemberAdded",
+					EventType:  string(eventtypes.UserGroupMemberAdded),
 					Data: map[string]any{
 						"group_id": groupID,
 						"user_id":  userID,
@@ -708,7 +709,7 @@ func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider db.Ident
 				h.appendEvent(ctx, store.Event{
 					StreamType: "user_group",
 					StreamID:   streamID,
-					EventType:  "UserGroupMemberRemoved",
+					EventType:  string(eventtypes.UserGroupMemberRemoved),
 					Data: map[string]any{
 						"group_id": groupID,
 						"user_id":  userID,
@@ -757,7 +758,7 @@ func (h *Handler) deleteGroup(w http.ResponseWriter, r *http.Request) {
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "scim_group_mapping",
 		StreamID:   mapping.ID,
-		EventType:  "SCIMGroupUnmapped",
+		EventType:  string(eventtypes.SCIMGroupUnmapped),
 		Data: map[string]any{
 			"provider_id":   provider.ID,
 			"scim_group_id": mapping.ScimGroupID,
@@ -805,7 +806,7 @@ func (h *Handler) reconcileGroupMembers(ctx context.Context, provider db.Identit
 			h.appendEvent(ctx, store.Event{
 				StreamType: "user_group",
 				StreamID:   streamID,
-				EventType:  "UserGroupMemberAdded",
+				EventType:  string(eventtypes.UserGroupMemberAdded),
 				Data: map[string]any{
 					"group_id": groupID,
 					"user_id":  userID,
@@ -824,7 +825,7 @@ func (h *Handler) reconcileGroupMembers(ctx context.Context, provider db.Identit
 			h.appendEvent(ctx, store.Event{
 				StreamType: "user_group",
 				StreamID:   streamID,
-				EventType:  "UserGroupMemberRemoved",
+				EventType:  string(eventtypes.UserGroupMemberRemoved),
 				Data: map[string]any{
 					"group_id": groupID,
 					"user_id":  userID,
@@ -899,7 +900,7 @@ func (h *Handler) restoreOrphanedGroup(ctx context.Context, providerID string, m
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user_group",
 		StreamID:   newGroupID,
-		EventType:  "UserGroupCreated",
+		EventType:  string(eventtypes.UserGroupCreated),
 		Data: map[string]any{
 			"name":        m.ScimDisplayName,
 			"description": "SCIM-provisioned group (restored)",
@@ -914,7 +915,7 @@ func (h *Handler) restoreOrphanedGroup(ctx context.Context, providerID string, m
 	h.appendEvent(ctx, store.Event{
 		StreamType: "scim_group_mapping",
 		StreamID:   m.ID,
-		EventType:  "SCIMGroupUnmapped",
+		EventType:  string(eventtypes.SCIMGroupUnmapped),
 		Data: map[string]any{
 			"provider_id":   providerID,
 			"scim_group_id": m.ScimGroupID,
@@ -928,7 +929,7 @@ func (h *Handler) restoreOrphanedGroup(ctx context.Context, providerID string, m
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "scim_group_mapping",
 		StreamID:   newMappingID,
-		EventType:  "SCIMGroupMapped",
+		EventType:  string(eventtypes.SCIMGroupMapped),
 		Data: map[string]any{
 			"provider_id":       providerID,
 			"scim_group_id":     m.ScimGroupID,

--- a/internal/scim/users.go
+++ b/internal/scim/users.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -243,7 +244,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 			err = h.store.AppendEvent(ctx, store.Event{
 				StreamType: "identity_provider",
 				StreamID:   linkID,
-				EventType:  "IdentityLinked",
+				EventType:  string(eventtypes.IdentityLinked),
 				Data: map[string]any{
 					"user_id":        existingUser.ID,
 					"provider_id":    provider.ID,
@@ -299,7 +300,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   userID,
-		EventType:  "UserCreatedWithRoles",
+		EventType:  string(eventtypes.UserCreatedWithRoles),
 		Data: map[string]any{
 			"email":          email,
 			"display_name":   formatExternalName(scimUser.Name),
@@ -323,7 +324,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   linkID,
-		EventType:  "IdentityLinked",
+		EventType:  string(eventtypes.IdentityLinked),
 		Data: map[string]any{
 			"user_id":        userID,
 			"provider_id":    provider.ID,
@@ -346,7 +347,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 			if err := h.store.AppendEvent(ctx, store.Event{
 				StreamType: "user",
 				StreamID:   userID,
-				EventType:  "UserProvisioningSettingsUpdated",
+				EventType:  string(eventtypes.UserProvisioningSettingsUpdated),
 				Data:       map[string]any{"user_provisioning_enabled": true},
 				ActorType:  "system",
 				ActorID:    "scim",
@@ -358,7 +359,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 			if err := h.store.AppendEvent(ctx, store.Event{
 				StreamType: "user",
 				StreamID:   userID,
-				EventType:  "UserSshSettingsUpdated",
+				EventType:  string(eventtypes.UserSshSettingsUpdated),
 				Data: map[string]any{
 					"ssh_access_enabled": true,
 					"ssh_allow_pubkey":   true,
@@ -485,7 +486,7 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 		err = h.store.AppendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
-			EventType:  "UserEmailChanged",
+			EventType:  string(eventtypes.UserEmailChanged),
 			Data: map[string]any{
 				"email": newEmail,
 			},
@@ -504,7 +505,7 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 		if err := h.store.AppendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
-			EventType:  "UserDisabled",
+			EventType:  string(eventtypes.UserDisabled),
 			Data:       map[string]any{},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
@@ -517,7 +518,7 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 		if err := h.store.AppendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
-			EventType:  "UserEnabled",
+			EventType:  string(eventtypes.UserEnabled),
 			Data:       map[string]any{},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
@@ -536,7 +537,7 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 		if err := h.store.AppendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
-			EventType:  "UserProfileUpdated",
+			EventType:  string(eventtypes.UserProfileUpdated),
 			Data: map[string]any{
 				"display_name": newDisplayName,
 				"given_name":   newGivenName,
@@ -685,7 +686,7 @@ func (h *Handler) handleUserPatchReplace(ctx context.Context, provider db.Identi
 			return h.store.AppendEvent(ctx, store.Event{
 				StreamType: "user",
 				StreamID:   userID,
-				EventType:  "UserDisabled",
+				EventType:  string(eventtypes.UserDisabled),
 				Data:       map[string]any{},
 				ActorType:  "scim",
 				ActorID:    provider.ID,
@@ -694,7 +695,7 @@ func (h *Handler) handleUserPatchReplace(ctx context.Context, provider db.Identi
 			return h.store.AppendEvent(ctx, store.Event{
 				StreamType: "user",
 				StreamID:   userID,
-				EventType:  "UserEnabled",
+				EventType:  string(eventtypes.UserEnabled),
 				Data:       map[string]any{},
 				ActorType:  "scim",
 				ActorID:    provider.ID,
@@ -710,7 +711,7 @@ func (h *Handler) handleUserPatchReplace(ctx context.Context, provider db.Identi
 			return h.store.AppendEvent(ctx, store.Event{
 				StreamType: "user",
 				StreamID:   userID,
-				EventType:  "UserEmailChanged",
+				EventType:  string(eventtypes.UserEmailChanged),
 				Data: map[string]any{
 					"email": email,
 				},
@@ -737,7 +738,7 @@ func (h *Handler) handleUserPatchReplace(ctx context.Context, provider db.Identi
 			return h.store.AppendEvent(ctx, store.Event{
 				StreamType: "user",
 				StreamID:   userID,
-				EventType:  "UserEmailChanged",
+				EventType:  string(eventtypes.UserEmailChanged),
 				Data: map[string]any{
 					"email": email,
 				},
@@ -766,7 +767,7 @@ func (h *Handler) handleUserPatchReplace(ctx context.Context, provider db.Identi
 			return h.store.AppendEvent(ctx, store.Event{
 				StreamType: "user",
 				StreamID:   userID,
-				EventType:  "UserProfileUpdated",
+				EventType:  string(eventtypes.UserProfileUpdated),
 				Data:       data,
 				ActorType:  "scim",
 				ActorID:    provider.ID,
@@ -829,7 +830,7 @@ func (h *Handler) deleteUser(w http.ResponseWriter, r *http.Request) {
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   link.ID,
-		EventType:  "IdentityUnlinked",
+		EventType:  string(eventtypes.IdentityUnlinked),
 		Data:       map[string]any{},
 		ActorType:  "scim",
 		ActorID:    provider.ID,
@@ -862,7 +863,7 @@ func (h *Handler) deleteUser(w http.ResponseWriter, r *http.Request) {
 		err = h.store.AppendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
-			EventType:  "UserDeleted",
+			EventType:  string(eventtypes.UserDeleted),
 			Data:       map[string]any{},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
@@ -1077,7 +1078,7 @@ func (h *Handler) syncUserFromSCIM(ctx context.Context, provider db.IdentityProv
 		h.appendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
-			EventType:  "UserEmailChanged",
+			EventType:  string(eventtypes.UserEmailChanged),
 			Data:       map[string]any{"email": email},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
@@ -1090,7 +1091,7 @@ func (h *Handler) syncUserFromSCIM(ctx context.Context, provider db.IdentityProv
 		h.appendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
-			EventType:  "UserDisabled",
+			EventType:  string(eventtypes.UserDisabled),
 			Data:       map[string]any{},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
@@ -1099,7 +1100,7 @@ func (h *Handler) syncUserFromSCIM(ctx context.Context, provider db.IdentityProv
 		h.appendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
-			EventType:  "UserEnabled",
+			EventType:  string(eventtypes.UserEnabled),
 			Data:       map[string]any{},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
@@ -1114,7 +1115,7 @@ func (h *Handler) syncUserFromSCIM(ctx context.Context, provider db.IdentityProv
 		h.appendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
-			EventType:  "UserProfileUpdated",
+			EventType:  string(eventtypes.UserProfileUpdated),
 			Data: map[string]any{
 				"display_name": newDisplayName,
 				"given_name":   newGivenName,
@@ -1144,7 +1145,7 @@ func (h *Handler) syncIdentityLink(ctx context.Context, provider db.IdentityProv
 	h.appendEvent(ctx, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   link.ID,
-		EventType:  "IdentityLinkLoginUpdated",
+		EventType:  string(eventtypes.IdentityLinkLoginUpdated),
 		Data: map[string]any{
 			"provider_id":    provider.ID,
 			"external_id":    link.ExternalID,

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -18,6 +18,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/auth/totp"
 	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/projectors"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
@@ -141,7 +142,7 @@ func CreateTestUser(t *testing.T, st *store.Store, email, password, role string)
 	if err := st.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   id,
-		EventType:  "UserCreatedWithRoles",
+		EventType:  string(eventtypes.UserCreatedWithRoles),
 		Data: map[string]any{
 			"email":         email,
 			"password_hash": hash,
@@ -166,7 +167,7 @@ func CreateTestDevice(t *testing.T, st *store.Store, hostname string) string {
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   id,
-		EventType:  "DeviceRegistered",
+		EventType:  string(eventtypes.DeviceRegistered),
 		Data: map[string]any{
 			"hostname":      hostname,
 			"agent_version": "1.0.0",
@@ -196,7 +197,7 @@ func CreateTestActionWithDesiredState(t *testing.T, st *store.Store, actorID, na
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "action",
 		StreamID:   id,
-		EventType:  "ActionCreated",
+		EventType:  string(eventtypes.ActionCreated),
 		Data: map[string]any{
 			"name":            name,
 			"action_type":     actionType,
@@ -223,7 +224,7 @@ func CreateTestActionSet(t *testing.T, st *store.Store, actorID, name string) st
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "action_set",
 		StreamID:   id,
-		EventType:  "ActionSetCreated",
+		EventType:  string(eventtypes.ActionSetCreated),
 		Data: map[string]any{
 			"name": name,
 		},
@@ -246,7 +247,7 @@ func CreateTestDefinition(t *testing.T, st *store.Store, actorID, name string) s
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "definition",
 		StreamID:   id,
-		EventType:  "DefinitionCreated",
+		EventType:  string(eventtypes.DefinitionCreated),
 		Data: map[string]any{
 			"name": name,
 		},
@@ -269,7 +270,7 @@ func CreateTestDeviceGroup(t *testing.T, st *store.Store, actorID, name string) 
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "device_group",
 		StreamID:   id,
-		EventType:  "DeviceGroupCreated",
+		EventType:  string(eventtypes.DeviceGroupCreated),
 		Data: map[string]any{
 			"name":       name,
 			"is_dynamic": false,
@@ -293,7 +294,7 @@ func CreateTestToken(t *testing.T, st *store.Store, actorID, name, valueHash str
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "token",
 		StreamID:   id,
-		EventType:  "TokenCreated",
+		EventType:  string(eventtypes.TokenCreated),
 		Data: map[string]any{
 			"name":       name,
 			"value_hash": valueHash,
@@ -335,7 +336,7 @@ func SSOOnlyUserEvent(userID, email string) store.Event {
 	return store.Event{
 		StreamType: "user",
 		StreamID:   userID,
-		EventType:  "UserCreatedWithRoles",
+		EventType:  string(eventtypes.UserCreatedWithRoles),
 		Data: map[string]any{
 			"email":    email,
 			"role":     "user",
@@ -351,7 +352,7 @@ func DisableEvent(userID string) store.Event {
 	return store.Event{
 		StreamType: "user",
 		StreamID:   userID,
-		EventType:  "UserDisabled",
+		EventType:  string(eventtypes.UserDisabled),
 		Data:       map[string]any{},
 		ActorType:  "system",
 		ActorID:    "test",
@@ -377,7 +378,7 @@ func CreateTestRole(t *testing.T, st *store.Store, actorID, name string, permiss
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "role",
 		StreamID:   id,
-		EventType:  "RoleCreated",
+		EventType:  string(eventtypes.RoleCreated),
 		Data: map[string]any{
 			"name":        name,
 			"description": "",
@@ -403,7 +404,7 @@ func CreateTestUserGroup(t *testing.T, st *store.Store, actorID, name string) st
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "user_group",
 		StreamID:   id,
-		EventType:  "UserGroupCreated",
+		EventType:  string(eventtypes.UserGroupCreated),
 		Data: map[string]any{
 			"name":        name,
 			"description": "",
@@ -427,7 +428,7 @@ func AddUserToTestGroup(t *testing.T, st *store.Store, actorID, groupID, userID 
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "user_group",
 		StreamID:   streamID,
-		EventType:  "UserGroupMemberAdded",
+		EventType:  string(eventtypes.UserGroupMemberAdded),
 		Data: map[string]any{
 			"group_id": groupID,
 			"user_id":  userID,
@@ -449,7 +450,7 @@ func AssignRoleToTestGroup(t *testing.T, st *store.Store, actorID, groupID, role
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "user_group",
 		StreamID:   streamID,
-		EventType:  "UserGroupRoleAssigned",
+		EventType:  string(eventtypes.UserGroupRoleAssigned),
 		Data: map[string]any{
 			"group_id": groupID,
 			"role_id":  roleID,
@@ -471,7 +472,7 @@ func AssignRoleToTestUser(t *testing.T, st *store.Store, actorID, userID, roleID
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "user_role",
 		StreamID:   streamID,
-		EventType:  "UserRoleAssigned",
+		EventType:  string(eventtypes.UserRoleAssigned),
 		Data: map[string]any{
 			"user_id": userID,
 			"role_id": roleID,
@@ -492,7 +493,7 @@ func AssignDeviceToUser(t *testing.T, st *store.Store, actorID, deviceID, userID
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "device",
 		StreamID:   deviceID,
-		EventType:  "DeviceAssigned",
+		EventType:  string(eventtypes.DeviceAssigned),
 		Data: map[string]any{
 			"user_id": userID,
 		},
@@ -512,7 +513,7 @@ func AddDeviceToTestGroup(t *testing.T, st *store.Store, actorID, groupID, devic
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "device_group",
 		StreamID:   groupID,
-		EventType:  "DeviceGroupMemberAdded",
+		EventType:  string(eventtypes.DeviceGroupMemberAdded),
 		Data: map[string]any{
 			"device_id": deviceID,
 		},
@@ -533,7 +534,7 @@ func CreateTestAssignment(t *testing.T, st *store.Store, actorID, sourceType, so
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "assignment",
 		StreamID:   id,
-		EventType:  "AssignmentCreated",
+		EventType:  string(eventtypes.AssignmentCreated),
 		Data: map[string]any{
 			"source_type": sourceType,
 			"source_id":   sourceID,
@@ -559,7 +560,7 @@ func AddActionToTestSet(t *testing.T, st *store.Store, actorID, setID, actionID 
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "action_set",
 		StreamID:   setID,
-		EventType:  "ActionSetMemberAdded",
+		EventType:  string(eventtypes.ActionSetMemberAdded),
 		Data: map[string]any{
 			"action_id":  actionID,
 			"sort_order": sortOrder,
@@ -580,7 +581,7 @@ func AddActionSetToTestDefinition(t *testing.T, st *store.Store, actorID, defini
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "definition",
 		StreamID:   definitionID,
-		EventType:  "DefinitionMemberAdded",
+		EventType:  string(eventtypes.DefinitionMemberAdded),
 		Data: map[string]any{
 			"action_set_id": actionSetID,
 			"sort_order":    sortOrder,
@@ -629,7 +630,7 @@ func SetupTOTP(t *testing.T, st *store.Store, enc *crypto.Encryptor, userID, ema
 	if err := st.AppendEvent(ctx, store.Event{
 		StreamType: "totp",
 		StreamID:   userID,
-		EventType:  "TOTPSetupInitiated",
+		EventType:  string(eventtypes.TOTPSetupInitiated),
 		Data: map[string]any{
 			"secret_encrypted":  encryptedSecret,
 			"backup_codes_hash": hashes,
@@ -643,7 +644,7 @@ func SetupTOTP(t *testing.T, st *store.Store, enc *crypto.Encryptor, userID, ema
 	if err := st.AppendEvent(ctx, store.Event{
 		StreamType: "totp",
 		StreamID:   userID,
-		EventType:  "TOTPVerified",
+		EventType:  string(eventtypes.TOTPVerified),
 		Data:       map[string]any{},
 		ActorType:  "user",
 		ActorID:    userID,
@@ -668,7 +669,7 @@ func CreateTestIdentityProvider(t *testing.T, st *store.Store, enc *crypto.Encry
 	err = st.AppendEvent(ctx, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   id,
-		EventType:  "IdentityProviderCreated",
+		EventType:  string(eventtypes.IdentityProviderCreated),
 		Data: map[string]any{
 			"name":                    name,
 			"slug":                    slug,
@@ -699,7 +700,7 @@ func CreateTestIdentityLink(t *testing.T, st *store.Store, userID, providerID, e
 	err := st.AppendEvent(ctx, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   id,
-		EventType:  "IdentityLinked",
+		EventType:  string(eventtypes.IdentityLinked),
 		Data: map[string]any{
 			"user_id":        userID,
 			"provider_id":    providerID,
@@ -731,7 +732,7 @@ func EnableSCIMForProvider(t *testing.T, st *store.Store, actorID, providerID st
 	err = st.AppendEvent(ctx, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   providerID,
-		EventType:  "IdentityProviderSCIMEnabled",
+		EventType:  string(eventtypes.IdentityProviderSCIMEnabled),
 		Data: map[string]any{
 			"scim_token_hash": string(hash),
 		},


### PR DESCRIPTION
## Summary

Server-only refactor; no SDK or proto changes.

Eliminates ~465 stringly-typed event-type literals across 72 files by introducing `internal/eventtypes` — single source of truth for the 135 event-type identifiers stored in the `events.event_type` column.

## Why

Every projector listener had switches like:

```go
case "UserCreated":
case "UserPasswordChanged":
// ...
```

A typo such as `case "UserCrated":` silently dispatched nothing — exactly the bug class motivating this cleanup release. Constants now catch it at compile time.

## Files

- `internal/eventtypes/types.go` — 135 `EventType` constants grouped by stream + `All()` enumerator.
- `internal/eventtypes/types_test.go` — 3 invariant tests (uniqueness, non-empty, PascalCase pattern).
- **23 listener files** (`internal/projectors/*_listener.go` + `internal/api/{search,system_actions}_listener.go`) — every `case "X":` switched to `case string(eventtypes.X):`.
- **21 projector helper files** — `e.EventType` comparisons typed.
- **28 emit-site files** (`internal/api/`, `internal/scim/`, `internal/idp/linker.go`, `internal/control/inbox_worker.go`, `internal/testutil/testutil.go`) — every `EventType: "X"` now `EventType: string(eventtypes.X)`.

## Scope decisions

- Kept `store.Event.EventType` as `string` (not `eventtypes.EventType`) per lower-touch option. Typed constraint applies at call sites.
- Did NOT introduce `StreamType` constants (smaller surface, separate future PR if useful).
- Did NOT touch `_test.go` files (raw string literals are fine in tests).

## Verification

- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...`, `gofmt -l .` all clean.
- [x] `go test ./internal/eventtypes/...` passes (3 invariant tests).
- [x] `grep` for bare `case "Xxx":` event-type literals in non-test source returns 0 matches outside `eventtypes/types.go`.
- [x] CR-CLI returned 0 findings before push.

Pure refactor — no behavioral change. The `events.event_type` column type is unchanged; runtime string values are identical.

Part of the 2026.06 cleanup-release sweep. PRs E (leftover `map[string]string`) / F (typed event payload structs) follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized event-type identifiers and standardized event emission/processing across the system for improved consistency.
  * Added validation tests for the event-type set.
  * No user-visible functionality or API changes; behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->