### PR TITLE
docs(deploy): bump prerequisite to Go 1.25.10+ (CVE patch line)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -17,7 +17,10 @@
 #   ./deploy.sh --build-only
 #
 # Prerequisites:
-#   - Go 1.25+ installed locally
+#   - Go 1.25.10+ installed locally (matches go.mod's pinned go directive,
+#     which carries the stdlib patches for GO-2026-4986 / 4977 / 4971 /
+#     4918; older 1.25.x patches will still compile but ship a binary
+#     with the unpatched stdlib)
 #   - Podman installed locally
 #   - SSH access to the remote server
 #   - Docker + Docker Compose on the remote server


### PR DESCRIPTION
## Summary

`server/deploy/deploy.sh` lists the build prerequisite as "Go 1.25+", but `go.mod` pins the `go` directive at `1.25.10` to pull the stdlib patches for GO-2026-4986 / 4977 / 4971 / 4918 (mail, net, net/http). Operators building from main on Go 1.25.0–1.25.9 will still successfully compile, but their binaries ship with the unpatched stdlib — a silent downgrade that's exactly the kind of trap a "Go 1.25+ installed locally" prerequisite line is supposed to prevent.

## Fix

One-line update in the prerequisites comment block to require `Go 1.25.10+` and explain why.

No script behaviour change.

## Test plan

- [ ] `bash -n deploy/deploy.sh` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment prerequisites to clarify minimum Go version requirement (1.25.10+) and compatibility notes for build configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/194)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->