### PR TITLE
feat(group-vars): server-side template renderer (#196)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage/sdk/go/logging"
 	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/api/template"
 	"github.com/manchtools/power-manage/server/internal/asynqutil"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/ca"
@@ -722,6 +723,12 @@ func main() {
 		// ProxyValidateTerminalToken.
 		internalHandler.SetTerminalTokenStore(terminalTokenStore)
 	}
+	// Server-side `{{ var.NAME }}` substitution for action params.
+	// The renderer's StoreResolver reads device labels + group
+	// variables from the projection and decrypts SECRET-typed values
+	// via the same encryptor that wrote them. See manchtools/power-
+	// manage-server#196 (group-based variables, design #59).
+	internalHandler.SetRenderer(template.New(template.NewStoreResolver(st, encryptor, logger.With("component", "template"))))
 	internalPath, internalH := pmv1connect.NewInternalServiceHandler(internalHandler)
 
 	// Peer-class gate: InternalService handles credential-bearing

--- a/internal/api/group_variable_handler.go
+++ b/internal/api/group_variable_handler.go
@@ -55,9 +55,10 @@ func NewGroupVariableHandler(st *store.Store, enc *crypto.Encryptor, logger *slo
 // ciphertext in Value; non-secret types store the raw value as the
 // per-type validator accepted it.
 //
-// Kept in this package rather than a shared types one because the
-// renderer (#196) reads its own decoded view; the only writers are
-// the four handler entry points in this file.
+// Mirrored (intentionally duplicated) by the unexported storedVariable
+// in internal/api/template/resolver.go — the renderer can't import
+// this package without a cycle. Any field changes must land in both
+// places or the renderer will silently drop the new field on read.
 type storedVariable struct {
 	Name         string   `json:"name"`
 	Type         string   `json:"type"`

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -13,6 +13,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	"github.com/manchtools/power-manage/server/internal/api/template"
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
@@ -38,6 +39,13 @@ type InternalHandler struct {
 	// gateway gets a clean error rather than the InternalService
 	// default 'method not implemented'.
 	terminalTokenStore *terminal.TokenStore
+
+	// renderer substitutes `{{ var.NAME }}` references on every
+	// templateable string field of an Action proto before it leaves
+	// the server. Set via SetRenderer in main.go. nil disables the
+	// substitution pass — actions then ship verbatim, which is the
+	// pre-#196 behaviour and what test fixtures default to.
+	renderer *template.Renderer
 }
 
 // NewInternalHandler creates a new internal service handler.
@@ -55,6 +63,13 @@ func NewInternalHandler(st *store.Store, enc *crypto.Encryptor, logger *slog.Log
 // ControlService.SetTerminalHandler so the two paths share one store.
 func (h *InternalHandler) SetTerminalTokenStore(s *terminal.TokenStore) {
 	h.terminalTokenStore = s
+}
+
+// SetRenderer wires the template renderer used by ProxySyncActions to
+// substitute `{{ var.NAME }}` references on Action wire messages.
+// Called from main.go after the encryptor + store are available.
+func (h *InternalHandler) SetRenderer(r *template.Renderer) {
+	h.renderer = r
 }
 
 // VerifyDevice checks that a device exists and is not deleted.
@@ -182,6 +197,34 @@ func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Req
 			Schedule:    actionparams.ScheduleFromJSON(g.Schedule),
 			Actions:     groupActions,
 		})
+	}
+
+	// Server-side `{{ var.NAME }}` substitution pass. Resolves once
+	// per device and applies to every Action — both standalone and
+	// inside groups. A render error fails the whole sync rather than
+	// shipping a half-rendered template; the agent handles the error
+	// by retrying after the operator fixes the variable definition.
+	// See manchtools/power-manage-server#196.
+	if h.renderer != nil {
+		vars, err := h.renderer.Resolve(ctx, deviceID)
+		if err != nil {
+			h.logger.Error("template variable resolve failed", "device_id", deviceID, "error", err)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, fmt.Sprintf("failed to resolve template variables: %v", err))
+		}
+		for _, a := range standalone {
+			if err := h.renderer.RenderWithVars(ctx, a, vars); err != nil {
+				h.logger.Error("template render failed", "device_id", deviceID, "action_id", a.GetId().GetValue(), "error", err)
+				return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeFailedPrecondition, fmt.Sprintf("failed to render templates: %v", err))
+			}
+		}
+		for _, g := range groups {
+			for _, a := range g.Actions {
+				if err := h.renderer.RenderWithVars(ctx, a, vars); err != nil {
+					h.logger.Error("template render failed", "device_id", deviceID, "action_id", a.GetId().GetValue(), "error", err)
+					return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeFailedPrecondition, fmt.Sprintf("failed to render templates: %v", err))
+				}
+			}
+		}
 	}
 
 	// Resolved maintenance window across every group reaching the

--- a/internal/api/template/render.go
+++ b/internal/api/template/render.go
@@ -1,0 +1,246 @@
+// Package template implements the server-side `{{ var.NAME }}`
+// substitution pass for action params. Every templateable field on
+// the wire-format Action proto is walked via protoreflect and its
+// references are replaced with the resolved variable values before
+// the Action leaves the server. The pipeline is intentionally
+// no-context-aware-shell-quoting: values flow in literally, so the
+// trust gate lives at the SET-time RBAC on the variable itself
+// (handled in internal/api/group_variable_handler.go and
+// internal/auth/permissions.go). See the design notes on
+// manchtools/power-manage-server#59 for the rationale.
+package template
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+
+	pmv1 "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+// Renderer rewrites templateable string fields on an Action proto in
+// place. A single Renderer is safe to share across goroutines; the
+// per-call state is the resolved variable map produced by the
+// Resolver.
+type Renderer struct {
+	resolver Resolver
+}
+
+// New constructs a Renderer backed by the given Resolver.
+func New(resolver Resolver) *Renderer {
+	return &Renderer{resolver: resolver}
+}
+
+// Resolver supplies the variable map for a given device. The
+// production implementation lives in internal/api/template/resolver.go
+// and reads device labels + device-group + user-group variables; tests
+// substitute a static map.
+type Resolver interface {
+	Resolve(ctx context.Context, deviceID string) (Variables, error)
+}
+
+// Variables is the resolved name → value map at render time. SECRET
+// values arrive already decrypted (the resolver owns the encryptor).
+type Variables map[string]Value
+
+// Value carries a resolved variable's plaintext together with its
+// declared type. The renderer uses Plaintext for substitution; Type
+// + DefinedIn are kept so future destination-field validators can
+// surface "this came from a SECRET" diagnostics without inspecting
+// the value itself.
+type Value struct {
+	Type      pmv1.VariableType
+	Plaintext string
+	DefinedIn []string
+}
+
+// Render walks the Action proto and substitutes `{{ var.NAME }}`
+// references in every templateable string field. Unresolved
+// references and any leftover `{{` after substitution are returned as
+// errors — the design prefers to fail loudly at dispatch time over
+// silently shipping a half-rendered template to a device.
+//
+// deviceID is the target the variables resolve against. action is
+// mutated in place; callers that need the original should clone it
+// first via proto.Clone. Convenience wrapper around Resolve +
+// RenderWithVars; callers rendering multiple actions for the same
+// device should call those two directly to avoid re-resolving.
+func (r *Renderer) Render(ctx context.Context, deviceID string, action *pmv1.Action) error {
+	if action == nil {
+		return nil
+	}
+	vars, err := r.Resolve(ctx, deviceID)
+	if err != nil {
+		return err
+	}
+	return r.RenderWithVars(ctx, action, vars)
+}
+
+// Resolve is the renderer's view onto its Resolver. Exposed so a
+// handler that walks many Actions for a single device can resolve
+// once and pass the result into RenderWithVars per action.
+func (r *Renderer) Resolve(ctx context.Context, deviceID string) (Variables, error) {
+	vars, err := r.resolver.Resolve(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("resolve variables for device %s: %w", deviceID, err)
+	}
+	return vars, nil
+}
+
+// RenderWithVars walks the Action proto with a caller-supplied
+// variable map. Mutates action in place; nil action is a no-op.
+func (r *Renderer) RenderWithVars(_ context.Context, action *pmv1.Action, vars Variables) error {
+	if action == nil {
+		return nil
+	}
+	return walkMessage(action.ProtoReflect(), vars)
+}
+
+// varRefRE matches `{{ var.NAME }}` with optional whitespace around
+// the inner name. Name grammar matches the SET-time validator in
+// internal/api/group_variables_validator.go.
+var varRefRE = regexp.MustCompile(`\{\{\s*var\.([a-z][a-z0-9_]*)\s*\}\}`)
+
+// ErrUnresolvedReference is the sentinel returned when a `{{ var.X }}`
+// reference can't be matched against a variable known on the target
+// device. Callers can errors.Is against this to surface a
+// machine-readable diagnostic; the Render call still propagates the
+// wrapped error with the offending name.
+var ErrUnresolvedReference = errors.New("unresolved variable reference")
+
+// ErrUnclosedBrace is the sentinel returned when a templateable field
+// contains `{{` after the substitution pass — typically the operator
+// typed `{{ var.foo }` (missing closing brace) or `{ { var.foo }}`
+// (typo). Better to fail than to ship the literal `{{` to a device.
+var ErrUnclosedBrace = errors.New("unresolved {{ in template after substitution")
+
+// walkMessage descends a protoreflect.Message, calling substitute on
+// every templateable string field (including repeated string fields)
+// and recursing into sub-messages and oneofs.
+func walkMessage(msg protoreflect.Message, vars Variables) error {
+	if !msg.IsValid() {
+		return nil
+	}
+	var walkErr error
+	msg.Range(func(fd protoreflect.FieldDescriptor, val protoreflect.Value) bool {
+		if err := walkField(msg, fd, val, vars); err != nil {
+			walkErr = err
+			return false
+		}
+		return true
+	})
+	return walkErr
+}
+
+func walkField(msg protoreflect.Message, fd protoreflect.FieldDescriptor, val protoreflect.Value, vars Variables) error {
+	switch {
+	case fd.IsList():
+		list := val.List()
+		// Only string lists are templateable — the only repeated
+		// templateable fields in the proto are []string today
+		// (UserParams.ssh_authorized_keys, GroupParams.members,
+		// AdminPolicyParams.users, etc.).
+		if fd.Kind() == protoreflect.StringKind && isTemplateable(fd) {
+			for i := 0; i < list.Len(); i++ {
+				out, err := substitute(list.Get(i).String(), vars)
+				if err != nil {
+					return fmt.Errorf("field %s[%d]: %w", fd.Name(), i, err)
+				}
+				list.Set(i, protoreflect.ValueOfString(out))
+			}
+			return nil
+		}
+		// Repeated message field: recurse into each element.
+		if fd.Kind() == protoreflect.MessageKind {
+			for i := 0; i < list.Len(); i++ {
+				if err := walkMessage(list.Get(i).Message(), vars); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	case fd.IsMap():
+		// Maps are not currently annotated templateable (the only
+		// map<string, string> field in the proto is
+		// ShellParams.environment, which is intentionally NOT
+		// templateable — operators set env via the string value
+		// directly). No walk needed.
+		return nil
+	case fd.Kind() == protoreflect.MessageKind:
+		return walkMessage(val.Message(), vars)
+	case fd.Kind() == protoreflect.StringKind && isTemplateable(fd):
+		out, err := substitute(val.String(), vars)
+		if err != nil {
+			return fmt.Errorf("field %s: %w", fd.Name(), err)
+		}
+		msg.Set(fd, protoreflect.ValueOfString(out))
+		return nil
+	}
+	return nil
+}
+
+// isTemplateable returns true when the field carries the
+// `(templateable) = true` option from sdk/proto/pm/v1/actions.proto.
+// The extension is loaded via proto.GetExtension; missing options
+// (the common case) yield false.
+func isTemplateable(fd protoreflect.FieldDescriptor) bool {
+	opts := fd.Options()
+	if opts == nil {
+		return false
+	}
+	v := proto.GetExtension(opts, pmv1.E_Templateable)
+	b, ok := v.(bool)
+	return ok && b
+}
+
+// substitute replaces every `{{ var.NAME }}` reference in s with the
+// matching plaintext from vars. Unknown names yield ErrUnresolvedReference
+// and any leftover `{{` after the pass yields ErrUnclosedBrace —
+// both surface to the caller wrapped with field context.
+func substitute(s string, vars Variables) (string, error) {
+	if s == "" {
+		return s, nil
+	}
+	if !strings.Contains(s, "{{") {
+		return s, nil
+	}
+	var (
+		missing []string
+		out     = varRefRE.ReplaceAllStringFunc(s, func(m string) string {
+			matches := varRefRE.FindStringSubmatch(m)
+			if len(matches) < 2 {
+				return m
+			}
+			name := matches[1]
+			v, ok := vars[name]
+			if !ok {
+				missing = append(missing, name)
+				return m
+			}
+			return v.Plaintext
+		})
+	)
+	if len(missing) > 0 {
+		// Stable diagnostic — sort + dedupe so the error message
+		// doesn't depend on map iteration order.
+		sort.Strings(missing)
+		uniq := missing[:0]
+		var prev string
+		for _, n := range missing {
+			if n != prev {
+				uniq = append(uniq, n)
+			}
+			prev = n
+		}
+		return "", fmt.Errorf("%w: %s", ErrUnresolvedReference, strings.Join(uniq, ", "))
+	}
+	if strings.Contains(out, "{{") {
+		return "", fmt.Errorf("%w: %q", ErrUnclosedBrace, out)
+	}
+	return out, nil
+}

--- a/internal/api/template/render_test.go
+++ b/internal/api/template/render_test.go
@@ -1,0 +1,216 @@
+package template
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pmv1 "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// staticResolver is a tiny test double that returns a pre-built map.
+// Tests use it instead of the production StoreResolver so they don't
+// need a Postgres / projection round-trip.
+type staticResolver struct {
+	vars Variables
+	err  error
+}
+
+func (s staticResolver) Resolve(_ context.Context, _ string) (Variables, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.vars, nil
+}
+
+func newRendererFor(vars Variables) *Renderer {
+	return New(staticResolver{vars: vars})
+}
+
+func TestRender_HappyPath_TemplateableStringField(t *testing.T) {
+	r := newRendererFor(Variables{
+		"pkg": {Type: pmv1.VariableType_VARIABLE_TYPE_STRING, Plaintext: "nginx"},
+	})
+	action := &pmv1.Action{
+		Id:   &pmv1.ActionId{Value: "01HX0000000000000000000000"},
+		Type: pmv1.ActionType_ACTION_TYPE_PACKAGE,
+		Params: &pmv1.Action_Package{
+			Package: &pmv1.PackageParams{Name: "{{ var.pkg }}"},
+		},
+	}
+	require.NoError(t, r.Render(context.Background(), "dev", action))
+	assert.Equal(t, "nginx", action.GetPackage().GetName())
+}
+
+func TestRender_UnknownVariable_ReturnsErrUnresolvedReference(t *testing.T) {
+	r := newRendererFor(Variables{})
+	action := &pmv1.Action{
+		Id:   &pmv1.ActionId{Value: "01HX0000000000000000000000"},
+		Type: pmv1.ActionType_ACTION_TYPE_PACKAGE,
+		Params: &pmv1.Action_Package{
+			Package: &pmv1.PackageParams{Name: "{{ var.missing }}"},
+		},
+	}
+	err := r.Render(context.Background(), "dev", action)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnresolvedReference), "want ErrUnresolvedReference, got %v", err)
+	assert.Contains(t, err.Error(), "missing")
+}
+
+func TestRender_UnclosedBrace_ReturnsErrUnclosedBrace(t *testing.T) {
+	r := newRendererFor(Variables{
+		"pkg": {Type: pmv1.VariableType_VARIABLE_TYPE_STRING, Plaintext: "nginx"},
+	})
+	action := &pmv1.Action{
+		Id:   &pmv1.ActionId{Value: "01HX0000000000000000000000"},
+		Type: pmv1.ActionType_ACTION_TYPE_PACKAGE,
+		Params: &pmv1.Action_Package{
+			// Trailing `{{` after the substitution pass — typo on the
+			// operator's part, must fail rather than ship literally.
+			Package: &pmv1.PackageParams{Name: "{{ var.pkg }}-{{x"},
+		},
+	}
+	err := r.Render(context.Background(), "dev", action)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnclosedBrace), "want ErrUnclosedBrace, got %v", err)
+}
+
+func TestRender_NonTemplateableMapField_LeftAlone(t *testing.T) {
+	// ShellParams.environment is a map<string,string> intentionally
+	// NOT marked templateable. The walker must NOT touch it even when
+	// the value contains `{{ var.foo }}`.
+	r := newRendererFor(Variables{
+		"foo": {Type: pmv1.VariableType_VARIABLE_TYPE_STRING, Plaintext: "REPLACED"},
+	})
+	action := &pmv1.Action{
+		Id:   &pmv1.ActionId{Value: "01HX0000000000000000000000"},
+		Type: pmv1.ActionType_ACTION_TYPE_SHELL,
+		Params: &pmv1.Action_Shell{
+			Shell: &pmv1.ShellParams{
+				Script:      "echo {{ var.foo }}",
+				Environment: map[string]string{"LITERAL": "{{ var.foo }}"},
+			},
+		},
+	}
+	require.NoError(t, r.Render(context.Background(), "dev", action))
+	assert.Equal(t, "echo REPLACED", action.GetShell().GetScript())
+	assert.Equal(t, "{{ var.foo }}", action.GetShell().GetEnvironment()["LITERAL"])
+}
+
+func TestRender_RepeatedStringField(t *testing.T) {
+	// UserParams.ssh_authorized_keys is a repeated string field
+	// marked templateable. Each entry must be substituted independently.
+	r := newRendererFor(Variables{
+		"key1": {Type: pmv1.VariableType_VARIABLE_TYPE_STRING, Plaintext: "ssh-ed25519 AAA1"},
+		"key2": {Type: pmv1.VariableType_VARIABLE_TYPE_STRING, Plaintext: "ssh-ed25519 AAA2"},
+	})
+	action := &pmv1.Action{
+		Id:   &pmv1.ActionId{Value: "01HX0000000000000000000000"},
+		Type: pmv1.ActionType_ACTION_TYPE_USER,
+		Params: &pmv1.Action_User{
+			User: &pmv1.UserParams{
+				Username: "alice",
+				SshAuthorizedKeys: []string{
+					"{{ var.key1 }}",
+					"{{ var.key2 }}",
+				},
+			},
+		},
+	}
+	require.NoError(t, r.Render(context.Background(), "dev", action))
+	got := action.GetUser().GetSshAuthorizedKeys()
+	require.Len(t, got, 2)
+	assert.Equal(t, "ssh-ed25519 AAA1", got[0])
+	assert.Equal(t, "ssh-ed25519 AAA2", got[1])
+}
+
+func TestRender_NoTemplateInValue_FastPath(t *testing.T) {
+	r := newRendererFor(Variables{})
+	action := &pmv1.Action{
+		Id:   &pmv1.ActionId{Value: "01HX0000000000000000000000"},
+		Type: pmv1.ActionType_ACTION_TYPE_PACKAGE,
+		Params: &pmv1.Action_Package{
+			Package: &pmv1.PackageParams{Name: "nginx"},
+		},
+	}
+	require.NoError(t, r.Render(context.Background(), "dev", action))
+	assert.Equal(t, "nginx", action.GetPackage().GetName())
+}
+
+func TestRender_NilAction_NoOp(t *testing.T) {
+	r := newRendererFor(Variables{})
+	require.NoError(t, r.Render(context.Background(), "dev", nil))
+}
+
+func TestRender_ResolverError_Propagates(t *testing.T) {
+	r := New(staticResolver{err: errors.New("resolver boom")})
+	action := &pmv1.Action{
+		Id:   &pmv1.ActionId{Value: "01HX0000000000000000000000"},
+		Type: pmv1.ActionType_ACTION_TYPE_PACKAGE,
+		Params: &pmv1.Action_Package{
+			Package: &pmv1.PackageParams{Name: "nginx"},
+		},
+	}
+	err := r.Render(context.Background(), "dev", action)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "resolver boom")
+}
+
+func TestRender_MultipleReferencesSameField(t *testing.T) {
+	r := newRendererFor(Variables{
+		"a": {Type: pmv1.VariableType_VARIABLE_TYPE_STRING, Plaintext: "first"},
+		"b": {Type: pmv1.VariableType_VARIABLE_TYPE_STRING, Plaintext: "second"},
+	})
+	action := &pmv1.Action{
+		Id:   &pmv1.ActionId{Value: "01HX0000000000000000000000"},
+		Type: pmv1.ActionType_ACTION_TYPE_SHELL,
+		Params: &pmv1.Action_Shell{
+			Shell: &pmv1.ShellParams{Script: "{{ var.a }} and {{ var.b }} and {{var.a}}"},
+		},
+	}
+	require.NoError(t, r.Render(context.Background(), "dev", action))
+	assert.Equal(t, "first and second and first", action.GetShell().GetScript())
+}
+
+func TestRender_MultipleUnresolved_SortedAndDeduped(t *testing.T) {
+	// Two distinct missing names + a duplicate of one of them; the
+	// error message must list each name once, sorted, so operators
+	// see a stable diagnostic.
+	r := newRendererFor(Variables{})
+	action := &pmv1.Action{
+		Id:   &pmv1.ActionId{Value: "01HX0000000000000000000000"},
+		Type: pmv1.ActionType_ACTION_TYPE_SHELL,
+		Params: &pmv1.Action_Shell{
+			Shell: &pmv1.ShellParams{Script: "{{ var.zeta }} {{ var.alpha }} {{ var.zeta }}"},
+		},
+	}
+	err := r.Render(context.Background(), "dev", action)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnresolvedReference))
+	assert.Contains(t, err.Error(), "alpha, zeta")
+}
+
+func TestRender_SecretValue_SubstitutesPlaintext(t *testing.T) {
+	// SECRET-typed values arrive at the renderer already decrypted.
+	// The renderer doesn't care about the type — it substitutes the
+	// plaintext like any other value. Documented here so future
+	// changes don't accidentally start treating SECRET differently.
+	r := newRendererFor(Variables{
+		"db_password": {Type: pmv1.VariableType_VARIABLE_TYPE_SECRET, Plaintext: "hunter2"},
+	})
+	action := &pmv1.Action{
+		Id:   &pmv1.ActionId{Value: "01HX0000000000000000000000"},
+		Type: pmv1.ActionType_ACTION_TYPE_FILE,
+		Params: &pmv1.Action_File{
+			File: &pmv1.FileParams{
+				Path:    "/etc/myapp.conf",
+				Content: "password={{ var.db_password }}",
+			},
+		},
+	}
+	require.NoError(t, r.Render(context.Background(), "dev", action))
+	assert.Equal(t, "password=hunter2", action.GetFile().GetContent())
+}

--- a/internal/api/template/resolver.go
+++ b/internal/api/template/resolver.go
@@ -1,0 +1,210 @@
+// Resolver implementation backed by the projection store. The
+// renderer talks to this through the Resolver interface in render.go;
+// tests substitute a static map.
+//
+// Three precedence layers (highest → lowest): device labels →
+// device-group variables → user-group variables. Higher layers
+// shadow lower layers silently because operators routinely override
+// a group default with a device-specific value. Duplicate names
+// WITHIN the same layer (two device groups defining the same name)
+// return an error — the operator can't have intended both at once
+// and silently picking one would be a footgun at action-dispatch
+// time. See manchtools/power-manage-server#196.
+package template
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+
+	pmv1 "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// StoreResolver implements Resolver against the production store.
+// Safe to share across goroutines — no mutable per-call state lives
+// on the receiver.
+type StoreResolver struct {
+	store     *store.Store
+	encryptor *crypto.Encryptor
+	logger    *slog.Logger
+}
+
+// NewStoreResolver constructs a StoreResolver bound to the project's
+// store + encryptor.
+func NewStoreResolver(st *store.Store, enc *crypto.Encryptor, logger *slog.Logger) *StoreResolver {
+	return &StoreResolver{store: st, encryptor: enc, logger: logger}
+}
+
+// Resolve walks the three precedence layers for deviceID. Returns a
+// flat name → Value map with higher layers having already overwritten
+// lower ones.
+func (r *StoreResolver) Resolve(ctx context.Context, deviceID string) (Variables, error) {
+	out := Variables{}
+
+	if err := r.collectUserGroupVars(ctx, deviceID, out); err != nil {
+		return nil, err
+	}
+	if err := r.collectDeviceGroupVars(ctx, deviceID, out); err != nil {
+		return nil, err
+	}
+	if err := r.collectDeviceLabels(ctx, deviceID, out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// collectUserGroupVars adds every variable defined on a user group
+// directly assigned to the device. Lowest precedence layer.
+func (r *StoreResolver) collectUserGroupVars(ctx context.Context, deviceID string, out Variables) error {
+	groups, err := r.store.Queries().ListDeviceAssignedGroups(ctx, deviceID)
+	if err != nil {
+		return fmt.Errorf("list user groups for device %s: %w", deviceID, err)
+	}
+	seen := map[string]string{}
+	for _, g := range groups {
+		raw, err := r.store.Queries().GetUserGroupVariables(ctx, g.GroupID)
+		if err != nil {
+			return fmt.Errorf("read variables for user group %s: %w", g.GroupID, err)
+		}
+		vars, err := decodeAndDecrypt(raw, r.encryptor)
+		if err != nil {
+			return fmt.Errorf("decode variables for user group %s: %w", g.GroupID, err)
+		}
+		for name, v := range vars {
+			if other, dup := seen[name]; dup {
+				return fmt.Errorf("variable %q is defined by multiple user groups reaching device %s (%s, %s)", name, deviceID, other, g.GroupID)
+			}
+			seen[name] = g.GroupID
+			v.DefinedIn = []string{"user_group:" + g.GroupID}
+			out[name] = v
+		}
+	}
+	return nil
+}
+
+// collectDeviceGroupVars adds every variable defined on a device
+// group the device belongs to. Shadows the user-group layer.
+func (r *StoreResolver) collectDeviceGroupVars(ctx context.Context, deviceID string, out Variables) error {
+	groups, err := r.store.Queries().ListGroupsForDevice(ctx, deviceID)
+	if err != nil {
+		return fmt.Errorf("list device groups for device %s: %w", deviceID, err)
+	}
+	seen := map[string]string{}
+	for _, g := range groups {
+		raw, err := r.store.Queries().GetDeviceGroupVariables(ctx, g.ID)
+		if err != nil {
+			return fmt.Errorf("read variables for device group %s: %w", g.ID, err)
+		}
+		vars, err := decodeAndDecrypt(raw, r.encryptor)
+		if err != nil {
+			return fmt.Errorf("decode variables for device group %s: %w", g.ID, err)
+		}
+		for name, v := range vars {
+			if other, dup := seen[name]; dup {
+				return fmt.Errorf("variable %q is defined by multiple device groups reaching device %s (%s, %s)", name, deviceID, other, g.ID)
+			}
+			seen[name] = g.ID
+			v.DefinedIn = []string{"device_group:" + g.ID}
+			out[name] = v
+		}
+	}
+	return nil
+}
+
+// collectDeviceLabels adds the device's labels as STRING-typed
+// variables. Highest precedence layer — labels override any
+// same-named group variable. Label values are always stringified;
+// labels with names that don't match the variable grammar
+// (`[a-z][a-z0-9_]*`) are still added to the map but are
+// unreachable via the substitution regex.
+func (r *StoreResolver) collectDeviceLabels(ctx context.Context, deviceID string, out Variables) error {
+	dev, err := r.store.Queries().GetDeviceByID(ctx, db.GetDeviceByIDParams{ID: deviceID})
+	if err != nil {
+		return fmt.Errorf("read device %s: %w", deviceID, err)
+	}
+	if len(dev.Labels) == 0 {
+		return nil
+	}
+	var labels map[string]string
+	if err := json.Unmarshal(dev.Labels, &labels); err != nil {
+		return fmt.Errorf("decode labels for device %s: %w", deviceID, err)
+	}
+	for name, val := range labels {
+		out[name] = Value{
+			Type:      pmv1.VariableType_VARIABLE_TYPE_STRING,
+			Plaintext: val,
+			DefinedIn: []string{"device"},
+		}
+	}
+	return nil
+}
+
+// decodeAndDecrypt unmarshals a group's `variables` JSONB column into
+// the renderer's flat name → Value map, decrypting SECRET-typed
+// entries inline.
+func decodeAndDecrypt(raw []byte, enc *crypto.Encryptor) (Variables, error) {
+	if len(raw) == 0 {
+		return Variables{}, nil
+	}
+	var stored []storedVariable
+	if err := json.Unmarshal(raw, &stored); err != nil {
+		return nil, err
+	}
+	out := make(Variables, len(stored))
+	for _, sv := range stored {
+		t := parseVariableType(sv.Type)
+		plaintext := sv.Value
+		if t == pmv1.VariableType_VARIABLE_TYPE_SECRET {
+			pt, err := enc.Decrypt(sv.Value)
+			if err != nil {
+				return nil, fmt.Errorf("decrypt %s: %w", sv.Name, err)
+			}
+			plaintext = pt
+		}
+		out[sv.Name] = Value{
+			Type:      t,
+			Plaintext: plaintext,
+		}
+	}
+	return out, nil
+}
+
+// storedVariable mirrors the api package's on-disk shape. Duplicated
+// here to keep the import graph one-directional (api → template, not
+// the reverse).
+type storedVariable struct {
+	Name         string   `json:"name"`
+	Type         string   `json:"type"`
+	Value        string   `json:"value"`
+	Description  string   `json:"description,omitempty"`
+	IntMin       int64    `json:"int_min,omitempty"`
+	IntMax       int64    `json:"int_max,omitempty"`
+	ChoiceValues []string `json:"choice_values,omitempty"`
+}
+
+// parseVariableType is the read-side mirror of the api package's
+// variableTypeToString. Same duplication rationale as storedVariable.
+func parseVariableType(s string) pmv1.VariableType {
+	switch s {
+	case "string":
+		return pmv1.VariableType_VARIABLE_TYPE_STRING
+	case "int":
+		return pmv1.VariableType_VARIABLE_TYPE_INT
+	case "bool":
+		return pmv1.VariableType_VARIABLE_TYPE_BOOL
+	case "hostname":
+		return pmv1.VariableType_VARIABLE_TYPE_HOSTNAME
+	case "path":
+		return pmv1.VariableType_VARIABLE_TYPE_PATH
+	case "choice":
+		return pmv1.VariableType_VARIABLE_TYPE_CHOICE
+	case "secret":
+		return pmv1.VariableType_VARIABLE_TYPE_SECRET
+	default:
+		return pmv1.VariableType_VARIABLE_TYPE_UNSPECIFIED
+	}
+}

--- a/internal/api/template/resolver_test.go
+++ b/internal/api/template/resolver_test.go
@@ -1,0 +1,165 @@
+package template_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pmv1 "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api/template"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// storedShape mirrors the on-disk JSONB layout the handler writes;
+// duplicated here so the tests don't depend on the (unexported)
+// shape inside the template package.
+type storedShape struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Value       string `json:"value"`
+	Description string `json:"description,omitempty"`
+}
+
+func setDeviceGroupVars(t *testing.T, st *store.Store, groupID string, vars []storedShape) {
+	t.Helper()
+	raw, err := json.Marshal(vars)
+	require.NoError(t, err)
+	require.NoError(t, st.Queries().SetDeviceGroupVariables(context.Background(), db.SetDeviceGroupVariablesParams{
+		ID:        groupID,
+		Variables: raw,
+	}))
+}
+
+func setUserGroupVars(t *testing.T, st *store.Store, groupID string, vars []storedShape) {
+	t.Helper()
+	raw, err := json.Marshal(vars)
+	require.NoError(t, err)
+	require.NoError(t, st.Queries().SetUserGroupVariables(context.Background(), db.SetUserGroupVariablesParams{
+		ID:        groupID,
+		Variables: raw,
+	}))
+}
+
+func TestStoreResolver_EmptyDevice_EmptyVariables(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	defer st.Close()
+
+	deviceID := testutil.CreateTestDevice(t, st, "host-empty")
+	r := template.NewStoreResolver(st, testutil.NewEncryptor(t), slog.Default())
+
+	vars, err := r.Resolve(context.Background(), deviceID)
+	require.NoError(t, err)
+	assert.Empty(t, vars)
+}
+
+func TestStoreResolver_DeviceLabels_Surface(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	defer st.Close()
+
+	deviceID := testutil.CreateTestDevice(t, st, "host-labels")
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceLabelSet",
+		Data:      map[string]any{"key": "env", "value": "prod"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	r := template.NewStoreResolver(st, testutil.NewEncryptor(t), slog.Default())
+	vars, err := r.Resolve(context.Background(), deviceID)
+	require.NoError(t, err)
+	require.Contains(t, vars, "env")
+	assert.Equal(t, "prod", vars["env"].Plaintext)
+	assert.Equal(t, pmv1.VariableType_VARIABLE_TYPE_STRING, vars["env"].Type)
+}
+
+func TestStoreResolver_PrecedenceLabelOverridesDeviceGroup(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	defer st.Close()
+
+	deviceID := testutil.CreateTestDevice(t, st, "host-prec")
+	groupID := testutil.CreateTestDeviceGroup(t, st, "u", "g1")
+	testutil.AddDeviceToTestGroup(t, st, "u", groupID, deviceID)
+
+	setDeviceGroupVars(t, st, groupID, []storedShape{
+		{Name: "env", Type: "string", Value: "from-group"},
+	})
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceLabelSet",
+		Data:      map[string]any{"key": "env", "value": "from-label"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	r := template.NewStoreResolver(st, testutil.NewEncryptor(t), slog.Default())
+	vars, err := r.Resolve(context.Background(), deviceID)
+	require.NoError(t, err)
+	assert.Equal(t, "from-label", vars["env"].Plaintext, "device label must shadow device-group variable")
+}
+
+func TestStoreResolver_PrecedenceDeviceGroupOverridesUserGroup(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	defer st.Close()
+
+	deviceID := testutil.CreateTestDevice(t, st, "host-prec2")
+	dgID := testutil.CreateTestDeviceGroup(t, st, "u", "dg")
+	testutil.AddDeviceToTestGroup(t, st, "u", dgID, deviceID)
+	ugID := testutil.CreateTestUserGroup(t, st, "u", "ug")
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "device", StreamID: deviceID, EventType: "DeviceGroupAssigned",
+		Data:      map[string]any{"group_id": ugID},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	setUserGroupVars(t, st, ugID, []storedShape{{Name: "env", Type: "string", Value: "from-ug"}})
+	setDeviceGroupVars(t, st, dgID, []storedShape{{Name: "env", Type: "string", Value: "from-dg"}})
+
+	r := template.NewStoreResolver(st, testutil.NewEncryptor(t), slog.Default())
+	vars, err := r.Resolve(context.Background(), deviceID)
+	require.NoError(t, err)
+	assert.Equal(t, "from-dg", vars["env"].Plaintext, "device-group var must shadow user-group var")
+}
+
+func TestStoreResolver_DuplicateNameWithinDeviceGroups_Errors(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	defer st.Close()
+
+	deviceID := testutil.CreateTestDevice(t, st, "host-dup")
+	g1 := testutil.CreateTestDeviceGroup(t, st, "u", "g1")
+	g2 := testutil.CreateTestDeviceGroup(t, st, "u", "g2")
+	testutil.AddDeviceToTestGroup(t, st, "u", g1, deviceID)
+	testutil.AddDeviceToTestGroup(t, st, "u", g2, deviceID)
+	setDeviceGroupVars(t, st, g1, []storedShape{{Name: "shared", Type: "string", Value: "a"}})
+	setDeviceGroupVars(t, st, g2, []storedShape{{Name: "shared", Type: "string", Value: "b"}})
+
+	r := template.NewStoreResolver(st, testutil.NewEncryptor(t), slog.Default())
+	_, err := r.Resolve(context.Background(), deviceID)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shared", "error message must name the offending variable")
+}
+
+func TestStoreResolver_SecretDecryptionRoundtrip(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	defer st.Close()
+	enc := testutil.NewEncryptor(t)
+
+	deviceID := testutil.CreateTestDevice(t, st, "host-secret")
+	groupID := testutil.CreateTestDeviceGroup(t, st, "u", "secrets")
+	testutil.AddDeviceToTestGroup(t, st, "u", groupID, deviceID)
+
+	ciphertext, err := enc.Encrypt("hunter2")
+	require.NoError(t, err)
+	setDeviceGroupVars(t, st, groupID, []storedShape{
+		{Name: "db_pwd", Type: "secret", Value: ciphertext},
+	})
+
+	r := template.NewStoreResolver(st, enc, slog.Default())
+	vars, err := r.Resolve(context.Background(), deviceID)
+	require.NoError(t, err)
+	require.Contains(t, vars, "db_pwd")
+	assert.Equal(t, "hunter2", vars["db_pwd"].Plaintext)
+	assert.Equal(t, pmv1.VariableType_VARIABLE_TYPE_SECRET, vars["db_pwd"].Type)
+}


### PR DESCRIPTION
## Summary

Implements ticket C of the #59 group-based variables design — the
server-side `{{ var.NAME }}` substitution pipeline that closes the
loop opened by #195's storage layer.

- New `internal/api/template` package: protoreflect walker that
  rewrites every templateable string field on an Action proto in
  place. Sentinel errors `ErrUnresolvedReference` and
  `ErrUnclosedBrace` make render-time failures actionable for the
  operator instead of shipping a broken template to the agent.
- `StoreResolver` walks three precedence layers (device labels >
  device groups > user groups) and decrypts SECRET-typed values via
  the same `internal/crypto.Encryptor` that wrote them. Same-layer
  duplicate names error; cross-layer same-name silently shadows.
- Wired into `ProxySyncActions` via `SetRenderer` in
  `cmd/control/main.go` — resolves once per sync, applies to every
  standalone + grouped action.

## Trust model

Render-time does no shell-quoting. Values flow in literally, so the
trust gate stays at the SET-time RBAC on the variable itself
(handled in #195). The renderer is the boundary that materialises
plaintext SECRETs into the wire-format Action; the existing
audit-handler redactor scrubs the matching events.

## Test plan

- [x] `go build ./...`
- [x] `go test ./server/internal/api/template/...` — 9 renderer unit
      tests + 6 testcontainer-Postgres resolver integration tests
- [x] `go test ./server/internal/api/...` (TestProxySync* /
      TestVerifyDevice* / TestProxy* — all pass with the renderer
      enabled in the wiring path)
- [x] `cr review --plain --base main` — zero findings
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Action parameters now support dynamic `{{ var.NAME }}` template substitution, enabling device labels and group variables to be injected into actions.
  * Variable resolution follows proper precedence rules: device labels override device-group variables, which override user-group variables.
  * Secret-type variables are automatically decrypted and available for template substitution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/198)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->