### PR TITLE
fix(search): per-scope filter validation, reject cross-scope SYNTAX errors (#158)

### DIFF
--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -145,6 +146,14 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 		scopes = []string{"actions", "action_sets", "definitions", "compliance_policies", "devices", "users", "device_groups", "user_groups"}
 	}
 
+	// Reject filter fields that aren't supported by every scope in the
+	// query plan. Without this check, an unscoped `@status:{pending}`
+	// would propagate to e.g. idx:action_sets, which RediSearch rejects
+	// with a SYNTAX error surfaced as opaque CodeInternal. See #158.
+	if err := validateFiltersForScopes(ctx, scopes, req.Msg.DateFilters, req.Msg.TagFilters); err != nil {
+		return nil, err
+	}
+
 	scopeToIndex := map[string]string{
 		"actions":             "idx:actions",
 		"action_sets":         "idx:action_sets",
@@ -218,30 +227,96 @@ func (h *SearchHandler) RebuildSearchIndex(ctx context.Context, req *connect.Req
 	return connect.NewResponse(&pm.RebuildSearchIndexResponse{}), nil
 }
 
-// allowedSearchFields is the set of field names that can be used in search
-// date and tag filters. This prevents query injection via crafted field names.
-var allowedSearchFields = map[string]bool{
-	// NUMERIC fields (date filters)
-	"created_at":  true,
-	"updated_at":  true,
-	"occurred_at": true,
-	// TAG fields (tag filters)
-	"type":              true,
-	"is_compliance":     true,
-	"status":            true,
-	"action_type":       true,
-	"device_id":         true,
-	"stream_type":       true,
-	"actor_type":        true,
-	"actor_id":          true,
-	"disabled":          true,
-	"compliance_status": true,
-	"agent_version":     true,
-	"os_arch":           true,
-	"is_dynamic":        true,
-	"member_count":      true,
-	"registered_at":     true,
-	"last_seen_at":      true,
+// scopeFilterFields enumerates the indexed filter fields per scope.
+// Mirrors the FT.CREATE schemas in internal/search/index.go: a field
+// only appears here if its scope's RediSearch schema declares a NUMERIC
+// or TAG attribute for it. Sending @status:{pending} to an index that
+// doesn't declare a `status` attribute makes RediSearch reject the
+// query with a SYNTAX error — see manchtools/power-manage-server#158.
+//
+// The map drives two checks:
+//
+//  1. Up-front validation in Search: if the request's filters
+//     reference a field that isn't supported by every scope in the
+//     query plan, return InvalidArgument naming the scopes that DO
+//     support the field. Operators learn quickly; broken queries no
+//     longer surface as opaque CodeInternal.
+//
+//  2. The derived allowedSearchFields set below feeds buildFTQuery's
+//     defensive silent-drop check (defence in depth — the up-front
+//     validator already rejects unknown fields).
+var scopeFilterFields = map[string]map[string]bool{
+	"actions":             {"type": true, "is_compliance": true, "created_at": true, "updated_at": true},
+	"action_sets":         {"member_count": true, "created_at": true, "updated_at": true},
+	"definitions":         {"member_count": true, "created_at": true, "updated_at": true},
+	"compliance_policies": {},
+	"devices":             {"agent_version": true, "os_arch": true, "compliance_status": true, "registered_at": true, "last_seen_at": true},
+	"users":               {"disabled": true, "created_at": true},
+	"device_groups":       {"is_dynamic": true, "member_count": true, "created_at": true},
+	"user_groups":         {"is_dynamic": true, "member_count": true, "created_at": true},
+	"executions":          {"status": true, "action_type": true, "device_id": true, "created_at": true},
+	"audit_events":        {"stream_type": true, "actor_type": true, "actor_id": true, "occurred_at": true},
+}
+
+// allowedSearchFields is the union of every per-scope filter field.
+// Derived from scopeFilterFields so the two never drift. Used by
+// buildFTQuery as a final injection-prevention sieve; the up-front
+// validateFiltersForScopes call is the operator-facing check.
+var allowedSearchFields = func() map[string]bool {
+	out := map[string]bool{}
+	for _, fields := range scopeFilterFields {
+		for f := range fields {
+			out[f] = true
+		}
+	}
+	return out
+}()
+
+// validateFiltersForScopes returns InvalidArgument when the request's
+// filter fields reference attributes that aren't declared by every
+// index in the query plan. The error message names the scopes that
+// DO accept the field so the operator can re-issue with an explicit
+// scope.
+//
+// Same-name attributes across scopes (e.g. created_at on actions +
+// devices) pass when the query plan stays inside scopes that all
+// declare them.
+func validateFiltersForScopes(ctx context.Context, scopes []string, dateFilters []*pm.SearchDateFilter, tagFilters map[string]string) error {
+	used := map[string]bool{}
+	for _, df := range dateFilters {
+		if df.Field != "" {
+			used[df.Field] = true
+		}
+	}
+	for f, v := range tagFilters {
+		if f != "" && v != "" {
+			used[f] = true
+		}
+	}
+	for field := range used {
+		acceptedByAll := true
+		for _, sc := range scopes {
+			if !scopeFilterFields[sc][field] {
+				acceptedByAll = false
+				break
+			}
+		}
+		if acceptedByAll {
+			continue
+		}
+		var supportedBy []string
+		for sc, fields := range scopeFilterFields {
+			if fields[field] {
+				supportedBy = append(supportedBy, sc)
+			}
+		}
+		sort.Strings(supportedBy)
+		if len(supportedBy) == 0 {
+			return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, fmt.Sprintf("filter field %q is not supported by any search scope", field))
+		}
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, fmt.Sprintf("filter field %q is only valid for scope=%s", field, strings.Join(supportedBy, ",")))
+	}
+	return nil
 }
 
 // buildFTQuery constructs a RediSearch query string from text, date filters, and tag filters.

--- a/internal/api/search_handler_test.go
+++ b/internal/api/search_handler_test.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"context"
 	"testing"
 
+	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -335,4 +337,93 @@ func TestParseFTSearchResult_InvalidDocPair(t *testing.T) {
 	results, count := parseFTSearchResult(raw, "actions")
 	assert.Empty(t, results)
 	assert.Equal(t, int32(1), count)
+}
+
+// =============================================================================
+// validateFiltersForScopes — manchtools/power-manage-server#158
+// =============================================================================
+
+func TestValidateFiltersForScopes_NoFilters_OK(t *testing.T) {
+	require.NoError(t, validateFiltersForScopes(context.Background(), []string{"actions"}, nil, nil))
+}
+
+func TestValidateFiltersForScopes_FieldSupportedByAllScopes_OK(t *testing.T) {
+	// Restrict the plan to scopes that all declare created_at —
+	// some scopes (compliance_policies, devices, audit_events) use a
+	// different timestamp attribute or none at all, and would fail
+	// the per-scope check if included.
+	scopes := []string{"actions", "users", "device_groups"}
+	dateFilters := []*pm.SearchDateFilter{{Field: "created_at", Start: 1000, End: 2000}}
+	require.NoError(t, validateFiltersForScopes(context.Background(), scopes, dateFilters, nil))
+}
+
+func TestValidateFiltersForScopes_ExecutionFieldUnscoped_RejectsWithSupportedByList(t *testing.T) {
+	// The exact regression from #158: unscoped query with `status`
+	// filter previously fanned out to every index; idx:action_sets
+	// rejected the query as a SYNTAX error which surfaced as opaque
+	// CodeInternal. Now: InvalidArgument naming the scope that DOES
+	// accept `status`.
+	allScopes := []string{"actions", "action_sets", "definitions", "compliance_policies", "devices", "users", "device_groups", "user_groups"}
+	tagFilters := map[string]string{"status": "pending"}
+
+	err := validateFiltersForScopes(context.Background(), allScopes, nil, tagFilters)
+	require.Error(t, err)
+
+	connectErr := new(connect.Error)
+	require.ErrorAs(t, err, &connectErr)
+	assert.Equal(t, connect.CodeInvalidArgument, connectErr.Code())
+	assert.Contains(t, connectErr.Message(), `"status"`)
+	assert.Contains(t, connectErr.Message(), "executions")
+}
+
+func TestValidateFiltersForScopes_ExecutionFieldScopedToExecutions_OK(t *testing.T) {
+	// Same filter, but the operator scoped explicitly. The query plan
+	// is single-scope and `status` is supported there.
+	tagFilters := map[string]string{"status": "pending"}
+	require.NoError(t, validateFiltersForScopes(context.Background(), []string{"executions"}, nil, tagFilters))
+}
+
+func TestValidateFiltersForScopes_UnknownField_RejectsAsUnsupported(t *testing.T) {
+	tagFilters := map[string]string{"injected_field": "x"}
+	err := validateFiltersForScopes(context.Background(), []string{"actions"}, nil, tagFilters)
+	require.Error(t, err)
+
+	connectErr := new(connect.Error)
+	require.ErrorAs(t, err, &connectErr)
+	assert.Equal(t, connect.CodeInvalidArgument, connectErr.Code())
+	assert.Contains(t, connectErr.Message(), "not supported by any search scope")
+}
+
+func TestValidateFiltersForScopes_EmptyFieldOrValue_Skipped(t *testing.T) {
+	// Empty field names + empty values must NOT trip validation —
+	// they're silently dropped further down in buildFTQuery.
+	dateFilters := []*pm.SearchDateFilter{{Field: "", Start: 1, End: 2}}
+	tagFilters := map[string]string{"status": "", "": "x"}
+	require.NoError(t, validateFiltersForScopes(context.Background(), []string{"actions"}, dateFilters, tagFilters))
+}
+
+func TestValidateFiltersForScopes_DateFilterFromAuditUnscoped_Rejected(t *testing.T) {
+	// occurred_at is audit_events-only. Unscoped → reject.
+	allScopes := []string{"actions", "action_sets", "definitions", "compliance_policies", "devices", "users", "device_groups", "user_groups"}
+	dateFilters := []*pm.SearchDateFilter{{Field: "occurred_at", Start: 1, End: 2}}
+	err := validateFiltersForScopes(context.Background(), allScopes, dateFilters, nil)
+	require.Error(t, err)
+
+	connectErr := new(connect.Error)
+	require.ErrorAs(t, err, &connectErr)
+	assert.Equal(t, connect.CodeInvalidArgument, connectErr.Code())
+	assert.Contains(t, connectErr.Message(), "audit_events")
+}
+
+func TestAllowedSearchFields_DerivedFromScopeFilterFields(t *testing.T) {
+	// Guards against drift between the per-scope map and the derived
+	// global. Every per-scope field MUST be reachable through the
+	// global, otherwise buildFTQuery's defensive check would silently
+	// drop a field that validateFiltersForScopes accepted.
+	for scope, fields := range scopeFilterFields {
+		for f := range fields {
+			assert.Truef(t, allowedSearchFields[f],
+				"field %q from scope %q must be in derived allowedSearchFields", f, scope)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Closes manchtools/power-manage-server#158.

`search_handler.go` previously had a single global `allowedSearchFields`
that accepted execution-only and audit-only fields like `status`,
`stream_type`, etc. When a user sent `@status:{pending}` with no
explicit scope, the handler fanned the query out to all 8 default
indexes, and indexes that don't declare `status` (e.g. `idx:actions`,
`idx:devices`) made RediSearch return a SYNTAX error which surfaced
as opaque `CodeInternal`.

This PR replaces the global with `scopeFilterFields` — a
per-scope map mirroring the FT.CREATE schemas in
`internal/search/index.go` — and adds `validateFiltersForScopes` as
an up-front check. If a filter field isn't supported by every scope
in the query plan, the handler returns `CodeInvalidArgument` naming
the scope(s) that DO support the field.

The previous global is now derived from `scopeFilterFields` so
`buildFTQuery`'s defensive silent-drop check stays in sync. A
drift-guard test asserts the two never diverge.

## Variant chosen: B

The issue offered two shapes — A (per-scope filter narrowing) and
B (validation step). Picked B because explicit operator feedback
beats silent intent narrowing: an operator who filtered by
`status` clearly wanted executions, and getting back unrelated
hits from `actions` / `devices` indexes would mislead them.

## Test plan

- [x] `go test ./internal/api/ -run 'TestValidateFiltersForScopes|TestAllowedSearchFields|TestBuildFTQuery|TestEscapeRediSearch|TestScopeSortField|TestParseFTSearchResult'` — all pass
- [x] `cr review --plain --base main` — 1 finding (comment accuracy on cross-scope `created_at` coverage), addressed
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced search filter validation that now checks compatibility between requested filters and selected scopes upfront, returning descriptive errors when filters aren't supported.

* **Tests**
  * Added comprehensive test suite for filter validation logic covering scope compatibility, unsupported fields, and error messaging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/199)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->