### PR TITLE
test(search): end-to-end search-listener tests with recording fake (#115)

### DIFF
--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -17,6 +17,24 @@ import (
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
+// SearchIndex is the narrow surface SearchListener consumes from
+// the *search.Index concrete. Defined as an interface here so tests
+// can swap in a recording fake without bringing up Asynq + Valkey
+// — the production wiring still passes the concrete (it implicitly
+// satisfies this interface).
+//
+// Three methods, in order of how often they fire from this listener:
+//
+//   - EnqueueReindex — every reindex op
+//   - EnqueueRemove  — every delete op
+//   - GetReverseMembers — only on remove for scopes with cascading
+//     parent rebuilds (action / action_set / definition)
+type SearchIndex interface {
+	EnqueueReindex(ctx context.Context, scope, id string, data *taskqueue.SearchEntityData) error
+	EnqueueRemove(ctx context.Context, scope, id string, cascadeIDs []string) error
+	GetReverseMembers(ctx context.Context, scope, id string) []string
+}
+
 // SearchOp is the action a search-index listener should take in
 // response to a single event. Mirrors the SyncOp pattern from #77's
 // system-action listener but scoped to search-index updates: the
@@ -273,7 +291,7 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 // heavier work (e.g. cascade-ID lookups via GetReverseMembers can
 // add a second Valkey roundtrip), revisit and consider goroutine
 // dispatch like the system-action listener does.
-func SearchListener(st *store.Store, idx *search.Index, logger *slog.Logger) store.EventListener {
+func SearchListener(st *store.Store, idx SearchIndex, logger *slog.Logger) store.EventListener {
 	if st == nil || idx == nil {
 		// Guard: missing deps shouldn't crash AppendEvent. Return a
 		// no-op listener that logs once at registration time elsewhere.
@@ -612,7 +630,7 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 // will see an empty cascade list. The periodic indexer reconciler
 // catches the resulting drift within ~1h. Single-remove flows have
 // no race.
-func cascadeIDsForRemove(ctx context.Context, idx *search.Index, scope, id string) []string {
+func cascadeIDsForRemove(ctx context.Context, idx SearchIndex, scope, id string) []string {
 	switch scope {
 	case search.ScopeAction, search.ScopeActionSet, search.ScopeDefinition:
 		return idx.GetReverseMembers(ctx, scope, id)

--- a/internal/api/search_listener_e2e_test.go
+++ b/internal/api/search_listener_e2e_test.go
@@ -1,0 +1,356 @@
+package api_test
+
+// End-to-end search-listener tests per manchtools/power-manage-server#115.
+//
+// The classifier-table tests in search_listener_test.go prove that
+// AffectedSearchOps returns the right SearchAffected slice for each
+// event type. They do NOT exercise the listener's runtime behaviour:
+// loadSearchEntityData, cascadeIDsForRemove, the panic-recovery
+// wrapper, the synchronous Asynq enqueue, or the error-handling on
+// entity-not-found.
+//
+// These tests do, against a real Postgres testcontainer + an
+// in-memory recording fake of api.SearchIndex. One test per scope
+// fires a real event through st.AppendEvent and asserts the
+// listener enqueued exactly the expected (op, scope, id, payload)
+// triple. The cascade test exercises the GetReverseMembers →
+// EnqueueRemove path; the not-found test exercises the silent skip
+// when loadSearchEntityData returns pgx.ErrNoRows; the panic test
+// exercises the recover wrapper inside fireListeners.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/search"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/taskqueue"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// discardLogger silences listener log output so test runs stay clean.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// =============================================================================
+// Recording fake — implements api.SearchIndex
+// =============================================================================
+
+type reindexCall struct {
+	Scope string
+	ID    string
+	Data  *taskqueue.SearchEntityData
+}
+
+type removeCall struct {
+	Scope      string
+	ID         string
+	CascadeIDs []string
+}
+
+type fakeSearchIndex struct {
+	mu sync.Mutex
+
+	reindexed []reindexCall
+	removed   []removeCall
+
+	// reverse map keyed by scope+":"+id → cascade IDs returned by
+	// GetReverseMembers. Empty key returns nil (the production behaviour
+	// for scopes without reverse-member tracking).
+	reverse map[string][]string
+
+	// reindexErr / removeErr override the enqueue return value for
+	// negative-path tests. Defaults to nil (success).
+	reindexErr error
+	removeErr  error
+
+	// panicOnReindex flips the next EnqueueReindex call to panic.
+	// Used to validate the listener is wrapped by store.fireListeners'
+	// panic recovery and doesn't crash AppendEvent.
+	panicOnReindex bool
+}
+
+func newFakeSearchIndex() *fakeSearchIndex {
+	return &fakeSearchIndex{reverse: map[string][]string{}}
+}
+
+func (f *fakeSearchIndex) EnqueueReindex(_ context.Context, scope, id string, data *taskqueue.SearchEntityData) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.panicOnReindex {
+		f.panicOnReindex = false
+		panic("fakeSearchIndex.EnqueueReindex: forced panic for recovery test")
+	}
+	f.reindexed = append(f.reindexed, reindexCall{Scope: scope, ID: id, Data: data})
+	return f.reindexErr
+}
+
+func (f *fakeSearchIndex) EnqueueRemove(_ context.Context, scope, id string, cascadeIDs []string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removed = append(f.removed, removeCall{Scope: scope, ID: id, CascadeIDs: cascadeIDs})
+	return f.removeErr
+}
+
+func (f *fakeSearchIndex) GetReverseMembers(_ context.Context, scope, id string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.reverse[scope+":"+id]
+}
+
+func (f *fakeSearchIndex) lastReindex(t *testing.T) reindexCall {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	require.NotEmpty(t, f.reindexed, "expected at least one EnqueueReindex call")
+	return f.reindexed[len(f.reindexed)-1]
+}
+
+func (f *fakeSearchIndex) lastRemove(t *testing.T) removeCall {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	require.NotEmpty(t, f.removed, "expected at least one EnqueueRemove call")
+	return f.removed[len(f.removed)-1]
+}
+
+func (f *fakeSearchIndex) reindexCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.reindexed)
+}
+
+// setupListener wires the fake into the test store via a fresh
+// PostgreSQL testcontainer. Returns the store + the fake so the
+// caller can drive events and assert recorded calls.
+func setupListener(t *testing.T) (*store.Store, *fakeSearchIndex) {
+	t.Helper()
+	st := testutil.SetupPostgres(t)
+	t.Cleanup(func() { st.Close() })
+	fake := newFakeSearchIndex()
+	st.RegisterEventListener(api.SearchListener(st, fake, discardLogger()))
+	return st, fake
+}
+
+// =============================================================================
+// User scope
+// =============================================================================
+
+func TestSearchListener_UserCreated_Reindexes(t *testing.T) {
+	st, fake := setupListener(t)
+	userID := testutil.CreateTestUser(t, st, "alice@example.com", "pass", "viewer")
+
+	last := fake.lastReindex(t)
+	assert.Equal(t, search.ScopeUser, last.Scope)
+	assert.Equal(t, userID, last.ID)
+	require.NotNil(t, last.Data)
+	assert.Equal(t, "alice@example.com", last.Data.Email)
+}
+
+// =============================================================================
+// Device scope
+// =============================================================================
+
+func TestSearchListener_DeviceRegistered_Reindexes(t *testing.T) {
+	st, fake := setupListener(t)
+	deviceID := testutil.CreateTestDevice(t, st, "host-listener-1")
+
+	last := fake.lastReindex(t)
+	assert.Equal(t, search.ScopeDevice, last.Scope)
+	assert.Equal(t, deviceID, last.ID)
+	require.NotNil(t, last.Data)
+	assert.Equal(t, "host-listener-1", last.Data.Hostname)
+}
+
+// =============================================================================
+// DeviceGroup scope (incl. composite-StreamID member event)
+// =============================================================================
+
+func TestSearchListener_DeviceGroupCreated_Reindexes(t *testing.T) {
+	st, fake := setupListener(t)
+	groupID := testutil.CreateTestDeviceGroup(t, st, "u", "ops-east")
+
+	last := fake.lastReindex(t)
+	assert.Equal(t, search.ScopeDeviceGroup, last.Scope)
+	assert.Equal(t, groupID, last.ID)
+	require.NotNil(t, last.Data)
+	assert.Equal(t, "ops-east", last.Data.Name)
+}
+
+func TestSearchListener_DeviceGroupMemberAdded_ReindexesGroup(t *testing.T) {
+	st, fake := setupListener(t)
+	groupID := testutil.CreateTestDeviceGroup(t, st, "u", "members-test")
+	deviceID := testutil.CreateTestDevice(t, st, "host-member")
+
+	before := fake.reindexCount()
+	testutil.AddDeviceToTestGroup(t, st, "u", groupID, deviceID)
+
+	// AddDeviceToTestGroup fires a DeviceGroupMemberAdded event whose
+	// StreamID is the group ID directly (not composite). The listener
+	// reindexes the group so member_count refreshes.
+	require.Greater(t, fake.reindexCount(), before, "membership change must trigger a group reindex")
+	last := fake.lastReindex(t)
+	assert.Equal(t, search.ScopeDeviceGroup, last.Scope)
+	assert.Equal(t, groupID, last.ID)
+}
+
+// =============================================================================
+// UserGroup scope (composite-StreamID prefix-split path)
+// =============================================================================
+
+func TestSearchListener_UserGroupMemberAdded_ReindexesGroupViaPrefixSplit(t *testing.T) {
+	st, fake := setupListener(t)
+	groupID := testutil.CreateTestUserGroup(t, st, "u", "engineers")
+	userID := testutil.CreateTestUser(t, st, "bob@example.com", "pass", "viewer")
+
+	before := fake.reindexCount()
+	testutil.AddUserToTestGroup(t, st, "u", groupID, userID)
+
+	// AddUserToTestGroup uses a composite stream id "<group>:<user>".
+	// The listener must split on ':' and reindex the group only.
+	require.Greater(t, fake.reindexCount(), before)
+	last := fake.lastReindex(t)
+	assert.Equal(t, search.ScopeUserGroup, last.Scope)
+	assert.Equal(t, groupID, last.ID, "listener must drop the user_id suffix from the composite stream id")
+}
+
+// =============================================================================
+// ActionSet scope
+// =============================================================================
+
+func TestSearchListener_ActionSetCreated_Reindexes(t *testing.T) {
+	st, fake := setupListener(t)
+	setID := testutil.CreateTestActionSet(t, st, "u", "rollout-v1")
+
+	last := fake.lastReindex(t)
+	assert.Equal(t, search.ScopeActionSet, last.Scope)
+	assert.Equal(t, setID, last.ID)
+	require.NotNil(t, last.Data)
+	assert.Equal(t, "rollout-v1", last.Data.Name)
+}
+
+// =============================================================================
+// Definition scope
+// =============================================================================
+
+func TestSearchListener_DefinitionCreated_Reindexes(t *testing.T) {
+	st, fake := setupListener(t)
+	defID := testutil.CreateTestDefinition(t, st, "u", "baseline")
+
+	last := fake.lastReindex(t)
+	assert.Equal(t, search.ScopeDefinition, last.Scope)
+	assert.Equal(t, defID, last.ID)
+	require.NotNil(t, last.Data)
+	assert.Equal(t, "baseline", last.Data.Name)
+}
+
+// =============================================================================
+// Action scope
+// =============================================================================
+
+func TestSearchListener_ActionCreated_Reindexes(t *testing.T) {
+	st, fake := setupListener(t)
+	actionID := testutil.CreateTestAction(t, st, "u", "install-curl", 1) // ACTION_TYPE_PACKAGE
+
+	last := fake.lastReindex(t)
+	assert.Equal(t, search.ScopeAction, last.Scope)
+	assert.Equal(t, actionID, last.ID)
+	require.NotNil(t, last.Data)
+	assert.Equal(t, "install-curl", last.Data.Name)
+}
+
+// =============================================================================
+// Cascade-on-remove (Action / ActionSet / Definition)
+// =============================================================================
+
+func TestSearchListener_ActionDeleted_ResolvesCascadeAndEnqueuesRemove(t *testing.T) {
+	st, fake := setupListener(t)
+	actionID := testutil.CreateTestAction(t, st, "u", "doomed-action", 1)
+
+	// Seed the fake so cascadeIDsForRemove returns a non-empty list
+	// for the deleted action — this is the EnqueueRemove path the
+	// production GetReverseMembers feeds.
+	fake.reverse[search.ScopeAction+":"+actionID] = []string{"set-A", "set-B"}
+
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "action", StreamID: actionID, EventType: string(eventtypes.ActionDeleted),
+		Data:      map[string]any{},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	last := fake.lastRemove(t)
+	assert.Equal(t, search.ScopeAction, last.Scope)
+	assert.Equal(t, actionID, last.ID)
+	assert.Equal(t, []string{"set-A", "set-B"}, last.CascadeIDs,
+		"cascade IDs must be the GetReverseMembers result, passed through to EnqueueRemove")
+}
+
+// =============================================================================
+// Loader-not-found contract
+// =============================================================================
+
+func TestSearchListener_EntityGoneBeforeReindex_SilentlySkips(t *testing.T) {
+	st, fake := setupListener(t)
+
+	// AppendEvent for an unknown user_id triggers the listener; the
+	// loader returns pgx.ErrNoRows; the listener logs at Debug and
+	// MUST NOT enqueue. The reindex queue stays empty.
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user", StreamID: "01HXNONEXISTENT00000000000",
+		EventType: string(eventtypes.UserEmailChanged),
+		Data:      map[string]any{"email": "ghost@example.com"},
+		ActorType: "system", ActorID: "test",
+	}))
+
+	assert.Zero(t, fake.reindexCount(),
+		"listener must skip enqueue when the entity row is gone (pgx.ErrNoRows path)")
+}
+
+// =============================================================================
+// Panic recovery contract
+// =============================================================================
+
+func TestSearchListener_PanicInListenerDoesNotCrashAppendEvent(t *testing.T) {
+	st, fake := setupListener(t)
+	fake.panicOnReindex = true
+
+	// Even though the next listener call will panic, AppendEvent must
+	// return cleanly because store.fireListeners wraps each listener
+	// in a defer-recover. CreateTestUser asserts no error from the
+	// AppendEvent under the hood.
+	require.NotPanics(t, func() {
+		_ = testutil.CreateTestUser(t, st, "panic-test@example.com", "pass", "viewer")
+	})
+
+	// Sanity: the panic consumed the panicOnReindex flag and the next
+	// reindex (e.g., from a follow-up event) would proceed normally.
+	assert.False(t, fake.panicOnReindex, "panic flag should reset after firing once")
+}
+
+// =============================================================================
+// Loader error (non-NotFound) is logged, not enqueued
+// =============================================================================
+
+func TestSearchListener_EnqueueErrorIsSwallowed(t *testing.T) {
+	st, fake := setupListener(t)
+	fake.reindexErr = errors.New("simulated valkey timeout")
+
+	// The listener must swallow enqueue errors (post-commit
+	// notification contract — the periodic reconciler is the safety
+	// net). AppendEvent returns success regardless.
+	require.NotPanics(t, func() {
+		_ = testutil.CreateTestUser(t, st, "err-test@example.com", "pass", "viewer")
+	})
+	// Although the fake returned an error, it was still called once.
+	assert.Equal(t, 1, fake.reindexCount())
+}


### PR DESCRIPTION
## Summary

Closes manchtools/power-manage-server#115.

Adds runtime coverage for the listener's behaviour beyond what
the classifier-table tests in \`search_listener_test.go\` prove:
\`loadSearchEntityData\`, \`cascadeIDsForRemove\`, the panic-recovery
wrapper, and the synchronous Asynq enqueue path.

Each test fires a real event through \`st.AppendEvent\` (testcontainer
Postgres) and asserts the listener enqueued exactly the expected
\`(op, scope, id, payload)\` triple via a recording fake of the new
\`api.SearchIndex\` interface.

### Refactor

Extracted a 3-method \`SearchIndex\` interface that \`*search.Index\`
satisfies implicitly. \`SearchListener\` and \`cascadeIDsForRemove\`
take this interface so tests can swap in a fake without standing
up Asynq + Valkey. No production wiring change — \`main.go\` still
passes the concrete \`*search.Index\`.

### Coverage

- One reindex per scope: User, Device, DeviceGroup (incl. member event), UserGroup (composite-StreamID prefix-split), ActionSet, Definition, Action.
- Cascade-on-remove for Action: \`GetReverseMembers\` result passes through to \`EnqueueRemove\` unchanged.
- \`pgx.ErrNoRows\` path silently skips enqueue.
- Panic in listener body doesn't crash \`AppendEvent\`.
- Enqueue error swallowed — \`AppendEvent\` still returns success.

## Test plan

- [x] \`go test ./internal/api/ -run 'TestSearchListener_'\` — 11 testcases, all pass (~80s incl. testcontainer setup)
- [x] \`cr review --plain --base main\` — 0 findings
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture by introducing an abstraction layer for search index operations, enabling better separation of concerns and flexibility.

* **Tests**
  * Added comprehensive end-to-end test suite covering search listener functionality, cascade operations, error handling, and edge cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/200)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->