### PR TITLE
refactor(api): finish connect.NewError → apiErrorCtx sweep (#190)

### DIFF
--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -109,7 +109,7 @@ func searchScopeFromString(s string) pm.SearchScope {
 
 func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.SearchRequest]) (*connect.Response[pm.SearchResponse], error) {
 	if h.searchIdx == nil {
-		return nil, connect.NewError(connect.CodeUnavailable, nil)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable, "search index is not configured on this control instance")
 	}
 
 	query := strings.TrimSpace(req.Msg.Query)
@@ -135,7 +135,7 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 	if req.Msg.PageToken != "" {
 		v, err := strconv.Atoi(req.Msg.PageToken)
 		if err != nil || v < 0 || v > maxSearchOffset {
-			return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid page token"))
+			return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "invalid page token")
 		}
 		offset = v
 	}
@@ -194,7 +194,7 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 			if strings.Contains(errMsg, "Unknown index") || strings.Contains(errMsg, "Unknown Index") || strings.Contains(errMsg, "not found") {
 				continue
 			}
-			return nil, connect.NewError(connect.CodeInternal, err)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, fmt.Sprintf("search index query failed for scope %s: %v", scope, err))
 		}
 
 		parsed, count := parseFTSearchResult(raw, scope)
@@ -217,11 +217,11 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 
 func (h *SearchHandler) RebuildSearchIndex(ctx context.Context, req *connect.Request[pm.RebuildSearchIndexRequest]) (*connect.Response[pm.RebuildSearchIndexResponse], error) {
 	if h.searchIdx == nil {
-		return nil, connect.NewError(connect.CodeUnavailable, nil)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable, "search index is not configured on this control instance")
 	}
 
 	if err := h.searchIdx.Rebuild(ctx); err != nil {
-		return nil, connect.NewError(connect.CodeInternal, err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, fmt.Sprintf("search index rebuild failed: %v", err))
 	}
 
 	return connect.NewResponse(&pm.RebuildSearchIndexResponse{}), nil


### PR DESCRIPTION
## Summary

Closes manchtools/power-manage-server#190.

The 10+ sites the issue named in \`internal_handler.go\` were already
converted by intervening PRs (renderer wiring, earlier sweeps).
The same pattern still lived in \`search_handler.go\`: 5 \`connect.NewError\`
sites that bypass the project's \`apiErrorCtx\` convention and ship
opaque errors without the structured detail \`getErrorCode()\` reads
on the web client.

Sweep:
- \`Search()\` index-unavailable / invalid page token / per-scope
  query failure → \`apiErrorCtx(ErrInternal, ErrValidationFailed,
  ErrInternal)\` with descriptive messages.
- \`RebuildSearchIndex()\` index-unavailable / rebuild failure → same.

Re-uses the existing \`ErrInternal\` / \`ErrValidationFailed\` constants
so the wire codes the web client maps via \`getLocalizedError()\`
stay stable. No behavioural change beyond enriching the error
responses with the structured detail \`#190\`'s policy requires.

## Test plan

- [x] \`go test ./internal/api/ -run 'TestSearch|TestValidateFiltersForScopes'\` — pass
- [x] \`cr review --plain --base main\` — 0 findings
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* Improved error handling for search operations when the search index is not configured
* Enhanced error messages for invalid pagination tokens with clearer diagnostic information
* Better error reporting for search execution failures with more specific details

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/201)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->