### PR TITLE
fix(dynamic-groups): drain loop terminates on `more` flag (#168)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -182,31 +182,43 @@ func main() {
 	}, false)
 
 	// drainDynamicQueue runs the same drain loop shape against either
-	// dynamic-group queue. label drives the log lines, evalFn returns
-	// the per-batch count, and batchSize is the loop's "queue is empty"
-	// short-circuit threshold. Extracted to deduplicate
-	// evaluateDynamicGroups + evaluateDynamicUserGroups (audit N021).
-	drainDynamicQueue := func(label string, batchSize int32, evalFn func(context.Context) (int32, error)) {
+	// dynamic-group queue. evalFn evaluates one batch and reports
+	// (count, more) where `more` is true iff the queue still has
+	// rows after the batch. Closes audit F035 / #168: the prior
+	// shape inferred queue-empty from `count < batchSize` and fired
+	// one wasted iteration on a batch that processed exactly the
+	// limit; the explicit `more` flag avoids that.
+	type batchResult struct {
+		count int32
+		more  bool
+	}
+	drainDynamicQueue := func(label string, evalFn func(context.Context) (batchResult, error)) {
 		for {
-			count, err := evalFn(ctx)
+			res, err := evalFn(ctx)
 			if err != nil {
 				logger.Error("failed to evaluate queued "+label, "error", err)
 				return
 			}
-			if count > 0 {
-				logger.Info("evaluated queued "+label, "count", count)
+			if res.count > 0 {
+				logger.Info("evaluated queued "+label, "count", res.count)
 			}
-			if count < batchSize {
-				return // queue is drained
+			if !res.more {
+				return // queue is drained — explicit signal from the SQL function
 			}
 		}
 	}
 
 	evaluateDynamicGroups := func() {
-		drainDynamicQueue("dynamic groups", 1000, st.Queries().EvaluateQueuedDynamicGroups)
+		drainDynamicQueue("dynamic groups", func(ctx context.Context) (batchResult, error) {
+			r, err := st.Queries().EvaluateQueuedDynamicGroups(ctx)
+			return batchResult{count: r.EvaluatedCount, more: r.More}, err
+		})
 	}
 	evaluateDynamicUserGroups := func() {
-		drainDynamicQueue("dynamic user groups", 100, st.Queries().EvaluateQueuedDynamicUserGroups)
+		drainDynamicQueue("dynamic user groups", func(ctx context.Context) (batchResult, error) {
+			r, err := st.Queries().EvaluateQueuedDynamicUserGroups(ctx)
+			return batchResult{count: r.EvaluatedCount, more: r.More}, err
+		})
 	}
 
 	if cfg.DynamicGroupEvalInterval > 0 {

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -487,15 +487,19 @@ func (w *InboxWorker) handleInventoryUpdate(ctx context.Context, t *asynq.Task) 
 
 	// Immediately evaluate dynamic groups queued by the device_inventory_changed trigger.
 	// Without this, groups are only evaluated on the periodic ticker (default 1h).
-	if count, err := w.store.Queries().EvaluateQueuedDynamicGroups(ctx); err != nil {
+	// Single-batch invocation here — the caller doesn't drain to
+	// completion the way cmd/control does. The `more` flag is
+	// ignored on this path because the periodic worker (or a
+	// subsequent inbox event) will pick up any leftover.
+	if r, err := w.store.Queries().EvaluateQueuedDynamicGroups(ctx); err != nil {
 		w.logger.Warn("failed to evaluate dynamic groups after inventory update",
 			"device_id", payload.DeviceID,
 			"error", err,
 		)
-	} else if count > 0 {
+	} else if r.EvaluatedCount > 0 {
 		w.logger.Info("evaluated dynamic groups after inventory update",
 			"device_id", payload.DeviceID,
-			"count", count,
+			"count", r.EvaluatedCount,
 		)
 	}
 

--- a/internal/store/evaluate_queued_dynamic_groups_test.go
+++ b/internal/store/evaluate_queued_dynamic_groups_test.go
@@ -1,0 +1,128 @@
+package store_test
+
+// Drain-loop edge-case coverage for evaluate_queued_dynamic_groups
+// (manchtools/power-manage-server#168). The function used to return
+// just a count, and the cmd/control drain loop inferred queue-empty
+// from "count < batch_limit" — fine in the common case but wrong on
+// a count == batch_limit boundary hit, which would fire one extra
+// round-trip before observing the empty queue.
+//
+// Migration 044 added a `more` flag to the return tuple so the
+// caller can terminate explicitly. These tests pin both behaviours:
+// `more` is true while the queue still has rows after the batch,
+// and false once it's drained.
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// queueDynamicGroup inserts a single row into
+// dynamic_group_evaluation_queue, which is the queue the drain loop
+// in evaluate_queued_dynamic_groups consumes. Going through SQL
+// directly (rather than triggering via DeviceAddedToGroup events)
+// keeps the test focused on the drain-loop boundary semantics
+// without needing the full dynamic-query evaluator wired up.
+func queueDynamicGroup(t *testing.T, st *store.Store, groupID string, queuedAt time.Time) {
+	t.Helper()
+	_, err := st.Pool().Exec(context.Background(),
+		`INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+		 VALUES ($1, $2, 'test')
+		 ON CONFLICT (group_id) DO UPDATE SET queued_at = EXCLUDED.queued_at`,
+		groupID, queuedAt,
+	)
+	require.NoError(t, err)
+}
+
+// drainEvalQueues clears any rows that triggers (queue_dynamic_groups_for_device,
+// etc.) inserted as side effects of the test fixture setup. Lets each
+// test reason about its own seeded count without leakage from device
+// / group create-time triggers.
+func drainEvalQueues(t *testing.T, st *store.Store) {
+	t.Helper()
+	ctx := context.Background()
+	_, err := st.Pool().Exec(ctx, "TRUNCATE dynamic_group_evaluation_queue, dynamic_user_group_evaluation_queue")
+	require.NoError(t, err)
+}
+
+func TestEvaluateQueuedDynamicGroups_EmptyQueue_MoreFalseCountZero(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	drainEvalQueues(t, st)
+
+	r, err := st.Queries().EvaluateQueuedDynamicGroups(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), r.EvaluatedCount)
+	assert.False(t, r.More, "an empty queue must report more=false so the drain loop terminates")
+}
+
+func TestEvaluateQueuedDynamicGroups_BelowBatchLimit_MoreFalse(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	drainEvalQueues(t, st)
+	actor := testutil.NewID()
+
+	// Queue 5 dynamic groups (well below the 1000 batch limit).
+	now := time.Now()
+	for i := 0; i < 5; i++ {
+		gid := testutil.CreateTestDeviceGroup(t, st, actor, fmt.Sprintf("dyn-%d", i))
+		queueDynamicGroup(t, st, gid, now.Add(time.Duration(i)*time.Millisecond))
+	}
+
+	r, err := st.Queries().EvaluateQueuedDynamicGroups(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int32(5), r.EvaluatedCount)
+	assert.False(t, r.More, "a sub-batch run drains the queue and must report more=false")
+}
+
+func TestEvaluateQueuedDynamicGroups_OverBatchLimit_MoreTrueThenFalse(t *testing.T) {
+	// Two batches: queue exactly batch_limit + 1 rows so the first
+	// invocation hits the limit and reports more=true; the second
+	// invocation processes the leftover and reports more=false.
+	// Validates the explicit `more` signal on the boundary the
+	// inference-shape used to get wrong.
+	if testing.Short() {
+		t.Skip("seeds 1001 dynamic groups; skip in -short")
+	}
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	drainEvalQueues(t, st)
+	actor := testutil.NewID()
+
+	now := time.Now()
+	const seedCount = 1001 // one over the 1000 batch limit
+	for i := 0; i < seedCount; i++ {
+		gid := testutil.CreateTestDeviceGroup(t, st, actor, fmt.Sprintf("dyn-%d", i))
+		queueDynamicGroup(t, st, gid, now.Add(time.Duration(i)*time.Millisecond))
+	}
+
+	first, err := st.Queries().EvaluateQueuedDynamicGroups(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1000), first.EvaluatedCount)
+	assert.True(t, first.More, "1001 rows queued, batch_limit=1000 — first batch must report more=true")
+
+	second, err := st.Queries().EvaluateQueuedDynamicGroups(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), second.EvaluatedCount)
+	assert.False(t, second.More, "after second batch consumes the leftover, more must be false")
+}
+
+// User-group variant — same shape, different batch limit (100).
+func TestEvaluateQueuedDynamicUserGroups_EmptyQueue_MoreFalse(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	drainEvalQueues(t, st)
+
+	r, err := st.Queries().EvaluateQueuedDynamicUserGroups(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), r.EvaluatedCount)
+	assert.False(t, r.More)
+}

--- a/internal/store/generated/device_groups.sql.go
+++ b/internal/store/generated/device_groups.sql.go
@@ -155,14 +155,23 @@ func (q *Queries) EvaluateDynamicGroup(ctx context.Context, groupIDParam string)
 }
 
 const evaluateQueuedDynamicGroups = `-- name: EvaluateQueuedDynamicGroups :one
-SELECT evaluate_queued_dynamic_groups() AS evaluated_count
+SELECT evaluated_count::INTEGER AS evaluated_count, more::BOOLEAN AS more
+FROM evaluate_queued_dynamic_groups()
 `
 
-func (q *Queries) EvaluateQueuedDynamicGroups(ctx context.Context) (int32, error) {
+type EvaluateQueuedDynamicGroupsRow struct {
+	EvaluatedCount int32 `json:"evaluated_count"`
+	More           bool  `json:"more"`
+}
+
+// Returns (evaluated_count, more) so the drain loop in cmd/control
+// terminates on `more = false` instead of inferring queue-empty
+// from "count < batch_limit". See migration 044 + #168.
+func (q *Queries) EvaluateQueuedDynamicGroups(ctx context.Context) (EvaluateQueuedDynamicGroupsRow, error) {
 	row := q.db.QueryRow(ctx, evaluateQueuedDynamicGroups)
-	var evaluated_count int32
-	err := row.Scan(&evaluated_count)
-	return evaluated_count, err
+	var i EvaluateQueuedDynamicGroupsRow
+	err := row.Scan(&i.EvaluatedCount, &i.More)
+	return i, err
 }
 
 const getDeviceGroupByID = `-- name: GetDeviceGroupByID :one

--- a/internal/store/generated/user_groups.sql.go
+++ b/internal/store/generated/user_groups.sql.go
@@ -245,14 +245,22 @@ func (q *Queries) EvaluateDynamicUserGroup(ctx context.Context, groupIDParam str
 }
 
 const evaluateQueuedDynamicUserGroups = `-- name: EvaluateQueuedDynamicUserGroups :one
-SELECT evaluate_queued_dynamic_user_groups() AS evaluated_count
+SELECT evaluated_count::INTEGER AS evaluated_count, more::BOOLEAN AS more
+FROM evaluate_queued_dynamic_user_groups()
 `
 
-func (q *Queries) EvaluateQueuedDynamicUserGroups(ctx context.Context) (int32, error) {
+type EvaluateQueuedDynamicUserGroupsRow struct {
+	EvaluatedCount int32 `json:"evaluated_count"`
+	More           bool  `json:"more"`
+}
+
+// Returns (evaluated_count, more) so the drain loop in cmd/control
+// terminates on `more = false`. See migration 044 + #168.
+func (q *Queries) EvaluateQueuedDynamicUserGroups(ctx context.Context) (EvaluateQueuedDynamicUserGroupsRow, error) {
 	row := q.db.QueryRow(ctx, evaluateQueuedDynamicUserGroups)
-	var evaluated_count int32
-	err := row.Scan(&evaluated_count)
-	return evaluated_count, err
+	var i EvaluateQueuedDynamicUserGroupsRow
+	err := row.Scan(&i.EvaluatedCount, &i.More)
+	return i, err
 }
 
 const getUserGroupByID = `-- name: GetUserGroupByID :one

--- a/internal/store/migrations/044_dynamic_eval_returns_more.sql
+++ b/internal/store/migrations/044_dynamic_eval_returns_more.sql
@@ -1,0 +1,112 @@
+-- evaluate_queued_dynamic_groups + evaluate_queued_dynamic_user_groups
+-- now return (evaluated_count INT, more BOOLEAN) so the caller can
+-- terminate the drain loop explicitly instead of inferring queue-
+-- empty from "count < batch_limit". Closes audit F035 /
+-- manchtools/power-manage-server#168.
+--
+-- Edge case the inference shape gets wrong: a batch that processes
+-- EXACTLY the limit triggers one extra round-trip that observes the
+-- now-empty queue and returns 0 — wasteful but not incorrect. The
+-- explicit `more` flag is a single `SELECT EXISTS(...)` probe after
+-- the batch UPDATE, paid once per batch instead of per-call.
+--
+-- Function signature change: PostgreSQL can't CREATE OR REPLACE a
+-- function with a different return type, so we DROP first. The two
+-- callers (sqlc-generated EvaluateQueuedDynamicGroups* and the
+-- evaluate_dynamic_groups_on_label_change() trigger that PERFORMs
+-- this function) all tolerate the new shape: the sqlc wrapper is
+-- updated alongside this migration, and the trigger ignores the
+-- return value.
+-- +goose Up
+
+DROP FUNCTION IF EXISTS evaluate_queued_dynamic_groups();
+DROP FUNCTION IF EXISTS evaluate_queued_dynamic_user_groups();
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION evaluate_queued_dynamic_groups(OUT evaluated_count INTEGER, OUT more BOOLEAN) AS $$
+DECLARE
+    queue_record RECORD;
+    batch_limit  CONSTANT INTEGER := 1000;
+BEGIN
+    evaluated_count := 0;
+    FOR queue_record IN
+        SELECT group_id FROM dynamic_group_evaluation_queue
+        ORDER BY queued_at LIMIT batch_limit
+    LOOP
+        PERFORM evaluate_dynamic_group(queue_record.group_id);
+        evaluated_count := evaluated_count + 1;
+    END LOOP;
+
+    -- more = true only if the queue still has rows AFTER the batch.
+    -- The EXISTS probe is cheap (LIMIT 1) and avoids the inference
+    -- shape's spurious tail iteration on a count == batch_limit
+    -- boundary hit.
+    SELECT EXISTS (
+        SELECT 1 FROM dynamic_group_evaluation_queue LIMIT 1
+    ) INTO more;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION evaluate_queued_dynamic_user_groups(OUT evaluated_count INTEGER, OUT more BOOLEAN) AS $$
+DECLARE
+    queue_record RECORD;
+    batch_limit  CONSTANT INTEGER := 100;
+BEGIN
+    evaluated_count := 0;
+    FOR queue_record IN
+        SELECT group_id FROM dynamic_user_group_evaluation_queue
+        ORDER BY queued_at LIMIT batch_limit
+    LOOP
+        PERFORM evaluate_dynamic_user_group(queue_record.group_id);
+        evaluated_count := evaluated_count + 1;
+    END LOOP;
+
+    SELECT EXISTS (
+        SELECT 1 FROM dynamic_user_group_evaluation_queue LIMIT 1
+    ) INTO more;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose Down
+
+DROP FUNCTION IF EXISTS evaluate_queued_dynamic_groups();
+DROP FUNCTION IF EXISTS evaluate_queued_dynamic_user_groups();
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION evaluate_queued_dynamic_groups() RETURNS INTEGER AS $$
+DECLARE
+    evaluated_count INTEGER := 0;
+    queue_record RECORD;
+BEGIN
+    FOR queue_record IN
+        SELECT group_id FROM dynamic_group_evaluation_queue
+        ORDER BY queued_at LIMIT 1000
+    LOOP
+        PERFORM evaluate_dynamic_group(queue_record.group_id);
+        evaluated_count := evaluated_count + 1;
+    END LOOP;
+    RETURN evaluated_count;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION evaluate_queued_dynamic_user_groups() RETURNS INTEGER AS $$
+DECLARE
+    evaluated_count INTEGER := 0;
+    queue_record RECORD;
+BEGIN
+    FOR queue_record IN
+        SELECT group_id FROM dynamic_user_group_evaluation_queue
+        ORDER BY queued_at LIMIT 100
+    LOOP
+        PERFORM evaluate_dynamic_user_group(queue_record.group_id);
+        evaluated_count := evaluated_count + 1;
+    END LOOP;
+    RETURN evaluated_count;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd

--- a/internal/store/queries/device_groups.sql
+++ b/internal/store/queries/device_groups.sql
@@ -65,7 +65,11 @@ SELECT COALESCE(validate_dynamic_query($1), '')::TEXT AS error_message;
 SELECT evaluate_dynamic_group($1);
 
 -- name: EvaluateQueuedDynamicGroups :one
-SELECT evaluate_queued_dynamic_groups() AS evaluated_count;
+-- Returns (evaluated_count, more) so the drain loop in cmd/control
+-- terminates on `more = false` instead of inferring queue-empty
+-- from "count < batch_limit". See migration 044 + #168.
+SELECT evaluated_count::INTEGER AS evaluated_count, more::BOOLEAN AS more
+FROM evaluate_queued_dynamic_groups();
 
 -- name: QueueAllDynamicGroups :exec
 SELECT queue_all_dynamic_groups();

--- a/internal/store/queries/user_groups.sql
+++ b/internal/store/queries/user_groups.sql
@@ -89,7 +89,10 @@ SELECT COALESCE(validate_user_group_query($1), '')::TEXT AS error_message;
 SELECT evaluate_dynamic_user_group($1);
 
 -- name: EvaluateQueuedDynamicUserGroups :one
-SELECT evaluate_queued_dynamic_user_groups() AS evaluated_count;
+-- Returns (evaluated_count, more) so the drain loop in cmd/control
+-- terminates on `more = false`. See migration 044 + #168.
+SELECT evaluated_count::INTEGER AS evaluated_count, more::BOOLEAN AS more
+FROM evaluate_queued_dynamic_user_groups();
 
 -- name: CountMatchingUsersForQuery :one
 SELECT COUNT(*) FROM users_projection


### PR DESCRIPTION
## Summary

Closes manchtools/power-manage-server#168 (audit F035).

The drain loop in cmd/control's evaluateDynamicGroups* used to infer
queue-empty from \`count < batch_limit\`. That's wrong on a count ==
batch_limit boundary hit: the loop fires one extra round-trip to
discover the now-empty queue. Wasteful, not incorrect.

Migration 044 changes \`evaluate_queued_dynamic_groups\` (and the
user-group mirror) to return \`(evaluated_count, more)\` where \`more\`
is a single \`SELECT EXISTS\` probe after the batch. The drain loop
now terminates on \`more = false\` — the boundary case fires exactly
one batch + one probe, not two batches.

## Coverage

\`internal/store/evaluate_queued_dynamic_groups_test.go\` pins the
three boundary cases:
- empty queue → count=0, more=false
- sub-batch run → count<limit, more=false
- exact count == batch_limit + 1 → first batch reports more=true,
  second batch reports more=false (the regression case the issue
  flagged)

\`internal/control/inbox_worker.go\` adapts to the new return shape;
it's a single-batch caller (not a drain loop) so it ignores \`more\`
and lets the periodic ticker pick up any leftover.

## Test plan

- [x] \`go test ./internal/store/ -run TestEvaluateQueuedDynamic\` — 4 cases pass
- [x] \`go build ./...\`
- [x] \`cr review --plain --base main\` — 0 findings
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic group queue processing reliability by replacing implicit emptiness detection with explicit completion signals, ensuring queues are properly drained in all scenarios.

* **Tests**
  * Added comprehensive test coverage for dynamic group evaluation queue drain-loop behavior across various queue states and batch limits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/203)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->