### PR TITLE
fix(rebuild): scim_group_mappings rebuild target restores SCIM mappings (#175)

### DIFF
--- a/internal/projectors/scim_group_mapping_listener.go
+++ b/internal/projectors/scim_group_mapping_listener.go
@@ -3,6 +3,7 @@ package projectors
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -20,6 +21,10 @@ import (
 //   - SCIMGroupMappingUpdated: UPDATE display_name with NULLIF/COALESCE
 //
 // Wired in projectors.WireAll. Refs #105, tracker #107.
+//
+// Listener body delegates to ApplySCIMGroupMapping so the rebuild
+// path (RebuildAll) and the post-commit listener path share one
+// codepath. Any new event type only needs to be added in one place.
 func SCIMGroupMappingListener(st *store.Store, logger *slog.Logger) store.EventListener {
 	if st == nil {
 		return func(context.Context, store.PersistedEvent) {}
@@ -28,28 +33,44 @@ func SCIMGroupMappingListener(st *store.Store, logger *slog.Logger) store.EventL
 		if e.StreamType != "scim_group_mapping" {
 			return
 		}
-		switch e.EventType {
-		case string(eventtypes.SCIMGroupMapped):
-			applySCIMGroupMapped(ctx, st, logger, e)
-		case string(eventtypes.SCIMGroupUnmapped):
-			applySCIMGroupUnmapped(ctx, st, logger, e)
-		case string(eventtypes.SCIMGroupMappingUpdated):
-			applySCIMGroupMappingUpdated(ctx, st, logger, e)
+		if err := ApplySCIMGroupMapping(ctx, st.Queries(), e); err != nil {
+			if errors.Is(err, ErrIgnoredEvent) {
+				return
+			}
+			logger.Warn("scim_group_mapping projector: apply failed",
+				"event_id", e.ID, "event_type", e.EventType, "error", err)
 		}
 	}
 }
 
-func applySCIMGroupMapped(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+// ApplySCIMGroupMapping is the rebuild-applier-shape entry point.
+// Dispatches to the per-event-type helpers (each a single SQL
+// statement). RebuildAll registers this via
+// projectors.WireAll → Store.RegisterRebuildApply("scim_group_mappings", ApplySCIMGroupMapping)
+// so the new "scim_group_mappings" rebuild target replays the
+// stream after the user_groups target has restored the FK references.
+// See manchtools/power-manage-server#175.
+func ApplySCIMGroupMapping(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "scim_group_mapping" {
+		return nil
+	}
+	switch e.EventType {
+	case string(eventtypes.SCIMGroupMapped):
+		return applySCIMGroupMapped(ctx, q, e)
+	case string(eventtypes.SCIMGroupUnmapped):
+		return applySCIMGroupUnmapped(ctx, q, e)
+	case string(eventtypes.SCIMGroupMappingUpdated):
+		return applySCIMGroupMappingUpdated(ctx, q, e)
+	}
+	return nil
+}
+
+func applySCIMGroupMapped(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := SCIMGroupMappedFromEvent(e)
 	if err != nil {
-		if errors.Is(err, ErrIgnoredEvent) {
-			return
-		}
-		logger.Warn("scim_group_mapping projector: invalid SCIMGroupMapped payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().UpsertSCIMGroupMapping(ctx, db.UpsertSCIMGroupMappingParams{
+	if err := q.UpsertSCIMGroupMapping(ctx, db.UpsertSCIMGroupMappingParams{
 		ID:                payload.ID,
 		ProviderID:        payload.ProviderID,
 		ScimGroupID:       payload.SCIMGroupID,
@@ -58,53 +79,39 @@ func applySCIMGroupMapped(ctx context.Context, st *store.Store, logger *slog.Log
 		CreatedAt:         e.OccurredAt,
 		ProjectionVersion: deref(e.SequenceNum),
 	}); err != nil {
-		logger.Warn("scim_group_mapping projector: failed to upsert SCIMGroupMapped",
-			"event_id", e.ID, "mapping_id", payload.ID, "error", err)
+		return fmt.Errorf("upsert scim_group_mapping (mapping_id %s): %w", payload.ID, err)
 	}
+	return nil
 }
 
-func applySCIMGroupUnmapped(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applySCIMGroupUnmapped(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := SCIMGroupUnmappedFromEvent(e)
 	if err != nil {
-		if errors.Is(err, ErrIgnoredEvent) {
-			return
-		}
-		logger.Warn("scim_group_mapping projector: invalid SCIMGroupUnmapped payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().DeleteSCIMGroupMappingByCompositeKey(ctx, db.DeleteSCIMGroupMappingByCompositeKeyParams{
+	if err := q.DeleteSCIMGroupMappingByCompositeKey(ctx, db.DeleteSCIMGroupMappingByCompositeKeyParams{
 		ProviderID:  payload.ProviderID,
 		ScimGroupID: payload.SCIMGroupID,
 	}); err != nil {
-		logger.Warn("scim_group_mapping projector: failed to delete SCIMGroupUnmapped",
-			"event_id", e.ID,
-			"provider_id", payload.ProviderID,
-			"scim_group_id", payload.SCIMGroupID,
-			"error", err)
+		return fmt.Errorf("delete scim_group_mapping (provider_id %s, scim_group_id %s): %w",
+			payload.ProviderID, payload.SCIMGroupID, err)
 	}
+	return nil
 }
 
-func applySCIMGroupMappingUpdated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applySCIMGroupMappingUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := SCIMGroupMappingUpdatedFromEvent(e)
 	if err != nil {
-		if errors.Is(err, ErrIgnoredEvent) {
-			return
-		}
-		logger.Warn("scim_group_mapping projector: invalid SCIMGroupMappingUpdated payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().UpdateSCIMGroupMappingDisplayName(ctx, db.UpdateSCIMGroupMappingDisplayNameParams{
+	if err := q.UpdateSCIMGroupMappingDisplayName(ctx, db.UpdateSCIMGroupMappingDisplayNameParams{
 		ProviderID:        payload.ProviderID,
 		ScimGroupID:       payload.SCIMGroupID,
 		ScimDisplayName:   payload.SCIMDisplayName,
 		ProjectionVersion: deref(e.SequenceNum),
 	}); err != nil {
-		logger.Warn("scim_group_mapping projector: failed to apply SCIMGroupMappingUpdated",
-			"event_id", e.ID,
-			"provider_id", payload.ProviderID,
-			"scim_group_id", payload.SCIMGroupID,
-			"error", err)
+		return fmt.Errorf("update scim_group_mapping display_name (provider_id %s, scim_group_id %s): %w",
+			payload.ProviderID, payload.SCIMGroupID, err)
 	}
+	return nil
 }

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -138,6 +138,13 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 	st.RegisterRebuildApply("assignments", ApplyAssignment)
 	st.RegisterRebuildApply("user_groups", ApplyUserGroup)
 	st.RegisterRebuildApply("device_groups", ApplyDeviceGroup)
+	// scim_group_mappings rebuild — runs AFTER user_groups (target
+	// order in AllRebuildTargets) so the FK reference to
+	// user_groups_projection is restored before the upserts. Plugs
+	// the gap where user_groups' TRUNCATE CASCADE wiped the SCIM
+	// mappings but never replayed them. See manchtools/power-manage-
+	// server#175.
+	st.RegisterRebuildApply("scim_group_mappings", ApplySCIMGroupMapping)
 	// One Apply body, two rebuild targets: the "actions" target
 	// rebuilds actions_projection from BOTH action and definition
 	// streams (the synthesised-action path). The "definitions"

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -198,13 +198,38 @@ var AllRebuildTargets = []rebuildTarget{
 		// user_groups_projection — user_group_members_projection,
 		// user_group_roles_projection,
 		// dynamic_user_group_evaluation_queue, AND
-		// scim_group_mapping_projection. "user-group rebuild also wipes
-		// SCIM mappings" is the historical operator contract; preserve
-		// the quirk here until a future port revisits it.
+		// scim_group_mapping_projection.
+		//
+		// The scim_group_mapping_projection wipe used to be terminal:
+		// only user_group events were replayed, so SCIM mappings
+		// stayed empty after the rebuild. The follow-up
+		// scim_group_mappings target (declared immediately below)
+		// re-replays them. Order matters — scim_group_mappings runs
+		// AFTER user_groups so the FK references it depends on are
+		// restored first. See manchtools/power-manage-server#175.
 		Name:        "user_groups",
 		Tables:      []string{"user_groups_projection"},
 		Cascade:     true,
 		StreamTypes: []string{"user_group"},
+	},
+	{
+		// Applied by projectors.ApplySCIMGroupMapping via
+		// projectors.WireAll. user_groups' TRUNCATE CASCADE wipes
+		// scim_group_mapping_projection (FK reference); this target
+		// replays the scim_group_mapping stream so the table is
+		// non-empty again after the rebuild. Listed after user_groups
+		// in declaration order — RebuildAll runs targets in slice
+		// order when called with the default (full) set, so the FK
+		// references the scim_group_mapping upserts need are present
+		// by the time this target runs.
+		//
+		// Operators rebuilding a single target via
+		// RebuildAll("scim_group_mappings", ...) get the right
+		// behaviour too: the TRUNCATE clears the table, the replay
+		// re-derives every row from events.
+		Name:        "scim_group_mappings",
+		Tables:      []string{"scim_group_mapping_projection"},
+		StreamTypes: []string{"scim_group_mapping"},
 	},
 }
 

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -325,3 +325,84 @@ func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
 func TestRebuildAll_TransactionalAtomicity(t *testing.T) {
 	t.Skip("follow-up: inject a malformed event to force projector failure mid-replay")
 }
+
+// TestRebuildAll_UserGroupsRebuildPreservesSCIMMappings pins the
+// fix for manchtools/power-manage-server#175. Before the fix,
+// `RebuildAll(ctx)` ran the user_groups target whose
+// `TRUNCATE user_groups_projection CASCADE` walked the FK graph and
+// wiped scim_group_mapping_projection — but the rebuild only
+// replayed user_group events, so SCIM mappings stayed empty
+// afterwards. The fix adds a scim_group_mappings rebuild target
+// (declared after user_groups so the FK is restored first) that
+// re-replays the scim_group_mapping stream.
+func TestRebuildAll_UserGroupsRebuildPreservesSCIMMappings(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	groupID := testutil.CreateTestUserGroup(t, st, actor, "scim-managed-group")
+
+	// Seed an identity provider so the scim_group_mapping FK is
+	// satisfied. The minimal IdentityProviderCreated event the
+	// projector accepts.
+	providerID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "identity_provider", StreamID: providerID,
+		EventType: "IdentityProviderCreated",
+		Data: map[string]any{
+			"name":          "Test IdP",
+			"slug":          "test-idp-" + providerID[:8],
+			"provider_type": "oidc",
+			"client_id":     "test-client",
+			"issuer_url":    "https://idp.test/realms/test",
+			"scim_enabled":  true,
+		},
+		ActorType: "user", ActorID: actor,
+	}))
+
+	// Seed the SCIM mapping: maps SCIM group "sg-eng" on this
+	// provider to our user group.
+	mappingID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "scim_group_mapping", StreamID: mappingID,
+		EventType: "SCIMGroupMapped",
+		Data: map[string]any{
+			"provider_id":       providerID,
+			"scim_group_id":     "sg-eng",
+			"scim_display_name": "Engineering",
+			"user_group_id":     groupID,
+		},
+		ActorType: "user", ActorID: actor,
+	}))
+
+	// Pre-condition: live pipeline projected the mapping.
+	beforeCount, err := st.Queries().CountSCIMGroupMappings(ctx, providerID)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), beforeCount, "live projector must have written the mapping before rebuild")
+
+	// Run the full RebuildAll. user_groups' TRUNCATE CASCADE wipes
+	// scim_group_mapping_projection; the new scim_group_mappings
+	// target (declared AFTER user_groups in AllRebuildTargets) must
+	// then replay the SCIMGroupMapped event and restore the row.
+	res, err := st.RebuildAll(ctx)
+	require.NoError(t, err)
+
+	// Verify the scim_group_mappings target ran and replayed at
+	// least our seeded mapping.
+	var scimTarget *store.TargetResult
+	for i := range res.Targets {
+		if res.Targets[i].Name == "scim_group_mappings" {
+			scimTarget = &res.Targets[i]
+			break
+		}
+	}
+	require.NotNil(t, scimTarget, "scim_group_mappings target must be present in the result; the WireAll registration is what proves #175 is fixed")
+	assert.Greater(t, scimTarget.EventsApplied, int64(0),
+		"scim_group_mappings rebuild must have replayed at least the SCIMGroupMapped event we seeded")
+
+	// Post-condition: the mapping survived the rebuild.
+	afterCount, err := st.Queries().CountSCIMGroupMappings(ctx, providerID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), afterCount,
+		"#175 regression: user_groups rebuild wiped the SCIM mapping but the new scim_group_mappings target should have re-replayed it")
+}


### PR DESCRIPTION
## Summary

Closes manchtools/power-manage-server#175.

Before this change, \`RebuildAll(ctx)\` ran the user_groups target whose
\`TRUNCATE user_groups_projection CASCADE\` walked the FK graph and
wiped \`scim_group_mapping_projection\` — but the rebuild only replayed
user_group events, so SCIM mappings stayed empty afterwards. CR
review of PR #174 surfaced this as a real operational hazard
(pre-existing PL/pgSQL behaviour preserved verbatim by the port).

Picks variant 1 from the issue (the cleaner long-term fix):
- Refactor \`scim_group_mapping_listener.go\` to expose
  \`ApplySCIMGroupMapping\` matching the rebuild-applier signature
  \`(ctx, *Queries, PersistedEvent) → error\`. Runtime listener
  delegates to the same dispatcher.
- Add a \`scim_group_mappings\` rebuild target to
  \`AllRebuildTargets\` declared AFTER \`user_groups\` so the FK
  reference to \`user_groups_projection\` is restored before the
  SCIM upserts run.
- Register the applier in WireAll.
- Update the user_groups target's comment to point at the new target.

## Test plan

\`TestRebuildAll_UserGroupsRebuildPreservesSCIMMappings\` seeds a
user_group + identity_provider + SCIMGroupMapped event, runs the
full RebuildAll, and asserts the mapping survives. Pins the fix:
a regression to the old behaviour fails the assertion.

- [x] \`go test -run TestRebuildAll_UserGroupsRebuildPreservesSCIMMappings\` — pass
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where SCIM group mappings could be lost or truncated during system rebuild operations, particularly when user groups were rebuilt.
  * Enhanced error handling and reporting for SCIM group mapping events to provide better visibility into failures.

* **Tests**
  * Added regression test to ensure SCIM group mappings are properly preserved and restored during full system rebuild operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/206)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->