### PR TITLE
test(api): cover compliance_handler + logging_interceptor (#155)

### DIFF
--- a/internal/api/compliance_handler_test.go
+++ b/internal/api/compliance_handler_test.go
@@ -1,0 +1,116 @@
+package api_test
+
+// Test coverage for ComplianceHandler.GetDeviceCompliance
+// (manchtools/power-manage-server#155 / audit F034 — public RPC
+// surface, the highest-priority file in the gap list). Exercises
+// the result + summary load + the JSON detection_output decoding +
+// the empty-results path.
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+func newComplianceHandler(t *testing.T) (*api.ComplianceHandler, *store.Store) {
+	t.Helper()
+	st := testutil.SetupPostgres(t)
+	return api.NewComplianceHandler(st, slog.Default()), st
+}
+
+func TestGetDeviceCompliance_NoResults_EmptyChecks(t *testing.T) {
+	h, st := newComplianceHandler(t)
+	deviceID := testutil.CreateTestDevice(t, st, "compliance-empty")
+
+	resp, err := h.GetDeviceCompliance(context.Background(),
+		connect.NewRequest(&pm.GetDeviceComplianceRequest{DeviceId: deviceID}))
+	require.NoError(t, err)
+	assert.Empty(t, resp.Msg.Checks, "device with no compliance results returns empty Checks")
+}
+
+func TestGetDeviceCompliance_DeviceWithResults_DecodesDetectionOutput(t *testing.T) {
+	h, st := newComplianceHandler(t)
+	ctx := context.Background()
+
+	deviceID := testutil.CreateTestDevice(t, st, "compliance-with-results")
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, actorID, "ssh-config-check", 200) // ACTION_TYPE_SHELL
+
+	// Seed a ComplianceResultUpdated event so the projector lands a
+	// row in compliance_results_projection. Stream type is
+	// "compliance"; payload carries device_id + action_id (composite
+	// PK) + the detection_output sub-tree the handler unmarshals.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance", StreamID: deviceID + "_" + actionID,
+		EventType: "ComplianceResultUpdated",
+		Data: map[string]any{
+			"device_id":   deviceID,
+			"action_id":   actionID,
+			"action_name": "ssh-config-check",
+			"compliant":   false,
+			"detection_output": map[string]any{
+				"stdout":    "permit_root_login: yes",
+				"stderr":    "",
+				"exit_code": 1,
+			},
+		},
+		ActorType: "system", ActorID: "compliance-engine",
+	}))
+
+	resp, err := h.GetDeviceCompliance(ctx,
+		connect.NewRequest(&pm.GetDeviceComplianceRequest{DeviceId: deviceID}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Checks, 1)
+
+	check := resp.Msg.Checks[0]
+	assert.Equal(t, actionID, check.ActionId)
+	assert.Equal(t, "ssh-config-check", check.ActionName)
+	assert.False(t, check.Compliant)
+	require.NotNil(t, check.DetectionOutput, "detection_output JSON must decode into the typed CommandOutput")
+	assert.Equal(t, "permit_root_login: yes", check.DetectionOutput.Stdout)
+	assert.Equal(t, int32(1), check.DetectionOutput.ExitCode)
+}
+
+func TestGetDeviceCompliance_MissingDetectionOutput_NilCommandOutput(t *testing.T) {
+	// Replay-safe path: the projector accepts a ComplianceResultUpdated
+	// without a detection_output key; the handler's json.Unmarshal
+	// short-circuits because the column is empty/null. The check
+	// surfaces with DetectionOutput == nil instead of a populated
+	// zero-value struct that would falsely look like "ran with empty
+	// output".
+	h, st := newComplianceHandler(t)
+	ctx := context.Background()
+
+	deviceID := testutil.CreateTestDevice(t, st, "compliance-no-output")
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, actorID, "no-output-check", 200)
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "compliance", StreamID: deviceID + "_" + actionID,
+		EventType: "ComplianceResultUpdated",
+		Data: map[string]any{
+			"device_id":   deviceID,
+			"action_id":   actionID,
+			"action_name": "no-output-check",
+			"compliant":   true,
+			// no detection_output
+		},
+		ActorType: "system", ActorID: "compliance-engine",
+	}))
+
+	resp, err := h.GetDeviceCompliance(ctx,
+		connect.NewRequest(&pm.GetDeviceComplianceRequest{DeviceId: deviceID}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Checks, 1)
+	assert.Nil(t, resp.Msg.Checks[0].DetectionOutput,
+		"a missing detection_output column must surface as nil — populating an empty CommandOutput would lie")
+}

--- a/internal/api/logging_interceptor_test.go
+++ b/internal/api/logging_interceptor_test.go
@@ -1,0 +1,133 @@
+package api_test
+
+// Logging-interceptor coverage (manchtools/power-manage-server#155
+// audit F034). The interceptor's severity-mapping branch
+// (Warn for client errors / Error for server errors) is the most
+// regression-prone surface — a misclassified server error gets
+// missed by oncall pages, a misclassified client error spams them.
+// These tests pin the mapping so a future addition or removal of
+// a CodeXxx case doesn't drift silently.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/manchtools/power-manage/server/internal/api"
+)
+
+// captureLogs builds a slog.Logger that writes JSON records into a
+// bytes buffer. Tests parse the records to assert level + key fields.
+func captureLogs() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), &buf
+}
+
+// runInterceptor invokes the WrapUnary chain with `next` returning
+// the supplied resp + err. Returns the buffered log output for
+// assertion. Spec().Procedure is filled in via a fresh AnyRequest
+// — connect's request type carries it on the spec.
+func runInterceptor(t *testing.T, logger *slog.Logger, nextErr error) {
+	t.Helper()
+	ic := api.NewLoggingInterceptor(logger)
+	next := func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		if nextErr != nil {
+			return nil, nextErr
+		}
+		return connect.NewResponse(&emptypb.Empty{}), nil
+	}
+	wrapped := ic.WrapUnary(next)
+	req := connect.NewRequest(&emptypb.Empty{})
+	_, _ = wrapped(context.Background(), req)
+}
+
+// parseLogLevels reads the buffer (one JSON record per line) and
+// returns the level of each record in order.
+func parseLogLevels(t *testing.T, buf *bytes.Buffer) []string {
+	t.Helper()
+	var levels []string
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &rec))
+		levels = append(levels, rec["level"].(string))
+	}
+	return levels
+}
+
+func TestLoggingInterceptor_HappyPath_LogsAtDebug(t *testing.T) {
+	logger, buf := captureLogs()
+	runInterceptor(t, logger, nil)
+	assert.Equal(t, []string{"DEBUG"}, parseLogLevels(t, buf))
+}
+
+func TestLoggingInterceptor_ClientError_LogsAtWarn(t *testing.T) {
+	cases := []struct {
+		name string
+		code connect.Code
+	}{
+		{"InvalidArgument", connect.CodeInvalidArgument},
+		{"NotFound", connect.CodeNotFound},
+		{"AlreadyExists", connect.CodeAlreadyExists},
+		{"PermissionDenied", connect.CodePermissionDenied},
+		{"Unauthenticated", connect.CodeUnauthenticated},
+		{"FailedPrecondition", connect.CodeFailedPrecondition},
+		{"ResourceExhausted", connect.CodeResourceExhausted},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			logger, buf := captureLogs()
+			runInterceptor(t, logger, connect.NewError(c.code, errors.New("boom")))
+			levels := parseLogLevels(t, buf)
+			require.Len(t, levels, 1)
+			assert.Equal(t, "WARN", levels[0],
+				"client-class connect code %q must log at Warn — Error would page oncall on a user-input bug", c.code.String())
+		})
+	}
+}
+
+func TestLoggingInterceptor_ServerError_LogsAtError(t *testing.T) {
+	cases := []struct {
+		name string
+		code connect.Code
+	}{
+		{"Internal", connect.CodeInternal},
+		{"Unavailable", connect.CodeUnavailable},
+		{"Unknown", connect.CodeUnknown},
+		{"DataLoss", connect.CodeDataLoss},
+		{"DeadlineExceeded", connect.CodeDeadlineExceeded},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			logger, buf := captureLogs()
+			runInterceptor(t, logger, connect.NewError(c.code, errors.New("boom")))
+			levels := parseLogLevels(t, buf)
+			require.Len(t, levels, 1)
+			assert.Equal(t, "ERROR", levels[0],
+				"server-class connect code %q must log at Error so oncall sees it; Warn would silently swallow", c.code.String())
+		})
+	}
+}
+
+func TestLoggingInterceptor_NonConnectError_LogsAtError(t *testing.T) {
+	// A plain error (no connect.Error type) is unexpected from a
+	// well-behaved handler — log at Error so the operator sees the
+	// missing wrapper rather than missing the misshape entirely.
+	logger, buf := captureLogs()
+	runInterceptor(t, logger, errors.New("plain error from a handler that forgot to wrap"))
+	levels := parseLogLevels(t, buf)
+	require.Len(t, levels, 1)
+	assert.Equal(t, "ERROR", levels[0])
+}


### PR DESCRIPTION
## Summary

Partial close of manchtools/power-manage-server#155 (audit F034).
The issue lists 8 internal/api files with no sibling tests; this
PR covers the two highest-value surfaces:

### compliance_handler.go (public RPC surface)

- Empty-results path: device with no compliance results returns
  empty Checks (not nil-vs-zero confusion).
- Happy path: ComplianceResultUpdated event flows through the
  projector, the handler reads it back via GetDeviceComplianceResults
  + GetDeviceComplianceSummary, and the JSON detection_output decodes
  into the typed CommandOutput correctly.
- Replay-safe edge: a ComplianceResultUpdated event with no
  detection_output key surfaces with DetectionOutput == nil — an
  empty zero-value would falsely look like "ran with empty output".

### logging_interceptor.go (severity-mapping branch)

- Happy path → Debug
- Each client-class connect code (InvalidArgument, NotFound,
  AlreadyExists, PermissionDenied, Unauthenticated, FailedPrecondition,
  ResourceExhausted) → Warn
- Each server-class connect code (Internal, Unavailable, Unknown,
  DataLoss, DeadlineExceeded) → Error
- Plain non-connect error → Error (handler-forgot-to-wrap shape)

The remaining files in the issue (handler_base.go is mixin-struct
field setters only; util.go + errors.go + helpers.go already have
\`*_test.go\` siblings) qualify for the issue's "or a justification
comment" path.

## Test plan

- [x] \`go test -run 'TestGetDeviceCompliance|TestLoggingInterceptor_'\` — pass
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for compliance handler functionality, including device compliance result retrieval, detection output decoding, and edge cases with missing data.
  * Added test coverage for logging interceptor severity mapping, verifying proper log levels across successful operations and various error scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/209)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->