### PR TITLE
test(idp): cover VerifyAndExtractClaims with signed id_token (#161 follow-up)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-oidc/v3 v3.17.0
+	github.com/go-jose/go-jose/v4 v4.1.3
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
@@ -48,7 +49,6 @@ require (
 	github.com/ebitengine/purego v0.8.4 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.12 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/internal/idp/oidc_verify_test.go
+++ b/internal/idp/oidc_verify_test.go
@@ -1,0 +1,213 @@
+package idp_test
+
+// OIDC token-verify happy-path coverage — extends the discovery
+// fixture from #217 with a real RSA-signed id_token so
+// VerifyAndExtractClaims can be exercised end-to-end. Closes the
+// "OIDC token+verify follow-up" item from
+// manchtools/power-manage-server#161.
+//
+// Strategy: generate an in-test RSA key pair, sign a JWT with
+// go-jose/v4, expose the public key via the existing fake JWKS
+// endpoint pattern, and hand the signed token to
+// VerifyAndExtractClaims via an oauth2.Token whose id_token Extra
+// is the signed JWS. Skips the network ExchangeCode round-trip —
+// that's just golang.org/x/oauth2 internals which the upstream
+// library tests already cover.
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/manchtools/power-manage/server/internal/idp"
+)
+
+// signedOIDCFixture stands up an httptest.Server that publishes a
+// discovery doc + JWKS containing the test RSA public key.
+// signIDToken signs a JWT against the same key so VerifyAndExtractClaims
+// will accept it.
+type signedOIDCFixture struct {
+	srv  *httptest.Server
+	priv *rsa.PrivateKey
+	kid  string
+}
+
+func newSignedOIDCFixture(t *testing.T) *signedOIDCFixture {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	kid := "test-key-1"
+
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                srv.URL,
+			"authorization_endpoint":                srv.URL + "/authorize",
+			"token_endpoint":                        srv.URL + "/token",
+			"jwks_uri":                              srv.URL + "/jwks.json",
+			"response_types_supported":              []string{"code"},
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	})
+
+	mux.HandleFunc("/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		jwks := jose.JSONWebKeySet{
+			Keys: []jose.JSONWebKey{{
+				Key:       &priv.PublicKey,
+				KeyID:     kid,
+				Algorithm: "RS256",
+				Use:       "sig",
+			}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(jwks)
+	})
+
+	return &signedOIDCFixture{srv: srv, priv: priv, kid: kid}
+}
+
+// signIDToken builds + signs a minimal id_token with the given
+// custom claims merged on top of the standard JWT claims. The
+// fixture's RSA key signs it; go-oidc's verifier will then accept
+// it via the JWKS published by the fixture.
+func (f *signedOIDCFixture) signIDToken(t *testing.T, audience, nonce string, extra map[string]any) string {
+	t.Helper()
+
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: f.priv},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", f.kid),
+	)
+	require.NoError(t, err)
+
+	now := time.Now()
+	claims := map[string]any{
+		"iss":   f.srv.URL,
+		"sub":   "test-subject-123",
+		"aud":   audience,
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"iat":   now.Unix(),
+		"nonce": nonce,
+	}
+	for k, v := range extra {
+		claims[k] = v
+	}
+
+	raw, err := jwt.Signed(signer).Claims(claims).Serialize()
+	require.NoError(t, err)
+	return raw
+}
+
+func TestVerifyAndExtractClaims_HappyPath(t *testing.T) {
+	f := newSignedOIDCFixture(t)
+	p, err := idp.NewOIDCProvider(context.Background(), idp.ProviderConfig{
+		IssuerURL:   f.srv.URL,
+		ClientID:    "test-client",
+		RedirectURL: "https://app.example.com/cb",
+	})
+	require.NoError(t, err)
+
+	idToken := f.signIDToken(t, "test-client", "the-expected-nonce", map[string]any{
+		"email":      "alice@example.com",
+		"name":       "Alice Test",
+		"given_name": "Alice",
+	})
+	tok := (&oauth2.Token{}).WithExtra(map[string]any{"id_token": idToken})
+
+	claims, err := p.VerifyAndExtractClaims(context.Background(), tok, "the-expected-nonce")
+	require.NoError(t, err)
+	assert.Equal(t, "test-subject-123", claims.Subject)
+	assert.Equal(t, "alice@example.com", claims.Email)
+	assert.Equal(t, "Alice Test", claims.Name)
+	assert.Equal(t, "Alice", claims.GivenName)
+}
+
+func TestVerifyAndExtractClaims_NonceMismatch(t *testing.T) {
+	// Critical anti-replay defence: an id_token that doesn't carry
+	// the nonce the SSO handler issued in the auth request must
+	// fail verification. Without this, a captured-and-replayed
+	// id_token from another session could be accepted.
+	f := newSignedOIDCFixture(t)
+	p, err := idp.NewOIDCProvider(context.Background(), idp.ProviderConfig{
+		IssuerURL:   f.srv.URL,
+		ClientID:    "test-client",
+		RedirectURL: "https://app.example.com/cb",
+	})
+	require.NoError(t, err)
+
+	idToken := f.signIDToken(t, "test-client", "captured-nonce-from-other-session", nil)
+	tok := (&oauth2.Token{}).WithExtra(map[string]any{"id_token": idToken})
+
+	_, err = p.VerifyAndExtractClaims(context.Background(), tok, "the-expected-nonce")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nonce mismatch",
+		"nonce mismatch must surface with the explicit 'nonce mismatch' message — operators rely on this string for anti-replay diagnostics")
+}
+
+func TestVerifyAndExtractClaims_NoIDToken(t *testing.T) {
+	// An oauth2.Token without an id_token (e.g. a non-OIDC OAuth2
+	// flow) must fail verification — we never want to silently
+	// accept "the access_token must be valid because it exists".
+	f := newSignedOIDCFixture(t)
+	p, err := idp.NewOIDCProvider(context.Background(), idp.ProviderConfig{
+		IssuerURL:   f.srv.URL,
+		ClientID:    "test-client",
+		RedirectURL: "https://app.example.com/cb",
+	})
+	require.NoError(t, err)
+
+	tokWithoutID := &oauth2.Token{} // no id_token Extra
+	_, err = p.VerifyAndExtractClaims(context.Background(), tokWithoutID, "any")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no id_token in token response")
+}
+
+func TestVerifyAndExtractClaims_InvalidSignature(t *testing.T) {
+	// id_token signed with a different key (not in JWKS) must fail.
+	f := newSignedOIDCFixture(t)
+	p, err := idp.NewOIDCProvider(context.Background(), idp.ProviderConfig{
+		IssuerURL:   f.srv.URL,
+		ClientID:    "test-client",
+		RedirectURL: "https://app.example.com/cb",
+	})
+	require.NoError(t, err)
+
+	// Sign with a fresh key the fixture's JWKS doesn't publish.
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: otherKey},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", "rogue-key"),
+	)
+	require.NoError(t, err)
+	now := time.Now()
+	raw, err := jwt.Signed(signer).Claims(map[string]any{
+		"iss":   f.srv.URL,
+		"sub":   "test-subject",
+		"aud":   "test-client",
+		"exp":   now.Add(5 * time.Minute).Unix(),
+		"iat":   now.Unix(),
+		"nonce": "n",
+	}).Serialize()
+	require.NoError(t, err)
+
+	tok := (&oauth2.Token{}).WithExtra(map[string]any{"id_token": raw})
+	_, err = p.VerifyAndExtractClaims(context.Background(), tok, "n")
+	require.Error(t, err, "id_token signed by a non-JWKS key MUST fail verification")
+	assert.Contains(t, err.Error(), "verify id_token")
+}


### PR DESCRIPTION
## Summary

Closes the OIDC token+verify follow-up the discovery PR (#217)
deferred. Extends the fake OIDC server with a real RSA-signed
id_token so \`VerifyAndExtractClaims\` gets exercised end-to-end.

## Coverage on internal/idp/oidc.go

| Function                | Before | After |
|-------------------------|--------|-------|
| VerifyAndExtractClaims  | 0%     | 79.3% |
| NewOIDCProvider         | 94.7%  | 94.7% |
| AuthCodeURL             | 100%   | 100%  |
| ExchangeCode            | 0%     | 0% ¹  |
| extractGroups           | 0%     | 0%    |

¹ \`ExchangeCode\` is literally \`golang.org/x/oauth2\`'s
\`Config.Exchange\` — third-party library, well-tested upstream.

## Tests (4 cases)

- Happy path: signed id_token with email + name + given_name
  decodes into \`UserClaims\`.
- Nonce mismatch returns the explicit "nonce mismatch" error
  (anti-replay diagnostic — operators rely on this string).
- Missing id_token in \`oauth2.Token\` returns "no id_token in
  token response" (defends against a non-OIDC OAuth2 flow being
  silently accepted).
- id_token signed by a key not in JWKS returns "verify id_token"
  wrapped error (rogue-key defence).

Promotes \`go-jose/v4\` from indirect → direct dep — used for the
test-side JWS signing. Was already in go.sum.

## Test plan

- [x] \`go test ./internal/idp/ -run TestVerifyAndExtractClaims_\` — pass
- [x] \`gofmt -l .\` clean
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for OpenID Connect verification functionality, covering happy-path scenarios, nonce validation, missing tokens, and signature verification.

* **Chores**
  * Updated dependency for OpenID Connect handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/221)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->