### PR TITLE
chore(deps): pin SDK to v2026.06-rc1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260510162620-caa0a92808f7
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260510215956-ce9b38ba6a66

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260510162620-caa0a92808f7 h1:8ZYxAMk0hhAK5mvy3nDLkCVMjhnUGcrWiZbVZM4EAq8=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260510162620-caa0a92808f7/go.mod h1:hG7NcdIGAG0VzhLL/W12FDAgVQJxeK+jHFtHb2eF3A8=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260510215956-ce9b38ba6a66 h1:+aPVNGWlsNpaoj3WSSJUvL8hH/zv2YeeCVyYT1uUt4s=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260510215956-ce9b38ba6a66/go.mod h1:hG7NcdIGAG0VzhLL/W12FDAgVQJxeK+jHFtHb2eF3A8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=


### PR DESCRIPTION
## Summary
- Bumps the SDK pseudo-version pin in `go.mod` to `ce9b38b`, which is tagged `v2026.06-rc1` on the SDK repo.
- Captures the group-vars proto (SDK #61) + TS-client wrappers (SDK #62) inside the deterministic SDK build that the server's upcoming `v2026.06-rc1` tag will reference.

## Why now
Server `v2026.06-rc1` is the last open release-tag in the v2026.06 train. Cutting it before this bump would tag the server against the previous SDK pseudo-version (caa0a92), which doesn't carry the group-vars TS wrappers.

## Test plan
- [x] `go build ./...` clean locally.
- [x] Local CR review clean.
- [ ] CI gate (Unit Tests + Integration Tests + gofmt/vet/staticcheck/govulncheck).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency to a newer version to ensure compatibility and improvements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/223)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->