### PR TITLE
refactor(control): extract periodic-worker boot helpers (#157)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -181,115 +181,14 @@ func main() {
 		}
 	}, false)
 
-	// drainDynamicQueue runs the same drain loop shape against either
-	// dynamic-group queue. evalFn evaluates one batch and reports
-	// (count, more) where `more` is true iff the queue still has
-	// rows after the batch. Closes audit F035 / #168: the prior
-	// shape inferred queue-empty from `count < batchSize` and fired
-	// one wasted iteration on a batch that processed exactly the
-	// limit; the explicit `more` flag avoids that.
-	type batchResult struct {
-		count int32
-		more  bool
-	}
-	drainDynamicQueue := func(label string, evalFn func(context.Context) (batchResult, error)) {
-		for {
-			res, err := evalFn(ctx)
-			if err != nil {
-				logger.Error("failed to evaluate queued "+label, "error", err)
-				return
-			}
-			if res.count > 0 {
-				logger.Info("evaluated queued "+label, "count", res.count)
-			}
-			if !res.more {
-				return // queue is drained — explicit signal from the SQL function
-			}
-		}
-	}
-
-	evaluateDynamicGroups := func() {
-		drainDynamicQueue("dynamic groups", func(ctx context.Context) (batchResult, error) {
-			r, err := st.Queries().EvaluateQueuedDynamicGroups(ctx)
-			return batchResult{count: r.EvaluatedCount, more: r.More}, err
-		})
-	}
-	evaluateDynamicUserGroups := func() {
-		drainDynamicQueue("dynamic user groups", func(ctx context.Context) (batchResult, error) {
-			r, err := st.Queries().EvaluateQueuedDynamicUserGroups(ctx)
-			return batchResult{count: r.EvaluatedCount, more: r.More}, err
-		})
-	}
-
 	if cfg.DynamicGroupEvalInterval > 0 {
 		logger.Info("starting dynamic group evaluation worker", "interval", cfg.DynamicGroupEvalInterval)
-		go func() {
-			// Run immediately on startup to process any groups queued during downtime
-			evaluateDynamicGroups()
-			evaluateDynamicUserGroups()
-
-			ticker := time.NewTicker(cfg.DynamicGroupEvalInterval)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					evaluateDynamicGroups()
-					evaluateDynamicUserGroups()
-				case <-ctx.Done():
-					return
-				}
-			}
-		}()
-
-		// Periodic full re-evaluation as a safety net (every 24h).
-		// Queues all dynamic groups for evaluation; the worker above drains them.
-		go runPeriodic(ctx, 24*time.Hour, func() {
-			if err := st.Queries().QueueAllDynamicGroups(ctx); err != nil {
-				logger.Error("failed to queue full dynamic group re-evaluation", "error", err)
-			} else {
-				logger.Info("queued full dynamic group re-evaluation")
-			}
-		}, false)
+		startDynamicGroupWorker(ctx, st, cfg.DynamicGroupEvalInterval, logger)
 	} else {
 		logger.Info("dynamic group evaluation worker disabled")
 	}
 
-	// Start periodic expiry of stale executions (pending/dispatched too long)
-	go func() {
-		ticker := time.NewTicker(1 * time.Minute)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-ticker.C:
-				stale, err := st.Queries().ListStaleExecutions(ctx)
-				if err != nil {
-					logger.Error("failed to list stale executions", "error", err)
-					continue
-				}
-				for _, exec := range stale {
-					errMsg := fmt.Sprintf("execution timed out: device did not respond (status was %s)", exec.Status)
-					completedAt := time.Now().UTC().Format(time.RFC3339Nano)
-					if err := st.AppendEvent(ctx, store.Event{
-						StreamType: "execution",
-						StreamID:   exec.ID,
-						EventType:  string(eventtypes.ExecutionTimedOut),
-						Data: payloads.ExecutionTimedOut{
-							Error:       &errMsg,
-							CompletedAt: &completedAt,
-						},
-						ActorType: "system",
-						ActorID:   "expiry",
-					}); err != nil {
-						logger.Error("failed to expire stale execution", "error", err, "execution_id", exec.ID)
-					} else {
-						logger.Info("expired stale execution", "execution_id", exec.ID, "status", exec.Status, "device_id", exec.DeviceID)
-					}
-				}
-			case <-ctx.Done():
-				return
-			}
-		}
-	}()
+	startStaleExecutionExpiry(ctx, st, logger)
 
 	// Start periodic cleanup of stale OSQuery results
 	go runPeriodic(ctx, 5*time.Minute, func() {
@@ -986,24 +885,6 @@ func ensureAdminUser(ctx context.Context, st *store.Store, email, password strin
 // indirection — call sites now reference config.EnvString,
 // config.ClampInterval, etc. directly. See manchtools/power-
 // manage-server#152 (audit F017+F018).
-
-// runPeriodic calls fn on every tick until ctx is cancelled.
-// If runImmediately is true, fn is called once before the first tick.
-func runPeriodic(ctx context.Context, interval time.Duration, fn func(), runImmediately bool) {
-	if runImmediately {
-		fn()
-	}
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ticker.C:
-			fn()
-		case <-ctx.Done():
-			return
-		}
-	}
-}
 
 // maskDatabaseURL masks the password in a database URL for logging.
 // Uses net/url parsing so URL-encoded credentials (e.g. passwords that

--- a/cmd/control/periodic.go
+++ b/cmd/control/periodic.go
@@ -1,0 +1,160 @@
+// Periodic-worker boot helpers extracted from main.go (audit F043 / #157).
+// These are pure goroutine launchers — they own the ticker loop, the
+// ctx-cancellation shutdown, and the structured-log surface, but they
+// take all collaborators as arguments so each can be unit-tested in
+// isolation against a fake store/Queries.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// runPeriodic calls fn on every tick until ctx is cancelled.
+// If runImmediately is true, fn is called once before the first tick.
+func runPeriodic(ctx context.Context, interval time.Duration, fn func(), runImmediately bool) {
+	if runImmediately {
+		fn()
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			fn()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// dynamicQueueBatch is what one drain iteration reports: how many rows
+// the SQL function evaluated and whether the queue still has more rows
+// after the batch (closes audit F035 / #168 — the prior shape inferred
+// queue-empty from `count < batchSize`, which fired one wasted iteration
+// on a batch that processed exactly the limit).
+type dynamicQueueBatch struct {
+	count int32
+	more  bool
+}
+
+// drainDynamicQueue runs the same drain loop shape against either
+// dynamic-group queue. evalFn evaluates one batch and reports
+// (count, more); the loop terminates when more is false or evalFn
+// returns an error (logged, treated as terminal so we don't busy-loop
+// on a wedged DB).
+func drainDynamicQueue(ctx context.Context, label string, logger *slog.Logger, evalFn func(context.Context) (dynamicQueueBatch, error)) {
+	for {
+		res, err := evalFn(ctx)
+		if err != nil {
+			logger.Error("failed to evaluate queued "+label, "error", err)
+			return
+		}
+		if res.count > 0 {
+			logger.Info("evaluated queued "+label, "count", res.count)
+		}
+		if !res.more {
+			return // queue is drained — explicit signal from the SQL function
+		}
+	}
+}
+
+// startDynamicGroupWorker launches the worker that drains both dynamic-
+// group queues on the configured interval and queues a full re-evaluation
+// every 24h as a safety net. Returns immediately after spawning its
+// goroutines; ctx cancellation stops them.
+//
+// When interval is 0 the worker is disabled entirely (a one-line Info
+// is logged in main.go's else branch — kept there because main owns
+// the boot-time "feature is disabled" reporting).
+func startDynamicGroupWorker(ctx context.Context, st *store.Store, interval time.Duration, logger *slog.Logger) {
+	evalGroups := func() {
+		drainDynamicQueue(ctx, "dynamic groups", logger, func(ctx context.Context) (dynamicQueueBatch, error) {
+			r, err := st.Queries().EvaluateQueuedDynamicGroups(ctx)
+			return dynamicQueueBatch{count: r.EvaluatedCount, more: r.More}, err
+		})
+	}
+	evalUserGroups := func() {
+		drainDynamicQueue(ctx, "dynamic user groups", logger, func(ctx context.Context) (dynamicQueueBatch, error) {
+			r, err := st.Queries().EvaluateQueuedDynamicUserGroups(ctx)
+			return dynamicQueueBatch{count: r.EvaluatedCount, more: r.More}, err
+		})
+	}
+
+	go func() {
+		// Run immediately on startup to process any groups queued during downtime
+		evalGroups()
+		evalUserGroups()
+
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				evalGroups()
+				evalUserGroups()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Periodic full re-evaluation as a safety net (every 24h).
+	// Queues all dynamic groups for evaluation; the worker above drains them.
+	go runPeriodic(ctx, 24*time.Hour, func() {
+		if err := st.Queries().QueueAllDynamicGroups(ctx); err != nil {
+			logger.Error("failed to queue full dynamic group re-evaluation", "error", err)
+		} else {
+			logger.Info("queued full dynamic group re-evaluation")
+		}
+	}, false)
+}
+
+// startStaleExecutionExpiry launches a 1-minute ticker that lists
+// executions stuck in pending/dispatched past their deadline and emits
+// ExecutionTimedOut events for each. The 1-minute cadence is fixed —
+// there's no operator knob today and the prior inline goroutine in
+// main.go didn't expose one either; this is a straight extraction.
+func startStaleExecutionExpiry(ctx context.Context, st *store.Store, logger *slog.Logger) {
+	go func() {
+		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				stale, err := st.Queries().ListStaleExecutions(ctx)
+				if err != nil {
+					logger.Error("failed to list stale executions", "error", err)
+					continue
+				}
+				for _, exec := range stale {
+					errMsg := fmt.Sprintf("execution timed out: device did not respond (status was %s)", exec.Status)
+					completedAt := time.Now().UTC().Format(time.RFC3339Nano)
+					if err := st.AppendEvent(ctx, store.Event{
+						StreamType: "execution",
+						StreamID:   exec.ID,
+						EventType:  string(eventtypes.ExecutionTimedOut),
+						Data: payloads.ExecutionTimedOut{
+							Error:       &errMsg,
+							CompletedAt: &completedAt,
+						},
+						ActorType: "system",
+						ActorID:   "expiry",
+					}); err != nil {
+						logger.Error("failed to expire stale execution", "error", err, "execution_id", exec.ID)
+					} else {
+						logger.Info("expired stale execution", "execution_id", exec.ID, "status", exec.Status, "device_id", exec.DeviceID)
+					}
+				}
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}

--- a/cmd/control/periodic_test.go
+++ b/cmd/control/periodic_test.go
@@ -1,0 +1,146 @@
+package main
+
+// Smoke coverage for the periodic-worker helpers extracted from main.go
+// (audit F043 / #157). These tests don't stand up a real Store —
+// they exercise the loop shapes (drainDynamicQueue's terminate-on-more=false,
+// runPeriodic's runImmediately + ctx-cancel paths) against fakes,
+// which is the part that's actually regression-prone.
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// discardLogger silences periodic-worker log output during tests so a
+// failed assertion isn't drowned in expected Info/Error lines.
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// =============================================================================
+// drainDynamicQueue
+// =============================================================================
+
+func TestDrainDynamicQueue_StopsWhenMoreFalse(t *testing.T) {
+	// The drain loop's terminate condition is the explicit `more` flag
+	// returned from the SQL function. Closes audit F035 / #168 — verify
+	// that drain stops the moment more=false, regardless of the count
+	// the last batch reported.
+	calls := []dynamicQueueBatch{
+		{count: 100, more: true},
+		{count: 100, more: true},
+		{count: 50, more: false}, // partial batch but more=false → must stop
+	}
+	var idx atomic.Int32
+	evalFn := func(_ context.Context) (dynamicQueueBatch, error) {
+		i := idx.Add(1) - 1
+		require.Less(t, int(i), len(calls), "drain called more times than expected")
+		return calls[i], nil
+	}
+
+	drainDynamicQueue(context.Background(), "test", discardLogger(), evalFn)
+	assert.Equal(t, int32(3), idx.Load(), "drain must run exactly 3 batches before more=false")
+}
+
+func TestDrainDynamicQueue_StopsOnError(t *testing.T) {
+	// An error must terminate the drain — busy-looping on a wedged DB
+	// would amplify backend pressure during an outage. Verify the loop
+	// exits after exactly one error.
+	var idx atomic.Int32
+	evalFn := func(_ context.Context) (dynamicQueueBatch, error) {
+		idx.Add(1)
+		return dynamicQueueBatch{}, errors.New("DB exploded")
+	}
+
+	drainDynamicQueue(context.Background(), "test", discardLogger(), evalFn)
+	assert.Equal(t, int32(1), idx.Load(), "drain must terminate after first error, not retry")
+}
+
+func TestDrainDynamicQueue_NoOpOnImmediateMoreFalse(t *testing.T) {
+	// Empty queue (count=0, more=false) — drain runs once and returns.
+	// Verifies we don't busy-loop on an idle queue.
+	var idx atomic.Int32
+	evalFn := func(_ context.Context) (dynamicQueueBatch, error) {
+		idx.Add(1)
+		return dynamicQueueBatch{count: 0, more: false}, nil
+	}
+
+	drainDynamicQueue(context.Background(), "test", discardLogger(), evalFn)
+	assert.Equal(t, int32(1), idx.Load(), "drain must call evalFn exactly once on an empty queue")
+}
+
+// =============================================================================
+// runPeriodic
+// =============================================================================
+
+func TestRunPeriodic_RunImmediatelyFiresBeforeFirstTick(t *testing.T) {
+	// runImmediately=true must invoke fn once before the ticker even
+	// starts. Used by the dynamic-group safety-net loop and the
+	// startup sweep callers — a missed startup invocation would mean
+	// the safety net only kicks in after the first 24h tick.
+	var calls atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runPeriodic(ctx, 1*time.Hour, func() { calls.Add(1) }, true)
+		close(done)
+	}()
+
+	// Give the goroutine time to fire the immediate call but not enough
+	// to reach the 1h tick. 50ms is generous on every CI box we run on
+	// and tight enough that nobody will yell about test latency.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	assert.Equal(t, int32(1), calls.Load(), "runImmediately=true must fire fn exactly once before ctx cancel")
+}
+
+func TestRunPeriodic_RunImmediatelyFalseSkipsFirstCall(t *testing.T) {
+	// runImmediately=false → fn must not fire until the first tick.
+	// The token-revocation cleanup uses this shape; firing it on boot
+	// would burn cycles on a freshly-restarted server with nothing to
+	// clean up.
+	var calls atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runPeriodic(ctx, 1*time.Hour, func() { calls.Add(1) }, false)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	assert.Equal(t, int32(0), calls.Load(), "runImmediately=false must not fire fn before first tick")
+}
+
+func TestRunPeriodic_StopsOnContextCancel(t *testing.T) {
+	// Verifies the ctx.Done() path actually returns. Without this the
+	// goroutine would leak across the server's lifetime — the periodic
+	// helpers are spawned from main() with no shutdown wait, so a
+	// blocked goroutine would survive shutdown indefinitely.
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		runPeriodic(ctx, 1*time.Hour, func() {}, false)
+		close(done)
+	}()
+
+	cancel()
+	select {
+	case <-done:
+		// happy path
+	case <-time.After(1 * time.Second):
+		t.Fatal("runPeriodic did not return within 1s of ctx cancel")
+	}
+}


### PR DESCRIPTION
## Summary
First slice of the cmd/control/main.go subsystem-builder extraction (audit F043 / #157).

Pulls the dynamic-group worker (drain loop + 24h safety-net), the stale-execution expiry loop, and the \`runPeriodic\` helper itself out of \`main()\` into a sibling \`cmd/control/periodic.go\` file.

- \`main.go\`: 1022 → 903 LOC (-119)
- New: \`cmd/control/periodic.go\` (160 LOC, +docstrings)
- New: \`cmd/control/periodic_test.go\` (146 LOC, 6 testcases)

## Why
\`main()\` is currently 826 LOC of imperative wiring and untestable in isolation. The drain loop's \`more=false\` terminate condition (closes audit F035 / #168) and the \`runPeriodic\` ctx-cancel + runImmediately paths are now exercised by direct unit tests against fakes — no test fixtures stand up a real Store / Queries.

This is **slice 1 of N**. Follow-up slices will lift the Valkey/Asynq subsystem, the HTTP server bootstrap, and the system-action wiring before main() reaches the issue's <300 LOC acceptance bar.

## No behaviour change
The extracted functions take the same \`ctx\`, \`store\`, and \`logger\` the inline goroutines did. Spawn order from \`main()\` is preserved. The dynamic-group worker still emits its \"starting / disabled\" Info line from \`main()\` (kept there because main owns the boot-time \"feature is on/off\" reporting).

## Test plan
- [x] \`go build ./...\` clean.
- [x] \`go test ./cmd/control/...\` clean (6 new tests pass).
- [x] \`go vet\` clean.
- [x] gofmt clean.
- [x] Local CR review: no findings.
- [ ] CI gate (Unit Tests + Integration Tests + gofmt/vet/staticcheck/govulncheck + CodeRabbit).

Refs manchtools/power-manage-server#157 (audit F043).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized periodic background tasks by consolidating dynamic group evaluation and stale execution expiry logic into dedicated helper functions for improved code organization.

* **Tests**
  * Added comprehensive test coverage for periodic worker operations, including validation of task scheduling, queue draining, and error handling behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/224)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->