### PR TITLE
refactor(control): extract HTTP server bootstrap (#157 slice 2)

### DIFF
--- a/cmd/control/httpserver.go
+++ b/cmd/control/httpserver.go
@@ -1,0 +1,85 @@
+// HTTP-server boot helpers extracted from main.go (audit F043 / #157,
+// slice 2). The public listener and the internal mTLS listener
+// previously inlined ~50 LOC of TLS+http2 plumbing each in main(); the
+// builders here own that plumbing so main() reads as wire-the-handlers
+// + start-the-listeners rather than wire-the-handlers + load-certs +
+// build-tls-config + configure-h2 + start-the-listeners.
+package main
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"time"
+
+	"golang.org/x/net/http2"
+
+	"github.com/manchtools/power-manage/server/internal/ca"
+)
+
+// buildPublicServer constructs the public-facing HTTP server with the
+// supplied handler, configuring TLS + HTTP/2 when cfg.TLSEnabled. Plain
+// HTTP/1.1 is used otherwise (development / behind-Traefik deployments).
+//
+// Idle/read-header timeouts are fixed (120s / 10s) — they're tuned for
+// long-poll style RPCs and a header parse window that catches slow-loris
+// without breaking the slowest legitimate client we've seen. No operator
+// knob is exposed because nobody has ever needed to tune these.
+func buildPublicServer(cfg *Config, handler http.Handler) (*http.Server, error) {
+	srv := &http.Server{
+		Addr:              cfg.ListenAddr,
+		Handler:           handler,
+		IdleTimeout:       120 * time.Second,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	if !cfg.TLSEnabled {
+		return srv, nil
+	}
+
+	cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
+	if err != nil {
+		return nil, fmt.Errorf("load public TLS key pair: %w", err)
+	}
+	srv.TLSConfig = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+	}
+	if err := http2.ConfigureServer(srv, &http2.Server{}); err != nil {
+		return nil, fmt.Errorf("configure HTTP/2 for public server: %w", err)
+	}
+	return srv, nil
+}
+
+// buildInternalServer constructs the mTLS-protected internal listener
+// the gateway connects to for InternalService RPCs. Client certs MUST
+// be presented and verified against the control's CA pool — a
+// compromised agent cert (which uses a different chain in production
+// but can race during enrollment) is rejected at the TLS layer before
+// any handler sees the request. The peer-class gate inside the handler
+// chain is a defence-in-depth on top of this.
+//
+// HTTP/2 is mandatory: Connect-RPC's bidirectional streaming uses h2
+// frames over the TLS transport.
+func buildInternalServer(cfg *Config, certAuth *ca.CA, handler http.Handler) (*http.Server, error) {
+	internalTLSCert, err := tls.LoadX509KeyPair(cfg.InternalTLSCert, cfg.InternalTLSKey)
+	if err != nil {
+		return nil, fmt.Errorf("load internal TLS key pair (cert=%s key=%s): %w", cfg.InternalTLSCert, cfg.InternalTLSKey, err)
+	}
+
+	srv := &http.Server{
+		Addr:    cfg.InternalListenAddr,
+		Handler: handler,
+		TLSConfig: &tls.Config{
+			Certificates: []tls.Certificate{internalTLSCert},
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+			ClientCAs:    certAuth.TrustPool(),
+			MinVersion:   tls.VersionTLS13,
+		},
+		IdleTimeout:       120 * time.Second,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	if err := http2.ConfigureServer(srv, &http2.Server{}); err != nil {
+		return nil, fmt.Errorf("configure HTTP/2 for internal server: %w", err)
+	}
+	return srv, nil
+}

--- a/cmd/control/httpserver_test.go
+++ b/cmd/control/httpserver_test.go
@@ -1,0 +1,160 @@
+package main
+
+// Smoke coverage for the HTTP-server boot helpers (audit F043 / #157,
+// slice 2). The builders own enough TLS plumbing that a regression in
+// the disabled→TLS branch (or the mTLS verification mode) would be
+// invisible until prod boot — tests here lock the resulting *http.Server
+// fields in place against a pair of self-signed certs generated for
+// the test only.
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/ca"
+)
+
+// writeSelfSignedCert mints an ECDSA P-256 self-signed cert + key in
+// PEM form, writes them to tmpdir, and returns the on-disk paths.
+// ECDSA keeps the test cheap (no RSA key gen) and the resulting cert
+// is enough for tls.LoadX509KeyPair to succeed.
+func writeSelfSignedCert(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tpl, tpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+
+	certPEM, err := os.Create(certPath)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(certPEM, &pem.Block{Type: "CERTIFICATE", Bytes: der}))
+	require.NoError(t, certPEM.Close())
+
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	require.NoError(t, err)
+	keyPEM, err := os.Create(keyPath)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(keyPEM, &pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}))
+	require.NoError(t, keyPEM.Close())
+
+	return certPath, keyPath
+}
+
+// =============================================================================
+// buildPublicServer
+// =============================================================================
+
+func TestBuildPublicServer_PlainHTTPWhenTLSDisabled(t *testing.T) {
+	srv, err := buildPublicServer(&Config{
+		ListenAddr: ":0",
+		TLSEnabled: false,
+	}, http.NewServeMux())
+	require.NoError(t, err)
+	require.NotNil(t, srv)
+
+	assert.Equal(t, ":0", srv.Addr)
+	assert.Nil(t, srv.TLSConfig, "TLSConfig must be nil when TLS is disabled — h1 plain serve")
+	assert.Equal(t, 120*time.Second, srv.IdleTimeout)
+	assert.Equal(t, 10*time.Second, srv.ReadHeaderTimeout)
+}
+
+func TestBuildPublicServer_TLSConfigPopulatedWhenEnabled(t *testing.T) {
+	dir := t.TempDir()
+	cert, key := writeSelfSignedCert(t, dir)
+	srv, err := buildPublicServer(&Config{
+		ListenAddr: ":0",
+		TLSEnabled: true,
+		TLSCert:    cert,
+		TLSKey:     key,
+	}, http.NewServeMux())
+	require.NoError(t, err)
+	require.NotNil(t, srv.TLSConfig)
+	assert.Equal(t, uint16(tls.VersionTLS13), srv.TLSConfig.MinVersion,
+		"public TLS must pin TLS 1.3 — older TLS is rejected at the listener for compliance")
+	assert.Len(t, srv.TLSConfig.Certificates, 1)
+}
+
+func TestBuildPublicServer_BadCertReturnsErrorNotPanic(t *testing.T) {
+	// A misconfigured cert path (operator typo) MUST surface as an
+	// error so main() can log + exit cleanly. The prior shape called
+	// log.Fatal — equally safe but harder to test; the helper now
+	// returns the error so a unit test can exercise this branch.
+	_, err := buildPublicServer(&Config{
+		ListenAddr: ":0",
+		TLSEnabled: true,
+		TLSCert:    "/nonexistent/cert.pem",
+		TLSKey:     "/nonexistent/key.pem",
+	}, http.NewServeMux())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "load public TLS key pair",
+		"error must be wrapped with the source phase so the operator-facing log line points at the right config knob")
+}
+
+// =============================================================================
+// buildInternalServer
+// =============================================================================
+
+func TestBuildInternalServer_RequiresClientCertVerification(t *testing.T) {
+	// The mTLS contract is the entire reason this listener exists —
+	// the gateway proves identity via its CA-signed client cert. If
+	// ClientAuth ever drifts from RequireAndVerifyClientCert, every
+	// credential-bearing proxy call (LUKS keys, LPS passwords) becomes
+	// reachable from any TLS client. Lock it.
+	dir := t.TempDir()
+	cert, key := writeSelfSignedCert(t, dir)
+	authority, err := ca.New(cert, key, 1*time.Hour)
+	require.NoError(t, err)
+
+	srv, err := buildInternalServer(&Config{
+		InternalListenAddr: ":0",
+		InternalTLSCert:    cert,
+		InternalTLSKey:     key,
+	}, authority, http.NewServeMux())
+	require.NoError(t, err)
+	require.NotNil(t, srv.TLSConfig)
+	assert.Equal(t, tls.RequireAndVerifyClientCert, srv.TLSConfig.ClientAuth,
+		"internal mTLS listener MUST require + verify client certs — the entire trust model depends on this")
+	assert.NotNil(t, srv.TLSConfig.ClientCAs, "ClientCAs must be wired from the CA TrustPool")
+	assert.Equal(t, uint16(tls.VersionTLS13), srv.TLSConfig.MinVersion)
+	assert.Len(t, srv.TLSConfig.Certificates, 1)
+}
+
+func TestBuildInternalServer_BadCertReturnsErrorNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	cert, key := writeSelfSignedCert(t, dir)
+	authority, err := ca.New(cert, key, 1*time.Hour)
+	require.NoError(t, err)
+
+	_, err = buildInternalServer(&Config{
+		InternalListenAddr: ":0",
+		InternalTLSCert:    "/nonexistent/cert.pem",
+		InternalTLSKey:     "/nonexistent/key.pem",
+	}, authority, http.NewServeMux())
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "load internal TLS key pair")
+}

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/oklog/ulid/v2"
 	"github.com/redis/go-redis/v9"
-	"golang.org/x/net/http2"
 
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage/sdk/go/logging"
@@ -594,28 +593,10 @@ func main() {
 	corsHandler := middleware.CORS(cfg.CORSOrigins, cfg.CORSAllowAll, logger)(mux)
 	securedHandler := middleware.RequestID(middleware.SecurityHeaders(corsHandler))
 
-	server := &http.Server{
-		Addr:              cfg.ListenAddr,
-		Handler:           securedHandler,
-		IdleTimeout:       120 * time.Second,
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-
-	// Configure TLS for public listener if enabled
-	if cfg.TLSEnabled {
-		cert, err := tls.LoadX509KeyPair(cfg.TLSCert, cfg.TLSKey)
-		if err != nil {
-			logger.Error("failed to load public TLS certificate", "error", err)
-			os.Exit(1)
-		}
-		server.TLSConfig = &tls.Config{
-			Certificates: []tls.Certificate{cert},
-			MinVersion:   tls.VersionTLS13,
-		}
-		if err := http2.ConfigureServer(server, &http2.Server{}); err != nil {
-			logger.Error("failed to configure HTTP/2 for public server", "error", err)
-			os.Exit(1)
-		}
+	server, err := buildPublicServer(cfg, securedHandler)
+	if err != nil {
+		logger.Error("failed to build public server", "error", err)
+		os.Exit(1)
 	}
 
 	// Add health check endpoint.
@@ -654,30 +635,9 @@ func main() {
 		_, _ = w.Write([]byte("ok"))
 	})
 
-	internalTLSCert, err := tls.LoadX509KeyPair(cfg.InternalTLSCert, cfg.InternalTLSKey)
+	internalServer, err := buildInternalServer(cfg, certAuth, internalMux)
 	if err != nil {
-		logger.Error("failed to load internal TLS certificate", "error", err, "cert", cfg.InternalTLSCert, "key", cfg.InternalTLSKey)
-		os.Exit(1)
-	}
-
-	internalCAPool := certAuth.TrustPool()
-
-	internalTLSConfig := &tls.Config{
-		Certificates: []tls.Certificate{internalTLSCert},
-		ClientAuth:   tls.RequireAndVerifyClientCert,
-		ClientCAs:    internalCAPool,
-		MinVersion:   tls.VersionTLS13,
-	}
-
-	internalServer := &http.Server{
-		Addr:              cfg.InternalListenAddr,
-		Handler:           internalMux,
-		TLSConfig:         internalTLSConfig,
-		IdleTimeout:       120 * time.Second,
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-	if err := http2.ConfigureServer(internalServer, &http2.Server{}); err != nil {
-		logger.Error("failed to configure HTTP/2 for internal server", "error", err)
+		logger.Error("failed to build internal mTLS server", "error", err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary
Second slice of the cmd/control/main.go subsystem-builder extraction (audit F043 / #157, follow-up to #224).

Pulls the public + internal HTTP server construction (TLS load, http2.ConfigureServer, mTLS ClientAuth wiring) out of \`main()\` into a sibling \`cmd/control/httpserver.go\` file.

- \`main.go\`: 903 → 863 LOC (-40, cumulative -159 from baseline 1022)
- New: \`cmd/control/httpserver.go\` (85 LOC)
- New: \`cmd/control/httpserver_test.go\` (160 LOC, 5 testcases)

## Why
The mTLS contract — \`RequireAndVerifyClientCert\`, \`ClientCAs\` from CA \`TrustPool()\`, MinVersion TLS 1.3 — is the entire credential-bearing trust model for InternalService. Locking it under a unit test stops a future drift toward \`RequestClientCert\` from slipping past code review unnoticed. Both builders now return errors instead of \`log.Fatal\`-ing inline so the error path is testable and \`main()\`'s shape stays linear (build → run).

## Test plan
- [x] \`go build ./...\` clean.
- [x] \`go test ./cmd/control/...\` clean (5 new tests pass).
- [x] \`go vet\` clean.
- [x] gofmt clean.
- [x] Local CR review: no findings.
- [ ] CI gate (Unit Tests + Integration Tests + gofmt/vet/staticcheck/govulncheck + CodeRabbit).

Refs manchtools/power-manage-server#157 (audit F043). More slices to follow before \`main()\` reaches the issue's <300 LOC acceptance bar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for HTTP server initialization, TLS configuration validation, mTLS client certificate verification, and error handling for misconfigured certificates.

* **Refactor**
  * Improved code organization by extracting HTTP server startup logic into dedicated helper functions, enhancing maintainability and reducing initialization complexity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/225)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->