### PR TITLE
refactor(scim): extract user-flow sync + patch + helpers (#149 slice 2)

### DIFF
--- a/internal/scim/users.go
+++ b/internal/scim/users.go
@@ -2,28 +2,22 @@ package scim
 
 import (
 	"context"
-	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
-	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/oklog/ulid/v2"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
-func newULID() string {
-	entropy := ulid.Monotonic(rand.Reader, 0)
-	return ulid.MustNew(ulid.Timestamp(time.Now()), entropy).String()
-}
+// newULID + Linux-username derivation + sync/patch helpers all live
+// in users_helpers.go. SCIM-resource shapers live in users_translation.go.
 
 // listUsers handles GET /scim/v2/{slug}/Users
 func (h *Handler) listUsers(w http.ResponseWriter, r *http.Request) {
@@ -897,210 +891,7 @@ func (h *Handler) deleteUser(w http.ResponseWriter, r *http.Request) {
 // SCIM user-resource shapers (userToSCIM, userRowToSCIM, etc.) +
 // safeNameField live in users_translation.go.
 
-// syncUserFromSCIM syncs email, active status, profile, and identity link data from SCIM.
-// SCIM is treated as the source of truth — any differences are overwritten.
-func (h *Handler) syncUserFromSCIM(ctx context.Context, provider db.IdentityProvidersProjection, userID, email string, active *bool, name *SCIMName) {
-	user, err := h.store.Queries().GetUserByID(ctx, userID)
-	if err != nil {
-		h.logger.Error("failed to get user for SCIM sync", "user_id", userID, "error", err)
-		return
-	}
-
-	// Sync email
-	if email != "" && email != user.Email {
-		h.appendEvent(ctx, store.Event{
-			StreamType: "user",
-			StreamID:   userID,
-			EventType:  string(eventtypes.UserEmailChanged),
-			Data:       map[string]any{"email": email},
-			ActorType:  "scim",
-			ActorID:    provider.ID,
-		})
-	}
-
-	// Sync active status (nil = not provided, default to true per SCIM RFC 7643)
-	isActive := active == nil || *active
-	if !isActive && !user.Disabled {
-		h.appendEvent(ctx, store.Event{
-			StreamType: "user",
-			StreamID:   userID,
-			EventType:  string(eventtypes.UserDisabled),
-			Data:       map[string]any{},
-			ActorType:  "scim",
-			ActorID:    provider.ID,
-		})
-	} else if isActive && user.Disabled {
-		h.appendEvent(ctx, store.Event{
-			StreamType: "user",
-			StreamID:   userID,
-			EventType:  string(eventtypes.UserEnabled),
-			Data:       map[string]any{},
-			ActorType:  "scim",
-			ActorID:    provider.ID,
-		})
-	}
-
-	// Sync profile fields (display_name, given_name, family_name)
-	newDisplayName := formatExternalName(name)
-	newGivenName := safeNameField(name, "given")
-	newFamilyName := safeNameField(name, "family")
-	if newDisplayName != "" || newGivenName != "" || newFamilyName != "" {
-		h.appendEvent(ctx, store.Event{
-			StreamType: "user",
-			StreamID:   userID,
-			EventType:  string(eventtypes.UserProfileUpdated),
-			Data: map[string]any{
-				"display_name": newDisplayName,
-				"given_name":   newGivenName,
-				"family_name":  newFamilyName,
-			},
-			ActorType: "scim",
-			ActorID:   provider.ID,
-		})
-	}
-
-	// Sync identity link (external_email + external_name)
-	h.syncIdentityLink(ctx, provider, userID, email, name)
-}
-
-// syncIdentityLink updates the identity link's external_email and external_name
-// to reflect the latest data from the SCIM provider (source of truth).
-func (h *Handler) syncIdentityLink(ctx context.Context, provider db.IdentityProvidersProjection, userID, email string, name *SCIMName) {
-	link, err := h.store.Queries().GetIdentityLinkByProviderAndUser(ctx, db.GetIdentityLinkByProviderAndUserParams{
-		ProviderID: provider.ID,
-		UserID:     userID,
-	})
-	if err != nil {
-		h.logger.Error("failed to get identity link for SCIM sync", "user_id", userID, "provider_id", provider.ID, "error", err)
-		return
-	}
-
-	h.appendEvent(ctx, store.Event{
-		StreamType: "identity_provider",
-		StreamID:   link.ID,
-		EventType:  string(eventtypes.IdentityLinkLoginUpdated),
-		Data: map[string]any{
-			"provider_id":    provider.ID,
-			"external_id":    link.ExternalID,
-			"external_email": email,
-			"external_name":  formatExternalName(name),
-		},
-		ActorType: "scim",
-		ActorID:   provider.ID,
-	})
-}
-
-// extractNameFromPatchOps scans PATCH operations for name-related changes and
-// returns a SCIMName if any were found, or nil if none.
-func extractNameFromPatchOps(ops []SCIMPatchOp) *SCIMName {
-	var name SCIMName
-	found := false
-
-	for _, op := range ops {
-		if op.Op.Normalize() != SCIMPatchOpReplace {
-			continue
-		}
-		path := strings.ToLower(op.Path)
-
-		switch path {
-		case "name":
-			// Value is a name object
-			if m, ok := op.Value.(map[string]any); ok {
-				if v, ok := m["givenName"].(string); ok {
-					name.GivenName = v
-					found = true
-				}
-				if v, ok := m["familyName"].(string); ok {
-					name.FamilyName = v
-					found = true
-				}
-				if v, ok := m["formatted"].(string); ok {
-					name.Formatted = v
-					found = true
-				}
-			}
-		case "name.givenname":
-			if v, ok := op.Value.(string); ok {
-				name.GivenName = v
-				found = true
-			}
-		case "name.familyname":
-			if v, ok := op.Value.(string); ok {
-				name.FamilyName = v
-				found = true
-			}
-		case "name.formatted":
-			if v, ok := op.Value.(string); ok {
-				name.Formatted = v
-				found = true
-			}
-		}
-	}
-
-	if !found {
-		return nil
-	}
-	return &name
-}
-
-// formatExternalName extracts a display name from SCIM name fields.
-func formatExternalName(name *SCIMName) string {
-	if name == nil {
-		return ""
-	}
-	if name.Formatted != "" {
-		return name.Formatted
-	}
-	parts := []string{}
-	if name.GivenName != "" {
-		parts = append(parts, name.GivenName)
-	}
-	if name.FamilyName != "" {
-		parts = append(parts, name.FamilyName)
-	}
-	return strings.Join(parts, " ")
-}
-
-// verifyProviderOwnership checks that the user has an identity link to the
-// given SCIM provider. This prevents one provider from accessing or modifying
-// users provisioned by a different provider.
-func (h *Handler) verifyProviderOwnership(ctx context.Context, providerID, userID string) error {
-	_, err := h.store.Queries().GetIdentityLinkByProviderAndUser(ctx, db.GetIdentityLinkByProviderAndUserParams{
-		ProviderID: providerID,
-		UserID:     userID,
-	})
-	return err
-}
-
-// baseURLFromRequest constructs the SCIM base URL from the request.
-func baseURLFromRequest(r *http.Request, slug string) string {
-	scheme := "https"
-	if r.TLS == nil {
-		if fwd := r.Header.Get("X-Forwarded-Proto"); fwd == "https" || fwd == "http" {
-			scheme = fwd
-		} else {
-			scheme = "http"
-		}
-	}
-	return fmt.Sprintf("%s://%s/scim/v2/%s", scheme, r.Host, slug)
-}
-
-var linuxUsernameSanitizeRe = regexp.MustCompile(`[^a-z0-9_.\-]`)
-
-func deriveLinuxUsername(email, preferredUsername string) string {
-	var username string
-	switch {
-	case preferredUsername != "":
-		username = preferredUsername
-	case strings.Contains(email, "@"):
-		username = email[:strings.Index(email, "@")]
-	default:
-		username = email
-	}
-	username = strings.ToLower(username)
-	username = linuxUsernameSanitizeRe.ReplaceAllString(username, "_")
-	if len(username) > 32 {
-		username = username[:32]
-	}
-	return username
-}
+// SCIM user sync helpers (syncUserFromSCIM, syncIdentityLink),
+// patch-op extractors (extractNameFromPatchOps, formatExternalName),
+// provider-ownership guard, request-shape helpers, and Linux-username
+// derivation live in users_helpers.go.

--- a/internal/scim/users_helpers.go
+++ b/internal/scim/users_helpers.go
@@ -1,0 +1,244 @@
+// SCIM user-flow helpers extracted from users.go (audit F009 / #149,
+// slice 2). Keeps users.go focused on the per-RPC HTTP handlers
+// (list / get / create / replace / patch / delete) by lifting the
+// support functions they share — sync helpers, patch-op extractors,
+// linux-username derivation, and small request-shape helpers — into
+// this sibling file.
+package scim
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// newULID returns a monotonic-clock ULID string. Used for new event
+// stream IDs that the SCIM handlers append.
+func newULID() string {
+	entropy := ulid.Monotonic(rand.Reader, 0)
+	return ulid.MustNew(ulid.Timestamp(time.Now()), entropy).String()
+}
+
+// syncUserFromSCIM syncs email, active status, profile, and identity link data from SCIM.
+// SCIM is treated as the source of truth — any differences are overwritten.
+func (h *Handler) syncUserFromSCIM(ctx context.Context, provider db.IdentityProvidersProjection, userID, email string, active *bool, name *SCIMName) {
+	user, err := h.store.Queries().GetUserByID(ctx, userID)
+	if err != nil {
+		h.logger.Error("failed to get user for SCIM sync", "user_id", userID, "error", err)
+		return
+	}
+
+	// Sync email
+	if email != "" && email != user.Email {
+		h.appendEvent(ctx, store.Event{
+			StreamType: "user",
+			StreamID:   userID,
+			EventType:  string(eventtypes.UserEmailChanged),
+			Data:       map[string]any{"email": email},
+			ActorType:  "scim",
+			ActorID:    provider.ID,
+		})
+	}
+
+	// Sync active status (nil = not provided, default to true per SCIM RFC 7643)
+	isActive := active == nil || *active
+	if !isActive && !user.Disabled {
+		h.appendEvent(ctx, store.Event{
+			StreamType: "user",
+			StreamID:   userID,
+			EventType:  string(eventtypes.UserDisabled),
+			Data:       map[string]any{},
+			ActorType:  "scim",
+			ActorID:    provider.ID,
+		})
+	} else if isActive && user.Disabled {
+		h.appendEvent(ctx, store.Event{
+			StreamType: "user",
+			StreamID:   userID,
+			EventType:  string(eventtypes.UserEnabled),
+			Data:       map[string]any{},
+			ActorType:  "scim",
+			ActorID:    provider.ID,
+		})
+	}
+
+	// Sync profile fields (display_name, given_name, family_name)
+	newDisplayName := formatExternalName(name)
+	newGivenName := safeNameField(name, "given")
+	newFamilyName := safeNameField(name, "family")
+	if newDisplayName != "" || newGivenName != "" || newFamilyName != "" {
+		h.appendEvent(ctx, store.Event{
+			StreamType: "user",
+			StreamID:   userID,
+			EventType:  string(eventtypes.UserProfileUpdated),
+			Data: map[string]any{
+				"display_name": newDisplayName,
+				"given_name":   newGivenName,
+				"family_name":  newFamilyName,
+			},
+			ActorType: "scim",
+			ActorID:   provider.ID,
+		})
+	}
+
+	// Sync identity link (external_email + external_name)
+	h.syncIdentityLink(ctx, provider, userID, email, name)
+}
+
+// syncIdentityLink updates the identity link's external_email and external_name
+// to reflect the latest data from the SCIM provider (source of truth).
+func (h *Handler) syncIdentityLink(ctx context.Context, provider db.IdentityProvidersProjection, userID, email string, name *SCIMName) {
+	link, err := h.store.Queries().GetIdentityLinkByProviderAndUser(ctx, db.GetIdentityLinkByProviderAndUserParams{
+		ProviderID: provider.ID,
+		UserID:     userID,
+	})
+	if err != nil {
+		h.logger.Error("failed to get identity link for SCIM sync", "user_id", userID, "provider_id", provider.ID, "error", err)
+		return
+	}
+
+	h.appendEvent(ctx, store.Event{
+		StreamType: "identity_provider",
+		StreamID:   link.ID,
+		EventType:  string(eventtypes.IdentityLinkLoginUpdated),
+		Data: map[string]any{
+			"provider_id":    provider.ID,
+			"external_id":    link.ExternalID,
+			"external_email": email,
+			"external_name":  formatExternalName(name),
+		},
+		ActorType: "scim",
+		ActorID:   provider.ID,
+	})
+}
+
+// extractNameFromPatchOps scans PATCH operations for name-related changes and
+// returns a SCIMName if any were found, or nil if none.
+func extractNameFromPatchOps(ops []SCIMPatchOp) *SCIMName {
+	var name SCIMName
+	found := false
+
+	for _, op := range ops {
+		if op.Op.Normalize() != SCIMPatchOpReplace {
+			continue
+		}
+		path := strings.ToLower(op.Path)
+
+		switch path {
+		case "name":
+			// Value is a name object
+			if m, ok := op.Value.(map[string]any); ok {
+				if v, ok := m["givenName"].(string); ok {
+					name.GivenName = v
+					found = true
+				}
+				if v, ok := m["familyName"].(string); ok {
+					name.FamilyName = v
+					found = true
+				}
+				if v, ok := m["formatted"].(string); ok {
+					name.Formatted = v
+					found = true
+				}
+			}
+		case "name.givenname":
+			if v, ok := op.Value.(string); ok {
+				name.GivenName = v
+				found = true
+			}
+		case "name.familyname":
+			if v, ok := op.Value.(string); ok {
+				name.FamilyName = v
+				found = true
+			}
+		case "name.formatted":
+			if v, ok := op.Value.(string); ok {
+				name.Formatted = v
+				found = true
+			}
+		}
+	}
+
+	if !found {
+		return nil
+	}
+	return &name
+}
+
+// formatExternalName extracts a display name from SCIM name fields.
+func formatExternalName(name *SCIMName) string {
+	if name == nil {
+		return ""
+	}
+	if name.Formatted != "" {
+		return name.Formatted
+	}
+	parts := []string{}
+	if name.GivenName != "" {
+		parts = append(parts, name.GivenName)
+	}
+	if name.FamilyName != "" {
+		parts = append(parts, name.FamilyName)
+	}
+	return strings.Join(parts, " ")
+}
+
+// verifyProviderOwnership checks that the user has an identity link to the
+// given SCIM provider. This prevents one provider from accessing or modifying
+// users provisioned by a different provider.
+func (h *Handler) verifyProviderOwnership(ctx context.Context, providerID, userID string) error {
+	_, err := h.store.Queries().GetIdentityLinkByProviderAndUser(ctx, db.GetIdentityLinkByProviderAndUserParams{
+		ProviderID: providerID,
+		UserID:     userID,
+	})
+	return err
+}
+
+// baseURLFromRequest constructs the SCIM base URL from the request.
+func baseURLFromRequest(r *http.Request, slug string) string {
+	scheme := "https"
+	if r.TLS == nil {
+		if fwd := r.Header.Get("X-Forwarded-Proto"); fwd == "https" || fwd == "http" {
+			scheme = fwd
+		} else {
+			scheme = "http"
+		}
+	}
+	return fmt.Sprintf("%s://%s/scim/v2/%s", scheme, r.Host, slug)
+}
+
+var linuxUsernameSanitizeRe = regexp.MustCompile(`[^a-z0-9_.\-]`)
+
+// deriveLinuxUsername picks a system-username from the SCIM payload.
+// Preference order: explicit preferredUsername → email local-part →
+// the email itself. Sanitisation lowercases then replaces any
+// non-allowlisted byte with `_` (Linux useradd rejects shell-meta
+// characters in usernames). Capped at 32 bytes — the longest
+// historically-portable useradd-accepted length.
+func deriveLinuxUsername(email, preferredUsername string) string {
+	var username string
+	switch {
+	case preferredUsername != "":
+		username = preferredUsername
+	case strings.Contains(email, "@"):
+		username = email[:strings.Index(email, "@")]
+	default:
+		username = email
+	}
+	username = strings.ToLower(username)
+	username = linuxUsernameSanitizeRe.ReplaceAllString(username, "_")
+	if len(username) > 32 {
+		username = username[:32]
+	}
+	return username
+}


### PR DESCRIPTION
## Summary
Second slice of the scim/users.go decomposition (audit F009 / #149, follow-up to #231).

Lifts the per-RPC support functions out of users.go into a sibling \`users_helpers.go\` file:

- \`newULID\` (free function, top-of-file)
- \`syncUserFromSCIM\` + \`syncIdentityLink\` (sync helpers)
- \`extractNameFromPatchOps\` + \`formatExternalName\` (patch-op extractors)
- \`verifyProviderOwnership\` (provider-ownership guard)
- \`baseURLFromRequest\` (request-shape helper)
- \`linuxUsernameSanitizeRe\` + \`deriveLinuxUsername\` (Linux-username derivation)

## Size delta
- \`users.go\`: 1106 → **897 LOC (-209)**
- **Cumulative since baseline (1273 LOC): −376**
- New: \`users_helpers.go\` (250 LOC)

users.go now contains only the per-RPC HTTP handlers (list / listFiltered / get / create / replace / patch / handleUserPatchReplace / delete). Pure file-shuffling — zero behaviour change.

## Test plan
- [x] All SCIM v2 conformance tests still pass (206s integration suite)
- [x] \`go build ./...\` clean
- [x] \`go vet\` + gofmt clean
- [ ] CI gate

Refs manchtools/power-manage-server#149 (audit F009).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal identity provider integration code for improved maintainability and modularity within the SCIM user handling system.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/232)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->