### PR TITLE
fix(template): drop device-labels resolver + add DispatchAction template gate (#196)

### DIFF
--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -22,6 +22,7 @@ import (
 	"github.com/oklog/ulid/v2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api/template"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -144,6 +145,35 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 
 	default:
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "either action_id or inline_action is required")
+	}
+
+	// Templated-params gate: ad-hoc DispatchAction has no group context
+	// to resolve `{{ var.NAME }}` from (variables are exclusively a
+	// group concept; the renderer only runs on the SyncActions path
+	// where the agent's device → group memberships supply the values).
+	// Refuse here rather than enqueueing literal `{{ ... }}` markers
+	// the agent would consume verbatim.
+	//
+	// Marshals to JSON once for the scan, regardless of params shape
+	// (map[string]any from the stored branch, []byte from the inline
+	// branch, or the rare string fallback). The marshal happens again
+	// downstream for signing — a one-extra-allocation cost in exchange
+	// for one shared scan path. Marshal failure here MUST be fail-
+	// closed: a params shape we can't serialise can't be scanned for
+	// templates either, and silently bypassing the gate would let
+	// templated content through that we couldn't see. The downstream
+	// signing step would also fail on the same params, but failing
+	// here is more honest about which gate is rejecting the call.
+	paramsJSONForScan, err := json.Marshal(inputs.params)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
+			fmt.Sprintf("failed to marshal action params for template scan: %v", err))
+	}
+	if template.HasReference(string(paramsJSONForScan)) {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeFailedPrecondition,
+			"this action contains templated parameters ({{ var.NAME }}) and cannot be dispatched ad-hoc to a single device. "+
+				"Variables are resolved from device-group / user-group memberships at agent sync time. "+
+				"Assign the action to a device-group or user-group instead of running it directly.")
 	}
 
 	id := ulid.Make().String()

--- a/internal/api/dispatch_validation_test.go
+++ b/internal/api/dispatch_validation_test.go
@@ -178,6 +178,43 @@ func TestDispatchAction_PreconditionNoTaskQueue(t *testing.T) {
 	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
 }
 
+// TestDispatchAction_TemplatedParamsRefused pins the templated-params
+// gate added for #196 scope correction. Variables resolve only via
+// device-group / user-group memberships at agent SyncActions time; an
+// ad-hoc DispatchAction has no group context so the renderer can't
+// resolve `{{ var.NAME }}` references. The gate refuses with
+// CodeFailedPrecondition rather than enqueueing literal `{{ ... }}`
+// markers the agent would consume verbatim.
+func TestDispatchAction_TemplatedParamsRefused(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "templated-host")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_InlineAction{
+			InlineAction: &pm.Action{
+				Id:           &pm.ActionId{Value: testutil.NewID()},
+				Type:         pm.ActionType_ACTION_TYPE_SHELL,
+				DesiredState: pm.DesiredState_DESIRED_STATE_PRESENT,
+				Params: &pm.Action_Shell{
+					Shell: &pm.ShellParams{
+						Script: "echo {{ var.greeting }}",
+					},
+				},
+			},
+		},
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err),
+		"templated params on ad-hoc dispatch MUST surface FailedPrecondition — anything else lets literal {{ var.X }} reach the agent verbatim")
+	assert.Contains(t, err.Error(), "templated parameters",
+		"error message must explain that variables are group-only and the action should be assigned to a group instead")
+}
+
 // TestDispatchInstantAction_PreconditionNoTaskQueue pins the
 // matching fail-closed behaviour for the instant-action path.
 func TestDispatchInstantAction_PreconditionNoTaskQueue(t *testing.T) {

--- a/internal/api/template/render.go
+++ b/internal/api/template/render.go
@@ -38,8 +38,10 @@ func New(resolver Resolver) *Renderer {
 
 // Resolver supplies the variable map for a given device. The
 // production implementation lives in internal/api/template/resolver.go
-// and reads device labels + device-group + user-group variables; tests
-// substitute a static map.
+// and reads variables from the device's device-group + user-group
+// memberships (variables are exclusively a group concept; device
+// labels do NOT participate in resolution); tests substitute a
+// static map.
 type Resolver interface {
 	Resolve(ctx context.Context, deviceID string) (Variables, error)
 }
@@ -105,6 +107,18 @@ func (r *Renderer) RenderWithVars(_ context.Context, action *pmv1.Action, vars V
 // the inner name. Name grammar matches the SET-time validator in
 // internal/api/group_variables_validator.go.
 var varRefRE = regexp.MustCompile(`\{\{\s*var\.([a-z][a-z0-9_]*)\s*\}\}`)
+
+// HasReference reports whether s contains at least one `{{ var.NAME }}`
+// reference. Callers use it to gate paths that can't render templates
+// (e.g. ad-hoc one-off DispatchAction, where there is no group context
+// to resolve from). Cheap — regex with a string anchor; no allocation
+// when s contains no `{{` at all.
+func HasReference(s string) bool {
+	if !strings.Contains(s, "{{") {
+		return false
+	}
+	return varRefRE.MatchString(s)
+}
 
 // ErrUnresolvedReference is the sentinel returned when a `{{ var.X }}`
 // reference can't be matched against a variable known on the target

--- a/internal/api/template/resolver.go
+++ b/internal/api/template/resolver.go
@@ -2,14 +2,18 @@
 // renderer talks to this through the Resolver interface in render.go;
 // tests substitute a static map.
 //
-// Three precedence layers (highest → lowest): device labels →
-// device-group variables → user-group variables. Higher layers
-// shadow lower layers silently because operators routinely override
-// a group default with a device-specific value. Duplicate names
-// WITHIN the same layer (two device groups defining the same name)
-// return an error — the operator can't have intended both at once
-// and silently picking one would be a footgun at action-dispatch
-// time. See manchtools/power-manage-server#196.
+// Two precedence layers (highest → lowest): device-group variables →
+// user-group variables. Higher layers shadow lower layers silently
+// because operators routinely override a user-group default with a
+// device-group-specific value. Duplicate names WITHIN the same layer
+// (two device groups defining the same name) return an error — the
+// operator can't have intended both at once and silently picking one
+// would be a footgun at action-dispatch time.
+//
+// Variables are EXCLUSIVELY a group concept: device labels do NOT
+// participate in resolution. Labels are a separate concept (group-
+// membership filter / dynamic-group eval), not a variable source.
+// See manchtools/power-manage-server#196.
 package template
 
 import (
@@ -21,7 +25,6 @@ import (
 	pmv1 "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // StoreResolver implements Resolver against the production store.
@@ -39,7 +42,8 @@ func NewStoreResolver(st *store.Store, enc *crypto.Encryptor, logger *slog.Logge
 	return &StoreResolver{store: st, encryptor: enc, logger: logger}
 }
 
-// Resolve walks the three precedence layers for deviceID. Returns a
+// Resolve walks the two precedence layers for deviceID (user-group
+// variables first, then device-group variables on top). Returns a
 // flat name → Value map with higher layers having already overwritten
 // lower ones.
 func (r *StoreResolver) Resolve(ctx context.Context, deviceID string) (Variables, error) {
@@ -49,9 +53,6 @@ func (r *StoreResolver) Resolve(ctx context.Context, deviceID string) (Variables
 		return nil, err
 	}
 	if err := r.collectDeviceGroupVars(ctx, deviceID, out); err != nil {
-		return nil, err
-	}
-	if err := r.collectDeviceLabels(ctx, deviceID, out); err != nil {
 		return nil, err
 	}
 	return out, nil
@@ -110,34 +111,6 @@ func (r *StoreResolver) collectDeviceGroupVars(ctx context.Context, deviceID str
 			seen[name] = g.ID
 			v.DefinedIn = []string{"device_group:" + g.ID}
 			out[name] = v
-		}
-	}
-	return nil
-}
-
-// collectDeviceLabels adds the device's labels as STRING-typed
-// variables. Highest precedence layer — labels override any
-// same-named group variable. Label values are always stringified;
-// labels with names that don't match the variable grammar
-// (`[a-z][a-z0-9_]*`) are still added to the map but are
-// unreachable via the substitution regex.
-func (r *StoreResolver) collectDeviceLabels(ctx context.Context, deviceID string, out Variables) error {
-	dev, err := r.store.Queries().GetDeviceByID(ctx, db.GetDeviceByIDParams{ID: deviceID})
-	if err != nil {
-		return fmt.Errorf("read device %s: %w", deviceID, err)
-	}
-	if len(dev.Labels) == 0 {
-		return nil
-	}
-	var labels map[string]string
-	if err := json.Unmarshal(dev.Labels, &labels); err != nil {
-		return fmt.Errorf("decode labels for device %s: %w", deviceID, err)
-	}
-	for name, val := range labels {
-		out[name] = Value{
-			Type:      pmv1.VariableType_VARIABLE_TYPE_STRING,
-			Plaintext: val,
-			DefinedIn: []string{"device"},
 		}
 	}
 	return nil

--- a/internal/api/template/resolver_test.go
+++ b/internal/api/template/resolver_test.go
@@ -58,47 +58,11 @@ func TestStoreResolver_EmptyDevice_EmptyVariables(t *testing.T) {
 	assert.Empty(t, vars)
 }
 
-func TestStoreResolver_DeviceLabels_Surface(t *testing.T) {
-	st := testutil.SetupPostgres(t)
-	defer st.Close()
-
-	deviceID := testutil.CreateTestDevice(t, st, "host-labels")
-	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
-		StreamType: "device", StreamID: deviceID, EventType: "DeviceLabelSet",
-		Data:      map[string]any{"key": "env", "value": "prod"},
-		ActorType: "user", ActorID: "u",
-	}))
-
-	r := template.NewStoreResolver(st, testutil.NewEncryptor(t), slog.Default())
-	vars, err := r.Resolve(context.Background(), deviceID)
-	require.NoError(t, err)
-	require.Contains(t, vars, "env")
-	assert.Equal(t, "prod", vars["env"].Plaintext)
-	assert.Equal(t, pmv1.VariableType_VARIABLE_TYPE_STRING, vars["env"].Type)
-}
-
-func TestStoreResolver_PrecedenceLabelOverridesDeviceGroup(t *testing.T) {
-	st := testutil.SetupPostgres(t)
-	defer st.Close()
-
-	deviceID := testutil.CreateTestDevice(t, st, "host-prec")
-	groupID := testutil.CreateTestDeviceGroup(t, st, "u", "g1")
-	testutil.AddDeviceToTestGroup(t, st, "u", groupID, deviceID)
-
-	setDeviceGroupVars(t, st, groupID, []storedShape{
-		{Name: "env", Type: "string", Value: "from-group"},
-	})
-	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
-		StreamType: "device", StreamID: deviceID, EventType: "DeviceLabelSet",
-		Data:      map[string]any{"key": "env", "value": "from-label"},
-		ActorType: "user", ActorID: "u",
-	}))
-
-	r := template.NewStoreResolver(st, testutil.NewEncryptor(t), slog.Default())
-	vars, err := r.Resolve(context.Background(), deviceID)
-	require.NoError(t, err)
-	assert.Equal(t, "from-label", vars["env"].Plaintext, "device label must shadow device-group variable")
-}
+// (Removed: TestStoreResolver_DeviceLabels_Surface +
+// TestStoreResolver_PrecedenceLabelOverridesDeviceGroup. Device labels
+// do NOT participate in variable resolution any more — variables are
+// exclusively a group concept. See manchtools/power-manage-server#196
+// scope correction.)
 
 func TestStoreResolver_PrecedenceDeviceGroupOverridesUserGroup(t *testing.T) {
 	st := testutil.SetupPostgres(t)


### PR DESCRIPTION
## Summary
Two scope corrections to the group-variables feature shipped in #196.

### Drop device-labels rung from the resolver
Variables are EXCLUSIVELY a group concept (defined on device-groups + user-groups). The original implementation added a third resolver layer that read device.Labels and surfaced them as STRING-typed variables with highest precedence — that was never in scope. Device labels are a separate concept (group-membership filter / dynamic-group eval), not a variable source.

- \`internal/api/template/resolver.go\`: drop \`collectDeviceLabels\` + the call site; update doc comments to two-layer (device-group > user-group) precedence.
- \`internal/api/template/render.go\`: update Resolver doc.
- \`internal/api/template/resolver_test.go\`: drop \`TestStoreResolver_DeviceLabels_Surface\` + \`TestStoreResolver_PrecedenceLabelOverridesDeviceGroup\` (they exercised the now-removed code path).

### Add templated-params gate to DispatchAction
Ad-hoc \`DispatchAction\` has no group context to resolve \`{{ var.NAME }}\` from — the renderer only runs on the SyncActions path where the agent's device → group memberships supply the values. Without this gate, an operator who tries to run-now an action whose params contain \`{{ var.X }}\` would have those literal markers enqueued to the device verbatim. The agent would then consume them as opaque strings.

- \`internal/api/template/render.go\`: new exported \`HasReference(s)\` helper colocated with the renderer's regex (single source of truth for the \`{{ var.NAME }}\` grammar).
- \`internal/api/action_dispatch.go\`: marshal \`inputs.params\` once, scan via \`template.HasReference\`, return \`CodeFailedPrecondition\` with a clear operator message: \"this action contains templated parameters... assign it to a device-group or user-group instead of running it directly.\" Marshal failure is fail-closed (\`CodeInternal\`).
- \`internal/api/dispatch_validation_test.go\`: new \`TestDispatchAction_TemplatedParamsRefused\`.

\`DispatchToGroup\`, \`DispatchActionSet\`, \`DispatchDefinition\`, and \`DispatchToMultiple\` all funnel into \`DispatchAction\` — the single gate covers every ad-hoc dispatch path. \`DispatchInstantAction\` is parameterless (REBOOT/SYNC) and unaffected.

## Test plan
- [x] \`go build ./...\` clean.
- [x] \`go test -short ./internal/api/...\` clean (including the new test + the existing resolver tests with the two device-label tests removed).
- [x] \`go vet\` + gofmt clean.
- [x] Local CR review clean (one finding from first pass — fail-closed on marshal error — addressed).
- [ ] CI gate.

## Follow-ups
This is PR 1 of a 4-PR scope correction:
- **PR 2 (sdk)**: reshape \`ListAvailableVariablesRequest\` to take group IDs instead of \`device_id\`.
- **PR 3 (server)**: rewire the handler to the new proto + bump SDK pin.
- **PR 4 (web)**: per-group autocomplete on the action-create form + variables tab; show the \`FailedPrecondition\` error from this PR with a clear UI message.

Refs manchtools/power-manage-server#196 (scope correction).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent direct dispatch of templated actions to individual devices; users must now assign such actions to groups instead.

* **Bug Fixes**
  * Variable resolution now exclusively uses group-based variables; device labels no longer participate in variable sourcing.

* **Tests**
  * Added test coverage for templated parameter validation.
  * Removed obsolete tests related to device-label variable resolution.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/236)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->