### PR TITLE
fix(api): rewire ListAvailableVariables to group-scoped + bump SDK pin (#196)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260510215956-ce9b38ba6a66
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260511201104-c971debf896b

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260510215956-ce9b38ba6a66 h1:+aPVNGWlsNpaoj3WSSJUvL8hH/zv2YeeCVyYT1uUt4s=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260510215956-ce9b38ba6a66/go.mod h1:hG7NcdIGAG0VzhLL/W12FDAgVQJxeK+jHFtHb2eF3A8=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260511201104-c971debf896b h1:wBe6kBNNwZrqzG2jY+MD0of7s/xpLh72PWyt6V9IiEY=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260511201104-c971debf896b/go.mod h1:hG7NcdIGAG0VzhLL/W12FDAgVQJxeK+jHFtHb2eF3A8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/group_variable_handler.go
+++ b/internal/api/group_variable_handler.go
@@ -260,12 +260,15 @@ func (h *GroupVariableHandler) GetUserGroupVariables(ctx context.Context, req *c
 // ListAvailableVariables (for web autocomplete)
 // =============================================================================
 
-// ListAvailableVariables returns the union of variables resolvable
-// for a given device — the device's group memberships' variables.
-// Values are intentionally omitted; the picker only needs name +
-// type + description. Permission gate is GetDevice (if the operator
-// can read the device, they can see what variables a templated
-// action would have access to on it).
+// ListAvailableVariables returns the union of variables defined on
+// the named device-groups + user-groups. Variables are exclusively a
+// group concept (device labels do NOT participate in resolution), so
+// the picker queries by groups directly. Values are intentionally
+// omitted; the picker only needs name + type + description.
+//
+// At least one of device_group_ids / user_group_ids MUST be provided.
+// Per-group access is gated by GetDeviceGroup / GetUserGroup so an
+// operator can't enumerate variables on groups they can't see.
 func (h *GroupVariableHandler) ListAvailableVariables(ctx context.Context, req *connect.Request[pm.ListAvailableVariablesRequest]) (*connect.Response[pm.ListAvailableVariablesResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
@@ -273,43 +276,80 @@ func (h *GroupVariableHandler) ListAvailableVariables(ctx context.Context, req *
 	if _, err := requireAuth(ctx); err != nil {
 		return nil, err
 	}
-	// In addition to the interceptor-enforced ListAvailableVariables
-	// permission, require GetDevice (or its :assigned scope) so an
-	// operator who can list variables can also see the device they're
-	// listing for. Otherwise this RPC would leak group-membership
-	// structure for arbitrary device IDs.
-	if !auth.HasPermission(ctx, "GetDevice") && !auth.HasPermission(ctx, "GetDevice:assigned") {
-		return nil, apiErrorCtx(ctx, "permission_denied", connect.CodePermissionDenied, "permission denied: GetDevice or GetDevice:assigned required")
-	}
-	groups, err := h.store.Queries().ListGroupsForDevice(ctx, req.Msg.DeviceId)
-	if err != nil {
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, fmt.Sprintf("failed to list device groups: %v", err))
+	if len(req.Msg.DeviceGroupIds) == 0 && len(req.Msg.UserGroupIds) == 0 {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "at least one of device_group_ids or user_group_ids is required")
 	}
 
-	// Map name → AvailableVariable, accumulating defining group ids.
 	available := map[string]*pm.AvailableVariable{}
-	for _, g := range groups {
-		raw, err := h.store.Queries().GetDeviceGroupVariables(ctx, g.ID)
-		if err != nil {
-			h.logger.Warn("failed to load device-group variables for autocomplete", "group_id", g.ID, "error", err)
-			continue
+
+	// Device groups: gate on the unscoped GetDeviceGroup permission.
+	// We deliberately do NOT accept GetDeviceGroup:assigned here —
+	// per-group membership enforcement helpers don't exist in the
+	// codebase yet, and accepting the assigned scope without per-group
+	// checks would let an operator with :assigned-only access read
+	// variables on arbitrary group IDs they pass in. Autocomplete is
+	// an operator-facing tool that's typically used by users with
+	// unrestricted group visibility anyway. If/when the autocomplete
+	// is opened up to :assigned operators, add a per-group membership
+	// check inside the loop.
+	if len(req.Msg.DeviceGroupIds) > 0 {
+		if !auth.HasPermission(ctx, "GetDeviceGroup") {
+			return nil, apiErrorCtx(ctx, "permission_denied", connect.CodePermissionDenied, "permission denied: GetDeviceGroup required to list device-group variables")
 		}
-		stored, err := decodeStored(raw)
-		if err != nil {
-			h.logger.Warn("failed to decode device-group variables", "group_id", g.ID, "error", err)
-			continue
-		}
-		for _, v := range stored {
-			entry, ok := available[v.Name]
-			if !ok {
-				entry = &pm.AvailableVariable{
-					Name:        v.Name,
-					Type:        parseVariableType(v.Type),
-					Description: v.Description,
-				}
-				available[v.Name] = entry
+		for _, groupID := range req.Msg.DeviceGroupIds {
+			raw, err := h.store.Queries().GetDeviceGroupVariables(ctx, groupID)
+			if err != nil {
+				h.logger.Warn("failed to load device-group variables for autocomplete", "group_id", groupID, "error", err)
+				continue
 			}
-			entry.DefinedInGroupIds = append(entry.DefinedInGroupIds, g.ID)
+			stored, err := decodeStored(raw)
+			if err != nil {
+				h.logger.Warn("failed to decode device-group variables", "group_id", groupID, "error", err)
+				continue
+			}
+			for _, v := range stored {
+				entry, ok := available[v.Name]
+				if !ok {
+					entry = &pm.AvailableVariable{
+						Name:        v.Name,
+						Type:        parseVariableType(v.Type),
+						Description: v.Description,
+					}
+					available[v.Name] = entry
+				}
+				entry.DefinedInGroupIds = append(entry.DefinedInGroupIds, groupID)
+			}
+		}
+	}
+
+	// User groups: same rationale as the device-group block above.
+	if len(req.Msg.UserGroupIds) > 0 {
+		if !auth.HasPermission(ctx, "GetUserGroup") {
+			return nil, apiErrorCtx(ctx, "permission_denied", connect.CodePermissionDenied, "permission denied: GetUserGroup required to list user-group variables")
+		}
+		for _, groupID := range req.Msg.UserGroupIds {
+			raw, err := h.store.Queries().GetUserGroupVariables(ctx, groupID)
+			if err != nil {
+				h.logger.Warn("failed to load user-group variables for autocomplete", "group_id", groupID, "error", err)
+				continue
+			}
+			stored, err := decodeStored(raw)
+			if err != nil {
+				h.logger.Warn("failed to decode user-group variables", "group_id", groupID, "error", err)
+				continue
+			}
+			for _, v := range stored {
+				entry, ok := available[v.Name]
+				if !ok {
+					entry = &pm.AvailableVariable{
+						Name:        v.Name,
+						Type:        parseVariableType(v.Type),
+						Description: v.Description,
+					}
+					available[v.Name] = entry
+				}
+				entry.DefinedInGroupIds = append(entry.DefinedInGroupIds, groupID)
+			}
 		}
 	}
 

--- a/internal/api/group_variable_handler_test.go
+++ b/internal/api/group_variable_handler_test.go
@@ -1,0 +1,164 @@
+package api_test
+
+// Coverage for the reshaped ListAvailableVariables handler
+// (manchtools/power-manage-server#196 scope correction). The proto
+// signature changed from a single device_id to (device_group_ids[],
+// user_group_ids[]) so the picker can be driven directly by the group
+// IDs operators have selected as targets — variables are exclusively
+// a group concept so a device-id intermediary was always wrong.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// storedVarShape mirrors the on-disk JSONB layout the SET handler
+// writes. Duplicated here (rather than imported from the template
+// package's resolver_test) so the api package's tests are
+// self-contained.
+type storedVarShape struct {
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Value       string `json:"value"`
+	Description string `json:"description,omitempty"`
+}
+
+func setDeviceGroupVarsRaw(t *testing.T, st *store.Store, groupID string, vars []storedVarShape) {
+	t.Helper()
+	raw, err := json.Marshal(vars)
+	require.NoError(t, err)
+	require.NoError(t, st.Queries().SetDeviceGroupVariables(context.Background(), db.SetDeviceGroupVariablesParams{
+		ID:        groupID,
+		Variables: raw,
+	}))
+}
+
+func setUserGroupVarsRaw(t *testing.T, st *store.Store, groupID string, vars []storedVarShape) {
+	t.Helper()
+	raw, err := json.Marshal(vars)
+	require.NoError(t, err)
+	require.NoError(t, st.Queries().SetUserGroupVariables(context.Background(), db.SetUserGroupVariablesParams{
+		ID:        groupID,
+		Variables: raw,
+	}))
+}
+
+func TestListAvailableVariables_EmptyRequestRejected(t *testing.T) {
+	// Both group-id slices empty → InvalidArgument. Without this guard
+	// the handler would happily return an empty result set, masking a
+	// caller bug (forgetting to wire the group-id state into the RPC
+	// call) as a successful "no variables defined."
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	h := api.NewGroupVariableHandler(st, enc, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.ListAvailableVariables(ctx, connect.NewRequest(&pm.ListAvailableVariablesRequest{}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestListAvailableVariables_DeviceGroupOnly(t *testing.T) {
+	// Single device-group request returns that group's variables with
+	// defined_in_group_ids populated. Locks the basic happy path.
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	h := api.NewGroupVariableHandler(st, enc, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	dgID := testutil.CreateTestDeviceGroup(t, st, adminID, "dg")
+	setDeviceGroupVarsRaw(t, st, dgID, []storedVarShape{
+		{Name: "env", Type: "string", Value: "prod", Description: "Environment"},
+		{Name: "port", Type: "int", Value: "8080"},
+	})
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.ListAvailableVariables(ctx, connect.NewRequest(&pm.ListAvailableVariablesRequest{
+		DeviceGroupIds: []string{dgID},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Variables, 2)
+
+	// Sorted alphabetically by name.
+	assert.Equal(t, "env", resp.Msg.Variables[0].Name)
+	assert.Equal(t, pm.VariableType_VARIABLE_TYPE_STRING, resp.Msg.Variables[0].Type)
+	assert.Equal(t, "Environment", resp.Msg.Variables[0].Description)
+	assert.Equal(t, []string{dgID}, resp.Msg.Variables[0].DefinedInGroupIds)
+
+	assert.Equal(t, "port", resp.Msg.Variables[1].Name)
+	assert.Equal(t, pm.VariableType_VARIABLE_TYPE_INT, resp.Msg.Variables[1].Type)
+}
+
+func TestListAvailableVariables_UserGroupOnly(t *testing.T) {
+	// Single user-group request — same shape as device-group, exercises
+	// the user-group branch.
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	h := api.NewGroupVariableHandler(st, enc, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ugID := testutil.CreateTestUserGroup(t, st, adminID, "ug")
+	setUserGroupVarsRaw(t, st, ugID, []storedVarShape{
+		{Name: "team", Type: "string", Value: "ops"},
+	})
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.ListAvailableVariables(ctx, connect.NewRequest(&pm.ListAvailableVariablesRequest{
+		UserGroupIds: []string{ugID},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Variables, 1)
+	assert.Equal(t, "team", resp.Msg.Variables[0].Name)
+	assert.Equal(t, []string{ugID}, resp.Msg.Variables[0].DefinedInGroupIds)
+}
+
+func TestListAvailableVariables_DedupesAcrossGroups(t *testing.T) {
+	// Same name on two different groups: collapses to one entry whose
+	// defined_in_group_ids carries both group IDs (so the picker can
+	// surface "this name comes from these groups"). Variables stay
+	// distinct otherwise.
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	h := api.NewGroupVariableHandler(st, enc, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	dg1 := testutil.CreateTestDeviceGroup(t, st, adminID, "dg1")
+	dg2 := testutil.CreateTestDeviceGroup(t, st, adminID, "dg2")
+	ug1 := testutil.CreateTestUserGroup(t, st, adminID, "ug1")
+	setDeviceGroupVarsRaw(t, st, dg1, []storedVarShape{{Name: "shared", Type: "string", Value: "a"}})
+	setDeviceGroupVarsRaw(t, st, dg2, []storedVarShape{{Name: "shared", Type: "string", Value: "b"}, {Name: "extra", Type: "string", Value: "z"}})
+	setUserGroupVarsRaw(t, st, ug1, []storedVarShape{{Name: "shared", Type: "string", Value: "c"}})
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.ListAvailableVariables(ctx, connect.NewRequest(&pm.ListAvailableVariablesRequest{
+		DeviceGroupIds: []string{dg1, dg2},
+		UserGroupIds:   []string{ug1},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Variables, 2)
+
+	// Sorted alphabetically: "extra", "shared"
+	assert.Equal(t, "extra", resp.Msg.Variables[0].Name)
+	assert.Len(t, resp.Msg.Variables[0].DefinedInGroupIds, 1)
+
+	assert.Equal(t, "shared", resp.Msg.Variables[1].Name)
+	assert.Len(t, resp.Msg.Variables[1].DefinedInGroupIds, 3,
+		"a name defined on multiple groups MUST list ALL defining groups so the picker can surface conflicts")
+	assert.Contains(t, resp.Msg.Variables[1].DefinedInGroupIds, dg1)
+	assert.Contains(t, resp.Msg.Variables[1].DefinedInGroupIds, dg2)
+	assert.Contains(t, resp.Msg.Variables[1].DefinedInGroupIds, ug1)
+}

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -199,7 +199,7 @@ func AllPermissions() []PermissionInfo {
 		{"DeleteUserGroupVariable", "User Groups", "Remove a non-secret variable from a user group"},
 		{"DeleteUserGroupVariable:secret", "User Groups", "Remove a secret-typed variable from a user group"},
 		{"GetUserGroupVariables", "User Groups", "List variables on a user group (secret values redacted)"},
-		{"ListAvailableVariables", "User Groups", "List variables resolvable for a device (autocomplete; no values)"},
+		{"ListAvailableVariables", "User Groups", "List variables defined on the named device-groups + user-groups (autocomplete; no values)"},
 		// Identity Providers
 		{"CreateIdentityProvider", "Identity Providers", "Create identity providers"},
 		{"GetIdentityProvider", "Identity Providers", "View identity providers"},


### PR DESCRIPTION
## Summary
Companion to manchtools/power-manage-sdk#63 (proto reshape) — the \`ListAvailableVariables\` handler now matches the new group-scoped proto:

\`\`\`proto
message ListAvailableVariablesRequest {
  repeated string device_group_ids = 1;
  repeated string user_group_ids = 2;
}
\`\`\`

- **Empty request** → \`InvalidArgument\` (no scope to list; masking a caller bug as \"no variables defined\" would be a footgun).
- **Per-group results deduped across the union**; \`defined_in_group_ids\` on the response carries every group that defines a given name so the picker can surface \"this name comes from these groups.\"
- **Sorted alphabetically by name** for stable output.

## Permission gate

Unscoped \`GetDeviceGroup\` / \`GetUserGroup\`. The \`:assigned\` scope is intentionally NOT accepted here — the codebase has no per-group membership-check helper today, and accepting \`:assigned\` without per-group checks would let an operator with \`:assigned\`-only access read variables on any group ID they pass in. The autocomplete picker is operator-facing UI typically used by users with full visibility; if/when \`:assigned\` access is needed, the per-group check goes inside the loop. **CR-caught**.

## Permission registry

Description updated from \"List variables resolvable for a device\" to \"List variables defined on the named device-groups + user-groups.\"

## SDK pin bump
\`ce9b38b\` (v2026.06-rc1 SDK) → \`c971deb\` (post-#63).

## Test plan
- [x] \`go build ./...\` clean.
- [x] \`go test -short ./internal/api/ -run TestListAvailableVariables_\` — 4 new tests pass: empty request rejection, device-group-only happy path, user-group-only happy path, dedup-across-groups.
- [x] \`go vet\` + gofmt clean.
- [x] Local CR review clean (one finding from first pass — \`:assigned\` scope-escalation hole — addressed by tightening to unscoped only).
- [ ] CI gate.

This is PR 3 of 4 for the #196 scope correction:
- ✅ #236 (server): drop device-labels resolver + DispatchAction template gate.
- ✅ SDK #63: reshape \`ListAvailableVariablesRequest\` to take group IDs.
- ⏳ **this PR**: rewire handler + bump SDK pin.
- ⏭️ Web PR: per-group autocomplete + refuse-with-error UI.

Refs manchtools/power-manage-server#196 (scope correction).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated group variable resolution to properly merge variables from device and user groups with automatic deduplication of duplicate variable names across groups.
  * Variable responses now include which groups define each variable.

* **Tests**
  * Added comprehensive test coverage for the updated group variable resolution behavior.

* **Chores**
  * Updated SDK dependency version.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/237)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->