### PR TITLE
fix(auth): tighten + extend rate-limit middleware (#142, #145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,13 +417,17 @@ The full permission catalog lives in `internal/auth/permissions.go`; the interce
 
 ### Rate Limiting (`internal/auth/ratelimit.go`)
 
-Sliding-window rate limiter keyed by IP address. Current configured limits in `cmd/control/main.go`:
+Sliding-window rate limiter keyed by IP address. Current per-procedure-family limits in `cmd/control/main.go` (audit F036 — closes [#142](https://github.com/manchtools/power-manage-server/issues/142) + [#145](https://github.com/manchtools/power-manage-server/issues/145)):
 
-- Login: 1000 attempts per minute
-- RefreshToken: 1000 attempts per minute
-- Register: 1000 attempts per minute
+| Limiter | Procedures gated | Limit | Rationale |
+|---|---|---|---|
+| `Login` | `Login`, `VerifyLoginTOTP`, `SSOCallback` | 10 / min / IP | credential-spray defense; all three RPCs share one budget — they're all auth-attempt vectors |
+| `Refresh` | `RefreshToken` | 60 / min / IP | legitimate refreshes are frequent; budget large enough for normal use |
+| `Register` | `Register` | 5 / min / IP | registration spam protection |
+| `Logout` | `Logout` | 30 / min / IP | legitimate ceiling for multi-session logout (a real user might log out of several sessions sequentially) |
+| `RenewCert` | `RenewCertificate` | 5 / min / IP | cert rotation happens at 80% of cert lifetime, not in a tight loop; CA signing is the limiting resource |
 
-These values are deliberately loose (operator-friendly defaults that stop pathological retry loops without rejecting legitimate clients). Tightening to credential-spray-resistant values is tracked separately — see [#142](https://github.com/manchtools/power-manage-server/issues/142) (rate-limit gaps on Logout / RenewCertificate) and [#145](https://github.com/manchtools/power-manage-server/issues/145) (Login / Register tightening, audit F036).
+`PublicProcedures` lists `Logout` + `RenewCertificate` alongside the auth flows — both bypass the access-token check, so the rate-limiter is the only spray defense in front of them.
 
 Background goroutine cleans up stale entries every 5 minutes.
 

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -231,13 +231,24 @@ func main() {
 	}
 	defer valkey.Close()
 
-	loginLimiter := auth.NewRateLimiter(1000, 1*time.Minute)
-	refreshLimiter := auth.NewRateLimiter(1000, 1*time.Minute)
-	registerLimiter := auth.NewRateLimiter(1000, 1*time.Minute)
+	// Per-procedure rate limits (audit F036 / #145 / #142). Shared
+	// limiters keyed by client IP; a determined attacker behind many
+	// IPs can rotate sources but the per-procedure ceiling is tight
+	// enough that any single IP is locked out of credential-spray
+	// patterns within seconds. Login + VerifyLoginTOTP + SSOCallback
+	// share one limiter — they're all auth-attempt vectors that a
+	// defender treats as one logical "attempt" per IP.
+	rateLimiters := auth.RateLimiters{
+		Login:     auth.NewRateLimiter(10, 1*time.Minute), // credential-spray defense
+		Refresh:   auth.NewRateLimiter(60, 1*time.Minute), // legitimate refreshes are frequent
+		Register:  auth.NewRateLimiter(5, 1*time.Minute),  // registration spam protection
+		Logout:    auth.NewRateLimiter(30, 1*time.Minute), // legitimate multi-session logout ceiling
+		RenewCert: auth.NewRateLimiter(5, 1*time.Minute),  // cert rotation = once/lifetime, not in tight loop
+	}
 
 	interceptors := connect.WithInterceptors(
 		api.NewLoggingInterceptor(logger),
-		auth.NewAuthInterceptor(logger, jwtManager, loginLimiter, refreshLimiter, registerLimiter),
+		auth.NewAuthInterceptor(logger, jwtManager, rateLimiters),
 		auth.NewAuthzInterceptor(),
 	)
 

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -113,18 +113,36 @@ func clientIP(req connect.AnyRequest) string {
 	return peerIP
 }
 
+// RateLimiters bundles the per-procedure-family rate limiters the
+// AuthInterceptor consults. nil fields disable the corresponding gate.
+// The split lets each family carry a different ceiling: Login is a
+// credential-spray vector and gets the tightest budget; RefreshToken
+// has the loosest because legitimate clients refresh frequently.
+//
+// Procedure → field mapping (see WrapUnary):
+//   - Login / VerifyLoginTOTP / SSOCallback → Login
+//   - RefreshToken                          → Refresh
+//   - Register                              → Register
+//   - Logout                                → Logout
+//   - RenewCertificate                      → RenewCert
+type RateLimiters struct {
+	Login     *RateLimiter
+	Refresh   *RateLimiter
+	Register  *RateLimiter
+	Logout    *RateLimiter
+	RenewCert *RateLimiter
+}
+
 // AuthInterceptor provides Connect-RPC authentication interceptor.
 type AuthInterceptor struct {
-	logger          *slog.Logger
-	jwtManager      *JWTManager
-	loginLimiter    *RateLimiter
-	refreshLimiter  *RateLimiter
-	registerLimiter *RateLimiter
+	logger     *slog.Logger
+	jwtManager *JWTManager
+	limiters   RateLimiters
 }
 
 // NewAuthInterceptor creates a new authentication interceptor.
-func NewAuthInterceptor(logger *slog.Logger, jwtManager *JWTManager, loginLimiter, refreshLimiter, registerLimiter *RateLimiter) *AuthInterceptor {
-	return &AuthInterceptor{logger: logger, jwtManager: jwtManager, loginLimiter: loginLimiter, refreshLimiter: refreshLimiter, registerLimiter: registerLimiter}
+func NewAuthInterceptor(logger *slog.Logger, jwtManager *JWTManager, limiters RateLimiters) *AuthInterceptor {
+	return &AuthInterceptor{logger: logger, jwtManager: jwtManager, limiters: limiters}
 }
 
 // WrapUnary implements connect.Interceptor.
@@ -132,30 +150,57 @@ func (i *AuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
 		procedure := req.Spec().Procedure
 
-		// Rate limit login attempts by client IP
-		if (procedure == "/pm.v1.ControlService/Login" || procedure == "/pm.v1.ControlService/VerifyLoginTOTP" || procedure == "/pm.v1.ControlService/SSOCallback") && i.loginLimiter != nil {
+		// Rate limit login attempts by client IP. Login + VerifyLoginTOTP +
+		// SSOCallback share one budget — they're all credential-spray
+		// vectors that a defender treats as one logical "auth attempt"
+		// regardless of which RPC the attacker pokes.
+		if (procedure == "/pm.v1.ControlService/Login" || procedure == "/pm.v1.ControlService/VerifyLoginTOTP" || procedure == "/pm.v1.ControlService/SSOCallback") && i.limiters.Login != nil {
 			ip := clientIP(req)
-			if !i.loginLimiter.Allow(ip) {
+			if !i.limiters.Login.Allow(ip) {
 				i.logger.Warn("rate limit exceeded", "limiter", "login", "ip", ip, "procedure", procedure)
 				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many login attempts, try again later")
 			}
 		}
 
 		// Rate limit token refresh attempts by client IP
-		if procedure == "/pm.v1.ControlService/RefreshToken" && i.refreshLimiter != nil {
+		if procedure == "/pm.v1.ControlService/RefreshToken" && i.limiters.Refresh != nil {
 			ip := clientIP(req)
-			if !i.refreshLimiter.Allow(ip) {
+			if !i.limiters.Refresh.Allow(ip) {
 				i.logger.Warn("rate limit exceeded", "limiter", "refresh", "ip", ip, "procedure", procedure)
 				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many refresh attempts, try again later")
 			}
 		}
 
 		// Rate limit registration attempts by client IP
-		if procedure == "/pm.v1.ControlService/Register" && i.registerLimiter != nil {
+		if procedure == "/pm.v1.ControlService/Register" && i.limiters.Register != nil {
 			ip := clientIP(req)
-			if !i.registerLimiter.Allow(ip) {
+			if !i.limiters.Register.Allow(ip) {
 				i.logger.Warn("rate limit exceeded", "limiter", "register", "ip", ip, "procedure", procedure)
 				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many registration attempts, try again later")
+			}
+		}
+
+		// Rate limit Logout — public procedure (#142). Without a limiter,
+		// an attacker who learned a session token (XSS, log leak, shared
+		// browser) could invalidate that user's sessions arbitrarily often:
+		// each call is a single DB write with no backoff.
+		if procedure == "/pm.v1.ControlService/Logout" && i.limiters.Logout != nil {
+			ip := clientIP(req)
+			if !i.limiters.Logout.Allow(ip) {
+				i.logger.Warn("rate limit exceeded", "limiter", "logout", "ip", ip, "procedure", procedure)
+				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many logout attempts, try again later")
+			}
+		}
+
+		// Rate limit RenewCertificate — public procedure (#142). Each
+		// call exercises the CA signing path + a DB write; concurrent
+		// floods could exhaust signer throughput. Cert rotation happens
+		// once per cert-lifetime so the legitimate ceiling is very low.
+		if procedure == "/pm.v1.ControlService/RenewCertificate" && i.limiters.RenewCert != nil {
+			ip := clientIP(req)
+			if !i.limiters.RenewCert.Allow(ip) {
+				i.logger.Warn("rate limit exceeded", "limiter", "renew_cert", "ip", ip, "procedure", procedure)
+				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many certificate renewal attempts, try again later")
 			}
 		}
 

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -18,21 +18,27 @@ var testLogger = slog.Default()
 
 func TestAuthInterceptor_Creation(t *testing.T) {
 	jwtMgr := NewJWTManager(JWTConfig{Secret: []byte("test")})
-	loginLimiter := NewRateLimiter(10, time.Minute)
-	refreshLimiter := NewRateLimiter(20, time.Minute)
-	registerLimiter := NewRateLimiter(5, time.Minute)
+	limiters := RateLimiters{
+		Login:     NewRateLimiter(10, time.Minute),
+		Refresh:   NewRateLimiter(60, time.Minute),
+		Register:  NewRateLimiter(5, time.Minute),
+		Logout:    NewRateLimiter(30, time.Minute),
+		RenewCert: NewRateLimiter(5, time.Minute),
+	}
 
-	interceptor := NewAuthInterceptor(testLogger, jwtMgr, loginLimiter, refreshLimiter, registerLimiter)
+	interceptor := NewAuthInterceptor(testLogger, jwtMgr, limiters)
 	assert.NotNil(t, interceptor)
 	assert.NotNil(t, interceptor.jwtManager)
-	assert.NotNil(t, interceptor.loginLimiter)
-	assert.NotNil(t, interceptor.refreshLimiter)
-	assert.NotNil(t, interceptor.registerLimiter)
+	assert.NotNil(t, interceptor.limiters.Login)
+	assert.NotNil(t, interceptor.limiters.Refresh)
+	assert.NotNil(t, interceptor.limiters.Register)
+	assert.NotNil(t, interceptor.limiters.Logout)
+	assert.NotNil(t, interceptor.limiters.RenewCert)
 }
 
 func TestAuthInterceptor_NilLimiters(t *testing.T) {
 	jwtMgr := NewJWTManager(JWTConfig{Secret: []byte("test")})
-	interceptor := NewAuthInterceptor(testLogger, jwtMgr, nil, nil, nil)
+	interceptor := NewAuthInterceptor(testLogger, jwtMgr, RateLimiters{})
 	assert.NotNil(t, interceptor)
 }
 
@@ -64,7 +70,7 @@ func TestAuthzInterceptor_Creation(t *testing.T) {
 
 func TestAuthInterceptor_StreamingPassthrough(t *testing.T) {
 	jwtMgr := NewJWTManager(JWTConfig{Secret: []byte("test")})
-	interceptor := NewAuthInterceptor(testLogger, jwtMgr, nil, nil, nil)
+	interceptor := NewAuthInterceptor(testLogger, jwtMgr, RateLimiters{})
 
 	clientFunc := func(ctx context.Context, spec connect.Spec) connect.StreamingClientConn {
 		return nil
@@ -104,7 +110,7 @@ func setupInterceptorTest(t *testing.T) (string, *JWTManager) {
 		Secret:            []byte("test-secret-for-interceptor-test"),
 		AccessTokenExpiry: 15 * time.Minute,
 	})
-	interceptor := NewAuthInterceptor(testLogger, jwtMgr, nil, nil, nil)
+	interceptor := NewAuthInterceptor(testLogger, jwtMgr, RateLimiters{})
 
 	mux := http.NewServeMux()
 
@@ -315,4 +321,85 @@ func TestAuthInterceptor_WrongSecret(t *testing.T) {
 	_, err = client.CallUnary(context.Background(), req)
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+// setupRateLimitedInterceptorTest stands up an httptest server that
+// mounts a single connect handler under the named procedure with the
+// AuthInterceptor's rate limiters fully configured. Returns the URL.
+func setupRateLimitedInterceptorTest(t *testing.T, procedure string, limiters RateLimiters) string {
+	t.Helper()
+	jwtMgr := NewJWTManager(JWTConfig{
+		Secret:            []byte("test-secret-for-ratelimit-test"),
+		AccessTokenExpiry: 15 * time.Minute,
+	})
+	interceptor := NewAuthInterceptor(testLogger, jwtMgr, limiters)
+
+	mux := http.NewServeMux()
+	mux.Handle(procedure, connect.NewUnaryHandler(
+		procedure,
+		func(_ context.Context, _ *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+			return connect.NewResponse(&emptypb.Empty{}), nil
+		},
+		connect.WithInterceptors(interceptor),
+	))
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+// TestAuthInterceptor_LogoutRateLimit pins the #142 fix: Logout was
+// listed in PublicProcedures but had no rate limiter. An attacker who
+// learned a session token (XSS, log leak, shared browser) could
+// invalidate that user's sessions arbitrarily often. The new Logout
+// limiter caps the call rate per IP.
+func TestAuthInterceptor_LogoutRateLimit(t *testing.T) {
+	procedure := "/pm.v1.ControlService/Logout"
+	url := setupRateLimitedInterceptorTest(t, procedure, RateLimiters{
+		Logout: NewRateLimiter(2, time.Minute),
+	})
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, url+procedure)
+
+	for i := 0; i < 2; i++ {
+		_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err, "call %d should succeed within the 2/min budget", i+1)
+	}
+	_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.Error(t, err, "call 3 MUST be rate-limited — Logout was previously unrate-limited (issue #142)")
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "too many logout attempts")
+}
+
+// TestAuthInterceptor_RenewCertificateRateLimit pins the #142 fix for
+// the second Public-but-unrate-limited procedure. Each RenewCertificate
+// call exercises the CA signing path; concurrent floods could exhaust
+// signer throughput.
+func TestAuthInterceptor_RenewCertificateRateLimit(t *testing.T) {
+	procedure := "/pm.v1.ControlService/RenewCertificate"
+	url := setupRateLimitedInterceptorTest(t, procedure, RateLimiters{
+		RenewCert: NewRateLimiter(1, time.Minute),
+	})
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, url+procedure)
+
+	_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err)
+
+	_, err = client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.Error(t, err, "RenewCertificate MUST be rate-limited — was previously unrate-limited (issue #142)")
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "too many certificate renewal attempts")
+}
+
+// TestAuthInterceptor_LogoutWithoutLimiter_PassesThrough verifies the
+// nil-limiter contract: when RateLimiters.Logout is nil, the gate is
+// a no-op and the call falls through. Mirrors the long-standing
+// behaviour for the other limiters.
+func TestAuthInterceptor_LogoutWithoutLimiter_PassesThrough(t *testing.T) {
+	procedure := "/pm.v1.ControlService/Logout"
+	url := setupRateLimitedInterceptorTest(t, procedure, RateLimiters{})
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, url+procedure)
+
+	for i := 0; i < 5; i++ {
+		_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err, "with no Logout limiter configured, every call must pass through")
+	}
 }


### PR DESCRIPTION
## Summary
Two related rate-limit hardening fixes audited under F036 + the CR-caught Bundle B follow-up.

### #145 (audit-recommended Option A values)
The existing limiters were configured at 1000 attempts/min/IP — effectively no rate limit against credential-spray. Tightened:

| Limiter | Old | New | Notes |
|---|---|---|---|
| Login (gates VerifyLoginTOTP + SSOCallback too) | 1000/min | **10/min** | credential-spray defense |
| RefreshToken | 1000/min | **60/min** | legitimate refreshes are frequent |
| Register | 1000/min | **5/min** | registration spam protection |

### #142 (Public-procedure rate-limit gaps)
\`Logout\` + \`RenewCertificate\` are listed in \`PublicProcedures\` (bypass access-token check) but had no rate limiter. Added:

| Limiter | New | Notes |
|---|---|---|
| Logout | **30/min/IP** | Without this, an attacker who learned a session token (XSS, log leak, shared browser) could invalidate sessions arbitrarily often |
| RenewCertificate | **5/min/IP** | Each call exercises the CA signing path; floods could exhaust signer throughput. Cert rotation happens once per cert-lifetime |

## Refactor

\`NewAuthInterceptor\`'s signature changed from 3 positional \`*RateLimiter\` args to a single \`RateLimiters\` struct. Adding 2 more limiters via positional args would have produced a 7-arg signature; the struct is also documentation of which procedure each limiter gates. Field comments map procedures to limiters.

## Tests added (acceptance criterion of #142)

- \`TestAuthInterceptor_LogoutRateLimit\` — third call hits the budget
- \`TestAuthInterceptor_RenewCertificateRateLimit\` — second call hits
- \`TestAuthInterceptor_LogoutWithoutLimiter_PassesThrough\` — nil-limiter contract preserved (operator can disable a gate by leaving the field nil)

Existing \`TestAuthInterceptor_Creation\` / \`NilLimiters\` / \`StreamingPassthrough\` updated to the new struct shape.

README rate-limit section rewritten as a per-limiter table with rationale for each value.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet\` + gofmt clean
- [x] All updated + new auth tests pass
- [x] Local CR review clean
- [ ] CI gate

Closes #142, #145.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated rate-limiting documentation with detailed per-IP rate limits for all authentication procedures.

* **Security Enhancements**
  * Extended rate-limiting protection to Logout and RenewCertificate endpoints, improving credential-spray defense.
  * Adjusted per-IP rate caps across all authentication flows (e.g., Login 10/min, Register 5/min, Logout 30/min).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/240)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->