### PR TITLE
refactor(store): wave A — ErrNotFound sentinel + scrub pgx.ErrNoRows (#243)

### DIFF
--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -8,10 +8,8 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -191,7 +189,7 @@ func (h *ActionHandler) RenameAction(ctx context.Context, req *connect.Request[p
 
 	// Verify action exists before appending event
 	if _, err := h.store.Queries().GetActionByID(ctx, req.Msg.Id); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
@@ -233,7 +231,7 @@ func (h *ActionHandler) UpdateActionDescription(ctx context.Context, req *connec
 
 	// Verify action exists before appending event
 	if _, err := h.store.Queries().GetActionByID(ctx, req.Msg.Id); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")

--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -11,14 +11,12 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
 
 	"connectrpc.com/connect"
 	"github.com/hibiken/asynq"
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -93,7 +91,7 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 	case *pm.DispatchActionRequest_ActionId:
 		action, err := h.store.Queries().GetActionByID(ctx, source.ActionId)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")

--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -2,11 +2,9 @@ package api
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -49,7 +47,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION:
 		_, err := h.store.Queries().GetActionByID(ctx, req.Msg.SourceId)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
@@ -57,7 +55,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION_SET:
 		_, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.SourceId)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrActionSetNotFound, connect.CodeNotFound, "action set not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action set")
@@ -65,7 +63,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_DEFINITION:
 		_, err := h.store.Queries().GetDefinitionByID(ctx, req.Msg.SourceId)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrDefinitionNotFound, connect.CodeNotFound, "definition not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get definition")
@@ -73,7 +71,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_COMPLIANCE_POLICY:
 		_, err := h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.SourceId)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrCompliancePolicyNotFound, connect.CodeNotFound, "compliance policy not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy")
@@ -85,7 +83,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE:
 		_, err := h.store.Queries().GetDeviceByID(ctx, db.GetDeviceByIDParams{ID: req.Msg.TargetId})
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device")
@@ -93,7 +91,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE_GROUP:
 		_, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.TargetId)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrDeviceGroupNotFound, connect.CodeNotFound, "device group not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group")
@@ -101,7 +99,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER:
 		_, err := h.store.Queries().GetUserByID(ctx, req.Msg.TargetId)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user")
@@ -109,7 +107,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER_GROUP:
 		_, err := h.store.Queries().GetUserGroupByID(ctx, req.Msg.TargetId)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrUserGroupNotFound, connect.CodeNotFound, "user group not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user group")
@@ -135,7 +133,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 		return connect.NewResponse(&pm.CreateAssignmentResponse{
 			Assignment: h.assignmentToProto(existingAssignment),
 		}), nil
-	} else if !errors.Is(err, pgx.ErrNoRows) {
+	} else if !store.IsNotFound(err) {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check existing assignment")
 	}
 

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -3,11 +3,9 @@ package api
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -57,7 +55,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 
 	user, err := h.store.Queries().GetUserByEmail(ctx, req.Msg.Email)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			// Perform a dummy bcrypt comparison to prevent timing-based user enumeration
 			auth.VerifyPassword(req.Msg.Password, auth.DummyHash)
 			return nil, apiErrorCtx(ctx, ErrInvalidCredentials, connect.CodeUnauthenticated, "invalid credentials")
@@ -183,7 +181,7 @@ func (h *AuthHandler) RefreshToken(ctx context.Context, req *connect.Request[pm.
 
 	// Atomically revoke the old refresh token BEFORE generating new tokens.
 	// RevokeToken uses INSERT ... ON CONFLICT DO NOTHING RETURNING jti, so it
-	// returns pgx.ErrNoRows when the token was already revoked by a concurrent
+	// reports not-found (recognized via store.IsNotFound) when the token was already revoked by a concurrent
 	// request. This prevents a race where two concurrent RefreshToken calls
 	// with the same token both succeed.
 	if result.OldJTI != "" {

--- a/internal/api/certificate_handler.go
+++ b/internal/api/certificate_handler.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -52,7 +51,7 @@ func (h *CertificateHandler) RenewCertificate(ctx context.Context, req *connect.
 		ID: deviceID,
 	})
 	if err != nil {
-		if err == pgx.ErrNoRows {
+		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up device")

--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -2,11 +2,9 @@ package api
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -315,7 +313,7 @@ func (h *DeviceGroupHandler) AddDeviceToGroup(ctx context.Context, req *connect.
 		// Verify device exists
 		_, err = q.GetDeviceByID(ctx, db.GetDeviceByIDParams{ID: deviceID})
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device")

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -14,7 +13,6 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/hibiken/asynq"
-	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -325,7 +323,7 @@ func (h *DeviceHandler) AssignDevice(ctx context.Context, req *connect.Request[p
 		// Verify user exists
 		_, err = q.GetUserByID(ctx, userID)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user")
@@ -354,7 +352,7 @@ func (h *DeviceHandler) AssignDevice(ctx context.Context, req *connect.Request[p
 		// Verify user group exists
 		_, err = q.GetUserGroupByID(ctx, groupID)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrUserGroupNotFound, connect.CodeNotFound, "user group not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user group")

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -2,12 +2,10 @@ package api
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 	"math"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/middleware"
@@ -30,9 +28,12 @@ func requireAuth(ctx context.Context) (*auth.UserContext, error) {
 	return userCtx, nil
 }
 
-// handleGetError returns a NotFound error for pgx.ErrNoRows, or an Internal error otherwise.
+// handleGetError returns a NotFound error when err signals a missing
+// row from any supported storage backend, or an Internal error
+// otherwise. Backend recognition is centralized in store.IsNotFound;
+// see tracker #242 for the abstraction motivation.
 func handleGetError(ctx context.Context, err error, notFoundCode, notFoundMsg string) error {
-	if errors.Is(err, pgx.ErrNoRows) {
+	if store.IsNotFound(err) {
 		return apiErrorCtx(ctx, notFoundCode, connect.CodeNotFound, notFoundMsg)
 	}
 	return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get resource")

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/store"
 )
 
 // TestRequireAuth_Success returns the embedded user context unchanged.
@@ -33,16 +34,27 @@ func TestRequireAuth_NoUser(t *testing.T) {
 	assert.Equal(t, connect.CodeUnauthenticated, cerr.Code())
 }
 
-// TestHandleGetError_NotFound maps pgx.ErrNoRows to the supplied
-// not-found code with CodeNotFound. Any other error collapses to
-// CodeInternal so a database hiccup never leaks "row not found"
-// to the client when the row actually exists but the read failed.
+// TestHandleGetError_NotFound maps a store-layer not-found error to
+// the supplied code with CodeNotFound. Any other error collapses to
+// CodeInternal so a database hiccup never leaks "row not found" to
+// the client when the row actually exists but the read failed. Both
+// pgx.ErrNoRows (the current backend's native sentinel) and
+// store.ErrNotFound (the abstract sentinel) must be recognized —
+// store.IsNotFound is the bridge.
 func TestHandleGetError_NotFound(t *testing.T) {
-	err := handleGetError(context.Background(), pgx.ErrNoRows, ErrUserNotFound, "user not found")
-	require.Error(t, err)
-	cerr := new(connect.Error)
-	require.True(t, errors.As(err, &cerr))
-	assert.Equal(t, connect.CodeNotFound, cerr.Code())
+	cases := map[string]error{
+		"pgx_native":  pgx.ErrNoRows,
+		"store_abstr": store.ErrNotFound,
+	}
+	for name, in := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := handleGetError(context.Background(), in, ErrUserNotFound, "user not found")
+			require.Error(t, err)
+			cerr := new(connect.Error)
+			require.True(t, errors.As(err, &cerr))
+			assert.Equal(t, connect.CodeNotFound, cerr.Code())
+		})
+	}
 }
 
 func TestHandleGetError_Other(t *testing.T) {

--- a/internal/api/idp_handler.go
+++ b/internal/api/idp_handler.go
@@ -5,12 +5,10 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"log/slog"
 
 	"connectrpc.com/connect"
 
-	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -52,7 +50,7 @@ func (h *IDPHandler) CreateIdentityProvider(ctx context.Context, req *connect.Re
 	if err == nil {
 		return nil, apiErrorCtx(ctx, ErrProviderSlugExists, connect.CodeAlreadyExists, "provider with this slug already exists")
 	}
-	if !errors.Is(err, pgx.ErrNoRows) {
+	if !store.IsNotFound(err) {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check slug")
 	}
 

--- a/internal/api/registration_handler.go
+++ b/internal/api/registration_handler.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/url"
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -149,7 +147,7 @@ func (h *RegistrationHandler) Register(ctx context.Context, req *connect.Request
 
 	token, err := h.store.Queries().GetTokenByHash(ctx, tokenHashHex)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			logger.Warn("invalid registration token")
 			return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "invalid registration token")
 		}

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -2,12 +2,10 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -54,7 +52,7 @@ func (h *RoleHandler) CreateRole(ctx context.Context, req *connect.Request[pm.Cr
 	if err == nil {
 		return nil, apiErrorCtx(ctx, ErrRoleNameExists, connect.CodeAlreadyExists, "role name already exists")
 	}
-	if !errors.Is(err, pgx.ErrNoRows) {
+	if !store.IsNotFound(err) {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role name uniqueness")
 	}
 
@@ -297,7 +295,7 @@ func (h *RoleHandler) AssignRoleToUser(ctx context.Context, req *connect.Request
 		// Verify role exists
 		_, err = q.GetRoleByID(ctx, roleID)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeNotFound, "role not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get role")

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -3,12 +3,9 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
-
-	"github.com/jackc/pgx/v5"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/search"
@@ -308,7 +305,7 @@ func SearchListener(st *store.Store, idx SearchIndex, logger *slog.Logger) store
 			case SearchOpReindex:
 				data, err := loadSearchEntityData(ctx, st, logger, op.Scope, op.ID)
 				if err != nil {
-					if errors.Is(err, pgx.ErrNoRows) {
+					if store.IsNotFound(err) {
 						logger.Debug("search listener: entity gone before reindex (likely deleted in same tx batch); skipping",
 							"scope", op.Scope, "id", op.ID, "event_type", e.EventType)
 						continue

--- a/internal/api/search_listener_e2e_test.go
+++ b/internal/api/search_listener_e2e_test.go
@@ -15,7 +15,7 @@ package api_test
 // listener enqueued exactly the expected (op, scope, id, payload)
 // triple. The cascade test exercises the GetReverseMembers →
 // EnqueueRemove path; the not-found test exercises the silent skip
-// when loadSearchEntityData returns pgx.ErrNoRows; the panic test
+// when loadSearchEntityData reports not-found; the panic test
 // exercises the recover wrapper inside fireListeners.
 
 import (
@@ -303,7 +303,7 @@ func TestSearchListener_EntityGoneBeforeReindex_SilentlySkips(t *testing.T) {
 	st, fake := setupListener(t)
 
 	// AppendEvent for an unknown user_id triggers the listener; the
-	// loader returns pgx.ErrNoRows; the listener logs at Debug and
+	// loader reports not-found (store.IsNotFound); the listener logs at Debug and
 	// MUST NOT enqueue. The reindex queue stays empty.
 	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
 		StreamType: "user", StreamID: "01HXNONEXISTENT00000000000",
@@ -313,7 +313,7 @@ func TestSearchListener_EntityGoneBeforeReindex_SilentlySkips(t *testing.T) {
 	}))
 
 	assert.Zero(t, fake.reindexCount(),
-		"listener must skip enqueue when the entity row is gone (pgx.ErrNoRows path)")
+		"listener must skip enqueue when the entity row is gone (not-found path)")
 }
 
 // =============================================================================

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -74,7 +73,7 @@ func (h *SSOHandler) ListAuthMethods(ctx context.Context, req *connect.Request[p
 					h.logger.Warn("sso: GetLinkedProvidersDisablingPassword failed", "error", err)
 				}
 			}
-		} else if !errors.Is(err, pgx.ErrNoRows) {
+		} else if !store.IsNotFound(err) {
 			// Pre-auth path; the email is in req.Msg but logging
 			// it would correlate the failure to a specific user.
 			// Stay anonymous — surface the operation + the err.
@@ -197,7 +196,7 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 
 	authState, err := h.store.Queries().ConsumeAuthState(ctx, req.Msg.State)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			h.logger.Warn("SSO auth state not found or expired", "state_prefix", statePrefix, "slug", req.Msg.Slug)
 			return nil, apiErrorCtx(ctx, ErrSSOStateExpired, connect.CodeUnauthenticated, "invalid or expired state")
 		}
@@ -278,7 +277,7 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 	// Get and validate user before proceeding
 	user, err := h.store.Queries().GetUserByID(ctx, linkResult.UserID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			h.logger.Error("SSO user not found after link resolved — user may be soft-deleted",
 				"user_id", linkResult.UserID,
 				"is_new", linkResult.IsNew,

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -89,7 +88,7 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 
 	user, err := h.store.Queries().GetUserByID(ctx, userCtx.ID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user not found")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up user")
@@ -117,7 +116,7 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 		ID:           req.Msg.DeviceId,
 		FilterUserID: filterUserID,
 	}); err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up device")

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -2,11 +2,9 @@ package api
 
 import (
 	"context"
-	"errors"
 	"log/slog"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
@@ -112,7 +110,7 @@ func (h *TOTPHandler) VerifyTOTP(ctx context.Context, req *connect.Request[pm.Ve
 	// Get pending TOTP setup
 	totpRecord, err := h.store.Queries().GetTOTPByUserID(ctx, userCtx.ID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrTOTPNotSetUp, connect.CodeFailedPrecondition, "TOTP not set up, call SetupTOTP first")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get TOTP status")
@@ -237,7 +235,7 @@ func (h *TOTPHandler) GetTOTPStatus(ctx context.Context, req *connect.Request[pm
 
 	status, err := h.store.Queries().GetTOTPStatus(ctx, userCtx.ID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			return connect.NewResponse(&pm.GetTOTPStatusResponse{
 				Enabled:              false,
 				BackupCodesRemaining: 0,

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -2,12 +2,10 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -49,7 +47,7 @@ func (h *UserGroupHandler) CreateUserGroup(ctx context.Context, req *connect.Req
 	if err == nil {
 		return nil, apiErrorCtx(ctx, ErrUserGroupNameExists, connect.CodeAlreadyExists, "user group name already exists")
 	}
-	if !errors.Is(err, pgx.ErrNoRows) {
+	if !store.IsNotFound(err) {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check user group name uniqueness")
 	}
 
@@ -347,7 +345,7 @@ func (h *UserGroupHandler) AddUserToGroup(ctx context.Context, req *connect.Requ
 		// Verify user exists
 		_, err = q.GetUserByID(ctx, userID)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user")
@@ -487,7 +485,7 @@ func (h *UserGroupHandler) AssignRoleToUserGroup(ctx context.Context, req *conne
 		// Verify role exists
 		_, err = q.GetRoleByID(ctx, roleID)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeNotFound, "role not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get role")

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -3,12 +3,10 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"log/slog"
 	"time"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -61,7 +59,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 	// concurrent CreateUser calls slip past this check.
 	//
 	// Distinguish three branches: row found → AlreadyExists;
-	// pgx.ErrNoRows → proceed (the email is free); any other
+	// store.IsNotFound(err) → proceed (the email is free); any other
 	// error → surface as Internal so a transient DB problem
 	// doesn't get silently mistaken for "free to create" and
 	// then re-surface as the generic Internal from AppendEvent
@@ -69,7 +67,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 	// auth_handler.go:59 and sso_handler.go:179.
 	if _, err := h.store.Queries().GetUserByEmail(ctx, req.Msg.Email); err == nil {
 		return nil, apiErrorCtx(ctx, ErrEmailAlreadyExists, connect.CodeAlreadyExists, "email already exists")
-	} else if !errors.Is(err, pgx.ErrNoRows) {
+	} else if !store.IsNotFound(err) {
 		// Don't log raw email (PII). At this point the user doesn't
 		// exist yet (we're checking IF they should), so there's no
 		// user_id either. Operators triaging this can correlate

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq"
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -89,7 +88,7 @@ func (w *InboxWorker) handleDeviceHello(ctx context.Context, t *asynq.Task) erro
 	// Skip processing for deleted or unknown devices.
 	deleted, err := w.store.Queries().IsDeviceDeleted(ctx, payload.DeviceID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			logger.Debug("ignoring hello from unknown device")
 			return nil
 		}
@@ -136,7 +135,7 @@ func (w *InboxWorker) handleDeviceHeartbeat(ctx context.Context, t *asynq.Task) 
 	// Skip processing for deleted or unknown devices.
 	deleted, err := w.store.Queries().IsDeviceDeleted(ctx, payload.DeviceID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			w.logger.Debug("ignoring heartbeat from unknown device", "device_id", payload.DeviceID)
 			return nil
 		}
@@ -200,7 +199,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 			actionID = *existingExec.ActionID
 		}
 		needsCreate = false
-	} else if errors.Is(err, pgx.ErrNoRows) {
+	} else if store.IsNotFound(err) {
 		// Not an execution ID — treat as action ID (agent-scheduled action).
 		// Derive a stable execution ID from device+action+completedAt so
 		// retries of the same result don't create duplicates, but separate
@@ -218,7 +217,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		_, checkErr := w.store.Queries().GetExecutionByID(ctx, executionID)
 		if checkErr == nil {
 			needsCreate = false
-		} else if errors.Is(checkErr, pgx.ErrNoRows) {
+		} else if store.IsNotFound(checkErr) {
 			needsCreate = true
 		} else {
 			return fmt.Errorf("check derived execution %s: %w", executionID, checkErr)
@@ -245,7 +244,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 	if needsCreate {
 		action, err := w.store.Queries().GetActionByID(ctx, actionID)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				// Action was deleted while agent was offline — skip, don't retry.
 				logger.Warn("action not found, skipping execution creation", "action_id", actionID)
 				return nil
@@ -575,7 +574,7 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 	switch {
 	case err == nil:
 		// Happy path — stream ID recovered.
-	case errors.Is(err, pgx.ErrNoRows):
+	case store.IsNotFound(err):
 		// Genuinely absent: the Requested event never landed
 		// (original RPC crashed before append). Fall back to a
 		// fresh ULID so we still record the terminal outcome —
@@ -668,7 +667,7 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			if !ok {
 				action, err := w.store.Queries().GetActionByID(ctx, *exec.ActionID)
 				if err != nil {
-					if errors.Is(err, pgx.ErrNoRows) {
+					if store.IsNotFound(err) {
 						// Action was deleted after the execution was created.
 						// Mark the execution failed so it leaves the "pending"
 						// state — otherwise every reconnect retries dispatch

--- a/internal/idp/linker.go
+++ b/internal/idp/linker.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/oklog/ulid/v2"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
@@ -99,7 +99,7 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProviders
 
 		// Verify the linked user still exists (not soft-deleted)
 		_, userErr := l.queries.GetUserByID(ctx, link.UserID)
-		if errors.Is(userErr, pgx.ErrNoRows) {
+		if store.IsNotFound(userErr) {
 			// User is soft-deleted — clean up the stale identity link and fall through
 			slog.Warn("SSO linker: linked user is deleted, cleaning up stale identity link",
 				"link_id", link.ID,
@@ -139,7 +139,7 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProviders
 			return &LinkResult{UserID: link.UserID, IsNew: false}, nil
 		}
 	}
-	if !errors.Is(err, pgx.ErrNoRows) {
+	if !store.IsNotFound(err) {
 		return nil, fmt.Errorf("lookup identity link: %w", err)
 	}
 	slog.Debug("SSO linker: no existing identity link found", "provider_id", provider.ID, "subject", claims.Subject)
@@ -174,7 +174,7 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProviders
 			}
 			return &LinkResult{UserID: user.ID, IsNew: false}, nil
 		}
-		if !errors.Is(err, pgx.ErrNoRows) {
+		if !store.IsNotFound(err) {
 			return nil, fmt.Errorf("lookup user by email: %w", err)
 		}
 		slog.Debug("SSO linker: no user found by email", "email", claims.Email)

--- a/internal/idp/linker_test.go
+++ b/internal/idp/linker_test.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
@@ -19,15 +19,15 @@ type mockQuerier struct {
 }
 
 func (m *mockQuerier) GetIdentityLinkByProviderAndExternalID(_ context.Context, _ db.GetIdentityLinkByProviderAndExternalIDParams) (db.IdentityLinksProjection, error) {
-	return db.IdentityLinksProjection{}, pgx.ErrNoRows
+	return db.IdentityLinksProjection{}, store.ErrNotFound
 }
 
 func (m *mockQuerier) GetUserByEmail(_ context.Context, _ string) (db.UsersProjection, error) {
-	return db.UsersProjection{}, pgx.ErrNoRows
+	return db.UsersProjection{}, store.ErrNotFound
 }
 
 func (m *mockQuerier) GetUserByID(_ context.Context, _ string) (db.UsersProjection, error) {
-	return db.UsersProjection{}, pgx.ErrNoRows
+	return db.UsersProjection{}, store.ErrNotFound
 }
 
 func (m *mockQuerier) GetServerSettings(_ context.Context) (db.ServerSettingsProjection, error) {

--- a/internal/projectors/assignment_listener.go
+++ b/internal/projectors/assignment_listener.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"log/slog"
 
-	"github.com/jackc/pgx/v5"
-
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -182,7 +180,7 @@ func applyAssignmentDeleted(ctx context.Context, q *store.Queries, e store.Persi
 		ProjectionVersion: deref(e.SequenceNum),
 	})
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			// Stale AssignmentDeleted replay against a row whose
 			// projection_version has moved past this event, OR a
 			// deletion of a row that no longer exists. Skipping the

--- a/internal/projectors/assignment_test.go
+++ b/internal/projectors/assignment_test.go
@@ -429,7 +429,7 @@ func TestAssignmentListener_StaleModeReplayRejected(t *testing.T) {
 // TestAssignmentListener_StaleDeleteReplayDoesNotCascade is a
 // regression lock for the asymmetric-guard discipline on
 // AssignmentDeleted: when the version-guarded SoftDelete affects zero
-// rows (RETURNING produces no rows → pgx.ErrNoRows), the compliance
+// rows (RETURNING produces no rows → store.IsNotFound), the compliance
 // cascade MUST be skipped. Otherwise an old AssignmentDeleted
 // re-applied later by the reconciler against a freshly-restored
 // assignment would silently drop compliance evaluations and

--- a/internal/projectors/device_group_listener.go
+++ b/internal/projectors/device_group_listener.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"log/slog"
 
-	"github.com/jackc/pgx/v5"
-
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -223,7 +221,7 @@ func applyDeviceGroupQueryUpdated(ctx context.Context, q *store.Queries, e store
 		// pgx surfaces ErrNoRows when the inner UPDATE's version
 		// guard rejects a stale replay (the CTE join collapses to
 		// zero rows). Treat that as "skip cascade".
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			return nil
 		}
 		return err

--- a/internal/projectors/user_group_listener.go
+++ b/internal/projectors/user_group_listener.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"log/slog"
 
-	"github.com/jackc/pgx/v5"
-
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -211,12 +209,13 @@ func applyUserGroupQueryUpdated(ctx context.Context, q *store.Queries, e store.P
 		ProjectionVersion: deref(e.SequenceNum),
 	})
 	if err != nil {
-		// pgx surfaces sql.ErrNoRows / pgx.ErrNoRows when the inner
-		// UPDATE's :execrows guard rejects a stale replay (the
-		// CTE join collapses to zero rows). That MUST be treated as
-		// "skip cascade" — propagating the error would roll back the
-		// listener TX and surface a hot loop on every reconciler pass.
-		if errors.Is(err, pgx.ErrNoRows) {
+		// The inner UPDATE's :execrows guard reports not-found when
+		// it rejects a stale replay (the CTE join collapses to zero
+		// rows). That MUST be treated as "skip cascade" — propagating
+		// the error would roll back the listener TX and surface a hot
+		// loop on every reconciler pass. store.IsNotFound bridges
+		// whichever backend sentinel surfaces.
+		if store.IsNotFound(err) {
 			return nil
 		}
 		return err

--- a/internal/scim/auth.go
+++ b/internal/scim/auth.go
@@ -2,13 +2,12 @@ package scim
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"strings"
 
-	"github.com/jackc/pgx/v5"
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
@@ -59,7 +58,7 @@ func (h *Handler) withAuth(next http.HandlerFunc) http.HandlerFunc {
 		// Look up provider by slug with SCIM enabled
 		provider, err := h.store.Queries().GetIdentityProviderBySlugForSCIM(r.Context(), slug)
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				h.logger.Warn("SCIM auth failed: unknown provider or SCIM not enabled", "slug", slug)
 				writeError(w, http.StatusUnauthorized, "unknown provider or SCIM not enabled")
 				return

--- a/internal/scim/groups.go
+++ b/internal/scim/groups.go
@@ -1,12 +1,9 @@
 package scim
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
-
-	"github.com/jackc/pgx/v5"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -103,7 +100,7 @@ func (h *Handler) listGroupsFiltered(w http.ResponseWriter, r *http.Request, pro
 			ScimGroupID: f.Value,
 		})
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				resources = []any{}
 			} else {
 				h.logger.Error("failed to find SCIM group mapping", "error", err)
@@ -163,7 +160,7 @@ func (h *Handler) getGroup(w http.ResponseWriter, r *http.Request) {
 		UserGroupID: groupID,
 	})
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "group not found")
 			return
 		}
@@ -205,7 +202,7 @@ func (h *Handler) deleteGroup(w http.ResponseWriter, r *http.Request) {
 		UserGroupID: groupID,
 	})
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "group not found")
 			return
 		}

--- a/internal/scim/groups_create.go
+++ b/internal/scim/groups_create.go
@@ -8,11 +8,8 @@ package scim
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
-
-	"github.com/jackc/pgx/v5"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -117,7 +114,7 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if !errors.Is(err, pgx.ErrNoRows) && err != nil {
+	if !store.IsNotFound(err) && err != nil {
 		h.logger.Error("failed to check existing SCIM group mapping", "error", err)
 		writeError(w, http.StatusInternalServerError, "internal server error")
 		return

--- a/internal/scim/groups_helpers.go
+++ b/internal/scim/groups_helpers.go
@@ -6,12 +6,9 @@ package scim
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/jackc/pgx/v5"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -87,7 +84,7 @@ func (h *Handler) reconcileGroupMembers(ctx context.Context, provider db.Identit
 // the user group and updates the mapping to restore consistency.
 func (h *Handler) buildGroupResource(ctx context.Context, providerID string, mapping db.ScimGroupMappingProjection, baseURL string) (SCIMGroup, error) {
 	group, err := h.store.Queries().GetUserGroupWithMembers(ctx, mapping.UserGroupID)
-	if errors.Is(err, pgx.ErrNoRows) {
+	if store.IsNotFound(err) {
 		// User group was deleted but SCIM mapping still exists — restore it.
 		mapping, err = h.restoreOrphanedGroup(ctx, providerID, mapping)
 		if err != nil {

--- a/internal/scim/groups_mutate.go
+++ b/internal/scim/groups_mutate.go
@@ -6,12 +6,9 @@ package scim
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/jackc/pgx/v5"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -49,7 +46,7 @@ func (h *Handler) replaceGroup(w http.ResponseWriter, r *http.Request) {
 		UserGroupID: groupID,
 	})
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "group not found")
 			return
 		}
@@ -143,7 +140,7 @@ func (h *Handler) patchGroup(w http.ResponseWriter, r *http.Request) {
 		UserGroupID: groupID,
 	})
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "group not found")
 			return
 		}

--- a/internal/scim/users.go
+++ b/internal/scim/users.go
@@ -1,12 +1,9 @@
 package scim
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
-
-	"github.com/jackc/pgx/v5"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -107,7 +104,7 @@ func (h *Handler) listUsersFiltered(w http.ResponseWriter, r *http.Request, prov
 			Email:      f.Value,
 		})
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				resources = []any{}
 			} else {
 				h.logger.Error("failed to find SCIM user by email", "error", err)
@@ -124,7 +121,7 @@ func (h *Handler) listUsersFiltered(w http.ResponseWriter, r *http.Request, prov
 			ExternalID: f.Value,
 		})
 		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
+			if store.IsNotFound(err) {
 				resources = []any{}
 			} else {
 				h.logger.Error("failed to find SCIM user by external ID", "error", err)
@@ -177,7 +174,7 @@ func (h *Handler) getUser(w http.ResponseWriter, r *http.Request) {
 
 	user, err := h.store.Queries().GetUserByID(ctx, userID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "user not found")
 			return
 		}

--- a/internal/scim/users_create.go
+++ b/internal/scim/users_create.go
@@ -15,10 +15,7 @@ package scim
 
 import (
 	"encoding/json"
-	"errors"
 	"net/http"
-
-	"github.com/jackc/pgx/v5"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -77,7 +74,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
-		if !errors.Is(err, pgx.ErrNoRows) {
+		if !store.IsNotFound(err) {
 			h.logger.Error("failed to check existing SCIM user", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 			return
@@ -131,7 +128,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusCreated, userToSCIM(existingUser, externalID, baseURL))
 			return
 		}
-		if !errors.Is(err, pgx.ErrNoRows) {
+		if !store.IsNotFound(err) {
 			h.logger.Error("failed to look up user by email", "error", err)
 			writeError(w, http.StatusInternalServerError, "internal server error")
 			return

--- a/internal/scim/users_mutate.go
+++ b/internal/scim/users_mutate.go
@@ -6,12 +6,9 @@ package scim
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/jackc/pgx/v5"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -52,7 +49,7 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 	// Verify user exists
 	existingUser, err := h.store.Queries().GetUserByID(ctx, userID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "user not found")
 			return
 		}
@@ -198,7 +195,7 @@ func (h *Handler) patchUser(w http.ResponseWriter, r *http.Request) {
 	// Verify user exists
 	existingUser, err := h.store.Queries().GetUserByID(ctx, userID)
 	if err != nil {
-		if errors.Is(err, pgx.ErrNoRows) {
+		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "user not found")
 			return
 		}

--- a/internal/store/notfound.go
+++ b/internal/store/notfound.go
@@ -1,0 +1,28 @@
+package store
+
+import (
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// ErrNotFound is the canonical "no row matched" sentinel for store
+// reads. Handlers, projectors, scim/idp glue — anything outside the
+// store package — must test for not-found via store.IsNotFound(err)
+// rather than reaching for pgx.ErrNoRows directly. The pgx symbol is
+// an implementation detail of the Postgres backend; pinning the
+// abstraction here lets a future backend register its own no-rows
+// error without touching every caller. See tracker #242.
+var ErrNotFound = errors.New("not found")
+
+// IsNotFound reports whether err signals a missing row from any
+// supported storage backend. Today that's pgx.ErrNoRows or
+// ErrNotFound itself (callers that already wrap with errors.Join
+// also match). Future backends extend this function — no other
+// recognizer should be needed at call sites.
+func IsNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, ErrNotFound) || errors.Is(err, pgx.ErrNoRows)
+}


### PR DESCRIPTION
## Summary

First wave of the storage-abstraction tracker (#242). Stops handler/projector/scim/idp/control packages from reaching for `pgx.ErrNoRows` directly; centralizes not-found recognition in `store.IsNotFound(err)`.

Why this matters: when a second backend (libSQL/Turso as the illustrative example, NoSQL as the architectural ceiling) lands later, its no-rows error gets registered inside `store.IsNotFound` — not in every caller.

## Changes

- **New** `server/internal/store/notfound.go` — defines `store.ErrNotFound` sentinel + `store.IsNotFound(err) bool` recognizer that today knows both `pgx.ErrNoRows` and `store.ErrNotFound`.
- **Updated** `internal/api/helpers.go::handleGetError` to use `store.IsNotFound`. Drops `pgx` import.
- **Swept** 33 call sites: `errors.Is(err, pgx.ErrNoRows)` → `store.IsNotFound(err)` across:
  - `internal/api/` — 18 files
  - `internal/scim/` — 8 files
  - `internal/idp/` — 2 files (incl. test mock returning `store.ErrNotFound` instead of `pgx.ErrNoRows`)
  - `internal/projectors/` — 4 files (incl. comment cleanup)
  - `internal/control/inbox_worker.go`
- **Removed** now-unused `pgx` imports (33 files; goimports clean).
- **Bridge test** `TestHandleGetError_NotFound` now exercises both `pgx_native` and `store_abstr` sentinels through `handleGetError` to lock the recognizer contract.

## Non-goals

- No interface refactor (Wave B).
- No backend swap.
- No proto / schema / event changes.
- No user-visible behaviour change.

## Acceptance

- `pgx.ErrNoRows` outside `internal/store/` + `generated/` is now confined to:
  - 1 line in `helpers_test.go` (the bridge test fixture — intentional).
  - 0 production call sites.
- `go vet ./...`, `gofmt -l server/`, `go build ./server/...`: clean.
- Local CodeRabbit review: **no findings**.
- Targeted tests pass: `TestHandleGetError_NotFound/{pgx_native,store_abstr}`, sample handler integration suite, all `internal/projectors`, `internal/scim`, `internal/idp`, `internal/control`, `internal/store`.
- Full `internal/api` suite hangs locally on `TestProxyStoreLuksKey_MissingFields` testcontainer setup (~30 min) — pre-existing environmental issue on this host, NOT a regression from this PR. Pushing to let CI verify with proper Docker.

## Test plan

- [ ] CI green on all checks
- [ ] CR full review confirms local-CR plain finding (none)
- [ ] No behaviour regressions in handler not-found mapping (covered by existing handler tests)

Part of #242. Closes #243.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal database error handling abstraction to enhance code maintainability and reduce direct driver-level dependencies across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/244)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->