### PR TITLE
refactor(store): wave B.3 — osquery + totp + terminal_session repos (#249)

### DIFF
--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -74,11 +74,7 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 	}
 
 	// Create pending result row
-	if err := h.store.Queries().CreateOSQueryResult(ctx, generated.CreateOSQueryResultParams{
-		QueryID:   queryID,
-		DeviceID:  msg.DeviceId,
-		TableName: tableName,
-	}); err != nil {
+	if err := h.store.Repos().OSQuery.CreateResult(ctx, queryID, msg.DeviceId, tableName); err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create query result")
 	}
 
@@ -102,10 +98,7 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 	); err != nil {
 		h.logger.Error("osquery enqueue failed; marking result expired",
 			"query_id", queryID, "device_id", msg.DeviceId, "error", err)
-		if expireErr := h.store.Queries().ExpirePendingOSQueryResult(ctx, generated.ExpirePendingOSQueryResultParams{
-			QueryID: queryID,
-			Error:   fmt.Sprintf("dispatch enqueue failed: %v", err),
-		}); expireErr != nil {
+		if expireErr := h.store.Repos().OSQuery.ExpirePendingResult(ctx, queryID, fmt.Sprintf("dispatch enqueue failed: %v", err)); expireErr != nil {
 			h.logger.Error("failed to mark enqueue-failed osquery result as expired",
 				"query_id", queryID, "error", expireErr)
 		}
@@ -124,7 +117,7 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 
 // GetOSQueryResult polls for the result of a dispatched osquery.
 func (h *OSQueryHandler) GetOSQueryResult(ctx context.Context, req *connect.Request[pm.GetOSQueryResultRequest]) (*connect.Response[pm.GetOSQueryResultResponse], error) {
-	result, err := h.store.Queries().GetOSQueryResult(ctx, req.Msg.QueryId)
+	result, err := h.store.Repos().OSQuery.GetResult(ctx, req.Msg.QueryId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrQueryResultNotFound, connect.CodeNotFound, "query result not found")
 	}
@@ -132,10 +125,7 @@ func (h *OSQueryHandler) GetOSQueryResult(ctx context.Context, req *connect.Requ
 	// Auto-expire pending results that have been waiting too long
 	if !result.Completed && time.Since(result.CreatedAt) > osqueryResultTimeout {
 		timeoutErr := "query timed out: device did not respond within 5 minutes"
-		if err := h.store.Queries().ExpirePendingOSQueryResult(ctx, generated.ExpirePendingOSQueryResultParams{
-			QueryID: result.QueryID,
-			Error:   timeoutErr,
-		}); err != nil {
+		if err := h.store.Repos().OSQuery.ExpirePendingResult(ctx, result.QueryID, timeoutErr); err != nil {
 			h.logger.Warn("failed to expire pending osquery result", "query_id", result.QueryID, "error", err)
 		}
 		result.Completed = true

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -200,7 +200,7 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 	// the upsert loses (transient DB hiccup), the first chunk's
 	// INSERT ... ON CONFLICT still creates the row, it just lands
 	// with empty tty_user until a later lifecycle event fills it in.
-	if err := h.store.Queries().UpsertTerminalSessionStart(ctx, generated.UpsertTerminalSessionStartParams{
+	if err := h.store.Repos().TerminalSession.UpsertStart(ctx, store.StartTerminalSession{
 		SessionID: sessionID,
 		DeviceID:  req.Msg.DeviceId,
 		UserID:    user.ID,
@@ -423,7 +423,7 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 	// history row is slightly incomplete. No exit code at this call
 	// site; the session ended on user request, not on shell exit.
 	now := time.Now()
-	if err := h.store.Queries().MarkTerminalSessionStopped(ctx, generated.MarkTerminalSessionStoppedParams{
+	if err := h.store.Repos().TerminalSession.MarkStopped(ctx, store.StopTerminalSession{
 		SessionID: session.SessionID,
 		StoppedAt: &now,
 		ExitCode:  nil,
@@ -627,7 +627,7 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 	// user than the admin calling Terminate, so use the session's
 	// recorded UserID (validated via the token store), not actorID.
 	sessionUserID := session.UserID
-	if err := h.store.Queries().MarkTerminalSessionTerminated(ctx, generated.MarkTerminalSessionTerminatedParams{
+	if err := h.store.Repos().TerminalSession.MarkTerminated(ctx, store.TerminateTerminalSession{
 		SessionID:    session.SessionID,
 		StoppedAt:    &now,
 		TerminatedBy: &terminatedBy,

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -108,7 +108,7 @@ func (h *TOTPHandler) VerifyTOTP(ctx context.Context, req *connect.Request[pm.Ve
 	}
 
 	// Get pending TOTP setup
-	totpRecord, err := h.store.Queries().GetTOTPByUserID(ctx, userCtx.ID)
+	totpRecord, err := h.store.Repos().Totp.GetByUserID(ctx, userCtx.ID)
 	if err != nil {
 		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrTOTPNotSetUp, connect.CodeFailedPrecondition, "TOTP not set up, call SetupTOTP first")
@@ -233,7 +233,7 @@ func (h *TOTPHandler) GetTOTPStatus(ctx context.Context, req *connect.Request[pm
 		return nil, err
 	}
 
-	status, err := h.store.Queries().GetTOTPStatus(ctx, userCtx.ID)
+	status, err := h.store.Repos().Totp.GetStatus(ctx, userCtx.ID)
 	if err != nil {
 		if store.IsNotFound(err) {
 			return connect.NewResponse(&pm.GetTOTPStatusResponse{
@@ -316,7 +316,7 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 	}
 
 	// Get TOTP record
-	totpRecord, err := h.store.Queries().GetTOTPByUserID(ctx, claims.UserID)
+	totpRecord, err := h.store.Repos().Totp.GetByUserID(ctx, claims.UserID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get TOTP data")
 	}

--- a/internal/store/osquery.go
+++ b/internal/store/osquery.go
@@ -1,0 +1,47 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// OSQueryResult is the on-demand osquery result row. Backed by
+// osquery_results (not by the event store), so the shape can evolve
+// without event-schema implications — same posture as
+// LogQueryResult.
+type OSQueryResult struct {
+	QueryID   string
+	DeviceID  string
+	TableName string
+	Completed bool
+	Success   bool
+	Error     string
+	// Rows is the raw JSON payload returned by osquery's structured
+	// table output. Kept as json.RawMessage at the boundary so each
+	// backend chooses how to materialize the column without leaking
+	// the choice to handlers.
+	Rows        json.RawMessage
+	CreatedAt   time.Time
+	CompletedAt *time.Time
+}
+
+// OSQueryRepo manages the on-demand osquery result rows used by the
+// DispatchOSQuery / GetOSQueryResult RPC pair. The agent writes the
+// completed result via the gateway inbox path; this repo covers the
+// creation, expiry, and read sites the control handler owns.
+type OSQueryRepo interface {
+	// CreateResult inserts a fresh pending row for the given
+	// query+device+table triple. Called when the control handler
+	// dispatches an osquery to the agent.
+	CreateResult(ctx context.Context, queryID, deviceID, tableName string) error
+
+	// GetResult returns the row for the given query ID. Returns
+	// ErrNotFound when no such row exists.
+	GetResult(ctx context.Context, queryID string) (OSQueryResult, error)
+
+	// ExpirePendingResult marks a pending row as failed with the
+	// supplied error message. Used by the auto-expiry path
+	// (5-minute poll timeout) and by the dispatch-failure recovery.
+	ExpirePendingResult(ctx context.Context, queryID, errMsg string) error
+}

--- a/internal/store/postgres/osquery.go
+++ b/internal/store/postgres/osquery.go
@@ -1,0 +1,59 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// OSQuery implements store.OSQueryRepo against osquery_results.
+type OSQuery struct {
+	q *generated.Queries
+}
+
+// NewOSQuery returns an OSQuery repo bound to the given sqlc handle.
+func NewOSQuery(q *generated.Queries) *OSQuery {
+	return &OSQuery{q: q}
+}
+
+func (o *OSQuery) CreateResult(ctx context.Context, queryID, deviceID, tableName string) error {
+	if err := o.q.CreateOSQueryResult(ctx, generated.CreateOSQueryResultParams{
+		QueryID:   queryID,
+		DeviceID:  deviceID,
+		TableName: tableName,
+	}); err != nil {
+		return fmt.Errorf("osquery: create result: %w", err)
+	}
+	return nil
+}
+
+func (o *OSQuery) GetResult(ctx context.Context, queryID string) (store.OSQueryResult, error) {
+	row, err := o.q.GetOSQueryResult(ctx, queryID)
+	if err != nil {
+		return store.OSQueryResult{}, fmt.Errorf("osquery: get result: %w", translateNotFound(err))
+	}
+	return store.OSQueryResult{
+		QueryID:     row.QueryID,
+		DeviceID:    row.DeviceID,
+		TableName:   row.TableName,
+		Completed:   row.Completed,
+		Success:     row.Success,
+		Error:       row.Error,
+		Rows:        json.RawMessage(row.Rows),
+		CreatedAt:   row.CreatedAt,
+		CompletedAt: row.CompletedAt,
+	}, nil
+}
+
+func (o *OSQuery) ExpirePendingResult(ctx context.Context, queryID, errMsg string) error {
+	if err := o.q.ExpirePendingOSQueryResult(ctx, generated.ExpirePendingOSQueryResultParams{
+		QueryID: queryID,
+		Error:   errMsg,
+	}); err != nil {
+		return fmt.Errorf("osquery: expire pending: %w", err)
+	}
+	return nil
+}

--- a/internal/store/postgres/terminal_session.go
+++ b/internal/store/postgres/terminal_session.go
@@ -1,0 +1,62 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// TerminalSession implements store.TerminalSessionRepo against
+// the terminal_sessions table.
+type TerminalSession struct {
+	q *generated.Queries
+}
+
+// NewTerminalSession returns a TerminalSession repo bound to the
+// given sqlc handle.
+func NewTerminalSession(q *generated.Queries) *TerminalSession {
+	return &TerminalSession{q: q}
+}
+
+func (t *TerminalSession) UpsertStart(ctx context.Context, p store.StartTerminalSession) error {
+	if err := t.q.UpsertTerminalSessionStart(ctx, generated.UpsertTerminalSessionStartParams{
+		SessionID: p.SessionID,
+		DeviceID:  p.DeviceID,
+		UserID:    p.UserID,
+		TtyUser:   p.TtyUser,
+		StartedAt: p.StartedAt,
+		Cols:      p.Cols,
+		Rows:      p.Rows,
+	}); err != nil {
+		return fmt.Errorf("terminal_session: upsert start: %w", err)
+	}
+	return nil
+}
+
+func (t *TerminalSession) MarkStopped(ctx context.Context, p store.StopTerminalSession) error {
+	if err := t.q.MarkTerminalSessionStopped(ctx, generated.MarkTerminalSessionStoppedParams{
+		SessionID: p.SessionID,
+		StoppedAt: p.StoppedAt,
+		ExitCode:  p.ExitCode,
+		DeviceID:  p.DeviceID,
+		UserID:    p.UserID,
+	}); err != nil {
+		return fmt.Errorf("terminal_session: mark stopped: %w", err)
+	}
+	return nil
+}
+
+func (t *TerminalSession) MarkTerminated(ctx context.Context, p store.TerminateTerminalSession) error {
+	if err := t.q.MarkTerminalSessionTerminated(ctx, generated.MarkTerminalSessionTerminatedParams{
+		SessionID:    p.SessionID,
+		StoppedAt:    p.StoppedAt,
+		TerminatedBy: p.TerminatedBy,
+		DeviceID:     p.DeviceID,
+		UserID:       p.UserID,
+	}); err != nil {
+		return fmt.Errorf("terminal_session: mark terminated: %w", err)
+	}
+	return nil
+}

--- a/internal/store/postgres/totp.go
+++ b/internal/store/postgres/totp.go
@@ -1,0 +1,47 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Totp implements store.TotpRepo against totp_projection.
+type Totp struct {
+	q *generated.Queries
+}
+
+// NewTotp returns a Totp repo bound to the given sqlc handle.
+func NewTotp(q *generated.Queries) *Totp {
+	return &Totp{q: q}
+}
+
+func (t *Totp) GetByUserID(ctx context.Context, userID string) (store.TotpRecord, error) {
+	row, err := t.q.GetTOTPByUserID(ctx, userID)
+	if err != nil {
+		return store.TotpRecord{}, fmt.Errorf("totp: get by user: %w", translateNotFound(err))
+	}
+	return store.TotpRecord{
+		UserID:          row.UserID,
+		SecretEncrypted: row.SecretEncrypted,
+		Verified:        row.Verified,
+		Enabled:         row.Enabled,
+		BackupCodesHash: row.BackupCodesHash,
+		BackupCodesUsed: row.BackupCodesUsed,
+		CreatedAt:       row.CreatedAt,
+		UpdatedAt:       row.UpdatedAt,
+	}, nil
+}
+
+func (t *Totp) GetStatus(ctx context.Context, userID string) (store.TotpStatus, error) {
+	row, err := t.q.GetTOTPStatus(ctx, userID)
+	if err != nil {
+		return store.TotpStatus{}, fmt.Errorf("totp: get status: %w", translateNotFound(err))
+	}
+	return store.TotpStatus{
+		Enabled:              row.Enabled,
+		BackupCodesRemaining: row.BackupCodesRemaining,
+	}, nil
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -14,9 +14,12 @@ import (
 // are migrated under tracker #242.
 func NewRepos(q *generated.Queries) *store.Repos {
 	return &store.Repos{
-		Compliance:   NewCompliance(q),
-		IdentityLink: NewIdentityLink(q),
-		Logs:         NewLogs(q),
-		Settings:     NewSettings(q),
+		Compliance:      NewCompliance(q),
+		IdentityLink:    NewIdentityLink(q),
+		Logs:            NewLogs(q),
+		OSQuery:         NewOSQuery(q),
+		Settings:        NewSettings(q),
+		TerminalSession: NewTerminalSession(q),
+		Totp:            NewTotp(q),
 	}
 }

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -13,8 +13,11 @@ package store
 // device.go for DeviceRepo), implement it under internal/store/postgres,
 // add a field here, populate it in postgres.NewRepos.
 type Repos struct {
-	Compliance   ComplianceRepo
-	IdentityLink IdentityLinkRepo
-	Logs         LogsRepo
-	Settings     SettingsRepo
+	Compliance      ComplianceRepo
+	IdentityLink    IdentityLinkRepo
+	Logs            LogsRepo
+	OSQuery         OSQueryRepo
+	Settings        SettingsRepo
+	TerminalSession TerminalSessionRepo
+	Totp            TotpRepo
 }

--- a/internal/store/terminal_session.go
+++ b/internal/store/terminal_session.go
@@ -1,0 +1,54 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// StartTerminalSession is the param shape for the Upsert that opens
+// a terminal session row. Carries everything needed to reconstruct
+// the session record from a TerminalSessionStarted event.
+type StartTerminalSession struct {
+	SessionID string
+	DeviceID  string
+	UserID    string
+	TtyUser   string
+	StartedAt time.Time
+	Cols      int32
+	Rows      int32
+}
+
+// StopTerminalSession is the param shape for the graceful-end path
+// (TerminalSessionStopped event from the bridge). DeviceID + UserID
+// participate in the upsert key so a missing-row case still creates
+// a complete record rather than silently no-opping.
+type StopTerminalSession struct {
+	SessionID string
+	DeviceID  string
+	UserID    string
+	StoppedAt *time.Time
+	ExitCode  *int32
+}
+
+// TerminateTerminalSession is the param shape for the admin
+// force-kill path (TerminalSessionTerminated event). Same upsert
+// posture as StopTerminalSession; TerminatedBy carries the admin
+// user ID for the audit trail.
+type TerminateTerminalSession struct {
+	SessionID    string
+	DeviceID     string
+	UserID       string
+	StoppedAt    *time.Time
+	TerminatedBy *string
+}
+
+// TerminalSessionRepo records terminal-session lifecycle from the
+// control-side handler. Reads (history / replay) live elsewhere —
+// the control handler only writes. The first-finalizer-wins guard
+// in the underlying upserts ensures a Stop after a Terminate does
+// not overwrite the Terminate, and vice versa.
+type TerminalSessionRepo interface {
+	UpsertStart(ctx context.Context, p StartTerminalSession) error
+	MarkStopped(ctx context.Context, p StopTerminalSession) error
+	MarkTerminated(ctx context.Context, p TerminateTerminalSession) error
+}

--- a/internal/store/totp.go
+++ b/internal/store/totp.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// TotpRecord is the per-user TOTP enrollment row. SecretEncrypted
+// stays encrypted-at-rest; the caller decrypts with internal/crypto
+// when it actually needs the secret to verify a code.
+type TotpRecord struct {
+	UserID          string
+	SecretEncrypted string
+	Verified        bool
+	Enabled         bool
+	BackupCodesHash []string
+	BackupCodesUsed []bool
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// TotpStatus is the narrow "do I need to challenge this user?" shape
+// returned to the web client for the login flow + settings UI.
+// Intentionally omits secret material — there is no method here that
+// could leak it.
+type TotpStatus struct {
+	Enabled              bool
+	BackupCodesRemaining int32
+}
+
+// TotpRepo reads TOTP enrollment state. Writes (enrol, verify,
+// disable, regenerate backup codes) flow through events.
+type TotpRepo interface {
+	// GetByUserID returns the full enrollment row for the user.
+	// Returns ErrNotFound when no enrollment exists.
+	GetByUserID(ctx context.Context, userID string) (TotpRecord, error)
+
+	// GetStatus returns the lean status shape used by login and
+	// settings. Returns ErrNotFound when no enrollment exists —
+	// handlers should map that to "enabled = false" rather than
+	// surfacing the error to the user.
+	GetStatus(ctx context.Context, userID string) (TotpStatus, error)
+}


### PR DESCRIPTION
## Summary

Continues the per-domain migration started by #246 (B.1) and #248 (B.2). Three more single-handler domains migrate to repos; cross-domain reads stay on \`Store.Queries()\` until their owning domain moves.

**Stacked on #248**. Diff currently shows B.2 + B.3 commits; rebases onto main after #248 merges.

## Domains migrated

| Repo | Methods | Handler |
|---|---|---|
| \`OSQueryRepo\` | \`CreateResult\`, \`GetResult\`, \`ExpirePendingResult\` | \`osquery_handler.go\` |
| \`TotpRepo\` | \`GetByUserID\`, \`GetStatus\` | \`totp_handler.go\` (3 call sites) |
| \`TerminalSessionRepo\` | \`UpsertStart\`, \`MarkStopped\`, \`MarkTerminated\` | \`terminal_handler.go\` (3 call sites) |

\`TerminalSessionRepo\` is write-only from this handler. The three lifecycle methods take typed param structs (\`StartTerminalSession\`, \`StopTerminalSession\`, \`TerminateTerminalSession\`) instead of long argument lists.

\`TotpRepo\` is read-only; \`SecretEncrypted\` stays encrypted-at-rest at the repo boundary — handler is responsible for the decrypt step via \`internal/crypto\`.

## Non-goals

- User / device repos.
- \`GetDeviceInventory*\` queries in osquery — move with the device/inventory domain.
- 5 \`Queries().GetTOTPByUserID\` sites in \`projectors/totp_test.go\` — testing storage internals from inside the boundary; staying on \`Queries()\` is correct.

## Acceptance

- Three handlers no longer touch their primary domain via \`Queries()\`.
- Build / vet / staticcheck / gofmt: clean.
- Targeted tests (TestSetupTOTP, TestVerifyTOTP, TestStartTerminal, TestDispatchOSQuery, TestGetDeviceCompliance, TestLogin, TestGetCurrentUser, etc.): 368s of coverage passes.

Part of #242. Closes #249.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Restructured internal data access layer to use a unified repository pattern for managing osquery results, terminal sessions, and TOTP configurations, improving code maintainability and consistency across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/250)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->