### PR TITLE
refactor(store): wave B.4 — compliance policy CRUD repo (#251)

### DIFF
--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -14,7 +14,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // CompliancePolicyHandler handles compliance policy RPCs.
@@ -59,7 +58,7 @@ func (h *CompliancePolicyHandler) CreateCompliancePolicy(ctx context.Context, re
 		return nil, err
 	}
 
-	policy, err := h.store.Queries().GetCompliancePolicyByID(ctx, id)
+	policy, err := h.store.Repos().Compliance.GetPolicy(ctx, id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy")
 	}
@@ -75,12 +74,12 @@ func (h *CompliancePolicyHandler) GetCompliancePolicy(ctx context.Context, req *
 		return nil, err
 	}
 
-	policy, err := h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.Id)
+	policy, err := h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrCompliancePolicyNotFound, "compliance policy not found")
 	}
 
-	rules, err := h.store.Queries().ListCompliancePolicyRules(ctx, req.Msg.Id)
+	rules, err := h.store.Repos().Compliance.ListPolicyRules(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy rules")
 	}
@@ -97,7 +96,7 @@ func (h *CompliancePolicyHandler) ListCompliancePolicies(ctx context.Context, re
 		return nil, err
 	}
 
-	policies, err := h.store.Queries().ListCompliancePolicies(ctx, db.ListCompliancePoliciesParams{
+	policies, err := h.store.Repos().Compliance.ListPolicies(ctx, store.ListCompliancePoliciesFilter{
 		Limit:  pageSize,
 		Offset: offset,
 	})
@@ -105,7 +104,7 @@ func (h *CompliancePolicyHandler) ListCompliancePolicies(ctx context.Context, re
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list compliance policies")
 	}
 
-	count, err := h.store.Queries().CountCompliancePolicies(ctx)
+	count, err := h.store.Repos().Compliance.CountPolicies(ctx)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count compliance policies")
 	}
@@ -136,7 +135,7 @@ func (h *CompliancePolicyHandler) RenameCompliancePolicy(ctx context.Context, re
 	}
 
 	// Verify policy exists before emitting event
-	_, err = h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.Id)
+	_, err = h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrCompliancePolicyNotFound, "compliance policy not found")
 	}
@@ -154,7 +153,7 @@ func (h *CompliancePolicyHandler) RenameCompliancePolicy(ctx context.Context, re
 		return nil, err
 	}
 
-	policy, err := h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.Id)
+	policy, err := h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy")
 	}
@@ -176,7 +175,7 @@ func (h *CompliancePolicyHandler) UpdateCompliancePolicyDescription(ctx context.
 	}
 
 	// Verify policy exists before emitting event
-	_, err = h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.Id)
+	_, err = h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrCompliancePolicyNotFound, "compliance policy not found")
 	}
@@ -194,7 +193,7 @@ func (h *CompliancePolicyHandler) UpdateCompliancePolicyDescription(ctx context.
 		return nil, err
 	}
 
-	policy, err := h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.Id)
+	policy, err := h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy")
 	}
@@ -216,7 +215,7 @@ func (h *CompliancePolicyHandler) DeleteCompliancePolicy(ctx context.Context, re
 	}
 
 	// Verify policy exists before emitting delete event
-	_, err = h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.Id)
+	_, err = h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrCompliancePolicyNotFound, "compliance policy not found")
 	}
@@ -250,7 +249,7 @@ func (h *CompliancePolicyHandler) AddCompliancePolicyRule(ctx context.Context, r
 	}
 
 	// Verify policy exists
-	_, err = h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.PolicyId)
+	_, err = h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.PolicyId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrCompliancePolicyNotFound, "compliance policy not found")
 	}
@@ -291,12 +290,12 @@ func (h *CompliancePolicyHandler) AddCompliancePolicyRule(ctx context.Context, r
 		return nil, err
 	}
 
-	policy, err := h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.PolicyId)
+	policy, err := h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.PolicyId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy")
 	}
 
-	rules, err := h.store.Queries().ListCompliancePolicyRules(ctx, req.Msg.PolicyId)
+	rules, err := h.store.Repos().Compliance.ListPolicyRules(ctx, req.Msg.PolicyId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy rules")
 	}
@@ -318,7 +317,7 @@ func (h *CompliancePolicyHandler) RemoveCompliancePolicyRule(ctx context.Context
 	}
 
 	// Verify policy exists before emitting event
-	_, err = h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.PolicyId)
+	_, err = h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.PolicyId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrCompliancePolicyNotFound, "compliance policy not found")
 	}
@@ -336,12 +335,12 @@ func (h *CompliancePolicyHandler) RemoveCompliancePolicyRule(ctx context.Context
 		return nil, err
 	}
 
-	policy, err := h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.PolicyId)
+	policy, err := h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.PolicyId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy")
 	}
 
-	rules, err := h.store.Queries().ListCompliancePolicyRules(ctx, req.Msg.PolicyId)
+	rules, err := h.store.Repos().Compliance.ListPolicyRules(ctx, req.Msg.PolicyId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy rules")
 	}
@@ -363,7 +362,7 @@ func (h *CompliancePolicyHandler) UpdateCompliancePolicyRule(ctx context.Context
 	}
 
 	// Verify policy exists before emitting event
-	_, err = h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.PolicyId)
+	_, err = h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.PolicyId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrCompliancePolicyNotFound, "compliance policy not found")
 	}
@@ -382,12 +381,12 @@ func (h *CompliancePolicyHandler) UpdateCompliancePolicyRule(ctx context.Context
 		return nil, err
 	}
 
-	policy, err := h.store.Queries().GetCompliancePolicyByID(ctx, req.Msg.PolicyId)
+	policy, err := h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.PolicyId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy")
 	}
 
-	rules, err := h.store.Queries().ListCompliancePolicyRules(ctx, req.Msg.PolicyId)
+	rules, err := h.store.Repos().Compliance.ListPolicyRules(ctx, req.Msg.PolicyId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance policy rules")
 	}
@@ -403,7 +402,7 @@ func (h *CompliancePolicyHandler) GetDeviceCompliancePolicyStatus(ctx context.Co
 		return nil, err
 	}
 
-	evals, err := h.store.Queries().GetDeviceCompliancePolicyEvaluations(ctx, req.Msg.DeviceId)
+	evals, err := h.store.Repos().Compliance.ListDeviceEvaluations(ctx, req.Msg.DeviceId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance evaluations")
 	}
@@ -496,7 +495,7 @@ func (h *CompliancePolicyHandler) GetDeviceCompliancePolicyStatus(ctx context.Co
 	}), nil
 }
 
-func (h *CompliancePolicyHandler) policyToProto(p db.CompliancePoliciesProjection, rules []db.CompliancePolicyRulesProjection) *pm.CompliancePolicy {
+func (h *CompliancePolicyHandler) policyToProto(p store.CompliancePolicy, rules []store.CompliancePolicyRule) *pm.CompliancePolicy {
 	policy := &pm.CompliancePolicy{
 		Id:          p.ID,
 		Name:        p.Name,

--- a/internal/store/compliance.go
+++ b/internal/store/compliance.go
@@ -33,10 +33,56 @@ type ComplianceSummary struct {
 	CheckedAt *time.Time
 }
 
-// ComplianceRepo reads device-compliance state from the projection.
-// Writes flow through the event store + projector pipeline, not
-// through this interface — the read path stays narrowly scoped so
-// future backends only need to satisfy this small surface.
+// CompliancePolicy is a CRUD-side compliance policy row. Rules are
+// fetched separately via ListPolicyRules to keep the list/get paths
+// cheap when only the policy header is needed.
+type CompliancePolicy struct {
+	ID          string
+	Name        string
+	Description string
+	RuleCount   int32
+	CreatedAt   *time.Time
+	CreatedBy   string
+}
+
+// CompliancePolicyRule is one rule (action + grace period) belonging
+// to a compliance policy.
+type CompliancePolicyRule struct {
+	PolicyID         string
+	ActionID         string
+	ActionName       string
+	GracePeriodHours int32
+	AddedAt          *time.Time
+}
+
+// ListCompliancePoliciesFilter is the pagination shape for the
+// policy list endpoint.
+type ListCompliancePoliciesFilter struct {
+	Limit  int32
+	Offset int32
+}
+
+// DevicePolicyEvaluation is the per-(device,policy,rule) evaluation
+// row, joined with policy_name + rule fields. Shape matches what
+// GetDeviceCompliancePolicyStatus needs to build its proto response.
+type DevicePolicyEvaluation struct {
+	DeviceID         string
+	PolicyID         string
+	PolicyName       string
+	ActionID         string
+	ActionName       string
+	Compliant        bool
+	Status           int32
+	GracePeriodHours int32
+	CheckedAt        *time.Time
+	FirstFailedAt    *time.Time
+}
+
+// ComplianceRepo reads device-compliance state and compliance-policy
+// definitions from the projection. Writes flow through the event
+// store + projector pipeline, not through this interface — the read
+// path stays narrowly scoped so future backends only need to satisfy
+// this small surface.
 //
 // Part of the storage-abstraction tracker (#242). The Postgres
 // implementation lives in internal/store/postgres.
@@ -50,4 +96,27 @@ type ComplianceRepo interface {
 	// given device. Returns ErrNotFound if the device row itself is
 	// missing from the projection. Test the error via IsNotFound.
 	DeviceSummary(ctx context.Context, deviceID string) (ComplianceSummary, error)
+
+	// GetPolicy returns the policy header. Returns ErrNotFound when
+	// no such policy exists.
+	GetPolicy(ctx context.Context, id string) (CompliancePolicy, error)
+
+	// ListPolicies returns a page of policies (excluding soft-deleted).
+	// Caller pairs this with CountPolicies for total-count pagination.
+	ListPolicies(ctx context.Context, filter ListCompliancePoliciesFilter) ([]CompliancePolicy, error)
+
+	// CountPolicies returns the total count of non-deleted policies
+	// for pagination.
+	CountPolicies(ctx context.Context) (int64, error)
+
+	// ListPolicyRules returns the rules belonging to a policy,
+	// ordered as the projection emits them. Empty slice when the
+	// policy has no rules yet.
+	ListPolicyRules(ctx context.Context, policyID string) ([]CompliancePolicyRule, error)
+
+	// ListDeviceEvaluations returns the per-(policy, rule)
+	// evaluation rows for a device, joined with policy_name /
+	// action_name / grace_period_hours. Empty slice when the device
+	// has no policy assignments evaluated yet.
+	ListDeviceEvaluations(ctx context.Context, deviceID string) ([]DevicePolicyEvaluation, error)
 }

--- a/internal/store/postgres/compliance.go
+++ b/internal/store/postgres/compliance.go
@@ -70,6 +70,105 @@ func (c *Compliance) DeviceSummary(ctx context.Context, deviceID string) (store.
 	}, nil
 }
 
+// GetPolicy returns the policy header by ID. pgx.ErrNoRows is
+// translated to store.ErrNotFound.
+func (c *Compliance) GetPolicy(ctx context.Context, id string) (store.CompliancePolicy, error) {
+	row, err := c.q.GetCompliancePolicyByID(ctx, id)
+	if err != nil {
+		return store.CompliancePolicy{}, fmt.Errorf("compliance: get policy: %w", translateNotFound(err))
+	}
+	return policyFromRow(row), nil
+}
+
+// ListPolicies returns the paginated policy list. Empty slice when
+// the offset is past the end; no ErrNotFound.
+func (c *Compliance) ListPolicies(ctx context.Context, filter store.ListCompliancePoliciesFilter) ([]store.CompliancePolicy, error) {
+	rows, err := c.q.ListCompliancePolicies(ctx, generated.ListCompliancePoliciesParams{
+		Limit:  filter.Limit,
+		Offset: filter.Offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("compliance: list policies: %w", err)
+	}
+	out := make([]store.CompliancePolicy, len(rows))
+	for i, r := range rows {
+		out[i] = policyFromRow(r)
+	}
+	return out, nil
+}
+
+// CountPolicies returns the total count of non-deleted policies. The
+// COUNT(*) :one query never returns ErrNoRows in practice but the
+// translateNotFound wrap keeps the contract symmetric with sibling
+// counts elsewhere.
+func (c *Compliance) CountPolicies(ctx context.Context) (int64, error) {
+	n, err := c.q.CountCompliancePolicies(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("compliance: count policies: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+// ListPolicyRules returns the rules for a policy in the order the
+// projection emits them. Empty slice when the policy has no rules.
+func (c *Compliance) ListPolicyRules(ctx context.Context, policyID string) ([]store.CompliancePolicyRule, error) {
+	rows, err := c.q.ListCompliancePolicyRules(ctx, policyID)
+	if err != nil {
+		return nil, fmt.Errorf("compliance: list policy rules: %w", err)
+	}
+	out := make([]store.CompliancePolicyRule, len(rows))
+	for i, r := range rows {
+		out[i] = store.CompliancePolicyRule{
+			PolicyID:         r.PolicyID,
+			ActionID:         r.ActionID,
+			ActionName:       r.ActionName,
+			GracePeriodHours: r.GracePeriodHours,
+			AddedAt:          r.AddedAt,
+		}
+	}
+	return out, nil
+}
+
+// ListDeviceEvaluations returns the per-(policy, rule) evaluation
+// rows for a device, joined with policy_name + action_name + grace.
+// Empty slice when no policies are assigned to the device yet.
+func (c *Compliance) ListDeviceEvaluations(ctx context.Context, deviceID string) ([]store.DevicePolicyEvaluation, error) {
+	rows, err := c.q.GetDeviceCompliancePolicyEvaluations(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("compliance: list device evaluations: %w", err)
+	}
+	out := make([]store.DevicePolicyEvaluation, len(rows))
+	for i, r := range rows {
+		out[i] = store.DevicePolicyEvaluation{
+			DeviceID:         r.DeviceID,
+			PolicyID:         r.PolicyID,
+			PolicyName:       r.PolicyName,
+			ActionID:         r.ActionID,
+			ActionName:       r.ActionName,
+			Compliant:        r.Compliant,
+			Status:           r.Status,
+			GracePeriodHours: r.GracePeriodHours,
+			CheckedAt:        r.CheckedAt,
+			FirstFailedAt:    r.FirstFailedAt,
+		}
+	}
+	return out, nil
+}
+
+// policyFromRow translates a sqlc projection row to the domain shape.
+// Shared by GetPolicy and ListPolicies so the field-mapping lives in
+// one place.
+func policyFromRow(r generated.CompliancePoliciesProjection) store.CompliancePolicy {
+	return store.CompliancePolicy{
+		ID:          r.ID,
+		Name:        r.Name,
+		Description: r.Description,
+		RuleCount:   r.RuleCount,
+		CreatedAt:   r.CreatedAt,
+		CreatedBy:   r.CreatedBy,
+	}
+}
+
 // translateNotFound maps pgx.ErrNoRows to store.ErrNotFound at the
 // repository boundary. The original error is dropped intentionally
 // — handlers depend on store.IsNotFound and have no need for the


### PR DESCRIPTION
## Summary

Continues the per-domain migration. **Same domain as Wave B.1** — extends the existing \`ComplianceRepo\` interface with the policy-CRUD half that \`compliance_policy_handler.go\` owns. After this, the only remaining \`Queries()\` call in that handler is \`GetActionByID\` (cross-domain, stays until the action sub-wave).

## Why one repo, not two

Compliance-policy definitions and device-side evaluations share the projection pipeline. Splitting \`CompliancePolicyRepo\` from \`ComplianceRepo\` would create artificial boundaries on what's conceptually one domain. Extending the existing interface keeps the surface cohesive.

## New methods on ComplianceRepo

| Method | Maps to |
|---|---|
| \`GetPolicy(id)\` | \`Queries.GetCompliancePolicyByID\` |
| \`ListPolicies(filter)\` | \`Queries.ListCompliancePolicies\` |
| \`CountPolicies()\` | \`Queries.CountCompliancePolicies\` |
| \`ListPolicyRules(policyID)\` | \`Queries.ListCompliancePolicyRules\` |
| \`ListDeviceEvaluations(deviceID)\` | \`Queries.GetDeviceCompliancePolicyEvaluations\` |

New domain types: \`CompliancePolicy\`, \`CompliancePolicyRule\`, \`ListCompliancePoliciesFilter\`, \`DevicePolicyEvaluation\`. Field names normalized away from sqlc row-type identifiers.

## Call sites migrated

20 sites in \`compliance_policy_handler.go\`:
- 14 \`GetPolicy\`
- 3 \`ListPolicyRules\`
- 1 \`ListPolicies\`
- 1 \`CountPolicies\`
- 1 \`ListDeviceEvaluations\`

\`policyToProto\` signature shifted to take \`store.CompliancePolicy\` / \`[]store.CompliancePolicyRule\` instead of the sqlc-generated types.

## Non-goals

- Action domain (\`GetActionByID\` stays on \`Queries()\`).

## Acceptance

- \`compliance_policy_handler.go\` has only one remaining \`Queries()\` call (\`GetActionByID\`).
- Build / vet / staticcheck / gofmt: clean.
- Targeted tests pass (54s).

Part of #242. Closes #251.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved compliance policy and rule data access and handling for more consistent behavior.
  * Centralized policy/rule loading to ensure responses include latest policy plus rules.

* **New Features**
  * Added paginated policy listing with total counts.
  * Added device compliance evaluation listing for clearer device policy status retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/252)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->