### PR TITLE
refactor(store): wave B.5 — role repo (#253)

### DIFF
--- a/cmd/control/admin_user.go
+++ b/cmd/control/admin_user.go
@@ -41,7 +41,7 @@ func ensureAdminUser(ctx context.Context, st *store.Store, email, password strin
 	// Go projector treats a missing role_ids key the same as an
 	// empty slice and skips the per-role INSERT loop.
 	var roleIDs []string
-	if adminRole, err := st.Queries().GetRoleByName(ctx, "Admin"); err == nil {
+	if adminRole, err := st.Repos().Role.GetByName(ctx, "Admin"); err == nil {
 		roleIDs = []string{adminRole.ID}
 	} else {
 		logger.Warn("failed to look up Admin role for bootstrap user; user will be created with no roles",

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -129,7 +129,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 
 	protoUser := userToProto(user)
 	// Populate user roles
-	if roles, err := h.store.Queries().GetUserRoles(ctx, user.ID); err == nil {
+	if roles, err := h.store.Repos().Role.ListUserRoles(ctx, user.ID); err == nil {
 		for _, r := range roles {
 			protoUser.Roles = append(protoUser.Roles, roleToProto(r))
 		}
@@ -252,7 +252,7 @@ func (h *AuthHandler) GetCurrentUser(ctx context.Context, req *connect.Request[p
 
 	protoUser := userToProto(user)
 	// Populate user roles
-	if roles, err := h.store.Queries().GetUserRoles(ctx, user.ID); err == nil {
+	if roles, err := h.store.Repos().Role.ListUserRoles(ctx, user.ID); err == nil {
 		for _, r := range roles {
 			protoUser.Roles = append(protoUser.Roles, roleToProto(r))
 		}

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -48,7 +48,7 @@ func (h *RoleHandler) CreateRole(ctx context.Context, req *connect.Request[pm.Cr
 	// Check name uniqueness — distinguishing NotFound from a transient
 	// DB error matters: silently treating any error as "name available"
 	// would let a concurrent CreateRole succeed twice on a flaky DB.
-	_, err := h.store.Queries().GetRoleByName(ctx, req.Msg.Name)
+	_, err := h.store.Repos().Role.GetByName(ctx, req.Msg.Name)
 	if err == nil {
 		return nil, apiErrorCtx(ctx, ErrRoleNameExists, connect.CodeAlreadyExists, "role name already exists")
 	}
@@ -84,7 +84,7 @@ func (h *RoleHandler) CreateRole(ctx context.Context, req *connect.Request[pm.Cr
 		return nil, err
 	}
 
-	role, err := h.store.Queries().GetRoleByID(ctx, id)
+	role, err := h.store.Repos().Role.Get(ctx, id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to read role")
 	}
@@ -100,12 +100,12 @@ func (h *RoleHandler) GetRole(ctx context.Context, req *connect.Request[pm.GetRo
 		return nil, err
 	}
 
-	role, err := h.store.Queries().GetRoleByID(ctx, req.Msg.Id)
+	role, err := h.store.Repos().Role.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrRoleNotFound, "role not found")
 	}
 
-	userCount, err := h.store.Queries().CountUsersWithRole(ctx, req.Msg.Id)
+	userCount, err := h.store.Repos().Role.CountUsersWithRole(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count users")
 	}
@@ -123,7 +123,7 @@ func (h *RoleHandler) ListRoles(ctx context.Context, req *connect.Request[pm.Lis
 		return nil, err
 	}
 
-	roles, err := h.store.Queries().ListRoles(ctx, db.ListRolesParams{
+	roles, err := h.store.Repos().Role.List(ctx, store.ListRolesFilter{
 		Limit:  pageSize,
 		Offset: offset,
 	})
@@ -131,7 +131,7 @@ func (h *RoleHandler) ListRoles(ctx context.Context, req *connect.Request[pm.Lis
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list roles")
 	}
 
-	count, err := h.store.Queries().CountRoles(ctx)
+	count, err := h.store.Repos().Role.Count(ctx)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count roles")
 	}
@@ -156,7 +156,7 @@ func (h *RoleHandler) UpdateRole(ctx context.Context, req *connect.Request[pm.Up
 		return nil, err
 	}
 
-	role, err := h.store.Queries().GetRoleByID(ctx, req.Msg.RoleId)
+	role, err := h.store.Repos().Role.Get(ctx, req.Msg.RoleId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrRoleNotFound, "role not found")
 	}
@@ -202,7 +202,7 @@ func (h *RoleHandler) UpdateRole(ctx context.Context, req *connect.Request[pm.Up
 	// Bump session_version for all users with this role to invalidate cached permissions
 	h.bumpSessionVersionForRole(ctx, req.Msg.RoleId, userCtx.ID)
 
-	updated, err := h.store.Queries().GetRoleByID(ctx, req.Msg.RoleId)
+	updated, err := h.store.Repos().Role.Get(ctx, req.Msg.RoleId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to read role")
 	}
@@ -218,7 +218,7 @@ func (h *RoleHandler) DeleteRole(ctx context.Context, req *connect.Request[pm.De
 		return nil, err
 	}
 
-	role, err := h.store.Queries().GetRoleByID(ctx, req.Msg.Id)
+	role, err := h.store.Repos().Role.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrRoleNotFound, "role not found")
 	}
@@ -227,7 +227,7 @@ func (h *RoleHandler) DeleteRole(ctx context.Context, req *connect.Request[pm.De
 		return nil, apiErrorCtx(ctx, ErrCannotDeleteSystemRole, connect.CodeFailedPrecondition, "cannot delete system role")
 	}
 
-	userCount, err := h.store.Queries().CountUsersWithRole(ctx, req.Msg.Id)
+	userCount, err := h.store.Repos().Role.CountUsersWithRole(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count users")
 	}
@@ -235,7 +235,7 @@ func (h *RoleHandler) DeleteRole(ctx context.Context, req *connect.Request[pm.De
 		return nil, apiErrorCtx(ctx, ErrRoleInUse, connect.CodeFailedPrecondition, fmt.Sprintf("role still has %d assigned users", userCount))
 	}
 
-	groupCount, err := h.store.Queries().CountGroupsWithRole(ctx, req.Msg.Id)
+	groupCount, err := h.store.Repos().Role.CountGroupsWithRole(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count user groups")
 	}
@@ -349,14 +349,14 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 	}
 
 	// Check if the role is the Admin system role
-	role, err := h.store.Queries().GetRoleByID(ctx, req.Msg.RoleId)
+	role, err := h.store.Repos().Role.Get(ctx, req.Msg.RoleId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrRoleNotFound, "role not found")
 	}
 
 	// Prevent removing the last user from the Admin system role
 	if role.IsSystem && role.Name == "Admin" {
-		userCount, err := h.store.Queries().CountUsersWithRole(ctx, req.Msg.RoleId)
+		userCount, err := h.store.Repos().Role.CountUsersWithRole(ctx, req.Msg.RoleId)
 		if err != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count users")
 		}
@@ -371,10 +371,7 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 	}
 
 	// Check if the user currently has the role — skip the event on retry/idempotent call
-	hasRole, err := h.store.Queries().UserHasRole(ctx, db.UserHasRoleParams{
-		UserID: req.Msg.UserId,
-		RoleID: req.Msg.RoleId,
-	})
+	hasRole, err := h.store.Repos().Role.UserHasRole(ctx, req.Msg.UserId, req.Msg.RoleId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
 	}
@@ -458,7 +455,7 @@ func (h *RoleHandler) bumpSessionVersionForRole(ctx context.Context, roleID, act
 	seen := make(map[string]bool)
 
 	// Direct role assignments
-	userIDs, err := h.store.Queries().ListUserIDsWithRole(ctx, roleID)
+	userIDs, err := h.store.Repos().Role.ListUserIDsWithRole(ctx, roleID)
 	if err != nil {
 		h.logger.Error("failed to list users with role for session invalidation",
 			"role_id", roleID, "error", err)
@@ -475,7 +472,7 @@ func (h *RoleHandler) bumpSessionVersionForRole(ctx context.Context, roleID, act
 	}
 
 	// User group role assignments
-	groupUserIDs, err := h.store.Queries().ListUserIDsWithGroupRole(ctx, roleID)
+	groupUserIDs, err := h.store.Repos().Role.ListUserIDsWithGroupRole(ctx, roleID)
 	if err != nil {
 		h.logger.Error("failed to list group users with role for session invalidation",
 			"role_id", roleID, "error", err)
@@ -491,8 +488,8 @@ func (h *RoleHandler) bumpSessionVersionForRole(ctx context.Context, roleID, act
 	}
 }
 
-// roleToProto converts a database role projection to a protobuf Role.
-func roleToProto(r db.RolesProjection) *pm.Role {
+// roleToProto converts a domain Role to a protobuf Role.
+func roleToProto(r store.Role) *pm.Role {
 	role := &pm.Role{
 		Id:          r.ID,
 		Name:        r.Name,

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -373,7 +373,7 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 	}
 
 	protoUser := userToProto(user)
-	if roles, err := h.store.Queries().GetUserRoles(ctx, user.ID); err == nil {
+	if roles, err := h.store.Repos().Role.ListUserRoles(ctx, user.ID); err == nil {
 		for _, r := range roles {
 			protoUser.Roles = append(protoUser.Roles, roleToProto(r))
 		}

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -430,7 +430,7 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 	}
 
 	protoUser := userToProto(user)
-	if roles, err := h.store.Queries().GetUserRoles(ctx, user.ID); err == nil {
+	if roles, err := h.store.Repos().Role.ListUserRoles(ctx, user.ID); err == nil {
 		for _, r := range roles {
 			protoUser.Roles = append(protoUser.Roles, roleToProto(r))
 		}

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -820,7 +820,19 @@ func userGroupToProto(g db.UserGroupsProjection, roles []db.RolesProjection, isS
 	group.CreatedAt = timestamppb.New(g.CreatedAt)
 
 	for _, r := range roles {
-		group.Roles = append(group.Roles, roleToProto(r))
+		// Transitional: until UserGroup migrates to a repo, the
+		// GetUserGroupRoles query returns generated.RolesProjection.
+		// Convert to the domain shape so roleToProto stays repo-typed.
+		group.Roles = append(group.Roles, roleToProto(store.Role{
+			ID:          r.ID,
+			Name:        r.Name,
+			Description: r.Description,
+			Permissions: r.Permissions,
+			IsSystem:    r.IsSystem,
+			CreatedAt:   r.CreatedAt,
+			CreatedBy:   r.CreatedBy,
+			UpdatedAt:   r.UpdatedAt,
+		}))
 	}
 
 	return group

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -94,7 +94,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 	// silently is the bug operators triage.
 	roleIDs := req.Msg.RoleIds
 	if len(roleIDs) == 0 {
-		userRole, err := h.store.Queries().GetRoleByName(ctx, "User")
+		userRole, err := h.store.Repos().Role.GetByName(ctx, "User")
 		if err == nil {
 			roleIDs = []string{userRole.ID}
 		} else {
@@ -810,7 +810,7 @@ func (h *UserHandler) populateUserIdentityLinks(ctx context.Context, user *pm.Us
 
 // populateUserRoles loads roles for a user and attaches them to the proto User.
 func (h *UserHandler) populateUserRoles(ctx context.Context, user *pm.User) {
-	roles, err := h.store.Queries().GetUserRoles(ctx, user.Id)
+	roles, err := h.store.Repos().Role.ListUserRoles(ctx, user.Id)
 	if err != nil {
 		return
 	}

--- a/internal/store/postgres/role.go
+++ b/internal/store/postgres/role.go
@@ -1,0 +1,130 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Role implements store.RoleRepo against the roles_projection +
+// user_roles_projection tables.
+type Role struct {
+	q *generated.Queries
+}
+
+// NewRole returns a Role repo bound to the given sqlc handle.
+func NewRole(q *generated.Queries) *Role {
+	return &Role{q: q}
+}
+
+func (r *Role) Get(ctx context.Context, id string) (store.Role, error) {
+	row, err := r.q.GetRoleByID(ctx, id)
+	if err != nil {
+		return store.Role{}, fmt.Errorf("role: get: %w", translateNotFound(err))
+	}
+	return roleFromRow(row), nil
+}
+
+func (r *Role) GetByName(ctx context.Context, name string) (store.Role, error) {
+	row, err := r.q.GetRoleByName(ctx, name)
+	if err != nil {
+		return store.Role{}, fmt.Errorf("role: get by name: %w", translateNotFound(err))
+	}
+	return roleFromRow(row), nil
+}
+
+func (r *Role) List(ctx context.Context, filter store.ListRolesFilter) ([]store.Role, error) {
+	rows, err := r.q.ListRoles(ctx, generated.ListRolesParams{
+		Limit:  filter.Limit,
+		Offset: filter.Offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("role: list: %w", err)
+	}
+	out := make([]store.Role, len(rows))
+	for i, row := range rows {
+		out[i] = roleFromRow(row)
+	}
+	return out, nil
+}
+
+func (r *Role) Count(ctx context.Context) (int64, error) {
+	n, err := r.q.CountRoles(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("role: count: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (r *Role) ListUserRoles(ctx context.Context, userID string) ([]store.Role, error) {
+	rows, err := r.q.GetUserRoles(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("role: list user roles: %w", err)
+	}
+	out := make([]store.Role, len(rows))
+	for i, row := range rows {
+		out[i] = roleFromRow(row)
+	}
+	return out, nil
+}
+
+func (r *Role) UserHasRole(ctx context.Context, userID, roleID string) (bool, error) {
+	has, err := r.q.UserHasRole(ctx, generated.UserHasRoleParams{
+		UserID: userID,
+		RoleID: roleID,
+	})
+	if err != nil {
+		return false, fmt.Errorf("role: user has role: %w", translateNotFound(err))
+	}
+	return has, nil
+}
+
+func (r *Role) CountUsersWithRole(ctx context.Context, roleID string) (int64, error) {
+	n, err := r.q.CountUsersWithRole(ctx, roleID)
+	if err != nil {
+		return 0, fmt.Errorf("role: count users with role: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (r *Role) CountGroupsWithRole(ctx context.Context, roleID string) (int64, error) {
+	n, err := r.q.CountGroupsWithRole(ctx, roleID)
+	if err != nil {
+		return 0, fmt.Errorf("role: count groups with role: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (r *Role) ListUserIDsWithRole(ctx context.Context, roleID string) ([]string, error) {
+	ids, err := r.q.ListUserIDsWithRole(ctx, roleID)
+	if err != nil {
+		return nil, fmt.Errorf("role: list user ids: %w", err)
+	}
+	return ids, nil
+}
+
+func (r *Role) ListUserIDsWithGroupRole(ctx context.Context, roleID string) ([]string, error) {
+	ids, err := r.q.ListUserIDsWithGroupRole(ctx, roleID)
+	if err != nil {
+		return nil, fmt.Errorf("role: list group-role user ids: %w", err)
+	}
+	return ids, nil
+}
+
+// roleFromRow translates a sqlc projection row to the domain shape.
+// Shared so the field mapping lives in one place across Get /
+// GetByName / List / ListUserRoles.
+func roleFromRow(row generated.RolesProjection) store.Role {
+	return store.Role{
+		ID:          row.ID,
+		Name:        row.Name,
+		Description: row.Description,
+		Permissions: row.Permissions,
+		IsSystem:    row.IsSystem,
+		CreatedAt:   row.CreatedAt,
+		CreatedBy:   row.CreatedBy,
+		UpdatedAt:   row.UpdatedAt,
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -18,6 +18,7 @@ func NewRepos(q *generated.Queries) *store.Repos {
 		IdentityLink:    NewIdentityLink(q),
 		Logs:            NewLogs(q),
 		OSQuery:         NewOSQuery(q),
+		Role:            NewRole(q),
 		Settings:        NewSettings(q),
 		TerminalSession: NewTerminalSession(q),
 		Totp:            NewTotp(q),

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -17,6 +17,7 @@ type Repos struct {
 	IdentityLink    IdentityLinkRepo
 	Logs            LogsRepo
 	OSQuery         OSQueryRepo
+	Role            RoleRepo
 	Settings        SettingsRepo
 	TerminalSession TerminalSessionRepo
 	Totp            TotpRepo

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -1,0 +1,81 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// Role is a permission-bearing role definition. Permissions is the
+// flat list of permission keys this role grants — names match what
+// auth.HasPermission checks against. IsSystem flags roles that the
+// platform manages (e.g. the built-in Admin / User roles) and that
+// the role-CRUD endpoints refuse to delete or mutate.
+type Role struct {
+	ID          string
+	Name        string
+	Description string
+	Permissions []string
+	IsSystem    bool
+	CreatedAt   time.Time
+	CreatedBy   string
+	UpdatedAt   *time.Time
+}
+
+// ListRolesFilter is the pagination shape for the role list endpoint.
+type ListRolesFilter struct {
+	Limit  int32
+	Offset int32
+}
+
+// RoleRepo reads role definitions and per-user role membership from
+// the projection. Writes (RoleCreated / RoleUpdated / RoleDeleted /
+// UserRoleAssigned / UserRoleRevoked) flow through the event store.
+//
+// The repo bundles both the role catalog (Get / List / Count) and
+// the user-role membership graph (ListUserRoles / UserHasRole /
+// ListUserIDsWithRole / ...) because they share the same projection
+// pipeline and are queried together from the role handler.
+type RoleRepo interface {
+	// Get returns a role by ID. Returns ErrNotFound when no role
+	// with that ID exists.
+	Get(ctx context.Context, id string) (Role, error)
+
+	// GetByName returns a role by its display name. Returns
+	// ErrNotFound when no role with that name exists. Used by the
+	// CreateRole pre-check and admin bootstrap.
+	GetByName(ctx context.Context, name string) (Role, error)
+
+	// List returns a page of roles. Empty slice past the end.
+	List(ctx context.Context, filter ListRolesFilter) ([]Role, error)
+
+	// Count returns the total role count for pagination.
+	Count(ctx context.Context) (int64, error)
+
+	// ListUserRoles returns all roles assigned to the user — both
+	// directly and via groups, deduplicated. Empty slice when the
+	// user has no roles.
+	ListUserRoles(ctx context.Context, userID string) ([]Role, error)
+
+	// UserHasRole reports whether the user has the given role
+	// assigned, either directly or via a group membership.
+	UserHasRole(ctx context.Context, userID, roleID string) (bool, error)
+
+	// CountUsersWithRole returns the number of users with this role
+	// assigned directly. Used by the "cannot delete role with
+	// active users" pre-condition.
+	CountUsersWithRole(ctx context.Context, roleID string) (int64, error)
+
+	// CountGroupsWithRole returns the number of user-groups that
+	// carry this role. Same delete-pre-condition use case.
+	CountGroupsWithRole(ctx context.Context, roleID string) (int64, error)
+
+	// ListUserIDsWithRole returns the IDs of users with this role
+	// assigned directly. Used by the session-version bump pathway
+	// when a role's permission set changes.
+	ListUserIDsWithRole(ctx context.Context, roleID string) ([]string, error)
+
+	// ListUserIDsWithGroupRole returns the IDs of users transitively
+	// assigned this role via a user-group. Same session-version
+	// bump pathway.
+	ListUserIDsWithGroupRole(ctx context.Context, roleID string) ([]string, error)
+}


### PR DESCRIPTION
## Summary

\`RoleRepo\` — biggest single-domain migration so far. 10 methods, 22 call sites across 6 files. Covers both the role catalog and the per-user role membership graph; both share the projection pipeline.

Branches off main directly (independent of #250 / #252 — different files).

## Methods

| Catalog | Membership graph |
|---|---|
| \`Get(id)\` | \`ListUserRoles(userID)\` |
| \`GetByName(name)\` | \`UserHasRole(userID, roleID)\` |
| \`List(filter)\` | \`CountUsersWithRole(roleID)\` |
| \`Count()\` | \`CountGroupsWithRole(roleID)\` |
|  | \`ListUserIDsWithRole(roleID)\` |
|  | \`ListUserIDsWithGroupRole(roleID)\` |

## Call sites migrated (22)

- \`role_handler.go\` — 17 sites
- \`auth_handler.go\` — 2 sites (login response role population)
- \`sso_handler.go\` — 1 site
- \`totp_handler.go\` — 1 site
- \`user_handler.go\` — 1 site (\`populateUserRoles\`)
- \`cmd/control/admin_user.go\` — 1 site (admin bootstrap)

\`roleToProto\` signature shifted from \`generated.RolesProjection\` → \`store.Role\`. \`user_group_handler.go\` still uses the sqlc shape (UserGroup domain stays on \`Queries()\` until its migration) and does a transitional inline conversion at the one \`roleToProto\` call.

## Non-goals

- \`GetUserGroupRoles\` / \`UserGroupHasRole\` — UserGroup domain.
- \`ListInheritedRolesByUserIDs\` — bulk-page join shape handled when User migrates.
- Write-side (\`UserRoleAssigned\` etc.) — flows through events.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Targeted tests (\`TestCreateRole\`, \`TestAssignRole\`, \`TestRevokeRole\`, \`TestLogin\`, \`TestSetupTOTP\`, \`TestSSOCallback\`, etc.): 249s of coverage passes.

Part of #242. Closes #253.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified role-loading and role-management internals for consistent behavior across login, SSO, TOTP, user/group views, and admin bootstrap; no changes to user-visible behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/254)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->