### PR TITLE
refactor(store): wave B.6 — token + revoked_token repos (#255)

### DIFF
--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
-	"github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // AuthHandler handles authentication RPCs.
@@ -159,7 +158,7 @@ func (h *AuthHandler) RefreshToken(ctx context.Context, req *connect.Request[pm.
 
 	// Validate refresh token and check revocation
 	isRevoked := func(jti string) (bool, error) {
-		return h.store.Queries().IsTokenRevoked(ctx, jti)
+		return h.store.Repos().RevokedToken.IsRevoked(ctx, jti)
 	}
 
 	result, err := h.jwtManager.ValidateRefreshToken(refreshToken, isRevoked)
@@ -185,10 +184,7 @@ func (h *AuthHandler) RefreshToken(ctx context.Context, req *connect.Request[pm.
 	// request. This prevents a race where two concurrent RefreshToken calls
 	// with the same token both succeed.
 	if result.OldJTI != "" {
-		_, err := h.store.Queries().RevokeToken(ctx, generated.RevokeTokenParams{
-			Jti:       result.OldJTI,
-			ExpiresAt: result.OldExp,
-		})
+		_, err := h.store.Repos().RevokedToken.Revoke(ctx, result.OldJTI, result.OldExp)
 		if err != nil {
 			return nil, apiErrorCtx(ctx, ErrTokenExpired, connect.CodeUnauthenticated, "refresh token already used")
 		}
@@ -226,10 +222,7 @@ func (h *AuthHandler) Logout(ctx context.Context, req *connect.Request[pm.Logout
 	if refreshToken != "" {
 		claims, err := h.jwtManager.ValidateToken(refreshToken, auth.TokenTypeRefresh)
 		if err == nil && claims.ID != "" {
-			if _, err := h.store.Queries().RevokeToken(ctx, generated.RevokeTokenParams{
-				Jti:       claims.ID,
-				ExpiresAt: claims.ExpiresAt.Time,
-			}); err != nil {
+			if _, err := h.store.Repos().RevokedToken.Revoke(ctx, claims.ID, claims.ExpiresAt.Time); err != nil {
 				h.logger.Warn("failed to revoke token on logout", "jti", claims.ID, "error", err)
 			}
 		}

--- a/internal/api/registration_handler.go
+++ b/internal/api/registration_handler.go
@@ -145,7 +145,7 @@ func (h *RegistrationHandler) Register(ctx context.Context, req *connect.Request
 	tokenHash := sha256.Sum256([]byte(req.Msg.Token))
 	tokenHashHex := hex.EncodeToString(tokenHash[:])
 
-	token, err := h.store.Queries().GetTokenByHash(ctx, tokenHashHex)
+	token, err := h.store.Repos().Token.GetByHash(ctx, tokenHashHex)
 	if err != nil {
 		if store.IsNotFound(err) {
 			logger.Warn("invalid registration token")

--- a/internal/api/token_handler.go
+++ b/internal/api/token_handler.go
@@ -18,7 +18,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // TokenHandler handles registration token management RPCs.
@@ -106,7 +105,7 @@ func (h *TokenHandler) CreateToken(ctx context.Context, req *connect.Request[pm.
 	}
 
 	// Read back from projection
-	token, err := h.store.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: id})
+	token, err := h.store.Repos().Token.Get(ctx, id, nil)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get token")
 	}
@@ -125,7 +124,7 @@ func (h *TokenHandler) GetToken(ctx context.Context, req *connect.Request[pm.Get
 		return nil, err
 	}
 
-	token, err := h.store.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: req.Msg.Id})
+	token, err := h.store.Repos().Token.Get(ctx, req.Msg.Id, nil)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrTokenNotFound, "token not found")
 	}
@@ -142,19 +141,19 @@ func (h *TokenHandler) ListTokens(ctx context.Context, req *connect.Request[pm.L
 		return nil, err
 	}
 
-	tokens, err := h.store.Queries().ListTokens(ctx, db.ListTokensParams{
-		Column1:       req.Msg.IncludeDisabled,
-		Limit:         pageSize,
-		Offset:        offset,
-		FilterOwnerID: userFilterID(ctx, "ListTokens"),
+	tokens, err := h.store.Repos().Token.List(ctx, store.ListTokensFilter{
+		IncludeDisabled: req.Msg.IncludeDisabled,
+		Limit:           pageSize,
+		Offset:          offset,
+		OwnerScope:      userFilterID(ctx, "ListTokens"),
 	})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list tokens")
 	}
 
-	count, err := h.store.Queries().CountTokens(ctx, db.CountTokensParams{
-		Column1:       req.Msg.IncludeDisabled,
-		FilterOwnerID: userFilterID(ctx, "ListTokens"),
+	count, err := h.store.Repos().Token.Count(ctx, store.CountTokensFilter{
+		IncludeDisabled: req.Msg.IncludeDisabled,
+		OwnerScope:      userFilterID(ctx, "ListTokens"),
 	})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count tokens")
@@ -200,7 +199,7 @@ func (h *TokenHandler) RenameToken(ctx context.Context, req *connect.Request[pm.
 	}
 
 	// Read back from projection
-	token, err := h.store.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: req.Msg.Id})
+	token, err := h.store.Repos().Token.Get(ctx, req.Msg.Id, nil)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrTokenNotFound, "token not found")
 	}
@@ -239,7 +238,7 @@ func (h *TokenHandler) SetTokenDisabled(ctx context.Context, req *connect.Reques
 	}
 
 	// Read back from projection
-	token, err := h.store.Queries().GetTokenByID(ctx, db.GetTokenByIDParams{ID: req.Msg.Id})
+	token, err := h.store.Repos().Token.Get(ctx, req.Msg.Id, nil)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrTokenNotFound, "token not found")
 	}
@@ -275,8 +274,8 @@ func (h *TokenHandler) DeleteToken(ctx context.Context, req *connect.Request[pm.
 	return connect.NewResponse(&pm.DeleteTokenResponse{}), nil
 }
 
-// tokenToProto converts a database token projection to a protobuf token.
-func tokenToProto(t db.TokensProjection) *pm.RegistrationToken {
+// tokenToProto converts a domain Token to a protobuf token.
+func tokenToProto(t store.Token) *pm.RegistrationToken {
 	token := &pm.RegistrationToken{
 		Id:          t.ID,
 		Name:        t.Name,

--- a/internal/store/postgres/revoked_token.go
+++ b/internal/store/postgres/revoked_token.go
@@ -1,0 +1,40 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// RevokedToken implements store.RevokedTokenRepo against the
+// revoked_tokens table.
+type RevokedToken struct {
+	q *generated.Queries
+}
+
+// NewRevokedToken returns a RevokedToken repo bound to the given
+// sqlc handle.
+func NewRevokedToken(q *generated.Queries) *RevokedToken {
+	return &RevokedToken{q: q}
+}
+
+func (r *RevokedToken) Revoke(ctx context.Context, jti string, expiresAt time.Time) (string, error) {
+	out, err := r.q.RevokeToken(ctx, generated.RevokeTokenParams{
+		Jti:       jti,
+		ExpiresAt: expiresAt,
+	})
+	if err != nil {
+		return "", fmt.Errorf("revoked_token: revoke: %w", translateNotFound(err))
+	}
+	return out, nil
+}
+
+func (r *RevokedToken) IsRevoked(ctx context.Context, jti string) (bool, error) {
+	revoked, err := r.q.IsTokenRevoked(ctx, jti)
+	if err != nil {
+		return false, fmt.Errorf("revoked_token: is revoked: %w", translateNotFound(err))
+	}
+	return revoked, nil
+}

--- a/internal/store/postgres/token.go
+++ b/internal/store/postgres/token.go
@@ -1,0 +1,85 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Token implements store.TokenRepo against tokens_projection.
+type Token struct {
+	q *generated.Queries
+}
+
+// NewToken returns a Token repo bound to the given sqlc handle.
+func NewToken(q *generated.Queries) *Token {
+	return &Token{q: q}
+}
+
+func (t *Token) Get(ctx context.Context, id string, ownerScope *string) (store.Token, error) {
+	row, err := t.q.GetTokenByID(ctx, generated.GetTokenByIDParams{
+		ID:            id,
+		FilterOwnerID: ownerScope,
+	})
+	if err != nil {
+		return store.Token{}, fmt.Errorf("token: get: %w", translateNotFound(err))
+	}
+	return tokenFromRow(row), nil
+}
+
+func (t *Token) GetByHash(ctx context.Context, valueHash string) (store.Token, error) {
+	row, err := t.q.GetTokenByHash(ctx, valueHash)
+	if err != nil {
+		return store.Token{}, fmt.Errorf("token: get by hash: %w", translateNotFound(err))
+	}
+	return tokenFromRow(row), nil
+}
+
+func (t *Token) List(ctx context.Context, filter store.ListTokensFilter) ([]store.Token, error) {
+	rows, err := t.q.ListTokens(ctx, generated.ListTokensParams{
+		Column1:       filter.IncludeDisabled,
+		Limit:         filter.Limit,
+		Offset:        filter.Offset,
+		FilterOwnerID: filter.OwnerScope,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("token: list: %w", err)
+	}
+	out := make([]store.Token, len(rows))
+	for i, row := range rows {
+		out[i] = tokenFromRow(row)
+	}
+	return out, nil
+}
+
+func (t *Token) Count(ctx context.Context, filter store.CountTokensFilter) (int64, error) {
+	n, err := t.q.CountTokens(ctx, generated.CountTokensParams{
+		Column1:       filter.IncludeDisabled,
+		FilterOwnerID: filter.OwnerScope,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("token: count: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+// tokenFromRow translates a sqlc projection row to the domain shape.
+// Shared by Get / GetByHash / List so the field mapping lives in
+// one place.
+func tokenFromRow(row generated.TokensProjection) store.Token {
+	return store.Token{
+		ID:          row.ID,
+		ValueHash:   row.ValueHash,
+		Name:        row.Name,
+		OneTime:     row.OneTime,
+		MaxUses:     row.MaxUses,
+		CurrentUses: row.CurrentUses,
+		ExpiresAt:   row.ExpiresAt,
+		CreatedAt:   row.CreatedAt,
+		CreatedBy:   row.CreatedBy,
+		Disabled:    row.Disabled,
+		OwnerID:     row.OwnerID,
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -18,9 +18,11 @@ func NewRepos(q *generated.Queries) *store.Repos {
 		IdentityLink:    NewIdentityLink(q),
 		Logs:            NewLogs(q),
 		OSQuery:         NewOSQuery(q),
+		RevokedToken:    NewRevokedToken(q),
 		Role:            NewRole(q),
 		Settings:        NewSettings(q),
 		TerminalSession: NewTerminalSession(q),
+		Token:           NewToken(q),
 		Totp:            NewTotp(q),
 	}
 }

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -17,8 +17,10 @@ type Repos struct {
 	IdentityLink    IdentityLinkRepo
 	Logs            LogsRepo
 	OSQuery         OSQueryRepo
+	RevokedToken    RevokedTokenRepo
 	Role            RoleRepo
 	Settings        SettingsRepo
 	TerminalSession TerminalSessionRepo
+	Token           TokenRepo
 	Totp            TotpRepo
 }

--- a/internal/store/revoked_token.go
+++ b/internal/store/revoked_token.go
@@ -1,0 +1,26 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// RevokedTokenRepo manages the JWT refresh-token revocation list. It
+// is intentionally separate from TokenRepo — registration tokens
+// (tokens_projection) and revoked JWTs (revoked_tokens) share only
+// the word "token"; they're different tables with different
+// lifecycles. The auth handler uses both, but the two domains are
+// otherwise unrelated.
+type RevokedTokenRepo interface {
+	// Revoke inserts the jti into the revocation list with the
+	// supplied TTL (the JWT's original expiry). Returns the inserted
+	// jti on success; ErrNotFound when the row was already present
+	// (the underlying INSERT ... ON CONFLICT DO NOTHING RETURNING
+	// shape), which the caller uses to detect concurrent-revocation
+	// races without surfacing them as errors.
+	Revoke(ctx context.Context, jti string, expiresAt time.Time) (string, error)
+
+	// IsRevoked reports whether the jti is on the revocation list.
+	// Used in the refresh-token validation path.
+	IsRevoked(ctx context.Context, jti string) (bool, error)
+}

--- a/internal/store/token.go
+++ b/internal/store/token.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// Token is a registration-token row from tokens_projection. Used for
+// agent enrollment + one-time / multi-use scoped issuance. JWT
+// refresh-token revocations are a separate table — see RevokedTokenRepo.
+type Token struct {
+	ID          string
+	ValueHash   string
+	Name        string
+	OneTime     bool
+	MaxUses     int32
+	CurrentUses int32
+	ExpiresAt   *time.Time
+	CreatedAt   *time.Time
+	CreatedBy   string
+	Disabled    bool
+	OwnerID     *string
+}
+
+// ListTokensFilter is the pagination + scoping shape for ListTokens.
+//
+// OwnerScope == nil → no owner scoping (admin view, all tokens).
+// OwnerScope != nil → restrict to tokens whose owner_id matches —
+//
+//	used by the `:self`-scoped variant of the list permission so
+//	users only see their own tokens.
+type ListTokensFilter struct {
+	IncludeDisabled bool
+	OwnerScope      *string
+	Limit           int32
+	Offset          int32
+}
+
+// CountTokensFilter mirrors ListTokensFilter for the count side; the
+// filter shape must stay identical so pagination totals line up with
+// what ListTokens actually returns.
+type CountTokensFilter struct {
+	IncludeDisabled bool
+	OwnerScope      *string
+}
+
+// TokenRepo reads + manages the registration-token projection. Writes
+// flow through the event store (TokenCreated, TokenDisabled,
+// TokenDeleted, TokenUsed), not through this interface.
+type TokenRepo interface {
+	// Get returns a token by ID. ownerScope, when non-nil, restricts
+	// the lookup to tokens owned by that user — yields ErrNotFound
+	// instead of a permission error when the owner doesn't match,
+	// preserving the existing handler behaviour. nil = no scope.
+	Get(ctx context.Context, id string, ownerScope *string) (Token, error)
+
+	// GetByHash looks up a token by its value hash. Used by the
+	// registration handler when an agent presents a token; the
+	// projection's UNIQUE(value_hash) guarantees at most one row.
+	GetByHash(ctx context.Context, valueHash string) (Token, error)
+
+	// List returns a page of tokens matching the filter. Empty slice
+	// past the end.
+	List(ctx context.Context, filter ListTokensFilter) ([]Token, error)
+
+	// Count returns the total matching the filter. Pair with List
+	// for paginated UIs.
+	Count(ctx context.Context, filter CountTokensFilter) (int64, error)
+}


### PR DESCRIPTION
## Summary

Two new repos. Different tables, different lifecycles → kept separate even though both are "token-shaped":

| Repo | Table | Methods |
|---|---|---|
| \`TokenRepo\` | \`tokens_projection\` | \`Get(id, ownerScope)\`, \`GetByHash\`, \`List(filter)\`, \`Count(filter)\` |
| \`RevokedTokenRepo\` | \`revoked_tokens\` | \`Revoke(jti, expiresAt)\`, \`IsRevoked(jti)\` |

\`OwnerScope\` (nil = no filter; non-nil = restrict to that owner) replaces the \`FilterOwnerID *string\` shape the sqlc params used directly — it models the existing \`:self\`-scoped permission cleanly at the domain boundary.

Branches off main directly.

## Call sites migrated (10 total)

- \`token_handler.go\` — 6 sites (Get ×4, List, Count)
- \`registration_handler.go\` — 1 site (GetByHash)
- \`auth_handler.go\` — 3 sites (IsRevoked + 2× Revoke)

\`tokenToProto\` signature shifted from \`generated.TokensProjection\` → \`store.Token\`.

## Non-goals

- **LUKS tokens** (\`CreateLuksToken\` / \`ValidateAndConsumeLuksToken\`) — LUKS sub-wave.
- \`RotateIdentityProviderSCIMToken\` — IdP-domain projector write.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Targeted tests (TestCreateToken, TestListTokens, TestRegister*, TestLogin, TestLogout, TestRefreshToken): 304s of coverage passes.

Part of #242. Closes #255.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Token revocation and token management now use unified repository-backed implementations.
  * Authentication and registration flows updated to use the new token handling.
  * Token listing/counting keep existing pagination and filtering behavior.
  * New token and revocation backends added to improve reliability and future extensibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/256)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->