### PR TITLE
refactor(store): wave B.7 — auth_state + user_selection + inventory repos (#257)

### DIFF
--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -157,16 +157,13 @@ func (h *OSQueryHandler) GetOSQueryResult(ctx context.Context, req *connect.Requ
 func (h *OSQueryHandler) GetDeviceInventory(ctx context.Context, req *connect.Request[pm.GetDeviceInventoryRequest]) (*connect.Response[pm.GetDeviceInventoryResponse], error) {
 	msg := req.Msg
 
-	var rows []generated.DeviceInventory
+	var rows []store.InventoryTable
 	var err error
 
 	if len(msg.TableNames) > 0 {
-		rows, err = h.store.Queries().GetDeviceInventoryByTables(ctx, generated.GetDeviceInventoryByTablesParams{
-			DeviceID: msg.DeviceId,
-			Column2:  msg.TableNames,
-		})
+		rows, err = h.store.Repos().Inventory.ListTables(ctx, msg.DeviceId, msg.TableNames)
 	} else {
-		rows, err = h.store.Queries().GetDeviceInventory(ctx, msg.DeviceId)
+		rows, err = h.store.Repos().Inventory.ListAllTables(ctx, msg.DeviceId)
 	}
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get inventory")

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -17,7 +17,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/idp"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // SSOHandler handles SSO authentication flow RPCs.
@@ -136,12 +135,12 @@ func (h *SSOHandler) GetSSOLoginURL(ctx context.Context, req *connect.Request[pm
 
 	// Store auth state (10 min expiry)
 	expiresAt := time.Now().Add(10 * time.Minute)
-	err = h.store.Queries().CreateAuthState(ctx, db.CreateAuthStateParams{
+	err = h.store.Repos().AuthState.Create(ctx, store.CreateAuthStateParams{
 		State:        state,
 		ProviderID:   provider.ID,
 		Nonce:        nonce,
 		CodeVerifier: codeVerifier,
-		RedirectUri:  req.Msg.RedirectUrl,
+		RedirectURI:  req.Msg.RedirectUrl,
 		ExpiresAt:    expiresAt,
 	})
 	if err != nil {
@@ -194,7 +193,7 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 	}
 	h.logger.Info("SSO callback received", "slug", req.Msg.Slug, "state_prefix", statePrefix)
 
-	authState, err := h.store.Queries().ConsumeAuthState(ctx, req.Msg.State)
+	authState, err := h.store.Repos().AuthState.Consume(ctx, req.Msg.State)
 	if err != nil {
 		if store.IsNotFound(err) {
 			h.logger.Warn("SSO auth state not found or expired", "state_prefix", statePrefix, "slug", req.Msg.Slug)
@@ -228,7 +227,7 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 	// Create OIDC provider.
 	// Use the redirect URI stored during GetSSOLoginURL so the token exchange
 	// redirect_uri matches the one used in the authorization request.
-	callbackURL := authState.RedirectUri
+	callbackURL := authState.RedirectURI
 	if callbackURL == "" {
 		callbackURL = h.callbackBaseURL + "/auth/callback/" + provider.Slug
 	}

--- a/internal/api/user_selection_handler.go
+++ b/internal/api/user_selection_handler.go
@@ -89,7 +89,7 @@ func (h *UserSelectionHandler) SetUserSelection(ctx context.Context, req *connec
 		return nil, err
 	}
 
-	selection, err := h.store.Queries().GetUserSelection(ctx, db.GetUserSelectionParams{
+	selection, err := h.store.Repos().UserSelection.Get(ctx, store.GetUserSelectionKey{
 		DeviceID:   req.Msg.DeviceId,
 		SourceType: sourceTypeStr,
 		SourceID:   req.Msg.SourceId,
@@ -125,7 +125,7 @@ func (h *UserSelectionHandler) ListAvailableActions(ctx context.Context, req *co
 	}
 
 	// Get user selections for this device
-	selections, err := h.store.Queries().ListUserSelectionsForDevice(ctx, req.Msg.DeviceId)
+	selections, err := h.store.Repos().UserSelection.ListForDevice(ctx, req.Msg.DeviceId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list user selections")
 	}
@@ -187,7 +187,7 @@ func (h *UserSelectionHandler) ListAvailableActions(ctx context.Context, req *co
 	}), nil
 }
 
-func userSelectionToProto(s db.UserSelectionsProjection) *pm.UserSelection {
+func userSelectionToProto(s store.UserSelection) *pm.UserSelection {
 	sel := &pm.UserSelection{
 		Id:         s.ID,
 		DeviceId:   s.DeviceID,

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -471,7 +471,7 @@ func (w *InboxWorker) handleInventoryUpdate(ctx context.Context, t *asynq.Task) 
 	)
 
 	for _, table := range payload.Tables {
-		if err := w.store.Queries().UpsertDeviceInventory(ctx, db.UpsertDeviceInventoryParams{
+		if err := w.store.Repos().Inventory.Upsert(ctx, store.UpsertInventoryTable{
 			DeviceID:  payload.DeviceID,
 			TableName: table.TableName,
 			Rows:      table.RowsJSON,

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -666,10 +666,7 @@ func (idx *Index) warmDevices(ctx context.Context) (int, error) {
 			}
 
 			// Enrich with inventory data (os_version, system_info, kernel_info).
-			inv, err := idx.store.Queries().GetDeviceInventoryByTables(ctx, db.GetDeviceInventoryByTablesParams{
-				DeviceID: d.ID,
-				Column2:  []string{"os_version", "system_info", "kernel_info"},
-			})
+			inv, err := idx.store.Repos().Inventory.ListTables(ctx, d.ID, []string{"os_version", "system_info", "kernel_info"})
 			if err == nil {
 				for _, t := range inv {
 					osName, osVer, osArch, kernel := extractInventoryFields(t.TableName, t.Rows)

--- a/internal/store/auth_state.go
+++ b/internal/store/auth_state.go
@@ -1,0 +1,48 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// AuthState is the per-flow OIDC/OAuth state row used to thread the
+// authorization-code dance through the SSO handler. Each row pins
+// the original nonce + code verifier + redirect URI for one in-flight
+// login attempt; rows are consumed on first read so any replay
+// surfaces as ErrNotFound.
+type AuthState struct {
+	State        string
+	ProviderID   string
+	Nonce        string
+	CodeVerifier string
+	RedirectURI  string
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+}
+
+// CreateAuthStateParams carries the fields the SSO handler stages
+// when initiating a login. The state token (PKCE-bound) is the
+// primary key.
+type CreateAuthStateParams struct {
+	State        string
+	ProviderID   string
+	Nonce        string
+	CodeVerifier string
+	RedirectURI  string
+	ExpiresAt    time.Time
+}
+
+// AuthStateRepo manages short-lived SSO/OIDC authorization-state rows.
+// The Consume path is destructive — the row is deleted as part of the
+// read so a stolen state token can't be replayed.
+type AuthStateRepo interface {
+	// Create stages a fresh state row. The underlying :exec query
+	// has no return shape; integrity-error surface (e.g. duplicate
+	// state) bubbles up unchanged.
+	Create(ctx context.Context, params CreateAuthStateParams) error
+
+	// Consume reads-and-deletes the state row in one statement.
+	// Returns ErrNotFound when the state is unknown, expired, or
+	// already consumed by an earlier callback.
+	Consume(ctx context.Context, state string) (AuthState, error)
+}

--- a/internal/store/inventory.go
+++ b/internal/store/inventory.go
@@ -1,0 +1,48 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// InventoryTable is one captured osquery-style table for a device.
+// Rows is the raw JSON payload (osquery returns a JSON array of
+// per-row objects); kept as json.RawMessage at the repo boundary so
+// each backend chooses how to materialize the column without leaking
+// that choice into handlers.
+type InventoryTable struct {
+	DeviceID    string
+	TableName   string
+	Rows        json.RawMessage
+	CollectedAt time.Time
+}
+
+// UpsertInventoryTable carries the fields the inbox-worker writes
+// when an agent uploads a fresh inventory snapshot.
+type UpsertInventoryTable struct {
+	DeviceID  string
+	TableName string
+	Rows      json.RawMessage
+}
+
+// InventoryRepo manages the per-device inventory snapshots
+// (device_inventory). Reads serve the osquery-style UI exploration
+// flows; the write side is driven by agent uploads landing in the
+// gateway inbox worker.
+type InventoryRepo interface {
+	// ListAllTables returns every inventory row for the device,
+	// ordered as the projection emits them. Empty slice when the
+	// device has no inventory yet.
+	ListAllTables(ctx context.Context, deviceID string) ([]InventoryTable, error)
+
+	// ListTables returns only the named tables for the device.
+	// Lets the UI fetch the few tables it needs without pulling the
+	// full inventory snapshot.
+	ListTables(ctx context.Context, deviceID string, tableNames []string) ([]InventoryTable, error)
+
+	// Upsert overwrites the (device, table) row with fresh data
+	// from an agent upload. CollectedAt is set server-side by the
+	// underlying query (NOW()).
+	Upsert(ctx context.Context, p UpsertInventoryTable) error
+}

--- a/internal/store/postgres/auth_state.go
+++ b/internal/store/postgres/auth_state.go
@@ -1,0 +1,49 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// AuthState implements store.AuthStateRepo against auth_states.
+type AuthState struct {
+	q *generated.Queries
+}
+
+// NewAuthState returns an AuthState repo bound to the given sqlc handle.
+func NewAuthState(q *generated.Queries) *AuthState {
+	return &AuthState{q: q}
+}
+
+func (a *AuthState) Create(ctx context.Context, params store.CreateAuthStateParams) error {
+	if err := a.q.CreateAuthState(ctx, generated.CreateAuthStateParams{
+		State:        params.State,
+		ProviderID:   params.ProviderID,
+		Nonce:        params.Nonce,
+		CodeVerifier: params.CodeVerifier,
+		RedirectUri:  params.RedirectURI,
+		ExpiresAt:    params.ExpiresAt,
+	}); err != nil {
+		return fmt.Errorf("auth_state: create: %w", err)
+	}
+	return nil
+}
+
+func (a *AuthState) Consume(ctx context.Context, state string) (store.AuthState, error) {
+	row, err := a.q.ConsumeAuthState(ctx, state)
+	if err != nil {
+		return store.AuthState{}, fmt.Errorf("auth_state: consume: %w", translateNotFound(err))
+	}
+	return store.AuthState{
+		State:        row.State,
+		ProviderID:   row.ProviderID,
+		Nonce:        row.Nonce,
+		CodeVerifier: row.CodeVerifier,
+		RedirectURI:  row.RedirectUri,
+		CreatedAt:    row.CreatedAt,
+		ExpiresAt:    row.ExpiresAt,
+	}, nil
+}

--- a/internal/store/postgres/inventory.go
+++ b/internal/store/postgres/inventory.go
@@ -1,0 +1,67 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Inventory implements store.InventoryRepo against device_inventory.
+type Inventory struct {
+	q *generated.Queries
+}
+
+// NewInventory returns an Inventory repo bound to the given sqlc handle.
+func NewInventory(q *generated.Queries) *Inventory {
+	return &Inventory{q: q}
+}
+
+func (i *Inventory) ListAllTables(ctx context.Context, deviceID string) ([]store.InventoryTable, error) {
+	rows, err := i.q.GetDeviceInventory(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("inventory: list all tables: %w", err)
+	}
+	out := make([]store.InventoryTable, len(rows))
+	for j, r := range rows {
+		out[j] = inventoryFromRow(r)
+	}
+	return out, nil
+}
+
+func (i *Inventory) ListTables(ctx context.Context, deviceID string, tableNames []string) ([]store.InventoryTable, error) {
+	rows, err := i.q.GetDeviceInventoryByTables(ctx, generated.GetDeviceInventoryByTablesParams{
+		DeviceID: deviceID,
+		Column2:  tableNames,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("inventory: list tables: %w", err)
+	}
+	out := make([]store.InventoryTable, len(rows))
+	for j, r := range rows {
+		out[j] = inventoryFromRow(r)
+	}
+	return out, nil
+}
+
+func (i *Inventory) Upsert(ctx context.Context, p store.UpsertInventoryTable) error {
+	if err := i.q.UpsertDeviceInventory(ctx, generated.UpsertDeviceInventoryParams{
+		DeviceID:  p.DeviceID,
+		TableName: p.TableName,
+		Rows:      []byte(p.Rows),
+	}); err != nil {
+		return fmt.Errorf("inventory: upsert: %w", err)
+	}
+	return nil
+}
+
+func inventoryFromRow(r generated.DeviceInventory) store.InventoryTable {
+	return store.InventoryTable{
+		DeviceID:    r.DeviceID,
+		TableName:   r.TableName,
+		Rows:        json.RawMessage(r.Rows),
+		CollectedAt: r.CollectedAt,
+	}
+}

--- a/internal/store/postgres/user_selection.go
+++ b/internal/store/postgres/user_selection.go
@@ -1,0 +1,57 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// UserSelection implements store.UserSelectionRepo against
+// user_selections_projection.
+type UserSelection struct {
+	q *generated.Queries
+}
+
+// NewUserSelection returns a UserSelection repo bound to the given
+// sqlc handle.
+func NewUserSelection(q *generated.Queries) *UserSelection {
+	return &UserSelection{q: q}
+}
+
+func (u *UserSelection) Get(ctx context.Context, key store.GetUserSelectionKey) (store.UserSelection, error) {
+	row, err := u.q.GetUserSelection(ctx, generated.GetUserSelectionParams{
+		DeviceID:   key.DeviceID,
+		SourceType: key.SourceType,
+		SourceID:   key.SourceID,
+	})
+	if err != nil {
+		return store.UserSelection{}, fmt.Errorf("user_selection: get: %w", translateNotFound(err))
+	}
+	return userSelectionFromRow(row), nil
+}
+
+func (u *UserSelection) ListForDevice(ctx context.Context, deviceID string) ([]store.UserSelection, error) {
+	rows, err := u.q.ListUserSelectionsForDevice(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("user_selection: list for device: %w", err)
+	}
+	out := make([]store.UserSelection, len(rows))
+	for i, row := range rows {
+		out[i] = userSelectionFromRow(row)
+	}
+	return out, nil
+}
+
+func userSelectionFromRow(row generated.UserSelectionsProjection) store.UserSelection {
+	return store.UserSelection{
+		ID:         row.ID,
+		DeviceID:   row.DeviceID,
+		SourceType: row.SourceType,
+		SourceID:   row.SourceID,
+		Selected:   row.Selected,
+		UpdatedAt:  row.UpdatedAt,
+		CreatedBy:  row.CreatedBy,
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -14,8 +14,10 @@ import (
 // are migrated under tracker #242.
 func NewRepos(q *generated.Queries) *store.Repos {
 	return &store.Repos{
+		AuthState:       NewAuthState(q),
 		Compliance:      NewCompliance(q),
 		IdentityLink:    NewIdentityLink(q),
+		Inventory:       NewInventory(q),
 		Logs:            NewLogs(q),
 		OSQuery:         NewOSQuery(q),
 		RevokedToken:    NewRevokedToken(q),
@@ -24,5 +26,6 @@ func NewRepos(q *generated.Queries) *store.Repos {
 		TerminalSession: NewTerminalSession(q),
 		Token:           NewToken(q),
 		Totp:            NewTotp(q),
+		UserSelection:   NewUserSelection(q),
 	}
 }

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -13,8 +13,10 @@ package store
 // device.go for DeviceRepo), implement it under internal/store/postgres,
 // add a field here, populate it in postgres.NewRepos.
 type Repos struct {
+	AuthState       AuthStateRepo
 	Compliance      ComplianceRepo
 	IdentityLink    IdentityLinkRepo
+	Inventory       InventoryRepo
 	Logs            LogsRepo
 	OSQuery         OSQueryRepo
 	RevokedToken    RevokedTokenRepo
@@ -23,4 +25,5 @@ type Repos struct {
 	TerminalSession TerminalSessionRepo
 	Token           TokenRepo
 	Totp            TotpRepo
+	UserSelection   UserSelectionRepo
 }

--- a/internal/store/user_selection.go
+++ b/internal/store/user_selection.go
@@ -1,0 +1,43 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// UserSelection is the per-(device, source) flag tracking which
+// users (directly or via groups) should be provisioned on each
+// device. Backed by user_selections_projection. SourceType is the
+// owning relationship type ("user", "user_group", etc.); SourceID
+// is that relationship's ID.
+type UserSelection struct {
+	ID         string
+	DeviceID   string
+	SourceType string
+	SourceID   string
+	Selected   bool
+	UpdatedAt  time.Time
+	CreatedBy  string
+}
+
+// GetUserSelectionKey is the composite key used to look up a single
+// user-selection row. The three fields together are unique per row.
+type GetUserSelectionKey struct {
+	DeviceID   string
+	SourceType string
+	SourceID   string
+}
+
+// UserSelectionRepo reads the per-device user-provisioning selection
+// rows. Writes flow through UserSelectionUpdated events; the
+// listener owns the upsert into the projection.
+type UserSelectionRepo interface {
+	// Get returns the selection for a single (device, source) tuple.
+	// Returns ErrNotFound when no row exists for that key.
+	Get(ctx context.Context, key GetUserSelectionKey) (UserSelection, error)
+
+	// ListForDevice returns every selection row touching the given
+	// device, ordered as the projection emits them. Empty slice
+	// when the device has no selections yet.
+	ListForDevice(ctx context.Context, deviceID string) ([]UserSelection, error)
+}


### PR DESCRIPTION
## Summary

Three small domains in one PR. Pivoted from the planned "certificate + auth_state" — \`certificate_handler.go\` only touches \`GetDeviceByID\` (cross-domain, Device) so there's no certificate-domain surface to migrate. Substituted \`UserSelection\` and \`Inventory\` instead.

Branches off main directly.

## Domains migrated

| Repo | Table | Methods |
|---|---|---|
| \`AuthStateRepo\` | \`auth_states\` | \`Create\`, \`Consume\` (destructive read) |
| \`UserSelectionRepo\` | \`user_selections_projection\` | \`Get(key)\`, \`ListForDevice\` |
| \`InventoryRepo\` | \`device_inventory\` | \`ListAllTables\`, \`ListTables\`, \`Upsert\` |

\`InventoryTable.Rows\` stays as \`json.RawMessage\` at the boundary — inbox worker writes raw upload bytes, search reads them for enrichment, osquery_handler decodes per-table in the UI layer.

## Call sites migrated (8)

- \`sso_handler.go\` — 2 (auth_state Create + Consume)
- \`user_selection_handler.go\` — 2 (Get + ListForDevice) + \`userSelectionToProto\` signature
- \`osquery_handler.go\` — 2 (inventory reads)
- \`control/inbox_worker.go\` — 1 (inventory upsert from agent uploads)
- \`search/index.go\` — 1 (inventory enrichment for search docs)

## Non-goals

- Certificate domain — no primary-domain queries.
- Other \`search/index.go\` \`Queries()\` calls (~20) — Device / User / UserGroup, move with those domains.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Tests (\`TestSSO*\`, \`TestUserSelection*\`, \`TestOSQuery*\`, \`TestGetDeviceInventory*\`, search): 210s of coverage passes.

Part of #242. Closes #257.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Storage and data-access for auth state, device inventory, and user selections moved to new repository-backed implementations.
  * Infrastructure added for inventory and selection data models and auth-state lifecycle.
  * Wiring updated so the application uses the new repositories.
  * No changes to end-user functionality or behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/258)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->