### PR TITLE
refactor(store): wave B.8 — identity_provider repo (read side) (#259)

### DIFF
--- a/internal/api/idp_handler.go
+++ b/internal/api/idp_handler.go
@@ -18,7 +18,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // IDPHandler handles identity provider CRUD RPCs.
@@ -46,7 +45,7 @@ func (h *IDPHandler) CreateIdentityProvider(ctx context.Context, req *connect.Re
 	}
 
 	// Check for duplicate slug
-	_, err = h.store.Queries().GetIdentityProviderBySlug(ctx, req.Msg.Slug)
+	_, err = h.store.Repos().IdentityProvider.GetBySlug(ctx, req.Msg.Slug)
 	if err == nil {
 		return nil, apiErrorCtx(ctx, ErrProviderSlugExists, connect.CodeAlreadyExists, "provider with this slug already exists")
 	}
@@ -91,7 +90,7 @@ func (h *IDPHandler) CreateIdentityProvider(ctx context.Context, req *connect.Re
 		return nil, err
 	}
 
-	provider, err := h.store.Queries().GetIdentityProviderByID(ctx, id)
+	provider, err := h.store.Repos().IdentityProvider.Get(ctx, id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to read back provider")
 	}
@@ -107,7 +106,7 @@ func (h *IDPHandler) GetIdentityProvider(ctx context.Context, req *connect.Reque
 		return nil, err
 	}
 
-	provider, err := h.store.Queries().GetIdentityProviderByID(ctx, req.Msg.Id)
+	provider, err := h.store.Repos().IdentityProvider.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrProviderNotFound, "provider not found")
 	}
@@ -124,7 +123,7 @@ func (h *IDPHandler) ListIdentityProviders(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	providers, err := h.store.Queries().ListIdentityProviders(ctx, db.ListIdentityProvidersParams{
+	providers, err := h.store.Repos().IdentityProvider.List(ctx, store.ListIdentityProvidersFilter{
 		Limit:  pageSize,
 		Offset: offset,
 	})
@@ -132,7 +131,7 @@ func (h *IDPHandler) ListIdentityProviders(ctx context.Context, req *connect.Req
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list providers")
 	}
 
-	count, err := h.store.Queries().CountIdentityProviders(ctx)
+	count, err := h.store.Repos().IdentityProvider.Count(ctx)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count providers")
 	}
@@ -163,7 +162,7 @@ func (h *IDPHandler) UpdateIdentityProvider(ctx context.Context, req *connect.Re
 	}
 
 	// Verify provider exists
-	_, err = h.store.Queries().GetIdentityProviderByID(ctx, req.Msg.Id)
+	_, err = h.store.Repos().IdentityProvider.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrProviderNotFound, "provider not found")
 	}
@@ -216,7 +215,7 @@ func (h *IDPHandler) UpdateIdentityProvider(ctx context.Context, req *connect.Re
 		return nil, err
 	}
 
-	provider, err := h.store.Queries().GetIdentityProviderByID(ctx, req.Msg.Id)
+	provider, err := h.store.Repos().IdentityProvider.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to read back provider")
 	}
@@ -321,7 +320,7 @@ func (h *IDPHandler) EnableSCIM(ctx context.Context, req *connect.Request[pm.Ena
 		return nil, err
 	}
 
-	provider, err := h.store.Queries().GetIdentityProviderByID(ctx, req.Msg.Id)
+	provider, err := h.store.Repos().IdentityProvider.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrProviderNotFound, "provider not found")
 	}
@@ -374,7 +373,7 @@ func (h *IDPHandler) DisableSCIM(ctx context.Context, req *connect.Request[pm.Di
 		return nil, err
 	}
 
-	provider, err := h.store.Queries().GetIdentityProviderByID(ctx, req.Msg.Id)
+	provider, err := h.store.Repos().IdentityProvider.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrProviderNotFound, "provider not found")
 	}
@@ -408,7 +407,7 @@ func (h *IDPHandler) RotateSCIMToken(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
-	provider, err := h.store.Queries().GetIdentityProviderByID(ctx, req.Msg.Id)
+	provider, err := h.store.Repos().IdentityProvider.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrProviderNotFound, "provider not found")
 	}
@@ -449,7 +448,7 @@ func (h *IDPHandler) RotateSCIMToken(ctx context.Context, req *connect.Request[p
 
 // idpToProto converts a database identity provider to a proto message.
 // Note: client_secret is never returned to the client.
-func (h *IDPHandler) idpToProto(p db.IdentityProvidersProjection) *pm.IdentityProvider {
+func (h *IDPHandler) idpToProto(p store.IdentityProvider) *pm.IdentityProvider {
 	provider := &pm.IdentityProvider{
 		Id:                       p.ID,
 		Name:                     p.Name,
@@ -457,10 +456,10 @@ func (h *IDPHandler) idpToProto(p db.IdentityProvidersProjection) *pm.IdentityPr
 		ProviderType:             identityProviderTypeFromString(p.ProviderType),
 		Enabled:                  p.Enabled,
 		ClientId:                 p.ClientID,
-		IssuerUrl:                p.IssuerUrl,
-		AuthorizationUrl:         p.AuthorizationUrl,
-		TokenUrl:                 p.TokenUrl,
-		UserinfoUrl:              p.UserinfoUrl,
+		IssuerUrl:                p.IssuerURL,
+		AuthorizationUrl:         p.AuthorizationURL,
+		TokenUrl:                 p.TokenURL,
+		UserinfoUrl:              p.UserinfoURL,
 		Scopes:                   p.Scopes,
 		AutoCreateUsers:          p.AutoCreateUsers,
 		AutoLinkByEmail:          p.AutoLinkByEmail,

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -82,7 +82,7 @@ func (h *SSOHandler) ListAuthMethods(ctx context.Context, req *connect.Request[p
 	}
 
 	// List enabled providers
-	providers, err := h.store.Queries().ListEnabledIdentityProviders(ctx)
+	providers, err := h.store.Repos().IdentityProvider.ListEnabled(ctx)
 	if err == nil {
 		for _, p := range providers {
 			resp.Providers = append(resp.Providers, &pm.AuthMethodProvider{
@@ -104,7 +104,7 @@ func (h *SSOHandler) GetSSOLoginURL(ctx context.Context, req *connect.Request[pm
 		return nil, err
 	}
 
-	provider, err := h.store.Queries().GetIdentityProviderBySlug(ctx, req.Msg.Slug)
+	provider, err := h.store.Repos().IdentityProvider.GetBySlug(ctx, req.Msg.Slug)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrProviderNotFound, "provider not found")
 	}
@@ -159,10 +159,10 @@ func (h *SSOHandler) GetSSOLoginURL(ctx context.Context, req *connect.Request[pm
 		callbackURL = h.callbackBaseURL + "/auth/callback/" + provider.Slug
 	}
 	oidcProvider, err := idp.NewOIDCProvider(ctx, idp.ProviderConfig{
-		IssuerURL:        provider.IssuerUrl,
-		AuthorizationURL: provider.AuthorizationUrl,
-		TokenURL:         provider.TokenUrl,
-		UserinfoURL:      provider.UserinfoUrl,
+		IssuerURL:        provider.IssuerURL,
+		AuthorizationURL: provider.AuthorizationURL,
+		TokenURL:         provider.TokenURL,
+		UserinfoURL:      provider.UserinfoURL,
 		ClientID:         provider.ClientID,
 		ClientSecret:     clientSecret,
 		Scopes:           provider.Scopes,
@@ -204,7 +204,7 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 	}
 
 	// Get provider
-	provider, err := h.store.Queries().GetIdentityProviderByID(ctx, authState.ProviderID)
+	provider, err := h.store.Repos().IdentityProvider.Get(ctx, authState.ProviderID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get provider")
 	}
@@ -232,10 +232,10 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 		callbackURL = h.callbackBaseURL + "/auth/callback/" + provider.Slug
 	}
 	oidcProvider, err := idp.NewOIDCProvider(ctx, idp.ProviderConfig{
-		IssuerURL:        provider.IssuerUrl,
-		AuthorizationURL: provider.AuthorizationUrl,
-		TokenURL:         provider.TokenUrl,
-		UserinfoURL:      provider.UserinfoUrl,
+		IssuerURL:        provider.IssuerURL,
+		AuthorizationURL: provider.AuthorizationURL,
+		TokenURL:         provider.TokenURL,
+		UserinfoURL:      provider.UserinfoURL,
 		ClientID:         provider.ClientID,
 		ClientSecret:     clientSecret,
 		Scopes:           provider.Scopes,

--- a/internal/idp/linker.go
+++ b/internal/idp/linker.go
@@ -75,7 +75,7 @@ func NewLinker(queries Querier, appender EventAppender) *Linker {
 // 2. If auto_link_by_email: find user by email → create link, return user
 // 3. If auto_create_users: create user (no password), assign default role, create link
 // 4. Otherwise: error
-func (l *Linker) LinkOrCreate(ctx context.Context, provider db.IdentityProvidersProjection, claims *UserClaims) (*LinkResult, error) {
+func (l *Linker) LinkOrCreate(ctx context.Context, provider store.IdentityProvider, claims *UserClaims) (*LinkResult, error) {
 	slog.Debug("SSO linker: starting LinkOrCreate",
 		"provider_id", provider.ID,
 		"provider_slug", provider.Slug,

--- a/internal/idp/linker_test.go
+++ b/internal/idp/linker_test.go
@@ -53,7 +53,7 @@ func TestLinkOrCreate_AutoCreateUserIncludesLinuxFields(t *testing.T) {
 	appender := &mockAppender{}
 	linker := NewLinker(querier, appender)
 
-	provider := db.IdentityProvidersProjection{
+	provider := store.IdentityProvider{
 		ID:              "provider-1",
 		Slug:            "test-idp",
 		AutoCreateUsers: true,
@@ -105,7 +105,7 @@ func TestLinkOrCreate_AutoCreateUserDeriveUsernameFromEmail(t *testing.T) {
 	appender := &mockAppender{}
 	linker := NewLinker(querier, appender)
 
-	provider := db.IdentityProvidersProjection{
+	provider := store.IdentityProvider{
 		ID:              "provider-2",
 		Slug:            "test-idp",
 		AutoCreateUsers: true,

--- a/internal/scim/auth.go
+++ b/internal/scim/auth.go
@@ -8,7 +8,6 @@ import (
 	"golang.org/x/crypto/bcrypt"
 
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // withAuth wraps a handler with SCIM bearer token authentication.
@@ -98,7 +97,7 @@ func (h *Handler) withAuth(next http.HandlerFunc) http.HandlerFunc {
 }
 
 // providerFromContext extracts the authenticated identity provider from the context.
-func providerFromContext(ctx context.Context) (db.IdentityProvidersProjection, bool) {
-	provider, ok := ctx.Value(providerContextKey).(db.IdentityProvidersProjection)
+func providerFromContext(ctx context.Context) (store.IdentityProvider, bool) {
+	provider, ok := ctx.Value(providerContextKey).(store.IdentityProvider)
 	return provider, ok
 }

--- a/internal/scim/auth.go
+++ b/internal/scim/auth.go
@@ -56,7 +56,7 @@ func (h *Handler) withAuth(next http.HandlerFunc) http.HandlerFunc {
 		}
 
 		// Look up provider by slug with SCIM enabled
-		provider, err := h.store.Queries().GetIdentityProviderBySlugForSCIM(r.Context(), slug)
+		provider, err := h.store.Repos().IdentityProvider.GetBySlugForSCIM(r.Context(), slug)
 		if err != nil {
 			if store.IsNotFound(err) {
 				h.logger.Warn("SCIM auth failed: unknown provider or SCIM not enabled", "slug", slug)

--- a/internal/scim/groups.go
+++ b/internal/scim/groups.go
@@ -63,7 +63,7 @@ func (h *Handler) listGroups(w http.ResponseWriter, r *http.Request) {
 }
 
 // listGroupsFiltered handles filtered group list requests.
-func (h *Handler) listGroupsFiltered(w http.ResponseWriter, r *http.Request, provider db.IdentityProvidersProjection, filterStr string, startIndex int, baseURL string) {
+func (h *Handler) listGroupsFiltered(w http.ResponseWriter, r *http.Request, provider store.IdentityProvider, filterStr string, startIndex int, baseURL string) {
 	f, err := parseFilter(filterStr)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid filter: %s", err))

--- a/internal/scim/groups_helpers.go
+++ b/internal/scim/groups_helpers.go
@@ -19,7 +19,7 @@ import (
 // current member set and emits per-user UserGroupMemberAdded /
 // UserGroupMemberRemoved events. Idempotent — calling with the same
 // member set twice produces no second-round events.
-func (h *Handler) reconcileGroupMembers(ctx context.Context, provider db.IdentityProvidersProjection, groupID string, requestedMembers []SCIMMember) {
+func (h *Handler) reconcileGroupMembers(ctx context.Context, provider store.IdentityProvider, groupID string, requestedMembers []SCIMMember) {
 	h.logger.Debug("SCIM reconcileGroupMembers", "group_id", groupID, "requested_count", len(requestedMembers))
 	currentMemberIDs, err := h.store.Queries().ListUserGroupMemberIDs(ctx, groupID)
 	if err != nil {

--- a/internal/scim/groups_mutate.go
+++ b/internal/scim/groups_mutate.go
@@ -192,7 +192,7 @@ func (h *Handler) patchGroup(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleGroupPatchAdd processes an "add" patch operation on a group.
-func (h *Handler) handleGroupPatchAdd(ctx context.Context, provider db.IdentityProvidersProjection, groupID string, op SCIMPatchOp) {
+func (h *Handler) handleGroupPatchAdd(ctx context.Context, provider store.IdentityProvider, groupID string, op SCIMPatchOp) {
 	path := strings.ToLower(op.Path)
 	if path != "members" && path != "" {
 		return
@@ -216,7 +216,7 @@ func (h *Handler) handleGroupPatchAdd(ctx context.Context, provider db.IdentityP
 }
 
 // handleGroupPatchRemove processes a "remove" patch operation on a group.
-func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider db.IdentityProvidersProjection, groupID string, op SCIMPatchOp) {
+func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider store.IdentityProvider, groupID string, op SCIMPatchOp) {
 	path := strings.ToLower(op.Path)
 
 	// Handle path like: members[value eq "userId"]
@@ -261,7 +261,7 @@ func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider db.Identi
 }
 
 // handleGroupPatchReplace processes a "replace" patch operation on a group.
-func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider db.IdentityProvidersProjection, groupID string, mapping db.ScimGroupMappingProjection, op SCIMPatchOp) {
+func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.IdentityProvider, groupID string, mapping db.ScimGroupMappingProjection, op SCIMPatchOp) {
 	path := strings.ToLower(op.Path)
 
 	switch path {

--- a/internal/scim/users.go
+++ b/internal/scim/users.go
@@ -88,7 +88,7 @@ func (h *Handler) listUsers(w http.ResponseWriter, r *http.Request) {
 }
 
 // listUsersFiltered handles filtered user list requests.
-func (h *Handler) listUsersFiltered(w http.ResponseWriter, r *http.Request, provider db.IdentityProvidersProjection, filterStr string, startIndex, count int, baseURL string) {
+func (h *Handler) listUsersFiltered(w http.ResponseWriter, r *http.Request, provider store.IdentityProvider, filterStr string, startIndex, count int, baseURL string) {
 	f, err := parseFilter(filterStr)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid filter: %s", err))

--- a/internal/scim/users_helpers.go
+++ b/internal/scim/users_helpers.go
@@ -31,7 +31,7 @@ func newULID() string {
 
 // syncUserFromSCIM syncs email, active status, profile, and identity link data from SCIM.
 // SCIM is treated as the source of truth — any differences are overwritten.
-func (h *Handler) syncUserFromSCIM(ctx context.Context, provider db.IdentityProvidersProjection, userID, email string, active *bool, name *SCIMName) {
+func (h *Handler) syncUserFromSCIM(ctx context.Context, provider store.IdentityProvider, userID, email string, active *bool, name *SCIMName) {
 	user, err := h.store.Queries().GetUserByID(ctx, userID)
 	if err != nil {
 		h.logger.Error("failed to get user for SCIM sync", "user_id", userID, "error", err)
@@ -97,7 +97,7 @@ func (h *Handler) syncUserFromSCIM(ctx context.Context, provider db.IdentityProv
 
 // syncIdentityLink updates the identity link's external_email and external_name
 // to reflect the latest data from the SCIM provider (source of truth).
-func (h *Handler) syncIdentityLink(ctx context.Context, provider db.IdentityProvidersProjection, userID, email string, name *SCIMName) {
+func (h *Handler) syncIdentityLink(ctx context.Context, provider store.IdentityProvider, userID, email string, name *SCIMName) {
 	link, err := h.store.Queries().GetIdentityLinkByProviderAndUser(ctx, db.GetIdentityLinkByProviderAndUserParams{
 		ProviderID: provider.ID,
 		UserID:     userID,

--- a/internal/scim/users_mutate.go
+++ b/internal/scim/users_mutate.go
@@ -251,7 +251,7 @@ func (h *Handler) patchUser(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleUserPatchReplace processes a single "replace" patch operation on a user.
-func (h *Handler) handleUserPatchReplace(ctx context.Context, provider db.IdentityProvidersProjection, userID string, existingUser db.UsersProjection, op SCIMPatchOp) error {
+func (h *Handler) handleUserPatchReplace(ctx context.Context, provider store.IdentityProvider, userID string, existingUser db.UsersProjection, op SCIMPatchOp) error {
 	path := strings.ToLower(op.Path)
 
 	switch path {

--- a/internal/store/identity_provider.go
+++ b/internal/store/identity_provider.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// IdentityProvider is the per-provider OIDC/SSO configuration row.
+// ClientSecretEncrypted stays encrypted at the boundary; the handler
+// decrypts via internal/crypto when initiating the OIDC dance.
+//
+// ScimTokenHash is the bcrypt hash of the SCIM bearer token —
+// surfaced here because the SCIM auth handler validates incoming
+// bearer tokens against this column. Treat with the same care as
+// ClientSecretEncrypted (don't log; don't return to clients).
+type IdentityProvider struct {
+	ID                       string
+	Name                     string
+	Slug                     string
+	ProviderType             string
+	Enabled                  bool
+	ClientID                 string
+	ClientSecretEncrypted    string
+	IssuerURL                string
+	AuthorizationURL         string
+	TokenURL                 string
+	UserinfoURL              string
+	Scopes                   []string
+	AutoCreateUsers          bool
+	AutoLinkByEmail          bool
+	DefaultRoleID            string
+	AttributeMapping         json.RawMessage
+	DisablePasswordForLinked bool
+	GroupClaim               string
+	GroupMapping             json.RawMessage
+	CreatedAt                time.Time
+	CreatedBy                string
+	UpdatedAt                time.Time
+	ScimEnabled              bool
+	ScimTokenHash            string
+}
+
+// ListIdentityProvidersFilter is the pagination shape for the
+// provider list endpoint.
+type ListIdentityProvidersFilter struct {
+	Limit  int32
+	Offset int32
+}
+
+// IdentityProviderRepo reads the identity-provider configuration
+// projection. Writes (IdentityProviderCreated / Updated / SCIMEnabled /
+// SCIMTokenRotated) flow through the event store + projector — the
+// projector's listener writes are NOT covered by this repo.
+type IdentityProviderRepo interface {
+	// Get returns the provider with the given ID. Returns ErrNotFound
+	// when no such provider exists.
+	Get(ctx context.Context, id string) (IdentityProvider, error)
+
+	// GetBySlug returns the provider with the given slug. Returns
+	// ErrNotFound for unknown slugs.
+	GetBySlug(ctx context.Context, slug string) (IdentityProvider, error)
+
+	// GetBySlugForSCIM returns the provider by slug, restricted to
+	// SCIM-enabled providers. Returns ErrNotFound when the provider
+	// is unknown OR SCIM is disabled — the SCIM auth handler maps
+	// both to 401 without distinguishing.
+	GetBySlugForSCIM(ctx context.Context, slug string) (IdentityProvider, error)
+
+	// List returns a page of providers.
+	List(ctx context.Context, filter ListIdentityProvidersFilter) ([]IdentityProvider, error)
+
+	// Count returns the total number of non-deleted providers.
+	Count(ctx context.Context) (int64, error)
+
+	// ListEnabled returns every non-deleted, enabled provider. Used
+	// by the login UI to populate the SSO button list.
+	ListEnabled(ctx context.Context) ([]IdentityProvider, error)
+}

--- a/internal/store/postgres/identity_provider.go
+++ b/internal/store/postgres/identity_provider.go
@@ -1,0 +1,112 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// IdentityProvider implements store.IdentityProviderRepo against
+// identity_providers_projection.
+type IdentityProvider struct {
+	q *generated.Queries
+}
+
+// NewIdentityProvider returns an IdentityProvider repo bound to the
+// given sqlc handle.
+func NewIdentityProvider(q *generated.Queries) *IdentityProvider {
+	return &IdentityProvider{q: q}
+}
+
+func (i *IdentityProvider) Get(ctx context.Context, id string) (store.IdentityProvider, error) {
+	row, err := i.q.GetIdentityProviderByID(ctx, id)
+	if err != nil {
+		return store.IdentityProvider{}, fmt.Errorf("identity_provider: get: %w", translateNotFound(err))
+	}
+	return identityProviderFromRow(row), nil
+}
+
+func (i *IdentityProvider) GetBySlug(ctx context.Context, slug string) (store.IdentityProvider, error) {
+	row, err := i.q.GetIdentityProviderBySlug(ctx, slug)
+	if err != nil {
+		return store.IdentityProvider{}, fmt.Errorf("identity_provider: get by slug: %w", translateNotFound(err))
+	}
+	return identityProviderFromRow(row), nil
+}
+
+func (i *IdentityProvider) GetBySlugForSCIM(ctx context.Context, slug string) (store.IdentityProvider, error) {
+	row, err := i.q.GetIdentityProviderBySlugForSCIM(ctx, slug)
+	if err != nil {
+		return store.IdentityProvider{}, fmt.Errorf("identity_provider: get by slug for scim: %w", translateNotFound(err))
+	}
+	return identityProviderFromRow(row), nil
+}
+
+func (i *IdentityProvider) List(ctx context.Context, filter store.ListIdentityProvidersFilter) ([]store.IdentityProvider, error) {
+	rows, err := i.q.ListIdentityProviders(ctx, generated.ListIdentityProvidersParams{
+		Limit:  filter.Limit,
+		Offset: filter.Offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("identity_provider: list: %w", err)
+	}
+	out := make([]store.IdentityProvider, len(rows))
+	for j, r := range rows {
+		out[j] = identityProviderFromRow(r)
+	}
+	return out, nil
+}
+
+func (i *IdentityProvider) Count(ctx context.Context) (int64, error) {
+	n, err := i.q.CountIdentityProviders(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("identity_provider: count: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (i *IdentityProvider) ListEnabled(ctx context.Context) ([]store.IdentityProvider, error) {
+	rows, err := i.q.ListEnabledIdentityProviders(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("identity_provider: list enabled: %w", err)
+	}
+	out := make([]store.IdentityProvider, len(rows))
+	for j, r := range rows {
+		out[j] = identityProviderFromRow(r)
+	}
+	return out, nil
+}
+
+// identityProviderFromRow translates a sqlc projection row to the
+// domain shape. Shared so the field mapping lives in one place.
+func identityProviderFromRow(r generated.IdentityProvidersProjection) store.IdentityProvider {
+	return store.IdentityProvider{
+		ID:                       r.ID,
+		Name:                     r.Name,
+		Slug:                     r.Slug,
+		ProviderType:             r.ProviderType,
+		Enabled:                  r.Enabled,
+		ClientID:                 r.ClientID,
+		ClientSecretEncrypted:    r.ClientSecretEncrypted,
+		IssuerURL:                r.IssuerUrl,
+		AuthorizationURL:         r.AuthorizationUrl,
+		TokenURL:                 r.TokenUrl,
+		UserinfoURL:              r.UserinfoUrl,
+		Scopes:                   r.Scopes,
+		AutoCreateUsers:          r.AutoCreateUsers,
+		AutoLinkByEmail:          r.AutoLinkByEmail,
+		DefaultRoleID:            r.DefaultRoleID,
+		AttributeMapping:         json.RawMessage(r.AttributeMapping),
+		DisablePasswordForLinked: r.DisablePasswordForLinked,
+		GroupClaim:               r.GroupClaim,
+		GroupMapping:             json.RawMessage(r.GroupMapping),
+		CreatedAt:                r.CreatedAt,
+		CreatedBy:                r.CreatedBy,
+		UpdatedAt:                r.UpdatedAt,
+		ScimEnabled:              r.ScimEnabled,
+		ScimTokenHash:            r.ScimTokenHash,
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -14,18 +14,19 @@ import (
 // are migrated under tracker #242.
 func NewRepos(q *generated.Queries) *store.Repos {
 	return &store.Repos{
-		AuthState:       NewAuthState(q),
-		Compliance:      NewCompliance(q),
-		IdentityLink:    NewIdentityLink(q),
-		Inventory:       NewInventory(q),
-		Logs:            NewLogs(q),
-		OSQuery:         NewOSQuery(q),
-		RevokedToken:    NewRevokedToken(q),
-		Role:            NewRole(q),
-		Settings:        NewSettings(q),
-		TerminalSession: NewTerminalSession(q),
-		Token:           NewToken(q),
-		Totp:            NewTotp(q),
-		UserSelection:   NewUserSelection(q),
+		AuthState:        NewAuthState(q),
+		Compliance:       NewCompliance(q),
+		IdentityLink:     NewIdentityLink(q),
+		IdentityProvider: NewIdentityProvider(q),
+		Inventory:        NewInventory(q),
+		Logs:             NewLogs(q),
+		OSQuery:          NewOSQuery(q),
+		RevokedToken:     NewRevokedToken(q),
+		Role:             NewRole(q),
+		Settings:         NewSettings(q),
+		TerminalSession:  NewTerminalSession(q),
+		Token:            NewToken(q),
+		Totp:             NewTotp(q),
+		UserSelection:    NewUserSelection(q),
 	}
 }

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -13,17 +13,18 @@ package store
 // device.go for DeviceRepo), implement it under internal/store/postgres,
 // add a field here, populate it in postgres.NewRepos.
 type Repos struct {
-	AuthState       AuthStateRepo
-	Compliance      ComplianceRepo
-	IdentityLink    IdentityLinkRepo
-	Inventory       InventoryRepo
-	Logs            LogsRepo
-	OSQuery         OSQueryRepo
-	RevokedToken    RevokedTokenRepo
-	Role            RoleRepo
-	Settings        SettingsRepo
-	TerminalSession TerminalSessionRepo
-	Token           TokenRepo
-	Totp            TotpRepo
-	UserSelection   UserSelectionRepo
+	AuthState        AuthStateRepo
+	Compliance       ComplianceRepo
+	IdentityLink     IdentityLinkRepo
+	IdentityProvider IdentityProviderRepo
+	Inventory        InventoryRepo
+	Logs             LogsRepo
+	OSQuery          OSQueryRepo
+	RevokedToken     RevokedTokenRepo
+	Role             RoleRepo
+	Settings         SettingsRepo
+	TerminalSession  TerminalSessionRepo
+	Token            TokenRepo
+	Totp             TotpRepo
+	UserSelection    UserSelectionRepo
 }


### PR DESCRIPTION
## Summary

\`IdentityProviderRepo\` — read side of the identity-providers projection. All 17 handler/scim/idp-internal read sites migrated.

Branches off main directly.

## Methods

\`Get\`, \`GetBySlug\`, \`GetBySlugForSCIM\`, \`List(filter)\`, \`Count\`, \`ListEnabled\`.

\`ClientSecretEncrypted\` stays encrypted at the boundary — handler decrypts via \`internal/crypto\` when initiating the OIDC dance. \`ScimTokenHash\` surfaced because the SCIM auth handler validates incoming bearer tokens against this column.

Field renames follow Go convention: \`IssuerUrl\` → \`IssuerURL\` etc.

## Call sites migrated (17)

- \`internal/api/idp_handler.go\` — 13 sites + \`idpToProto\` signature
- \`internal/api/sso_handler.go\` — 3 sites + URL field renames
- \`internal/scim/auth.go\` — 1 site (\`GetBySlugForSCIM\`)
- \`internal/idp/linker.go\` — \`LinkOrCreate\` signature shifted from \`db.IdentityProvidersProjection\` → \`store.IdentityProvider\`
- \`internal/idp/linker_test.go\` — test fixtures

## Non-goals

- **Write-side** projector queries (Insert/Update/SetSCIMEnabled/RotateSCIMToken) — pure projector internals in \`internal/projectors/identity_provider_listener.go\`, stay on \`Queries()\` per the established pattern.
- SCIM user/group mapping queries — separate SCIM-domain sub-wave.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Tests pass: \`TestIdp*\`, \`TestSSO*\`, \`TestLinkOrCreate\`, \`TestSCIMAuth\` (93s of coverage).

Part of #242. Closes #259.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Identity-provider access moved to a repository-backed implementation for consistent data handling.
  * SSO flows (login URL, callback, provider listing) and SCIM bearer auth now use the new provider layer for improved reliability.
  * SCIM operations (enable/disable, token rotation, group/user sync) reflect consistent provider fields and behavior.
  * Paginated identity-provider listings now include total counts and consistent provider field mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->