### PR TITLE
refactor(store): wave B.9 — SCIM group mapping repo (#261)

### DIFF
--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -128,7 +128,7 @@ func (h *UserGroupHandler) GetUserGroup(ctx context.Context, req *connect.Reques
 		protoMembers[i].AddedAt = timestamppb.New(m.AddedAt)
 	}
 
-	isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, req.Msg.Id)
+	isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
 
 	return connect.NewResponse(&pm.GetUserGroupResponse{
 		Group:   userGroupToProto(group, roles, isScimManaged),
@@ -161,7 +161,7 @@ func (h *UserGroupHandler) ListUserGroups(ctx context.Context, req *connect.Requ
 	protoGroups := make([]*pm.UserGroup, len(groups))
 	for i, g := range groups {
 		roles, _ := h.store.Queries().GetUserGroupRoles(ctx, g.ID)
-		isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, g.ID)
+		isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, g.ID)
 		protoGroups[i] = userGroupToProto(g, roles, isScimManaged)
 	}
 
@@ -209,7 +209,7 @@ func (h *UserGroupHandler) UpdateUserGroup(ctx context.Context, req *connect.Req
 
 	roles, _ := h.store.Queries().GetUserGroupRoles(ctx, req.Msg.GroupId)
 
-	isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, req.Msg.GroupId)
+	isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, req.Msg.GroupId)
 
 	return connect.NewResponse(&pm.UpdateUserGroupResponse{
 		Group: userGroupToProto(updated, roles, isScimManaged),
@@ -257,7 +257,7 @@ func (h *UserGroupHandler) SetUserGroupMaintenanceWindow(ctx context.Context, re
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to read user group")
 	}
 	roles, _ := h.store.Queries().GetUserGroupRoles(ctx, req.Msg.Id)
-	isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, req.Msg.Id)
+	isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
 
 	return connect.NewResponse(&pm.UpdateUserGroupResponse{
 		Group: userGroupToProto(updated, roles, isScimManaged),
@@ -276,7 +276,7 @@ func (h *UserGroupHandler) DeleteUserGroup(ctx context.Context, req *connect.Req
 	}
 
 	// Prevent deletion of SCIM-managed groups
-	isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, req.Msg.Id)
+	isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
 	if isScimManaged {
 		return nil, apiErrorCtx(ctx, ErrSCIMManagedResource, connect.CodeFailedPrecondition, "cannot delete a SCIM-managed group — remove it from the identity provider instead")
 	}
@@ -591,7 +591,7 @@ func (h *UserGroupHandler) ListUserGroupsForUser(ctx context.Context, req *conne
 	protoGroups := make([]*pm.UserGroup, len(groups))
 	for i, g := range groups {
 		roles, _ := h.store.Queries().GetUserGroupRoles(ctx, g.ID)
-		isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, g.ID)
+		isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, g.ID)
 		protoGroups[i] = userGroupToProto(g, roles, isScimManaged)
 	}
 
@@ -645,7 +645,7 @@ func (h *UserGroupHandler) UpdateUserGroupQuery(ctx context.Context, req *connec
 	}
 
 	roles, _ := h.store.Queries().GetUserGroupRoles(ctx, req.Msg.Id)
-	isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, req.Msg.Id)
+	isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
 
 	return connect.NewResponse(&pm.UpdateUserGroupQueryResponse{
 		Group: userGroupToProto(group, roles, isScimManaged),
@@ -734,7 +734,7 @@ func (h *UserGroupHandler) EvaluateDynamicUserGroup(ctx context.Context, req *co
 	}
 
 	roles, _ := h.store.Queries().GetUserGroupRoles(ctx, req.Msg.Id)
-	isScimManaged, _ := h.store.Queries().IsUserGroupSCIMManaged(ctx, req.Msg.Id)
+	isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
 
 	// Bump session versions for all current members (permissions
 	// may have changed). Unconditional now that auth is enforced

--- a/internal/scim/groups.go
+++ b/internal/scim/groups.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // listGroups handles GET /scim/v2/{slug}/Groups
@@ -36,7 +35,7 @@ func (h *Handler) listGroups(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// List all SCIM group mappings for this provider
-	mappings, err := h.store.Queries().ListSCIMGroupMappings(ctx, provider.ID)
+	mappings, err := h.store.Repos().SCIM.ListGroupMappings(ctx, provider.ID)
 	if err != nil {
 		h.logger.Error("failed to list SCIM group mappings", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to list groups")
@@ -76,7 +75,7 @@ func (h *Handler) listGroupsFiltered(w http.ResponseWriter, r *http.Request, pro
 	switch f.Attribute {
 	case "displayName":
 		// Search by display name — iterate through mappings
-		mappings, err := h.store.Queries().ListSCIMGroupMappings(ctx, provider.ID)
+		mappings, err := h.store.Repos().SCIM.ListGroupMappings(ctx, provider.ID)
 		if err != nil {
 			h.logger.Error("failed to list SCIM group mappings for filter", "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to search groups")
@@ -84,7 +83,7 @@ func (h *Handler) listGroupsFiltered(w http.ResponseWriter, r *http.Request, pro
 		}
 
 		for _, m := range mappings {
-			if m.ScimDisplayName == f.Value {
+			if m.SCIMDisplayName == f.Value {
 				group, err := h.buildGroupResource(ctx, provider.ID, m, baseURL)
 				if err != nil {
 					h.logger.Error("failed to build group resource", "mapping_id", m.ID, "error", err)
@@ -95,10 +94,7 @@ func (h *Handler) listGroupsFiltered(w http.ResponseWriter, r *http.Request, pro
 		}
 
 	case "externalId":
-		mapping, err := h.store.Queries().GetSCIMGroupMapping(ctx, db.GetSCIMGroupMappingParams{
-			ProviderID:  provider.ID,
-			ScimGroupID: f.Value,
-		})
+		mapping, err := h.store.Repos().SCIM.GetGroupMapping(ctx, store.SCIMGroupMappingKey{ProviderID: provider.ID, SCIMGroupID: f.Value})
 		if err != nil {
 			if store.IsNotFound(err) {
 				resources = []any{}
@@ -155,10 +151,7 @@ func (h *Handler) getGroup(w http.ResponseWriter, r *http.Request) {
 	baseURL := baseURLFromRequest(r, provider.Slug)
 
 	// Look up the SCIM group mapping by user_group_id
-	mapping, err := h.store.Queries().GetSCIMGroupMappingByUserGroup(ctx, db.GetSCIMGroupMappingByUserGroupParams{
-		ProviderID:  provider.ID,
-		UserGroupID: groupID,
-	})
+	mapping, err := h.store.Repos().SCIM.GetGroupMappingByUserGroup(ctx, store.SCIMGroupMappingByUserGroupKey{ProviderID: provider.ID, UserGroupID: groupID})
 	if err != nil {
 		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "group not found")
@@ -197,10 +190,7 @@ func (h *Handler) deleteGroup(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
 	// Look up the mapping
-	mapping, err := h.store.Queries().GetSCIMGroupMappingByUserGroup(ctx, db.GetSCIMGroupMappingByUserGroupParams{
-		ProviderID:  provider.ID,
-		UserGroupID: groupID,
-	})
+	mapping, err := h.store.Repos().SCIM.GetGroupMappingByUserGroup(ctx, store.SCIMGroupMappingByUserGroupKey{ProviderID: provider.ID, UserGroupID: groupID})
 	if err != nil {
 		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "group not found")
@@ -218,7 +208,7 @@ func (h *Handler) deleteGroup(w http.ResponseWriter, r *http.Request) {
 		EventType:  string(eventtypes.SCIMGroupUnmapped),
 		Data: map[string]any{
 			"provider_id":   provider.ID,
-			"scim_group_id": mapping.ScimGroupID,
+			"scim_group_id": mapping.SCIMGroupID,
 		},
 		ActorType: "scim",
 		ActorID:   provider.ID,

--- a/internal/scim/groups_create.go
+++ b/internal/scim/groups_create.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // createGroup handles POST /scim/v2/{slug}/Groups
@@ -50,15 +49,12 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check if this SCIM group is already mapped
-	existing, err := h.store.Queries().GetSCIMGroupMapping(ctx, db.GetSCIMGroupMappingParams{
-		ProviderID:  provider.ID,
-		ScimGroupID: scimGroupID,
-	})
+	existing, err := h.store.Repos().SCIM.GetGroupMapping(ctx, store.SCIMGroupMappingKey{ProviderID: provider.ID, SCIMGroupID: scimGroupID})
 	if err == nil {
 		// Already exists — update display name if changed and return existing resource.
 		h.logger.Debug("SCIM createGroup: group already exists, syncing", "scim_group_id", scimGroupID, "user_group_id", existing.UserGroupID)
 		// This makes POST idempotent, which handles SCIM clients that re-POST on every sync.
-		if existing.ScimDisplayName != scimGroup.DisplayName {
+		if existing.SCIMDisplayName != scimGroup.DisplayName {
 			h.appendEvent(ctx, store.Event{
 				StreamType: "scim_group_mapping",
 				StreamID:   existing.ID,
@@ -103,7 +99,7 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 				EventType:  string(eventtypes.SCIMGroupUnmapped),
 				Data: map[string]any{
 					"provider_id":   provider.ID,
-					"scim_group_id": existing.ScimGroupID,
+					"scim_group_id": existing.SCIMGroupID,
 				},
 				ActorType: "scim",
 				ActorID:   provider.ID,
@@ -181,10 +177,7 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build response
-	mapping, err := h.store.Queries().GetSCIMGroupMapping(ctx, db.GetSCIMGroupMappingParams{
-		ProviderID:  provider.ID,
-		ScimGroupID: scimGroupID,
-	})
+	mapping, err := h.store.Repos().SCIM.GetGroupMapping(ctx, store.SCIMGroupMappingKey{ProviderID: provider.ID, SCIMGroupID: scimGroupID})
 	if err != nil {
 		// Fall back to a minimal response
 		writeJSON(w, http.StatusCreated, SCIMGroup{

--- a/internal/scim/groups_helpers.go
+++ b/internal/scim/groups_helpers.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // reconcileGroupMembers diff's the requested member set against the
@@ -82,7 +81,7 @@ func (h *Handler) reconcileGroupMembers(ctx context.Context, provider store.Iden
 // buildGroupResource constructs a SCIMGroup from a mapping and its associated user group.
 // If the user group was deleted but the mapping still exists (orphaned), it re-creates
 // the user group and updates the mapping to restore consistency.
-func (h *Handler) buildGroupResource(ctx context.Context, providerID string, mapping db.ScimGroupMappingProjection, baseURL string) (SCIMGroup, error) {
+func (h *Handler) buildGroupResource(ctx context.Context, providerID string, mapping store.SCIMGroupMapping, baseURL string) (SCIMGroup, error) {
 	group, err := h.store.Queries().GetUserGroupWithMembers(ctx, mapping.UserGroupID)
 	if store.IsNotFound(err) {
 		// User group was deleted but SCIM mapping still exists — restore it.
@@ -117,7 +116,7 @@ func (h *Handler) buildGroupResource(ctx context.Context, providerID string, map
 	sg := SCIMGroup{
 		Schemas:     []string{GroupSchema},
 		ID:          mapping.UserGroupID,
-		ExternalID:  mapping.ScimGroupID,
+		ExternalID:  mapping.SCIMGroupID,
 		DisplayName: group.Name,
 		Members:     members,
 		Meta: &SCIMMeta{
@@ -134,9 +133,9 @@ func (h *Handler) buildGroupResource(ctx context.Context, providerID string, map
 
 // restoreOrphanedGroup re-creates the user group and updates the SCIM mapping
 // when the original user group was deleted but the SCIM mapping still exists.
-func (h *Handler) restoreOrphanedGroup(ctx context.Context, providerID string, m db.ScimGroupMappingProjection) (db.ScimGroupMappingProjection, error) {
+func (h *Handler) restoreOrphanedGroup(ctx context.Context, providerID string, m store.SCIMGroupMapping) (store.SCIMGroupMapping, error) {
 	h.logger.Warn("restoring orphaned SCIM group: re-creating user group",
-		"mapping_id", m.ID, "user_group_id", m.UserGroupID, "display_name", m.ScimDisplayName)
+		"mapping_id", m.ID, "user_group_id", m.UserGroupID, "display_name", m.SCIMDisplayName)
 
 	newGroupID := newULID()
 	if err := h.store.AppendEvent(ctx, store.Event{
@@ -144,7 +143,7 @@ func (h *Handler) restoreOrphanedGroup(ctx context.Context, providerID string, m
 		StreamID:   newGroupID,
 		EventType:  string(eventtypes.UserGroupCreated),
 		Data: map[string]any{
-			"name":        m.ScimDisplayName,
+			"name":        m.SCIMDisplayName,
 			"description": "SCIM-provisioned group (restored)",
 		},
 		ActorType: "scim",
@@ -160,7 +159,7 @@ func (h *Handler) restoreOrphanedGroup(ctx context.Context, providerID string, m
 		EventType:  string(eventtypes.SCIMGroupUnmapped),
 		Data: map[string]any{
 			"provider_id":   providerID,
-			"scim_group_id": m.ScimGroupID,
+			"scim_group_id": m.SCIMGroupID,
 		},
 		ActorType: "scim",
 		ActorID:   providerID,
@@ -174,8 +173,8 @@ func (h *Handler) restoreOrphanedGroup(ctx context.Context, providerID string, m
 		EventType:  string(eventtypes.SCIMGroupMapped),
 		Data: map[string]any{
 			"provider_id":       providerID,
-			"scim_group_id":     m.ScimGroupID,
-			"scim_display_name": m.ScimDisplayName,
+			"scim_group_id":     m.SCIMGroupID,
+			"scim_display_name": m.SCIMDisplayName,
 			"user_group_id":     newGroupID,
 		},
 		ActorType: "scim",
@@ -184,10 +183,7 @@ func (h *Handler) restoreOrphanedGroup(ctx context.Context, providerID string, m
 		return m, fmt.Errorf("create mapping: %w", err)
 	}
 
-	newMapping, err := h.store.Queries().GetSCIMGroupMapping(ctx, db.GetSCIMGroupMappingParams{
-		ProviderID:  providerID,
-		ScimGroupID: m.ScimGroupID,
-	})
+	newMapping, err := h.store.Repos().SCIM.GetGroupMapping(ctx, store.SCIMGroupMappingKey{ProviderID: providerID, SCIMGroupID: m.SCIMGroupID})
 	if err != nil {
 		return m, fmt.Errorf("read new mapping: %w", err)
 	}

--- a/internal/scim/groups_mutate.go
+++ b/internal/scim/groups_mutate.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // replaceGroup handles PUT /scim/v2/{slug}/Groups/{id}
@@ -41,10 +40,7 @@ func (h *Handler) replaceGroup(w http.ResponseWriter, r *http.Request) {
 	baseURL := baseURLFromRequest(r, provider.Slug)
 
 	// Look up the SCIM group mapping
-	mapping, err := h.store.Queries().GetSCIMGroupMappingByUserGroup(ctx, db.GetSCIMGroupMappingByUserGroupParams{
-		ProviderID:  provider.ID,
-		UserGroupID: groupID,
-	})
+	mapping, err := h.store.Repos().SCIM.GetGroupMappingByUserGroup(ctx, store.SCIMGroupMappingByUserGroupKey{ProviderID: provider.ID, UserGroupID: groupID})
 	if err != nil {
 		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "group not found")
@@ -56,14 +52,14 @@ func (h *Handler) replaceGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Update display name if changed
-	if scimGroup.DisplayName != "" && scimGroup.DisplayName != mapping.ScimDisplayName {
+	if scimGroup.DisplayName != "" && scimGroup.DisplayName != mapping.SCIMDisplayName {
 		h.appendEvent(ctx, store.Event{
 			StreamType: "scim_group_mapping",
 			StreamID:   mapping.ID,
 			EventType:  string(eventtypes.SCIMGroupMappingUpdated),
 			Data: map[string]any{
 				"provider_id":       provider.ID,
-				"scim_group_id":     mapping.ScimGroupID,
+				"scim_group_id":     mapping.SCIMGroupID,
 				"scim_display_name": scimGroup.DisplayName,
 			},
 			ActorType: "scim",
@@ -91,10 +87,7 @@ func (h *Handler) replaceGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Read back and return
-	updatedMapping, err := h.store.Queries().GetSCIMGroupMappingByUserGroup(ctx, db.GetSCIMGroupMappingByUserGroupParams{
-		ProviderID:  provider.ID,
-		UserGroupID: groupID,
-	})
+	updatedMapping, err := h.store.Repos().SCIM.GetGroupMappingByUserGroup(ctx, store.SCIMGroupMappingByUserGroupKey{ProviderID: provider.ID, UserGroupID: groupID})
 	if err != nil {
 		updatedMapping = mapping
 	}
@@ -135,10 +128,7 @@ func (h *Handler) patchGroup(w http.ResponseWriter, r *http.Request) {
 	baseURL := baseURLFromRequest(r, provider.Slug)
 
 	// Verify group exists
-	mapping, err := h.store.Queries().GetSCIMGroupMappingByUserGroup(ctx, db.GetSCIMGroupMappingByUserGroupParams{
-		ProviderID:  provider.ID,
-		UserGroupID: groupID,
-	})
+	mapping, err := h.store.Repos().SCIM.GetGroupMappingByUserGroup(ctx, store.SCIMGroupMappingByUserGroupKey{ProviderID: provider.ID, UserGroupID: groupID})
 	if err != nil {
 		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "group not found")
@@ -173,10 +163,7 @@ func (h *Handler) patchGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Read back and return
-	updatedMapping, err := h.store.Queries().GetSCIMGroupMappingByUserGroup(ctx, db.GetSCIMGroupMappingByUserGroupParams{
-		ProviderID:  provider.ID,
-		UserGroupID: groupID,
-	})
+	updatedMapping, err := h.store.Repos().SCIM.GetGroupMappingByUserGroup(ctx, store.SCIMGroupMappingByUserGroupKey{ProviderID: provider.ID, UserGroupID: groupID})
 	if err != nil {
 		updatedMapping = mapping
 	}
@@ -261,7 +248,7 @@ func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider store.Ide
 }
 
 // handleGroupPatchReplace processes a "replace" patch operation on a group.
-func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.IdentityProvider, groupID string, mapping db.ScimGroupMappingProjection, op SCIMPatchOp) {
+func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.IdentityProvider, groupID string, mapping store.SCIMGroupMapping, op SCIMPatchOp) {
 	path := strings.ToLower(op.Path)
 
 	switch path {
@@ -277,7 +264,7 @@ func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.Id
 			EventType:  string(eventtypes.SCIMGroupMappingUpdated),
 			Data: map[string]any{
 				"provider_id":       provider.ID,
-				"scim_group_id":     mapping.ScimGroupID,
+				"scim_group_id":     mapping.SCIMGroupID,
 				"scim_display_name": name,
 			},
 			ActorType: "scim",

--- a/internal/store/postgres/scim.go
+++ b/internal/store/postgres/scim.go
@@ -1,0 +1,72 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// SCIM implements store.SCIMRepo against scim_group_mapping_projection.
+type SCIM struct {
+	q *generated.Queries
+}
+
+// NewSCIM returns a SCIM repo bound to the given sqlc handle.
+func NewSCIM(q *generated.Queries) *SCIM {
+	return &SCIM{q: q}
+}
+
+func (s *SCIM) GetGroupMapping(ctx context.Context, key store.SCIMGroupMappingKey) (store.SCIMGroupMapping, error) {
+	row, err := s.q.GetSCIMGroupMapping(ctx, generated.GetSCIMGroupMappingParams{
+		ProviderID:  key.ProviderID,
+		ScimGroupID: key.SCIMGroupID,
+	})
+	if err != nil {
+		return store.SCIMGroupMapping{}, fmt.Errorf("scim: get group mapping: %w", translateNotFound(err))
+	}
+	return scimGroupMappingFromRow(row), nil
+}
+
+func (s *SCIM) GetGroupMappingByUserGroup(ctx context.Context, key store.SCIMGroupMappingByUserGroupKey) (store.SCIMGroupMapping, error) {
+	row, err := s.q.GetSCIMGroupMappingByUserGroup(ctx, generated.GetSCIMGroupMappingByUserGroupParams{
+		ProviderID:  key.ProviderID,
+		UserGroupID: key.UserGroupID,
+	})
+	if err != nil {
+		return store.SCIMGroupMapping{}, fmt.Errorf("scim: get group mapping by user group: %w", translateNotFound(err))
+	}
+	return scimGroupMappingFromRow(row), nil
+}
+
+func (s *SCIM) ListGroupMappings(ctx context.Context, providerID string) ([]store.SCIMGroupMapping, error) {
+	rows, err := s.q.ListSCIMGroupMappings(ctx, providerID)
+	if err != nil {
+		return nil, fmt.Errorf("scim: list group mappings: %w", err)
+	}
+	out := make([]store.SCIMGroupMapping, len(rows))
+	for i, r := range rows {
+		out[i] = scimGroupMappingFromRow(r)
+	}
+	return out, nil
+}
+
+func (s *SCIM) IsUserGroupSCIMManaged(ctx context.Context, userGroupID string) (bool, error) {
+	managed, err := s.q.IsUserGroupSCIMManaged(ctx, userGroupID)
+	if err != nil {
+		return false, fmt.Errorf("scim: is user group scim managed: %w", translateNotFound(err))
+	}
+	return managed, nil
+}
+
+func scimGroupMappingFromRow(r generated.ScimGroupMappingProjection) store.SCIMGroupMapping {
+	return store.SCIMGroupMapping{
+		ID:              r.ID,
+		ProviderID:      r.ProviderID,
+		SCIMGroupID:     r.ScimGroupID,
+		SCIMDisplayName: r.ScimDisplayName,
+		UserGroupID:     r.UserGroupID,
+		CreatedAt:       r.CreatedAt,
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -23,6 +23,7 @@ func NewRepos(q *generated.Queries) *store.Repos {
 		OSQuery:          NewOSQuery(q),
 		RevokedToken:     NewRevokedToken(q),
 		Role:             NewRole(q),
+		SCIM:             NewSCIM(q),
 		Settings:         NewSettings(q),
 		TerminalSession:  NewTerminalSession(q),
 		Token:            NewToken(q),

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -22,6 +22,7 @@ type Repos struct {
 	OSQuery          OSQueryRepo
 	RevokedToken     RevokedTokenRepo
 	Role             RoleRepo
+	SCIM             SCIMRepo
 	Settings         SettingsRepo
 	TerminalSession  TerminalSessionRepo
 	Token            TokenRepo

--- a/internal/store/scim.go
+++ b/internal/store/scim.go
@@ -1,0 +1,63 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// SCIMGroupMapping is one (provider, scim_group_id, user_group_id)
+// triple from scim_group_mapping_projection. The mapping links a SCIM
+// group provisioned by the upstream IdP to a Power Manage user_group;
+// the projection enforces uniqueness on (provider_id, scim_group_id)
+// AND on (provider_id, user_group_id) so each side is single-bound.
+type SCIMGroupMapping struct {
+	ID              string
+	ProviderID      string
+	SCIMGroupID     string
+	SCIMDisplayName string
+	UserGroupID     string
+	CreatedAt       time.Time
+}
+
+// SCIMGroupMappingKey is the composite key used by the SCIM API to
+// look up a single mapping by (provider, SCIM group ID).
+type SCIMGroupMappingKey struct {
+	ProviderID  string
+	SCIMGroupID string
+}
+
+// SCIMGroupMappingByUserGroupKey is the inverse-direction lookup —
+// SCIM patch handlers receive a Power Manage user_group_id and need
+// to find the matching SCIM mapping (if any) to round-trip the
+// display_name back to the IdP.
+type SCIMGroupMappingByUserGroupKey struct {
+	ProviderID  string
+	UserGroupID string
+}
+
+// SCIMRepo reads SCIM mapping state. SCIM user reads
+// (FindSCIMUserByEmail / ListSCIMUsers / etc.) return user-projection-
+// shaped rows and migrate with the User domain in a later wave. Writes
+// to scim_group_mapping_projection happen inside the projector
+// listener — pure projector internals, stay on Queries().
+type SCIMRepo interface {
+	// GetGroupMapping returns the mapping for a (provider, SCIM
+	// group) pair. Returns ErrNotFound when no mapping exists.
+	GetGroupMapping(ctx context.Context, key SCIMGroupMappingKey) (SCIMGroupMapping, error)
+
+	// GetGroupMappingByUserGroup returns the mapping for a
+	// (provider, user_group) pair. Returns ErrNotFound when no
+	// mapping exists (the user-group is not SCIM-managed).
+	GetGroupMappingByUserGroup(ctx context.Context, key SCIMGroupMappingByUserGroupKey) (SCIMGroupMapping, error)
+
+	// ListGroupMappings returns every mapping for the given
+	// provider, ordered by scim_display_name. Empty slice when the
+	// provider has no SCIM groups yet.
+	ListGroupMappings(ctx context.Context, providerID string) ([]SCIMGroupMapping, error)
+
+	// IsUserGroupSCIMManaged reports whether the given user_group
+	// is managed by SCIM (i.e. has a mapping row for some
+	// provider). Used by the user-group handler to refuse member
+	// edits on SCIM-managed groups.
+	IsUserGroupSCIMManaged(ctx context.Context, userGroupID string) (bool, error)
+}


### PR DESCRIPTION
## Summary

\`SCIMRepo\` — read side of SCIM group-mapping state plus cross-handler \`IsUserGroupSCIMManaged\`. Branches off main directly.

## Methods

- \`GetGroupMapping(provider, scimGroupID)\`
- \`GetGroupMappingByUserGroup(provider, userGroupID)\`
- \`ListGroupMappings(provider)\`
- \`IsUserGroupSCIMManaged(userGroupID)\`

Field renames at the type boundary follow Go convention: \`ScimGroupID\` → \`SCIMGroupID\`, \`ScimDisplayName\` → \`SCIMDisplayName\`.

## Call sites migrated (~16)

- \`internal/scim/groups.go\` — 5
- \`internal/scim/groups_create.go\` — 2
- \`internal/scim/groups_mutate.go\` — 4
- \`internal/scim/groups_helpers.go\` — 1 + \`restoreOrphanedGroup\` + \`buildGroupResource\` signatures
- \`internal/api/user_group_handler.go\` — 8 \`IsUserGroupSCIMManaged\` sites

## Non-goals

- **SCIM user reads** (\`FindSCIMUserByEmail\`, \`FindSCIMUserByExternalID\`, \`ListSCIMUsers\`, \`CountSCIMUsers\`) — return user-projection-shaped rows; migrate with User domain in a later wave.
- **SCIM mapping writes** (\`UpsertSCIMGroupMapping\`, \`DeleteSCIMGroupMappingByCompositeKey\`, \`UpdateSCIMGroupMappingDisplayName\`) — pure projector listener internals, stay on \`Queries()\`.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Tests pass: \`TestSCIMGroup*\` etc. (18s of scim coverage).

Part of #242. Closes #261.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked SCIM group mapping access to a repository-based backend for more consistent and maintainable group management flows.
* **Bug Fixes / Reliability**
  * Improved detection of SCIM-managed groups and consistency of SCIM IDs and display names across create, update, list, delete, and evaluation operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/262?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->