### PR TITLE
refactor(store): wave B.11 — device_group repo (#265)

### DIFF
--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -89,7 +89,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device")
 		}
 	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_DEVICE_GROUP:
-		_, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.TargetId)
+		_, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.TargetId)
 		if err != nil {
 			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrDeviceGroupNotFound, connect.CodeNotFound, "device group not found")

--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -75,7 +75,7 @@ func (h *DeviceGroupHandler) CreateDeviceGroup(ctx context.Context, req *connect
 		return nil, err
 	}
 
-	group, err := h.store.Queries().GetDeviceGroupByID(ctx, id)
+	group, err := h.store.Repos().DeviceGroup.Get(ctx, id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group")
 	}
@@ -91,12 +91,12 @@ func (h *DeviceGroupHandler) GetDeviceGroup(ctx context.Context, req *connect.Re
 		return nil, err
 	}
 
-	group, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id)
+	group, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
 	}
 
-	members, err := h.store.Queries().ListDeviceGroupMembers(ctx, req.Msg.Id)
+	members, err := h.store.Repos().DeviceGroup.ListMembers(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group members")
 	}
@@ -129,15 +129,12 @@ func (h *DeviceGroupHandler) ListDeviceGroups(ctx context.Context, req *connect.
 		return nil, err
 	}
 
-	groups, err := h.store.Queries().ListDeviceGroups(ctx, db.ListDeviceGroupsParams{
-		Limit:  pageSize,
-		Offset: offset,
-	})
+	groups, err := h.store.Repos().DeviceGroup.List(ctx, store.ListDeviceGroupsFilter{Limit: pageSize, Offset: offset})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list device groups")
 	}
 
-	count, err := h.store.Queries().CountDeviceGroups(ctx)
+	count, err := h.store.Repos().DeviceGroup.Count(ctx)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count device groups")
 	}
@@ -162,7 +159,7 @@ func (h *DeviceGroupHandler) ListDeviceGroupsForDevice(ctx context.Context, req 
 		return nil, err
 	}
 
-	groups, err := h.store.Queries().ListGroupsForDevice(ctx, req.Msg.DeviceId)
+	groups, err := h.store.Repos().DeviceGroup.ListForDevice(ctx, req.Msg.DeviceId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list groups for device")
 	}
@@ -201,7 +198,7 @@ func (h *DeviceGroupHandler) RenameDeviceGroup(ctx context.Context, req *connect
 		return nil, err
 	}
 
-	group, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id)
+	group, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
 	}
@@ -235,7 +232,7 @@ func (h *DeviceGroupHandler) UpdateDeviceGroupDescription(ctx context.Context, r
 		return nil, err
 	}
 
-	group, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id)
+	group, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
 	}
@@ -299,7 +296,7 @@ func (h *DeviceGroupHandler) AddDeviceToGroup(ctx context.Context, req *connect.
 	q := h.store.Queries()
 
 	// Verify group exists and is not dynamic
-	group, err := q.GetDeviceGroupByID(ctx, req.Msg.GroupId)
+	group, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.GroupId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
 	}
@@ -333,7 +330,7 @@ func (h *DeviceGroupHandler) AddDeviceToGroup(ctx context.Context, req *connect.
 		}
 	}
 
-	group, err = q.GetDeviceGroupByID(ctx, req.Msg.GroupId)
+	group, err = h.store.Repos().DeviceGroup.Get(ctx, req.Msg.GroupId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group")
 	}
@@ -355,7 +352,7 @@ func (h *DeviceGroupHandler) RemoveDeviceFromGroup(ctx context.Context, req *con
 	}
 
 	// Verify group exists and is not dynamic
-	group, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.GroupId)
+	group, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.GroupId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
 	}
@@ -378,7 +375,7 @@ func (h *DeviceGroupHandler) RemoveDeviceFromGroup(ctx context.Context, req *con
 		return nil, err
 	}
 
-	group, err = h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.GroupId)
+	group, err = h.store.Repos().DeviceGroup.Get(ctx, req.Msg.GroupId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group")
 	}
@@ -427,7 +424,7 @@ func (h *DeviceGroupHandler) UpdateDeviceGroupQuery(ctx context.Context, req *co
 		return nil, err
 	}
 
-	group, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id)
+	group, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
 	}
@@ -474,7 +471,7 @@ func (h *DeviceGroupHandler) EvaluateDynamicGroup(ctx context.Context, req *conn
 	}
 
 	// Verify group exists and is dynamic
-	group, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id)
+	group, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
 	}
@@ -493,7 +490,7 @@ func (h *DeviceGroupHandler) EvaluateDynamicGroup(ctx context.Context, req *conn
 	}
 
 	// Get updated group
-	group, err = h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id)
+	group, err = h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group")
 	}
@@ -531,7 +528,7 @@ func (h *DeviceGroupHandler) SetDeviceGroupSyncInterval(ctx context.Context, req
 	}
 
 	// Verify group exists
-	_, err = h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id)
+	_, err = h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
 	}
@@ -549,7 +546,7 @@ func (h *DeviceGroupHandler) SetDeviceGroupSyncInterval(ctx context.Context, req
 		return nil, err
 	}
 
-	group, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id)
+	group, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group")
 	}
@@ -578,7 +575,7 @@ func (h *DeviceGroupHandler) SetDeviceGroupMaintenanceWindow(ctx context.Context
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, err.Error())
 	}
 
-	if _, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id); err != nil {
+	if _, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id); err != nil {
 		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
 	}
 
@@ -595,7 +592,7 @@ func (h *DeviceGroupHandler) SetDeviceGroupMaintenanceWindow(ctx context.Context
 		return nil, err
 	}
 
-	group, err := h.store.Queries().GetDeviceGroupByID(ctx, req.Msg.Id)
+	group, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group")
 	}
@@ -605,7 +602,7 @@ func (h *DeviceGroupHandler) SetDeviceGroupMaintenanceWindow(ctx context.Context
 	}), nil
 }
 
-func (h *DeviceGroupHandler) deviceGroupToProto(g db.DeviceGroupsProjection) *pm.DeviceGroup {
+func (h *DeviceGroupHandler) deviceGroupToProto(g store.DeviceGroup) *pm.DeviceGroup {
 	group := &pm.DeviceGroup{
 		Id:                  g.ID,
 		Name:                g.Name,

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -788,10 +788,7 @@ func (idx *Index) warmDeviceGroups(ctx context.Context) (int, error) {
 	var total int
 
 	for {
-		groups, err := idx.store.Queries().ListDeviceGroups(ctx, db.ListDeviceGroupsParams{
-			Limit:  pageSize,
-			Offset: offset,
-		})
+		groups, err := idx.store.Repos().DeviceGroup.List(ctx, store.ListDeviceGroupsFilter{Limit: pageSize, Offset: offset})
 		if err != nil {
 			return total, err
 		}

--- a/internal/store/device_group.go
+++ b/internal/store/device_group.go
@@ -1,0 +1,71 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// DeviceGroup is the device-group projection row. SyncIntervalMinutes
+// drives the per-group dynamic-group re-evaluation cadence;
+// MaintenanceWindow stays as json.RawMessage at the boundary per the
+// JSONB normalize plan.
+type DeviceGroup struct {
+	ID                  string
+	Name                string
+	Description         string
+	MemberCount         int32
+	CreatedAt           *time.Time
+	CreatedBy           string
+	IsDynamic           bool
+	DynamicQuery        *string
+	SyncIntervalMinutes int32
+	MaintenanceWindow   json.RawMessage
+}
+
+// DeviceGroupMember is one row in the device-group membership join,
+// hydrated with the device hostname + agent_version + last_seen_at
+// for the UI's member listing.
+type DeviceGroupMember struct {
+	GroupID      string
+	DeviceID     string
+	AddedAt      *time.Time
+	Hostname     string
+	AgentVersion string
+	LastSeenAt   *time.Time
+}
+
+// ListDeviceGroupsFilter is the pagination shape for the device-group
+// list endpoint.
+type ListDeviceGroupsFilter struct {
+	Limit  int32
+	Offset int32
+}
+
+// DeviceGroupRepo reads device-group state from the projection.
+// Writes flow through events; the dynamic-query evaluator
+// (EvaluateDynamicGroup / ValidateDynamicQuery / etc.) stays on
+// Queries() until the Wave C PL/pgSQL → Go port.
+type DeviceGroupRepo interface {
+	// Get returns the group by ID. Returns ErrNotFound when no
+	// group with that ID exists.
+	Get(ctx context.Context, id string) (DeviceGroup, error)
+
+	// GetByName returns the group by display name. Used by the
+	// CreateDeviceGroup duplicate-name pre-check.
+	GetByName(ctx context.Context, name string) (DeviceGroup, error)
+
+	// List returns a page of groups.
+	List(ctx context.Context, filter ListDeviceGroupsFilter) ([]DeviceGroup, error)
+
+	// Count returns the total non-deleted group count.
+	Count(ctx context.Context) (int64, error)
+
+	// ListForDevice returns every group the device belongs to
+	// (direct + dynamic-materialized membership).
+	ListForDevice(ctx context.Context, deviceID string) ([]DeviceGroup, error)
+
+	// ListMembers returns the member rows hydrated with the
+	// device hostname.
+	ListMembers(ctx context.Context, groupID string) ([]DeviceGroupMember, error)
+}

--- a/internal/store/postgres/device_group.go
+++ b/internal/store/postgres/device_group.go
@@ -1,0 +1,107 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// DeviceGroup implements store.DeviceGroupRepo against
+// device_groups_projection + device_group_members_projection.
+type DeviceGroup struct {
+	q *generated.Queries
+}
+
+// NewDeviceGroup returns a DeviceGroup repo bound to the given sqlc
+// handle.
+func NewDeviceGroup(q *generated.Queries) *DeviceGroup {
+	return &DeviceGroup{q: q}
+}
+
+func (g *DeviceGroup) Get(ctx context.Context, id string) (store.DeviceGroup, error) {
+	row, err := g.q.GetDeviceGroupByID(ctx, id)
+	if err != nil {
+		return store.DeviceGroup{}, fmt.Errorf("device_group: get: %w", translateNotFound(err))
+	}
+	return deviceGroupFromRow(row), nil
+}
+
+func (g *DeviceGroup) GetByName(ctx context.Context, name string) (store.DeviceGroup, error) {
+	row, err := g.q.GetDeviceGroupByName(ctx, name)
+	if err != nil {
+		return store.DeviceGroup{}, fmt.Errorf("device_group: get by name: %w", translateNotFound(err))
+	}
+	return deviceGroupFromRow(row), nil
+}
+
+func (g *DeviceGroup) List(ctx context.Context, filter store.ListDeviceGroupsFilter) ([]store.DeviceGroup, error) {
+	rows, err := g.q.ListDeviceGroups(ctx, generated.ListDeviceGroupsParams{
+		Limit:  filter.Limit,
+		Offset: filter.Offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("device_group: list: %w", err)
+	}
+	out := make([]store.DeviceGroup, len(rows))
+	for i, r := range rows {
+		out[i] = deviceGroupFromRow(r)
+	}
+	return out, nil
+}
+
+func (g *DeviceGroup) Count(ctx context.Context) (int64, error) {
+	n, err := g.q.CountDeviceGroups(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("device_group: count: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (g *DeviceGroup) ListForDevice(ctx context.Context, deviceID string) ([]store.DeviceGroup, error) {
+	rows, err := g.q.ListGroupsForDevice(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("device_group: list for device: %w", err)
+	}
+	out := make([]store.DeviceGroup, len(rows))
+	for i, r := range rows {
+		out[i] = deviceGroupFromRow(r)
+	}
+	return out, nil
+}
+
+func (g *DeviceGroup) ListMembers(ctx context.Context, groupID string) ([]store.DeviceGroupMember, error) {
+	rows, err := g.q.ListDeviceGroupMembers(ctx, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("device_group: list members: %w", err)
+	}
+	out := make([]store.DeviceGroupMember, len(rows))
+	for i, r := range rows {
+		out[i] = store.DeviceGroupMember{
+			GroupID:      r.GroupID,
+			DeviceID:     r.DeviceID,
+			AddedAt:      r.AddedAt,
+			Hostname:     r.Hostname,
+			AgentVersion: r.AgentVersion,
+			LastSeenAt:   r.LastSeenAt,
+		}
+	}
+	return out, nil
+}
+
+func deviceGroupFromRow(r generated.DeviceGroupsProjection) store.DeviceGroup {
+	return store.DeviceGroup{
+		ID:                  r.ID,
+		Name:                r.Name,
+		Description:         r.Description,
+		MemberCount:         r.MemberCount,
+		CreatedAt:           r.CreatedAt,
+		CreatedBy:           r.CreatedBy,
+		IsDynamic:           r.IsDynamic,
+		DynamicQuery:        r.DynamicQuery,
+		SyncIntervalMinutes: r.SyncIntervalMinutes,
+		MaintenanceWindow:   json.RawMessage(r.MaintenanceWindow),
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -16,6 +16,7 @@ func NewRepos(q *generated.Queries) *store.Repos {
 	return &store.Repos{
 		AuthState:        NewAuthState(q),
 		Compliance:       NewCompliance(q),
+		DeviceGroup:      NewDeviceGroup(q),
 		IdentityLink:     NewIdentityLink(q),
 		IdentityProvider: NewIdentityProvider(q),
 		Inventory:        NewInventory(q),

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -15,6 +15,7 @@ package store
 type Repos struct {
 	AuthState        AuthStateRepo
 	Compliance       ComplianceRepo
+	DeviceGroup      DeviceGroupRepo
 	IdentityLink     IdentityLinkRepo
 	IdentityProvider IdentityProviderRepo
 	Inventory        InventoryRepo


### PR DESCRIPTION
## Summary

\`DeviceGroupRepo\` mirrors \`UserGroupRepo\` (#263). Read side of \`device_groups_projection\` + \`device_group_members_projection\`. Branches off main directly.

## Methods

- \`Get\`, \`GetByName\`
- \`List(filter)\`, \`Count\`
- \`ListForDevice\` — all groups for a device
- \`ListMembers\` — member rows hydrated with hostname + agent_version + last_seen_at

\`MaintenanceWindow\` stays as \`json.RawMessage\` at the boundary. \`SyncIntervalMinutes\` carried so the dynamic-group worker can read its cadence.

## Call sites migrated (~18)

- \`internal/api/device_group_handler.go\` — 14 sites + \`deviceGroupToProto\` signature
- \`internal/api/device_handler.go\` — 1 site
- \`internal/search/index.go\` — 1 site

## Non-goals

- \`ValidateDynamicQuery\` / \`EvaluateDynamicGroup\` / \`CountMatchingDevicesForQuery\` — PL/pgSQL evaluator, moves with Wave C (dynamic-query interpreter port).
- Write-side projector queries — stay on \`Queries()\` per pattern.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Tests pass: \`TestCreateDeviceGroup\`, \`TestListDeviceGroups\`, \`TestUpdateDeviceGroup\`, \`TestAddDeviceToGroup\`, \`TestRemoveDeviceFromGroup\`, etc. (39s).

Part of #242. Closes #265.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic group evaluation: responses now report added/removed device counts more accurately after evaluation.

* **Refactor**
  * Device group management (create/get/list/update/rename/add/remove/maintenance/sync) now uses a unified data layer for more consistent, reliable behavior.
  * Search indexing warm-up aligned with the unified device-group data access for more predictable indexing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->