### PR TITLE
refactor(store): wave B.12 — user repo (#267)

### DIFF
--- a/cmd/control/admin_user.go
+++ b/cmd/control/admin_user.go
@@ -20,7 +20,7 @@ import (
 
 func ensureAdminUser(ctx context.Context, st *store.Store, email, password string, logger *slog.Logger) error {
 	// Check if user exists via the projection
-	_, err := st.Queries().GetUserByEmail(ctx, email)
+	_, err := st.Repos().User.GetByEmail(ctx, email)
 	if err == nil {
 		logger.Info("admin user already exists", "email", email)
 		return nil

--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -97,7 +97,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get device group")
 		}
 	case pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER:
-		_, err := h.store.Queries().GetUserByID(ctx, req.Msg.TargetId)
+		_, err := h.store.Repos().User.Get(ctx, req.Msg.TargetId)
 		if err != nil {
 			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user not found")

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -52,7 +52,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 		return nil, apiErrorCtx(ctx, ErrPasswordLoginDisabled, connect.CodeUnauthenticated, "password login is disabled on this server")
 	}
 
-	user, err := h.store.Queries().GetUserByEmail(ctx, req.Msg.Email)
+	user, err := h.store.Repos().User.GetByEmail(ctx, req.Msg.Email)
 	if err != nil {
 		if store.IsNotFound(err) {
 			// Perform a dummy bcrypt comparison to prevent timing-based user enumeration
@@ -94,7 +94,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 	}
 
 	// Resolve permissions from DB and embed in JWT
-	permissions, err := h.store.Queries().GetUserPermissionsWithGroups(ctx, user.ID)
+	permissions, err := h.store.Repos().User.Permissions(ctx, user.ID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve permissions")
 	}
@@ -167,7 +167,7 @@ func (h *AuthHandler) RefreshToken(ctx context.Context, req *connect.Request[pm.
 	}
 
 	// Check user status (disabled, deleted) and session version before issuing new tokens
-	info, err := h.store.Queries().GetUserSessionInfo(ctx, result.Claims.UserID)
+	info, err := h.store.Repos().User.SessionInfo(ctx, result.Claims.UserID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeUnauthenticated, "user not found")
 	}
@@ -191,7 +191,7 @@ func (h *AuthHandler) RefreshToken(ctx context.Context, req *connect.Request[pm.
 	}
 
 	// Resolve fresh permissions from DB
-	permissions, err := h.store.Queries().GetUserPermissionsWithGroups(ctx, result.Claims.UserID)
+	permissions, err := h.store.Repos().User.Permissions(ctx, result.Claims.UserID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve permissions")
 	}
@@ -238,7 +238,7 @@ func (h *AuthHandler) GetCurrentUser(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
-	user, err := h.store.Queries().GetUserByID(ctx, userCtx.ID)
+	user, err := h.store.Repos().User.Get(ctx, userCtx.ID)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}

--- a/internal/api/identity_link_handler.go
+++ b/internal/api/identity_link_handler.go
@@ -72,7 +72,7 @@ func (h *IdentityLinkHandler) UnlinkIdentity(ctx context.Context, req *connect.R
 	targetUserID := link.UserID
 
 	// Prevent unlinking last auth method
-	user, err := h.store.Queries().GetUserByID(ctx, targetUserID)
+	user, err := h.store.Repos().User.Get(ctx, targetUserID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user")
 	}

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -107,7 +107,7 @@ func (h *SettingsHandler) UpdateServerSettings(ctx context.Context, req *connect
 // enableProvisioningForAllUsers sets user_provisioning_enabled=true on every user
 // that doesn't already have it enabled.
 func (h *SettingsHandler) enableProvisioningForAllUsers(ctx context.Context) error {
-	users, err := h.store.Queries().ListAllNonDeletedUsers(ctx)
+	users, err := h.store.Repos().User.ListAllNonDeleted(ctx)
 	if err != nil {
 		return fmt.Errorf("list users: %w", err)
 	}
@@ -138,7 +138,7 @@ func (h *SettingsHandler) enableProvisioningForAllUsers(ctx context.Context) err
 // enableSshAccessForAllUsers sets ssh_access_enabled=true on every user
 // that doesn't already have it enabled.
 func (h *SettingsHandler) enableSshAccessForAllUsers(ctx context.Context) error {
-	users, err := h.store.Queries().ListAllNonDeletedUsers(ctx)
+	users, err := h.store.Repos().User.ListAllNonDeleted(ctx)
 	if err != nil {
 		return fmt.Errorf("list users: %w", err)
 	}

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -53,7 +53,7 @@ func (h *SSOHandler) ListAuthMethods(ctx context.Context, req *connect.Request[p
 	// between "no such user" and "lookup errored" — that's a deliberate
 	// info-leak guard, see the comment below.
 	if req.Msg.Email != "" {
-		user, err := h.store.Queries().GetUserByEmail(ctx, req.Msg.Email)
+		user, err := h.store.Repos().User.GetByEmail(ctx, req.Msg.Email)
 		if err == nil {
 			resp.TotpEnabled = user.TotpEnabled
 
@@ -274,7 +274,7 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 	}
 
 	// Get and validate user before proceeding
-	user, err := h.store.Queries().GetUserByID(ctx, linkResult.UserID)
+	user, err := h.store.Repos().User.Get(ctx, linkResult.UserID)
 	if err != nil {
 		if store.IsNotFound(err) {
 			h.logger.Error("SSO user not found after link resolved — user may be soft-deleted",
@@ -361,7 +361,7 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 	}
 
 	// Generate tokens
-	permissions, err := h.store.Queries().GetUserPermissionsWithGroups(ctx, user.ID)
+	permissions, err := h.store.Repos().User.Permissions(ctx, user.ID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve permissions")
 	}

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -12,7 +12,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // SystemActionManager creates and maintains system-managed actions
@@ -54,7 +53,7 @@ func NewSystemActionManager(st *store.Store, signer ca.ActionSigner, logger *slo
 // SyncAllUsersSystemActions ensures all users have correct system actions.
 // Called at startup and after global settings changes. Idempotent.
 func (m *SystemActionManager) SyncAllUsersSystemActions(ctx context.Context) error {
-	users, err := m.store.Queries().ListAllNonDeletedUsers(ctx)
+	users, err := m.store.Repos().User.ListAllNonDeleted(ctx)
 	if err != nil {
 		return fmt.Errorf("list users: %w", err)
 	}
@@ -145,7 +144,7 @@ func (m *SystemActionManager) StartReconciliation(ctx context.Context, interval,
 // Disabled users get a disabled flag in their USER action params.
 // Idempotent and safe to call after any user mutation.
 func (m *SystemActionManager) SyncUserSystemActions(ctx context.Context, userID string) error {
-	user, err := m.store.Queries().GetUserByID(ctx, userID)
+	user, err := m.store.Repos().User.Get(ctx, userID)
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
 	}
@@ -199,7 +198,7 @@ func (m *SystemActionManager) SyncUserSystemActions(ctx context.Context, userID 
 	// If the permission query fails, we skip the TTY block entirely
 	// and leave the existing state untouched — a transient DB error
 	// must NOT trigger a cleanup that deletes a working TTY account.
-	permissions, err := m.store.Queries().GetUserPermissionsWithGroups(ctx, userID)
+	permissions, err := m.store.Repos().User.Permissions(ctx, userID)
 	if err != nil {
 		m.logger.Error("failed to resolve user permissions for tty action sync; leaving TTY state unchanged",
 			"user_id", userID, "error", err)
@@ -227,7 +226,7 @@ func (m *SystemActionManager) SyncUserSystemActions(ctx context.Context, userID 
 
 // CleanupDeletedUserActions removes all system actions for a deleted user.
 // Must be called with the user projection loaded BEFORE the delete event.
-func (m *SystemActionManager) CleanupDeletedUserActions(ctx context.Context, user db.UsersProjection) error {
+func (m *SystemActionManager) CleanupDeletedUserActions(ctx context.Context, user store.User) error {
 	if user.SystemUserActionID != "" {
 		if err := m.actions.DeleteAction(ctx, user.SystemUserActionID); err != nil {
 			m.logger.Error("failed to delete system user action", "action_id", user.SystemUserActionID, "error", err)
@@ -255,7 +254,7 @@ func (m *SystemActionManager) CleanupDeletedUserActions(ctx context.Context, use
 	return nil
 }
 
-func (m *SystemActionManager) syncUserProvisionAction(ctx context.Context, user db.UsersProjection, sshKeys []string) error {
+func (m *SystemActionManager) syncUserProvisionAction(ctx context.Context, user store.User, sshKeys []string) error {
 	comment := user.DisplayName
 	if comment == "" {
 		comment = user.Email
@@ -268,7 +267,7 @@ func (m *SystemActionManager) syncUserProvisionAction(ctx context.Context, user 
 	// recur here.
 	params := &pm.UserParams{
 		Username:   user.LinuxUsername,
-		Uid:        user.LinuxUid,
+		Uid:        user.LinuxUID,
 		CreateHome: true,
 		Comment:    comment,
 		Disabled:   user.Disabled,
@@ -316,7 +315,7 @@ func (m *SystemActionManager) syncUserProvisionAction(ctx context.Context, user 
 	return nil
 }
 
-func (m *SystemActionManager) syncSshAccessAction(ctx context.Context, user db.UsersProjection) error {
+func (m *SystemActionManager) syncSshAccessAction(ctx context.Context, user store.User) error {
 	// Typed *pm.SshParams — same rationale as syncUserProvisionAction.
 	params := &pm.SshParams{
 		Users:         []string{user.LinuxUsername},
@@ -363,7 +362,7 @@ func (m *SystemActionManager) syncSshAccessAction(ctx context.Context, user db.U
 	return nil
 }
 
-func (m *SystemActionManager) cleanupUserAction(ctx context.Context, user db.UsersProjection) error {
+func (m *SystemActionManager) cleanupUserAction(ctx context.Context, user store.User) error {
 	if user.SystemUserActionID == "" {
 		return nil
 	}
@@ -377,7 +376,7 @@ func (m *SystemActionManager) cleanupUserAction(ctx context.Context, user db.Use
 	return nil
 }
 
-func (m *SystemActionManager) cleanupSshAction(ctx context.Context, user db.UsersProjection) error {
+func (m *SystemActionManager) cleanupSshAction(ctx context.Context, user store.User) error {
 	if user.SystemSshActionID == "" {
 		return nil
 	}
@@ -402,7 +401,7 @@ func (m *SystemActionManager) cleanupSshAction(ctx context.Context, user db.User
 // The action uses nologin as the shell (the agent temporarily
 // activates it during a session), no home directory, and the
 // deterministic UID from the SDK's TTYUID helper.
-func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.UsersProjection) error {
+func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user store.User) error {
 	// Typed *pm.UserParams so the Go compiler rejects field-name
 	// typos. The previous map[string]any form accepted "system": true
 	// as a sibling of real fields — protojson silently dropped it on
@@ -467,9 +466,9 @@ func (m *SystemActionManager) syncTtyUserAction(ctx context.Context, user db.Use
 	return nil
 }
 
-func systemTtyUserParams(user db.UsersProjection) *pm.UserParams {
+func systemTtyUserParams(user store.User) *pm.UserParams {
 	ttyUsername := "pm-tty-" + user.LinuxUsername
-	ttyUID := int32(int(user.LinuxUid) + 100000) // terminal.DefaultUIDOffset
+	ttyUID := int32(int(user.LinuxUID) + 100000) // terminal.DefaultUIDOffset
 
 	return &pm.UserParams{
 		Username:   ttyUsername,
@@ -482,7 +481,7 @@ func systemTtyUserParams(user db.UsersProjection) *pm.UserParams {
 	}
 }
 
-func (m *SystemActionManager) cleanupTtyAction(ctx context.Context, user db.UsersProjection) error {
+func (m *SystemActionManager) cleanupTtyAction(ctx context.Context, user store.User) error {
 	if user.SystemTtyActionID == "" {
 		return nil
 	}

--- a/internal/api/system_actions_manager_test.go
+++ b/internal/api/system_actions_manager_test.go
@@ -71,7 +71,7 @@ func TestSyncUserSystemActions_NoLinuxUsername_NoOps(t *testing.T) {
 
 	require.NoError(t, m.SyncUserSystemActions(context.Background(), userID))
 
-	user, err := st.Queries().GetUserByID(context.Background(), userID)
+	user, err := st.Repos().User.Get(context.Background(), userID)
 	require.NoError(t, err)
 	assert.Empty(t, user.SystemUserActionID, "no linux_username → manager must NOT have created a USER action")
 	assert.Empty(t, user.SystemSshActionID, "no linux_username → no SSH action either")
@@ -90,7 +90,7 @@ func TestSyncUserSystemActions_ProvisioningDisabled_NoActionsCreated(t *testing.
 
 	require.NoError(t, m.SyncUserSystemActions(context.Background(), userID))
 
-	user, err := st.Queries().GetUserByID(context.Background(), userID)
+	user, err := st.Repos().User.Get(context.Background(), userID)
 	require.NoError(t, err)
 	assert.Empty(t, user.SystemUserActionID,
 		"provisioning disabled + no prior action → cleanup branch is a no-op (nothing to delete)")
@@ -108,7 +108,7 @@ func TestSyncUserSystemActions_GlobalProvisioning_CreatesUserAction(t *testing.T
 
 	require.NoError(t, m.SyncUserSystemActions(context.Background(), userID))
 
-	user, err := st.Queries().GetUserByID(context.Background(), userID)
+	user, err := st.Repos().User.Get(context.Background(), userID)
 	require.NoError(t, err)
 	require.NotEmpty(t, user.SystemUserActionID,
 		"provisioning enabled + linux_username → manager must create + link a system USER action")
@@ -131,7 +131,7 @@ func TestSyncUserSystemActions_SecondRun_UpdatesExistingAction(t *testing.T) {
 	enableGlobalProvisioning(t, st)
 
 	require.NoError(t, m.SyncUserSystemActions(context.Background(), userID))
-	user1, err := st.Queries().GetUserByID(context.Background(), userID)
+	user1, err := st.Repos().User.Get(context.Background(), userID)
 	require.NoError(t, err)
 	originalActionID := user1.SystemUserActionID
 	require.NotEmpty(t, originalActionID)
@@ -140,7 +140,7 @@ func TestSyncUserSystemActions_SecondRun_UpdatesExistingAction(t *testing.T) {
 	// branch (not the create branch) so the action ID stays stable —
 	// otherwise downstream assignments would dangle.
 	require.NoError(t, m.SyncUserSystemActions(context.Background(), userID))
-	user2, err := st.Queries().GetUserByID(context.Background(), userID)
+	user2, err := st.Repos().User.Get(context.Background(), userID)
 	require.NoError(t, err)
 	assert.Equal(t, originalActionID, user2.SystemUserActionID,
 		"second sync MUST keep the same action ID — re-creating would orphan the assignment row")
@@ -157,7 +157,7 @@ func TestCleanupDeletedUserActions_RemovesAllSystemActions(t *testing.T) {
 	enableGlobalProvisioning(t, st)
 
 	require.NoError(t, m.SyncUserSystemActions(context.Background(), userID))
-	user, err := st.Queries().GetUserByID(context.Background(), userID)
+	user, err := st.Repos().User.Get(context.Background(), userID)
 	require.NoError(t, err)
 	require.NotEmpty(t, user.SystemUserActionID, "precondition: user has a system action")
 
@@ -167,7 +167,7 @@ func TestCleanupDeletedUserActions_RemovesAllSystemActions(t *testing.T) {
 
 	// User's link columns are now empty — confirms the cleanup
 	// emitted UserSystemActionLinked with action_id="".
-	after, err := st.Queries().GetUserByID(context.Background(), userID)
+	after, err := st.Repos().User.Get(context.Background(), userID)
 	require.NoError(t, err)
 	assert.Empty(t, after.SystemUserActionID, "cleanup MUST clear system_user_action_id")
 }
@@ -184,7 +184,7 @@ func TestSyncUserSystemActions_DisablingProvisioningCleansUpExistingAction(t *te
 
 	// First sync creates the action.
 	require.NoError(t, m.SyncUserSystemActions(context.Background(), userID))
-	user, err := st.Queries().GetUserByID(context.Background(), userID)
+	user, err := st.Repos().User.Get(context.Background(), userID)
 	require.NoError(t, err)
 	require.NotEmpty(t, user.SystemUserActionID)
 
@@ -199,7 +199,7 @@ func TestSyncUserSystemActions_DisablingProvisioningCleansUpExistingAction(t *te
 
 	// Second sync must take the cleanup branch.
 	require.NoError(t, m.SyncUserSystemActions(context.Background(), userID))
-	after, err := st.Queries().GetUserByID(context.Background(), userID)
+	after, err := st.Repos().User.Get(context.Background(), userID)
 	require.NoError(t, err)
 	assert.Empty(t, after.SystemUserActionID,
 		"provisioning flipped off → cleanup branch must clear the prior link")

--- a/internal/api/system_actions_params_canary_test.go
+++ b/internal/api/system_actions_params_canary_test.go
@@ -9,7 +9,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/store"
 )
 
 // Tests in this file lock down the "system-managed actions must
@@ -153,9 +153,9 @@ func TestMarshalActionParamsRejectsNil(t *testing.T) {
 }
 
 func TestSystemTtyUserActionParamsOutput(t *testing.T) {
-	params, err := serializeProtoParams(systemTtyUserParams(db.UsersProjection{
+	params, err := serializeProtoParams(systemTtyUserParams(store.User{
 		LinuxUsername: "alice",
-		LinuxUid:      1000,
+		LinuxUID:      1000,
 		Disabled:      false,
 	}))
 	if err != nil {

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -86,7 +86,7 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 		return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, "not authenticated")
 	}
 
-	user, err := h.store.Queries().GetUserByID(ctx, userCtx.ID)
+	user, err := h.store.Repos().User.Get(ctx, userCtx.ID)
 	if err != nil {
 		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user not found")

--- a/internal/api/token_handler.go
+++ b/internal/api/token_handler.go
@@ -78,7 +78,7 @@ func (h *TokenHandler) CreateToken(ctx context.Context, req *connect.Request[pm.
 			eventData["expires_at"] = req.Msg.ExpiresAt.AsTime().Format(time.RFC3339)
 		}
 		if req.Msg.OwnerId != "" {
-			if _, err := h.store.Queries().GetUserByID(ctx, req.Msg.OwnerId); err != nil {
+			if _, err := h.store.Repos().User.Get(ctx, req.Msg.OwnerId); err != nil {
 				return nil, handleGetError(ctx, err, ErrUserNotFound, "owner user not found")
 			}
 			eventData["owner_id"] = req.Msg.OwnerId

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -48,7 +48,7 @@ func (h *TOTPHandler) SetupTOTP(ctx context.Context, req *connect.Request[pm.Set
 	}
 
 	// SSO-only users cannot set up TOTP — they must use their identity provider's MFA
-	user, err := h.store.Queries().GetUserByID(ctx, userCtx.ID)
+	user, err := h.store.Repos().User.Get(ctx, userCtx.ID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user")
 	}
@@ -157,7 +157,7 @@ func (h *TOTPHandler) DisableTOTP(ctx context.Context, req *connect.Request[pm.D
 	}
 
 	// Verify password
-	user, err := h.store.Queries().GetUserByID(ctx, userCtx.ID)
+	user, err := h.store.Repos().User.Get(ctx, userCtx.ID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user")
 	}
@@ -203,7 +203,7 @@ func (h *TOTPHandler) AdminDisableUserTOTP(ctx context.Context, req *connect.Req
 	targetUserID := req.Msg.UserId
 
 	// Check target user exists and has TOTP enabled
-	user, err := h.store.Queries().GetUserByID(ctx, targetUserID)
+	user, err := h.store.Repos().User.Get(ctx, targetUserID)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
@@ -262,7 +262,7 @@ func (h *TOTPHandler) RegenerateBackupCodes(ctx context.Context, req *connect.Re
 	}
 
 	// Verify password
-	user, err := h.store.Queries().GetUserByID(ctx, userCtx.ID)
+	user, err := h.store.Repos().User.Get(ctx, userCtx.ID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user")
 	}
@@ -375,7 +375,7 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 	}
 
 	// Check user status
-	info, err := h.store.Queries().GetUserSessionInfo(ctx, claims.UserID)
+	info, err := h.store.Repos().User.SessionInfo(ctx, claims.UserID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeUnauthenticated, "user not found")
 	}
@@ -387,7 +387,7 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 	}
 
 	// Resolve permissions and generate real tokens
-	permissions, err := h.store.Queries().GetUserPermissionsWithGroups(ctx, claims.UserID)
+	permissions, err := h.store.Repos().User.Permissions(ctx, claims.UserID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve permissions")
 	}
@@ -424,7 +424,7 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 	}
 
 	// Get full user for response
-	user, err := h.store.Queries().GetUserByID(ctx, claims.UserID)
+	user, err := h.store.Repos().User.Get(ctx, claims.UserID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user")
 	}

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -575,7 +575,7 @@ func (h *UserGroupHandler) ListUserGroupsForUser(ctx context.Context, req *conne
 	}
 
 	// Verify user exists
-	_, err := h.store.Queries().GetUserByID(ctx, req.Msg.UserId)
+	_, err := h.store.Repos().User.Get(ctx, req.Msg.UserId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -15,7 +15,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // UserHandler handles user management RPCs.
@@ -65,7 +64,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 	// then re-surface as the generic Internal from AppendEvent
 	// later — matching the established pattern in
 	// auth_handler.go:59 and sso_handler.go:179.
-	if _, err := h.store.Queries().GetUserByEmail(ctx, req.Msg.Email); err == nil {
+	if _, err := h.store.Repos().User.GetByEmail(ctx, req.Msg.Email); err == nil {
 		return nil, apiErrorCtx(ctx, ErrEmailAlreadyExists, connect.CodeAlreadyExists, "email already exists")
 	} else if !store.IsNotFound(err) {
 		// Don't log raw email (PII). At this point the user doesn't
@@ -77,7 +76,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 	}
 
 	// Assign Linux UID and derive username
-	linuxUID, err := h.store.Queries().GetNextLinuxUID(ctx)
+	linuxUID, err := h.store.Repos().User.NextLinuxUID(ctx)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to assign linux uid")
 	}
@@ -185,7 +184,7 @@ func (h *UserHandler) CreateUser(ctx context.Context, req *connect.Request[pm.Cr
 	}
 
 	// Read back from projection
-	user, err := h.store.Queries().GetUserByID(ctx, id)
+	user, err := h.store.Repos().User.Get(ctx, id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get user")
 	}
@@ -213,7 +212,7 @@ func (h *UserHandler) GetUser(ctx context.Context, req *connect.Request[pm.GetUs
 		return nil, err
 	}
 
-	user, err := h.store.Queries().GetUserByID(ctx, req.Msg.Id)
+	user, err := h.store.Repos().User.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
@@ -234,15 +233,12 @@ func (h *UserHandler) ListUsers(ctx context.Context, req *connect.Request[pm.Lis
 		return nil, err
 	}
 
-	users, err := h.store.Queries().ListUsers(ctx, db.ListUsersParams{
-		Limit:  pageSize,
-		Offset: offset,
-	})
+	users, err := h.store.Repos().User.List(ctx, store.ListUsersFilter{Limit: pageSize, Offset: offset})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list users")
 	}
 
-	count, err := h.store.Queries().CountUsers(ctx)
+	count, err := h.store.Repos().User.Count(ctx)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count users")
 	}
@@ -320,7 +316,7 @@ func (h *UserHandler) UpdateUserEmail(ctx context.Context, req *connect.Request[
 	}
 
 	// Read back from projection
-	user, err := h.store.Queries().GetUserByID(ctx, req.Msg.Id)
+	user, err := h.store.Repos().User.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
@@ -351,7 +347,7 @@ func (h *UserHandler) UpdateUserPassword(ctx context.Context, req *connect.Reque
 			return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "current_password is required for self-update")
 		}
 
-		user, err := h.store.Queries().GetUserByID(ctx, req.Msg.Id)
+		user, err := h.store.Repos().User.Get(ctx, req.Msg.Id)
 		if err != nil {
 			return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user not found")
 		}
@@ -383,7 +379,7 @@ func (h *UserHandler) UpdateUserPassword(ctx context.Context, req *connect.Reque
 	}
 
 	// Read back from projection
-	user, err := h.store.Queries().GetUserByID(ctx, req.Msg.Id)
+	user, err := h.store.Repos().User.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
@@ -423,7 +419,7 @@ func (h *UserHandler) SetUserDisabled(ctx context.Context, req *connect.Request[
 	}
 
 	// Read back from projection
-	user, err := h.store.Queries().GetUserByID(ctx, req.Msg.Id)
+	user, err := h.store.Repos().User.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
@@ -447,7 +443,7 @@ func (h *UserHandler) DeleteUser(ctx context.Context, req *connect.Request[pm.De
 	}
 
 	// Load user BEFORE delete to get system action IDs for cleanup
-	user, err := h.store.Queries().GetUserByID(ctx, req.Msg.Id)
+	user, err := h.store.Repos().User.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
@@ -512,7 +508,7 @@ func (h *UserHandler) UpdateUserProfile(ctx context.Context, req *connect.Reques
 	}
 
 	// Read back from projection
-	user, err := h.store.Queries().GetUserByID(ctx, req.Msg.Id)
+	user, err := h.store.Repos().User.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
@@ -525,7 +521,7 @@ func (h *UserHandler) UpdateUserProfile(ctx context.Context, req *connect.Reques
 }
 
 // userToProto converts a database user projection to a protobuf user.
-func userToProto(u db.UsersProjection) *pm.User {
+func userToProto(u store.User) *pm.User {
 	user := &pm.User{
 		Id:                      u.ID,
 		Email:                   u.Email,
@@ -539,7 +535,7 @@ func userToProto(u db.UsersProjection) *pm.User {
 		Picture:                 u.Picture,
 		Locale:                  u.Locale,
 		LinuxUsername:           u.LinuxUsername,
-		LinuxUid:                u.LinuxUid,
+		LinuxUid:                u.LinuxUID,
 		SshAccessEnabled:        u.SshAccessEnabled,
 		SshAllowPubkey:          u.SshAllowPubkey,
 		SshAllowPassword:        u.SshAllowPassword,
@@ -608,7 +604,7 @@ func (h *UserHandler) SetUserProvisioningEnabled(ctx context.Context, req *conne
 
 	// System-action sync runs from the post-commit listener (rc11 #77).
 
-	user, err := h.store.Queries().GetUserByID(ctx, req.Msg.UserId)
+	user, err := h.store.Repos().User.Get(ctx, req.Msg.UserId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
@@ -657,7 +653,7 @@ func (h *UserHandler) UpdateUserLinuxUsername(ctx context.Context, req *connect.
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to update linux username")
 	}
 
-	user, err := h.store.Queries().GetUserByID(ctx, req.Msg.UserId)
+	user, err := h.store.Repos().User.Get(ctx, req.Msg.UserId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
@@ -785,7 +781,7 @@ func (h *UserHandler) UpdateUserSshSettings(ctx context.Context, req *connect.Re
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to update SSH settings")
 	}
 
-	user, err := h.store.Queries().GetUserByID(ctx, req.Msg.UserId)
+	user, err := h.store.Repos().User.Get(ctx, req.Msg.UserId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}

--- a/internal/scim/groups_helpers.go
+++ b/internal/scim/groups_helpers.go
@@ -106,7 +106,7 @@ func (h *Handler) buildGroupResource(ctx context.Context, providerID string, map
 			Value: uid,
 			Ref:   baseURL + "/Users/" + uid,
 		}
-		u, err := h.store.Queries().GetUserByID(ctx, uid)
+		u, err := h.store.Repos().User.Get(ctx, uid)
 		if err == nil {
 			member.Display = u.Email
 		}

--- a/internal/scim/handler.go
+++ b/internal/scim/handler.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // appendEvent appends an event and logs any error.
@@ -36,7 +35,7 @@ const providerContextKey contextKey = "scim_provider"
 // cleanup entirely on user deletion, leaving orphan pm-tty-* and
 // USER provision actions on devices.
 type SystemActionsCleaner interface {
-	CleanupDeletedUserActions(ctx context.Context, user db.UsersProjection) error
+	CleanupDeletedUserActions(ctx context.Context, user store.User) error
 }
 
 // Handler handles SCIM v2 API requests.

--- a/internal/scim/handler_test.go
+++ b/internal/scim/handler_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/scim"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
@@ -29,10 +28,10 @@ import (
 // recorded call list.
 type fakeSystemActionsCleaner struct {
 	mu    sync.Mutex
-	calls []db.UsersProjection
+	calls []store.User
 }
 
-func (f *fakeSystemActionsCleaner) CleanupDeletedUserActions(_ context.Context, u db.UsersProjection) error {
+func (f *fakeSystemActionsCleaner) CleanupDeletedUserActions(_ context.Context, u store.User) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.calls = append(f.calls, u)
@@ -45,7 +44,7 @@ func (f *fakeSystemActionsCleaner) callCount() int {
 	return len(f.calls)
 }
 
-func (f *fakeSystemActionsCleaner) lastCall() db.UsersProjection {
+func (f *fakeSystemActionsCleaner) lastCall() store.User {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if len(f.calls) == 0 {
@@ -53,7 +52,7 @@ func (f *fakeSystemActionsCleaner) lastCall() db.UsersProjection {
 		// zero value so the resulting test failure has a readable
 		// "want X, got <empty UsersProjection>" diff instead of a
 		// panic stack trace.
-		return db.UsersProjection{}
+		return store.User{}
 	}
 	return f.calls[len(f.calls)-1]
 }

--- a/internal/scim/users.go
+++ b/internal/scim/users.go
@@ -172,7 +172,7 @@ func (h *Handler) getUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := h.store.Queries().GetUserByID(ctx, userID)
+	user, err := h.store.Repos().User.Get(ctx, userID)
 	if err != nil {
 		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "user not found")
@@ -256,7 +256,7 @@ func (h *Handler) deleteUser(w http.ResponseWriter, r *http.Request) {
 		// SCIM was previously bypassing this cleanup entirely,
 		// leaving orphan pm-tty-* and USER provision actions on
 		// every device the deleted user was assigned to.
-		user, loadErr := h.store.Queries().GetUserByID(ctx, userID)
+		user, loadErr := h.store.Repos().User.Get(ctx, userID)
 
 		err = h.store.AppendEvent(ctx, store.Event{
 			StreamType: "user",

--- a/internal/scim/users_create.go
+++ b/internal/scim/users_create.go
@@ -66,7 +66,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 			// of 409 makes POST idempotent for SCIM clients that re-POST on
 			// every sync cycle.
 			h.syncUserFromSCIM(ctx, provider, existing.ID, email, scimUser.Active, scimUser.Name)
-			user, err := h.store.Queries().GetUserByID(ctx, existing.ID)
+			user, err := h.store.Repos().User.Get(ctx, existing.ID)
 			if err != nil {
 				writeJSON(w, http.StatusOK, findExternalIDUserRowToSCIM(existing, baseURL))
 			} else {
@@ -90,7 +90,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 		if err == nil {
 			// Already linked — sync data from SCIM (source of truth) and return
 			h.syncUserFromSCIM(ctx, provider, existing.ID, email, scimUser.Active, scimUser.Name)
-			user, readErr := h.store.Queries().GetUserByID(ctx, existing.ID)
+			user, readErr := h.store.Repos().User.Get(ctx, existing.ID)
 			if readErr != nil {
 				writeJSON(w, http.StatusOK, findUserRowToSCIM(existing, baseURL))
 			} else {
@@ -100,7 +100,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Check if user exists but is not yet linked
-		existingUser, err := h.store.Queries().GetUserByEmail(ctx, email)
+		existingUser, err := h.store.Repos().User.GetByEmail(ctx, email)
 		if err == nil {
 			// User exists — create identity link
 			h.logger.Debug("SCIM createUser: linking existing user by email", "user_id", existingUser.ID, "email", email)
@@ -139,7 +139,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 	h.logger.Debug("SCIM createUser: creating new user", "email", email, "external_id", externalID)
 	userID := newULID()
 
-	linuxUID, err := h.store.Queries().GetNextLinuxUID(ctx)
+	linuxUID, err := h.store.Repos().User.NextLinuxUID(ctx)
 	if err != nil {
 		h.logger.Error("failed to assign linux uid via SCIM", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to assign linux uid")
@@ -240,7 +240,7 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Read back created user
-	user, err := h.store.Queries().GetUserByID(ctx, userID)
+	user, err := h.store.Repos().User.Get(ctx, userID)
 	if err != nil {
 		h.logger.Error("failed to read back created user", "error", err)
 		writeError(w, http.StatusInternalServerError, "user created but failed to read back")

--- a/internal/scim/users_helpers.go
+++ b/internal/scim/users_helpers.go
@@ -32,7 +32,7 @@ func newULID() string {
 // syncUserFromSCIM syncs email, active status, profile, and identity link data from SCIM.
 // SCIM is treated as the source of truth — any differences are overwritten.
 func (h *Handler) syncUserFromSCIM(ctx context.Context, provider store.IdentityProvider, userID, email string, active *bool, name *SCIMName) {
-	user, err := h.store.Queries().GetUserByID(ctx, userID)
+	user, err := h.store.Repos().User.Get(ctx, userID)
 	if err != nil {
 		h.logger.Error("failed to get user for SCIM sync", "user_id", userID, "error", err)
 		return

--- a/internal/scim/users_mutate.go
+++ b/internal/scim/users_mutate.go
@@ -47,7 +47,7 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 	baseURL := baseURLFromRequest(r, provider.Slug)
 
 	// Verify user exists
-	existingUser, err := h.store.Queries().GetUserByID(ctx, userID)
+	existingUser, err := h.store.Repos().User.Get(ctx, userID)
 	if err != nil {
 		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "user not found")
@@ -139,7 +139,7 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 	h.syncIdentityLink(ctx, provider, userID, effectiveEmail, scimUser.Name)
 
 	// Read back updated user
-	user, err := h.store.Queries().GetUserByID(ctx, userID)
+	user, err := h.store.Repos().User.Get(ctx, userID)
 	if err != nil {
 		h.logger.Error("failed to read back updated user", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to read user")
@@ -193,7 +193,7 @@ func (h *Handler) patchUser(w http.ResponseWriter, r *http.Request) {
 	baseURL := baseURLFromRequest(r, provider.Slug)
 
 	// Verify user exists
-	existingUser, err := h.store.Queries().GetUserByID(ctx, userID)
+	existingUser, err := h.store.Repos().User.Get(ctx, userID)
 	if err != nil {
 		if store.IsNotFound(err) {
 			writeError(w, http.StatusNotFound, "user not found")
@@ -229,7 +229,7 @@ func (h *Handler) patchUser(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Sync identity link with any name/email changes from PATCH ops
-	patchedUser, err := h.store.Queries().GetUserByID(ctx, userID)
+	patchedUser, err := h.store.Repos().User.Get(ctx, userID)
 	if err != nil {
 		h.logger.Error("failed to read back patched user", "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to read user")
@@ -251,7 +251,7 @@ func (h *Handler) patchUser(w http.ResponseWriter, r *http.Request) {
 }
 
 // handleUserPatchReplace processes a single "replace" patch operation on a user.
-func (h *Handler) handleUserPatchReplace(ctx context.Context, provider store.IdentityProvider, userID string, existingUser db.UsersProjection, op SCIMPatchOp) error {
+func (h *Handler) handleUserPatchReplace(ctx context.Context, provider store.IdentityProvider, userID string, existingUser store.User, op SCIMPatchOp) error {
 	path := strings.ToLower(op.Path)
 
 	switch path {

--- a/internal/scim/users_translation.go
+++ b/internal/scim/users_translation.go
@@ -11,6 +11,7 @@ package scim
 import (
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
@@ -69,7 +70,7 @@ func scimUserFromFields(f scimUserFields, baseURL string) SCIMUser {
 // ScimExternalID column directly — it lives on the
 // scim_user_links table) plus an externally-resolved externalID
 // into a SCIM resource.
-func userToSCIM(user db.UsersProjection, externalID, baseURL string) SCIMUser {
+func userToSCIM(user store.User, externalID, baseURL string) SCIMUser {
 	return scimUserFromFields(scimUserFields{
 		ID:          user.ID,
 		ExternalID:  externalID,

--- a/internal/store/postgres/user.go
+++ b/internal/store/postgres/user.go
@@ -1,0 +1,134 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// User implements store.UserRepo against users_projection.
+type User struct {
+	q *generated.Queries
+}
+
+// NewUser returns a User repo bound to the given sqlc handle.
+func NewUser(q *generated.Queries) *User {
+	return &User{q: q}
+}
+
+func (u *User) Get(ctx context.Context, id string) (store.User, error) {
+	row, err := u.q.GetUserByID(ctx, id)
+	if err != nil {
+		return store.User{}, fmt.Errorf("user: get: %w", translateNotFound(err))
+	}
+	return userFromRow(row), nil
+}
+
+func (u *User) GetByEmail(ctx context.Context, email string) (store.User, error) {
+	row, err := u.q.GetUserByEmail(ctx, email)
+	if err != nil {
+		return store.User{}, fmt.Errorf("user: get by email: %w", translateNotFound(err))
+	}
+	return userFromRow(row), nil
+}
+
+func (u *User) SessionInfo(ctx context.Context, userID string) (store.UserSessionInfo, error) {
+	row, err := u.q.GetUserSessionInfo(ctx, userID)
+	if err != nil {
+		return store.UserSessionInfo{}, fmt.Errorf("user: session info: %w", translateNotFound(err))
+	}
+	return store.UserSessionInfo{
+		Disabled:       row.Disabled,
+		SessionVersion: row.SessionVersion,
+		IsDeleted:      row.IsDeleted,
+	}, nil
+}
+
+func (u *User) Permissions(ctx context.Context, userID string) ([]string, error) {
+	perms, err := u.q.GetUserPermissionsWithGroups(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("user: permissions: %w", err)
+	}
+	return perms, nil
+}
+
+func (u *User) NextLinuxUID(ctx context.Context) (int32, error) {
+	uid, err := u.q.GetNextLinuxUID(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("user: next linux uid: %w", translateNotFound(err))
+	}
+	return uid, nil
+}
+
+func (u *User) List(ctx context.Context, filter store.ListUsersFilter) ([]store.User, error) {
+	rows, err := u.q.ListUsers(ctx, generated.ListUsersParams{
+		Limit:  filter.Limit,
+		Offset: filter.Offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("user: list: %w", err)
+	}
+	out := make([]store.User, len(rows))
+	for i, r := range rows {
+		out[i] = userFromRow(r)
+	}
+	return out, nil
+}
+
+func (u *User) Count(ctx context.Context) (int64, error) {
+	n, err := u.q.CountUsers(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("user: count: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (u *User) ListAllNonDeleted(ctx context.Context) ([]store.User, error) {
+	rows, err := u.q.ListAllNonDeletedUsers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("user: list all non-deleted: %w", err)
+	}
+	out := make([]store.User, len(rows))
+	for i, r := range rows {
+		out[i] = userFromRow(r)
+	}
+	return out, nil
+}
+
+// userFromRow translates a sqlc projection row to the domain shape.
+// Shared so the field mapping lives in one place.
+func userFromRow(r generated.UsersProjection) store.User {
+	return store.User{
+		ID:                      r.ID,
+		Email:                   r.Email,
+		PasswordHash:            r.PasswordHash,
+		Role:                    r.Role,
+		CreatedAt:               r.CreatedAt,
+		UpdatedAt:               r.UpdatedAt,
+		LastLoginAt:             r.LastLoginAt,
+		Disabled:                r.Disabled,
+		IsDeleted:               r.IsDeleted,
+		SessionVersion:          r.SessionVersion,
+		HasPassword:             r.HasPassword,
+		TotpEnabled:             r.TotpEnabled,
+		DisplayName:             r.DisplayName,
+		GivenName:               r.GivenName,
+		FamilyName:              r.FamilyName,
+		PreferredUsername:       r.PreferredUsername,
+		Picture:                 r.Picture,
+		Locale:                  r.Locale,
+		LinuxUsername:           r.LinuxUsername,
+		LinuxUID:                r.LinuxUid,
+		SshPublicKeys:           json.RawMessage(r.SshPublicKeys),
+		SshAccessEnabled:        r.SshAccessEnabled,
+		SshAllowPubkey:          r.SshAllowPubkey,
+		SshAllowPassword:        r.SshAllowPassword,
+		SystemUserActionID:      r.SystemUserActionID,
+		SystemSshActionID:       r.SystemSshActionID,
+		UserProvisioningEnabled: r.UserProvisioningEnabled,
+		SystemTtyActionID:       r.SystemTtyActionID,
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -29,6 +29,7 @@ func NewRepos(q *generated.Queries) *store.Repos {
 		TerminalSession:  NewTerminalSession(q),
 		Token:            NewToken(q),
 		Totp:             NewTotp(q),
+		User:             NewUser(q),
 		UserGroup:        NewUserGroup(q),
 		UserSelection:    NewUserSelection(q),
 	}

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -28,6 +28,7 @@ type Repos struct {
 	TerminalSession  TerminalSessionRepo
 	Token            TokenRepo
 	Totp             TotpRepo
+	User             UserRepo
 	UserGroup        UserGroupRepo
 	UserSelection    UserSelectionRepo
 }

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// User is the user projection row. PasswordHash and SSH key material
+// stay encoded as-stored at the boundary; handlers verify against
+// auth.VerifyPassword / parse SSH keys when they actually need to
+// consume those bytes.
+//
+// SshPublicKeys is JSON at the row level (an array of {id, key, …}
+// objects) and stays as json.RawMessage at the boundary per the
+// JSONB normalize plan in #242.
+type User struct {
+	ID                      string
+	Email                   string
+	PasswordHash            *string
+	Role                    string
+	CreatedAt               *time.Time
+	UpdatedAt               *time.Time
+	LastLoginAt             *time.Time
+	Disabled                bool
+	IsDeleted               bool
+	SessionVersion          int32
+	HasPassword             bool
+	TotpEnabled             bool
+	DisplayName             string
+	GivenName               string
+	FamilyName              string
+	PreferredUsername       string
+	Picture                 string
+	Locale                  string
+	LinuxUsername           string
+	LinuxUID                int32
+	SshPublicKeys           json.RawMessage
+	SshAccessEnabled        bool
+	SshAllowPubkey          bool
+	SshAllowPassword        bool
+	SystemUserActionID      string
+	SystemSshActionID       string
+	UserProvisioningEnabled bool
+	SystemTtyActionID       string
+}
+
+// UserSessionInfo is the narrow shape returned for the refresh-token
+// validation path. Pulling only the three fields the handler needs
+// keeps the hot login path light.
+type UserSessionInfo struct {
+	Disabled       bool
+	SessionVersion int32
+	IsDeleted      bool
+}
+
+// ListUsersFilter is the pagination shape for the user list endpoint.
+type ListUsersFilter struct {
+	Limit  int32
+	Offset int32
+}
+
+// UserRepo reads user-projection state. Writes flow through events
+// (UserCreated / UserUpdated / UserDeleted / UserPasswordChanged /
+// UserDisabled / etc.) — there are no Set / Update / Delete methods
+// on this interface by design.
+type UserRepo interface {
+	// Get returns a user by ID. Returns ErrNotFound when no user
+	// with that ID exists.
+	Get(ctx context.Context, id string) (User, error)
+
+	// GetByEmail returns a user by email address. Returns
+	// ErrNotFound when the email is not registered.
+	GetByEmail(ctx context.Context, email string) (User, error)
+
+	// SessionInfo returns the narrow disabled / session_version /
+	// is_deleted shape used by the refresh-token validation path.
+	SessionInfo(ctx context.Context, userID string) (UserSessionInfo, error)
+
+	// Permissions returns the flattened permission list for the
+	// user, combining direct role permissions with permissions
+	// inherited from user_group memberships.
+	Permissions(ctx context.Context, userID string) ([]string, error)
+
+	// NextLinuxUID returns the next available Linux UID for new
+	// user provisioning. The underlying query is a SERIAL-style
+	// allocator backed by users.linux_uid + a synthesized bump.
+	NextLinuxUID(ctx context.Context) (int32, error)
+
+	// List returns a page of users.
+	List(ctx context.Context, filter ListUsersFilter) ([]User, error)
+
+	// Count returns the total non-deleted user count.
+	Count(ctx context.Context) (int64, error)
+
+	// ListAllNonDeleted returns every non-deleted user. Used by
+	// the server-settings handler's batch-enable propagation
+	// (provisioning + SSH access) and the system-action
+	// reconciler — both of which legitimately need every user.
+	ListAllNonDeleted(ctx context.Context) ([]User, error)
+}


### PR DESCRIPTION
## Summary

Biggest single-domain migration in Wave B. \`UserRepo\` covers the core user-projection reads consumed across 21 files. Branches off main directly.

## Methods

- \`Get(id)\` / \`GetByEmail(email)\`
- \`SessionInfo(userID)\` — narrow shape for hot refresh-token validation
- \`Permissions(userID)\` — flattened direct + user-group inherited permissions
- \`NextLinuxUID()\` — UID allocator
- \`List(filter)\` / \`Count()\` / \`ListAllNonDeleted()\`

## Call sites migrated (~70)

- **api** (12 handlers): \`user_handler\`, \`auth_handler\`, \`sso_handler\`, \`totp_handler\`, \`settings_handler\`, \`system_actions\` + tests, \`terminal_handler\`, \`token_handler\`, \`identity_link_handler\`, \`assignment_handler\`, \`user_group_handler\`
- **scim** (6 files): \`users\`, \`users_create\`, \`users_helpers\`, \`users_mutate\`, \`users_translation\`, \`handler\` (interface)
- **idp**: \`linker\` + \`linker_test\`
- **cmd/control**: \`admin_user\`

## Signatures shifted

- \`userToProto\`, \`userToSCIM\` — both now take \`store.User\`
- \`SystemActionsCleaner.CleanupDeletedUserActions\` (+ test fake)
- 6 system-action helpers + \`systemTtyUserParams\`

## Field renames

\`LinuxUid\` → \`LinuxUID\` at the domain type. \`SshPublicKeys\` stays as \`json.RawMessage\` at the boundary per the JSONB normalize plan.

## Non-goals

- SCIM user reads (\`FindSCIMUser*\`, \`ListSCIMUsers\`, \`CountSCIMUsers\`) — return user-projection-shaped rows but conceptually SCIM domain; SCIM follow-up.
- Write-side projector queries — stay on \`Queries()\` per pattern.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Tests pass: api (6m30s), scim (1m12s), idp.

Part of #242. Closes #267.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched internal user-data access to a new repository-backed implementation across many services and tests, consolidating user models and repositories. No changes to public APIs or user-facing behavior—existing features, responses, and workflows remain the same.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/268)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->