### PR TITLE
refactor(store): wave B.14 — action repo (#271)

### DIFF
--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -16,7 +16,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // CreateAction creates a new action (single executable).
@@ -41,8 +40,8 @@ func (h *ActionHandler) CreateAction(ctx context.Context, req *connect.Request[p
 
 	// Auto-assign priority for SSHD actions based on creation order
 	if req.Msg.Type == pm.ActionType_ACTION_TYPE_SSHD {
-		count, countErr := h.store.Queries().CountActions(ctx, db.CountActionsParams{
-			Column1: int32(pm.ActionType_ACTION_TYPE_SSHD),
+		count, countErr := h.store.Repos().Action.Count(ctx, store.CountActionsFilter{
+			ActionTypeFilter: int32(pm.ActionType_ACTION_TYPE_SSHD),
 		})
 		if countErr != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count SSHD actions")
@@ -96,7 +95,7 @@ func (h *ActionHandler) CreateAction(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
-	action, err := h.store.Queries().GetActionByID(ctx, id)
+	action, err := h.store.Repos().Action.Get(ctx, id)
 	if err != nil {
 		h.logger.Error("failed to get action after create", "error", err, "id", id)
 		// Projection row may already exist without signature; roll
@@ -125,7 +124,7 @@ func (h *ActionHandler) GetAction(ctx context.Context, req *connect.Request[pm.G
 		return nil, err
 	}
 
-	action, err := h.store.Queries().GetActionByID(ctx, req.Msg.Id)
+	action, err := h.store.Repos().Action.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}
@@ -144,20 +143,12 @@ func (h *ActionHandler) ListActions(ctx context.Context, req *connect.Request[pm
 
 	typeFilter := int32(req.Msg.TypeFilter)
 
-	actions, err := h.store.Queries().ListActions(ctx, db.ListActionsParams{
-		Column1:        typeFilter,
-		Limit:          pageSize,
-		Offset:         offset,
-		UnassignedOnly: req.Msg.UnassignedOnly,
-	})
+	actions, err := h.store.Repos().Action.List(ctx, store.ListActionsFilter{ActionTypeFilter: typeFilter, Limit: pageSize, Offset: offset, UnassignedOnly: req.Msg.UnassignedOnly})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list actions")
 	}
 
-	count, err := h.store.Queries().CountActions(ctx, db.CountActionsParams{
-		Column1:        typeFilter,
-		UnassignedOnly: req.Msg.UnassignedOnly,
-	})
+	count, err := h.store.Repos().Action.Count(ctx, store.CountActionsFilter{ActionTypeFilter: typeFilter, UnassignedOnly: req.Msg.UnassignedOnly})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count actions")
 	}
@@ -188,7 +179,7 @@ func (h *ActionHandler) RenameAction(ctx context.Context, req *connect.Request[p
 	}
 
 	// Verify action exists before appending event
-	if _, err := h.store.Queries().GetActionByID(ctx, req.Msg.Id); err != nil {
+	if _, err := h.store.Repos().Action.Get(ctx, req.Msg.Id); err != nil {
 		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
 		}
@@ -208,7 +199,7 @@ func (h *ActionHandler) RenameAction(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
-	action, err := h.store.Queries().GetActionByID(ctx, req.Msg.Id)
+	action, err := h.store.Repos().Action.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
 	}
@@ -230,7 +221,7 @@ func (h *ActionHandler) UpdateActionDescription(ctx context.Context, req *connec
 	}
 
 	// Verify action exists before appending event
-	if _, err := h.store.Queries().GetActionByID(ctx, req.Msg.Id); err != nil {
+	if _, err := h.store.Repos().Action.Get(ctx, req.Msg.Id); err != nil {
 		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
 		}
@@ -250,7 +241,7 @@ func (h *ActionHandler) UpdateActionDescription(ctx context.Context, req *connec
 		return nil, err
 	}
 
-	action, err := h.store.Queries().GetActionByID(ctx, req.Msg.Id)
+	action, err := h.store.Repos().Action.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
 	}
@@ -275,7 +266,7 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	existing, err := h.store.Queries().GetActionByID(ctx, req.Msg.Id)
+	existing, err := h.store.Repos().Action.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}
@@ -335,7 +326,7 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	action, err := h.store.Queries().GetActionByID(ctx, req.Msg.Id)
+	action, err := h.store.Repos().Action.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}
@@ -389,12 +380,8 @@ func (h *ActionHandler) computeActionSignature(ctx context.Context, id string, a
 // On failure the row stays unsigned — callers SHOULD emit a
 // compensating ActionDeleted so the operator doesn't see a broken
 // unsigned row. See rollbackUnsignedCreate.
-func (h *ActionHandler) persistActionSignature(ctx context.Context, action *db.ActionsProjection, sig, paramsCanonical []byte) error {
-	if err := h.store.Queries().UpdateActionSignature(ctx, db.UpdateActionSignatureParams{
-		ID:              action.ID,
-		Signature:       sig,
-		ParamsCanonical: paramsCanonical,
-	}); err != nil {
+func (h *ActionHandler) persistActionSignature(ctx context.Context, action *store.Action, sig, paramsCanonical []byte) error {
+	if err := h.store.Repos().Action.UpdateSignature(ctx, store.UpdateActionSignatureParams{ID: action.ID, Signature: sig, ParamsCanonical: paramsCanonical}); err != nil {
 		h.logger.Error("failed to store action signature", "action_id", action.ID, "error", err)
 		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to store action signature")
 	}

--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -89,7 +89,7 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 
 	switch source := req.Msg.ActionSource.(type) {
 	case *pm.DispatchActionRequest_ActionId:
-		action, err := h.store.Queries().GetActionByID(ctx, source.ActionId)
+		action, err := h.store.Repos().Action.Get(ctx, source.ActionId)
 		if err != nil {
 			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
@@ -591,7 +591,7 @@ func (h *ActionHandler) GetExecution(ctx context.Context, req *connect.Request[p
 
 	// Fetch action name
 	if exec.ActionID != nil {
-		rows, err := h.store.Queries().GetActionNamesByIDs(ctx, []string{*exec.ActionID})
+		rows, err := h.store.Repos().Action.NamesByIDs(ctx, []string{*exec.ActionID})
 		if err == nil && len(rows) > 0 {
 			protoExec.ActionName = rows[0].Name
 		} else if err != nil {
@@ -662,7 +662,7 @@ func (h *ActionHandler) ListExecutions(ctx context.Context, req *connect.Request
 		}
 	}
 	if len(actionIDs) > 0 {
-		rows, err := h.store.Queries().GetActionNamesByIDs(ctx, actionIDs)
+		rows, err := h.store.Repos().Action.NamesByIDs(ctx, actionIDs)
 		if err != nil {
 			h.logger.Warn("GetActionNamesByIDs bulk enrichment failed",
 				"action_id_count", len(actionIDs), "error", err)

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -67,7 +67,7 @@ func NewActionHandler(st *store.Store, logger *slog.Logger, signer ca.ActionSign
 	}
 }
 
-func (h *ActionHandler) actionToProto(a db.ActionsProjection) *pm.ManagedAction {
+func (h *ActionHandler) actionToProto(a store.Action) *pm.ManagedAction {
 	action := &pm.ManagedAction{
 		Id:             a.ID,
 		Name:           a.Name,

--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -301,7 +301,7 @@ func (h *ActionSetHandler) AddActionToSet(ctx context.Context, req *connect.Requ
 	}
 
 	// Verify action exists
-	action, err := h.store.Queries().GetActionByID(ctx, req.Msg.ActionId)
+	action, err := h.store.Repos().Action.Get(ctx, req.Msg.ActionId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}

--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 
 	"connectrpc.com/connect"
@@ -45,7 +46,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	// Validate source exists
 	switch req.Msg.SourceType {
 	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION:
-		_, err := h.store.Queries().GetActionByID(ctx, req.Msg.SourceId)
+		_, err := h.store.Repos().Action.Get(ctx, req.Msg.SourceId)
 		if err != nil {
 			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
@@ -281,17 +282,21 @@ func (h *AssignmentHandler) GetDeviceAssignments(ctx context.Context, req *conne
 
 	protoActions := make([]*pm.ManagedAction, len(actions))
 	for i, a := range actions {
-		protoActions[i] = h.actionHandler.actionToProto(db.ActionsProjection{
-			ID:                a.ID,
-			Name:              a.Name,
-			Description:       a.Description,
-			ActionType:        a.ActionType,
-			Params:            a.Params,
-			TimeoutSeconds:    a.TimeoutSeconds,
-			CreatedAt:         a.CreatedAt,
-			CreatedBy:         a.CreatedBy,
-			IsDeleted:         a.IsDeleted,
-			ProjectionVersion: a.ProjectionVersion,
+		// Transitional: ListAssignedActionsForDevice returns a
+		// db-specific join row; convert the subset of fields used
+		// by actionToProto into the domain shape inline. The full
+		// store.Action will be the natural return type when
+		// ListAssignedActionsForDevice itself migrates with the
+		// assignment domain.
+		protoActions[i] = h.actionHandler.actionToProto(store.Action{
+			ID:             a.ID,
+			Name:           a.Name,
+			Description:    a.Description,
+			ActionType:     a.ActionType,
+			Params:         json.RawMessage(a.Params),
+			TimeoutSeconds: a.TimeoutSeconds,
+			CreatedAt:      a.CreatedAt,
+			CreatedBy:      a.CreatedBy,
 		})
 	}
 

--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -255,7 +255,7 @@ func (h *CompliancePolicyHandler) AddCompliancePolicyRule(ctx context.Context, r
 	}
 
 	// Verify action exists and is a compliance action
-	action, err := h.store.Queries().GetActionByID(ctx, req.Msg.ActionId)
+	action, err := h.store.Repos().Action.Get(ctx, req.Msg.ActionId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -603,7 +603,7 @@ func (h *DeviceHandler) loadActionNamesByIDs(ctx context.Context, ids []string) 
 	if len(ids) == 0 {
 		return nil
 	}
-	rows, err := h.store.Queries().GetActionNamesByIDs(ctx, ids)
+	rows, err := h.store.Repos().Action.NamesByIDs(ctx, ids)
 	if err != nil {
 		logEnrichmentErr("GetActionNamesByIDs", "action_id_count", fmt.Sprint(len(ids)), err)
 		return nil
@@ -835,7 +835,7 @@ func (h *DeviceHandler) CreateLuksToken(ctx context.Context, req *connect.Reques
 	}
 
 	// Verify the action exists and is a LUKS action
-	action, err := h.store.Queries().GetActionByID(ctx, req.Msg.ActionId)
+	action, err := h.store.Repos().Action.Get(ctx, req.Msg.ActionId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}

--- a/internal/api/system_action_store.go
+++ b/internal/api/system_action_store.go
@@ -20,7 +20,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // systemActionStore is the collaborator that owns event-shape
@@ -162,7 +161,7 @@ func (s *systemActionStore) SignActionByID(ctx context.Context, actionID string)
 		return fmt.Errorf("sign system action %s: signer not configured", actionID)
 	}
 
-	action, err := s.store.Queries().GetActionByID(ctx, actionID)
+	action, err := s.store.Repos().Action.Get(ctx, actionID)
 	if err != nil {
 		return fmt.Errorf("load system action %s for signing: %w", actionID, err)
 	}
@@ -177,11 +176,7 @@ func (s *systemActionStore) SignActionByID(ctx context.Context, actionID string)
 		return fmt.Errorf("sign system action %s: %w", actionID, err)
 	}
 
-	if err := s.store.Queries().UpdateActionSignature(ctx, db.UpdateActionSignatureParams{
-		ID:              action.ID,
-		Signature:       sig,
-		ParamsCanonical: paramsJSON,
-	}); err != nil {
+	if err := s.store.Repos().Action.UpdateSignature(ctx, store.UpdateActionSignatureParams{ID: action.ID, Signature: sig, ParamsCanonical: paramsJSON}); err != nil {
 		return fmt.Errorf("store system action %s signature: %w", actionID, err)
 	}
 

--- a/internal/api/user_selection_handler.go
+++ b/internal/api/user_selection_handler.go
@@ -151,7 +151,7 @@ func (h *UserSelectionHandler) ListAvailableActions(ctx context.Context, req *co
 		// Load source metadata
 		switch asn.SourceType {
 		case "action":
-			action, err := h.store.Queries().GetActionByID(ctx, asn.SourceID)
+			action, err := h.store.Repos().Action.Get(ctx, asn.SourceID)
 			if err == nil {
 				item.SourceName = action.Name
 				if action.Description != nil {

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -239,10 +239,10 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 	}
 
 	// Cache the action lookup — reused for both execution creation and compliance check.
-	var cachedAction *db.ActionsProjection
+	var cachedAction *store.Action
 
 	if needsCreate {
-		action, err := w.store.Queries().GetActionByID(ctx, actionID)
+		action, err := w.store.Repos().Action.Get(ctx, actionID)
 		if err != nil {
 			if store.IsNotFound(err) {
 				// Action was deleted while agent was offline — skip, don't retry.
@@ -361,7 +361,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 	if result.DetectionOutput != nil && actionID != "" {
 		// Reuse cached action if available, otherwise fetch
 		if cachedAction == nil {
-			if a, err := w.store.Queries().GetActionByID(ctx, actionID); err != nil {
+			if a, err := w.store.Repos().Action.Get(ctx, actionID); err != nil {
 				logger.Warn("failed to look up action for compliance check", "action_id", actionID, "error", err)
 			} else {
 				cachedAction = &a
@@ -665,7 +665,7 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 			}
 			cached, ok := actionCache[*exec.ActionID]
 			if !ok {
-				action, err := w.store.Queries().GetActionByID(ctx, *exec.ActionID)
+				action, err := w.store.Repos().Action.Get(ctx, *exec.ActionID)
 				if err != nil {
 					if store.IsNotFound(err) {
 						// Action was deleted after the execution was created.

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -374,10 +374,10 @@ func (idx *Index) warmActions(ctx context.Context) (int, map[string]string, erro
 	actionNames := map[string]string{}
 
 	for {
-		actions, err := idx.store.Queries().ListActions(ctx, db.ListActionsParams{
-			Column1: 0, // no type filter
-			Limit:   pageSize,
-			Offset:  offset,
+		actions, err := idx.store.Repos().Action.List(ctx, store.ListActionsFilter{
+			ActionTypeFilter: 0, // no type filter
+			Limit:            pageSize,
+			Offset:           offset,
 		})
 		if err != nil {
 			return total, actionNames, err
@@ -922,7 +922,7 @@ func (idx *Index) warmExecutions(ctx context.Context) (int, error) {
 				actionID = *e.ActionID
 				name, ok := actionNames[*e.ActionID]
 				if !ok {
-					a, err := idx.store.Queries().GetActionByID(ctx, *e.ActionID)
+					a, err := idx.store.Repos().Action.Get(ctx, *e.ActionID)
 					if err == nil {
 						name = a.Name
 					}

--- a/internal/store/action.go
+++ b/internal/store/action.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Action is the action-projection row. Params + ParamsCanonical +
+// Schedule + Signature stay as opaque bytes/json.RawMessage at the
+// boundary — they're verified / signed / executed by code that
+// already operates on the raw shapes.
+type Action struct {
+	ID              string
+	Name            string
+	Description     *string
+	ActionType      int32
+	Params          json.RawMessage
+	TimeoutSeconds  int32
+	CreatedAt       *time.Time
+	CreatedBy       string
+	Signature       []byte
+	ParamsCanonical json.RawMessage
+	DesiredState    int32
+	IsSystem        bool
+	UpdatedAt       *time.Time
+	Schedule        json.RawMessage
+}
+
+// ActionNamePair is the narrow (id, name) shape returned by the
+// bulk-name lookup. Used by response builders.
+type ActionNamePair struct {
+	ID   string
+	Name string
+}
+
+// ListActionsFilter pairs pagination with the optional
+// action-type filter and "unassigned only" flag. ActionTypeFilter == 0
+// disables the type filter (returns all types).
+type ListActionsFilter struct {
+	ActionTypeFilter int32
+	UnassignedOnly   bool
+	Limit            int32
+	Offset           int32
+}
+
+// CountActionsFilter mirrors ListActionsFilter's filter fields for
+// the matching count side. Both shapes must stay in sync so
+// pagination totals line up with the rows actually returned.
+type CountActionsFilter struct {
+	ActionTypeFilter int32
+	UnassignedOnly   bool
+}
+
+// UpdateActionSignatureParams carries the fields a re-signing pass
+// writes back to the action row. Used after the CA rotates the
+// signing key — every action's signature + canonical-params blob is
+// recomputed.
+type UpdateActionSignatureParams struct {
+	ID              string
+	Signature       []byte
+	ParamsCanonical json.RawMessage
+}
+
+// ActionRepo reads + maintains the action catalog. Writes other
+// than the signature-rewrite flow through events.
+type ActionRepo interface {
+	// Get returns an action by ID. Returns ErrNotFound when no
+	// action with that ID exists.
+	Get(ctx context.Context, id string) (Action, error)
+
+	// List returns a page of actions matching the filter. Empty
+	// slice past the end.
+	List(ctx context.Context, filter ListActionsFilter) ([]Action, error)
+
+	// Count returns the total matching the filter. Pair with List.
+	Count(ctx context.Context, filter CountActionsFilter) (int64, error)
+
+	// NamesByIDs returns the (id, name) pairs for the given action
+	// IDs in a single round-trip. Used by response builders that
+	// need to hydrate action names without re-loading each row.
+	NamesByIDs(ctx context.Context, ids []string) ([]ActionNamePair, error)
+
+	// UpdateSignature rewrites the signature + canonical-params
+	// pair on an action. The CA key-rotation pathway is the only
+	// expected caller; everything else routes signature changes
+	// through events.
+	UpdateSignature(ctx context.Context, p UpdateActionSignatureParams) error
+}

--- a/internal/store/postgres/action.go
+++ b/internal/store/postgres/action.go
@@ -1,0 +1,98 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Action implements store.ActionRepo against actions_projection.
+type Action struct {
+	q *generated.Queries
+}
+
+// NewAction returns an Action repo bound to the given sqlc handle.
+func NewAction(q *generated.Queries) *Action {
+	return &Action{q: q}
+}
+
+func (a *Action) Get(ctx context.Context, id string) (store.Action, error) {
+	row, err := a.q.GetActionByID(ctx, id)
+	if err != nil {
+		return store.Action{}, fmt.Errorf("action: get: %w", translateNotFound(err))
+	}
+	return actionFromRow(row), nil
+}
+
+func (a *Action) List(ctx context.Context, filter store.ListActionsFilter) ([]store.Action, error) {
+	rows, err := a.q.ListActions(ctx, generated.ListActionsParams{
+		Column1:        filter.ActionTypeFilter,
+		Limit:          filter.Limit,
+		Offset:         filter.Offset,
+		UnassignedOnly: filter.UnassignedOnly,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("action: list: %w", err)
+	}
+	out := make([]store.Action, len(rows))
+	for i, r := range rows {
+		out[i] = actionFromRow(r)
+	}
+	return out, nil
+}
+
+func (a *Action) Count(ctx context.Context, filter store.CountActionsFilter) (int64, error) {
+	n, err := a.q.CountActions(ctx, generated.CountActionsParams{
+		Column1:        filter.ActionTypeFilter,
+		UnassignedOnly: filter.UnassignedOnly,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("action: count: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (a *Action) NamesByIDs(ctx context.Context, ids []string) ([]store.ActionNamePair, error) {
+	rows, err := a.q.GetActionNamesByIDs(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("action: names by ids: %w", err)
+	}
+	out := make([]store.ActionNamePair, len(rows))
+	for i, r := range rows {
+		out[i] = store.ActionNamePair{ID: r.ID, Name: r.Name}
+	}
+	return out, nil
+}
+
+func (a *Action) UpdateSignature(ctx context.Context, p store.UpdateActionSignatureParams) error {
+	if err := a.q.UpdateActionSignature(ctx, generated.UpdateActionSignatureParams{
+		ID:              p.ID,
+		Signature:       p.Signature,
+		ParamsCanonical: []byte(p.ParamsCanonical),
+	}); err != nil {
+		return fmt.Errorf("action: update signature: %w", err)
+	}
+	return nil
+}
+
+func actionFromRow(r generated.ActionsProjection) store.Action {
+	return store.Action{
+		ID:              r.ID,
+		Name:            r.Name,
+		Description:     r.Description,
+		ActionType:      r.ActionType,
+		Params:          json.RawMessage(r.Params),
+		TimeoutSeconds:  r.TimeoutSeconds,
+		CreatedAt:       r.CreatedAt,
+		CreatedBy:       r.CreatedBy,
+		Signature:       r.Signature,
+		ParamsCanonical: json.RawMessage(r.ParamsCanonical),
+		DesiredState:    r.DesiredState,
+		IsSystem:        r.IsSystem,
+		UpdatedAt:       r.UpdatedAt,
+		Schedule:        json.RawMessage(r.Schedule),
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -14,6 +14,7 @@ import (
 // are migrated under tracker #242.
 func NewRepos(q *generated.Queries) *store.Repos {
 	return &store.Repos{
+		Action:           NewAction(q),
 		AuthState:        NewAuthState(q),
 		Compliance:       NewCompliance(q),
 		Device:           NewDevice(q),

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -13,6 +13,7 @@ package store
 // device.go for DeviceRepo), implement it under internal/store/postgres,
 // add a field here, populate it in postgres.NewRepos.
 type Repos struct {
+	Action           ActionRepo
 	AuthState        AuthStateRepo
 	Compliance       ComplianceRepo
 	Device           DeviceRepo


### PR DESCRIPTION
## Summary

\`ActionRepo\` — foundation of the action-chain cluster. ActionSet / Definition / Execution / Assignment follow in subsequent sub-waves (the cluster is too big for one PR). Branches off main directly.

## Methods

- \`Get(id)\` / \`List(filter)\` / \`Count(filter)\` — \`ActionTypeFilter\` + \`UnassignedOnly\` shared between List and Count
- \`NamesByIDs(ids)\` — bulk name lookup for response builders
- \`UpdateSignature(p)\` — CA key-rotation rewrite (the only non-event write the action domain owns)

\`Params\` / \`ParamsCanonical\` / \`Schedule\` stay as \`json.RawMessage\` at the boundary per the JSONB normalize plan; \`Signature\` stays \`[]byte\` (already opaque at the wire).

## Call sites migrated (~20)

- \`action_crud.go\` + \`action_handler.go\` — full CRUD + \`actionToProto\` / \`persistActionSignature\` signatures
- \`assignment_handler.go\` — source validation + transitional inline conversion for \`ListAssignedActionsForDevice\`
- \`system_action_store.go\` — system-action rebuild lookups
- \`user_selection_handler.go\` — Action source enrichment
- \`control/inbox_worker.go\` — 3 sites (dispatch, compliance, agent-scheduled)
- \`search/index.go\` — action reindex sweep

## Non-goals

- ActionSet / Definition / Execution / Assignment — follow-ups.
- Write-side projector queries — stay on \`Queries()\` per pattern.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Tests pass: api (7m), control (9s).

Part of #242. Closes #271.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated action data access across the app to a unified repository API for more consistent behavior and maintainability.
* **New Features**
  * Added a core action domain model and a Postgres-backed action repository to support action listing, retrieval, name lookups, counting, and signature updates.
* **Chores**
  * Removed legacy generated store import and aligned callers to the new repository layer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/272)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->