### PR TITLE
refactor(store): wave B.15 — action_set repo (#273)

### DIFF
--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -462,7 +462,7 @@ func (h *ActionHandler) DispatchDefinition(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	actionSets, err := h.store.Queries().ListActionSetsInDefinition(ctx, req.Msg.DefinitionId)
+	actionSets, err := h.store.Repos().ActionSet.ListInDefinition(ctx, req.Msg.DefinitionId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action sets in definition")
 	}

--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // ActionSetHandler handles action set RPCs.
@@ -68,7 +67,7 @@ func (h *ActionSetHandler) CreateActionSet(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	set, err := h.store.Queries().GetActionSetByID(ctx, id)
+	set, err := h.store.Repos().ActionSet.Get(ctx, id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action set")
 	}
@@ -84,12 +83,12 @@ func (h *ActionSetHandler) GetActionSet(ctx context.Context, req *connect.Reques
 		return nil, err
 	}
 
-	set, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.Id)
+	set, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
 
-	members, err := h.store.Queries().ListActionSetMembers(ctx, req.Msg.Id)
+	members, err := h.store.Repos().ActionSet.ListMembers(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action set members")
 	}
@@ -117,16 +116,12 @@ func (h *ActionSetHandler) ListActionSets(ctx context.Context, req *connect.Requ
 		return nil, err
 	}
 
-	sets, err := h.store.Queries().ListActionSets(ctx, db.ListActionSetsParams{
-		Limit:          pageSize,
-		Offset:         offset,
-		UnassignedOnly: req.Msg.UnassignedOnly,
-	})
+	sets, err := h.store.Repos().ActionSet.List(ctx, store.ListActionSetsFilter{Limit: pageSize, Offset: offset, UnassignedOnly: req.Msg.UnassignedOnly})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list action sets")
 	}
 
-	count, err := h.store.Queries().CountActionSets(ctx, req.Msg.UnassignedOnly)
+	count, err := h.store.Repos().ActionSet.Count(ctx, req.Msg.UnassignedOnly)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count action sets")
 	}
@@ -169,7 +164,7 @@ func (h *ActionSetHandler) RenameActionSet(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	set, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.Id)
+	set, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
@@ -209,7 +204,7 @@ func (h *ActionSetHandler) UpdateActionSetSchedule(ctx context.Context, req *con
 		return nil, err
 	}
 
-	set, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.Id)
+	set, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
@@ -243,7 +238,7 @@ func (h *ActionSetHandler) UpdateActionSetDescription(ctx context.Context, req *
 		return nil, err
 	}
 
-	set, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.Id)
+	set, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
@@ -295,7 +290,7 @@ func (h *ActionSetHandler) AddActionToSet(ctx context.Context, req *connect.Requ
 	}
 
 	// Verify set exists
-	_, err = h.store.Queries().GetActionSetByID(ctx, req.Msg.SetId)
+	_, err = h.store.Repos().ActionSet.Get(ctx, req.Msg.SetId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
@@ -320,7 +315,7 @@ func (h *ActionSetHandler) AddActionToSet(ctx context.Context, req *connect.Requ
 		return nil, err
 	}
 
-	set, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.SetId)
+	set, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.SetId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action set")
 	}
@@ -360,7 +355,7 @@ func (h *ActionSetHandler) RemoveActionFromSet(ctx context.Context, req *connect
 		return nil, err
 	}
 
-	set, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.SetId)
+	set, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.SetId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
@@ -401,7 +396,7 @@ func (h *ActionSetHandler) ReorderActionInSet(ctx context.Context, req *connect.
 		return nil, err
 	}
 
-	set, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.SetId)
+	set, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.SetId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
@@ -411,7 +406,7 @@ func (h *ActionSetHandler) ReorderActionInSet(ctx context.Context, req *connect.
 	}), nil
 }
 
-func (h *ActionSetHandler) actionSetToProto(s db.ActionSetsProjection) *pm.ActionSet {
+func (h *ActionSetHandler) actionSetToProto(s store.ActionSet) *pm.ActionSet {
 	set := &pm.ActionSet{
 		Id:          s.ID,
 		Name:        s.Name,

--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -54,7 +54,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
 		}
 	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION_SET:
-		_, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.SourceId)
+		_, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.SourceId)
 		if err != nil {
 			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrActionSetNotFound, connect.CodeNotFound, "action set not found")
@@ -342,7 +342,7 @@ func (h *AssignmentHandler) GetDeviceAssignments(ctx context.Context, req *conne
 	protoActionSets := make([]*pm.ActionSet, 0, len(actionSetIDs))
 	protoActionSetDetails := make([]*pm.GetActionSetResponse, 0, len(actionSetIDs))
 	for id := range actionSetIDs {
-		set, err := h.store.Queries().GetActionSetByID(ctx, id)
+		set, err := h.store.Repos().ActionSet.Get(ctx, id)
 		if err != nil {
 			continue
 		}
@@ -358,7 +358,7 @@ func (h *AssignmentHandler) GetDeviceAssignments(ctx context.Context, req *conne
 		}
 		protoActionSets = append(protoActionSets, protoSet)
 
-		members, err := h.store.Queries().ListActionSetMembers(ctx, id)
+		members, err := h.store.Repos().ActionSet.ListMembers(ctx, id)
 		if err != nil {
 			continue
 		}

--- a/internal/api/definition_handler.go
+++ b/internal/api/definition_handler.go
@@ -299,7 +299,7 @@ func (h *DefinitionHandler) AddActionSetToDefinition(ctx context.Context, req *c
 	}
 
 	// Verify action set exists
-	actionSet, err := h.store.Queries().GetActionSetByID(ctx, req.Msg.ActionSetId)
+	actionSet, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.ActionSetId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}

--- a/internal/api/user_selection_handler.go
+++ b/internal/api/user_selection_handler.go
@@ -161,7 +161,7 @@ func (h *UserSelectionHandler) ListAvailableActions(ctx context.Context, req *co
 				logEnrichmentErr("GetActionByID", "action_id", asn.SourceID, err)
 			}
 		case "action_set":
-			set, err := h.store.Queries().GetActionSetByID(ctx, asn.SourceID)
+			set, err := h.store.Repos().ActionSet.Get(ctx, asn.SourceID)
 			if err == nil {
 				item.SourceName = set.Name
 				item.SourceDescription = set.Description

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -440,7 +440,7 @@ func (idx *Index) warmActionSets(ctx context.Context, actionNames map[string]str
 	setMembers := map[string][]string{}
 
 	for {
-		sets, err := idx.store.Queries().ListActionSets(ctx, db.ListActionSetsParams{
+		sets, err := idx.store.Repos().ActionSet.List(ctx, store.ListActionSetsFilter{
 			Limit:  pageSize,
 			Offset: offset,
 		})
@@ -453,7 +453,7 @@ func (idx *Index) warmActionSets(ctx context.Context, actionNames map[string]str
 
 		for _, s := range sets {
 			// Get members for this set.
-			members, err := idx.store.Queries().ListActionSetMembers(ctx, s.ID)
+			members, err := idx.store.Repos().ActionSet.ListMembers(ctx, s.ID)
 			if err != nil {
 				idx.logger.Warn("failed to list action set members", "set_id", s.ID, "error", err)
 				continue

--- a/internal/store/action_set.go
+++ b/internal/store/action_set.go
@@ -1,0 +1,64 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// ActionSet is the action-set projection row — a named, ordered
+// collection of actions. Schedule stays as json.RawMessage at the
+// boundary per the JSONB normalize plan.
+type ActionSet struct {
+	ID          string
+	Name        string
+	Description string
+	MemberCount int32
+	CreatedAt   *time.Time
+	CreatedBy   string
+	UpdatedAt   *time.Time
+	Schedule    json.RawMessage
+}
+
+// ActionSetMember is one row in the action-set membership join,
+// hydrated with the action's name + type for display.
+type ActionSetMember struct {
+	SetID      string
+	ActionID   string
+	SortOrder  int32
+	AddedAt    *time.Time
+	ActionName string
+	ActionType int32
+}
+
+// ListActionSetsFilter pairs pagination with the "unassigned only"
+// flag (sets with no assignment targeting them).
+type ListActionSetsFilter struct {
+	UnassignedOnly bool
+	Limit          int32
+	Offset         int32
+}
+
+// ActionSetRepo reads action-set state. Writes flow through events.
+type ActionSetRepo interface {
+	// Get returns a set by ID. Returns ErrNotFound when no set
+	// with that ID exists.
+	Get(ctx context.Context, id string) (ActionSet, error)
+
+	// List returns a page of sets.
+	List(ctx context.Context, filter ListActionSetsFilter) ([]ActionSet, error)
+
+	// Count returns the total non-deleted set count, honouring
+	// UnassignedOnly so pagination totals stay aligned.
+	Count(ctx context.Context, unassignedOnly bool) (int64, error)
+
+	// ListMembers returns the action members of a set in their
+	// configured sort order, hydrated with the action's display
+	// name + type.
+	ListMembers(ctx context.Context, setID string) ([]ActionSetMember, error)
+
+	// ListInDefinition returns every action set that belongs to a
+	// given definition. Used by definition-detail handlers and the
+	// definition reindex sweep.
+	ListInDefinition(ctx context.Context, definitionID string) ([]ActionSet, error)
+}

--- a/internal/store/postgres/action_set.go
+++ b/internal/store/postgres/action_set.go
@@ -1,0 +1,98 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// ActionSet implements store.ActionSetRepo against
+// action_sets_projection + action_set_members_projection.
+type ActionSet struct {
+	q *generated.Queries
+}
+
+// NewActionSet returns an ActionSet repo bound to the given sqlc
+// handle.
+func NewActionSet(q *generated.Queries) *ActionSet {
+	return &ActionSet{q: q}
+}
+
+func (s *ActionSet) Get(ctx context.Context, id string) (store.ActionSet, error) {
+	row, err := s.q.GetActionSetByID(ctx, id)
+	if err != nil {
+		return store.ActionSet{}, fmt.Errorf("action_set: get: %w", translateNotFound(err))
+	}
+	return actionSetFromRow(row), nil
+}
+
+func (s *ActionSet) List(ctx context.Context, filter store.ListActionSetsFilter) ([]store.ActionSet, error) {
+	rows, err := s.q.ListActionSets(ctx, generated.ListActionSetsParams{
+		Limit:          filter.Limit,
+		Offset:         filter.Offset,
+		UnassignedOnly: filter.UnassignedOnly,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("action_set: list: %w", err)
+	}
+	out := make([]store.ActionSet, len(rows))
+	for i, r := range rows {
+		out[i] = actionSetFromRow(r)
+	}
+	return out, nil
+}
+
+func (s *ActionSet) Count(ctx context.Context, unassignedOnly bool) (int64, error) {
+	n, err := s.q.CountActionSets(ctx, unassignedOnly)
+	if err != nil {
+		return 0, fmt.Errorf("action_set: count: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (s *ActionSet) ListMembers(ctx context.Context, setID string) ([]store.ActionSetMember, error) {
+	rows, err := s.q.ListActionSetMembers(ctx, setID)
+	if err != nil {
+		return nil, fmt.Errorf("action_set: list members: %w", err)
+	}
+	out := make([]store.ActionSetMember, len(rows))
+	for i, r := range rows {
+		out[i] = store.ActionSetMember{
+			SetID:      r.SetID,
+			ActionID:   r.ActionID,
+			SortOrder:  r.SortOrder,
+			AddedAt:    r.AddedAt,
+			ActionName: r.ActionName,
+			ActionType: r.ActionType,
+		}
+	}
+	return out, nil
+}
+
+func (s *ActionSet) ListInDefinition(ctx context.Context, definitionID string) ([]store.ActionSet, error) {
+	rows, err := s.q.ListActionSetsInDefinition(ctx, definitionID)
+	if err != nil {
+		return nil, fmt.Errorf("action_set: list in definition: %w", err)
+	}
+	out := make([]store.ActionSet, len(rows))
+	for i, r := range rows {
+		out[i] = actionSetFromRow(r)
+	}
+	return out, nil
+}
+
+func actionSetFromRow(r generated.ActionSetsProjection) store.ActionSet {
+	return store.ActionSet{
+		ID:          r.ID,
+		Name:        r.Name,
+		Description: r.Description,
+		MemberCount: r.MemberCount,
+		CreatedAt:   r.CreatedAt,
+		CreatedBy:   r.CreatedBy,
+		UpdatedAt:   r.UpdatedAt,
+		Schedule:    json.RawMessage(r.Schedule),
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -15,6 +15,7 @@ import (
 func NewRepos(q *generated.Queries) *store.Repos {
 	return &store.Repos{
 		Action:           NewAction(q),
+		ActionSet:        NewActionSet(q),
 		AuthState:        NewAuthState(q),
 		Compliance:       NewCompliance(q),
 		Device:           NewDevice(q),

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -14,6 +14,7 @@ package store
 // add a field here, populate it in postgres.NewRepos.
 type Repos struct {
 	Action           ActionRepo
+	ActionSet        ActionSetRepo
 	AuthState        AuthStateRepo
 	Compliance       ComplianceRepo
 	Device           DeviceRepo


### PR DESCRIPTION
## Summary

\`ActionSetRepo\` — read side of \`action_sets_projection\` + \`action_set_members_projection\`. Branches off main directly.

## Methods

- \`Get(id)\` / \`List(filter)\` / \`Count(unassignedOnly)\`
- \`ListMembers(setID)\` — hydrated with action_name + action_type
- \`ListInDefinition(definitionID)\` — sets belonging to a definition

\`Schedule\` stays as \`json.RawMessage\` at the boundary.

## Call sites migrated (~20)

- \`action_set_handler.go\` — full CRUD + \`actionSetToProto\` signature
- \`assignment_handler.go\` — source validation for ActionSet
- \`user_selection_handler.go\` — ActionSet source enrichment
- \`search/index.go\` — set reindex sweep, member-list, definition-set membership

## Non-goals

- Definition / Execution / Assignment — subsequent sub-waves.
- Write-side projector queries — stay on \`Queries()\`.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Tests pass: api (34s).

Part of #242. Closes #273.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated action-set data access behind a repository layer for consistent read handling.
  * Added persistent action-set storage and membership support plus repository wiring to the backend.
  * Updated indexing and dispatch flows to use the new action-set repository, improving reliability and maintainability without changing user-facing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->