### PR TITLE
refactor(store): wave B.16 — definition repo (#275)

### DIFF
--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -62,7 +62,7 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action set")
 		}
 	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_DEFINITION:
-		_, err := h.store.Queries().GetDefinitionByID(ctx, req.Msg.SourceId)
+		_, err := h.store.Repos().Definition.Get(ctx, req.Msg.SourceId)
 		if err != nil {
 			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrDefinitionNotFound, connect.CodeNotFound, "definition not found")
@@ -381,7 +381,7 @@ func (h *AssignmentHandler) GetDeviceAssignments(ctx context.Context, req *conne
 	protoDefinitions := make([]*pm.Definition, 0, len(definitionIDs))
 	protoDefinitionDetails := make([]*pm.GetDefinitionResponse, 0, len(definitionIDs))
 	for id := range definitionIDs {
-		def, err := h.store.Queries().GetDefinitionByID(ctx, id)
+		def, err := h.store.Repos().Definition.Get(ctx, id)
 		if err != nil {
 			continue
 		}
@@ -397,7 +397,7 @@ func (h *AssignmentHandler) GetDeviceAssignments(ctx context.Context, req *conne
 		}
 		protoDefinitions = append(protoDefinitions, protoDef)
 
-		members, err := h.store.Queries().ListDefinitionMembers(ctx, id)
+		members, err := h.store.Repos().Definition.ListMembers(ctx, id)
 		if err != nil {
 			continue
 		}

--- a/internal/api/definition_handler.go
+++ b/internal/api/definition_handler.go
@@ -13,7 +13,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // DefinitionHandler handles definition (collection of action sets) RPCs.
@@ -67,7 +66,7 @@ func (h *DefinitionHandler) CreateDefinition(ctx context.Context, req *connect.R
 		return nil, err
 	}
 
-	def, err := h.store.Queries().GetDefinitionByID(ctx, id)
+	def, err := h.store.Repos().Definition.Get(ctx, id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get definition")
 	}
@@ -83,12 +82,12 @@ func (h *DefinitionHandler) GetDefinition(ctx context.Context, req *connect.Requ
 		return nil, err
 	}
 
-	def, err := h.store.Queries().GetDefinitionByID(ctx, req.Msg.Id)
+	def, err := h.store.Repos().Definition.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
 
-	members, err := h.store.Queries().ListDefinitionMembers(ctx, req.Msg.Id)
+	members, err := h.store.Repos().Definition.ListMembers(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get definition members")
 	}
@@ -115,15 +114,12 @@ func (h *DefinitionHandler) ListDefinitions(ctx context.Context, req *connect.Re
 		return nil, err
 	}
 
-	defs, err := h.store.Queries().ListDefinitions(ctx, db.ListDefinitionsParams{
-		Limit:  pageSize,
-		Offset: offset,
-	})
+	defs, err := h.store.Repos().Definition.List(ctx, store.ListDefinitionsFilter{Limit: pageSize, Offset: offset})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list definitions")
 	}
 
-	count, err := h.store.Queries().CountDefinitions(ctx)
+	count, err := h.store.Repos().Definition.Count(ctx)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count definitions")
 	}
@@ -166,7 +162,7 @@ func (h *DefinitionHandler) RenameDefinition(ctx context.Context, req *connect.R
 		return nil, err
 	}
 
-	def, err := h.store.Queries().GetDefinitionByID(ctx, req.Msg.Id)
+	def, err := h.store.Repos().Definition.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
@@ -207,7 +203,7 @@ func (h *DefinitionHandler) UpdateDefinitionSchedule(ctx context.Context, req *c
 		return nil, err
 	}
 
-	def, err := h.store.Queries().GetDefinitionByID(ctx, req.Msg.Id)
+	def, err := h.store.Repos().Definition.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
@@ -241,7 +237,7 @@ func (h *DefinitionHandler) UpdateDefinitionDescription(ctx context.Context, req
 		return nil, err
 	}
 
-	def, err := h.store.Queries().GetDefinitionByID(ctx, req.Msg.Id)
+	def, err := h.store.Repos().Definition.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
@@ -293,7 +289,7 @@ func (h *DefinitionHandler) AddActionSetToDefinition(ctx context.Context, req *c
 	}
 
 	// Verify definition exists
-	_, err = h.store.Queries().GetDefinitionByID(ctx, req.Msg.DefinitionId)
+	_, err = h.store.Repos().Definition.Get(ctx, req.Msg.DefinitionId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
@@ -318,7 +314,7 @@ func (h *DefinitionHandler) AddActionSetToDefinition(ctx context.Context, req *c
 		return nil, err
 	}
 
-	def, err := h.store.Queries().GetDefinitionByID(ctx, req.Msg.DefinitionId)
+	def, err := h.store.Repos().Definition.Get(ctx, req.Msg.DefinitionId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get definition")
 	}
@@ -358,7 +354,7 @@ func (h *DefinitionHandler) RemoveActionSetFromDefinition(ctx context.Context, r
 		return nil, err
 	}
 
-	def, err := h.store.Queries().GetDefinitionByID(ctx, req.Msg.DefinitionId)
+	def, err := h.store.Repos().Definition.Get(ctx, req.Msg.DefinitionId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
@@ -399,7 +395,7 @@ func (h *DefinitionHandler) ReorderActionSetInDefinition(ctx context.Context, re
 		return nil, err
 	}
 
-	def, err := h.store.Queries().GetDefinitionByID(ctx, req.Msg.DefinitionId)
+	def, err := h.store.Repos().Definition.Get(ctx, req.Msg.DefinitionId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
@@ -409,7 +405,7 @@ func (h *DefinitionHandler) ReorderActionSetInDefinition(ctx context.Context, re
 	}), nil
 }
 
-func (h *DefinitionHandler) definitionToProto(d db.DefinitionsProjection) *pm.Definition {
+func (h *DefinitionHandler) definitionToProto(d store.Definition) *pm.Definition {
 	def := &pm.Definition{
 		Id:          d.ID,
 		Name:        d.Name,

--- a/internal/api/user_selection_handler.go
+++ b/internal/api/user_selection_handler.go
@@ -169,7 +169,7 @@ func (h *UserSelectionHandler) ListAvailableActions(ctx context.Context, req *co
 				logEnrichmentErr("GetActionSetByID", "action_set_id", asn.SourceID, err)
 			}
 		case "definition":
-			def, err := h.store.Queries().GetDefinitionByID(ctx, asn.SourceID)
+			def, err := h.store.Repos().Definition.Get(ctx, asn.SourceID)
 			if err == nil {
 				item.SourceName = def.Name
 				item.SourceDescription = def.Description

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -517,10 +517,7 @@ func (idx *Index) warmDefinitions(ctx context.Context, actionNames, setNames map
 	var total int
 
 	for {
-		defs, err := idx.store.Queries().ListDefinitions(ctx, db.ListDefinitionsParams{
-			Limit:  pageSize,
-			Offset: offset,
-		})
+		defs, err := idx.store.Repos().Definition.List(ctx, store.ListDefinitionsFilter{Limit: pageSize, Offset: offset})
 		if err != nil {
 			return total, err
 		}
@@ -530,7 +527,7 @@ func (idx *Index) warmDefinitions(ctx context.Context, actionNames, setNames map
 
 		for _, d := range defs {
 			// Get members for this definition.
-			members, err := idx.store.Queries().ListDefinitionMembers(ctx, d.ID)
+			members, err := idx.store.Repos().Definition.ListMembers(ctx, d.ID)
 			if err != nil {
 				idx.logger.Warn("failed to list definition members", "def_id", d.ID, "error", err)
 				continue

--- a/internal/store/definition.go
+++ b/internal/store/definition.go
@@ -1,0 +1,57 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Definition is the definition-projection row — the top of the
+// action-chain hierarchy (definition → action_sets → actions).
+// Schedule stays as json.RawMessage at the boundary per the JSONB
+// normalize plan.
+type Definition struct {
+	ID          string
+	Name        string
+	Description string
+	MemberCount int32
+	CreatedAt   *time.Time
+	CreatedBy   string
+	UpdatedAt   *time.Time
+	Schedule    json.RawMessage
+}
+
+// DefinitionMember is one row in the definition-members join,
+// hydrated with the action_set's display name.
+type DefinitionMember struct {
+	DefinitionID  string
+	ActionSetID   string
+	SortOrder     int32
+	AddedAt       *time.Time
+	ActionSetName string
+}
+
+// ListDefinitionsFilter is the pagination shape.
+type ListDefinitionsFilter struct {
+	Limit  int32
+	Offset int32
+}
+
+// DefinitionRepo reads definition state. Writes flow through events.
+// Lookups for "what action sets does this definition contain" live
+// on ActionSetRepo.ListInDefinition (already migrated in #273).
+type DefinitionRepo interface {
+	// Get returns a definition by ID. Returns ErrNotFound when no
+	// definition with that ID exists.
+	Get(ctx context.Context, id string) (Definition, error)
+
+	// List returns a page of definitions.
+	List(ctx context.Context, filter ListDefinitionsFilter) ([]Definition, error)
+
+	// Count returns the total non-deleted definition count.
+	Count(ctx context.Context) (int64, error)
+
+	// ListMembers returns the action_set members of a definition in
+	// their configured sort order, hydrated with action_set_name.
+	ListMembers(ctx context.Context, definitionID string) ([]DefinitionMember, error)
+}

--- a/internal/store/postgres/definition.go
+++ b/internal/store/postgres/definition.go
@@ -1,0 +1,84 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Definition implements store.DefinitionRepo against
+// definitions_projection + definition_members_projection.
+type Definition struct {
+	q *generated.Queries
+}
+
+// NewDefinition returns a Definition repo bound to the given sqlc
+// handle.
+func NewDefinition(q *generated.Queries) *Definition {
+	return &Definition{q: q}
+}
+
+func (d *Definition) Get(ctx context.Context, id string) (store.Definition, error) {
+	row, err := d.q.GetDefinitionByID(ctx, id)
+	if err != nil {
+		return store.Definition{}, fmt.Errorf("definition: get: %w", translateNotFound(err))
+	}
+	return definitionFromRow(row), nil
+}
+
+func (d *Definition) List(ctx context.Context, filter store.ListDefinitionsFilter) ([]store.Definition, error) {
+	rows, err := d.q.ListDefinitions(ctx, generated.ListDefinitionsParams{
+		Limit:  filter.Limit,
+		Offset: filter.Offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("definition: list: %w", err)
+	}
+	out := make([]store.Definition, len(rows))
+	for i, r := range rows {
+		out[i] = definitionFromRow(r)
+	}
+	return out, nil
+}
+
+func (d *Definition) Count(ctx context.Context) (int64, error) {
+	n, err := d.q.CountDefinitions(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("definition: count: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (d *Definition) ListMembers(ctx context.Context, definitionID string) ([]store.DefinitionMember, error) {
+	rows, err := d.q.ListDefinitionMembers(ctx, definitionID)
+	if err != nil {
+		return nil, fmt.Errorf("definition: list members: %w", err)
+	}
+	out := make([]store.DefinitionMember, len(rows))
+	for i, r := range rows {
+		out[i] = store.DefinitionMember{
+			DefinitionID:  r.DefinitionID,
+			ActionSetID:   r.ActionSetID,
+			SortOrder:     r.SortOrder,
+			AddedAt:       r.AddedAt,
+			ActionSetName: r.ActionSetName,
+		}
+	}
+	return out, nil
+}
+
+func definitionFromRow(r generated.DefinitionsProjection) store.Definition {
+	return store.Definition{
+		ID:          r.ID,
+		Name:        r.Name,
+		Description: r.Description,
+		MemberCount: r.MemberCount,
+		CreatedAt:   r.CreatedAt,
+		CreatedBy:   r.CreatedBy,
+		UpdatedAt:   r.UpdatedAt,
+		Schedule:    json.RawMessage(r.Schedule),
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -18,6 +18,7 @@ func NewRepos(q *generated.Queries) *store.Repos {
 		ActionSet:        NewActionSet(q),
 		AuthState:        NewAuthState(q),
 		Compliance:       NewCompliance(q),
+		Definition:       NewDefinition(q),
 		Device:           NewDevice(q),
 		DeviceGroup:      NewDeviceGroup(q),
 		IdentityLink:     NewIdentityLink(q),

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -17,6 +17,7 @@ type Repos struct {
 	ActionSet        ActionSetRepo
 	AuthState        AuthStateRepo
 	Compliance       ComplianceRepo
+	Definition       DefinitionRepo
 	Device           DeviceRepo
 	DeviceGroup      DeviceGroupRepo
 	IdentityLink     IdentityLinkRepo


### PR DESCRIPTION
## Summary

\`DefinitionRepo\` — read side of \`definitions_projection\` + \`definition_members_projection\`. Top of the action-chain hierarchy. Branches off main directly.

## Methods

- \`Get(id)\` / \`List(filter)\` / \`Count\`
- \`ListMembers(definitionID)\` — action_set members hydrated with \`action_set_name\`

\`Schedule\` stays as \`json.RawMessage\` at the boundary. \`ActionSetRepo.ListInDefinition\` (already migrated in #273) handles the inverse direction.

## Call sites migrated

- \`definition_handler.go\` — full CRUD + \`definitionToProto\` signature
- \`assignment_handler.go\` — source validation
- \`user_selection_handler.go\` — Definition source enrichment
- \`search/index.go\` — reindex sweep + member-list

## Non-goals

- Execution / Assignment — subsequent sub-waves.
- Write-side projector queries — stay on \`Queries()\`.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Tests pass: api (39s).

Part of #242. Closes #275.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified how definition data is accessed across assignment handling, user selection, search, and repository wiring to improve consistency and reliability.
* **Chores**
  * Added a new internal definitions repository and integrated it with the store.
* **Notes**
  * No public API or user-facing behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->