### PR TITLE
refactor(store): wave B.17 — execution repo (#277)

### DIFF
--- a/cmd/control/periodic.go
+++ b/cmd/control/periodic.go
@@ -128,7 +128,7 @@ func startStaleExecutionExpiry(ctx context.Context, st *store.Store, logger *slo
 		for {
 			select {
 			case <-ticker.C:
-				stale, err := st.Queries().ListStaleExecutions(ctx)
+				stale, err := st.Repos().Execution.ListStale(ctx)
 				if err != nil {
 					logger.Error("failed to list stale executions", "error", err)
 					continue

--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -23,7 +23,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
@@ -308,7 +307,7 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to enqueue action dispatch")
 	}
 
-	exec, err := h.store.Queries().GetExecutionByID(ctx, id)
+	exec, err := h.store.Repos().Execution.Get(ctx, id)
 	if err != nil {
 		h.logger.Error("failed to get execution after creation", "error", err, "execution_id", id)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get execution")
@@ -582,7 +581,7 @@ func (h *ActionHandler) GetExecution(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
-	exec, err := h.store.Queries().GetExecutionByID(ctx, req.Msg.Id)
+	exec, err := h.store.Repos().Execution.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrExecutionNotFound, "execution not found")
 	}
@@ -625,24 +624,12 @@ func (h *ActionHandler) ListExecutions(ctx context.Context, req *connect.Request
 	typeFilter := int32(req.Msg.TypeFilter)
 	searchQuery := strings.TrimSpace(req.Msg.Search)
 
-	execs, err := h.store.Queries().ListExecutions(ctx, db.ListExecutionsParams{
-		Column1: req.Msg.DeviceId,
-		Column2: statusFilter,
-		Column3: typeFilter,
-		Column4: searchQuery,
-		Limit:   pageSize,
-		Offset:  offset,
-	})
+	execs, err := h.store.Repos().Execution.List(ctx, store.ListExecutionsFilter{DeviceID: req.Msg.DeviceId, Status: statusFilter, ActionTypeFilter: typeFilter, Search: searchQuery, Limit: pageSize, Offset: offset})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list executions")
 	}
 
-	count, err := h.store.Queries().CountExecutions(ctx, db.CountExecutionsParams{
-		Column1: req.Msg.DeviceId,
-		Column2: statusFilter,
-		Column3: typeFilter,
-		Column4: searchQuery,
-	})
+	count, err := h.store.Repos().Execution.Count(ctx, store.CountExecutionsFilter{DeviceID: req.Msg.DeviceId, Status: statusFilter, ActionTypeFilter: typeFilter, Search: searchQuery})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count executions")
 	}
@@ -803,7 +790,7 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to enqueue instant action dispatch")
 	}
 
-	exec, err := h.store.Queries().GetExecutionByID(ctx, id)
+	exec, err := h.store.Repos().Execution.Get(ctx, id)
 	if err != nil {
 		h.logger.Error("failed to get execution after creation", "error", err, "execution_id", id)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get execution")
@@ -835,7 +822,7 @@ func (h *ActionHandler) CancelExecution(ctx context.Context, req *connect.Reques
 		return nil, err
 	}
 
-	exec, err := h.store.Queries().GetExecutionByID(ctx, req.Msg.ExecutionId)
+	exec, err := h.store.Repos().Execution.Get(ctx, req.Msg.ExecutionId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrExecutionNotFound, "execution not found")
 	}
@@ -873,7 +860,7 @@ func (h *ActionHandler) CancelExecution(ctx context.Context, req *connect.Reques
 		return nil, err
 	}
 
-	exec, err = h.store.Queries().GetExecutionByID(ctx, req.Msg.ExecutionId)
+	exec, err = h.store.Repos().Execution.Get(ctx, req.Msg.ExecutionId)
 	if err != nil {
 		h.logger.Error("CancelExecution: failed to refetch execution after cancel", "execution_id", req.Msg.ExecutionId, "error", err)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to read execution after cancel")

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -46,7 +46,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
 // ActionHandler handles action (single executable) and execution RPCs.
@@ -100,7 +99,7 @@ func (h *ActionHandler) actionToProto(a store.Action) *pm.ManagedAction {
 	return action
 }
 
-func (h *ActionHandler) executionToProto(e db.ExecutionsProjection) *pm.ActionExecution {
+func (h *ActionHandler) executionToProto(e store.Execution) *pm.ActionExecution {
 	exec := &pm.ActionExecution{
 		Id:           e.ID,
 		DeviceId:     e.DeviceID,
@@ -205,7 +204,7 @@ func stringToStatus(s string) pm.ExecutionStatus {
 // loadLiveOutput loads streaming output chunks from the event store and
 // aggregates them into a CommandOutput.
 func (h *ActionHandler) loadLiveOutput(ctx context.Context, executionID string) *pm.CommandOutput {
-	chunks, err := h.store.Queries().LoadOutputChunks(ctx, executionID)
+	chunks, err := h.store.Repos().Execution.LoadOutputChunks(ctx, executionID)
 	if err != nil || len(chunks) == 0 {
 		return nil
 	}

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -192,7 +192,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 	var executionID, actionID string
 	var needsCreate bool
 
-	existingExec, err := w.store.Queries().GetExecutionByID(ctx, resultID)
+	existingExec, err := w.store.Repos().Execution.Get(ctx, resultID)
 	if err == nil {
 		executionID = existingExec.ID
 		if existingExec.ActionID != nil {
@@ -214,7 +214,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		executionID = stableExecutionID(deviceID, actionID, completedStr)
 
 		// Check if this derived execution already exists (retry of a previously processed result)
-		_, checkErr := w.store.Queries().GetExecutionByID(ctx, executionID)
+		_, checkErr := w.store.Repos().Execution.Get(ctx, executionID)
 		if checkErr == nil {
 			needsCreate = false
 		} else if store.IsNotFound(checkErr) {
@@ -629,7 +629,7 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID string, logger *slog.Logger) error {
 	logger.Debug("checking for pending executions")
 
-	executions, err := w.store.Queries().ListPendingExecutionsForDevice(ctx, deviceID)
+	executions, err := w.store.Repos().Execution.ListPendingForDevice(ctx, deviceID)
 	if err != nil {
 		return fmt.Errorf("list pending executions: %w", err)
 	}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -889,7 +889,7 @@ func (idx *Index) warmExecutions(ctx context.Context) (int, error) {
 	actionNames := make(map[string]string)
 
 	for {
-		execs, err := idx.store.Queries().ListExecutionsForWarm(ctx, db.ListExecutionsForWarmParams{
+		execs, err := idx.store.Repos().Execution.ListForWarm(ctx, store.WarmFilter{
 			Limit:  pageSize,
 			Offset: offset,
 		})

--- a/internal/store/execution.go
+++ b/internal/store/execution.go
@@ -1,0 +1,120 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Execution is the per-action-dispatch result row from
+// executions_projection. ActionID is *string because an execution
+// can be agent-scheduled (no API-side action row) or compliance-only
+// (action_id NULL after the action row is deleted). Params /
+// Output / DetectionOutput stay as opaque JSON at the boundary.
+type Execution struct {
+	ID              string
+	DeviceID        string
+	ActionID        *string
+	ActionType      int32
+	DesiredState    int32
+	Params          json.RawMessage
+	TimeoutSeconds  int32
+	Status          string
+	Error           *string
+	Output          json.RawMessage
+	CreatedAt       *time.Time
+	DispatchedAt    *time.Time
+	StartedAt       *time.Time
+	CompletedAt     *time.Time
+	DurationMs      *int64
+	CreatedByType   string
+	CreatedByID     string
+	Changed         bool
+	Compliant       bool
+	DetectionOutput json.RawMessage
+	ScheduledFor    *time.Time
+}
+
+// StaleExecution is the narrow shape returned by ListStale — the
+// stale-expiry sweep only needs the fields necessary to emit the
+// timeout event.
+type StaleExecution struct {
+	ID             string
+	DeviceID       string
+	TimeoutSeconds int32
+	Status         string
+	CreatedAt      *time.Time
+	DispatchedAt   *time.Time
+}
+
+// ListExecutionsFilter pairs pagination with the four filter axes
+// the UI exposes. Empty / zero values disable each filter
+// independently — the projection-side query treats "" / 0 as "no
+// filter on this axis".
+type ListExecutionsFilter struct {
+	DeviceID         string
+	Status           string
+	ActionTypeFilter int32
+	Search           string
+	Limit            int32
+	Offset           int32
+}
+
+// CountExecutionsFilter mirrors ListExecutionsFilter's filter
+// fields. Both shapes must stay in sync so pagination totals line
+// up with the rows actually returned.
+type CountExecutionsFilter struct {
+	DeviceID         string
+	Status           string
+	ActionTypeFilter int32
+	Search           string
+}
+
+// WarmFilter is the narrow pagination shape used by the search
+// warm-up sweep (no filters — just window-by-age cap + page).
+type WarmFilter struct {
+	Limit  int32
+	Offset int32
+}
+
+// ExecutionRepo reads execution state. Writes flow through events
+// (ExecutionCreated / Dispatched / Started / Completed / etc.) and
+// the projector listener.
+type ExecutionRepo interface {
+	// Get returns an execution by ID. Returns ErrNotFound when no
+	// execution with that ID exists.
+	Get(ctx context.Context, id string) (Execution, error)
+
+	// List returns a page of executions matching the filter, ordered
+	// by created_at descending.
+	List(ctx context.Context, filter ListExecutionsFilter) ([]Execution, error)
+
+	// Count returns the total matching the filter.
+	Count(ctx context.Context, filter CountExecutionsFilter) (int64, error)
+
+	// ListPendingForDevice returns 'pending' + 'dispatched'
+	// executions for a device, oldest first. Used by the
+	// reconnect-dispatch flow to re-send executions whose agent was
+	// offline.
+	ListPendingForDevice(ctx context.Context, deviceID string) ([]Execution, error)
+
+	// ListStale returns dispatched executions that have exceeded
+	// timeout + grace. The periodic expiry sweep uses this to emit
+	// ExecutionTimedOut events.
+	ListStale(ctx context.Context) ([]StaleExecution, error)
+
+	// ListForWarm returns recent (≤90d) executions for the search
+	// warm-up sweep.
+	ListForWarm(ctx context.Context, filter WarmFilter) ([]Execution, error)
+
+	// CountForWarm returns the total recent-execution count for the
+	// warm-up pagination.
+	CountForWarm(ctx context.Context) (int64, error)
+
+	// LoadOutputChunks loads every ExecutionOutputChunk event for
+	// the given execution stream ID, ordered by sequence. The
+	// chunks are stored on the event stream rather than as
+	// projection rows, hence the cross-shape (returns
+	// PersistedEvent rather than execution data).
+	LoadOutputChunks(ctx context.Context, executionID string) ([]PersistedEvent, error)
+}

--- a/internal/store/postgres/execution.go
+++ b/internal/store/postgres/execution.go
@@ -1,0 +1,151 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Execution implements store.ExecutionRepo against
+// executions_projection (and reaches into the event store for
+// LoadOutputChunks).
+type Execution struct {
+	q *generated.Queries
+}
+
+// NewExecution returns an Execution repo bound to the given sqlc
+// handle.
+func NewExecution(q *generated.Queries) *Execution {
+	return &Execution{q: q}
+}
+
+func (e *Execution) Get(ctx context.Context, id string) (store.Execution, error) {
+	row, err := e.q.GetExecutionByID(ctx, id)
+	if err != nil {
+		return store.Execution{}, fmt.Errorf("execution: get: %w", translateNotFound(err))
+	}
+	return executionFromRow(row), nil
+}
+
+func (e *Execution) List(ctx context.Context, filter store.ListExecutionsFilter) ([]store.Execution, error) {
+	rows, err := e.q.ListExecutions(ctx, generated.ListExecutionsParams{
+		Column1: filter.DeviceID,
+		Column2: filter.Status,
+		Column3: filter.ActionTypeFilter,
+		Column4: filter.Search,
+		Limit:   filter.Limit,
+		Offset:  filter.Offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("execution: list: %w", err)
+	}
+	out := make([]store.Execution, len(rows))
+	for i, r := range rows {
+		out[i] = executionFromRow(r)
+	}
+	return out, nil
+}
+
+func (e *Execution) Count(ctx context.Context, filter store.CountExecutionsFilter) (int64, error) {
+	n, err := e.q.CountExecutions(ctx, generated.CountExecutionsParams{
+		Column1: filter.DeviceID,
+		Column2: filter.Status,
+		Column3: filter.ActionTypeFilter,
+		Column4: filter.Search,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("execution: count: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (e *Execution) ListPendingForDevice(ctx context.Context, deviceID string) ([]store.Execution, error) {
+	rows, err := e.q.ListPendingExecutionsForDevice(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("execution: list pending for device: %w", err)
+	}
+	out := make([]store.Execution, len(rows))
+	for i, r := range rows {
+		out[i] = executionFromRow(r)
+	}
+	return out, nil
+}
+
+func (e *Execution) ListStale(ctx context.Context) ([]store.StaleExecution, error) {
+	rows, err := e.q.ListStaleExecutions(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("execution: list stale: %w", err)
+	}
+	out := make([]store.StaleExecution, len(rows))
+	for i, r := range rows {
+		out[i] = store.StaleExecution{
+			ID:             r.ID,
+			DeviceID:       r.DeviceID,
+			TimeoutSeconds: r.TimeoutSeconds,
+			Status:         r.Status,
+			CreatedAt:      r.CreatedAt,
+			DispatchedAt:   r.DispatchedAt,
+		}
+	}
+	return out, nil
+}
+
+func (e *Execution) ListForWarm(ctx context.Context, filter store.WarmFilter) ([]store.Execution, error) {
+	rows, err := e.q.ListExecutionsForWarm(ctx, generated.ListExecutionsForWarmParams{
+		Limit:  filter.Limit,
+		Offset: filter.Offset,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("execution: list for warm: %w", err)
+	}
+	out := make([]store.Execution, len(rows))
+	for i, r := range rows {
+		out[i] = executionFromRow(r)
+	}
+	return out, nil
+}
+
+func (e *Execution) CountForWarm(ctx context.Context) (int64, error) {
+	n, err := e.q.CountExecutionsForWarm(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("execution: count for warm: %w", translateNotFound(err))
+	}
+	return n, nil
+}
+
+func (e *Execution) LoadOutputChunks(ctx context.Context, executionID string) ([]store.PersistedEvent, error) {
+	rows, err := e.q.LoadOutputChunks(ctx, executionID)
+	if err != nil {
+		return nil, fmt.Errorf("execution: load output chunks: %w", err)
+	}
+	return rows, nil
+}
+
+func executionFromRow(r generated.ExecutionsProjection) store.Execution {
+	return store.Execution{
+		ID:              r.ID,
+		DeviceID:        r.DeviceID,
+		ActionID:        r.ActionID,
+		ActionType:      r.ActionType,
+		DesiredState:    r.DesiredState,
+		Params:          json.RawMessage(r.Params),
+		TimeoutSeconds:  r.TimeoutSeconds,
+		Status:          r.Status,
+		Error:           r.Error,
+		Output:          json.RawMessage(r.Output),
+		CreatedAt:       r.CreatedAt,
+		DispatchedAt:    r.DispatchedAt,
+		StartedAt:       r.StartedAt,
+		CompletedAt:     r.CompletedAt,
+		DurationMs:      r.DurationMs,
+		CreatedByType:   r.CreatedByType,
+		CreatedByID:     r.CreatedByID,
+		Changed:         r.Changed,
+		Compliant:       r.Compliant,
+		DetectionOutput: json.RawMessage(r.DetectionOutput),
+		ScheduledFor:    r.ScheduledFor,
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -21,6 +21,7 @@ func NewRepos(q *generated.Queries) *store.Repos {
 		Definition:       NewDefinition(q),
 		Device:           NewDevice(q),
 		DeviceGroup:      NewDeviceGroup(q),
+		Execution:        NewExecution(q),
 		IdentityLink:     NewIdentityLink(q),
 		IdentityProvider: NewIdentityProvider(q),
 		Inventory:        NewInventory(q),

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -20,6 +20,7 @@ type Repos struct {
 	Definition       DefinitionRepo
 	Device           DeviceRepo
 	DeviceGroup      DeviceGroupRepo
+	Execution        ExecutionRepo
 	IdentityLink     IdentityLinkRepo
 	IdentityProvider IdentityProviderRepo
 	Inventory        InventoryRepo


### PR DESCRIPTION
## Summary

\`ExecutionRepo\` — read side of \`executions_projection\` plus event-store-backed output chunk replay. Branches off main.

## Methods

- \`Get(id)\` / \`List(filter)\` / \`Count(filter)\` — 4-axis filter (device, status, action_type, search) shared between List + Count
- \`ListPendingForDevice(deviceID)\` — reconnect-dispatch flow
- \`ListStale()\` — periodic timeout-expiry sweep (narrow shape, no output bytes)
- \`ListForWarm(filter)\` / \`CountForWarm()\` — search warm-up (≤90d window)
- \`LoadOutputChunks(executionID)\` — replays \`ExecutionOutputChunk\` events from the event store; returns \`PersistedEvent\` because chunks live on the event stream rather than as projection rows

\`Params\` / \`Output\` / \`DetectionOutput\` stay as \`json.RawMessage\` at the boundary.

## Call sites migrated (~16)

- \`action_dispatch.go\` — 6 Get sites + List + Count + \`executionToProto\` signature
- \`control/inbox_worker.go\` — result correlation
- \`cmd/control/periodic.go\` — stale sweep
- \`search/index.go\` — warm-up
- \`logs_handler.go\` — LoadOutputChunks

## Non-goals

- Assignment — final action-chain sub-wave.
- Write-side projector queries — stay on \`Queries()\`.

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Tests pass: api (2m35s), control (9s).

Part of #242. Closes #277.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced internal execution data access with a unified repository layer.
  * Added execution repository interfaces and a PostgreSQL-backed implementation.
  * Integrated the new repository into the store wiring.
  * No public API/signature changes and no user-visible behavior differences; existing features continue to operate as before.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->