### PR TITLE
refactor(store): wave B.19 — lps + luks repos (#281)

### DIFF
--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -23,7 +23,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
-	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
 
@@ -639,13 +638,13 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 	}
 
 	// Get current passwords
-	current, err := h.store.Queries().GetCurrentLpsPasswords(ctx, req.Msg.DeviceId)
+	current, err := h.store.Repos().Lps.ListCurrent(ctx, req.Msg.DeviceId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load current LPS passwords")
 	}
 
 	// Get password history
-	history, err := h.store.Queries().GetLpsPasswordHistory(ctx, req.Msg.DeviceId)
+	history, err := h.store.Repos().Lps.ListHistory(ctx, req.Msg.DeviceId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load LPS password history")
 	}
@@ -722,12 +721,12 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 		return nil, err
 	}
 
-	current, err := h.store.Queries().GetCurrentLuksKeys(ctx, req.Msg.DeviceId)
+	current, err := h.store.Repos().Luks.ListCurrent(ctx, req.Msg.DeviceId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load current LUKS keys")
 	}
 
-	history, err := h.store.Queries().GetLuksKeyHistory(ctx, req.Msg.DeviceId)
+	history, err := h.store.Repos().Luks.ListHistory(ctx, req.Msg.DeviceId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load LUKS key history")
 	}
@@ -863,13 +862,7 @@ func (h *DeviceHandler) CreateLuksToken(ctx context.Context, req *connect.Reques
 	token := hex.EncodeToString(tokenBytes)
 
 	// Store in DB
-	_, err = h.store.Queries().CreateLuksToken(ctx, db.CreateLuksTokenParams{
-		DeviceID:   req.Msg.DeviceId,
-		ActionID:   req.Msg.ActionId,
-		Token:      token,
-		MinLength:  minLength,
-		Complexity: complexity,
-	})
+	_, err = h.store.Repos().Luks.CreateToken(ctx, store.CreateLuksTokenParams{DeviceID: req.Msg.DeviceId, ActionID: req.Msg.ActionId, Token: token, MinLength: minLength, Complexity: complexity})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create token")
 	}

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -245,20 +245,14 @@ func (h *InternalHandler) ProxyValidateLuksToken(ctx context.Context, req *conne
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id and token are required")
 	}
 
-	token, err := h.store.Queries().ValidateAndConsumeLuksToken(ctx, db.ValidateAndConsumeLuksTokenParams{
-		Token:    req.Msg.Token,
-		DeviceID: req.Msg.DeviceId,
-	})
+	token, err := h.store.Repos().Luks.ConsumeToken(ctx, store.ConsumeLuksTokenParams{Token: req.Msg.Token, DeviceID: req.Msg.DeviceId})
 	if err != nil {
 		h.logger.Warn("LUKS token validation failed", "device_id", req.Msg.DeviceId, "error", err)
 		return nil, apiErrorCtx(ctx, ErrTokenNotFound, connect.CodeNotFound, "token is invalid or has expired")
 	}
 
 	devicePath := ""
-	key, err := h.store.Queries().GetCurrentLuksKeyForAction(ctx, db.GetCurrentLuksKeyForActionParams{
-		DeviceID: req.Msg.DeviceId,
-		ActionID: token.ActionID,
-	})
+	key, err := h.store.Repos().Luks.GetCurrentForAction(ctx, store.LuksKeyByActionKey{DeviceID: req.Msg.DeviceId, ActionID: token.ActionID})
 	if err == nil {
 		devicePath = key.DevicePath
 	} else {
@@ -279,10 +273,7 @@ func (h *InternalHandler) ProxyGetLuksKey(ctx context.Context, req *connect.Requ
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id and action_id are required")
 	}
 
-	key, err := h.store.Queries().GetCurrentLuksKeyForAction(ctx, db.GetCurrentLuksKeyForActionParams{
-		DeviceID: req.Msg.DeviceId,
-		ActionID: req.Msg.ActionId,
-	})
+	key, err := h.store.Repos().Luks.GetCurrentForAction(ctx, store.LuksKeyByActionKey{DeviceID: req.Msg.DeviceId, ActionID: req.Msg.ActionId})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrLuksKeyNotFound, connect.CodeNotFound, "no LUKS key found for this action")
 	}

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -567,7 +567,7 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 	// a fresh stream ID so we still record the Failed outcome
 	// durably — an orphan Failed event is better than dropping the
 	// agent-reported failure on the floor.
-	luksStreamID, err := w.store.Queries().GetLuksRevocationStreamID(ctx, db.GetLuksRevocationStreamIDParams{
+	luksStreamID, err := w.store.Repos().Luks.GetRevocationStreamID(ctx, store.LuksRevocationStreamKey{
 		DeviceID: payload.DeviceID,
 		ActionID: payload.ActionID,
 	})

--- a/internal/store/lps.go
+++ b/internal/store/lps.go
@@ -1,0 +1,38 @@
+package store
+
+import (
+	"context"
+	"time"
+)
+
+// LpsPassword is one rotated LPS (Local Privileged Sudo) password
+// record for a (device, action, username) triple. Password stays as
+// the plaintext that the agent rotated — the projection holds it
+// encrypted at the column level via internal/crypto, but the repo
+// returns the decrypted value because every caller needs to read
+// it. Reduce-blast-radius rule: treat returned values as secret.
+type LpsPassword struct {
+	ID             string
+	DeviceID       string
+	ActionID       string
+	Username       string
+	Password       string
+	RotatedAt      time.Time
+	RotationReason string
+	IsCurrent      bool
+	CreatedAt      time.Time
+}
+
+// LpsRepo reads LPS-rotation state. Writes happen via the
+// LpsPasswordRotated event + projector listener — there is no
+// Insert/Update method here by design.
+type LpsRepo interface {
+	// ListCurrent returns the current (is_current = true) password
+	// row per (action, username) on the device — i.e. every account
+	// whose latest rotation is still in effect.
+	ListCurrent(ctx context.Context, deviceID string) ([]LpsPassword, error)
+
+	// ListHistory returns every recorded rotation for the device,
+	// most recent first. Used by the password-history UI.
+	ListHistory(ctx context.Context, deviceID string) ([]LpsPassword, error)
+}

--- a/internal/store/luks.go
+++ b/internal/store/luks.go
@@ -1,0 +1,108 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// LuksKey is one rotated LUKS passphrase record for a (device,
+// action) pair. Passphrase is the decrypted secret — same blast-
+// radius rule as LPS: treat values as sensitive in callers.
+type LuksKey struct {
+	ID               uuid.UUID
+	DeviceID         string
+	ActionID         string
+	DevicePath       string
+	Passphrase       string
+	RotatedAt        time.Time
+	RotationReason   string
+	IsCurrent        bool
+	CreatedAt        time.Time
+	RevocationStatus *string
+	RevocationError  *string
+	RevocationAt     *time.Time
+}
+
+// LuksToken is one short-lived one-time token a device must present
+// when retrieving the current LUKS key. Tokens carry the minimum
+// password requirements the rotation must satisfy.
+type LuksToken struct {
+	ID         uuid.UUID
+	DeviceID   string
+	ActionID   string
+	Token      string
+	MinLength  int32
+	Complexity int32
+	CreatedAt  time.Time
+	ExpiresAt  time.Time
+	Used       bool
+}
+
+// CreateLuksTokenParams is the input shape for minting a fresh
+// retrieval token.
+type CreateLuksTokenParams struct {
+	DeviceID   string
+	ActionID   string
+	Token      string
+	MinLength  int32
+	Complexity int32
+}
+
+// ConsumeLuksTokenParams is the input shape for the one-shot
+// validate+consume check the gateway proxy performs when a device
+// presents a token. The query returns the matching row AND marks it
+// used in one statement — replay yields ErrNotFound.
+type ConsumeLuksTokenParams struct {
+	Token    string
+	DeviceID string
+}
+
+// LuksKeyByActionKey is the composite (device, action) lookup used
+// by the gateway proxy when the agent asks for the current key
+// matching a known action.
+type LuksKeyByActionKey struct {
+	DeviceID string
+	ActionID string
+}
+
+// LuksRevocationStreamKey is the composite lookup the inbox worker
+// uses to find the event-stream ID that holds the revocation
+// request → revoked/failed chain for a (device, action).
+type LuksRevocationStreamKey struct {
+	DeviceID string
+	ActionID string
+}
+
+// LuksRepo reads LUKS-rotation state + manages the per-retrieval
+// one-time token. Token writes are repo-side (no event store
+// involvement); key rotation flows through events.
+type LuksRepo interface {
+	// ListCurrent returns the current LUKS key row per (action,
+	// device_path) on the device.
+	ListCurrent(ctx context.Context, deviceID string) ([]LuksKey, error)
+
+	// ListHistory returns every rotation for the device, most
+	// recent first.
+	ListHistory(ctx context.Context, deviceID string) ([]LuksKey, error)
+
+	// GetCurrentForAction returns the current key for a (device,
+	// action) pair — the gateway proxy uses this when the agent
+	// presents a token to redeem.
+	GetCurrentForAction(ctx context.Context, key LuksKeyByActionKey) (LuksKey, error)
+
+	// CreateToken mints a fresh one-time retrieval token row.
+	CreateToken(ctx context.Context, p CreateLuksTokenParams) (LuksToken, error)
+
+	// ConsumeToken validates and burns a presented token in one
+	// statement. Returns ErrNotFound when the token is unknown,
+	// already used, expired, or mismatched on device_id.
+	ConsumeToken(ctx context.Context, p ConsumeLuksTokenParams) (LuksToken, error)
+
+	// GetRevocationStreamID looks up the event-stream ID for the
+	// pending revocation request on a (device, action). Used by
+	// the inbox worker to append the terminal event to the SAME
+	// stream so the three-phase projection stitches together.
+	GetRevocationStreamID(ctx context.Context, key LuksRevocationStreamKey) (string, error)
+}

--- a/internal/store/postgres/lps.go
+++ b/internal/store/postgres/lps.go
@@ -1,0 +1,57 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Lps implements store.LpsRepo against lps_passwords_projection.
+type Lps struct {
+	q *generated.Queries
+}
+
+// NewLps returns an Lps repo bound to the given sqlc handle.
+func NewLps(q *generated.Queries) *Lps {
+	return &Lps{q: q}
+}
+
+func (l *Lps) ListCurrent(ctx context.Context, deviceID string) ([]store.LpsPassword, error) {
+	rows, err := l.q.GetCurrentLpsPasswords(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("lps: list current: %w", err)
+	}
+	out := make([]store.LpsPassword, len(rows))
+	for i, r := range rows {
+		out[i] = lpsFromRow(r)
+	}
+	return out, nil
+}
+
+func (l *Lps) ListHistory(ctx context.Context, deviceID string) ([]store.LpsPassword, error) {
+	rows, err := l.q.GetLpsPasswordHistory(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("lps: list history: %w", err)
+	}
+	out := make([]store.LpsPassword, len(rows))
+	for i, r := range rows {
+		out[i] = lpsFromRow(r)
+	}
+	return out, nil
+}
+
+func lpsFromRow(r generated.LpsPasswordsProjection) store.LpsPassword {
+	return store.LpsPassword{
+		ID:             r.ID.String(),
+		DeviceID:       r.DeviceID,
+		ActionID:       r.ActionID,
+		Username:       r.Username,
+		Password:       r.Password,
+		RotatedAt:      r.RotatedAt,
+		RotationReason: r.RotationReason,
+		IsCurrent:      r.IsCurrent,
+		CreatedAt:      r.CreatedAt,
+	}
+}

--- a/internal/store/postgres/luks.go
+++ b/internal/store/postgres/luks.go
@@ -1,0 +1,122 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Luks implements store.LuksRepo against luks_keys_projection +
+// luks_tokens.
+type Luks struct {
+	q *generated.Queries
+}
+
+// NewLuks returns a Luks repo bound to the given sqlc handle.
+func NewLuks(q *generated.Queries) *Luks {
+	return &Luks{q: q}
+}
+
+func (l *Luks) ListCurrent(ctx context.Context, deviceID string) ([]store.LuksKey, error) {
+	rows, err := l.q.GetCurrentLuksKeys(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("luks: list current: %w", err)
+	}
+	out := make([]store.LuksKey, len(rows))
+	for i, r := range rows {
+		out[i] = luksFromRow(r)
+	}
+	return out, nil
+}
+
+func (l *Luks) ListHistory(ctx context.Context, deviceID string) ([]store.LuksKey, error) {
+	rows, err := l.q.GetLuksKeyHistory(ctx, deviceID)
+	if err != nil {
+		return nil, fmt.Errorf("luks: list history: %w", err)
+	}
+	out := make([]store.LuksKey, len(rows))
+	for i, r := range rows {
+		out[i] = luksFromRow(r)
+	}
+	return out, nil
+}
+
+func (l *Luks) GetCurrentForAction(ctx context.Context, key store.LuksKeyByActionKey) (store.LuksKey, error) {
+	row, err := l.q.GetCurrentLuksKeyForAction(ctx, generated.GetCurrentLuksKeyForActionParams{
+		DeviceID: key.DeviceID,
+		ActionID: key.ActionID,
+	})
+	if err != nil {
+		return store.LuksKey{}, fmt.Errorf("luks: get current for action: %w", translateNotFound(err))
+	}
+	return luksFromRow(row), nil
+}
+
+func (l *Luks) CreateToken(ctx context.Context, p store.CreateLuksTokenParams) (store.LuksToken, error) {
+	row, err := l.q.CreateLuksToken(ctx, generated.CreateLuksTokenParams{
+		DeviceID:   p.DeviceID,
+		ActionID:   p.ActionID,
+		Token:      p.Token,
+		MinLength:  p.MinLength,
+		Complexity: p.Complexity,
+	})
+	if err != nil {
+		return store.LuksToken{}, fmt.Errorf("luks: create token: %w", err)
+	}
+	return luksTokenFromRow(row), nil
+}
+
+func (l *Luks) ConsumeToken(ctx context.Context, p store.ConsumeLuksTokenParams) (store.LuksToken, error) {
+	row, err := l.q.ValidateAndConsumeLuksToken(ctx, generated.ValidateAndConsumeLuksTokenParams{
+		Token:    p.Token,
+		DeviceID: p.DeviceID,
+	})
+	if err != nil {
+		return store.LuksToken{}, fmt.Errorf("luks: consume token: %w", translateNotFound(err))
+	}
+	return luksTokenFromRow(row), nil
+}
+
+func (l *Luks) GetRevocationStreamID(ctx context.Context, key store.LuksRevocationStreamKey) (string, error) {
+	id, err := l.q.GetLuksRevocationStreamID(ctx, generated.GetLuksRevocationStreamIDParams{
+		DeviceID: key.DeviceID,
+		ActionID: key.ActionID,
+	})
+	if err != nil {
+		return "", fmt.Errorf("luks: get revocation stream id: %w", translateNotFound(err))
+	}
+	return id, nil
+}
+
+func luksFromRow(r generated.LuksKeysProjection) store.LuksKey {
+	return store.LuksKey{
+		ID:               r.ID,
+		DeviceID:         r.DeviceID,
+		ActionID:         r.ActionID,
+		DevicePath:       r.DevicePath,
+		Passphrase:       r.Passphrase,
+		RotatedAt:        r.RotatedAt,
+		RotationReason:   r.RotationReason,
+		IsCurrent:        r.IsCurrent,
+		CreatedAt:        r.CreatedAt,
+		RevocationStatus: r.RevocationStatus,
+		RevocationError:  r.RevocationError,
+		RevocationAt:     r.RevocationAt,
+	}
+}
+
+func luksTokenFromRow(r generated.LuksToken) store.LuksToken {
+	return store.LuksToken{
+		ID:         r.ID,
+		DeviceID:   r.DeviceID,
+		ActionID:   r.ActionID,
+		Token:      r.Token,
+		MinLength:  r.MinLength,
+		Complexity: r.Complexity,
+		CreatedAt:  r.CreatedAt,
+		ExpiresAt:  r.ExpiresAt,
+		Used:       r.Used,
+	}
+}

--- a/internal/store/postgres/wire.go
+++ b/internal/store/postgres/wire.go
@@ -27,6 +27,8 @@ func NewRepos(q *generated.Queries) *store.Repos {
 		IdentityProvider: NewIdentityProvider(q),
 		Inventory:        NewInventory(q),
 		Logs:             NewLogs(q),
+		Lps:              NewLps(q),
+		Luks:             NewLuks(q),
 		OSQuery:          NewOSQuery(q),
 		RevokedToken:     NewRevokedToken(q),
 		Role:             NewRole(q),

--- a/internal/store/repos.go
+++ b/internal/store/repos.go
@@ -26,6 +26,8 @@ type Repos struct {
 	IdentityProvider IdentityProviderRepo
 	Inventory        InventoryRepo
 	Logs             LogsRepo
+	Lps              LpsRepo
+	Luks             LuksRepo
 	OSQuery          OSQueryRepo
 	RevokedToken     RevokedTokenRepo
 	Role             RoleRepo


### PR DESCRIPTION
## Summary

Two repos for the secret-rotation domains:

**\`LpsRepo\`** (lps_passwords_projection): \`ListCurrent\`, \`ListHistory\`.

**\`LuksRepo\`** (luks_keys_projection + luks_tokens):
- \`ListCurrent\` / \`ListHistory\`
- \`GetCurrentForAction\` — gateway proxy retrieval
- \`CreateToken\` / \`ConsumeToken\` — one-shot mint+burn
- \`GetRevocationStreamID\` — inbox worker appends terminal events to the original revocation stream

Decrypted secrets cross the boundary as plain strings — treat as sensitive in callers.

## Non-goals

- **SecurityAlertRepo** — only callers are the projector listener (Insert / Acknowledge). Pure projector internals; stays on \`Queries()\` until the projector-write wave (F).
- \`UpdateLuksKeyRevocationStatus\` — projector listener write.

## Call sites migrated

- \`device_handler.go\` — LPS + LUKS reads + CreateToken
- \`internal_handler.go\` — GetCurrentForAction ×2 + ConsumeToken
- \`control/inbox_worker.go\` — GetRevocationStreamID

## Acceptance

- Build / vet / staticcheck / gofmt: clean.
- Tests pass: api (40s).

Part of #242. Closes #281.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched device password and encryption-key access to a repository-layer architecture, consolidating read/write paths while preserving existing behavior.
* **New Features**
  * Added backend repositories for password rotation and encrypted-key management, including one-time token minting and consumption and Postgres-backed implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->