### PR TITLE
refactor(store): wave E.2 — drop data->> JSONB filter in GetLuksRevocationStreamID (#283)

### DIFF
--- a/internal/store/generated/luks.sql.go
+++ b/internal/store/generated/luks.sql.go
@@ -170,36 +170,6 @@ func (q *Queries) GetLuksKeyHistory(ctx context.Context, deviceID string) ([]Luk
 	return items, nil
 }
 
-const getLuksRevocationStreamID = `-- name: GetLuksRevocationStreamID :one
-SELECT stream_id
-FROM events
-WHERE stream_type = 'luks_key'
-  AND event_type IN ('LuksDeviceKeyRevocationRequested', 'LuksDeviceKeyRevocationDispatched')
-  AND data->>'device_id' = $1::text
-  AND data->>'action_id' = $2::text
-ORDER BY sequence_num DESC
-LIMIT 1
-`
-
-type GetLuksRevocationStreamIDParams struct {
-	DeviceID string `json:"device_id"`
-	ActionID string `json:"action_id"`
-}
-
-// GetLuksRevocationStreamID looks up the luks_key event-stream ID that
-// was minted when api/device_handler.go appended the
-// LuksDeviceKeyRevocationRequested event for this (device, action).
-// The inbox worker uses it to append the final Revoked / Failed event
-// to the SAME stream so the three-phase projection stitches together.
-// Returns the most recent request if somehow there are multiple (there
-// should only ever be one; LIMIT 1 is belt-and-braces).
-func (q *Queries) GetLuksRevocationStreamID(ctx context.Context, arg GetLuksRevocationStreamIDParams) (string, error) {
-	row := q.db.QueryRow(ctx, getLuksRevocationStreamID, arg.DeviceID, arg.ActionID)
-	var stream_id string
-	err := row.Scan(&stream_id)
-	return stream_id, err
-}
-
 const insertLuksKey = `-- name: InsertLuksKey :exec
 INSERT INTO luks_keys_projection
     (device_id, action_id, device_path, passphrase, rotated_at, rotation_reason, projection_version)
@@ -233,6 +203,53 @@ func (q *Queries) InsertLuksKey(ctx context.Context, arg InsertLuksKeyParams) er
 		arg.ProjectionVersion,
 	)
 	return err
+}
+
+const listLuksRevocationCandidates = `-- name: ListLuksRevocationCandidates :many
+SELECT stream_id, data
+FROM events
+WHERE stream_type = 'luks_key'
+  AND event_type IN ('LuksDeviceKeyRevocationRequested', 'LuksDeviceKeyRevocationDispatched')
+ORDER BY sequence_num DESC
+LIMIT 1000
+`
+
+type ListLuksRevocationCandidatesRow struct {
+	StreamID string `json:"stream_id"`
+	Data     []byte `json:"data"`
+}
+
+// ListLuksRevocationCandidates returns recent luks_key revocation-request /
+// dispatch events for Go-side (device_id, action_id) filtering. Wave E.2
+// moved the filter out of SQL — data->>'device_id' and ->>'action_id'
+// were the last JSONB operators on the events table, blocking the
+// portable-storage goal (tracker #242). The repo method consumes this
+// result and short-circuits on the first match.
+//
+// The LIMIT bounds the worst case: the matching event is typically the
+// most recent one for the requested pair. 1000 covers many devices'
+// recent revocation traffic without any practical risk of scanning past
+// the target. If the projection ever holds more pending revocations
+// than that, raise the LIMIT or paginate — but the inbox worker calls
+// this once per agent outcome, so volume stays bounded in practice.
+func (q *Queries) ListLuksRevocationCandidates(ctx context.Context) ([]ListLuksRevocationCandidatesRow, error) {
+	rows, err := q.db.Query(ctx, listLuksRevocationCandidates)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListLuksRevocationCandidatesRow{}
+	for rows.Next() {
+		var i ListLuksRevocationCandidatesRow
+		if err := rows.Scan(&i.StreamID, &i.Data); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const luksKeyExistsForDeviceActionPath = `-- name: LuksKeyExistsForDeviceActionPath :one

--- a/internal/store/postgres/luks.go
+++ b/internal/store/postgres/luks.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -80,14 +81,23 @@ func (l *Luks) ConsumeToken(ctx context.Context, p store.ConsumeLuksTokenParams)
 }
 
 func (l *Luks) GetRevocationStreamID(ctx context.Context, key store.LuksRevocationStreamKey) (string, error) {
-	id, err := l.q.GetLuksRevocationStreamID(ctx, generated.GetLuksRevocationStreamIDParams{
-		DeviceID: key.DeviceID,
-		ActionID: key.ActionID,
-	})
+	rows, err := l.q.ListLuksRevocationCandidates(ctx)
 	if err != nil {
-		return "", fmt.Errorf("luks: get revocation stream id: %w", translateNotFound(err))
+		return "", fmt.Errorf("luks: list revocation candidates: %w", err)
 	}
-	return id, nil
+	var payload struct {
+		DeviceID string `json:"device_id"`
+		ActionID string `json:"action_id"`
+	}
+	for _, r := range rows {
+		if err := json.Unmarshal(r.Data, &payload); err != nil {
+			continue
+		}
+		if payload.DeviceID == key.DeviceID && payload.ActionID == key.ActionID {
+			return r.StreamID, nil
+		}
+	}
+	return "", fmt.Errorf("luks: get revocation stream id: %w", store.ErrNotFound)
 }
 
 func luksFromRow(r generated.LuksKeysProjection) store.LuksKey {

--- a/internal/store/queries/luks.sql
+++ b/internal/store/queries/luks.sql
@@ -114,20 +114,24 @@ WHERE token = $1
   AND expires_at > NOW()
 RETURNING *;
 
--- GetLuksRevocationStreamID looks up the luks_key event-stream ID that
--- was minted when api/device_handler.go appended the
--- LuksDeviceKeyRevocationRequested event for this (device, action).
--- The inbox worker uses it to append the final Revoked / Failed event
--- to the SAME stream so the three-phase projection stitches together.
--- Returns the most recent request if somehow there are multiple (there
--- should only ever be one; LIMIT 1 is belt-and-braces).
+-- ListLuksRevocationCandidates returns recent luks_key revocation-request /
+-- dispatch events for Go-side (device_id, action_id) filtering. Wave E.2
+-- moved the filter out of SQL — data->>'device_id' and ->>'action_id'
+-- were the last JSONB operators on the events table, blocking the
+-- portable-storage goal (tracker #242). The repo method consumes this
+-- result and short-circuits on the first match.
 --
--- name: GetLuksRevocationStreamID :one
-SELECT stream_id
+-- The LIMIT bounds the worst case: the matching event is typically the
+-- most recent one for the requested pair. 1000 covers many devices'
+-- recent revocation traffic without any practical risk of scanning past
+-- the target. If the projection ever holds more pending revocations
+-- than that, raise the LIMIT or paginate — but the inbox worker calls
+-- this once per agent outcome, so volume stays bounded in practice.
+--
+-- name: ListLuksRevocationCandidates :many
+SELECT stream_id, data
 FROM events
 WHERE stream_type = 'luks_key'
   AND event_type IN ('LuksDeviceKeyRevocationRequested', 'LuksDeviceKeyRevocationDispatched')
-  AND data->>'device_id' = sqlc.arg(device_id)::text
-  AND data->>'action_id' = sqlc.arg(action_id)::text
 ORDER BY sequence_num DESC
-LIMIT 1;
+LIMIT 1000;


### PR DESCRIPTION
Part of the storage-abstraction tracker (#242), Wave E (JSONB normalization).

Closes #283.

## Summary

- Replaces the only remaining JSONB-operator query against the events table.
- New query (ListLuksRevocationCandidates) filters by stream_type + event_type only — both indexed via idx_events_stream / idx_events_stream_type.
- Repo method JSON-decodes and matches (device_id, action_id) in Go.
- Bounded LIMIT 1000 — the matching event is typically the most recent for the pair, so the scan terminates very early in practice.

After this lands the JSONB cleanup remaining for Wave E is on projection columns: users.ssh_public_keys (E.3, → child table) and devices.labels (E.4, → child table).

## Why this shape

Per the Wave E plan in project_storage_abstraction_plan.md: data filtering by JSONB operators doesn't translate to non-PG backends. Path (b) — restrict event-log filtering to indexed columns, decode + filter in Go — keeps the abstraction clean. The volume here is small enough that fetch-then-filter is fine; if profiling later shows a hot path that can't tolerate post-filter, promote that one field to a typed column with a backfill migration.

## Test plan

- [x] go build ./... clean
- [x] go vet ./... clean
- [ ] Integration suite (Asynq inbox worker covers the happy path + ErrNotFound fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized revocation stream lookup by restructuring the filtering logic. The system now retrieves candidate records and applies matching in the application layer rather than exclusively at the database level, improving code flexibility and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->