### PR TITLE
refactor(store): wave E.3 — users.ssh_public_keys → user_ssh_keys child table (#285)

### DIFF
--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"sync/atomic"
@@ -495,23 +494,13 @@ func (m *SystemActionManager) cleanupTtyAction(ctx context.Context, user store.U
 	return nil
 }
 
-// parseSshPublicKeys extracts the public_key strings from the JSONB array.
-func parseSshPublicKeys(raw []byte) []string {
-	if len(raw) == 0 {
-		return nil
-	}
-
-	var keys []struct {
-		PublicKey string `json:"public_key"`
-	}
-	if err := json.Unmarshal(raw, &keys); err != nil {
-		return nil
-	}
-
+// parseSshPublicKeys extracts the non-empty public_key strings from
+// the typed slice the user repo now returns (Wave E.3, tracker #242).
+func parseSshPublicKeys(keys []store.SshPublicKey) []string {
 	result := make([]string, 0, len(keys))
 	for _, k := range keys {
-		if k.PublicKey != "" {
-			result = append(result, k.PublicKey)
+		if k.PublicKey != nil && *k.PublicKey != "" {
+			result = append(result, *k.PublicKey)
 		}
 	}
 	return result

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/json"
 	"log/slog"
 	"time"
 
@@ -550,27 +549,18 @@ func userToProto(u store.User) *pm.User {
 		user.LastLoginAt = timestamppb.New(*u.LastLoginAt)
 	}
 
-	// Parse SSH public keys from JSONB
-	if len(u.SshPublicKeys) > 0 {
-		var keys []struct {
-			ID        string `json:"id"`
-			PublicKey string `json:"public_key"`
-			Comment   string `json:"comment"`
-			AddedAt   string `json:"added_at"`
+	for _, k := range u.SshPublicKeys {
+		pk := &pm.SshPublicKey{
+			Id:      k.KeyID,
+			AddedAt: timestamppb.New(k.AddedAt),
 		}
-		if err := json.Unmarshal(u.SshPublicKeys, &keys); err == nil {
-			for _, k := range keys {
-				pk := &pm.SshPublicKey{
-					Id:        k.ID,
-					PublicKey: k.PublicKey,
-					Comment:   k.Comment,
-				}
-				if t, err := time.Parse(time.RFC3339, k.AddedAt); err == nil {
-					pk.AddedAt = timestamppb.New(t)
-				}
-				user.SshPublicKeys = append(user.SshPublicKeys, pk)
-			}
+		if k.PublicKey != nil {
+			pk.PublicKey = *k.PublicKey
 		}
+		if k.Comment != nil {
+			pk.Comment = *k.Comment
+		}
+		user.SshPublicKeys = append(user.SshPublicKeys, pk)
 	}
 
 	return user

--- a/internal/projectors/user_listener.go
+++ b/internal/projectors/user_listener.go
@@ -358,12 +358,19 @@ func applyUserSshKeyAdded(ctx context.Context, q *store.Queries, e store.Persist
 		}
 		return err
 	}
-	if _, err := q.AppendUserSshKeyProjection(ctx, db.AppendUserSshKeyProjectionParams{
+	if err := q.InsertUserSshKey(ctx, db.InsertUserSshKeyParams{
+		UserID:    payload.ID,
+		KeyID:     payload.KeyID,
+		PublicKey: payload.PublicKey,
+		Comment:   payload.Comment,
+		AddedAt:   payload.AddedAt,
+	}); err != nil {
+		return err
+	}
+	updatedAt := payload.AddedAt
+	if _, err := q.TouchUserUpdatedAt(ctx, db.TouchUserUpdatedAtParams{
 		ID:                payload.ID,
-		KeyID:             payload.KeyID,
-		PublicKey:         payload.PublicKey,
-		Comment:           payload.Comment,
-		AddedAt:           payload.AddedAt,
+		UpdatedAt:         updatedAt,
 		ProjectionVersion: deref(e.SequenceNum),
 	}); err != nil {
 		return err
@@ -379,12 +386,16 @@ func applyUserSshKeyRemoved(ctx context.Context, q *store.Queries, e store.Persi
 		}
 		return err
 	}
-	updatedAt := e.OccurredAt
-	if _, err := q.RemoveUserSshKeyProjection(ctx, db.RemoveUserSshKeyProjectionParams{
+	if err := q.DeleteUserSshKey(ctx, db.DeleteUserSshKeyParams{
+		UserID: payload.ID,
+		KeyID:  payload.KeyID,
+	}); err != nil {
+		return err
+	}
+	if _, err := q.TouchUserUpdatedAt(ctx, db.TouchUserUpdatedAtParams{
 		ID:                payload.ID,
-		UpdatedAt:         &updatedAt,
+		UpdatedAt:         e.OccurredAt,
 		ProjectionVersion: deref(e.SequenceNum),
-		KeyID:             payload.KeyID,
 	}); err != nil {
 		return err
 	}

--- a/internal/projectors/user_test.go
+++ b/internal/projectors/user_test.go
@@ -557,10 +557,12 @@ func TestUserListener_FullLifecycle(t *testing.T) {
 		},
 		ActorType: "user", ActorID: "u",
 	}))
-	got, err = st.Queries().GetUserByID(ctx, userID)
+	keys, err := st.Queries().ListUserSshKeys(ctx, userID)
 	require.NoError(t, err)
-	assert.Contains(t, string(got.SshPublicKeys), "k-1")
-	assert.Contains(t, string(got.SshPublicKeys), "ssh-rsa AAA")
+	require.Len(t, keys, 1)
+	assert.Equal(t, "k-1", keys[0].KeyID)
+	require.NotNil(t, keys[0].PublicKey)
+	assert.Equal(t, "ssh-rsa AAA", *keys[0].PublicKey)
 
 	// 9. SshKeyRemoved — drops the matching element.
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
@@ -568,9 +570,9 @@ func TestUserListener_FullLifecycle(t *testing.T) {
 		Data:      map[string]any{"key_id": "k-1"},
 		ActorType: "user", ActorID: "u",
 	}))
-	got, err = st.Queries().GetUserByID(ctx, userID)
+	keys, err = st.Queries().ListUserSshKeys(ctx, userID)
 	require.NoError(t, err)
-	assert.NotContains(t, string(got.SshPublicKeys), "k-1")
+	assert.Empty(t, keys)
 
 	// 10. SshSettingsUpdated — explicit values.
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
@@ -684,11 +686,15 @@ func TestUserListener_SshKeyFilterIsolatesByID(t *testing.T) {
 		ActorType: "user", ActorID: "u",
 	}))
 
-	got, err := st.Queries().GetUserByID(ctx, userID)
+	keys, err := st.Queries().ListUserSshKeys(ctx, userID)
 	require.NoError(t, err)
-	assert.NotContains(t, string(got.SshPublicKeys), "key-A",
+	keyIDs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		keyIDs = append(keyIDs, k.KeyID)
+	}
+	assert.NotContains(t, keyIDs, "key-A",
 		"UserSshKeyRemoved must drop the matching element")
-	assert.Contains(t, string(got.SshPublicKeys), "key-B",
+	assert.Contains(t, keyIDs, "key-B",
 		"UserSshKeyRemoved must NOT touch other elements")
 }
 

--- a/internal/store/generated/models.go
+++ b/internal/store/generated/models.go
@@ -512,6 +512,14 @@ type UserSelectionsProjection struct {
 	ProjectionVersion int64     `json:"projection_version"`
 }
 
+type UserSshKey struct {
+	UserID    string    `json:"user_id"`
+	KeyID     string    `json:"key_id"`
+	PublicKey *string   `json:"public_key"`
+	Comment   *string   `json:"comment"`
+	AddedAt   time.Time `json:"added_at"`
+}
+
 type UsersProjection struct {
 	ID                      string     `json:"id"`
 	Email                   string     `json:"email"`
@@ -534,7 +542,6 @@ type UsersProjection struct {
 	Locale                  string     `json:"locale"`
 	LinuxUsername           string     `json:"linux_username"`
 	LinuxUid                int32      `json:"linux_uid"`
-	SshPublicKeys           []byte     `json:"ssh_public_keys"`
 	SshAccessEnabled        bool       `json:"ssh_access_enabled"`
 	SshAllowPubkey          bool       `json:"ssh_allow_pubkey"`
 	SshAllowPassword        bool       `json:"ssh_allow_password"`

--- a/internal/store/generated/scim.sql.go
+++ b/internal/store/generated/scim.sql.go
@@ -55,7 +55,7 @@ func (q *Queries) DeleteSCIMGroupMappingByCompositeKey(ctx context.Context, arg 
 }
 
 const findSCIMUserByEmail = `-- name: FindSCIMUserByEmail :one
-SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id, il.external_id AS scim_external_id
+SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id, il.external_id AS scim_external_id
 FROM users_projection u
 JOIN identity_links_projection il ON il.user_id = u.id
 WHERE il.provider_id = $1 AND u.email = $2 AND u.is_deleted = FALSE
@@ -88,7 +88,6 @@ type FindSCIMUserByEmailRow struct {
 	Locale                  string     `json:"locale"`
 	LinuxUsername           string     `json:"linux_username"`
 	LinuxUid                int32      `json:"linux_uid"`
-	SshPublicKeys           []byte     `json:"ssh_public_keys"`
 	SshAccessEnabled        bool       `json:"ssh_access_enabled"`
 	SshAllowPubkey          bool       `json:"ssh_allow_pubkey"`
 	SshAllowPassword        bool       `json:"ssh_allow_password"`
@@ -124,7 +123,6 @@ func (q *Queries) FindSCIMUserByEmail(ctx context.Context, arg FindSCIMUserByEma
 		&i.Locale,
 		&i.LinuxUsername,
 		&i.LinuxUid,
-		&i.SshPublicKeys,
 		&i.SshAccessEnabled,
 		&i.SshAllowPubkey,
 		&i.SshAllowPassword,
@@ -138,7 +136,7 @@ func (q *Queries) FindSCIMUserByEmail(ctx context.Context, arg FindSCIMUserByEma
 }
 
 const findSCIMUserByExternalID = `-- name: FindSCIMUserByExternalID :one
-SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id, il.external_id AS scim_external_id
+SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id, il.external_id AS scim_external_id
 FROM users_projection u
 JOIN identity_links_projection il ON il.user_id = u.id
 WHERE il.provider_id = $1 AND il.external_id = $2 AND u.is_deleted = FALSE
@@ -171,7 +169,6 @@ type FindSCIMUserByExternalIDRow struct {
 	Locale                  string     `json:"locale"`
 	LinuxUsername           string     `json:"linux_username"`
 	LinuxUid                int32      `json:"linux_uid"`
-	SshPublicKeys           []byte     `json:"ssh_public_keys"`
 	SshAccessEnabled        bool       `json:"ssh_access_enabled"`
 	SshAllowPubkey          bool       `json:"ssh_allow_pubkey"`
 	SshAllowPassword        bool       `json:"ssh_allow_password"`
@@ -207,7 +204,6 @@ func (q *Queries) FindSCIMUserByExternalID(ctx context.Context, arg FindSCIMUser
 		&i.Locale,
 		&i.LinuxUsername,
 		&i.LinuxUid,
-		&i.SshPublicKeys,
 		&i.SshAccessEnabled,
 		&i.SshAllowPubkey,
 		&i.SshAllowPassword,
@@ -310,7 +306,7 @@ func (q *Queries) GetSCIMGroupMappingByUserGroup(ctx context.Context, arg GetSCI
 }
 
 const getUserByExternalSCIMID = `-- name: GetUserByExternalSCIMID :one
-SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id FROM users_projection u
+SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id FROM users_projection u
 JOIN identity_links_projection il ON il.user_id = u.id
 WHERE il.provider_id = $1 AND il.external_id = $2 AND u.is_deleted = FALSE
 `
@@ -345,7 +341,6 @@ func (q *Queries) GetUserByExternalSCIMID(ctx context.Context, arg GetUserByExte
 		&i.Locale,
 		&i.LinuxUsername,
 		&i.LinuxUid,
-		&i.SshPublicKeys,
 		&i.SshAccessEnabled,
 		&i.SshAllowPubkey,
 		&i.SshAllowPassword,
@@ -453,7 +448,7 @@ func (q *Queries) ListSCIMGroupMappings(ctx context.Context, providerID string) 
 }
 
 const listSCIMUsers = `-- name: ListSCIMUsers :many
-SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_public_keys, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id, il.external_id AS scim_external_id
+SELECT u.id, u.email, u.password_hash, u.role, u.created_at, u.updated_at, u.last_login_at, u.disabled, u.is_deleted, u.projection_version, u.session_version, u.has_password, u.totp_enabled, u.display_name, u.given_name, u.family_name, u.preferred_username, u.picture, u.locale, u.linux_username, u.linux_uid, u.ssh_access_enabled, u.ssh_allow_pubkey, u.ssh_allow_password, u.system_user_action_id, u.system_ssh_action_id, u.user_provisioning_enabled, u.system_tty_action_id, il.external_id AS scim_external_id
 FROM users_projection u
 JOIN identity_links_projection il ON il.user_id = u.id
 WHERE il.provider_id = $1 AND u.is_deleted = FALSE
@@ -489,7 +484,6 @@ type ListSCIMUsersRow struct {
 	Locale                  string     `json:"locale"`
 	LinuxUsername           string     `json:"linux_username"`
 	LinuxUid                int32      `json:"linux_uid"`
-	SshPublicKeys           []byte     `json:"ssh_public_keys"`
 	SshAccessEnabled        bool       `json:"ssh_access_enabled"`
 	SshAllowPubkey          bool       `json:"ssh_allow_pubkey"`
 	SshAllowPassword        bool       `json:"ssh_allow_password"`
@@ -531,7 +525,6 @@ func (q *Queries) ListSCIMUsers(ctx context.Context, arg ListSCIMUsersParams) ([
 			&i.Locale,
 			&i.LinuxUsername,
 			&i.LinuxUid,
-			&i.SshPublicKeys,
 			&i.SshAccessEnabled,
 			&i.SshAllowPubkey,
 			&i.SshAllowPassword,

--- a/internal/store/generated/users.sql.go
+++ b/internal/store/generated/users.sql.go
@@ -10,53 +10,6 @@ import (
 	"time"
 )
 
-const appendUserSshKeyProjection = `-- name: AppendUserSshKeyProjection :execrows
-UPDATE users_projection
-SET ssh_public_keys = ssh_public_keys || jsonb_build_array(
-        jsonb_build_object(
-            'id', $1::TEXT,
-            'public_key', $2::TEXT,
-            'comment', $3::TEXT,
-            'added_at', $4::TIMESTAMPTZ
-        )
-    ),
-    updated_at         = $4::TIMESTAMPTZ,
-    projection_version = $5
-WHERE id = $6
-  AND projection_version < $5
-`
-
-type AppendUserSshKeyProjectionParams struct {
-	KeyID             string    `json:"key_id"`
-	PublicKey         *string   `json:"public_key"`
-	Comment           *string   `json:"comment"`
-	AddedAt           time.Time `json:"added_at"`
-	ProjectionVersion int64     `json:"projection_version"`
-	ID                string    `json:"id"`
-}
-
-// UserSshKeyAdded handler. Mirrors the PL/pgSQL JSONB array-append
-// exactly: builds a single-element array and concatenates.
-// public_key + comment use sqlc.narg so an omitted-key payload
-// writes JSON null into the JSONB element (PL/pgSQL parity:
-// `event.data->>'public_key'` returned NULL for missing keys, and
-// jsonb_build_object preserves NULL as a JSON null entry).
-// Stale-replay guard via projection_version.
-func (q *Queries) AppendUserSshKeyProjection(ctx context.Context, arg AppendUserSshKeyProjectionParams) (int64, error) {
-	result, err := q.db.Exec(ctx, appendUserSshKeyProjection,
-		arg.KeyID,
-		arg.PublicKey,
-		arg.Comment,
-		arg.AddedAt,
-		arg.ProjectionVersion,
-		arg.ID,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
-}
-
 const countUsers = `-- name: CountUsers :one
 SELECT COUNT(*) FROM users_projection
 WHERE is_deleted = FALSE
@@ -78,6 +31,24 @@ DELETE FROM identity_links_projection WHERE user_id = $1
 // in store.WithTx for inter-write atomicity.
 func (q *Queries) DeleteIdentityLinksByUser(ctx context.Context, userID string) error {
 	_, err := q.db.Exec(ctx, deleteIdentityLinksByUser, userID)
+	return err
+}
+
+const deleteUserSshKey = `-- name: DeleteUserSshKey :exec
+DELETE FROM user_ssh_keys
+WHERE user_id = $1
+  AND key_id = $2
+`
+
+type DeleteUserSshKeyParams struct {
+	UserID string `json:"user_id"`
+	KeyID  string `json:"key_id"`
+}
+
+// UserSshKeyRemoved handler. DELETE on the child table — replay-safe
+// because removing an already-absent row is a no-op.
+func (q *Queries) DeleteUserSshKey(ctx context.Context, arg DeleteUserSshKeyParams) error {
+	_, err := q.db.Exec(ctx, deleteUserSshKey, arg.UserID, arg.KeyID)
 	return err
 }
 
@@ -148,7 +119,7 @@ func (q *Queries) GetNextLinuxUID(ctx context.Context) (int32, error) {
 }
 
 const getUserByEmail = `-- name: GetUserByEmail :one
-SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
+SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 WHERE email = $1 AND is_deleted = FALSE
 `
 
@@ -177,7 +148,6 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (UsersProjec
 		&i.Locale,
 		&i.LinuxUsername,
 		&i.LinuxUid,
-		&i.SshPublicKeys,
 		&i.SshAccessEnabled,
 		&i.SshAllowPubkey,
 		&i.SshAllowPassword,
@@ -190,7 +160,7 @@ func (q *Queries) GetUserByEmail(ctx context.Context, email string) (UsersProjec
 }
 
 const getUserByID = `-- name: GetUserByID :one
-SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
+SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 WHERE id = $1 AND is_deleted = FALSE
 `
 
@@ -219,7 +189,6 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (UsersProjection, 
 		&i.Locale,
 		&i.LinuxUsername,
 		&i.LinuxUid,
-		&i.SshPublicKeys,
 		&i.SshAccessEnabled,
 		&i.SshAllowPubkey,
 		&i.SshAllowPassword,
@@ -307,6 +276,42 @@ func (q *Queries) InsertUserProjection(ctx context.Context, arg InsertUserProjec
 	return err
 }
 
+const insertUserSshKey = `-- name: InsertUserSshKey :exec
+INSERT INTO user_ssh_keys (user_id, key_id, public_key, comment, added_at)
+VALUES (
+    $1,
+    $2::TEXT,
+    $3::TEXT,
+    $4::TEXT,
+    $5::TIMESTAMPTZ
+)
+ON CONFLICT (user_id, key_id) DO NOTHING
+`
+
+type InsertUserSshKeyParams struct {
+	UserID    string    `json:"user_id"`
+	KeyID     string    `json:"key_id"`
+	PublicKey *string   `json:"public_key"`
+	Comment   *string   `json:"comment"`
+	AddedAt   time.Time `json:"added_at"`
+}
+
+// UserSshKeyAdded handler against the user_ssh_keys child table (Wave
+// E.3 — tracker #242). Replaces the JSONB array-append shape. The
+// ON CONFLICT clause makes replays safe: re-applying the same event
+// against an already-populated table no-ops on the (user_id, key_id)
+// PK rather than corrupting the row.
+func (q *Queries) InsertUserSshKey(ctx context.Context, arg InsertUserSshKeyParams) error {
+	_, err := q.db.Exec(ctx, insertUserSshKey,
+		arg.UserID,
+		arg.KeyID,
+		arg.PublicKey,
+		arg.Comment,
+		arg.AddedAt,
+	)
+	return err
+}
+
 const invalidateUserSessionProjection = `-- name: InvalidateUserSessionProjection :execrows
 UPDATE users_projection
 SET session_version    = session_version + 1,
@@ -382,7 +387,7 @@ func (q *Queries) LinkUserSystemActionProjection(ctx context.Context, arg LinkUs
 }
 
 const listAllNonDeletedUsers = `-- name: ListAllNonDeletedUsers :many
-SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
+SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 WHERE is_deleted = FALSE
 ORDER BY created_at
 `
@@ -418,7 +423,6 @@ func (q *Queries) ListAllNonDeletedUsers(ctx context.Context) ([]UsersProjection
 			&i.Locale,
 			&i.LinuxUsername,
 			&i.LinuxUid,
-			&i.SshPublicKeys,
 			&i.SshAccessEnabled,
 			&i.SshAllowPubkey,
 			&i.SshAllowPassword,
@@ -438,7 +442,7 @@ func (q *Queries) ListAllNonDeletedUsers(ctx context.Context) ([]UsersProjection
 }
 
 const listAllUsers = `-- name: ListAllUsers :many
-SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
+SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
 `
@@ -479,7 +483,6 @@ func (q *Queries) ListAllUsers(ctx context.Context, arg ListAllUsersParams) ([]U
 			&i.Locale,
 			&i.LinuxUsername,
 			&i.LinuxUid,
-			&i.SshPublicKeys,
 			&i.SshAccessEnabled,
 			&i.SshAllowPubkey,
 			&i.SshAllowPassword,
@@ -498,8 +501,78 @@ func (q *Queries) ListAllUsers(ctx context.Context, arg ListAllUsersParams) ([]U
 	return items, nil
 }
 
+const listUserSshKeys = `-- name: ListUserSshKeys :many
+SELECT user_id, key_id, public_key, comment, added_at
+FROM user_ssh_keys
+WHERE user_id = $1
+ORDER BY added_at, key_id
+`
+
+// Fetch all SSH keys for one user, ordered by added_at then key_id for
+// stable replay output. Used by user repo Get methods.
+func (q *Queries) ListUserSshKeys(ctx context.Context, userID string) ([]UserSshKey, error) {
+	rows, err := q.db.Query(ctx, listUserSshKeys, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UserSshKey{}
+	for rows.Next() {
+		var i UserSshKey
+		if err := rows.Scan(
+			&i.UserID,
+			&i.KeyID,
+			&i.PublicKey,
+			&i.Comment,
+			&i.AddedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUserSshKeysBatch = `-- name: ListUserSshKeysBatch :many
+SELECT user_id, key_id, public_key, comment, added_at
+FROM user_ssh_keys
+WHERE user_id = ANY($1::TEXT[])
+ORDER BY user_id, added_at, key_id
+`
+
+// Batch SSH-key fetch for list endpoints: returns rows for every user
+// in the input slice in a single round-trip so repo.List doesn't N+1.
+func (q *Queries) ListUserSshKeysBatch(ctx context.Context, userIds []string) ([]UserSshKey, error) {
+	rows, err := q.db.Query(ctx, listUserSshKeysBatch, userIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UserSshKey{}
+	for rows.Next() {
+		var i UserSshKey
+		if err := rows.Scan(
+			&i.UserID,
+			&i.KeyID,
+			&i.PublicKey,
+			&i.Comment,
+			&i.AddedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUsers = `-- name: ListUsers :many
-SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_public_keys, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
+SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 WHERE is_deleted = FALSE
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
@@ -541,7 +614,6 @@ func (q *Queries) ListUsers(ctx context.Context, arg ListUsersParams) ([]UsersPr
 			&i.Locale,
 			&i.LinuxUsername,
 			&i.LinuxUid,
-			&i.SshPublicKeys,
 			&i.SshAccessEnabled,
 			&i.SshAllowPubkey,
 			&i.SshAllowPassword,
@@ -558,43 +630,6 @@ func (q *Queries) ListUsers(ctx context.Context, arg ListUsersParams) ([]UsersPr
 		return nil, err
 	}
 	return items, nil
-}
-
-const removeUserSshKeyProjection = `-- name: RemoveUserSshKeyProjection :execrows
-UPDATE users_projection
-SET ssh_public_keys = COALESCE((
-        SELECT jsonb_agg(e.value)
-        FROM jsonb_array_elements(ssh_public_keys) AS e(value)
-        WHERE e.value->>'id' != $4::TEXT
-    ), '[]'::JSONB),
-    updated_at         = $2,
-    projection_version = $3
-WHERE id = $1
-  AND projection_version < $3
-`
-
-type RemoveUserSshKeyProjectionParams struct {
-	ID                string     `json:"id"`
-	UpdatedAt         *time.Time `json:"updated_at"`
-	ProjectionVersion int64      `json:"projection_version"`
-	KeyID             string     `json:"key_id"`
-}
-
-// UserSshKeyRemoved handler. Mirrors the PL/pgSQL JSONB filter-by-id
-// via subquery exactly — the array filter happens in SQL so we
-// don't read-modify-write the JSONB blob through Go.
-// Stale-replay guard via projection_version.
-func (q *Queries) RemoveUserSshKeyProjection(ctx context.Context, arg RemoveUserSshKeyProjectionParams) (int64, error) {
-	result, err := q.db.Exec(ctx, removeUserSshKeyProjection,
-		arg.ID,
-		arg.UpdatedAt,
-		arg.ProjectionVersion,
-		arg.KeyID,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
 }
 
 const softDeleteUserProjection = `-- name: SoftDeleteUserProjection :execrows
@@ -621,6 +656,33 @@ type SoftDeleteUserProjectionParams struct {
 // on PR #101 pattern).
 func (q *Queries) SoftDeleteUserProjection(ctx context.Context, arg SoftDeleteUserProjectionParams) (int64, error) {
 	result, err := q.db.Exec(ctx, softDeleteUserProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const touchUserUpdatedAt = `-- name: TouchUserUpdatedAt :execrows
+UPDATE users_projection
+SET updated_at         = $1::TIMESTAMPTZ,
+    projection_version = $2
+WHERE id = $3
+  AND projection_version < $2
+`
+
+type TouchUserUpdatedAtParams struct {
+	UpdatedAt         time.Time `json:"updated_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+	ID                string    `json:"id"`
+}
+
+// Companion write for InsertUserSshKey + DeleteUserSshKey. The PL/pgSQL
+// shape coupled the JSONB write to updated_at + projection_version on
+// users_projection. The child table replaces the array but the listener
+// still wants to mark the user row updated and bump the stale-replay
+// version. Stale-replay guard via projection_version.
+func (q *Queries) TouchUserUpdatedAt(ctx context.Context, arg TouchUserUpdatedAtParams) (int64, error) {
+	result, err := q.db.Exec(ctx, touchUserUpdatedAt, arg.UpdatedAt, arg.ProjectionVersion, arg.ID)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/migrations/045_user_ssh_keys_child_table.sql
+++ b/internal/store/migrations/045_user_ssh_keys_child_table.sql
@@ -1,0 +1,57 @@
+-- Wave E.3 (tracker manchtools/power-manage-server#242): normalize the
+-- users_projection.ssh_public_keys JSONB array into a relational child
+-- table. The previous shape (jsonb_array_elements + array-append +
+-- filter-by-id) doesn't translate to non-Postgres backends; INSERT /
+-- DELETE against a child table does.
+--
+-- Idempotency for projector replay: PRIMARY KEY (user_id, key_id)
+-- combined with ON CONFLICT DO NOTHING on insert (handled in the new
+-- sqlc query) makes UserSshKeyAdded replays a safe no-op. DELETE is
+-- inherently idempotent.
+
+-- +goose Up
+CREATE TABLE user_ssh_keys (
+    user_id    TEXT        NOT NULL REFERENCES users_projection(id) ON DELETE CASCADE,
+    key_id     TEXT        NOT NULL,
+    public_key TEXT,
+    comment    TEXT,
+    added_at   TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (user_id, key_id)
+);
+
+CREATE INDEX idx_user_ssh_keys_user ON user_ssh_keys(user_id);
+
+INSERT INTO user_ssh_keys (user_id, key_id, public_key, comment, added_at)
+SELECT
+    u.id,
+    e.value->>'id',
+    NULLIF(e.value->>'public_key', ''),
+    NULLIF(e.value->>'comment', ''),
+    COALESCE((e.value->>'added_at')::TIMESTAMPTZ, u.created_at)
+FROM users_projection u,
+     jsonb_array_elements(u.ssh_public_keys) AS e(value)
+WHERE u.ssh_public_keys IS NOT NULL
+  AND jsonb_typeof(u.ssh_public_keys) = 'array'
+  AND e.value->>'id' IS NOT NULL
+ON CONFLICT (user_id, key_id) DO NOTHING;
+
+ALTER TABLE users_projection DROP COLUMN ssh_public_keys;
+
+-- +goose Down
+ALTER TABLE users_projection
+    ADD COLUMN ssh_public_keys JSONB NOT NULL DEFAULT '[]';
+
+UPDATE users_projection u
+SET ssh_public_keys = COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+            'id', k.key_id,
+            'public_key', k.public_key,
+            'comment', k.comment,
+            'added_at', k.added_at
+        ))
+        FROM user_ssh_keys k
+        WHERE k.user_id = u.id
+    ), '[]'::JSONB);
+
+DROP INDEX IF EXISTS idx_user_ssh_keys_user;
+DROP TABLE user_ssh_keys;

--- a/internal/store/postgres/user.go
+++ b/internal/store/postgres/user.go
@@ -2,14 +2,14 @@ package postgres
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
-// User implements store.UserRepo against users_projection.
+// User implements store.UserRepo against users_projection +
+// user_ssh_keys (the SSH keys live in a child table after Wave E.3).
 type User struct {
 	q *generated.Queries
 }
@@ -24,7 +24,13 @@ func (u *User) Get(ctx context.Context, id string) (store.User, error) {
 	if err != nil {
 		return store.User{}, fmt.Errorf("user: get: %w", translateNotFound(err))
 	}
-	return userFromRow(row), nil
+	user := userFromRow(row)
+	keys, err := u.q.ListUserSshKeys(ctx, id)
+	if err != nil {
+		return store.User{}, fmt.Errorf("user: list ssh keys: %w", err)
+	}
+	user.SshPublicKeys = sshKeysFromRows(keys)
+	return user, nil
 }
 
 func (u *User) GetByEmail(ctx context.Context, email string) (store.User, error) {
@@ -32,7 +38,13 @@ func (u *User) GetByEmail(ctx context.Context, email string) (store.User, error)
 	if err != nil {
 		return store.User{}, fmt.Errorf("user: get by email: %w", translateNotFound(err))
 	}
-	return userFromRow(row), nil
+	user := userFromRow(row)
+	keys, err := u.q.ListUserSshKeys(ctx, user.ID)
+	if err != nil {
+		return store.User{}, fmt.Errorf("user: list ssh keys: %w", err)
+	}
+	user.SshPublicKeys = sshKeysFromRows(keys)
+	return user, nil
 }
 
 func (u *User) SessionInfo(ctx context.Context, userID string) (store.UserSessionInfo, error) {
@@ -72,8 +84,13 @@ func (u *User) List(ctx context.Context, filter store.ListUsersFilter) ([]store.
 		return nil, fmt.Errorf("user: list: %w", err)
 	}
 	out := make([]store.User, len(rows))
+	ids := make([]string, len(rows))
 	for i, r := range rows {
 		out[i] = userFromRow(r)
+		ids[i] = r.ID
+	}
+	if err := u.attachSshKeys(ctx, out, ids); err != nil {
+		return nil, err
 	}
 	return out, nil
 }
@@ -92,14 +109,62 @@ func (u *User) ListAllNonDeleted(ctx context.Context) ([]store.User, error) {
 		return nil, fmt.Errorf("user: list all non-deleted: %w", err)
 	}
 	out := make([]store.User, len(rows))
+	ids := make([]string, len(rows))
 	for i, r := range rows {
 		out[i] = userFromRow(r)
+		ids[i] = r.ID
+	}
+	if err := u.attachSshKeys(ctx, out, ids); err != nil {
+		return nil, err
 	}
 	return out, nil
 }
 
+// attachSshKeys batch-loads SSH keys for the given user IDs and
+// distributes them across the matching slice entries. Single round-trip
+// for list endpoints so callers don't N+1.
+func (u *User) attachSshKeys(ctx context.Context, users []store.User, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	rows, err := u.q.ListUserSshKeysBatch(ctx, ids)
+	if err != nil {
+		return fmt.Errorf("user: list ssh keys batch: %w", err)
+	}
+	byUser := make(map[string][]store.SshPublicKey, len(ids))
+	for _, k := range rows {
+		byUser[k.UserID] = append(byUser[k.UserID], sshKeyFromRow(k))
+	}
+	for i := range users {
+		users[i].SshPublicKeys = byUser[users[i].ID]
+	}
+	return nil
+}
+
+func sshKeysFromRows(rows []generated.UserSshKey) []store.SshPublicKey {
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make([]store.SshPublicKey, len(rows))
+	for i, r := range rows {
+		out[i] = sshKeyFromRow(r)
+	}
+	return out
+}
+
+func sshKeyFromRow(r generated.UserSshKey) store.SshPublicKey {
+	return store.SshPublicKey{
+		KeyID:     r.KeyID,
+		PublicKey: r.PublicKey,
+		Comment:   r.Comment,
+		AddedAt:   r.AddedAt,
+	}
+}
+
 // userFromRow translates a sqlc projection row to the domain shape.
-// Shared so the field mapping lives in one place.
+// SshPublicKeys is populated separately from the user_ssh_keys child
+// table — callers should follow up with a ListUserSshKeys / batch fetch
+// (the Get / List methods on this repo do this automatically).
 func userFromRow(r generated.UsersProjection) store.User {
 	return store.User{
 		ID:                      r.ID,
@@ -122,7 +187,6 @@ func userFromRow(r generated.UsersProjection) store.User {
 		Locale:                  r.Locale,
 		LinuxUsername:           r.LinuxUsername,
 		LinuxUID:                r.LinuxUid,
-		SshPublicKeys:           json.RawMessage(r.SshPublicKeys),
 		SshAccessEnabled:        r.SshAccessEnabled,
 		SshAllowPubkey:          r.SshAllowPubkey,
 		SshAllowPassword:        r.SshAllowPassword,

--- a/internal/store/queries/users.sql
+++ b/internal/store/queries/users.sql
@@ -166,43 +166,56 @@ WHERE id = $1
 -- in store.WithTx for inter-write atomicity.
 DELETE FROM identity_links_projection WHERE user_id = $1;
 
--- name: AppendUserSshKeyProjection :execrows
--- UserSshKeyAdded handler. Mirrors the PL/pgSQL JSONB array-append
--- exactly: builds a single-element array and concatenates.
--- public_key + comment use sqlc.narg so an omitted-key payload
--- writes JSON null into the JSONB element (PL/pgSQL parity:
--- `event.data->>'public_key'` returned NULL for missing keys, and
--- jsonb_build_object preserves NULL as a JSON null entry).
--- Stale-replay guard via projection_version.
+-- name: InsertUserSshKey :exec
+-- UserSshKeyAdded handler against the user_ssh_keys child table (Wave
+-- E.3 — tracker #242). Replaces the JSONB array-append shape. The
+-- ON CONFLICT clause makes replays safe: re-applying the same event
+-- against an already-populated table no-ops on the (user_id, key_id)
+-- PK rather than corrupting the row.
+INSERT INTO user_ssh_keys (user_id, key_id, public_key, comment, added_at)
+VALUES (
+    sqlc.arg(user_id),
+    sqlc.arg(key_id)::TEXT,
+    sqlc.narg(public_key)::TEXT,
+    sqlc.narg(comment)::TEXT,
+    sqlc.arg(added_at)::TIMESTAMPTZ
+)
+ON CONFLICT (user_id, key_id) DO NOTHING;
+
+-- name: TouchUserUpdatedAt :execrows
+-- Companion write for InsertUserSshKey + DeleteUserSshKey. The PL/pgSQL
+-- shape coupled the JSONB write to updated_at + projection_version on
+-- users_projection. The child table replaces the array but the listener
+-- still wants to mark the user row updated and bump the stale-replay
+-- version. Stale-replay guard via projection_version.
 UPDATE users_projection
-SET ssh_public_keys = ssh_public_keys || jsonb_build_array(
-        jsonb_build_object(
-            'id', sqlc.arg(key_id)::TEXT,
-            'public_key', sqlc.narg(public_key)::TEXT,
-            'comment', sqlc.narg(comment)::TEXT,
-            'added_at', sqlc.arg(added_at)::TIMESTAMPTZ
-        )
-    ),
-    updated_at         = sqlc.arg(added_at)::TIMESTAMPTZ,
+SET updated_at         = sqlc.arg(updated_at)::TIMESTAMPTZ,
     projection_version = sqlc.arg(projection_version)
 WHERE id = sqlc.arg(id)
   AND projection_version < sqlc.arg(projection_version);
 
--- name: RemoveUserSshKeyProjection :execrows
--- UserSshKeyRemoved handler. Mirrors the PL/pgSQL JSONB filter-by-id
--- via subquery exactly — the array filter happens in SQL so we
--- don't read-modify-write the JSONB blob through Go.
--- Stale-replay guard via projection_version.
-UPDATE users_projection
-SET ssh_public_keys = COALESCE((
-        SELECT jsonb_agg(e.value)
-        FROM jsonb_array_elements(ssh_public_keys) AS e(value)
-        WHERE e.value->>'id' != @key_id::TEXT
-    ), '[]'::JSONB),
-    updated_at         = $2,
-    projection_version = $3
-WHERE id = $1
-  AND projection_version < $3;
+-- name: DeleteUserSshKey :exec
+-- UserSshKeyRemoved handler. DELETE on the child table — replay-safe
+-- because removing an already-absent row is a no-op.
+DELETE FROM user_ssh_keys
+WHERE user_id = sqlc.arg(user_id)
+  AND key_id = sqlc.arg(key_id);
+
+-- name: ListUserSshKeys :many
+-- Fetch all SSH keys for one user, ordered by added_at then key_id for
+-- stable replay output. Used by user repo Get methods.
+SELECT user_id, key_id, public_key, comment, added_at
+FROM user_ssh_keys
+WHERE user_id = $1
+ORDER BY added_at, key_id;
+
+-- name: ListUserSshKeysBatch :many
+-- Batch SSH-key fetch for list endpoints: returns rows for every user
+-- in the input slice in a single round-trip so repo.List doesn't N+1.
+SELECT user_id, key_id, public_key, comment, added_at
+FROM user_ssh_keys
+WHERE user_id = ANY(sqlc.arg(user_ids)::TEXT[])
+ORDER BY user_id, added_at, key_id;
 
 -- name: UpdateUserSshSettingsProjection :execrows
 -- UserSshSettingsUpdated handler. Each boolean is COALESCE-preserved

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -2,18 +2,16 @@ package store
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 )
 
-// User is the user projection row. PasswordHash and SSH key material
-// stay encoded as-stored at the boundary; handlers verify against
-// auth.VerifyPassword / parse SSH keys when they actually need to
-// consume those bytes.
+// User is the user projection row. PasswordHash stays encoded
+// as-stored at the boundary; handlers verify against auth.VerifyPassword
+// when they actually need to consume those bytes.
 //
-// SshPublicKeys is JSON at the row level (an array of {id, key, …}
-// objects) and stays as json.RawMessage at the boundary per the
-// JSONB normalize plan in #242.
+// SshPublicKeys is a typed slice loaded from the user_ssh_keys child
+// table (Wave E.3, tracker #242) — repo implementations populate it
+// alongside the core row.
 type User struct {
 	ID                      string
 	Email                   string
@@ -35,7 +33,7 @@ type User struct {
 	Locale                  string
 	LinuxUsername           string
 	LinuxUID                int32
-	SshPublicKeys           json.RawMessage
+	SshPublicKeys           []SshPublicKey
 	SshAccessEnabled        bool
 	SshAllowPubkey          bool
 	SshAllowPassword        bool
@@ -43,6 +41,17 @@ type User struct {
 	SystemSshActionID       string
 	UserProvisioningEnabled bool
 	SystemTtyActionID       string
+}
+
+// SshPublicKey is one row from the user_ssh_keys child table. PublicKey
+// and Comment are pointers because the projector preserves "field
+// absent in payload" semantics (PL/pgSQL parity: missing keys become
+// SQL NULL, which round-trips as nil for downstream consumers).
+type SshPublicKey struct {
+	KeyID     string
+	PublicKey *string
+	Comment   *string
+	AddedAt   time.Time
 }
 
 // UserSessionInfo is the narrow shape returned for the refresh-token


### PR DESCRIPTION
Part of the storage-abstraction tracker (#242), Wave E (JSONB normalization).

Closes #285.

## Summary

- Migration 045 creates user_ssh_keys(user_id FK, key_id, public_key, comment, added_at) with PK (user_id, key_id), backfills from the existing JSONB column, then drops users_projection.ssh_public_keys.
- Idempotent projector path via ON CONFLICT DO NOTHING for INSERT and inherently-idempotent DELETE — no projection_version guard needed on the child table itself; the user-row updated_at + projection_version bump goes through the new TouchUserUpdatedAt query.
- store.User.SshPublicKeys becomes a typed []SshPublicKey slice; postgres repo Get/List/ListAllNonDeleted methods populate it via ListUserSshKeys / ListUserSshKeysBatch.
- Handlers (user_handler.userToProto, system_actions.parseSshPublicKeys) iterate the typed slice directly.
- AllRebuildTargets unchanged — the existing 'users' target's TRUNCATE CASCADE follows the FK to user_ssh_keys.

## DoD checks

- [x] go build clean
- [x] go vet clean
- [x] Targeted projector tests pass (UserSshKey, UserListener)
- [ ] CI integration suite

Remaining JSONB operator usage on projection columns after this lands: devices.labels (E.4).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized SSH public key storage and retrieval architecture for improved database efficiency and maintainability.

* **Tests**
  * Updated SSH key-related test assertions to work with the new storage implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->