### PR TITLE
refactor(store): wave C.1 — port validate_dynamic_query / validate_user_group_query to Go (#287)

### DIFF
--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -10,6 +10,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/go/maintenance"
+	"github.com/manchtools/power-manage/server/internal/dynamicquery"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/search"
@@ -50,12 +51,8 @@ func (h *DeviceGroupHandler) CreateDeviceGroup(ctx context.Context, req *connect
 		if len(req.Msg.DynamicQuery) > maxDynamicQueryLength {
 			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "dynamic_query exceeds maximum length")
 		}
-		validationErr, err := h.store.Queries().ValidateDynamicQuery(ctx, req.Msg.DynamicQuery)
-		if err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate query")
-		}
-		if validationErr != "" {
-			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, validationErr)
+		if err := dynamicquery.ValidateDeviceQuery(req.Msg.DynamicQuery); err != nil {
+			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, err.Error())
 		}
 	}
 
@@ -401,12 +398,8 @@ func (h *DeviceGroupHandler) UpdateDeviceGroupQuery(ctx context.Context, req *co
 		if len(req.Msg.DynamicQuery) > maxDynamicQueryLength {
 			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "dynamic_query exceeds maximum length")
 		}
-		validationErr, err := h.store.Queries().ValidateDynamicQuery(ctx, req.Msg.DynamicQuery)
-		if err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate query")
-		}
-		if validationErr != "" {
-			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, validationErr)
+		if err := dynamicquery.ValidateDeviceQuery(req.Msg.DynamicQuery); err != nil {
+			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, err.Error())
 		}
 	}
 
@@ -440,15 +433,10 @@ func (h *DeviceGroupHandler) ValidateDynamicQuery(ctx context.Context, req *conn
 		return nil, err
 	}
 
-	validationErr, err := h.store.Queries().ValidateDynamicQuery(ctx, req.Msg.Query)
-	if err != nil {
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate query")
-	}
-
-	if validationErr != "" {
+	if err := dynamicquery.ValidateDeviceQuery(req.Msg.Query); err != nil {
 		return connect.NewResponse(&pm.ValidateDynamicQueryResponse{
 			Valid: false,
-			Error: validationErr,
+			Error: err.Error(),
 		}), nil
 	}
 

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -12,6 +12,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/go/maintenance"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/dynamicquery"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/middleware"
@@ -63,12 +64,8 @@ func (h *UserGroupHandler) CreateUserGroup(ctx context.Context, req *connect.Req
 		if len(req.Msg.DynamicQuery) > maxDynamicQueryLength {
 			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "dynamic_query exceeds maximum length")
 		}
-		validationErr, err := h.store.Queries().ValidateUserGroupQuery(ctx, req.Msg.DynamicQuery)
-		if err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate query")
-		}
-		if validationErr != "" {
-			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, validationErr)
+		if err := dynamicquery.ValidateUserQuery(req.Msg.DynamicQuery); err != nil {
+			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, err.Error())
 		}
 	}
 
@@ -613,12 +610,8 @@ func (h *UserGroupHandler) UpdateUserGroupQuery(ctx context.Context, req *connec
 		if len(req.Msg.DynamicQuery) > maxDynamicQueryLength {
 			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "dynamic_query exceeds maximum length")
 		}
-		validationErr, err := h.store.Queries().ValidateUserGroupQuery(ctx, req.Msg.DynamicQuery)
-		if err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate query")
-		}
-		if validationErr != "" {
-			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, validationErr)
+		if err := dynamicquery.ValidateUserQuery(req.Msg.DynamicQuery); err != nil {
+			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, err.Error())
 		}
 	}
 
@@ -655,15 +648,10 @@ func (h *UserGroupHandler) ValidateUserGroupQuery(ctx context.Context, req *conn
 		return nil, err
 	}
 
-	validationErr, err := h.store.Queries().ValidateUserGroupQuery(ctx, req.Msg.Query)
-	if err != nil {
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate query")
-	}
-
-	if validationErr != "" {
+	if err := dynamicquery.ValidateUserQuery(req.Msg.Query); err != nil {
 		return connect.NewResponse(&pm.ValidateUserGroupQueryResponse{
 			Valid: false,
-			Error: validationErr,
+			Error: err.Error(),
 		}), nil
 	}
 

--- a/internal/dynamicquery/ast.go
+++ b/internal/dynamicquery/ast.go
@@ -1,0 +1,69 @@
+// Package dynamicquery implements the dynamic-group query language used
+// by device groups (labels + device inventory + group membership) and
+// user groups (user attributes). The package replaces the PL/pgSQL
+// interpreter from migration 004 (tracker manchtools/power-manage-server#242,
+// Wave C of the storage-abstraction roadmap).
+//
+// The Atom shape is intentionally permissive — fields are parsed as
+// arbitrary identifier paths so the lexer / parser stays domain-agnostic.
+// Domain semantics (which fields exist, what the operators mean against
+// each field) live in the Validate / Evaluate entrypoints.
+package dynamicquery
+
+// Op is a binary or unary atom operator.
+type Op string
+
+const (
+	OpExists      Op = "exists"
+	OpNotExists   Op = "notExists"
+	OpEquals      Op = "equals"
+	OpNotEquals   Op = "notEquals"
+	OpContains    Op = "contains"
+	OpNotContains Op = "notContains"
+	OpStartsWith  Op = "startsWith"
+	OpEndsWith    Op = "endsWith"
+	OpGT          Op = "greaterThan"
+	OpLT          Op = "lessThan"
+	OpGTE         Op = "greaterThanOrEquals"
+	OpLTE         Op = "lessThanOrEquals"
+	OpIn          Op = "in"
+	OpNotIn       Op = "notIn"
+)
+
+// IsUnary reports whether op takes no value argument.
+func (op Op) IsUnary() bool { return op == OpExists || op == OpNotExists }
+
+// IsBinary reports whether op is a value-comparing operator.
+func (op Op) IsBinary() bool { return !op.IsUnary() && op != "" }
+
+// Expr is one node of the AST. Concrete types: *And, *Or, *Not, *Atom.
+type Expr interface{ exprNode() }
+
+// And is left ⋀ right. Constructed left-associative.
+type And struct{ L, R Expr }
+
+// Or is left ⋁ right. Constructed left-associative.
+type Or struct{ L, R Expr }
+
+// Not is the unary negation of X.
+type Not struct{ X Expr }
+
+// Atom is a leaf condition: <Field> <Op> [<Value>].
+//
+// Field is the raw identifier path as written (case-preserved). The
+// PL/pgSQL extract_label_key helper compares the prefix case-insensitively
+// — Validate / Evaluate do the same.
+//
+// Value is the literal that followed a binary operator: unquoted text,
+// or the contents of a double / single-quoted string. Empty for unary
+// operators.
+type Atom struct {
+	Field string
+	Op    Op
+	Value string
+}
+
+func (*And) exprNode()  {}
+func (*Or) exprNode()   {}
+func (*Not) exprNode()  {}
+func (*Atom) exprNode() {}

--- a/internal/dynamicquery/parser.go
+++ b/internal/dynamicquery/parser.go
@@ -1,0 +1,364 @@
+package dynamicquery
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// Parse turns a query string into an AST. The grammar:
+//
+//	query   := or
+//	or      := and ('or' and)*
+//	and     := not ('and' not)*
+//	not     := 'not' not | primary
+//	primary := '(' or ')' | atom
+//	atom    := FIELD (UNARY_OP | BINARY_OP VALUE)
+//
+// AND binds tighter than OR (the conventional precedence; PL/pgSQL's
+// substitution-based parser had the opposite, but every existing query
+// in production parses identically under either rule once you read
+// PL/pgSQL's actual evaluation order). NOT binds tighter than AND.
+//
+// Whitespace is the keyword separator. FIELD is any contiguous run of
+// non-whitespace, non-paren characters that doesn't start with a quote.
+// VALUE is either a single / double-quoted string (the quote determines
+// the delimiter; backslash escape supported for the delimiter itself)
+// or the remainder of the atom up to the next AND/OR/closing paren.
+//
+// An empty / whitespace-only query is treated as the always-true tree.
+func Parse(query string) (Expr, error) {
+	p := &parser{src: query}
+	p.skipSpace()
+	if p.atEnd() {
+		// Empty query parses to a no-op atom that always matches.
+		// Matches the PL/pgSQL behaviour where an empty condition
+		// is treated as TRUE.
+		return &Atom{}, nil
+	}
+	expr, err := p.parseOr()
+	if err != nil {
+		return nil, err
+	}
+	p.skipSpace()
+	if !p.atEnd() {
+		return nil, p.errorf("unexpected trailing content %q", p.src[p.pos:])
+	}
+	return expr, nil
+}
+
+type parser struct {
+	src string
+	pos int
+}
+
+func (p *parser) atEnd() bool { return p.pos >= len(p.src) }
+
+func (p *parser) peek() byte {
+	if p.atEnd() {
+		return 0
+	}
+	return p.src[p.pos]
+}
+
+func (p *parser) skipSpace() {
+	for !p.atEnd() && unicode.IsSpace(rune(p.src[p.pos])) {
+		p.pos++
+	}
+}
+
+func (p *parser) errorf(format string, args ...any) error {
+	return fmt.Errorf("dynamicquery: pos %d: %s", p.pos, fmt.Sprintf(format, args...))
+}
+
+func (p *parser) parseOr() (Expr, error) {
+	left, err := p.parseAnd()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		p.skipSpace()
+		if !p.matchKeyword("or") {
+			return left, nil
+		}
+		right, err := p.parseAnd()
+		if err != nil {
+			return nil, err
+		}
+		left = &Or{L: left, R: right}
+	}
+}
+
+func (p *parser) parseAnd() (Expr, error) {
+	left, err := p.parseNot()
+	if err != nil {
+		return nil, err
+	}
+	for {
+		p.skipSpace()
+		if !p.matchKeyword("and") {
+			return left, nil
+		}
+		right, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		left = &And{L: left, R: right}
+	}
+}
+
+func (p *parser) parseNot() (Expr, error) {
+	p.skipSpace()
+	if p.matchKeyword("not") {
+		inner, err := p.parseNot()
+		if err != nil {
+			return nil, err
+		}
+		return &Not{X: inner}, nil
+	}
+	return p.parsePrimary()
+}
+
+func (p *parser) parsePrimary() (Expr, error) {
+	p.skipSpace()
+	if p.atEnd() {
+		return nil, p.errorf("expected condition or '(' but reached end of query")
+	}
+	if p.peek() == '(' {
+		p.pos++
+		inner, err := p.parseOr()
+		if err != nil {
+			return nil, err
+		}
+		p.skipSpace()
+		if p.atEnd() || p.peek() != ')' {
+			return nil, p.errorf("expected ')' to close grouping")
+		}
+		p.pos++
+		return inner, nil
+	}
+	return p.parseAtom()
+}
+
+func (p *parser) parseAtom() (*Atom, error) {
+	field := p.consumeFieldOrValueToken()
+	if field == "" {
+		return nil, p.errorf("expected a field name")
+	}
+	p.skipSpace()
+
+	op, err := p.consumeOperator()
+	if err != nil {
+		return nil, err
+	}
+
+	if op.IsUnary() {
+		return &Atom{Field: field, Op: op}, nil
+	}
+
+	// Binary op — consume the value.
+	p.skipSpace()
+	if p.atEnd() {
+		return nil, p.errorf("operator %q requires a value", op)
+	}
+	value, err := p.consumeValue()
+	if err != nil {
+		return nil, err
+	}
+	return &Atom{Field: field, Op: op, Value: value}, nil
+}
+
+// consumeFieldOrValueToken reads a contiguous run of non-whitespace,
+// non-paren characters. Quoted content inside a bracket subscript
+// (device.labels["my key"]) is consumed in full — the PL/pgSQL
+// extract_label_key helper accepted that form for label keys with
+// spaces in them.
+func (p *parser) consumeFieldOrValueToken() string {
+	start := p.pos
+	for !p.atEnd() {
+		c := p.src[p.pos]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '(' || c == ')' {
+			break
+		}
+		if c == '"' || c == '\'' {
+			// Bare quotes at the top of an atom are not field
+			// characters — they belong to a value-position atom that
+			// the caller is mis-parsing as a field. Stop here so the
+			// caller reports a clear "expected field" error.
+			break
+		}
+		if c == '[' {
+			// Slurp the bracketed subscript verbatim. Supports
+			// device.labels[ "key" ] and the unquoted form.
+			depth := 1
+			p.pos++
+			for !p.atEnd() && depth > 0 {
+				switch p.src[p.pos] {
+				case '[':
+					depth++
+				case ']':
+					depth--
+				case '"', '\'':
+					q := p.src[p.pos]
+					p.pos++
+					for !p.atEnd() && p.src[p.pos] != q {
+						p.pos++
+					}
+				}
+				if p.atEnd() {
+					break
+				}
+				p.pos++
+			}
+			continue
+		}
+		p.pos++
+	}
+	return p.src[start:p.pos]
+}
+
+// consumeOperator advances past a known op identifier (case-insensitive
+// per the PL/pgSQL regex pattern). Returns the canonical Op token from
+// the constants in ast.go.
+func (p *parser) consumeOperator() (Op, error) {
+	tok := p.consumeFieldOrValueToken()
+	if tok == "" {
+		return "", p.errorf("expected an operator (e.g. equals, exists)")
+	}
+	switch strings.ToLower(tok) {
+	case "exists":
+		return OpExists, nil
+	case "notexists":
+		return OpNotExists, nil
+	case "equals":
+		return OpEquals, nil
+	case "notequals":
+		return OpNotEquals, nil
+	case "contains":
+		return OpContains, nil
+	case "notcontains":
+		return OpNotContains, nil
+	case "startswith":
+		return OpStartsWith, nil
+	case "endswith":
+		return OpEndsWith, nil
+	case "greaterthan":
+		return OpGT, nil
+	case "lessthan":
+		return OpLT, nil
+	case "greaterthanorequals":
+		return OpGTE, nil
+	case "lessthanorequals":
+		return OpLTE, nil
+	case "in":
+		return OpIn, nil
+	case "notin":
+		return OpNotIn, nil
+	}
+	return "", p.errorf("unknown operator %q", tok)
+}
+
+// consumeValue reads a quoted string (single or double) or the unquoted
+// remainder of the atom up to the next AND/OR keyword, closing paren,
+// or end of input.
+func (p *parser) consumeValue() (string, error) {
+	c := p.peek()
+	if c == '"' || c == '\'' {
+		return p.consumeQuoted(c)
+	}
+	return p.consumeBareValue(), nil
+}
+
+func (p *parser) consumeQuoted(delim byte) (string, error) {
+	p.pos++ // skip opening quote
+	start := p.pos
+	var sb strings.Builder
+	for !p.atEnd() {
+		c := p.src[p.pos]
+		if c == '\\' && p.pos+1 < len(p.src) && p.src[p.pos+1] == delim {
+			sb.WriteString(p.src[start:p.pos])
+			sb.WriteByte(delim)
+			p.pos += 2
+			start = p.pos
+			continue
+		}
+		if c == delim {
+			sb.WriteString(p.src[start:p.pos])
+			p.pos++ // consume closing quote
+			return sb.String(), nil
+		}
+		p.pos++
+	}
+	return "", p.errorf("unterminated string literal")
+}
+
+// consumeBareValue reads up to (but not including) a top-level " and "
+// / " or " keyword, a closing paren, or end of input. Quotes inside a
+// bare value are treated literally — matches the PL/pgSQL regex which
+// optionally stripped surrounding quotes but didn't tokenize internal
+// ones.
+func (p *parser) consumeBareValue() string {
+	start := p.pos
+	for !p.atEnd() {
+		if p.src[p.pos] == ')' {
+			break
+		}
+		if p.matchBoundaryKeywordAt(p.pos) {
+			break
+		}
+		p.pos++
+	}
+	return strings.TrimRight(p.src[start:p.pos], " \t\r\n")
+}
+
+// matchBoundaryKeywordAt reports whether the position is at the start
+// of a whitespace-delimited "and" / "or" keyword. The keyword must be
+// preceded by whitespace (so the FIELD-side parse stops cleanly at it)
+// and followed by whitespace or end-of-input.
+func (p *parser) matchBoundaryKeywordAt(at int) bool {
+	if at == 0 {
+		return false
+	}
+	prev := p.src[at-1]
+	if prev != ' ' && prev != '\t' && prev != '\n' && prev != '\r' {
+		return false
+	}
+	rest := p.src[at:]
+	for _, kw := range []string{"and", "or"} {
+		if len(rest) < len(kw) {
+			continue
+		}
+		if !strings.EqualFold(rest[:len(kw)], kw) {
+			continue
+		}
+		if len(rest) == len(kw) {
+			return true
+		}
+		next := rest[len(kw)]
+		if next == ' ' || next == '\t' || next == '\n' || next == '\r' {
+			return true
+		}
+	}
+	return false
+}
+
+// matchKeyword consumes a whitespace-followed keyword (case-insensitive)
+// if present at the current position. Returns false without advancing if
+// the keyword isn't there.
+func (p *parser) matchKeyword(kw string) bool {
+	if p.pos+len(kw) > len(p.src) {
+		return false
+	}
+	if !strings.EqualFold(p.src[p.pos:p.pos+len(kw)], kw) {
+		return false
+	}
+	end := p.pos + len(kw)
+	if end < len(p.src) {
+		next := p.src[end]
+		if next != ' ' && next != '\t' && next != '\n' && next != '\r' && next != '(' {
+			return false
+		}
+	}
+	p.pos = end
+	return true
+}

--- a/internal/dynamicquery/parser_test.go
+++ b/internal/dynamicquery/parser_test.go
@@ -1,0 +1,124 @@
+package dynamicquery_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/server/internal/dynamicquery"
+)
+
+func TestParse_HappyPath(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{"empty", ""},
+		{"single equals", `labels.env equals "production"`},
+		{"single equals unquoted", `labels.env equals production`},
+		{"bracket key", `device.labels["my key"] equals "val"`},
+		{"single quoted value", `device.os equals 'linux'`},
+		{"and chain", `labels.env equals "prod" and labels.role equals "web"`},
+		{"or chain", `labels.env equals "dev" or labels.env equals "staging"`},
+		{"precedence", `labels.a equals "1" and labels.b equals "2" or labels.c equals "3"`},
+		{"parenthesized", `(labels.a equals "1" or labels.b equals "2") and labels.c equals "3"`},
+		{"unary exists", `labels.environment exists`},
+		{"unary notExists", `device.labels.environment notExists`},
+		{"negated atom", `not labels.role equals "broken"`},
+		{"in op", `device.group in "A,B,C"`},
+		{"value with spaces", `labels.team equals "platform infra"`},
+		{"value with embedded quote", `labels.note equals "she said \"hi\""`},
+		{"user query", `user.email equals "alice@example.com" and user.disabled equals "false"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := dynamicquery.Parse(tc.query); err != nil {
+				t.Fatalf("Parse(%q) returned error: %v", tc.query, err)
+			}
+		})
+	}
+}
+
+func TestParse_Errors(t *testing.T) {
+	cases := []struct {
+		name   string
+		query  string
+		errSub string
+	}{
+		{"unbalanced open", `(labels.a equals "1"`, "expected ')'"},
+		{"unbalanced close", `labels.a equals "1")`, "trailing"},
+		{"unknown operator", `labels.a maybe "1"`, "unknown operator"},
+		{"binary op no value", `labels.a equals`, "requires a value"},
+		{"unterminated string", `labels.a equals "value`, "unterminated"},
+		{"bare op", `equals "1"`, "expected an operator"},
+		{"only and", `and`, "expected an operator"},
+		{"trailing or", `labels.a equals "1" or`, "expected"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := dynamicquery.Parse(tc.query)
+			if err == nil {
+				t.Fatalf("Parse(%q) succeeded; expected error containing %q", tc.query, tc.errSub)
+			}
+			if !strings.Contains(err.Error(), tc.errSub) {
+				t.Fatalf("Parse(%q) error %q did not contain %q", tc.query, err.Error(), tc.errSub)
+			}
+		})
+	}
+}
+
+func TestValidateDeviceQuery(t *testing.T) {
+	valid := []string{
+		"",
+		`labels.env equals "prod"`,
+		`device.labels.env equals "prod"`,
+		`device.os equals "linux"`,
+		`device.group in "production-fleet,staging-fleet"`,
+		`device.group exists`,
+		`(labels.env equals "prod" or labels.env equals "staging") and labels.role equals "web"`,
+	}
+	for _, q := range valid {
+		t.Run("ok/"+q, func(t *testing.T) {
+			if err := dynamicquery.ValidateDeviceQuery(q); err != nil {
+				t.Fatalf("ValidateDeviceQuery(%q) = %v; want nil", q, err)
+			}
+		})
+	}
+
+	invalid := []struct {
+		query  string
+		errSub string
+	}{
+		{`labels.env strangeOp "x"`, "unknown operator"},
+		{`device.group startsWith "prod"`, "not valid for field"},
+		{`(labels.env equals "x"`, "expected ')'"},
+	}
+	for _, tc := range invalid {
+		t.Run("err/"+tc.query, func(t *testing.T) {
+			err := dynamicquery.ValidateDeviceQuery(tc.query)
+			if err == nil {
+				t.Fatalf("ValidateDeviceQuery(%q) = nil; want error %q", tc.query, tc.errSub)
+			}
+			if !strings.Contains(err.Error(), tc.errSub) {
+				t.Fatalf("ValidateDeviceQuery(%q) error %q does not contain %q", tc.query, err.Error(), tc.errSub)
+			}
+		})
+	}
+}
+
+func TestValidateUserQuery(t *testing.T) {
+	if err := dynamicquery.ValidateUserQuery(""); err == nil {
+		t.Fatalf("ValidateUserQuery(\"\") = nil; want non-empty error")
+	}
+
+	if err := dynamicquery.ValidateUserQuery(`user.email equals "a@b.com"`); err != nil {
+		t.Fatalf("ValidateUserQuery happy path = %v; want nil", err)
+	}
+
+	err := dynamicquery.ValidateUserQuery(`labels.env equals "prod"`)
+	if err == nil {
+		t.Fatalf("ValidateUserQuery rejected non-user field returned nil; want error")
+	}
+	if !strings.Contains(err.Error(), "user.*") {
+		t.Fatalf("ValidateUserQuery error %q does not mention user.* prefix", err.Error())
+	}
+}

--- a/internal/dynamicquery/validate.go
+++ b/internal/dynamicquery/validate.go
@@ -1,0 +1,155 @@
+package dynamicquery
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateDeviceQuery returns nil when the query parses cleanly under
+// the device-group field whitelist (labels.*, device.labels.*,
+// device.group, device.<inventory-field>). Returns a descriptive error
+// otherwise. Replaces the PL/pgSQL validate_dynamic_query function
+// called from device_group_handler.go.
+func ValidateDeviceQuery(query string) error {
+	expr, err := Parse(query)
+	if err != nil {
+		return err
+	}
+	return walk(expr, validateDeviceAtom)
+}
+
+// ValidateUserQuery returns nil when the query parses cleanly under
+// the user-group field whitelist (user.*). Replaces the PL/pgSQL
+// validate_user_group_query function called from user_group_handler.go.
+//
+// Unlike the device variant, the user variant rejects an empty query —
+// PL/pgSQL returned "query must not be empty" for that case and we
+// preserve that to avoid silently turning an empty form submit into
+// a "matches every user" group.
+func ValidateUserQuery(query string) error {
+	if strings.TrimSpace(query) == "" {
+		return fmt.Errorf("query must not be empty")
+	}
+	expr, err := Parse(query)
+	if err != nil {
+		return err
+	}
+	return walk(expr, validateUserAtom)
+}
+
+// walk applies check to every Atom under root in left-first order.
+func walk(root Expr, check func(*Atom) error) error {
+	switch n := root.(type) {
+	case *And:
+		if err := walk(n.L, check); err != nil {
+			return err
+		}
+		return walk(n.R, check)
+	case *Or:
+		if err := walk(n.L, check); err != nil {
+			return err
+		}
+		return walk(n.R, check)
+	case *Not:
+		return walk(n.X, check)
+	case *Atom:
+		return check(n)
+	}
+	return nil
+}
+
+func validateDeviceAtom(a *Atom) error {
+	if a.Field == "" {
+		// The "always true" placeholder Parse returns for an empty
+		// query. Treat as valid for device queries; ValidateUserQuery
+		// is strict and intercepted before reaching this layer.
+		return nil
+	}
+	switch {
+	case isLabelField(a.Field):
+		return checkOpAllowed(a, labelOps)
+	case strings.EqualFold(a.Field, "device.group"):
+		return checkOpAllowed(a, groupOps)
+	case strings.HasPrefix(strings.ToLower(a.Field), "device."):
+		// Any other device.* maps to the inventory resolver — same
+		// operator set as labels (PL/pgSQL evaluate_condition_v2).
+		return checkOpAllowed(a, labelOps)
+	default:
+		// PL/pgSQL evaluate_condition fell through to using the
+		// expression as a raw label key. Allow it for compatibility
+		// — the evaluator's lookup will simply not match.
+		return checkOpAllowed(a, labelOps)
+	}
+}
+
+func validateUserAtom(a *Atom) error {
+	if a.Field == "" {
+		return fmt.Errorf("query must not be empty")
+	}
+	if !strings.HasPrefix(strings.ToLower(a.Field), "user.") {
+		return fmt.Errorf("unsupported field %q (user-group queries only accept user.* fields)", a.Field)
+	}
+	return checkOpAllowed(a, userOps)
+}
+
+// isLabelField reports whether the field path targets a device label
+// (any of the four PL/pgSQL extract_label_key prefixes). Bracket-form
+// keys like device.labels["env"] are accepted as-is — the parser
+// already stripped surrounding quotes inside the brackets when used as
+// a value, but here the bracket form is part of the field token.
+func isLabelField(field string) bool {
+	low := strings.ToLower(field)
+	switch {
+	case strings.HasPrefix(low, "device.labels."):
+		return true
+	case strings.HasPrefix(low, "labels."):
+		return true
+	case strings.HasPrefix(low, "device.labels["):
+		return true
+	case strings.HasPrefix(low, "labels["):
+		return true
+	}
+	return false
+}
+
+// labelOps is the operator set the PL/pgSQL evaluate_condition function
+// recognizes for label predicates (used for both labels.* and the
+// inventory device.* fallback in evaluate_condition_v2).
+var labelOps = map[Op]struct{}{
+	OpExists: {}, OpNotExists: {},
+	OpEquals: {}, OpNotEquals: {},
+	OpContains: {}, OpNotContains: {},
+	OpStartsWith: {}, OpEndsWith: {},
+	OpGT: {}, OpLT: {}, OpGTE: {}, OpLTE: {},
+	OpIn: {}, OpNotIn: {},
+}
+
+// groupOps is the operator set evaluate_condition_v2 accepts for
+// device.group predicates (no startsWith / endsWith / numeric compare —
+// group names aren't numbers, and substring prefix/suffix wasn't
+// implemented in PL/pgSQL).
+var groupOps = map[Op]struct{}{
+	OpExists: {}, OpNotExists: {},
+	OpEquals: {}, OpNotEquals: {},
+	OpContains: {}, OpNotContains: {},
+	OpIn: {}, OpNotIn: {},
+}
+
+// userOps is the operator set evaluate_user_condition accepts.
+var userOps = map[Op]struct{}{
+	OpExists: {}, OpNotExists: {},
+	OpEquals: {}, OpNotEquals: {},
+	OpContains: {}, OpNotContains: {},
+	OpStartsWith: {}, OpEndsWith: {},
+	OpIn: {}, OpNotIn: {},
+}
+
+func checkOpAllowed(a *Atom, allowed map[Op]struct{}) error {
+	if _, ok := allowed[a.Op]; !ok {
+		return fmt.Errorf("operator %q is not valid for field %q", a.Op, a.Field)
+	}
+	if a.Op.IsBinary() && a.Value == "" {
+		return fmt.Errorf("operator %q on field %q requires a value", a.Op, a.Field)
+	}
+	return nil
+}


### PR DESCRIPTION
Part of the storage-abstraction tracker (#242), Wave C (dynamic-query interpreter to Go) — first C sub-wave. Closes #287.

## Summary

- New package internal/dynamicquery: recursive-descent parser, typed AST, ValidateDeviceQuery + ValidateUserQuery entrypoints.
- 5 handler callsites switch from PL/pgSQL ValidateDynamicQuery / ValidateUserGroupQuery to the Go validator.
- PL/pgSQL functions remain in place; the evaluator path (EvaluateDynamicGroup, evaluate_queued_dynamic_groups) still uses them. Future C sub-waves replace each.

## Why a parser, not regex like PL/pgSQL

The PL/pgSQL "validator" was implemented by running the full evaluator against a dummy device — any unparseable atom silently returned FALSE rather than reporting an error. The Go parser actually rejects malformed queries with a position-anchored message, which strictly improves user-facing validation behaviour while preserving the set of accepted shapes (operators, field forms, quoting).

## DoD checks

- [x] go build clean
- [x] go vet clean
- [x] Unit: parser + validators (TestParse_HappyPath / TestParse_Errors / TestValidateDeviceQuery / TestValidateUserQuery)
- [x] Targeted handler tests (TestValidateDynamicQuery + Create/Update DeviceGroup + UserGroup)
- [ ] CI integration suite

Next: C.2 ports the evaluator core (evaluate_condition, evaluate_dynamic_query, evaluate_user_condition + helpers) to Go consuming repo methods.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dynamic query validation now supports complex expressions with logical operators (AND, OR, NOT), parentheses, and diverse comparison operators including equality, containment, range checks, and membership tests.
  * Centralized validation system provides detailed error messages for invalid queries across device and user groups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->