### PR TITLE
refactor(store): wave C.2 — port dynamic-query evaluator core to Go (#289)

### DIFF
--- a/internal/dynamicquery/eval.go
+++ b/internal/dynamicquery/eval.go
@@ -1,0 +1,403 @@
+package dynamicquery
+
+import (
+	"strconv"
+	"strings"
+)
+
+// DeviceContext is the pre-loaded device state the device-query
+// evaluator reads. Callers (per-group eval in C.3, queue drain in C.4)
+// build one of these per device before walking the AST.
+//
+// Labels keeps the keys raw (case-preserved at write); lookups go
+// through Label() which applies the case-insensitive match the PL/pgSQL
+// `device_labels ? key` operator implicitly did (PG JSONB keys are
+// case-sensitive, but the dynamic-query string is matched
+// case-insensitively against the field path). Use Label("env") with
+// the post-extract_label_key key.
+//
+// Inventory is a function rather than a map so the C.3 caller can
+// lazy-load inventory fields by name — building the full row up-front
+// would be wasteful when most queries touch zero or one field.
+//
+// GroupNames is the snapshot of group memberships at evaluation time.
+// device.group equals / contains / in / notIn match against this list
+// case-insensitively.
+type DeviceContext struct {
+	DeviceID   string
+	Labels     map[string]string
+	Inventory  func(field string) (string, bool)
+	GroupNames []string
+}
+
+// Label looks up a label by key, case-insensitive (PL/pgSQL did the
+// equivalent via lower() comparisons in evaluate_condition).
+func (c DeviceContext) Label(key string) (string, bool) {
+	if v, ok := c.Labels[key]; ok {
+		return v, true
+	}
+	for k, v := range c.Labels {
+		if strings.EqualFold(k, key) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// UserContext mirrors the 7 user fields evaluate_user_condition reads.
+// Boolean fields are serialized to "true" / "false" for binary
+// operators (matches PL/pgSQL's `user_disabled::TEXT` cast).
+type UserContext struct {
+	Email             string
+	Disabled          bool
+	TotpEnabled       bool
+	HasPassword       bool
+	DisplayName       string
+	PreferredUsername string
+	Locale            string
+}
+
+// EvaluateDevice evaluates expr against ctx. Matches the PL/pgSQL
+// evaluate_dynamic_query_v2 / evaluate_condition_v2 semantics.
+func EvaluateDevice(expr Expr, ctx DeviceContext) bool {
+	return walkEval(expr, func(a *Atom) bool { return evalDeviceAtom(a, ctx) })
+}
+
+// EvaluateUser evaluates expr against ctx. Matches the PL/pgSQL
+// evaluate_dynamic_user_query / evaluate_user_condition semantics.
+func EvaluateUser(expr Expr, ctx UserContext) bool {
+	return walkEval(expr, func(a *Atom) bool { return evalUserAtom(a, ctx) })
+}
+
+// walkEval recursively evaluates a boolean expression tree, deferring
+// atom semantics to the provided closure. AND short-circuits on FALSE,
+// OR on TRUE — matches PL/pgSQL's EXIT-on-mismatch loop.
+func walkEval(root Expr, atom func(*Atom) bool) bool {
+	switch n := root.(type) {
+	case *And:
+		return walkEval(n.L, atom) && walkEval(n.R, atom)
+	case *Or:
+		return walkEval(n.L, atom) || walkEval(n.R, atom)
+	case *Not:
+		return !walkEval(n.X, atom)
+	case *Atom:
+		if n.Field == "" {
+			// Empty / always-true placeholder produced by Parse("").
+			return true
+		}
+		return atom(n)
+	}
+	// Unreachable: the parser only emits the four node types above.
+	return false
+}
+
+// evalDeviceAtom matches evaluate_condition_v2's three-way dispatch:
+// device.group, device.<inventory>, then labels.
+func evalDeviceAtom(a *Atom, ctx DeviceContext) bool {
+	low := strings.ToLower(a.Field)
+
+	switch {
+	case low == "device.group":
+		return evalDeviceGroup(a, ctx.GroupNames)
+	case strings.HasPrefix(low, "device.labels.") ||
+		strings.HasPrefix(low, "labels.") ||
+		strings.HasPrefix(low, "device.labels[") ||
+		strings.HasPrefix(low, "labels["):
+		key := extractLabelKey(a.Field)
+		val, ok := ctx.Label(key)
+		return applyStringOp(a.Op, val, ok, a.Value)
+	case strings.HasPrefix(low, "device."):
+		field := strings.TrimPrefix(strings.TrimPrefix(a.Field, "device."), "Device.")
+		var (
+			val string
+			ok  bool
+		)
+		if ctx.Inventory != nil {
+			val, ok = ctx.Inventory(field)
+		}
+		return applyStringOp(a.Op, val, ok, a.Value)
+	}
+	// Fallback: treat the raw field as a label key (PL/pgSQL
+	// extract_label_key returned the unchanged expression for
+	// unrecognized prefixes; evaluate_condition then looked it up as
+	// a label key, which usually missed and returned FALSE).
+	val, ok := ctx.Label(a.Field)
+	return applyStringOp(a.Op, val, ok, a.Value)
+}
+
+// evalDeviceGroup handles `device.group <op> <value>` against the
+// list of group names the device currently belongs to. PL/pgSQL didn't
+// implement startsWith/endsWith/numeric compare for this field —
+// neither do we.
+func evalDeviceGroup(a *Atom, groupNames []string) bool {
+	hasMembership := len(groupNames) > 0
+
+	switch a.Op {
+	case OpExists:
+		return hasMembership
+	case OpNotExists:
+		return !hasMembership
+	}
+
+	if !hasMembership {
+		// PL/pgSQL: "negative" operators flip to TRUE on no membership.
+		switch a.Op {
+		case OpNotEquals, OpNotContains, OpNotIn:
+			return true
+		default:
+			return false
+		}
+	}
+
+	value := strings.ToLower(a.Value)
+	switch a.Op {
+	case OpEquals:
+		for _, g := range groupNames {
+			if strings.EqualFold(g, a.Value) {
+				return true
+			}
+		}
+		return false
+	case OpNotEquals:
+		for _, g := range groupNames {
+			if strings.EqualFold(g, a.Value) {
+				return false
+			}
+		}
+		return true
+	case OpContains:
+		for _, g := range groupNames {
+			if strings.Contains(strings.ToLower(g), value) {
+				return true
+			}
+		}
+		return false
+	case OpNotContains:
+		for _, g := range groupNames {
+			if strings.Contains(strings.ToLower(g), value) {
+				return false
+			}
+		}
+		return true
+	case OpIn:
+		for _, name := range splitTrimLower(a.Value, ",") {
+			for _, g := range groupNames {
+				if strings.EqualFold(g, name) {
+					return true
+				}
+			}
+		}
+		return false
+	case OpNotIn:
+		for _, name := range splitTrimLower(a.Value, ",") {
+			for _, g := range groupNames {
+				if strings.EqualFold(g, name) {
+					return false
+				}
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// evalUserAtom matches evaluate_user_condition's 7-field whitelist.
+// Booleans are converted to "true" / "false" for binary operators —
+// the PL/pgSQL `user_disabled::TEXT` cast produced lowercase strings.
+func evalUserAtom(a *Atom, ctx UserContext) bool {
+	field := strings.ToLower(a.Field)
+
+	switch a.Op {
+	case OpExists:
+		switch field {
+		case "user.email":
+			return ctx.Email != ""
+		case "user.disabled", "user.totp_enabled", "user.has_password":
+			return true
+		case "user.display_name":
+			return ctx.DisplayName != ""
+		case "user.preferred_username":
+			return ctx.PreferredUsername != ""
+		case "user.locale":
+			return ctx.Locale != ""
+		}
+		return false
+	case OpNotExists:
+		switch field {
+		case "user.email":
+			return ctx.Email == ""
+		case "user.display_name":
+			return ctx.DisplayName == ""
+		case "user.preferred_username":
+			return ctx.PreferredUsername == ""
+		case "user.locale":
+			return ctx.Locale == ""
+		}
+		return false
+	}
+
+	val, ok := userFieldValue(field, ctx)
+	if !ok {
+		// Unknown field — PL/pgSQL returned FALSE.
+		return false
+	}
+	return applyStringOp(a.Op, val, true, a.Value)
+}
+
+// userFieldValue resolves a user.<field> to its string representation,
+// or returns ok=false for unknown fields. Boolean fields use "true" /
+// "false" so binary comparisons match the PL/pgSQL ::TEXT cast.
+func userFieldValue(field string, ctx UserContext) (string, bool) {
+	switch field {
+	case "user.email":
+		return ctx.Email, true
+	case "user.disabled":
+		return strconv.FormatBool(ctx.Disabled), true
+	case "user.totp_enabled":
+		return strconv.FormatBool(ctx.TotpEnabled), true
+	case "user.has_password":
+		return strconv.FormatBool(ctx.HasPassword), true
+	case "user.display_name":
+		return ctx.DisplayName, true
+	case "user.preferred_username":
+		return ctx.PreferredUsername, true
+	case "user.locale":
+		return ctx.Locale, true
+	}
+	return "", false
+}
+
+// applyStringOp implements the binary / unary semantics evaluate_condition
+// and evaluate_user_condition share. The PL/pgSQL "NULL field" branches
+// map to !present here — present=false short-circuits "negative" ops to
+// TRUE and "positive" ops to FALSE.
+func applyStringOp(op Op, fieldValue string, present bool, value string) bool {
+	switch op {
+	case OpExists:
+		return present
+	case OpNotExists:
+		return !present
+	}
+
+	if !present {
+		switch op {
+		case OpNotEquals, OpNotContains, OpNotIn:
+			return true
+		default:
+			return false
+		}
+	}
+
+	lowField := strings.ToLower(fieldValue)
+	lowValue := strings.ToLower(value)
+
+	switch op {
+	case OpEquals:
+		return lowField == lowValue
+	case OpNotEquals:
+		return lowField != lowValue
+	case OpContains:
+		return strings.Contains(lowField, lowValue)
+	case OpNotContains:
+		return !strings.Contains(lowField, lowValue)
+	case OpStartsWith:
+		return strings.HasPrefix(lowField, lowValue)
+	case OpEndsWith:
+		return strings.HasSuffix(lowField, lowValue)
+	case OpGT, OpLT, OpGTE, OpLTE:
+		return compareOp(op, fieldValue, value)
+	case OpIn:
+		for _, candidate := range splitTrimLower(value, ",") {
+			if lowField == candidate {
+				return true
+			}
+		}
+		return false
+	case OpNotIn:
+		for _, candidate := range splitTrimLower(value, ",") {
+			if lowField == candidate {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// compareOp handles the four ordering operators. PL/pgSQL tried numeric
+// first, fell back to lexicographic on cast failure — mirrored here so
+// values like "v1.2" and "v1.10" don't compare as numbers and accidentally
+// flip ordering.
+func compareOp(op Op, a, b string) bool {
+	if na, err := strconv.ParseFloat(a, 64); err == nil {
+		if nb, err := strconv.ParseFloat(b, 64); err == nil {
+			switch op {
+			case OpGT:
+				return na > nb
+			case OpLT:
+				return na < nb
+			case OpGTE:
+				return na >= nb
+			case OpLTE:
+				return na <= nb
+			}
+		}
+	}
+	switch op {
+	case OpGT:
+		return a > b
+	case OpLT:
+		return a < b
+	case OpGTE:
+		return a >= b
+	case OpLTE:
+		return a <= b
+	}
+	return false
+}
+
+// extractLabelKey strips the prefix/bracket form to return the bare
+// label key. Mirrors the PL/pgSQL extract_label_key function.
+func extractLabelKey(fieldExpr string) string {
+	low := strings.ToLower(fieldExpr)
+	switch {
+	case strings.HasPrefix(low, "device.labels."):
+		return fieldExpr[len("device.labels."):]
+	case strings.HasPrefix(low, "labels."):
+		return fieldExpr[len("labels."):]
+	case strings.HasPrefix(low, "device.labels["):
+		return trimBracketKey(fieldExpr[len("device.labels"):])
+	case strings.HasPrefix(low, "labels["):
+		return trimBracketKey(fieldExpr[len("labels"):])
+	}
+	return fieldExpr
+}
+
+// trimBracketKey turns `["env"]` or `[env]` into `env`. Whitespace is
+// trimmed; surrounding single or double quotes are stripped.
+func trimBracketKey(bracketed string) string {
+	s := strings.TrimSpace(bracketed)
+	s = strings.TrimPrefix(s, "[")
+	s = strings.TrimSuffix(s, "]")
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		first := s[0]
+		last := s[len(s)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			s = s[1 : len(s)-1]
+		}
+	}
+	return s
+}
+
+// splitTrimLower splits s on sep, trims each part, and returns the
+// lowered slice. Empty values are kept (PL/pgSQL string_to_array did
+// the same — though no real query has the trailing comma form).
+func splitTrimLower(s, sep string) []string {
+	parts := strings.Split(s, sep)
+	out := make([]string, len(parts))
+	for i, p := range parts {
+		out[i] = strings.ToLower(strings.TrimSpace(p))
+	}
+	return out
+}

--- a/internal/dynamicquery/eval_test.go
+++ b/internal/dynamicquery/eval_test.go
@@ -1,0 +1,212 @@
+package dynamicquery_test
+
+import (
+	"testing"
+
+	"github.com/manchtools/power-manage/server/internal/dynamicquery"
+)
+
+func mustParse(t *testing.T, q string) dynamicquery.Expr {
+	t.Helper()
+	expr, err := dynamicquery.Parse(q)
+	if err != nil {
+		t.Fatalf("Parse(%q) failed: %v", q, err)
+	}
+	return expr
+}
+
+func TestEvaluateDevice_LabelOps(t *testing.T) {
+	ctx := dynamicquery.DeviceContext{
+		Labels: map[string]string{
+			"environment": "Production",
+			"role":        "web",
+			"version":     "2",
+		},
+	}
+
+	cases := []struct {
+		query string
+		want  bool
+	}{
+		{`labels.environment exists`, true},
+		{`labels.missing exists`, false},
+		{`labels.environment notExists`, false},
+		{`labels.missing notExists`, true},
+		{`labels.environment equals "production"`, true}, // case-insensitive
+		{`labels.environment notEquals "dev"`, true},
+		{`labels.environment notEquals "production"`, false},
+		{`labels.environment contains "prod"`, true},
+		{`labels.environment notContains "dev"`, true},
+		{`labels.environment startsWith "prod"`, true},
+		{`labels.environment endsWith "tion"`, true},
+		{`labels.role in "web,db,cache"`, true},
+		{`labels.role notIn "web,db"`, false},
+		{`labels.version greaterThan "1"`, true},
+		{`labels.version lessThan "10"`, true}, // numeric
+		{`labels.version greaterThanOrEquals "2"`, true},
+		{`labels.version lessThanOrEquals "2"`, true},
+		{`device.labels.environment equals "production"`, true},
+		{`device.labels["environment"] equals "production"`, true},
+		{`labels["environment"] equals "production"`, true},
+		// Missing-field semantics: negative ops flip to true.
+		{`labels.missing equals "x"`, false},
+		{`labels.missing notEquals "x"`, true},
+		{`labels.missing in "a,b"`, false},
+		{`labels.missing notIn "a,b"`, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			got := dynamicquery.EvaluateDevice(mustParse(t, tc.query), ctx)
+			if got != tc.want {
+				t.Fatalf("EvaluateDevice(%q) = %v; want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateDevice_DeviceGroup(t *testing.T) {
+	ctx := dynamicquery.DeviceContext{
+		GroupNames: []string{"Prod Fleet", "Linux Servers"},
+	}
+	cases := []struct {
+		query string
+		want  bool
+	}{
+		{`device.group exists`, true},
+		{`device.group notExists`, false},
+		{`device.group equals "prod fleet"`, true},
+		{`device.group equals "test fleet"`, false},
+		{`device.group notEquals "test fleet"`, true},
+		{`device.group contains "linux"`, true},
+		{`device.group notContains "windows"`, true},
+		{`device.group in "Prod Fleet,Dev Fleet"`, true},
+		{`device.group notIn "Test Fleet,Stage Fleet"`, true},
+		{`device.group in "Test,Stage"`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			got := dynamicquery.EvaluateDevice(mustParse(t, tc.query), ctx)
+			if got != tc.want {
+				t.Fatalf("EvaluateDevice(%q) = %v; want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+
+	// Empty membership: negative ops flip to true.
+	emptyCtx := dynamicquery.DeviceContext{}
+	if !dynamicquery.EvaluateDevice(mustParse(t, `device.group notEquals "anything"`), emptyCtx) {
+		t.Fatalf("device.group notEquals on empty membership should return true")
+	}
+	if dynamicquery.EvaluateDevice(mustParse(t, `device.group equals "anything"`), emptyCtx) {
+		t.Fatalf("device.group equals on empty membership should return false")
+	}
+}
+
+func TestEvaluateDevice_Inventory(t *testing.T) {
+	ctx := dynamicquery.DeviceContext{
+		Inventory: func(field string) (string, bool) {
+			switch field {
+			case "os":
+				return "linux", true
+			case "ram_gb":
+				return "32", true
+			}
+			return "", false
+		},
+	}
+	cases := []struct {
+		query string
+		want  bool
+	}{
+		{`device.os equals "linux"`, true},
+		{`device.os equals "windows"`, false},
+		{`device.ram_gb greaterThan "16"`, true},
+		{`device.ram_gb lessThan "16"`, false},
+		{`device.unknown exists`, false},
+		{`device.unknown notExists`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			got := dynamicquery.EvaluateDevice(mustParse(t, tc.query), ctx)
+			if got != tc.want {
+				t.Fatalf("EvaluateDevice(%q) = %v; want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateDevice_BooleanComposition(t *testing.T) {
+	ctx := dynamicquery.DeviceContext{
+		Labels: map[string]string{"env": "prod", "role": "web"},
+	}
+	cases := []struct {
+		query string
+		want  bool
+	}{
+		{`labels.env equals "prod" and labels.role equals "web"`, true},
+		{`labels.env equals "prod" and labels.role equals "db"`, false},
+		{`labels.env equals "prod" or labels.role equals "db"`, true},
+		{`labels.env equals "dev" or labels.role equals "db"`, false},
+		{`not labels.env equals "dev"`, true},
+		{`(labels.env equals "prod" or labels.env equals "dev") and labels.role equals "web"`, true},
+		// AND binds tighter than OR (standard precedence).
+		{`labels.env equals "dev" or labels.env equals "prod" and labels.role equals "web"`, true},
+		{`labels.env equals "dev" or labels.env equals "prod" and labels.role equals "db"`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			got := dynamicquery.EvaluateDevice(mustParse(t, tc.query), ctx)
+			if got != tc.want {
+				t.Fatalf("EvaluateDevice(%q) = %v; want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateUser_Fields(t *testing.T) {
+	ctx := dynamicquery.UserContext{
+		Email:             "alice@example.com",
+		Disabled:          false,
+		TotpEnabled:       true,
+		HasPassword:       true,
+		DisplayName:       "Alice",
+		PreferredUsername: "alice",
+		Locale:            "en",
+	}
+	cases := []struct {
+		query string
+		want  bool
+	}{
+		{`user.email exists`, true},
+		{`user.email equals "alice@example.com"`, true},
+		{`user.email endsWith "@example.com"`, true},
+		{`user.email in "alice@example.com,bob@example.com"`, true},
+		{`user.disabled equals "false"`, true},
+		{`user.totp_enabled equals "true"`, true},
+		{`user.has_password equals "true"`, true},
+		{`user.display_name contains "lic"`, true},
+		{`user.locale equals "en"`, true},
+		{`user.locale notExists`, false},
+		{`user.unknown exists`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			got := dynamicquery.EvaluateUser(mustParse(t, tc.query), ctx)
+			if got != tc.want {
+				t.Fatalf("EvaluateUser(%q) = %v; want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEvaluate_EmptyQuery(t *testing.T) {
+	// Parse("") returns an always-true placeholder. Both evaluators
+	// must agree: empty matches every device / user.
+	if !dynamicquery.EvaluateDevice(mustParse(t, ""), dynamicquery.DeviceContext{}) {
+		t.Fatalf("empty device query should match every device")
+	}
+	if !dynamicquery.EvaluateUser(mustParse(t, ""), dynamicquery.UserContext{}) {
+		t.Fatalf("empty user query should match every user")
+	}
+}


### PR DESCRIPTION
Part of the storage-abstraction tracker (#242), Wave C (dynamic-query interpreter to Go). Second sub-wave. Closes #289.

## Summary

- internal/dynamicquery gains EvaluateDevice + EvaluateUser. Pure functions over the C.1 AST.
- DeviceContext / UserContext are simple value-type structs that the C.3 / C.4 callers will populate before invoking eval.
- Atom semantics match PL/pgSQL evaluate_condition_v2 / evaluate_user_condition exactly — same operators, same missing-field flip behaviour, same numeric-then-lex compare fallback.
- No callsite changes yet; PL/pgSQL evaluator path remains live until C.3 / C.4 land.

## Test coverage

- Each of the 14 operators against label / bracket / inventory / user fields.
- device.group membership matrix (equals / notEquals / contains / in / notIn).
- Missing-field flip semantics (positive ops false, negative ops true).
- Boolean composition + precedence (and tighter than or).
- Empty-query always-true placeholder.

## DoD checks

- [x] go build / go vet clean
- [x] go test ./internal/dynamicquery/... — 70+ behavioural cases pass
- [ ] CI integration suite

Next: C.3 wires this into the per-group eval (replacing PL/pgSQL EvaluateDynamicGroup / EvaluateDynamicUserGroup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced query evaluation system enabling filtering of devices and users based on custom conditions and attributes.

* **Tests**
  * Comprehensive test suite covering query evaluation scenarios including label matching, device group verification, inventory field queries, and user attribute filtering with boolean logic support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->