### PR TITLE
refactor(store): wave C.4 — port dynamic-group queue drain to Go (#293)

### DIFF
--- a/cmd/control/periodic.go
+++ b/cmd/control/periodic.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/dyngroupeval"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -74,16 +75,17 @@ func drainDynamicQueue(ctx context.Context, label string, logger *slog.Logger, e
 // is logged in main.go's else branch — kept there because main owns
 // the boot-time "feature is disabled" reporting).
 func startDynamicGroupWorker(ctx context.Context, st *store.Store, interval time.Duration, logger *slog.Logger) {
+	ev := dyngroupeval.New(st, logger)
 	evalGroups := func() {
 		drainDynamicQueue(ctx, "dynamic groups", logger, func(ctx context.Context) (dynamicQueueBatch, error) {
-			r, err := st.Queries().EvaluateQueuedDynamicGroups(ctx)
-			return dynamicQueueBatch{count: r.EvaluatedCount, more: r.More}, err
+			r, err := ev.DrainDeviceGroupQueue(ctx)
+			return dynamicQueueBatch{count: r.Count, more: r.More}, err
 		})
 	}
 	evalUserGroups := func() {
 		drainDynamicQueue(ctx, "dynamic user groups", logger, func(ctx context.Context) (dynamicQueueBatch, error) {
-			r, err := st.Queries().EvaluateQueuedDynamicUserGroups(ctx)
-			return dynamicQueueBatch{count: r.EvaluatedCount, more: r.More}, err
+			r, err := ev.DrainUserGroupQueue(ctx)
+			return dynamicQueueBatch{count: r.Count, more: r.More}, err
 		})
 	}
 

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -15,6 +15,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/dyngroupeval"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -490,15 +491,15 @@ func (w *InboxWorker) handleInventoryUpdate(ctx context.Context, t *asynq.Task) 
 	// completion the way cmd/control does. The `more` flag is
 	// ignored on this path because the periodic worker (or a
 	// subsequent inbox event) will pick up any leftover.
-	if r, err := w.store.Queries().EvaluateQueuedDynamicGroups(ctx); err != nil {
+	if r, err := dyngroupeval.New(w.store, w.logger).DrainDeviceGroupQueue(ctx); err != nil {
 		w.logger.Warn("failed to evaluate dynamic groups after inventory update",
 			"device_id", payload.DeviceID,
 			"error", err,
 		)
-	} else if r.EvaluatedCount > 0 {
+	} else if r.Count > 0 {
 		w.logger.Info("evaluated dynamic groups after inventory update",
 			"device_id", payload.DeviceID,
-			"count", r.EvaluatedCount,
+			"count", r.Count,
 		)
 	}
 

--- a/internal/dyngroupeval/evaluator.go
+++ b/internal/dyngroupeval/evaluator.go
@@ -201,6 +201,75 @@ func (e *Evaluator) EvaluateUserGroup(ctx context.Context, groupID string) error
 	})
 }
 
+// DrainResult is the per-batch summary the drain loop returns. Count
+// is the number of groups evaluated; More is true when the queue still
+// has rows after this batch (the caller should iterate again).
+type DrainResult struct {
+	Count int32
+	More  bool
+}
+
+// device-group drain batch size matches the PL/pgSQL evaluate_queued_dynamic_groups
+// constant (audit F035 / #168 wave). User-group drain uses 100 — historical
+// asymmetry the PL/pgSQL function had; keep the parity until tuning data
+// suggests otherwise.
+const (
+	deviceQueueBatchLimit = 1000
+	userQueueBatchLimit   = 100
+)
+
+// DrainDeviceGroupQueue evaluates the next batch of device-group queue
+// entries and returns (count, more). Per-group failures are logged and
+// skipped — one bad group should not block evaluation of the rest of
+// the batch.
+//
+// Replaces the PL/pgSQL evaluate_queued_dynamic_groups call. Callers
+// loop until More is false (see cmd/control/drainDynamicQueue).
+func (e *Evaluator) DrainDeviceGroupQueue(ctx context.Context) (DrainResult, error) {
+	q := e.store.Queries()
+	ids, err := q.ListDynamicDeviceGroupQueueBatch(ctx, deviceQueueBatchLimit)
+	if err != nil {
+		return DrainResult{}, fmt.Errorf("dyngroupeval: list device-group queue batch: %w", err)
+	}
+	var count int32
+	for _, id := range ids {
+		if err := e.EvaluateDeviceGroup(ctx, id); err != nil {
+			e.logger.Warn("dyngroupeval: failed to evaluate queued device group; skipping",
+				"group_id", id, "error", err)
+			continue
+		}
+		count++
+	}
+	more, err := q.HasDynamicDeviceGroupQueueEntries(ctx)
+	if err != nil {
+		return DrainResult{}, fmt.Errorf("dyngroupeval: probe device-group queue: %w", err)
+	}
+	return DrainResult{Count: count, More: more}, nil
+}
+
+// DrainUserGroupQueue is the user-group sibling of DrainDeviceGroupQueue.
+func (e *Evaluator) DrainUserGroupQueue(ctx context.Context) (DrainResult, error) {
+	q := e.store.Queries()
+	ids, err := q.ListDynamicUserGroupQueueBatch(ctx, userQueueBatchLimit)
+	if err != nil {
+		return DrainResult{}, fmt.Errorf("dyngroupeval: list user-group queue batch: %w", err)
+	}
+	var count int32
+	for _, id := range ids {
+		if err := e.EvaluateUserGroup(ctx, id); err != nil {
+			e.logger.Warn("dyngroupeval: failed to evaluate queued user group; skipping",
+				"group_id", id, "error", err)
+			continue
+		}
+		count++
+	}
+	more, err := q.HasDynamicUserGroupQueueEntries(ctx)
+	if err != nil {
+		return DrainResult{}, fmt.Errorf("dyngroupeval: probe user-group queue: %w", err)
+	}
+	return DrainResult{Count: count, More: more}, nil
+}
+
 // CountMatchingDevices returns the number of non-deleted devices that
 // match the given query. Used by the ValidateDynamicQuery RPC's preview
 // count. Parse failure is surfaced as an error so the caller can

--- a/internal/store/generated/device_groups.sql.go
+++ b/internal/store/generated/device_groups.sql.go
@@ -309,6 +309,20 @@ func (q *Queries) GetDynamicGroupsNeedingEvaluation(ctx context.Context, limit i
 	return items, nil
 }
 
+const hasDynamicDeviceGroupQueueEntries = `-- name: HasDynamicDeviceGroupQueueEntries :one
+SELECT EXISTS (SELECT 1 FROM dynamic_group_evaluation_queue LIMIT 1)::BOOLEAN AS has_more
+`
+
+// Wave C.4: cheap EXISTS probe used by the in-process drain loop to
+// set the `more` flag after a batch is processed. Same semantic the
+// PL/pgSQL function's tail SELECT covered (closes audit F035 / #168).
+func (q *Queries) HasDynamicDeviceGroupQueueEntries(ctx context.Context) (bool, error) {
+	row := q.db.QueryRow(ctx, hasDynamicDeviceGroupQueueEntries)
+	var has_more bool
+	err := row.Scan(&has_more)
+	return has_more, err
+}
+
 const insertDeviceGroupMember = `-- name: InsertDeviceGroupMember :exec
 INSERT INTO device_group_members_projection (
     group_id, device_id, added_at, projection_version
@@ -593,6 +607,36 @@ func (q *Queries) ListDevicesInGroup(ctx context.Context, groupID string) ([]Dev
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listDynamicDeviceGroupQueueBatch = `-- name: ListDynamicDeviceGroupQueueBatch :many
+SELECT group_id FROM dynamic_group_evaluation_queue
+ORDER BY queued_at
+LIMIT $1
+`
+
+// Wave C.4: returns the next batch of queued group IDs for the
+// in-process drain loop, ordered by queued_at so older entries get
+// evaluated first. Replaces the SELECT inside the PL/pgSQL
+// evaluate_queued_dynamic_groups function.
+func (q *Queries) ListDynamicDeviceGroupQueueBatch(ctx context.Context, limit int32) ([]string, error) {
+	rows, err := q.db.Query(ctx, listDynamicDeviceGroupQueueBatch, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var group_id string
+		if err := rows.Scan(&group_id); err != nil {
+			return nil, err
+		}
+		items = append(items, group_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/store/generated/user_groups.sql.go
+++ b/internal/store/generated/user_groups.sql.go
@@ -402,6 +402,19 @@ func (q *Queries) GetUserPermissionsWithGroups(ctx context.Context, userID strin
 	return items, nil
 }
 
+const hasDynamicUserGroupQueueEntries = `-- name: HasDynamicUserGroupQueueEntries :one
+SELECT EXISTS (SELECT 1 FROM dynamic_user_group_evaluation_queue LIMIT 1)::BOOLEAN AS has_more
+`
+
+// Wave C.4: cheap EXISTS probe for the `more` flag — same semantic as
+// HasDynamicDeviceGroupQueueEntries.
+func (q *Queries) HasDynamicUserGroupQueueEntries(ctx context.Context) (bool, error) {
+	row := q.db.QueryRow(ctx, hasDynamicUserGroupQueueEntries)
+	var has_more bool
+	err := row.Scan(&has_more)
+	return has_more, err
+}
+
 const insertUserGroupMember = `-- name: InsertUserGroupMember :exec
 INSERT INTO user_group_members_projection (
     group_id, user_id, added_at, added_by, projection_version
@@ -539,6 +552,35 @@ func (q *Queries) IsUserInGroup(ctx context.Context, arg IsUserInGroupParams) (b
 	var is_member bool
 	err := row.Scan(&is_member)
 	return is_member, err
+}
+
+const listDynamicUserGroupQueueBatch = `-- name: ListDynamicUserGroupQueueBatch :many
+SELECT group_id FROM dynamic_user_group_evaluation_queue
+ORDER BY queued_at
+LIMIT $1
+`
+
+// Wave C.4: returns the next batch of queued user-group IDs for the
+// in-process drain loop, oldest first. Replaces the SELECT inside the
+// PL/pgSQL evaluate_queued_dynamic_user_groups function.
+func (q *Queries) ListDynamicUserGroupQueueBatch(ctx context.Context, limit int32) ([]string, error) {
+	rows, err := q.db.Query(ctx, listDynamicUserGroupQueueBatch, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var group_id string
+		if err := rows.Scan(&group_id); err != nil {
+			return nil, err
+		}
+		items = append(items, group_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listInheritedRolesByUserIDs = `-- name: ListInheritedRolesByUserIDs :many

--- a/internal/store/queries/device_groups.sql
+++ b/internal/store/queries/device_groups.sql
@@ -267,6 +267,21 @@ DELETE FROM dynamic_group_evaluation_queue
 WHERE group_id = sqlc.arg(group_id)::TEXT
   AND queued_at <= sqlc.arg(before_ts)::TIMESTAMPTZ;
 
+-- name: ListDynamicDeviceGroupQueueBatch :many
+-- Wave C.4: returns the next batch of queued group IDs for the
+-- in-process drain loop, ordered by queued_at so older entries get
+-- evaluated first. Replaces the SELECT inside the PL/pgSQL
+-- evaluate_queued_dynamic_groups function.
+SELECT group_id FROM dynamic_group_evaluation_queue
+ORDER BY queued_at
+LIMIT $1;
+
+-- name: HasDynamicDeviceGroupQueueEntries :one
+-- Wave C.4: cheap EXISTS probe used by the in-process drain loop to
+-- set the `more` flag after a batch is processed. Same semantic the
+-- PL/pgSQL function's tail SELECT covered (closes audit F035 / #168).
+SELECT EXISTS (SELECT 1 FROM dynamic_group_evaluation_queue LIMIT 1)::BOOLEAN AS has_more;
+
 -- name: ClaimDeviceGroupForMembership :execrows
 -- Atomic guard for the four member-mutation events
 -- (DeviceGroupMemberAdded, DeviceAddedToGroup, DeviceGroupMemberRemoved,

--- a/internal/store/queries/user_groups.sql
+++ b/internal/store/queries/user_groups.sql
@@ -288,6 +288,19 @@ DELETE FROM dynamic_user_group_evaluation_queue
 WHERE group_id = sqlc.arg(group_id)::TEXT
   AND queued_at <= sqlc.arg(before_ts)::TIMESTAMPTZ;
 
+-- name: ListDynamicUserGroupQueueBatch :many
+-- Wave C.4: returns the next batch of queued user-group IDs for the
+-- in-process drain loop, oldest first. Replaces the SELECT inside the
+-- PL/pgSQL evaluate_queued_dynamic_user_groups function.
+SELECT group_id FROM dynamic_user_group_evaluation_queue
+ORDER BY queued_at
+LIMIT $1;
+
+-- name: HasDynamicUserGroupQueueEntries :one
+-- Wave C.4: cheap EXISTS probe for the `more` flag — same semantic as
+-- HasDynamicDeviceGroupQueueEntries.
+SELECT EXISTS (SELECT 1 FROM dynamic_user_group_evaluation_queue LIMIT 1)::BOOLEAN AS has_more;
+
 -- name: ListUsersForDynamicEvaluation :many
 -- All non-deleted users' fields the user-group evaluator reads (matches
 -- the 7 parameters evaluate_user_condition takes plus id for membership


### PR DESCRIPTION
Part of the storage-abstraction tracker (#242), Wave C (dynamic-query interpreter to Go) — fourth sub-wave. Closes #293.

## Summary

- Evaluator.DrainDeviceGroupQueue + DrainUserGroupQueue replace the PL/pgSQL evaluate_queued_dynamic_groups / _user_groups functions.
- 3 callsites swap (2 in cmd/control/periodic.go, 1 in internal/control/inbox_worker.go).
- After this lands, no production code path hits the PL/pgSQL dynamic-query interpreter. C.5 drops the functions.

## DoD checks

- [x] go build + go vet clean
- [x] cmd/control unit tests (drainDynamicQueue shape) pass
- [ ] CI integration suite

The existing internal/store/evaluate_queued_dynamic_groups_test.go tests the PL/pgSQL functions directly. They stay green here (the functions still exist) and get removed alongside the C.5 migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized dynamic group evaluation workflow with improved batch processing efficiency
  * Enhanced error handling and logging during group evaluation operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->