### PR TITLE
refactor(store): wave E.4 — devices.labels JSONB → device_labels child table (#297)

### DIFF
--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -554,12 +553,8 @@ func (h *DeviceHandler) deviceToProtoWithAssignments(d store.Device, assignedUse
 		device.CertExpiresAt = timestamppb.New(*d.CertNotAfter)
 	}
 
-	// Parse labels from JSONB
 	if len(d.Labels) > 0 {
-		var labels map[string]string
-		if err := json.Unmarshal(d.Labels, &labels); err == nil {
-			device.Labels = labels
-		}
+		device.Labels = d.Labels
 	}
 
 	// Compliance fields

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -381,6 +381,15 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if err != nil {
 			return nil, err
 		}
+		// Wave E.4: labels live in device_labels — load separately.
+		labelRows, err := q.ListDeviceLabels(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		labels := make(map[string]string, len(labelRows))
+		for _, r := range labelRows {
+			labels[r.Key] = r.Value
+		}
 		var registeredAt, lastSeenAt int64
 		if d.RegisteredAt != nil {
 			registeredAt = d.RegisteredAt.Unix()
@@ -391,7 +400,7 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		data := &taskqueue.SearchEntityData{
 			Hostname:         d.Hostname,
 			AgentVersion:     d.AgentVersion,
-			Labels:           search.FlattenLabels(d.Labels),
+			Labels:           search.FlattenLabels(labels),
 			ComplianceStatus: d.ComplianceStatus,
 			RegisteredAt:     registeredAt,
 			LastSeenAt:       lastSeenAt,

--- a/internal/dyngroupeval/evaluator.go
+++ b/internal/dyngroupeval/evaluator.go
@@ -537,21 +537,6 @@ func anyToString(v any) string {
 	return fmt.Sprint(v)
 }
 
-func parseLabelsJSON(raw []byte) map[string]string {
-	if len(raw) == 0 {
-		return nil
-	}
-	var m map[string]any
-	if err := json.Unmarshal(raw, &m); err != nil {
-		return nil
-	}
-	out := make(map[string]string, len(m))
-	for k, v := range m {
-		out[k] = anyToString(v)
-	}
-	return out
-}
-
 func toSet(ids []string) map[string]bool {
 	out := make(map[string]bool, len(ids))
 	for _, id := range ids {

--- a/internal/dyngroupeval/evaluator.go
+++ b/internal/dyngroupeval/evaluator.go
@@ -70,17 +70,21 @@ func (e *Evaluator) EvaluateDeviceGroup(ctx context.Context, groupID string) err
 	}
 	currentSet := toSet(currentMembers)
 
-	devices, err := q.ListDevicesForDynamicEvaluation(ctx)
+	deviceIDs, err := q.ListDevicesForDynamicEvaluation(ctx)
 	if err != nil {
 		return fmt.Errorf("dyngroupeval: list devices: %w", err)
+	}
+	labelsByDevice, err := e.loadAllDeviceLabels(ctx)
+	if err != nil {
+		return err
 	}
 
 	needsGroups := referencesGroupField(expr)
 	newSet := make(map[string]bool, len(currentMembers))
-	for _, d := range devices {
-		dctx := e.attachGroupMembership(ctx, e.buildDeviceContext(ctx, d.ID, d.Labels), needsGroups)
+	for _, id := range deviceIDs {
+		dctx := e.attachGroupMembership(ctx, e.buildDeviceContext(ctx, id, labelsByDevice[id]), needsGroups)
 		if dynamicquery.EvaluateDevice(expr, dctx) {
-			newSet[d.ID] = true
+			newSet[id] = true
 		}
 	}
 
@@ -280,19 +284,45 @@ func (e *Evaluator) CountMatchingDevices(ctx context.Context, query string) (int
 	if err != nil {
 		return 0, fmt.Errorf("dyngroupeval: parse: %w", err)
 	}
-	devices, err := e.store.Queries().ListDevicesForDynamicEvaluation(ctx)
+	deviceIDs, err := e.store.Queries().ListDevicesForDynamicEvaluation(ctx)
 	if err != nil {
 		return 0, fmt.Errorf("dyngroupeval: list devices: %w", err)
 	}
+	labelsByDevice, err := e.loadAllDeviceLabels(ctx)
+	if err != nil {
+		return 0, err
+	}
 	needsGroups := referencesGroupField(expr)
 	var count int64
-	for _, d := range devices {
-		dctx := e.attachGroupMembership(ctx, e.buildDeviceContext(ctx, d.ID, d.Labels), needsGroups)
+	for _, id := range deviceIDs {
+		dctx := e.attachGroupMembership(ctx, e.buildDeviceContext(ctx, id, labelsByDevice[id]), needsGroups)
 		if dynamicquery.EvaluateDevice(expr, dctx) {
 			count++
 		}
 	}
 	return count, nil
+}
+
+// loadAllDeviceLabels pulls every (device_id, key, value) row in one
+// query and groups by device_id. The map's nil-entry semantics let
+// the callers index by device_id without needing a presence check;
+// missing entries simply yield nil maps which the evaluator treats as
+// "no labels."
+func (e *Evaluator) loadAllDeviceLabels(ctx context.Context) (map[string]map[string]string, error) {
+	rows, err := e.store.Queries().ListAllDeviceLabels(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("dyngroupeval: list all device labels: %w", err)
+	}
+	out := make(map[string]map[string]string)
+	for _, r := range rows {
+		m, ok := out[r.DeviceID]
+		if !ok {
+			m = map[string]string{}
+			out[r.DeviceID] = m
+		}
+		m[r.Key] = r.Value
+	}
+	return out, nil
 }
 
 // CountMatchingUsers returns the number of non-deleted users that
@@ -324,14 +354,11 @@ func (e *Evaluator) CountMatchingUsers(ctx context.Context, query string) (int64
 	return count, nil
 }
 
-// buildDeviceContext returns a DeviceContext that lazy-loads inventory
-// + group memberships on first reference. Both incur a per-device
-// round-trip the first time the AST touches device.<inventory> or
-// device.group; queries that only use labels stay at the single
-// list-devices query.
-func (e *Evaluator) buildDeviceContext(ctx context.Context, deviceID string, labelsJSON []byte) dynamicquery.DeviceContext {
-	labels := parseLabelsJSON(labelsJSON)
-
+// buildDeviceContext returns a DeviceContext with pre-loaded labels
+// and a lazy-loading Inventory closure. Wave E.4 dropped the labels
+// JSONB column — callers now pass the already-grouped map[string]string
+// from a single ListAllDeviceLabels round-trip.
+func (e *Evaluator) buildDeviceContext(ctx context.Context, deviceID string, labels map[string]string) dynamicquery.DeviceContext {
 	var (
 		inventoryLoaded bool
 		inventoryByCol  map[string]string

--- a/internal/projectors/device.go
+++ b/internal/projectors/device.go
@@ -10,11 +10,33 @@ import (
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
-// defaultDeviceLabels mirrors the PL/pgSQL projector's
-// `COALESCE(event.data->'labels', '{}')` fallback for
-// DeviceRegistered. Held as raw bytes so the listener can pass it
-// straight to the JSONB column without an extra marshal.
-var defaultDeviceLabels = []byte(`{}`)
+// decodeLabelsMap accepts the JSONB-encoded {key:value} bytes the
+// emitter put on the wire and returns the parallel map[string]string
+// the device_labels child table consumes. Returns nil on empty input
+// or a non-object payload so the listener can skip the child-write
+// path cleanly. Non-string values are coerced via fmt.Sprint to match
+// the PL/pgSQL `->>` coercion that always returned TEXT.
+func decodeLabelsMap(raw []byte) map[string]string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var any map[string]any
+	if err := json.Unmarshal(raw, &any); err != nil || len(any) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(any))
+	for k, v := range any {
+		switch x := v.(type) {
+		case string:
+			out[k] = x
+		case nil:
+			out[k] = ""
+		default:
+			out[k] = fmt.Sprint(x)
+		}
+	}
+	return out
+}
 
 // DeviceRegisteredPayload mirrors the fields the deleted PL/pgSQL
 // project_device_event() read out of a DeviceRegistered event:
@@ -38,7 +60,7 @@ type DeviceRegisteredPayload struct {
 	CertFingerprint     *string
 	CertNotAfter        *time.Time
 	RegistrationTokenID *string
-	Labels              []byte
+	Labels              map[string]string
 	AssignedUserID      *string
 }
 
@@ -61,7 +83,6 @@ func DeviceRegisteredFromEvent(e store.PersistedEvent) (DeviceRegisteredPayload,
 		CertFingerprint:     raw.CertFingerprint,
 		RegistrationTokenID: raw.RegistrationTokenID,
 		AssignedUserID:      raw.AssignedUserID,
-		Labels:              defaultDeviceLabels,
 	}
 	notAfter, err := parseOptionalRFC3339(raw.CertNotAfter)
 	if err != nil {
@@ -71,12 +92,7 @@ func DeviceRegisteredFromEvent(e store.PersistedEvent) (DeviceRegisteredPayload,
 	if raw.Hostname != nil {
 		out.Hostname = *raw.Hostname
 	}
-	if len(raw.Labels) > 0 {
-		// Preserve wire bytes verbatim so the listener writes the same
-		// JSONB the emitter sent (matches the PL/pgSQL projector's
-		// `event.data->'labels'`).
-		out.Labels = []byte(raw.Labels)
-	}
+	out.Labels = decodeLabelsMap(raw.Labels)
 	return out, nil
 }
 
@@ -207,18 +223,24 @@ func DeviceCertRenewedFromEvent(e store.PersistedEvent) (DeviceCertRenewedPayloa
 	}, nil
 }
 
-// DeviceLabelsUpdatedPayload mirrors the PL/pgSQL projector's
-// `COALESCE(event.data->'labels', labels)` for DeviceLabelsUpdated:
-// missing key preserves the existing labels JSONB, present key
-// REPLACES the entire blob.
+// DeviceLabelsUpdatedPayload carries the new label set for
+// DeviceLabelsUpdated. The listener clears the existing device_labels
+// rows for the device and inserts every (key, value) here in one
+// transaction — matches the PL/pgSQL projector's "REPLACE the entire
+// JSONB blob" semantics. HasLabels distinguishes "labels key was
+// missing on the wire — preserve" from "labels key was present and
+// empty — clear all".
 type DeviceLabelsUpdatedPayload struct {
-	ID     string
-	Labels []byte
+	ID        string
+	Labels    map[string]string
+	HasLabels bool
 }
 
-// DeviceLabelsUpdatedFromEvent decodes DeviceLabelsUpdated. Empty
-// labels => nil byte slice; the SQL COALESCE will preserve the
-// existing row value.
+// DeviceLabelsUpdatedFromEvent decodes DeviceLabelsUpdated. Absent
+// labels key on the wire => HasLabels=false; the listener will skip the
+// child-table writes (preserves the existing rows). Present labels =>
+// HasLabels=true and Labels carries the new set (possibly empty, which
+// means clear all).
 func DeviceLabelsUpdatedFromEvent(e store.PersistedEvent) (DeviceLabelsUpdatedPayload, error) {
 	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceLabelsUpdated) {
 		return DeviceLabelsUpdatedPayload{}, ErrIgnoredEvent
@@ -232,7 +254,8 @@ func DeviceLabelsUpdatedFromEvent(e store.PersistedEvent) (DeviceLabelsUpdatedPa
 		return DeviceLabelsUpdatedPayload{}, fmt.Errorf("projector: invalid DeviceLabelsUpdated payload: %w", err)
 	}
 	if len(raw.Labels) > 0 {
-		out.Labels = []byte(raw.Labels)
+		out.Labels = decodeLabelsMap(raw.Labels)
+		out.HasLabels = true
 	}
 	return out, nil
 }

--- a/internal/projectors/device_listener.go
+++ b/internal/projectors/device_listener.go
@@ -133,10 +133,23 @@ func applyDeviceRegistered(ctx context.Context, q *store.Queries, e store.Persis
 		CertNotAfter:        payload.CertNotAfter,
 		RegisteredAt:        &occurredAt,
 		RegistrationTokenID: payload.RegistrationTokenID,
-		Labels:              payload.Labels,
 		ProjectionVersion:   deref(e.SequenceNum),
 	}); err != nil {
 		return err
+	}
+	// Initial label rows for a freshly-registered device. ON CONFLICT
+	// inside SetDeviceLabel makes the re-register revival path safe —
+	// we keep whatever labels were already on the row (PL/pgSQL
+	// behaviour: ON CONFLICT DO UPDATE kept the EXCLUDED labels, so
+	// the new payload's labels are now applied per-key instead).
+	for k, v := range payload.Labels {
+		if err := q.SetDeviceLabel(ctx, db.SetDeviceLabelParams{
+			DeviceID: payload.ID,
+			Key:      k,
+			Value:    v,
+		}); err != nil {
+			return err
+		}
 	}
 	if payload.AssignedUserID == nil || *payload.AssignedUserID == "" {
 		return nil
@@ -223,12 +236,25 @@ func applyDeviceLabelsUpdated(ctx context.Context, q *store.Queries, e store.Per
 		}
 		return err
 	}
-	if _, err := q.UpdateDeviceLabelsProjection(ctx, db.UpdateDeviceLabelsProjectionParams{
-		ID:                payload.ID,
-		Labels:            payload.Labels,
-		ProjectionVersion: deref(e.SequenceNum),
-	}); err != nil {
+	if !payload.HasLabels {
+		// "labels" key absent on the wire — preserve existing rows.
+		return nil
+	}
+	advanced, err := advanceDeviceVersion(ctx, q, payload.ID, e.SequenceNum)
+	if err != nil || !advanced {
 		return err
+	}
+	if err := q.ClearDeviceLabels(ctx, payload.ID); err != nil {
+		return err
+	}
+	for k, v := range payload.Labels {
+		if err := q.SetDeviceLabel(ctx, db.SetDeviceLabelParams{
+			DeviceID: payload.ID,
+			Key:      k,
+			Value:    v,
+		}); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -241,15 +267,15 @@ func applyDeviceLabelSet(ctx context.Context, q *store.Queries, e store.Persiste
 		}
 		return err
 	}
-	if _, err := q.SetDeviceLabelKey(ctx, db.SetDeviceLabelKeyParams{
-		ID:                payload.ID,
-		Key:               payload.Key,
-		Value:             payload.Value,
-		ProjectionVersion: deref(e.SequenceNum),
-	}); err != nil {
+	advanced, err := advanceDeviceVersion(ctx, q, payload.ID, e.SequenceNum)
+	if err != nil || !advanced {
 		return err
 	}
-	return nil
+	return q.SetDeviceLabel(ctx, db.SetDeviceLabelParams{
+		DeviceID: payload.ID,
+		Key:      payload.Key,
+		Value:    payload.Value,
+	})
 }
 
 func applyDeviceLabelRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -260,14 +286,32 @@ func applyDeviceLabelRemoved(ctx context.Context, q *store.Queries, e store.Pers
 		}
 		return err
 	}
-	if _, err := q.RemoveDeviceLabelKey(ctx, db.RemoveDeviceLabelKeyParams{
-		ID:                payload.ID,
-		Key:               payload.Key,
-		ProjectionVersion: deref(e.SequenceNum),
-	}); err != nil {
+	advanced, err := advanceDeviceVersion(ctx, q, payload.ID, e.SequenceNum)
+	if err != nil || !advanced {
 		return err
 	}
-	return nil
+	return q.RemoveDeviceLabel(ctx, db.RemoveDeviceLabelParams{
+		DeviceID: payload.ID,
+		Key:      payload.Key,
+	})
+}
+
+// advanceDeviceVersion bumps devices_projection.projection_version to
+// sequenceNum if it was lower. Returns (true, nil) when the bump
+// succeeded — meaning the event is newer than the row's last-applied
+// state, so the caller should proceed with the child-table change.
+// Returns (false, nil) when the event is stale and must be skipped
+// (the corresponding label row would otherwise be overwritten by an
+// out-of-order replay).
+func advanceDeviceVersion(ctx context.Context, q *store.Queries, deviceID string, sequenceNum *int64) (bool, error) {
+	n, err := q.AdvanceDeviceProjectionVersion(ctx, db.AdvanceDeviceProjectionVersionParams{
+		ID:                deviceID,
+		ProjectionVersion: deref(sequenceNum),
+	})
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
 }
 
 func applyDeviceDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {

--- a/internal/projectors/device_test.go
+++ b/internal/projectors/device_test.go
@@ -46,19 +46,19 @@ func TestDeviceRegisteredFromEvent_Pure(t *testing.T) {
 		assert.Equal(t, "abc123", *got.CertFingerprint)
 		require.NotNil(t, got.RegistrationTokenID)
 		assert.Equal(t, "tok-1", *got.RegistrationTokenID)
-		assert.Contains(t, string(got.Labels), "prod")
+		assert.Equal(t, "prod", got.Labels["env"])
 		require.NotNil(t, got.AssignedUserID)
 		assert.Equal(t, "user-A", *got.AssignedUserID)
 	})
 
-	t.Run("defaults: missing hostname → '', missing labels → '{}', missing cert/assigned → nil", func(t *testing.T) {
+	t.Run("defaults: missing hostname → '', missing labels → nil map, missing cert/assigned → nil", func(t *testing.T) {
 		got, err := projectors.DeviceRegisteredFromEvent(store.PersistedEvent{
 			StreamType: "device", StreamID: "dev-2", EventType: "DeviceRegistered",
 			Data: jsonOrFail(t, map[string]any{}),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, "", got.Hostname)
-		assert.JSONEq(t, "{}", string(got.Labels))
+		assert.Empty(t, got.Labels)
 		assert.Nil(t, got.CertFingerprint)
 		assert.Nil(t, got.AssignedUserID)
 	})
@@ -193,6 +193,18 @@ func TestDeviceCertRenewedFromEvent_Pure(t *testing.T) {
 	})
 }
 
+// labelRowsAsMap flattens the sqlc ListDeviceLabels result into a
+// map[key]value for terse test assertions. Wave E.4 normalized labels
+// out of the JSONB column into device_labels; the tests grew this
+// helper alongside that move.
+func labelRowsAsMap(rows []db.ListDeviceLabelsRow) map[string]string {
+	out := make(map[string]string, len(rows))
+	for _, r := range rows {
+		out[r.Key] = r.Value
+	}
+	return out
+}
+
 // TestDeviceLabelsUpdatedFromEvent_Pure — missing labels stays nil so
 // the SQL COALESCE preserves the existing column value.
 func TestDeviceLabelsUpdatedFromEvent_Pure(t *testing.T) {
@@ -202,15 +214,17 @@ func TestDeviceLabelsUpdatedFromEvent_Pure(t *testing.T) {
 			Data: jsonOrFail(t, map[string]any{"labels": map[string]any{"env": "prod"}}),
 		})
 		require.NoError(t, err)
-		assert.Contains(t, string(got.Labels), "prod")
+		assert.True(t, got.HasLabels)
+		assert.Equal(t, "prod", got.Labels["env"])
 	})
 
-	t.Run("missing labels stays nil", func(t *testing.T) {
+	t.Run("missing labels => HasLabels false (preserve existing rows)", func(t *testing.T) {
 		got, err := projectors.DeviceLabelsUpdatedFromEvent(store.PersistedEvent{
 			StreamType: "device", StreamID: "dev-1", EventType: "DeviceLabelsUpdated",
 			Data: jsonOrFail(t, map[string]any{}),
 		})
 		require.NoError(t, err)
+		assert.False(t, got.HasLabels)
 		assert.Nil(t, got.Labels)
 	})
 
@@ -455,38 +469,42 @@ func TestDeviceListener_FullLifecycle(t *testing.T) {
 	require.NotNil(t, got.CertFingerprint)
 	assert.Equal(t, "renewed-fp", *got.CertFingerprint)
 
-	// 5. LabelsUpdated — REPLACES the entire labels JSONB.
+	// 5. LabelsUpdated — REPLACES the entire label set in device_labels.
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "device", StreamID: deviceID, EventType: "DeviceLabelsUpdated",
 		Data:      map[string]any{"labels": map[string]any{"env": "prod", "region": "eu"}},
 		ActorType: "user", ActorID: "u",
 	}))
-	got, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	labels, err := st.Queries().ListDeviceLabels(ctx, deviceID)
 	require.NoError(t, err)
-	assert.Contains(t, string(got.Labels), "prod")
-	assert.Contains(t, string(got.Labels), "eu")
+	labelMap := labelRowsAsMap(labels)
+	assert.Equal(t, "prod", labelMap["env"])
+	assert.Equal(t, "eu", labelMap["region"])
 
-	// 6. LabelSet — JSONB merge keeps existing labels and adds the new key.
+	// 6. LabelSet — UPSERT keeps existing labels and adds the new key.
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "device", StreamID: deviceID, EventType: "DeviceLabelSet",
 		Data:      map[string]any{"key": "tier", "value": "gold"},
 		ActorType: "user", ActorID: "u",
 	}))
-	got, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	labels, err = st.Queries().ListDeviceLabels(ctx, deviceID)
 	require.NoError(t, err)
-	assert.Contains(t, string(got.Labels), "gold", "DeviceLabelSet must merge new key into labels")
-	assert.Contains(t, string(got.Labels), "prod", "DeviceLabelSet must preserve existing keys")
+	labelMap = labelRowsAsMap(labels)
+	assert.Equal(t, "gold", labelMap["tier"], "DeviceLabelSet must add the new key")
+	assert.Equal(t, "prod", labelMap["env"], "DeviceLabelSet must preserve existing keys")
 
-	// 7. LabelRemoved — drops the key from labels.
+	// 7. LabelRemoved — drops the key from device_labels.
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "device", StreamID: deviceID, EventType: "DeviceLabelRemoved",
 		Data:      map[string]any{"key": "env"},
 		ActorType: "user", ActorID: "u",
 	}))
-	got, err = st.Queries().GetDeviceByID(ctx, deviceLookup(deviceID))
+	labels, err = st.Queries().ListDeviceLabels(ctx, deviceID)
 	require.NoError(t, err)
-	assert.NotContains(t, string(got.Labels), `"env"`, "DeviceLabelRemoved must drop the named key")
-	assert.Contains(t, string(got.Labels), "gold", "DeviceLabelRemoved must preserve other keys")
+	labelMap = labelRowsAsMap(labels)
+	_, hasEnv := labelMap["env"]
+	assert.False(t, hasEnv, "DeviceLabelRemoved must drop the named key")
+	assert.Equal(t, "gold", labelMap["tier"], "DeviceLabelRemoved must preserve other keys")
 
 	// 8. SyncIntervalSet — stamps the per-device override.
 	require.NoError(t, st.AppendEvent(ctx, store.Event{

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -863,13 +863,11 @@ func (idx *Index) warmUserGroups(ctx context.Context) (int, error) {
 	return total, nil
 }
 
-// FlattenLabels converts a JSONB labels map to a space-separated "key=value" string for TEXT search.
-func FlattenLabels(labelsJSON []byte) string {
-	if len(labelsJSON) == 0 {
-		return ""
-	}
-	var labels map[string]string
-	if err := json.Unmarshal(labelsJSON, &labels); err != nil {
+// FlattenLabels converts a labels map to a space-separated "key=value"
+// string for TEXT search. Wave E.4 dropped the JSONB intermediate;
+// callers pass the typed map directly.
+func FlattenLabels(labels map[string]string) string {
+	if len(labels) == 0 {
 		return ""
 	}
 	var parts []string

--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -2,15 +2,17 @@ package store
 
 import (
 	"context"
-	"encoding/json"
 	"time"
 )
 
 // Device is the device projection row. CertFingerprint pins the
 // agent cert the device currently uses — used by the
 // CertificateHandler to refuse renewals when a different fingerprint
-// presents. Labels stays as json.RawMessage at the boundary per the
-// JSONB normalize plan in #242.
+// presents.
+//
+// Labels is a typed map loaded from the device_labels child table
+// (Wave E.4, tracker #242); repo implementations populate it alongside
+// the core row.
 //
 // The compliance-status quadruple (Status / CheckedAt / Total /
 // Passing) is denormalized on the device row by the compliance
@@ -25,7 +27,7 @@ type Device struct {
 	RegisteredAt        *time.Time
 	LastSeenAt          *time.Time
 	RegistrationTokenID *string
-	Labels              json.RawMessage
+	Labels              map[string]string
 	IsDeleted           bool
 	SyncIntervalMinutes int32
 	ComplianceStatus    int32

--- a/internal/store/generated/device_groups.sql.go
+++ b/internal/store/generated/device_groups.sql.go
@@ -494,33 +494,26 @@ func (q *Queries) ListDeviceGroups(ctx context.Context, arg ListDeviceGroupsPara
 }
 
 const listDevicesForDynamicEvaluation = `-- name: ListDevicesForDynamicEvaluation :many
-SELECT id, labels FROM devices_projection
+SELECT id FROM devices_projection
 WHERE is_deleted = FALSE
 `
 
-type ListDevicesForDynamicEvaluationRow struct {
-	ID     string `json:"id"`
-	Labels []byte `json:"labels"`
-}
-
-// All non-deleted devices' (id, labels) for the in-process dynamic-group
-// evaluator (Wave C.3). Returning the JSONB labels column is still
-// correct pre-E.4; once labels move to the device_labels child table
-// this query becomes an id-only list and labels load via the child
-// repo.
-func (q *Queries) ListDevicesForDynamicEvaluation(ctx context.Context) ([]ListDevicesForDynamicEvaluationRow, error) {
+// Wave E.4: labels moved to device_labels — this query is now id-only.
+// The in-process evaluator follows up with ListAllDeviceLabels and
+// joins the two in Go to build per-device DeviceContext.Labels maps.
+func (q *Queries) ListDevicesForDynamicEvaluation(ctx context.Context) ([]string, error) {
 	rows, err := q.db.Query(ctx, listDevicesForDynamicEvaluation)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListDevicesForDynamicEvaluationRow{}
+	items := []string{}
 	for rows.Next() {
-		var i ListDevicesForDynamicEvaluationRow
-		if err := rows.Scan(&i.ID, &i.Labels); err != nil {
+		var id string
+		if err := rows.Scan(&id); err != nil {
 			return nil, err
 		}
-		items = append(items, i)
+		items = append(items, id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -529,7 +522,7 @@ func (q *Queries) ListDevicesForDynamicEvaluation(ctx context.Context) ([]ListDe
 }
 
 const listDevicesInGroup = `-- name: ListDevicesInGroup :many
-SELECT d.id, d.hostname, d.agent_version, d.cert_fingerprint, d.cert_not_after, d.registered_at, d.last_seen_at, d.registration_token_id, d.labels, d.is_deleted, d.projection_version, d.sync_interval_minutes, d.compliance_status, d.compliance_checked_at, d.compliance_total, d.compliance_passing FROM devices_projection d
+SELECT d.id, d.hostname, d.agent_version, d.cert_fingerprint, d.cert_not_after, d.registered_at, d.last_seen_at, d.registration_token_id, d.is_deleted, d.projection_version, d.sync_interval_minutes, d.compliance_status, d.compliance_checked_at, d.compliance_total, d.compliance_passing FROM devices_projection d
 JOIN device_group_members_projection m ON d.id = m.device_id
 WHERE m.group_id = $1 AND d.is_deleted = FALSE
 ORDER BY d.hostname ASC
@@ -553,7 +546,6 @@ func (q *Queries) ListDevicesInGroup(ctx context.Context, groupID string) ([]Dev
 			&i.RegisteredAt,
 			&i.LastSeenAt,
 			&i.RegistrationTokenID,
-			&i.Labels,
 			&i.IsDeleted,
 			&i.ProjectionVersion,
 			&i.SyncIntervalMinutes,

--- a/internal/store/generated/devices.sql.go
+++ b/internal/store/generated/devices.sql.go
@@ -10,6 +10,43 @@ import (
 	"time"
 )
 
+const advanceDeviceProjectionVersion = `-- name: AdvanceDeviceProjectionVersion :execrows
+UPDATE devices_projection
+SET projection_version = $1
+WHERE id = $2
+  AND projection_version < $1
+`
+
+type AdvanceDeviceProjectionVersionParams struct {
+	ProjectionVersion int64  `json:"projection_version"`
+	ID                string `json:"id"`
+}
+
+// Wave E.4: parent-row stale-replay guard for the device_labels child
+// table writes. The PL/pgSQL projector folded the version bump into
+// the JSONB UPDATE in one statement; with the column gone, the listener
+// runs this query first, checks the rows-affected, and only proceeds
+// with the child-table change when the bump succeeded.
+func (q *Queries) AdvanceDeviceProjectionVersion(ctx context.Context, arg AdvanceDeviceProjectionVersionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, advanceDeviceProjectionVersion, arg.ProjectionVersion, arg.ID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
+const clearDeviceLabels = `-- name: ClearDeviceLabels :exec
+DELETE FROM device_labels WHERE device_id = $1
+`
+
+// Bulk-replace half of DeviceLabelsUpdated. Listener follows this with
+// a series of SetDeviceLabel writes for the new label set, all under
+// the AdvanceDeviceProjectionVersion guard.
+func (q *Queries) ClearDeviceLabels(ctx context.Context, deviceID string) error {
+	_, err := q.db.Exec(ctx, clearDeviceLabels, deviceID)
+	return err
+}
+
 const countDevices = `-- name: CountDevices :one
 SELECT COUNT(*) FROM devices_projection
 WHERE is_deleted = FALSE
@@ -136,7 +173,7 @@ func (q *Queries) DeleteDeviceAssignedUsersByDevice(ctx context.Context, deviceI
 }
 
 const getDeviceByFingerprint = `-- name: GetDeviceByFingerprint :one
-SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, labels, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
+SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
 WHERE cert_fingerprint = $1 AND is_deleted = FALSE
 `
 
@@ -152,7 +189,6 @@ func (q *Queries) GetDeviceByFingerprint(ctx context.Context, certFingerprint *s
 		&i.RegisteredAt,
 		&i.LastSeenAt,
 		&i.RegistrationTokenID,
-		&i.Labels,
 		&i.IsDeleted,
 		&i.ProjectionVersion,
 		&i.SyncIntervalMinutes,
@@ -165,7 +201,7 @@ func (q *Queries) GetDeviceByFingerprint(ctx context.Context, certFingerprint *s
 }
 
 const getDeviceByID = `-- name: GetDeviceByID :one
-SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, labels, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
+SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
 WHERE id = $1 AND is_deleted = FALSE
   AND ($2::TEXT IS NULL
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = $2)
@@ -190,7 +226,6 @@ func (q *Queries) GetDeviceByID(ctx context.Context, arg GetDeviceByIDParams) (D
 		&i.RegisteredAt,
 		&i.LastSeenAt,
 		&i.RegistrationTokenID,
-		&i.Labels,
 		&i.IsDeleted,
 		&i.ProjectionVersion,
 		&i.SyncIntervalMinutes,
@@ -281,24 +316,29 @@ func (q *Queries) GetDeviceSyncInterval(ctx context.Context, dollar_1 string) (i
 }
 
 const getDevicesWithLabel = `-- name: GetDevicesWithLabel :many
-SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, labels, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
-WHERE is_deleted = FALSE
-  AND labels->>$1 = $2
-ORDER BY last_seen_at DESC
+SELECT d.id, d.hostname, d.agent_version, d.cert_fingerprint, d.cert_not_after, d.registered_at, d.last_seen_at, d.registration_token_id, d.is_deleted, d.projection_version, d.sync_interval_minutes, d.compliance_status, d.compliance_checked_at, d.compliance_total, d.compliance_passing FROM devices_projection d
+JOIN device_labels l ON l.device_id = d.id
+WHERE d.is_deleted = FALSE
+  AND l.key = $1
+  AND l.value = $2
+ORDER BY d.last_seen_at DESC
 LIMIT $3 OFFSET $4
 `
 
 type GetDevicesWithLabelParams struct {
-	Labels   []byte `json:"labels"`
-	Labels_2 []byte `json:"labels_2"`
-	Limit    int32  `json:"limit"`
-	Offset   int32  `json:"offset"`
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Limit  int32  `json:"limit"`
+	Offset int32  `json:"offset"`
 }
 
+// Wave E.4: labels live in the device_labels child table now. The JOIN
+// against (key, value) hits idx_device_labels_key_value for a direct
+// lookup; no more JSONB operator.
 func (q *Queries) GetDevicesWithLabel(ctx context.Context, arg GetDevicesWithLabelParams) ([]DevicesProjection, error) {
 	rows, err := q.db.Query(ctx, getDevicesWithLabel,
-		arg.Labels,
-		arg.Labels_2,
+		arg.Key,
+		arg.Value,
 		arg.Limit,
 		arg.Offset,
 	)
@@ -318,7 +358,6 @@ func (q *Queries) GetDevicesWithLabel(ctx context.Context, arg GetDevicesWithLab
 			&i.RegisteredAt,
 			&i.LastSeenAt,
 			&i.RegistrationTokenID,
-			&i.Labels,
 			&i.IsDeleted,
 			&i.ProjectionVersion,
 			&i.SyncIntervalMinutes,
@@ -432,6 +471,34 @@ func (q *Queries) IsDeviceDeleted(ctx context.Context, id string) (bool, error) 
 	var is_deleted bool
 	err := row.Scan(&is_deleted)
 	return is_deleted, err
+}
+
+const listAllDeviceLabels = `-- name: ListAllDeviceLabels :many
+SELECT device_id, key, value FROM device_labels
+ORDER BY device_id, key
+`
+
+// Wave E.4: load every label row in one query for the dyngroupeval
+// queue-drain hot path. Replaces the labels JSONB column that used
+// to come back with each device row.
+func (q *Queries) ListAllDeviceLabels(ctx context.Context) ([]DeviceLabel, error) {
+	rows, err := q.db.Query(ctx, listAllDeviceLabels)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []DeviceLabel{}
+	for rows.Next() {
+		var i DeviceLabel
+		if err := rows.Scan(&i.DeviceID, &i.Key, &i.Value); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listDeviceAssignedGroupIDs = `-- name: ListDeviceAssignedGroupIDs :many
@@ -608,8 +675,72 @@ func (q *Queries) ListDeviceAssignedUsers(ctx context.Context, deviceID string) 
 	return items, nil
 }
 
+const listDeviceLabels = `-- name: ListDeviceLabels :many
+SELECT key, value FROM device_labels
+WHERE device_id = $1
+ORDER BY key
+`
+
+type ListDeviceLabelsRow struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// Wave E.4: returns the (key, value) pairs for a single device.
+// Powers the in-process evaluator's per-device DeviceContext.Labels
+// map and any single-device repo callers that need the typed slice.
+func (q *Queries) ListDeviceLabels(ctx context.Context, deviceID string) ([]ListDeviceLabelsRow, error) {
+	rows, err := q.db.Query(ctx, listDeviceLabels, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListDeviceLabelsRow{}
+	for rows.Next() {
+		var i ListDeviceLabelsRow
+		if err := rows.Scan(&i.Key, &i.Value); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listDeviceLabelsBatch = `-- name: ListDeviceLabelsBatch :many
+SELECT device_id, key, value FROM device_labels
+WHERE device_id = ANY($1::TEXT[])
+ORDER BY device_id, key
+`
+
+// Wave E.4: batched per-device label fetch for repo.List and the
+// in-process group evaluator. Single round-trip across the slice of
+// device IDs avoids the N+1 the per-device ListDeviceLabels would
+// have at population time.
+func (q *Queries) ListDeviceLabelsBatch(ctx context.Context, deviceIds []string) ([]DeviceLabel, error) {
+	rows, err := q.db.Query(ctx, listDeviceLabelsBatch, deviceIds)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []DeviceLabel{}
+	for rows.Next() {
+		var i DeviceLabel
+		if err := rows.Scan(&i.DeviceID, &i.Key, &i.Value); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDevices = `-- name: ListDevices :many
-SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, labels, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
+SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
 WHERE is_deleted = FALSE
   AND ($3::TEXT IS NULL
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = $3)
@@ -643,7 +774,6 @@ func (q *Queries) ListDevices(ctx context.Context, arg ListDevicesParams) ([]Dev
 			&i.RegisteredAt,
 			&i.LastSeenAt,
 			&i.RegistrationTokenID,
-			&i.Labels,
 			&i.IsDeleted,
 			&i.ProjectionVersion,
 			&i.SyncIntervalMinutes,
@@ -663,7 +793,7 @@ func (q *Queries) ListDevices(ctx context.Context, arg ListDevicesParams) ([]Dev
 }
 
 const listDevicesOffline = `-- name: ListDevicesOffline :many
-SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, labels, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
+SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
 WHERE is_deleted = FALSE
   AND last_seen_at <= NOW() - INTERVAL '5 minutes'
   AND ($3::TEXT IS NULL
@@ -698,7 +828,6 @@ func (q *Queries) ListDevicesOffline(ctx context.Context, arg ListDevicesOffline
 			&i.RegisteredAt,
 			&i.LastSeenAt,
 			&i.RegistrationTokenID,
-			&i.Labels,
 			&i.IsDeleted,
 			&i.ProjectionVersion,
 			&i.SyncIntervalMinutes,
@@ -718,7 +847,7 @@ func (q *Queries) ListDevicesOffline(ctx context.Context, arg ListDevicesOffline
 }
 
 const listDevicesOnline = `-- name: ListDevicesOnline :many
-SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, labels, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
+SELECT id, hostname, agent_version, cert_fingerprint, cert_not_after, registered_at, last_seen_at, registration_token_id, is_deleted, projection_version, sync_interval_minutes, compliance_status, compliance_checked_at, compliance_total, compliance_passing FROM devices_projection
 WHERE is_deleted = FALSE
   AND last_seen_at > NOW() - INTERVAL '5 minutes'
   AND ($3::TEXT IS NULL
@@ -753,7 +882,6 @@ func (q *Queries) ListDevicesOnline(ctx context.Context, arg ListDevicesOnlinePa
 			&i.RegisteredAt,
 			&i.LastSeenAt,
 			&i.RegistrationTokenID,
-			&i.Labels,
 			&i.IsDeleted,
 			&i.ProjectionVersion,
 			&i.SyncIntervalMinutes,
@@ -772,61 +900,43 @@ func (q *Queries) ListDevicesOnline(ctx context.Context, arg ListDevicesOnlinePa
 	return items, nil
 }
 
-const removeDeviceLabelKey = `-- name: RemoveDeviceLabelKey :execrows
-UPDATE devices_projection
-SET labels             = labels - $3::TEXT,
-    projection_version = $2
-WHERE id = $1
-  AND projection_version < $2
+const removeDeviceLabel = `-- name: RemoveDeviceLabel :exec
+DELETE FROM device_labels
+WHERE device_id = $1
+  AND key = $2::TEXT
 `
 
-type RemoveDeviceLabelKeyParams struct {
-	ID                string `json:"id"`
-	ProjectionVersion int64  `json:"projection_version"`
-	Key               string `json:"key"`
+type RemoveDeviceLabelParams struct {
+	DeviceID string `json:"device_id"`
+	Key      string `json:"key"`
 }
 
-// DeviceLabelRemoved handler. JSONB minus operator drops the key from
-// the labels object. Stale-replay guard via projection_version.
-func (q *Queries) RemoveDeviceLabelKey(ctx context.Context, arg RemoveDeviceLabelKeyParams) (int64, error) {
-	result, err := q.db.Exec(ctx, removeDeviceLabelKey, arg.ID, arg.ProjectionVersion, arg.Key)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+// DeviceLabelRemoved handler. DELETE-with-no-match is silently fine
+// (matches the PL/pgSQL JSONB minus-operator behaviour on a missing key).
+func (q *Queries) RemoveDeviceLabel(ctx context.Context, arg RemoveDeviceLabelParams) error {
+	_, err := q.db.Exec(ctx, removeDeviceLabel, arg.DeviceID, arg.Key)
+	return err
 }
 
-const setDeviceLabelKey = `-- name: SetDeviceLabelKey :execrows
-UPDATE devices_projection
-SET labels             = COALESCE(labels, '{}'::JSONB) || jsonb_build_object($3::TEXT, $4::TEXT),
-    projection_version = $2
-WHERE id = $1
-  AND projection_version < $2
+const setDeviceLabel = `-- name: SetDeviceLabel :exec
+INSERT INTO device_labels (device_id, key, value)
+VALUES ($1, $2::TEXT, $3::TEXT)
+ON CONFLICT (device_id, key) DO UPDATE SET value = EXCLUDED.value
 `
 
-type SetDeviceLabelKeyParams struct {
-	ID                string `json:"id"`
-	ProjectionVersion int64  `json:"projection_version"`
-	Key               string `json:"key"`
-	Value             string `json:"value"`
+type SetDeviceLabelParams struct {
+	DeviceID string `json:"device_id"`
+	Key      string `json:"key"`
+	Value    string `json:"value"`
 }
 
-// DeviceLabelSet handler. Mirrors the PL/pgSQL JSONB merge:
-// `labels || jsonb_build_object(key, value)`. The first COALESCE on
-// labels handles the (theoretical) NULL case for legacy rows — matches
-// PL/pgSQL's `COALESCE(labels, '{}'::jsonb) || ...`. Stale-replay guard
-// via projection_version.
-func (q *Queries) SetDeviceLabelKey(ctx context.Context, arg SetDeviceLabelKeyParams) (int64, error) {
-	result, err := q.db.Exec(ctx, setDeviceLabelKey,
-		arg.ID,
-		arg.ProjectionVersion,
-		arg.Key,
-		arg.Value,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+// DeviceLabelSet handler against the device_labels child table (Wave E.4).
+// ON CONFLICT DO UPDATE preserves replay-safety: re-applying the same
+// event lands the same (key, value); a stale event would have already
+// been intercepted by AdvanceDeviceProjectionVersion above.
+func (q *Queries) SetDeviceLabel(ctx context.Context, arg SetDeviceLabelParams) error {
+	_, err := q.db.Exec(ctx, setDeviceLabel, arg.DeviceID, arg.Key, arg.Value)
+	return err
 }
 
 const softDeleteDeviceProjection = `-- name: SoftDeleteDeviceProjection :execrows
@@ -918,34 +1028,6 @@ func (q *Queries) UpdateDeviceHeartbeatProjection(ctx context.Context, arg Updat
 	return result.RowsAffected(), nil
 }
 
-const updateDeviceLabelsProjection = `-- name: UpdateDeviceLabelsProjection :execrows
-UPDATE devices_projection
-SET labels             = COALESCE($3::JSONB, labels),
-    projection_version = $2
-WHERE id = $1
-  AND projection_version < $2
-`
-
-type UpdateDeviceLabelsProjectionParams struct {
-	ID                string `json:"id"`
-	ProjectionVersion int64  `json:"projection_version"`
-	Labels            []byte `json:"labels"`
-}
-
-// DeviceLabelsUpdated handler. The decoder leaves a missing labels key
-// as a nil byte slice; the SQL COALESCE preserves the existing column
-// value in that case (matches PL/pgSQL `COALESCE(payload, labels)`).
-// The :: JSONB cast is required so PostgreSQL can resolve the parameter
-// type when the value is NULL.
-// Stale-replay guard via projection_version.
-func (q *Queries) UpdateDeviceLabelsProjection(ctx context.Context, arg UpdateDeviceLabelsProjectionParams) (int64, error) {
-	result, err := q.db.Exec(ctx, updateDeviceLabelsProjection, arg.ID, arg.ProjectionVersion, arg.Labels)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
-}
-
 const updateDeviceSeenProjection = `-- name: UpdateDeviceSeenProjection :execrows
 UPDATE devices_projection
 SET last_seen_at        = $2,
@@ -1017,8 +1099,8 @@ const upsertDeviceProjection = `-- name: UpsertDeviceProjection :exec
 INSERT INTO devices_projection (
     id, hostname, cert_fingerprint, cert_not_after,
     registered_at, last_seen_at, registration_token_id,
-    labels, projection_version
-) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8)
+    projection_version
+) VALUES ($1, $2, $3, $4, $5, $5, $6, $7)
 ON CONFLICT (id) DO UPDATE SET
     hostname              = EXCLUDED.hostname,
     cert_fingerprint      = EXCLUDED.cert_fingerprint,
@@ -1026,7 +1108,6 @@ ON CONFLICT (id) DO UPDATE SET
     registered_at         = EXCLUDED.registered_at,
     last_seen_at          = EXCLUDED.last_seen_at,
     registration_token_id = EXCLUDED.registration_token_id,
-    labels                = EXCLUDED.labels,
     projection_version    = EXCLUDED.projection_version,
     is_deleted            = FALSE
 `
@@ -1038,7 +1119,6 @@ type UpsertDeviceProjectionParams struct {
 	CertNotAfter        *time.Time `json:"cert_not_after"`
 	RegisteredAt        *time.Time `json:"registered_at"`
 	RegistrationTokenID *string    `json:"registration_token_id"`
-	Labels              []byte     `json:"labels"`
 	ProjectionVersion   int64      `json:"projection_version"`
 }
 
@@ -1072,6 +1152,10 @@ type UpsertDeviceProjectionParams struct {
 // timeline). projection_version is unconditionally bumped here because
 // DeviceRegistered is the stream's birthing event; replay safety for
 // subsequent events lives on their per-event guarded UPDATEs.
+//
+// Wave E.4: labels moved out of devices_projection into device_labels.
+// Initial-labels writes happen via InsertDeviceLabel in the listener
+// after this upsert, inside the same WithTx.
 func (q *Queries) UpsertDeviceProjection(ctx context.Context, arg UpsertDeviceProjectionParams) error {
 	_, err := q.db.Exec(ctx, upsertDeviceProjection,
 		arg.ID,
@@ -1080,7 +1164,6 @@ func (q *Queries) UpsertDeviceProjection(ctx context.Context, arg UpsertDevicePr
 		arg.CertNotAfter,
 		arg.RegisteredAt,
 		arg.RegistrationTokenID,
-		arg.Labels,
 		arg.ProjectionVersion,
 	)
 	return err

--- a/internal/store/generated/models.go
+++ b/internal/store/generated/models.go
@@ -181,6 +181,12 @@ type DeviceInventory struct {
 	CollectedAt time.Time `json:"collected_at"`
 }
 
+type DeviceLabel struct {
+	DeviceID string `json:"device_id"`
+	Key      string `json:"key"`
+	Value    string `json:"value"`
+}
+
 type DevicesProjection struct {
 	ID                  string     `json:"id"`
 	Hostname            string     `json:"hostname"`
@@ -190,7 +196,6 @@ type DevicesProjection struct {
 	RegisteredAt        *time.Time `json:"registered_at"`
 	LastSeenAt          *time.Time `json:"last_seen_at"`
 	RegistrationTokenID *string    `json:"registration_token_id"`
-	Labels              []byte     `json:"labels"`
 	IsDeleted           bool       `json:"is_deleted"`
 	ProjectionVersion   int64      `json:"projection_version"`
 	SyncIntervalMinutes int32      `json:"sync_interval_minutes"`

--- a/internal/store/migrations/047_device_labels_child_table.sql
+++ b/internal/store/migrations/047_device_labels_child_table.sql
@@ -1,0 +1,89 @@
+-- Wave E.4 (tracker manchtools/power-manage-server#242): normalize the
+-- devices_projection.labels JSONB column into a relational child table
+-- device_labels. The Go evaluator already consumes labels through a
+-- map; this migration is the last step of the JSONB cleanup, closing
+-- the Wave E DoD ("no JSONB operator in any sqlc query").
+--
+-- Idempotency for projector replay: the device-projector listener writes
+-- this child table under the parent projection_version guard (replacing
+-- the per-row JSONB-merge guard the PL/pgSQL projector did). Replay-safe
+-- because an out-of-order event hits the version check before any child
+-- write happens.
+--
+-- The dynamic-group queue trigger that previously fired on labels-JSONB
+-- updates is re-pointed at device_labels (INSERT/UPDATE/DELETE) so
+-- dynamic-group re-evaluation still queues on every label change.
+
+-- +goose Up
+
+CREATE TABLE device_labels (
+    device_id TEXT NOT NULL REFERENCES devices_projection(id) ON DELETE CASCADE,
+    key       TEXT NOT NULL,
+    value     TEXT NOT NULL,
+    PRIMARY KEY (device_id, key)
+);
+
+CREATE INDEX idx_device_labels_key_value ON device_labels(key, value);
+
+INSERT INTO device_labels (device_id, key, value)
+SELECT d.id, kv.key, kv.value
+FROM devices_projection d,
+     jsonb_each_text(d.labels) AS kv
+WHERE d.labels IS NOT NULL
+  AND jsonb_typeof(d.labels) = 'object';
+
+-- Drop the JSONB-column-driven trigger before re-creating it against
+-- the child table.
+DROP TRIGGER IF EXISTS device_label_change_trigger ON devices_projection;
+
+-- New trigger function pulls the device id from NEW or OLD so it
+-- handles INSERT/UPDATE/DELETE uniformly. Behaviour is identical: enqueue
+-- the device for dynamic-group re-evaluation.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION trigger_device_labels_child_change() RETURNS trigger AS $$
+DECLARE
+    target_id TEXT;
+BEGIN
+    target_id := COALESCE(NEW.device_id, OLD.device_id);
+    PERFORM queue_dynamic_groups_for_device(target_id);
+    RETURN COALESCE(NEW, OLD);
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER device_labels_change_trigger
+    AFTER INSERT OR UPDATE OR DELETE ON device_labels
+    FOR EACH ROW
+    EXECUTE FUNCTION trigger_device_labels_child_change();
+
+DROP INDEX IF EXISTS idx_devices_labels;
+ALTER TABLE devices_projection DROP COLUMN labels;
+
+-- +goose Down
+
+-- Re-create the JSONB column and backfill from the child table so a
+-- downgrade still has the projection state. The dynamic-group trigger
+-- re-pointing is reversed (drop child-table trigger, re-create the
+-- JSONB-column one).
+ALTER TABLE devices_projection
+    ADD COLUMN labels JSONB NOT NULL DEFAULT '{}';
+
+UPDATE devices_projection d
+SET labels = COALESCE((
+        SELECT jsonb_object_agg(l.key, l.value)
+        FROM device_labels l
+        WHERE l.device_id = d.id
+    ), '{}'::JSONB);
+
+CREATE INDEX idx_devices_labels ON devices_projection USING GIN (labels);
+
+DROP TRIGGER IF EXISTS device_labels_change_trigger ON device_labels;
+DROP FUNCTION IF EXISTS trigger_device_labels_child_change();
+
+CREATE TRIGGER device_label_change_trigger
+    AFTER INSERT OR UPDATE OF labels ON devices_projection
+    FOR EACH ROW
+    EXECUTE FUNCTION trigger_device_label_change();
+
+DROP INDEX IF EXISTS idx_device_labels_key_value;
+DROP TABLE device_labels;

--- a/internal/store/postgres/device.go
+++ b/internal/store/postgres/device.go
@@ -2,14 +2,14 @@ package postgres
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
-// Device implements store.DeviceRepo against devices_projection.
+// Device implements store.DeviceRepo against devices_projection +
+// device_labels (Wave E.4 normalized labels into a child table).
 type Device struct {
 	q *generated.Queries
 }
@@ -27,7 +27,13 @@ func (d *Device) Get(ctx context.Context, key store.GetDeviceKey) (store.Device,
 	if err != nil {
 		return store.Device{}, fmt.Errorf("device: get: %w", translateNotFound(err))
 	}
-	return deviceFromRow(row), nil
+	dev := deviceFromRow(row)
+	labels, err := d.q.ListDeviceLabels(ctx, key.ID)
+	if err != nil {
+		return store.Device{}, fmt.Errorf("device: load labels: %w", err)
+	}
+	dev.Labels = labelsFromRows(labels)
+	return dev, nil
 }
 
 func (d *Device) IsDeleted(ctx context.Context, id string) (bool, error) {
@@ -47,7 +53,7 @@ func (d *Device) List(ctx context.Context, filter store.ListDevicesFilter) ([]st
 	if err != nil {
 		return nil, fmt.Errorf("device: list: %w", err)
 	}
-	return deviceRowsToSlice(rows), nil
+	return d.deviceRowsToSlice(ctx, rows)
 }
 
 func (d *Device) ListOnline(ctx context.Context, filter store.ListDevicesFilter) ([]store.Device, error) {
@@ -59,7 +65,7 @@ func (d *Device) ListOnline(ctx context.Context, filter store.ListDevicesFilter)
 	if err != nil {
 		return nil, fmt.Errorf("device: list online: %w", err)
 	}
-	return deviceRowsToSlice(rows), nil
+	return d.deviceRowsToSlice(ctx, rows)
 }
 
 func (d *Device) ListOffline(ctx context.Context, filter store.ListDevicesFilter) ([]store.Device, error) {
@@ -71,7 +77,7 @@ func (d *Device) ListOffline(ctx context.Context, filter store.ListDevicesFilter
 	if err != nil {
 		return nil, fmt.Errorf("device: list offline: %w", err)
 	}
-	return deviceRowsToSlice(rows), nil
+	return d.deviceRowsToSlice(ctx, rows)
 }
 
 func (d *Device) Count(ctx context.Context, ownerScope *string) (int64, error) {
@@ -98,12 +104,53 @@ func (d *Device) CountOffline(ctx context.Context, ownerScope *string) (int64, e
 	return n, nil
 }
 
-// deviceRowsToSlice translates a slice of sqlc rows to domain
-// devices. Shared by List / ListOnline / ListOffline.
-func deviceRowsToSlice(rows []generated.DevicesProjection) []store.Device {
+// deviceRowsToSlice translates a slice of sqlc rows to domain devices
+// and batch-loads labels for all of them in a single round-trip.
+func (d *Device) deviceRowsToSlice(ctx context.Context, rows []generated.DevicesProjection) ([]store.Device, error) {
 	out := make([]store.Device, len(rows))
+	ids := make([]string, len(rows))
 	for i, r := range rows {
 		out[i] = deviceFromRow(r)
+		ids[i] = r.ID
+	}
+	if err := d.attachLabels(ctx, out, ids); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// attachLabels populates Labels across a slice of devices via a single
+// ListDeviceLabelsBatch query. Devices with no labels get a nil map.
+func (d *Device) attachLabels(ctx context.Context, devices []store.Device, ids []string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	rows, err := d.q.ListDeviceLabelsBatch(ctx, ids)
+	if err != nil {
+		return fmt.Errorf("device: list labels batch: %w", err)
+	}
+	byDevice := make(map[string]map[string]string, len(ids))
+	for _, r := range rows {
+		m, ok := byDevice[r.DeviceID]
+		if !ok {
+			m = map[string]string{}
+			byDevice[r.DeviceID] = m
+		}
+		m[r.Key] = r.Value
+	}
+	for i := range devices {
+		devices[i].Labels = byDevice[devices[i].ID]
+	}
+	return nil
+}
+
+func labelsFromRows(rows []generated.ListDeviceLabelsRow) map[string]string {
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(rows))
+	for _, r := range rows {
+		out[r.Key] = r.Value
 	}
 	return out
 }
@@ -128,8 +175,9 @@ func (d *Device) SyncInterval(ctx context.Context, deviceID string) (int32, erro
 	return mins, nil
 }
 
-// deviceFromRow translates a sqlc projection row to the domain
-// shape. Shared so the field mapping lives in one place.
+// deviceFromRow translates a sqlc projection row to the domain shape.
+// Labels are populated separately from the device_labels child table —
+// callers should follow up with attachLabels / ListDeviceLabels.
 func deviceFromRow(r generated.DevicesProjection) store.Device {
 	return store.Device{
 		ID:                  r.ID,
@@ -140,7 +188,6 @@ func deviceFromRow(r generated.DevicesProjection) store.Device {
 		RegisteredAt:        r.RegisteredAt,
 		LastSeenAt:          r.LastSeenAt,
 		RegistrationTokenID: r.RegistrationTokenID,
-		Labels:              json.RawMessage(r.Labels),
 		IsDeleted:           r.IsDeleted,
 		SyncIntervalMinutes: r.SyncIntervalMinutes,
 		ComplianceStatus:    r.ComplianceStatus,

--- a/internal/store/queries/device_groups.sql
+++ b/internal/store/queries/device_groups.sql
@@ -60,12 +60,10 @@ JOIN device_group_members_projection m ON g.id = m.group_id
 WHERE m.device_id = $1 AND g.is_deleted = FALSE;
 
 -- name: ListDevicesForDynamicEvaluation :many
--- All non-deleted devices' (id, labels) for the in-process dynamic-group
--- evaluator (Wave C.3). Returning the JSONB labels column is still
--- correct pre-E.4; once labels move to the device_labels child table
--- this query becomes an id-only list and labels load via the child
--- repo.
-SELECT id, labels FROM devices_projection
+-- Wave E.4: labels moved to device_labels — this query is now id-only.
+-- The in-process evaluator follows up with ListAllDeviceLabels and
+-- joins the two in Go to build per-device DeviceContext.Labels maps.
+SELECT id FROM devices_projection
 WHERE is_deleted = FALSE;
 
 -- Dynamic Group queries

--- a/internal/store/queries/devices.sql
+++ b/internal/store/queries/devices.sql
@@ -78,11 +78,40 @@ SELECT device_id, user_id FROM device_assigned_users_projection WHERE device_id 
 SELECT device_id, group_id FROM device_assigned_groups_projection WHERE device_id = ANY(@device_ids::text[]);
 
 -- name: GetDevicesWithLabel :many
-SELECT * FROM devices_projection
-WHERE is_deleted = FALSE
-  AND labels->>$1 = $2
-ORDER BY last_seen_at DESC
+-- Wave E.4: labels live in the device_labels child table now. The JOIN
+-- against (key, value) hits idx_device_labels_key_value for a direct
+-- lookup; no more JSONB operator.
+SELECT d.* FROM devices_projection d
+JOIN device_labels l ON l.device_id = d.id
+WHERE d.is_deleted = FALSE
+  AND l.key = $1
+  AND l.value = $2
+ORDER BY d.last_seen_at DESC
 LIMIT $3 OFFSET $4;
+
+-- name: ListDeviceLabels :many
+-- Wave E.4: returns the (key, value) pairs for a single device.
+-- Powers the in-process evaluator's per-device DeviceContext.Labels
+-- map and any single-device repo callers that need the typed slice.
+SELECT key, value FROM device_labels
+WHERE device_id = $1
+ORDER BY key;
+
+-- name: ListDeviceLabelsBatch :many
+-- Wave E.4: batched per-device label fetch for repo.List and the
+-- in-process group evaluator. Single round-trip across the slice of
+-- device IDs avoids the N+1 the per-device ListDeviceLabels would
+-- have at population time.
+SELECT device_id, key, value FROM device_labels
+WHERE device_id = ANY(sqlc.arg(device_ids)::TEXT[])
+ORDER BY device_id, key;
+
+-- name: ListAllDeviceLabels :many
+-- Wave E.4: load every label row in one query for the dyngroupeval
+-- queue-drain hot path. Replaces the labels JSONB column that used
+-- to come back with each device row.
+SELECT device_id, key, value FROM device_labels
+ORDER BY device_id, key;
 
 -- name: GetDeviceSyncInterval :one
 -- Effective sync interval for a device, in minutes.
@@ -180,11 +209,15 @@ WHERE id = ANY($1::TEXT[]) AND is_deleted = FALSE;
 -- timeline). projection_version is unconditionally bumped here because
 -- DeviceRegistered is the stream's birthing event; replay safety for
 -- subsequent events lives on their per-event guarded UPDATEs.
+--
+-- Wave E.4: labels moved out of devices_projection into device_labels.
+-- Initial-labels writes happen via InsertDeviceLabel in the listener
+-- after this upsert, inside the same WithTx.
 INSERT INTO devices_projection (
     id, hostname, cert_fingerprint, cert_not_after,
     registered_at, last_seen_at, registration_token_id,
-    labels, projection_version
-) VALUES ($1, $2, $3, $4, $5, $5, $6, $7, $8)
+    projection_version
+) VALUES ($1, $2, $3, $4, $5, $5, $6, $7)
 ON CONFLICT (id) DO UPDATE SET
     hostname              = EXCLUDED.hostname,
     cert_fingerprint      = EXCLUDED.cert_fingerprint,
@@ -192,7 +225,6 @@ ON CONFLICT (id) DO UPDATE SET
     registered_at         = EXCLUDED.registered_at,
     last_seen_at          = EXCLUDED.last_seen_at,
     registration_token_id = EXCLUDED.registration_token_id,
-    labels                = EXCLUDED.labels,
     projection_version    = EXCLUDED.projection_version,
     is_deleted            = FALSE;
 
@@ -245,39 +277,38 @@ SET cert_fingerprint   = $2,
 WHERE id = $1
   AND projection_version < $3;
 
--- name: UpdateDeviceLabelsProjection :execrows
--- DeviceLabelsUpdated handler. The decoder leaves a missing labels key
--- as a nil byte slice; the SQL COALESCE preserves the existing column
--- value in that case (matches PL/pgSQL `COALESCE(payload, labels)`).
--- The :: JSONB cast is required so PostgreSQL can resolve the parameter
--- type when the value is NULL.
--- Stale-replay guard via projection_version.
+-- name: AdvanceDeviceProjectionVersion :execrows
+-- Wave E.4: parent-row stale-replay guard for the device_labels child
+-- table writes. The PL/pgSQL projector folded the version bump into
+-- the JSONB UPDATE in one statement; with the column gone, the listener
+-- runs this query first, checks the rows-affected, and only proceeds
+-- with the child-table change when the bump succeeded.
 UPDATE devices_projection
-SET labels             = COALESCE(sqlc.narg('labels')::JSONB, labels),
-    projection_version = $2
-WHERE id = $1
-  AND projection_version < $2;
+SET projection_version = sqlc.arg(projection_version)
+WHERE id = sqlc.arg(id)
+  AND projection_version < sqlc.arg(projection_version);
 
--- name: SetDeviceLabelKey :execrows
--- DeviceLabelSet handler. Mirrors the PL/pgSQL JSONB merge:
--- `labels || jsonb_build_object(key, value)`. The first COALESCE on
--- labels handles the (theoretical) NULL case for legacy rows — matches
--- PL/pgSQL's `COALESCE(labels, '{}'::jsonb) || ...`. Stale-replay guard
--- via projection_version.
-UPDATE devices_projection
-SET labels             = COALESCE(labels, '{}'::JSONB) || jsonb_build_object(@key::TEXT, @value::TEXT),
-    projection_version = $2
-WHERE id = $1
-  AND projection_version < $2;
+-- name: SetDeviceLabel :exec
+-- DeviceLabelSet handler against the device_labels child table (Wave E.4).
+-- ON CONFLICT DO UPDATE preserves replay-safety: re-applying the same
+-- event lands the same (key, value); a stale event would have already
+-- been intercepted by AdvanceDeviceProjectionVersion above.
+INSERT INTO device_labels (device_id, key, value)
+VALUES (sqlc.arg(device_id), sqlc.arg(key)::TEXT, sqlc.arg(value)::TEXT)
+ON CONFLICT (device_id, key) DO UPDATE SET value = EXCLUDED.value;
 
--- name: RemoveDeviceLabelKey :execrows
--- DeviceLabelRemoved handler. JSONB minus operator drops the key from
--- the labels object. Stale-replay guard via projection_version.
-UPDATE devices_projection
-SET labels             = labels - @key::TEXT,
-    projection_version = $2
-WHERE id = $1
-  AND projection_version < $2;
+-- name: RemoveDeviceLabel :exec
+-- DeviceLabelRemoved handler. DELETE-with-no-match is silently fine
+-- (matches the PL/pgSQL JSONB minus-operator behaviour on a missing key).
+DELETE FROM device_labels
+WHERE device_id = sqlc.arg(device_id)
+  AND key = sqlc.arg(key)::TEXT;
+
+-- name: ClearDeviceLabels :exec
+-- Bulk-replace half of DeviceLabelsUpdated. Listener follows this with
+-- a series of SetDeviceLabel writes for the new label set, all under
+-- the AdvanceDeviceProjectionVersion guard.
+DELETE FROM device_labels WHERE device_id = $1;
 
 -- name: SoftDeleteDeviceProjection :execrows
 -- DeviceDeleted handler — first half. Returns rows-affected so the

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -399,14 +399,13 @@ func TestProjection_DeviceLabelSet(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	var labels []byte
+	var value string
 	err = st.Pool().QueryRow(ctx,
-		"SELECT labels FROM devices_projection WHERE id = $1",
-		deviceID,
-	).Scan(&labels)
+		"SELECT value FROM device_labels WHERE device_id = $1 AND key = $2",
+		deviceID, "environment",
+	).Scan(&value)
 	require.NoError(t, err)
-	assert.Contains(t, string(labels), "environment")
-	assert.Contains(t, string(labels), "production")
+	assert.Equal(t, "production", value)
 }
 
 func TestProjection_TokenCreated(t *testing.T) {


### PR DESCRIPTION
Part of the storage-abstraction tracker (#242), Wave E (JSONB normalization). **Closes Wave E** — after this lands, no JSONB operator (->>, ->, @>, jsonb_*) remains in any sqlc query.

## Summary

- Migration 047: new device_labels(device_id FK, key, value, PK (device_id, key)) + idx_device_labels_key_value, backfilled, devices_projection.labels dropped.
- Dynamic-group queue trigger re-pointed at device_labels INSERT/UPDATE/DELETE so re-evaluation still fires on label changes.
- store.Device.Labels switches from json.RawMessage to map[string]string; repo populates via batched ListDeviceLabelsBatch.
- Projector listener uses AdvanceDeviceProjectionVersion as the per-event guard around child-table writes (same shape as Wave E.3).
- DeviceLabelsUpdated semantics: HasLabels distinguishes "preserve" from "clear all" — matches the PL/pgSQL COALESCE(payload, labels).
- internal/dyngroupeval batch-loads labels via ListAllDeviceLabels for queue-drain and count-matching paths.
- internal/search.FlattenLabels takes the typed map; warm-index paths in api + search updated.
- api/device_handler.userToProto drops the json.Unmarshal block, copies the map directly.

## DoD checks

- [x] go build + go vet clean
- [x] gofmt clean
- [x] internal/projectors device tests pass (104s integration suite)
- [x] internal/store dynamic-group tests pass (43s integration suite)
- [x] internal/api device + dynamic-group tests pass
- [ ] CI integration suite

## After this lands

Wave E DoD met. Remaining storage-abstraction roadmap items: Wave F (reactive triggers → Go listeners) and Wave G (EventStore interface). Wave H is the validation backend (worked example: Turso/libSQL). The whole stack is now JSONB-operator-free and ready for those.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Normalized device labels into per-key storage and switched to typed label maps
  * Batch-loading of labels for evaluation and listing to improve performance
  * Per-label update flow and replay/version safeguards for safer concurrent updates
  * Search indexing now flattens typed label maps directly

* **Chores**
  * Database migration added to move labels to a child table

* **Tests**
  * Updated tests to assert label maps and child-table queries instead of JSON blobs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->