### PR TITLE
refactor(store): wave D — port compliance evaluator to Go (#299)

### DIFF
--- a/internal/compliance/evaluator.go
+++ b/internal/compliance/evaluator.go
@@ -1,0 +1,277 @@
+// Package compliance implements the in-process replacement for the
+// PL/pgSQL evaluate_device_compliance_policies / recalculate_device_compliance
+// / reevaluate_compliance_policy_devices functions from migration 003.
+// Same pattern as internal/dyngroupeval — listeners call into an
+// Evaluator that consumes repo methods instead of dispatching to
+// SELECT plpgsql_function($1) shims.
+//
+// Part of Wave D of the storage-abstraction roadmap (tracker
+// manchtools/power-manage-server#242).
+package compliance
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Compliance status codes mirror the PL/pgSQL integer values, which
+// also match the proto enum on the wire. Keep these constants in sync
+// with sdk/proto/pm/v1/compliance.proto.
+const (
+	StatusUnknown       int32 = 0
+	StatusCompliant     int32 = 1
+	StatusNonCompliant  int32 = 2
+	StatusInGracePeriod int32 = 3
+)
+
+// Evaluator is the in-process per-device compliance recomputer.
+// Listener callers wrap the per-event flow in a transaction and pass
+// the bound *store.Queries to EvaluateInTx / ReevaluatePolicyInTx so
+// the recomputation commits atomically with the listener's other
+// writes.
+type Evaluator struct {
+	logger *slog.Logger
+	now    func() time.Time
+}
+
+// New returns an Evaluator. The now closure stays injectable so unit
+// tests can pin grace-period boundaries without sleeping the test
+// goroutine.
+func New(lg *slog.Logger) *Evaluator {
+	if lg == nil {
+		lg = slog.Default()
+	}
+	return &Evaluator{logger: lg, now: time.Now}
+}
+
+// SetClock swaps the time source. Test-only; production callers leave
+// the default time.Now.
+func (e *Evaluator) SetClock(now func() time.Time) { e.now = now }
+
+// defaultEvaluator is the package-level instance the projector
+// listeners use through the EvaluateInTx / ReevaluatePolicyInTx
+// package-level shims. Tests that need clock injection construct
+// their own *Evaluator and call its methods directly.
+var defaultEvaluator = New(nil)
+
+// EvaluateInTx is the package-level convenience wrapper around
+// defaultEvaluator.EvaluateInTx. Projector listeners call it inside
+// their WithTx blocks so the compliance recompute commits atomically
+// with the listener's own writes.
+func EvaluateInTx(ctx context.Context, q *store.Queries, deviceID string) error {
+	return defaultEvaluator.EvaluateInTx(ctx, q, deviceID)
+}
+
+// ReevaluatePolicyInTx is the package-level convenience wrapper
+// around defaultEvaluator.ReevaluatePolicyInTx.
+func ReevaluatePolicyInTx(ctx context.Context, q *store.Queries, policyID string) error {
+	return defaultEvaluator.ReevaluatePolicyInTx(ctx, q, policyID)
+}
+
+// EvaluateInTx re-computes compliance for one device against the
+// supplied tx-bound *store.Queries. Same semantic as the PL/pgSQL
+// evaluate_device_compliance_policies(deviceID):
+//
+//   - No policies assigned → recalculate-only fallback (count results,
+//     roll up to device status).
+//   - Otherwise iterate every rule, look up the latest result, write
+//     a per-rule evaluation row, and finalise the device's denormalized
+//     compliance quadruple.
+//
+// Grace-period handling: a freshly-failing rule records the current
+// time as first_failed_at; subsequent failing evaluations preserve
+// that timestamp. A rule older than grace_period_hours past
+// first_failed_at graduates from IN_GRACE_PERIOD to NON_COMPLIANT.
+func (e *Evaluator) EvaluateInTx(ctx context.Context, q *store.Queries, deviceID string) error {
+	rules, err := q.ListComplianceRulesForDevice(ctx, deviceID)
+	if err != nil {
+		return fmt.Errorf("compliance: list rules for device %s: %w", deviceID, err)
+	}
+	if len(rules) == 0 {
+		return e.recalculateOnly(ctx, q, deviceID)
+	}
+
+	now := e.now().UTC()
+	var (
+		anyNonCompliant bool
+		anyInGrace      bool
+		allCompliant    = true
+		total           = int32(len(rules))
+		passing         int32
+	)
+
+	for _, rule := range rules {
+		ruleStatus, err := e.evalOne(ctx, q, deviceID, rule, now)
+		if err != nil {
+			return err
+		}
+		switch ruleStatus {
+		case StatusCompliant:
+			passing++
+		case StatusInGracePeriod:
+			anyInGrace = true
+			allCompliant = false
+		case StatusNonCompliant:
+			anyNonCompliant = true
+			allCompliant = false
+		case StatusUnknown:
+			allCompliant = false
+		}
+	}
+
+	overall := StatusUnknown
+	switch {
+	case anyNonCompliant:
+		overall = StatusNonCompliant
+	case anyInGrace:
+		overall = StatusInGracePeriod
+	case allCompliant && total > 0:
+		overall = StatusCompliant
+	}
+
+	return q.UpdateDeviceComplianceSummary(ctx, db.UpdateDeviceComplianceSummaryParams{
+		ID:                  deviceID,
+		ComplianceStatus:    overall,
+		ComplianceCheckedAt: &now,
+		ComplianceTotal:     total,
+		CompliancePassing:   passing,
+	})
+}
+
+// evalOne resolves the per-rule status the same way the PL/pgSQL
+// evaluator did: no result yet → UNKNOWN, compliant → COMPLIANT,
+// failing within grace → IN_GRACE_PERIOD, failing past grace → NON_COMPLIANT.
+func (e *Evaluator) evalOne(ctx context.Context, q *store.Queries, deviceID string, rule db.ListComplianceRulesForDeviceRow, now time.Time) (int32, error) {
+	result, err := q.GetLatestComplianceResultForAction(ctx, db.GetLatestComplianceResultForActionParams{
+		DeviceID: deviceID,
+		ActionID: rule.ActionID,
+	})
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		// No result yet — UNKNOWN. Persist a placeholder row so the
+		// device-list UI can surface "waiting for first check" per
+		// rule.
+		if err := q.UpsertComplianceEvaluation(ctx, db.UpsertComplianceEvaluationParams{
+			DeviceID:      deviceID,
+			PolicyID:      rule.PolicyID,
+			ActionID:      rule.ActionID,
+			Compliant:     false,
+			FirstFailedAt: nil,
+			Status:        StatusUnknown,
+			CheckedAt:     nil,
+		}); err != nil {
+			return 0, fmt.Errorf("compliance: write unknown eval for %s/%s/%s: %w", deviceID, rule.PolicyID, rule.ActionID, err)
+		}
+		return StatusUnknown, nil
+
+	case err != nil:
+		return 0, fmt.Errorf("compliance: load result for %s/%s: %w", deviceID, rule.ActionID, err)
+	}
+
+	if result.Compliant {
+		if err := q.UpsertComplianceEvaluation(ctx, db.UpsertComplianceEvaluationParams{
+			DeviceID:      deviceID,
+			PolicyID:      rule.PolicyID,
+			ActionID:      rule.ActionID,
+			Compliant:     true,
+			FirstFailedAt: nil,
+			Status:        StatusCompliant,
+			CheckedAt:     &result.CheckedAt,
+		}); err != nil {
+			return 0, fmt.Errorf("compliance: write compliant eval for %s/%s/%s: %w", deviceID, rule.PolicyID, rule.ActionID, err)
+		}
+		return StatusCompliant, nil
+	}
+
+	// Non-compliant: load existing first_failed_at (preserve across
+	// repeated failures), or seed with `now` on first transition.
+	existingFailedAt, err := q.GetComplianceEvaluationFirstFailedAt(ctx, db.GetComplianceEvaluationFirstFailedAtParams{
+		DeviceID: deviceID,
+		PolicyID: rule.PolicyID,
+		ActionID: rule.ActionID,
+	})
+	firstFailedAt := now
+	switch {
+	case errors.Is(err, store.ErrNotFound):
+		// First-ever non-compliant state for this rule.
+	case err != nil:
+		return 0, fmt.Errorf("compliance: read first_failed_at for %s/%s/%s: %w", deviceID, rule.PolicyID, rule.ActionID, err)
+	case existingFailedAt != nil:
+		firstFailedAt = *existingFailedAt
+	}
+
+	status := StatusNonCompliant
+	if rule.GracePeriodHours > 0 {
+		graceUntil := firstFailedAt.Add(time.Duration(rule.GracePeriodHours) * time.Hour)
+		if now.Before(graceUntil) {
+			status = StatusInGracePeriod
+		}
+	}
+
+	if err := q.UpsertComplianceEvaluation(ctx, db.UpsertComplianceEvaluationParams{
+		DeviceID:      deviceID,
+		PolicyID:      rule.PolicyID,
+		ActionID:      rule.ActionID,
+		Compliant:     false,
+		FirstFailedAt: &firstFailedAt,
+		Status:        status,
+		CheckedAt:     &result.CheckedAt,
+	}); err != nil {
+		return 0, fmt.Errorf("compliance: write non-compliant eval for %s/%s/%s: %w", deviceID, rule.PolicyID, rule.ActionID, err)
+	}
+	return status, nil
+}
+
+// recalculateOnly is the no-policies fallback that mirrors the PL/pgSQL
+// recalculate_device_compliance function: count compliance_results and
+// roll up to the device's denormalized status.
+func (e *Evaluator) recalculateOnly(ctx context.Context, q *store.Queries, deviceID string) error {
+	counts, err := q.ComplianceResultCounts(ctx, deviceID)
+	if err != nil {
+		return fmt.Errorf("compliance: count results for %s: %w", deviceID, err)
+	}
+
+	status := StatusUnknown
+	switch {
+	case counts.Total == 0:
+		status = StatusUnknown
+	case counts.Passing == counts.Total:
+		status = StatusCompliant
+	default:
+		status = StatusNonCompliant
+	}
+
+	now := e.now().UTC()
+	return q.UpdateDeviceComplianceSummary(ctx, db.UpdateDeviceComplianceSummaryParams{
+		ID:                  deviceID,
+		ComplianceStatus:    status,
+		ComplianceCheckedAt: &now,
+		ComplianceTotal:     counts.Total,
+		CompliancePassing:   counts.Passing,
+	})
+}
+
+// ReevaluatePolicyInTx fans out across every device touched by a policy
+// (direct + via device groups) and re-runs EvaluateInTx on each within
+// the supplied transaction. Per-device errors are logged + skipped —
+// the cascade should be best-effort so a single broken device doesn't
+// block the rest of the recompute.
+func (e *Evaluator) ReevaluatePolicyInTx(ctx context.Context, q *store.Queries, policyID string) error {
+	deviceIDs, err := q.ListDevicesForCompliancePolicy(ctx, policyID)
+	if err != nil {
+		return fmt.Errorf("compliance: list devices for policy %s: %w", policyID, err)
+	}
+	for _, id := range deviceIDs {
+		if err := e.EvaluateInTx(ctx, q, id); err != nil {
+			e.logger.Warn("compliance: failed to re-evaluate device for policy; skipping",
+				"policy_id", policyID, "device_id", id, "error", err)
+		}
+	}
+	return nil
+}

--- a/internal/projectors/action_listener.go
+++ b/internal/projectors/action_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/compliance"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -355,7 +356,7 @@ func applyActionDeleted(ctx context.Context, q *store.Queries, e store.Persisted
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		if err := q.EvaluateDeviceCompliancePolicies(ctx, deviceID); err != nil {
+		if err := compliance.EvaluateInTx(ctx, q, deviceID); err != nil {
 			return err
 		}
 	}

--- a/internal/projectors/assignment_listener.go
+++ b/internal/projectors/assignment_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/compliance"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -220,7 +221,7 @@ func cascadeComplianceForAssignment(ctx context.Context, q *store.Queries, sourc
 				return err
 			}
 		}
-		return q.EvaluateDeviceCompliancePolicies(ctx, targetID)
+		return compliance.EvaluateInTx(ctx, q, targetID)
 	case "device_group":
 		deviceIDs, err := q.ListDeviceGroupMemberDeviceIDs(ctx, targetID)
 		if err != nil {
@@ -235,7 +236,7 @@ func cascadeComplianceForAssignment(ctx context.Context, q *store.Queries, sourc
 					return err
 				}
 			}
-			if err := q.EvaluateDeviceCompliancePolicies(ctx, deviceID); err != nil {
+			if err := compliance.EvaluateInTx(ctx, q, deviceID); err != nil {
 				return err
 			}
 		}

--- a/internal/projectors/compliance_listener.go
+++ b/internal/projectors/compliance_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/compliance"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -110,7 +111,7 @@ func applyComplianceResultUpdated(ctx context.Context, q *store.Queries, e store
 	// per-action result mutation: the PL/pgSQL function recomputes
 	// the device's pass/fail/grace verdict by aggregating across
 	// every result + every assigned policy's grace window.
-	return q.EvaluateDeviceCompliancePolicies(ctx, payload.DeviceID)
+	return compliance.EvaluateInTx(ctx, q, payload.DeviceID)
 }
 
 func applyComplianceResultRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -140,5 +141,5 @@ func applyComplianceResultRemoved(ctx context.Context, q *store.Queries, e store
 	if n == 0 {
 		return nil
 	}
-	return q.EvaluateDeviceCompliancePolicies(ctx, payload.DeviceID)
+	return compliance.EvaluateInTx(ctx, q, payload.DeviceID)
 }

--- a/internal/projectors/compliance_policy_listener.go
+++ b/internal/projectors/compliance_policy_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/compliance"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -207,7 +208,7 @@ func applyCompliancePolicyDeleted(ctx context.Context, q *store.Queries, e store
 	// compliance status in sync with the policy deletion (devices
 	// whose only failing rule lived under the now-deleted policy
 	// flip back to compliant on the next read).
-	return q.ReevaluateCompliancePolicyDevices(ctx, e.StreamID)
+	return compliance.ReevaluatePolicyInTx(ctx, q, e.StreamID)
 }
 
 func applyCompliancePolicyRuleAdded(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -286,7 +287,7 @@ func applyCompliancePolicyRuleRemoved(ctx context.Context, q *store.Queries, e s
 	}); err != nil {
 		return err
 	}
-	return q.ReevaluateCompliancePolicyDevices(ctx, payload.PolicyID)
+	return compliance.ReevaluatePolicyInTx(ctx, q, payload.PolicyID)
 }
 
 func applyCompliancePolicyRuleUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {

--- a/internal/store/generated/assignments.sql.go
+++ b/internal/store/generated/assignments.sql.go
@@ -59,19 +59,6 @@ func (q *Queries) DeleteCompliancePolicyEvaluationsForDevicePolicy(ctx context.C
 	return err
 }
 
-const evaluateDeviceCompliancePolicies = `-- name: EvaluateDeviceCompliancePolicies :exec
-SELECT evaluate_device_compliance_policies($1::TEXT)
-`
-
-// Invokes the existing PL/pgSQL evaluate_device_compliance_policies
-// function. Compliance is deferred to a later phase of #136; until
-// then, the assignment listener calls through to PL/pgSQL via this
-// typed shim so the cascade behaviour is preserved.
-func (q *Queries) EvaluateDeviceCompliancePolicies(ctx context.Context, dollar_1 string) error {
-	_, err := q.db.Exec(ctx, evaluateDeviceCompliancePolicies, dollar_1)
-	return err
-}
-
 const getAssignment = `-- name: GetAssignment :one
 SELECT id, source_type, source_id, target_type, target_id, sort_order, mode, created_at, created_by, is_deleted, projection_version FROM assignments_projection
 WHERE source_type = $1 AND source_id = $2 AND target_type = $3 AND target_id = $4 AND is_deleted = FALSE

--- a/internal/store/generated/compliance_policies.sql.go
+++ b/internal/store/generated/compliance_policies.sql.go
@@ -47,6 +47,28 @@ func (q *Queries) ClaimCompliancePolicyForRuleMutation(ctx context.Context, arg 
 	return result.RowsAffected(), nil
 }
 
+const complianceResultCounts = `-- name: ComplianceResultCounts :one
+SELECT
+    COUNT(*)::INTEGER AS total,
+    COUNT(*) FILTER (WHERE compliant = TRUE)::INTEGER AS passing
+FROM compliance_results_projection
+WHERE device_id = $1
+`
+
+type ComplianceResultCountsRow struct {
+	Total   int32 `json:"total"`
+	Passing int32 `json:"passing"`
+}
+
+// Wave D: powers the no-policies fallback (recalculate_device_compliance).
+// Two filtered counts over compliance_results_projection in one query.
+func (q *Queries) ComplianceResultCounts(ctx context.Context, deviceID string) (ComplianceResultCountsRow, error) {
+	row := q.db.QueryRow(ctx, complianceResultCounts, deviceID)
+	var i ComplianceResultCountsRow
+	err := row.Scan(&i.Total, &i.Passing)
+	return i, err
+}
+
 const countCompliancePolicies = `-- name: CountCompliancePolicies :one
 SELECT COUNT(*) FROM compliance_policies_projection
 WHERE is_deleted = FALSE
@@ -121,6 +143,28 @@ DELETE FROM compliance_policy_rules_projection WHERE policy_id = $1
 func (q *Queries) DeleteCompliancePolicyRulesByPolicy(ctx context.Context, policyID string) error {
 	_, err := q.db.Exec(ctx, deleteCompliancePolicyRulesByPolicy, policyID)
 	return err
+}
+
+const getComplianceEvaluationFirstFailedAt = `-- name: GetComplianceEvaluationFirstFailedAt :one
+SELECT first_failed_at FROM compliance_policy_evaluation_projection
+WHERE device_id = $1 AND policy_id = $2 AND action_id = $3
+`
+
+type GetComplianceEvaluationFirstFailedAtParams struct {
+	DeviceID string `json:"device_id"`
+	PolicyID string `json:"policy_id"`
+	ActionID string `json:"action_id"`
+}
+
+// Wave D: preserves the PL/pgSQL "first-failed timestamp sticks across
+// repeated NON_COMPLIANT results" invariant. The evaluator reads the
+// existing value before writing; nil result means the rule transitioned
+// from compliant (or never observed) to non-compliant this round.
+func (q *Queries) GetComplianceEvaluationFirstFailedAt(ctx context.Context, arg GetComplianceEvaluationFirstFailedAtParams) (*time.Time, error) {
+	row := q.db.QueryRow(ctx, getComplianceEvaluationFirstFailedAt, arg.DeviceID, arg.PolicyID, arg.ActionID)
+	var first_failed_at *time.Time
+	err := row.Scan(&first_failed_at)
+	return first_failed_at, err
 }
 
 const getCompliancePolicyByID = `-- name: GetCompliancePolicyByID :one
@@ -233,6 +277,31 @@ func (q *Queries) GetDeviceCompliancePolicyEvaluations(ctx context.Context, devi
 		return nil, err
 	}
 	return items, nil
+}
+
+const getLatestComplianceResultForAction = `-- name: GetLatestComplianceResultForAction :one
+SELECT compliant, checked_at FROM compliance_results_projection
+WHERE device_id = $1 AND action_id = $2
+`
+
+type GetLatestComplianceResultForActionParams struct {
+	DeviceID string `json:"device_id"`
+	ActionID string `json:"action_id"`
+}
+
+type GetLatestComplianceResultForActionRow struct {
+	Compliant bool      `json:"compliant"`
+	CheckedAt time.Time `json:"checked_at"`
+}
+
+// Wave D: per-rule probe inside the evaluator loop. Returns whether
+// the most recent compliance check for (device, action) was compliant
+// and when it was checked.
+func (q *Queries) GetLatestComplianceResultForAction(ctx context.Context, arg GetLatestComplianceResultForActionParams) (GetLatestComplianceResultForActionRow, error) {
+	row := q.db.QueryRow(ctx, getLatestComplianceResultForAction, arg.DeviceID, arg.ActionID)
+	var i GetLatestComplianceResultForActionRow
+	err := row.Scan(&i.Compliant, &i.CheckedAt)
+	return i, err
 }
 
 const insertCompliancePolicyProjection = `-- name: InsertCompliancePolicyProjection :exec
@@ -374,6 +443,102 @@ func (q *Queries) ListCompliancePolicyRules(ctx context.Context, policyID string
 	return items, nil
 }
 
+const listComplianceRulesForDevice = `-- name: ListComplianceRulesForDevice :many
+
+SELECT r.policy_id, r.action_id, r.grace_period_hours
+FROM compliance_policy_rules_projection r
+JOIN compliance_policies_projection p
+    ON p.id = r.policy_id AND p.is_deleted = FALSE
+JOIN assignments_projection a
+    ON a.source_type = 'compliance_policy'
+       AND a.source_id = r.policy_id
+       AND a.is_deleted = FALSE
+WHERE (
+    (a.target_type = 'device' AND a.target_id = $1)
+    OR (a.target_type = 'device_group' AND a.target_id IN (
+        SELECT group_id FROM device_group_members_projection
+        WHERE device_id = $1
+    ))
+)
+`
+
+type ListComplianceRulesForDeviceRow struct {
+	PolicyID         string `json:"policy_id"`
+	ActionID         string `json:"action_id"`
+	GracePeriodHours int32  `json:"grace_period_hours"`
+}
+
+// ============================================================================
+// Wave D compliance-evaluator reads (manchtools/power-manage-server#242).
+// ============================================================================
+//
+// The PL/pgSQL evaluate_device_compliance_policies + recalculate_device_compliance
+// + reevaluate_compliance_policy_devices were dropped under Wave D. The
+// replacements in internal/compliance consume the queries below.
+// Wave D: returns every (policy_id, action_id, grace_period_hours)
+// rule applicable to a device via direct + device_group assignments
+// of compliance policies. Soft-deleted policies are excluded so a
+// pending re-assignment doesn't pollute the evaluation cycle.
+func (q *Queries) ListComplianceRulesForDevice(ctx context.Context, targetID string) ([]ListComplianceRulesForDeviceRow, error) {
+	rows, err := q.db.Query(ctx, listComplianceRulesForDevice, targetID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListComplianceRulesForDeviceRow{}
+	for rows.Next() {
+		var i ListComplianceRulesForDeviceRow
+		if err := rows.Scan(&i.PolicyID, &i.ActionID, &i.GracePeriodHours); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listDevicesForCompliancePolicy = `-- name: ListDevicesForCompliancePolicy :many
+SELECT a.target_id AS device_id
+FROM assignments_projection a
+WHERE a.source_type = 'compliance_policy'
+  AND a.source_id = $1
+  AND a.target_type = 'device'
+  AND a.is_deleted = FALSE
+UNION
+SELECT dgm.device_id
+FROM assignments_projection a
+JOIN device_group_members_projection dgm ON dgm.group_id = a.target_id
+WHERE a.source_type = 'compliance_policy'
+  AND a.source_id = $1
+  AND a.target_type = 'device_group'
+  AND a.is_deleted = FALSE
+`
+
+// Wave D: fan-out target list for ReevaluatePolicy. Mirrors the SQL
+// inside reevaluate_compliance_policy_devices — direct device targets
+// UNIONed with members of every targeted device group.
+func (q *Queries) ListDevicesForCompliancePolicy(ctx context.Context, sourceID string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listDevicesForCompliancePolicy, sourceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var device_id string
+		if err := rows.Scan(&device_id); err != nil {
+			return nil, err
+		}
+		items = append(items, device_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const recountCompliancePolicyRules = `-- name: RecountCompliancePolicyRules :exec
 UPDATE compliance_policies_projection
 SET rule_count = (
@@ -391,21 +556,6 @@ WHERE id = $1
 // re-stamping cannot regress.
 func (q *Queries) RecountCompliancePolicyRules(ctx context.Context, policyID string) error {
 	_, err := q.db.Exec(ctx, recountCompliancePolicyRules, policyID)
-	return err
-}
-
-const reevaluateCompliancePolicyDevices = `-- name: ReevaluateCompliancePolicyDevices :exec
-SELECT reevaluate_compliance_policy_devices($1)
-`
-
-// CompliancePolicyDeleted / CompliancePolicyRuleRemoved handler —
-// final cascade step. Thin shim around the still-PL/pgSQL
-// reevaluate_compliance_policy_devices(p_policy_id) function defined
-// in migration 003. Per #136 the eval engine itself stays in PL/pgSQL
-// until a later phase; the listener just calls into it so the per-
-// device compliance status reflects the rule mutation.
-func (q *Queries) ReevaluateCompliancePolicyDevices(ctx context.Context, pPolicyID string) error {
-	_, err := q.db.Exec(ctx, reevaluateCompliancePolicyDevices, pPolicyID)
 	return err
 }
 
@@ -515,6 +665,79 @@ func (q *Queries) UpdateCompliancePolicyRuleGracePeriod(ctx context.Context, arg
 		arg.ActionID,
 		arg.GracePeriodHours,
 		arg.ProjectionVersion,
+	)
+	return err
+}
+
+const updateDeviceComplianceSummary = `-- name: UpdateDeviceComplianceSummary :exec
+UPDATE devices_projection SET
+    compliance_status     = $2,
+    compliance_checked_at = $3,
+    compliance_total      = $4,
+    compliance_passing    = $5
+WHERE id = $1
+`
+
+type UpdateDeviceComplianceSummaryParams struct {
+	ID                  string     `json:"id"`
+	ComplianceStatus    int32      `json:"compliance_status"`
+	ComplianceCheckedAt *time.Time `json:"compliance_checked_at"`
+	ComplianceTotal     int32      `json:"compliance_total"`
+	CompliancePassing   int32      `json:"compliance_passing"`
+}
+
+// Wave D: writes the denormalized compliance quadruple on
+// devices_projection. Used by both code paths — the policy-evaluation
+// finaliser and the no-policies fallback. checked_at is the supplied
+// time so the recompute and the per-rule writes agree on a single
+// timestamp.
+func (q *Queries) UpdateDeviceComplianceSummary(ctx context.Context, arg UpdateDeviceComplianceSummaryParams) error {
+	_, err := q.db.Exec(ctx, updateDeviceComplianceSummary,
+		arg.ID,
+		arg.ComplianceStatus,
+		arg.ComplianceCheckedAt,
+		arg.ComplianceTotal,
+		arg.CompliancePassing,
+	)
+	return err
+}
+
+const upsertComplianceEvaluation = `-- name: UpsertComplianceEvaluation :exec
+INSERT INTO compliance_policy_evaluation_projection (
+    device_id, policy_id, action_id, compliant, first_failed_at,
+    status, checked_at, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, 0)
+ON CONFLICT (device_id, policy_id, action_id) DO UPDATE SET
+    compliant       = EXCLUDED.compliant,
+    first_failed_at = EXCLUDED.first_failed_at,
+    status          = EXCLUDED.status,
+    checked_at      = EXCLUDED.checked_at
+`
+
+type UpsertComplianceEvaluationParams struct {
+	DeviceID      string     `json:"device_id"`
+	PolicyID      string     `json:"policy_id"`
+	ActionID      string     `json:"action_id"`
+	Compliant     bool       `json:"compliant"`
+	FirstFailedAt *time.Time `json:"first_failed_at"`
+	Status        int32      `json:"status"`
+	CheckedAt     *time.Time `json:"checked_at"`
+}
+
+// Wave D: write one row of compliance_policy_evaluation_projection.
+// The Go evaluator resolves first_failed_at upstream — passes nil on a
+// compliant transition (clears the column) and the preserved-or-fresh
+// timestamp on a failing one — so the UPSERT writes the value verbatim
+// without a COALESCE-on-UPDATE branch.
+func (q *Queries) UpsertComplianceEvaluation(ctx context.Context, arg UpsertComplianceEvaluationParams) error {
+	_, err := q.db.Exec(ctx, upsertComplianceEvaluation,
+		arg.DeviceID,
+		arg.PolicyID,
+		arg.ActionID,
+		arg.Compliant,
+		arg.FirstFailedAt,
+		arg.Status,
+		arg.CheckedAt,
 	)
 	return err
 }

--- a/internal/store/migrations/048_drop_plpgsql_compliance_evaluator.sql
+++ b/internal/store/migrations/048_drop_plpgsql_compliance_evaluator.sql
@@ -1,0 +1,25 @@
+-- Wave D (tracker manchtools/power-manage-server#242): drop the PL/pgSQL
+-- compliance evaluator functions. Wave D ported every Go caller off
+-- these shims (internal/compliance), so they are unreachable from
+-- production code as of this migration.
+--
+-- DROP ordering matches caller-first: reevaluate_compliance_policy_devices
+-- calls evaluate_device_compliance_policies which calls
+-- recalculate_device_compliance.
+--
+-- Down: not reversible. Per the same convention as migration 046
+-- (Wave C.5), the bodies live in migration 003 history if needed for
+-- forensic reference. A real rollback is a code revert, not a goose
+-- down.
+
+-- +goose Up
+
+DROP FUNCTION IF EXISTS reevaluate_compliance_policy_devices(TEXT);
+DROP FUNCTION IF EXISTS evaluate_device_compliance_policies(TEXT);
+DROP FUNCTION IF EXISTS recalculate_device_compliance(TEXT);
+
+-- +goose Down
+
+-- Intentionally not reversible — see migration header. A regression
+-- requires restoring from migration 003's bodies as a code revert.
+SELECT 1;

--- a/internal/store/queries/assignments.sql
+++ b/internal/store/queries/assignments.sql
@@ -851,13 +851,6 @@ DELETE FROM compliance_policy_evaluation_projection
 WHERE device_id = $1
   AND policy_id = $2;
 
--- name: EvaluateDeviceCompliancePolicies :exec
--- Invokes the existing PL/pgSQL evaluate_device_compliance_policies
--- function. Compliance is deferred to a later phase of #136; until
--- then, the assignment listener calls through to PL/pgSQL via this
--- typed shim so the cascade behaviour is preserved.
-SELECT evaluate_device_compliance_policies($1::TEXT);
-
 -- Get all assignments targeting a user directly or via their user groups.
 -- name: ListAssignmentsForUser :many
 SELECT * FROM assignments_projection

--- a/internal/store/queries/compliance_policies.sql
+++ b/internal/store/queries/compliance_policies.sql
@@ -227,11 +227,103 @@ SET rule_count = (
 )
 WHERE id = $1;
 
--- name: ReevaluateCompliancePolicyDevices :exec
--- CompliancePolicyDeleted / CompliancePolicyRuleRemoved handler —
--- final cascade step. Thin shim around the still-PL/pgSQL
--- reevaluate_compliance_policy_devices(p_policy_id) function defined
--- in migration 003. Per #136 the eval engine itself stays in PL/pgSQL
--- until a later phase; the listener just calls into it so the per-
--- device compliance status reflects the rule mutation.
-SELECT reevaluate_compliance_policy_devices($1);
+-- ============================================================================
+-- Wave D compliance-evaluator reads (manchtools/power-manage-server#242).
+-- ============================================================================
+--
+-- The PL/pgSQL evaluate_device_compliance_policies + recalculate_device_compliance
+-- + reevaluate_compliance_policy_devices were dropped under Wave D. The
+-- replacements in internal/compliance consume the queries below.
+
+-- name: ListComplianceRulesForDevice :many
+-- Wave D: returns every (policy_id, action_id, grace_period_hours)
+-- rule applicable to a device via direct + device_group assignments
+-- of compliance policies. Soft-deleted policies are excluded so a
+-- pending re-assignment doesn't pollute the evaluation cycle.
+SELECT r.policy_id, r.action_id, r.grace_period_hours
+FROM compliance_policy_rules_projection r
+JOIN compliance_policies_projection p
+    ON p.id = r.policy_id AND p.is_deleted = FALSE
+JOIN assignments_projection a
+    ON a.source_type = 'compliance_policy'
+       AND a.source_id = r.policy_id
+       AND a.is_deleted = FALSE
+WHERE (
+    (a.target_type = 'device' AND a.target_id = $1)
+    OR (a.target_type = 'device_group' AND a.target_id IN (
+        SELECT group_id FROM device_group_members_projection
+        WHERE device_id = $1
+    ))
+);
+
+-- name: GetLatestComplianceResultForAction :one
+-- Wave D: per-rule probe inside the evaluator loop. Returns whether
+-- the most recent compliance check for (device, action) was compliant
+-- and when it was checked.
+SELECT compliant, checked_at FROM compliance_results_projection
+WHERE device_id = $1 AND action_id = $2;
+
+-- name: GetComplianceEvaluationFirstFailedAt :one
+-- Wave D: preserves the PL/pgSQL "first-failed timestamp sticks across
+-- repeated NON_COMPLIANT results" invariant. The evaluator reads the
+-- existing value before writing; nil result means the rule transitioned
+-- from compliant (or never observed) to non-compliant this round.
+SELECT first_failed_at FROM compliance_policy_evaluation_projection
+WHERE device_id = $1 AND policy_id = $2 AND action_id = $3;
+
+-- name: UpsertComplianceEvaluation :exec
+-- Wave D: write one row of compliance_policy_evaluation_projection.
+-- The Go evaluator resolves first_failed_at upstream — passes nil on a
+-- compliant transition (clears the column) and the preserved-or-fresh
+-- timestamp on a failing one — so the UPSERT writes the value verbatim
+-- without a COALESCE-on-UPDATE branch.
+INSERT INTO compliance_policy_evaluation_projection (
+    device_id, policy_id, action_id, compliant, first_failed_at,
+    status, checked_at, projection_version
+) VALUES ($1, $2, $3, $4, $5, $6, $7, 0)
+ON CONFLICT (device_id, policy_id, action_id) DO UPDATE SET
+    compliant       = EXCLUDED.compliant,
+    first_failed_at = EXCLUDED.first_failed_at,
+    status          = EXCLUDED.status,
+    checked_at      = EXCLUDED.checked_at;
+
+-- name: UpdateDeviceComplianceSummary :exec
+-- Wave D: writes the denormalized compliance quadruple on
+-- devices_projection. Used by both code paths — the policy-evaluation
+-- finaliser and the no-policies fallback. checked_at is the supplied
+-- time so the recompute and the per-rule writes agree on a single
+-- timestamp.
+UPDATE devices_projection SET
+    compliance_status     = $2,
+    compliance_checked_at = $3,
+    compliance_total      = $4,
+    compliance_passing    = $5
+WHERE id = $1;
+
+-- name: ComplianceResultCounts :one
+-- Wave D: powers the no-policies fallback (recalculate_device_compliance).
+-- Two filtered counts over compliance_results_projection in one query.
+SELECT
+    COUNT(*)::INTEGER AS total,
+    COUNT(*) FILTER (WHERE compliant = TRUE)::INTEGER AS passing
+FROM compliance_results_projection
+WHERE device_id = $1;
+
+-- name: ListDevicesForCompliancePolicy :many
+-- Wave D: fan-out target list for ReevaluatePolicy. Mirrors the SQL
+-- inside reevaluate_compliance_policy_devices — direct device targets
+-- UNIONed with members of every targeted device group.
+SELECT a.target_id AS device_id
+FROM assignments_projection a
+WHERE a.source_type = 'compliance_policy'
+  AND a.source_id = $1
+  AND a.target_type = 'device'
+  AND a.is_deleted = FALSE
+UNION
+SELECT dgm.device_id
+FROM assignments_projection a
+JOIN device_group_members_projection dgm ON dgm.group_id = a.target_id
+WHERE a.source_type = 'compliance_policy'
+  AND a.source_id = $1
+  AND a.target_type = 'device_group'
+  AND a.is_deleted = FALSE;


### PR DESCRIPTION
Part of the storage-abstraction tracker (#242), Wave D — compliance evaluator to Go. Same pattern as Wave C: listeners call an in-process Evaluator inside their existing WithTx blocks instead of dispatching to SELECT plpgsql_function($1) shims.

Closes #299.

## Summary

- New internal/compliance package with Evaluator + package-level EvaluateInTx / ReevaluatePolicyInTx shims.
- 7 listener callsites swapped: action_listener (post-action-deletion recompute), assignment_listener (post-assignment mutation, ×2), compliance_listener (ComplianceResultUpdated / Removed), compliance_policy_listener (policy-level + rule-level changes, ×2).
- Migration 048 drops the 3 PL/pgSQL functions (evaluate_device_compliance_policies, recalculate_device_compliance, reevaluate_compliance_policy_devices).
- 7 new sqlc queries cover the read + write fan-out the evaluator needs.

## DoD checks

- [x] go build + go vet clean
- [x] gofmt clean
- [x] Targeted compliance projector tests pass (118s testcontainer suite)
- [x] Targeted compliance API tests pass
- [ ] CI integration suite

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Migrated compliance policy evaluation logic from database functions to an optimized in-process Go implementation, improving system reliability and code maintainability while fully preserving all existing compliance rules, device evaluation behaviors, and grace-period handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/300?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->