### PR TITLE
refactor(store): wave F — reactive triggers → Go listeners (#301)

### DIFF
--- a/cmd/control/periodic.go
+++ b/cmd/control/periodic.go
@@ -109,9 +109,16 @@ func startDynamicGroupWorker(ctx context.Context, st *store.Store, interval time
 
 	// Periodic full re-evaluation as a safety net (every 24h).
 	// Queues all dynamic groups for evaluation; the worker above drains them.
+	// Wave F replacement for the PL/pgSQL queue_all_dynamic_groups
+	// function — two typed enqueues here instead of one SELECT
+	// fn() that did both inserts internally.
 	go runPeriodic(ctx, 24*time.Hour, func() {
-		if err := st.Queries().QueueAllDynamicGroups(ctx); err != nil {
-			logger.Error("failed to queue full dynamic group re-evaluation", "error", err)
+		const reason = "periodic_full_evaluation"
+		if err := st.Queries().EnqueueAllDynamicDeviceGroups(ctx, reason); err != nil {
+			logger.Error("failed to queue full dynamic device-group re-evaluation", "error", err)
+		}
+		if err := st.Queries().EnqueueAllDynamicUserGroups(ctx, reason); err != nil {
+			logger.Error("failed to queue full dynamic user-group re-evaluation", "error", err)
 		} else {
 			logger.Info("queued full dynamic group re-evaluation")
 		}

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -485,7 +485,18 @@ func (w *InboxWorker) handleInventoryUpdate(ctx context.Context, t *asynq.Task) 
 		}
 	}
 
-	// Immediately evaluate dynamic groups queued by the device_inventory_changed trigger.
+	// Enqueue dynamic device groups for re-evaluation. Wave F
+	// replacement for the PL/pgSQL device_inventory_changed trigger:
+	// since the trigger is gone, the inbox worker enqueues explicitly
+	// after the inventory upsert chain completes.
+	if err := w.store.Queries().EnqueueAllDynamicDeviceGroups(ctx, "device_"+payload.DeviceID+"_changed"); err != nil {
+		w.logger.Warn("failed to enqueue dynamic device groups after inventory update",
+			"device_id", payload.DeviceID,
+			"error", err,
+		)
+	}
+
+	// Immediately evaluate dynamic groups queued by the inventory update above.
 	// Without this, groups are only evaluated on the periodic ticker (default 1h).
 	// Single-batch invocation here — the caller doesn't drain to
 	// completion the way cmd/control does. The `more` flag is

--- a/internal/projectors/device_listener.go
+++ b/internal/projectors/device_listener.go
@@ -151,6 +151,13 @@ func applyDeviceRegistered(ctx context.Context, q *store.Queries, e store.Persis
 			return err
 		}
 	}
+	// Re-evaluation enqueue: freshly-registered devices with seed
+	// labels (or no labels — equally relevant) must be considered by
+	// every dynamic device group. Wave F replacement for the PL/pgSQL
+	// device_labels_change_trigger fan-out.
+	if err := enqueueDynamicDeviceGroupsForDevice(ctx, q, payload.ID); err != nil {
+		return err
+	}
 	if payload.AssignedUserID == nil || *payload.AssignedUserID == "" {
 		return nil
 	}
@@ -256,7 +263,7 @@ func applyDeviceLabelsUpdated(ctx context.Context, q *store.Queries, e store.Per
 			return err
 		}
 	}
-	return nil
+	return enqueueDynamicDeviceGroupsForDevice(ctx, q, payload.ID)
 }
 
 func applyDeviceLabelSet(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -271,11 +278,14 @@ func applyDeviceLabelSet(ctx context.Context, q *store.Queries, e store.Persiste
 	if err != nil || !advanced {
 		return err
 	}
-	return q.SetDeviceLabel(ctx, db.SetDeviceLabelParams{
+	if err := q.SetDeviceLabel(ctx, db.SetDeviceLabelParams{
 		DeviceID: payload.ID,
 		Key:      payload.Key,
 		Value:    payload.Value,
-	})
+	}); err != nil {
+		return err
+	}
+	return enqueueDynamicDeviceGroupsForDevice(ctx, q, payload.ID)
 }
 
 func applyDeviceLabelRemoved(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -290,10 +300,13 @@ func applyDeviceLabelRemoved(ctx context.Context, q *store.Queries, e store.Pers
 	if err != nil || !advanced {
 		return err
 	}
-	return q.RemoveDeviceLabel(ctx, db.RemoveDeviceLabelParams{
+	if err := q.RemoveDeviceLabel(ctx, db.RemoveDeviceLabelParams{
 		DeviceID: payload.ID,
 		Key:      payload.Key,
-	})
+	}); err != nil {
+		return err
+	}
+	return enqueueDynamicDeviceGroupsForDevice(ctx, q, payload.ID)
 }
 
 // advanceDeviceVersion bumps devices_projection.projection_version to
@@ -312,6 +325,15 @@ func advanceDeviceVersion(ctx context.Context, q *store.Queries, deviceID string
 		return false, err
 	}
 	return n > 0, nil
+}
+
+// enqueueDynamicDeviceGroupsForDevice queues every active dynamic
+// device group for re-evaluation, tagging the queue entry with a
+// human-readable reason ("device_<id>_changed"). Replaces the
+// PL/pgSQL trigger_device_label_change / trigger_inventory_change /
+// queue_dynamic_groups_for_device chain (Wave F, tracker #242).
+func enqueueDynamicDeviceGroupsForDevice(ctx context.Context, q *store.Queries, deviceID string) error {
+	return q.EnqueueAllDynamicDeviceGroups(ctx, "device_"+deviceID+"_changed")
 }
 
 func applyDeviceDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -334,7 +356,26 @@ func applyDeviceDeleted(ctx context.Context, q *store.Queries, e store.Persisted
 	if err := q.DeleteDeviceAssignedUsersByDevice(ctx, e.StreamID); err != nil {
 		return err
 	}
-	return q.DeleteDeviceAssignedGroupsByDevice(ctx, e.StreamID)
+	if err := q.DeleteDeviceAssignedGroupsByDevice(ctx, e.StreamID); err != nil {
+		return err
+	}
+	// Cascade out of every dynamic group membership the device
+	// participated in. Replaces the PL/pgSQL device_deleted_trigger
+	// (Wave F, tracker #242): scope the recount to just the affected
+	// groups instead of the trigger's full-table sweep.
+	affectedGroups, err := q.ListDeviceGroupMembershipsByDevice(ctx, e.StreamID)
+	if err != nil {
+		return err
+	}
+	if err := q.DeleteDeviceGroupMembershipsForDevice(ctx, e.StreamID); err != nil {
+		return err
+	}
+	for _, groupID := range affectedGroups {
+		if err := q.RecountDeviceGroupMembers(ctx, groupID); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func applyDeviceAssigned(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {

--- a/internal/projectors/totp_listener.go
+++ b/internal/projectors/totp_listener.go
@@ -86,6 +86,10 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 				logger.Warn("totp projector: failed to flip users_projection.totp_enabled=TRUE",
 					"event_id", e.ID, "user_id", userID, "error", err)
 			}
+			if err := enqueueDynamicUserGroupsForUser(ctx, q, userID); err != nil {
+				logger.Warn("totp projector: failed to enqueue dynamic user groups",
+					"event_id", e.ID, "user_id", userID, "error", err)
+			}
 
 		case string(eventtypes.TOTPDisabled):
 			if err := q.DeleteTotpProjection(ctx, userID); err != nil {
@@ -99,6 +103,10 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 				ProjectionVersion: deref(e.SequenceNum),
 			}); err != nil {
 				logger.Warn("totp projector: failed to flip users_projection.totp_enabled=FALSE",
+					"event_id", e.ID, "user_id", userID, "error", err)
+			}
+			if err := enqueueDynamicUserGroupsForUser(ctx, q, userID); err != nil {
+				logger.Warn("totp projector: failed to enqueue dynamic user groups",
 					"event_id", e.ID, "user_id", userID, "error", err)
 			}
 

--- a/internal/projectors/user_listener.go
+++ b/internal/projectors/user_listener.go
@@ -192,7 +192,18 @@ func applyUserCreatedWithRoles(ctx context.Context, q *store.Queries, e store.Pe
 			return err
 		}
 	}
-	return nil
+	return enqueueDynamicUserGroupsForUser(ctx, q, payload.ID)
+}
+
+// enqueueDynamicUserGroupsForUser queues every active dynamic user
+// group for re-evaluation after a column on users_projection that the
+// user-group query language reads has changed. Wave F replacement for
+// the PL/pgSQL user_attribute_change_trigger (tracker #242). Called
+// from every user-event handler that touched email / disabled /
+// totp_enabled / has_password / is_deleted / display_name /
+// preferred_username / locale.
+func enqueueDynamicUserGroupsForUser(ctx context.Context, q *store.Queries, userID string) error {
+	return q.EnqueueAllDynamicUserGroups(ctx, "user_"+userID+"_changed")
 }
 
 func applyUserProfileUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -217,7 +228,7 @@ func applyUserProfileUpdated(ctx context.Context, q *store.Queries, e store.Pers
 	}); err != nil {
 		return err
 	}
-	return nil
+	return enqueueDynamicUserGroupsForUser(ctx, q, payload.ID)
 }
 
 func applyUserEmailChanged(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -237,7 +248,7 @@ func applyUserEmailChanged(ctx context.Context, q *store.Queries, e store.Persis
 	}); err != nil {
 		return err
 	}
-	return nil
+	return enqueueDynamicUserGroupsForUser(ctx, q, payload.ID)
 }
 
 func applyUserPasswordChanged(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -258,7 +269,7 @@ func applyUserPasswordChanged(ctx context.Context, q *store.Queries, e store.Per
 	}); err != nil {
 		return err
 	}
-	return nil
+	return enqueueDynamicUserGroupsForUser(ctx, q, payload.ID)
 }
 
 func applyUserRoleChanged(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -302,7 +313,7 @@ func applyUserDisabled(ctx context.Context, q *store.Queries, e store.PersistedE
 	}); err != nil {
 		return err
 	}
-	return nil
+	return enqueueDynamicUserGroupsForUser(ctx, q, e.StreamID)
 }
 
 func applyUserEnabled(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -314,7 +325,7 @@ func applyUserEnabled(ctx context.Context, q *store.Queries, e store.PersistedEv
 	}); err != nil {
 		return err
 	}
-	return nil
+	return enqueueDynamicUserGroupsForUser(ctx, q, e.StreamID)
 }
 
 func applyUserLoggedIn(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
@@ -347,7 +358,10 @@ func applyUserDeleted(ctx context.Context, q *store.Queries, e store.PersistedEv
 		// user would silently nuke that user's identity links.
 		return nil
 	}
-	return q.DeleteIdentityLinksByUser(ctx, e.StreamID)
+	if err := q.DeleteIdentityLinksByUser(ctx, e.StreamID); err != nil {
+		return err
+	}
+	return enqueueDynamicUserGroupsForUser(ctx, q, e.StreamID)
 }
 
 func applyUserSshKeyAdded(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {

--- a/internal/store/generated/device_groups.sql.go
+++ b/internal/store/generated/device_groups.sql.go
@@ -97,6 +97,18 @@ func (q *Queries) DeleteDeviceGroupMembersByGroup(ctx context.Context, groupID s
 	return err
 }
 
+const deleteDeviceGroupMembershipsForDevice = `-- name: DeleteDeviceGroupMembershipsForDevice :exec
+DELETE FROM device_group_members_projection WHERE device_id = $1
+`
+
+// Wave F: removes every membership row for the deleted device.
+// Replaces the cascade half of the dropped device_deleted_trigger
+// (PL/pgSQL trigger_device_deleted).
+func (q *Queries) DeleteDeviceGroupMembershipsForDevice(ctx context.Context, deviceID string) error {
+	_, err := q.db.Exec(ctx, deleteDeviceGroupMembershipsForDevice, deviceID)
+	return err
+}
+
 const deleteDynamicDeviceGroupEvaluationQueueRow = `-- name: DeleteDynamicDeviceGroupEvaluationQueueRow :exec
 DELETE FROM dynamic_group_evaluation_queue WHERE group_id = $1
 `
@@ -126,6 +138,28 @@ type DeleteDynamicDeviceGroupQueueBeforeParams struct {
 // running, the newer queue entry survives so the drain loop re-evaluates.
 func (q *Queries) DeleteDynamicDeviceGroupQueueBefore(ctx context.Context, arg DeleteDynamicDeviceGroupQueueBeforeParams) error {
 	_, err := q.db.Exec(ctx, deleteDynamicDeviceGroupQueueBefore, arg.GroupID, arg.BeforeTs)
+	return err
+}
+
+const enqueueAllDynamicDeviceGroups = `-- name: EnqueueAllDynamicDeviceGroups :exec
+INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+SELECT id, clock_timestamp(), $1::TEXT
+FROM device_groups_projection
+WHERE is_dynamic = TRUE AND is_deleted = FALSE
+ON CONFLICT (group_id) DO UPDATE SET
+    queued_at = clock_timestamp(),
+    reason = EXCLUDED.reason
+`
+
+// Wave F: enqueues every non-deleted dynamic device group for
+// re-evaluation. Used by both the projector listeners (after a
+// side-table change like a label / inventory mutation, with
+// reason='device_<id>_changed') and the periodic safety-net
+// sweep (reason='periodic_full_evaluation'). Replaces the
+// PL/pgSQL queue_dynamic_groups_for_device + queue_all_dynamic_groups
+// helpers; the caller picks the reason.
+func (q *Queries) EnqueueAllDynamicDeviceGroups(ctx context.Context, reason string) error {
+	_, err := q.db.Exec(ctx, enqueueAllDynamicDeviceGroups, reason)
 	return err
 }
 
@@ -448,6 +482,35 @@ func (q *Queries) ListDeviceGroupMembers(ctx context.Context, groupID string) ([
 	return items, nil
 }
 
+const listDeviceGroupMembershipsByDevice = `-- name: ListDeviceGroupMembershipsByDevice :many
+SELECT group_id FROM device_group_members_projection
+WHERE device_id = $1
+`
+
+// Wave F: pre-fetch the (group_id) list a soft-deleted device belongs
+// to. The device-projector cascade uses this to scope the post-delete
+// recount to just the affected groups instead of recomputing every
+// group's member_count (what the dropped PL/pgSQL trigger did).
+func (q *Queries) ListDeviceGroupMembershipsByDevice(ctx context.Context, deviceID string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listDeviceGroupMembershipsByDevice, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var group_id string
+		if err := rows.Scan(&group_id); err != nil {
+			return nil, err
+		}
+		items = append(items, group_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDeviceGroups = `-- name: ListDeviceGroups :many
 SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, is_dynamic, dynamic_query, sync_interval_minutes, maintenance_window FROM device_groups_projection
 WHERE is_deleted = FALSE
@@ -702,15 +765,6 @@ func (q *Queries) ListGroupsForDevice(ctx context.Context, deviceID string) ([]D
 		return nil, err
 	}
 	return items, nil
-}
-
-const queueAllDynamicGroups = `-- name: QueueAllDynamicGroups :exec
-SELECT queue_all_dynamic_groups()
-`
-
-func (q *Queries) QueueAllDynamicGroups(ctx context.Context) error {
-	_, err := q.db.Exec(ctx, queueAllDynamicGroups)
-	return err
 }
 
 const recountDeviceGroupMembers = `-- name: RecountDeviceGroupMembers :exec

--- a/internal/store/generated/user_groups.sql.go
+++ b/internal/store/generated/user_groups.sql.go
@@ -218,6 +218,27 @@ func (q *Queries) DeleteUserGroupRolesByGroup(ctx context.Context, groupID strin
 	return err
 }
 
+const enqueueAllDynamicUserGroups = `-- name: EnqueueAllDynamicUserGroups :exec
+INSERT INTO dynamic_user_group_evaluation_queue (group_id, queued_at, reason)
+SELECT id, clock_timestamp(), $1::TEXT
+FROM user_groups_projection
+WHERE is_dynamic = TRUE AND is_deleted = FALSE
+ON CONFLICT (group_id) DO UPDATE SET
+    queued_at = clock_timestamp(),
+    reason = EXCLUDED.reason
+`
+
+// Wave F: enqueues every non-deleted dynamic user group for re-eval.
+// Used by user-attribute projector listeners after a column change
+// (reason='user_<id>_changed') and by the periodic safety-net sweep
+// (reason='periodic_full_evaluation'). Replaces the PL/pgSQL
+// queue_dynamic_user_groups_on_user_change + queue_all_dynamic_groups
+// helpers.
+func (q *Queries) EnqueueAllDynamicUserGroups(ctx context.Context, reason string) error {
+	_, err := q.db.Exec(ctx, enqueueAllDynamicUserGroups, reason)
+	return err
+}
+
 const enqueueDynamicUserGroupEvaluation = `-- name: EnqueueDynamicUserGroupEvaluation :exec
 INSERT INTO dynamic_user_group_evaluation_queue (group_id, reason)
 VALUES ($1, $2)

--- a/internal/store/migrations/049_drop_reactive_triggers.sql
+++ b/internal/store/migrations/049_drop_reactive_triggers.sql
@@ -1,0 +1,48 @@
+-- Wave F (tracker manchtools/power-manage-server#242): drop the
+-- reactive triggers that fired dynamic-group re-evaluation on side-
+-- table changes. Wave F moves the enqueueing into the Go projector
+-- listeners that already process the underlying events, so the PG
+-- triggers come out entirely.
+--
+-- Triggers dropped:
+-- 1. device_labels_change_trigger (on device_labels) — was added in
+--    047 to replace the JSONB-column trigger; both queueing flows
+--    now happen in the Go device-label listener (label set/removed/
+--    updated/registered).
+-- 2. device_deleted_trigger (on devices_projection) — cascade-delete
+--    of device_group_members + recount moved into the device-deleted
+--    listener.
+-- 3. device_inventory_changed (on device_inventory) — queueing moved
+--    into the inbox-worker's inventory-update flow.
+-- 4. user_attribute_change_trigger (on users_projection) — queueing
+--    moved into every user-event listener whose payload mutates one
+--    of the columns the user-group query language reads.
+--
+-- Plus the supporting PL/pgSQL functions: trigger_device_labels_child_change,
+-- trigger_device_label_change (legacy), trigger_device_deleted,
+-- trigger_inventory_change, queue_dynamic_groups_for_device,
+-- queue_dynamic_user_groups_on_user_change, queue_all_dynamic_groups.
+--
+-- Down: not reversible. Same pattern as the Wave C.5 + D drops. The
+-- bodies live in migration 004 / 047 history if needed for forensic
+-- reference.
+
+-- +goose Up
+
+DROP TRIGGER IF EXISTS device_labels_change_trigger ON device_labels;
+DROP TRIGGER IF EXISTS device_deleted_trigger ON devices_projection;
+DROP TRIGGER IF EXISTS device_inventory_changed ON device_inventory;
+DROP TRIGGER IF EXISTS user_attribute_change_trigger ON users_projection;
+
+DROP FUNCTION IF EXISTS trigger_device_labels_child_change();
+DROP FUNCTION IF EXISTS trigger_device_label_change();
+DROP FUNCTION IF EXISTS trigger_device_deleted();
+DROP FUNCTION IF EXISTS trigger_inventory_change();
+DROP FUNCTION IF EXISTS queue_dynamic_groups_for_device(TEXT);
+DROP FUNCTION IF EXISTS queue_dynamic_user_groups_on_user_change();
+DROP FUNCTION IF EXISTS queue_all_dynamic_groups();
+
+-- +goose Down
+
+-- Intentionally not reversible.
+SELECT 1;

--- a/internal/store/queries/device_groups.sql
+++ b/internal/store/queries/device_groups.sql
@@ -80,8 +80,21 @@ WHERE g.is_deleted = FALSE
 ORDER BY q.queued_at ASC
 LIMIT $1;
 
--- name: QueueAllDynamicGroups :exec
-SELECT queue_all_dynamic_groups();
+-- name: EnqueueAllDynamicDeviceGroups :exec
+-- Wave F: enqueues every non-deleted dynamic device group for
+-- re-evaluation. Used by both the projector listeners (after a
+-- side-table change like a label / inventory mutation, with
+-- reason='device_<id>_changed') and the periodic safety-net
+-- sweep (reason='periodic_full_evaluation'). Replaces the
+-- PL/pgSQL queue_dynamic_groups_for_device + queue_all_dynamic_groups
+-- helpers; the caller picks the reason.
+INSERT INTO dynamic_group_evaluation_queue (group_id, queued_at, reason)
+SELECT id, clock_timestamp(), sqlc.arg(reason)::TEXT
+FROM device_groups_projection
+WHERE is_dynamic = TRUE AND is_deleted = FALSE
+ON CONFLICT (group_id) DO UPDATE SET
+    queued_at = clock_timestamp(),
+    reason = EXCLUDED.reason;
 
 -- ============================================================================
 -- Projector listener writes (manchtools/power-manage-server#136).
@@ -237,6 +250,20 @@ DELETE FROM device_group_members_projection WHERE group_id = $1;
 -- the next dynamic-evaluation pass doesn't try to reconcile a deleted
 -- group.
 DELETE FROM dynamic_group_evaluation_queue WHERE group_id = $1;
+
+-- name: ListDeviceGroupMembershipsByDevice :many
+-- Wave F: pre-fetch the (group_id) list a soft-deleted device belongs
+-- to. The device-projector cascade uses this to scope the post-delete
+-- recount to just the affected groups instead of recomputing every
+-- group's member_count (what the dropped PL/pgSQL trigger did).
+SELECT group_id FROM device_group_members_projection
+WHERE device_id = $1;
+
+-- name: DeleteDeviceGroupMembershipsForDevice :exec
+-- Wave F: removes every membership row for the deleted device.
+-- Replaces the cascade half of the dropped device_deleted_trigger
+-- (PL/pgSQL trigger_device_deleted).
+DELETE FROM device_group_members_projection WHERE device_id = $1;
 
 -- name: DeleteDynamicDeviceGroupQueueBefore :exec
 -- Wave C.3: clear queue entries for `group_id` that were queued before

--- a/internal/store/queries/user_groups.sql
+++ b/internal/store/queries/user_groups.sql
@@ -207,6 +207,21 @@ INSERT INTO dynamic_user_group_evaluation_queue (group_id, reason)
 VALUES ($1, $2)
 ON CONFLICT (group_id) DO UPDATE SET queued_at = clock_timestamp();
 
+-- name: EnqueueAllDynamicUserGroups :exec
+-- Wave F: enqueues every non-deleted dynamic user group for re-eval.
+-- Used by user-attribute projector listeners after a column change
+-- (reason='user_<id>_changed') and by the periodic safety-net sweep
+-- (reason='periodic_full_evaluation'). Replaces the PL/pgSQL
+-- queue_dynamic_user_groups_on_user_change + queue_all_dynamic_groups
+-- helpers.
+INSERT INTO dynamic_user_group_evaluation_queue (group_id, queued_at, reason)
+SELECT id, clock_timestamp(), sqlc.arg(reason)::TEXT
+FROM user_groups_projection
+WHERE is_dynamic = TRUE AND is_deleted = FALSE
+ON CONFLICT (group_id) DO UPDATE SET
+    queued_at = clock_timestamp(),
+    reason = EXCLUDED.reason;
+
 -- name: UpdateUserGroupMaintenanceWindowProjection :execrows
 -- UserGroupMaintenanceWindowSet handler. Mirrors the PL/pgSQL
 -- `COALESCE(payload, '{}'::JSONB)`: the listener decoder substitutes


### PR DESCRIPTION
Part of the storage-abstraction tracker (#242), Wave F. Drops the four PL/pgSQL reactive triggers that fired dynamic-group re-evaluation on side-table changes; moves the enqueueing into the Go projector listeners that already process the underlying events.

Closes #301.

## Summary

Migration 049 drops:
- device_labels_change_trigger (on device_labels)
- device_deleted_trigger (on devices_projection)
- device_inventory_changed (on device_inventory)
- user_attribute_change_trigger (on users_projection)

Plus 7 supporting PL/pgSQL functions (trigger handlers + queue helpers).

## Go wiring

- 4 new sqlc queries (EnqueueAllDynamicDeviceGroups / EnqueueAllDynamicUserGroups with caller-supplied reason, ListDeviceGroupMembershipsByDevice, DeleteDeviceGroupMembershipsForDevice). Removed: QueueAllDynamicGroups (callerless after this PR).
- enqueueDynamicDeviceGroupsForDevice / enqueueDynamicUserGroupsForUser helpers in internal/projectors. Reason format preserved ('device_<id>_changed' / 'user_<id>_changed').
- Device-deleted cascade scope-tightened: recount only the affected groups, not every dynamic device group (PL/pgSQL trigger's wholesale sweep).
- Periodic safety-net sweep in cmd/control/periodic.go: one typed enqueue per side (device + user) instead of the SELECT queue_all_dynamic_groups() shim.

## DoD checks

- [x] go build + go vet clean
- [x] gofmt clean
- [x] Targeted projector tests pass (Device + User + Totp, 326s testcontainer suite)
- [ ] CI integration suite

After Wave F lands, the only remaining roadmap item before validation-backend / NoSQL work is **Wave G** (EventStore interface).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced dynamic group re-evaluation to be more responsive and reliable when device inventory, labels, and user attributes change.
  * Improved cascading behavior during device and user deletion to ensure dynamic group memberships are properly recalculated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/302?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->