### PR TITLE
refactor(store): wave G — define EventStore interface (#303)

### DIFF
--- a/internal/store/eventstore.go
+++ b/internal/store/eventstore.go
@@ -1,0 +1,80 @@
+package store
+
+import "context"
+
+// EventStore is the abstract event-sourcing entry point that decouples
+// handler-layer + projector-layer code from any particular database
+// driver. Wave G of the storage-abstraction roadmap (tracker
+// manchtools/power-manage-server#242).
+//
+// Postgres is the only impl shipped today (provided by *Store in this
+// package). Future backends — SQL via different drivers (sqlite, libSQL,
+// MySQL), document stores via conditional-write semantics — implement
+// the same shape so handlers stay backend-agnostic.
+//
+// # Optimistic-concurrency contract
+//
+// AppendEvent computes the next stream_version inline and retries on
+// constraint violation. AppendEventWithVersion takes a caller-supplied
+// expected version and surfaces the conflict to the caller (no retry).
+// On the Postgres impl both rely on the UNIQUE (stream_type, stream_id,
+// stream_version) constraint to serialize concurrent writers; on
+// NoSQL backends the same signature maps to conditional-write
+// semantics ("write only if attribute X equals Y").
+//
+// # Listener contract
+//
+// RegisterEventListener registers a post-commit hook. On the Postgres
+// impl the hook fires synchronously after AppendEvent returns success —
+// listeners that need to outlive the request context derive their own
+// (context.WithoutCancel + a timeout) before spawning async work.
+//
+// Cross-backend the contract is "best-effort post-commit notification."
+// A backend that can't guarantee synchronous post-commit (eg. eventually
+// consistent NoSQL) MUST document that listeners may be delayed and
+// MUST NOT promise that a listener's side effects are observable by
+// the time AppendEvent returns. The Postgres impl's synchronous
+// guarantee is an upgrade, not a contract requirement.
+//
+// # Loading streams
+//
+// LoadStream returns every event for a (stream_type, stream_id) pair
+// in stream_version order — the canonical replay path. LoadStreamByType
+// pages over every event of a stream_type ordered by sequence_num
+// descending; the limit / offset params mirror what the existing audit-
+// log handlers used to call directly via Queries(). Callers that need
+// finer-grained filtering (event_type, actor, time range) still go
+// through the typed sqlc queries — those aren't in the interface
+// because they're projection-shaped reads that don't map to NoSQL.
+type EventStore interface {
+	// AppendEvent writes a new event and fires registered listeners
+	// on success. Auto-computes stream_version with retry-on-conflict
+	// up to a small bound.
+	AppendEvent(ctx context.Context, event Event) error
+
+	// AppendEventWithVersion writes a new event only if the latest
+	// event in the stream has expectedVersion. Returns a conflict
+	// error otherwise — no retry.
+	AppendEventWithVersion(ctx context.Context, event Event, expectedVersion int32) error
+
+	// LoadStream returns every event for the given stream in
+	// stream_version order. Used by rebuild paths and any consumer
+	// that needs to replay a single aggregate's history.
+	LoadStream(ctx context.Context, streamType, streamID string) ([]PersistedEvent, error)
+
+	// LoadStreamByType pages over every event with the given
+	// stream_type, ordered by sequence_num descending. The paging
+	// shape matches the existing audit-log + reconciler call sites.
+	LoadStreamByType(ctx context.Context, streamType string, limit, offset int32) ([]PersistedEvent, error)
+
+	// RegisterEventListener installs a post-commit hook. Listeners
+	// fire in registration order; see the package doc on
+	// EventListener for failure / panic semantics.
+	RegisterEventListener(fn EventListener)
+}
+
+// Compile-time guarantee that *Store satisfies EventStore. A future
+// change that breaks the interface (rename, remove, change a
+// signature) surfaces as a build failure here rather than at the
+// first runtime callsite.
+var _ EventStore = (*Store)(nil)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -373,6 +373,29 @@ func (s *Store) Close() {
 	s.pool.Close()
 }
 
+// LoadStream satisfies EventStore.LoadStream. Thin wrapper over the
+// sqlc-generated LoadStream query; lifts the (stream_type, stream_id)
+// → []PersistedEvent shape onto Store so callers can depend on the
+// EventStore interface instead of reaching into Queries().
+func (s *Store) LoadStream(ctx context.Context, streamType, streamID string) ([]PersistedEvent, error) {
+	return s.queries.LoadStream(ctx, generated.LoadStreamParams{
+		StreamType: streamType,
+		StreamID:   streamID,
+	})
+}
+
+// LoadStreamByType satisfies EventStore.LoadStreamByType. Pages over
+// every event with the given stream_type ordered by sequence_num
+// descending. Mirrors the existing LoadEventsByStreamType query the
+// audit-log + reconciler callers used directly.
+func (s *Store) LoadStreamByType(ctx context.Context, streamType string, limit, offset int32) ([]PersistedEvent, error) {
+	return s.queries.LoadEventsByStreamType(ctx, generated.LoadEventsByStreamTypeParams{
+		StreamType: streamType,
+		Limit:      limit,
+		Offset:     offset,
+	})
+}
+
 // WithTx runs a function within a transaction.
 func (s *Store) WithTx(ctx context.Context, fn func(*Queries) error) error {
 	tx, err := s.pool.Begin(ctx)


### PR DESCRIPTION
Part of the storage-abstraction tracker (#242), Wave G. Final architectural piece before validation-backend work (Wave H).

Closes #303.

## Summary

- internal/store/eventstore.go defines the EventStore interface with the 5 methods the plan called out (AppendEvent / AppendEventWithVersion / LoadStream / LoadStreamByType / RegisterEventListener).
- *Store gains LoadStream + LoadStreamByType so the interface is fully covered.
- Compile-time assertion (var _ EventStore = (*Store)(nil)) catches any future Store change that breaks the contract at build time.
- Method names match the existing concrete Store methods so no caller-side churn — the interface is additive.

## Contract documentation

- OCC: AppendEvent retries on UNIQUE constraint violation; AppendEventWithVersion surfaces the conflict.
- Listener delivery: synchronous post-commit on the Postgres impl; cross-backend the contract is "best-effort post-commit notification."

## Scope boundary

Migrating handler/projector/repo callsites from *store.Store to EventStore is NOT in this PR — that's mechanical and pays off only when a second backend lands. The interface is what we're committing to here; consumer migration is a later step.

## DoD checks

- [x] go build + go vet clean
- [x] gofmt clean
- [ ] CI integration suite

After Wave G lands, the storage-abstraction roadmap A–G is complete. Wave H (validation backend, eg Turso/libSQL) and Wave I (optional NoSQL sketch) are the remaining items, but those are aspirational — the in-process abstractions are now done.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Established event storage infrastructure with support for recording and retrieving ordered events, version conflict management, and post-commit notifications to enable event-sourcing capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->