### PR TITLE
refactor(store): wave H cheap wins — IsVersionConflict + TestingPool + drop PL/pgSQL

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -216,6 +216,12 @@ func main() {
 	// periodic reconciler. See setup.go for the full rationale.
 	wireSystemActions(ctx, st, svc, cfg, logger)
 
+	// Boot-time seed of the "All Devices" dynamic group. Runs AFTER
+	// WireAll so the DeviceGroupCreated event flows through the
+	// registered projector listener (#242 Wave H — replaces the
+	// PL/pgSQL DO block in migration 008).
+	bootstrapAllDevicesGroup(ctx, st, logger)
+
 	configureTrustedProxies(cfg, logger)
 
 	// Valkey-backed subsystem: taskqueue.Client + RediSearch index +

--- a/cmd/control/setup.go
+++ b/cmd/control/setup.go
@@ -11,6 +11,8 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/oklog/ulid/v2"
+
 	"github.com/manchtools/power-manage/server/internal/api"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/crypto"
@@ -19,6 +21,46 @@ import (
 	"github.com/manchtools/power-manage/server/internal/projectors"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
+
+// bootstrapAllDevicesGroup emits the seed DeviceGroupCreated event
+// for the "All Devices" dynamic group on a fresh deployment. Previously
+// done in PL/pgSQL inside migration 008 via a DO block + generate_ulid()
+// function (#242 Wave H); moved into Go bootstrap so a future non-Postgres
+// backend doesn't need a dialect-specific seed.
+//
+// Must run AFTER projectors.WireAll so the event flows through the
+// registered DeviceGroup listener and materialises the projection row.
+// Idempotent — early-returns when the group already exists. Errors are
+// logged (not returned) because this is a best-effort boot convenience
+// matching seedSSHAccessForAll.
+func bootstrapAllDevicesGroup(ctx context.Context, st *store.Store, logger *slog.Logger) {
+	_, err := st.Repos().DeviceGroup.GetByName(ctx, "All Devices")
+	if err == nil {
+		return // already present
+	}
+	if !store.IsNotFound(err) {
+		logger.Error("bootstrap: All Devices group lookup failed", "error", err)
+		return
+	}
+	id := ulid.Make().String()
+	if err := st.AppendEvent(ctx, store.Event{
+		StreamType: "device_group",
+		StreamID:   id,
+		EventType:  string(eventtypes.DeviceGroupCreated),
+		Data: payloads.DeviceGroupCreated{
+			Name:         "All Devices",
+			Description:  "Dynamic group that matches all registered devices",
+			IsDynamic:    true,
+			DynamicQuery: "",
+		},
+		ActorType: "system",
+		ActorID:   "bootstrap",
+	}); err != nil {
+		logger.Error("bootstrap: failed to emit DeviceGroupCreated for All Devices", "error", err)
+		return
+	}
+	logger.Info("bootstrap: emitted DeviceGroupCreated for All Devices", "group_id", id)
+}
 
 // errEncryptionKeyRequired is the boot-time fatal returned when
 // CONTROL_ENCRYPTION_KEY is unset and the operator did not opt out

--- a/internal/api/sso_handler_failure_paths_test.go
+++ b/internal/api/sso_handler_failure_paths_test.go
@@ -116,7 +116,7 @@ func TestSSOCallback_StateIsSingleUse(t *testing.T) {
 	// which the handler must treat the same as never-existed.
 	state := "test-state-" + testutil.NewID()
 	ctx := context.Background()
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		`DELETE FROM auth_states WHERE state = $1`, state)
 	require.NoError(t, err)
 	// Use the SQL directly to insert; the auth_states table doesn't
@@ -126,7 +126,7 @@ func TestSSOCallback_StateIsSingleUse(t *testing.T) {
 	// build, but only AFTER ConsumeAuthState has deleted the row —
 	// which is the contract this test pins.
 	providerID := testutil.CreateTestIdentityProvider(t, st, enc, adminID, "Single Use", "single-use-fk")
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		`INSERT INTO auth_states (state, provider_id, nonce, code_verifier, redirect_uri, expires_at)
 		 VALUES ($1, $2, 'n', 'cv', '', NOW() + INTERVAL '5 minutes')`,
 		state, providerID,

--- a/internal/api/system_action_store_test.go
+++ b/internal/api/system_action_store_test.go
@@ -88,7 +88,7 @@ func TestSystemActionStore_AssignActionToUser_EmitsAssignmentCreated(t *testing.
 	// The assignment stream id is generated; we have to find it via
 	// the projection rather than by stream lookup. Use the assignments
 	// projection: source_id = act-1, target_id = user-1.
-	rows, err := st.Pool().Query(context.Background(),
+	rows, err := st.TestingPool().Query(context.Background(),
 		`SELECT source_type, target_type, mode FROM assignments_projection
 		 WHERE source_id = $1 AND target_id = $2`, "act-1", "user-1")
 	require.NoError(t, err)

--- a/internal/projectors/action_set_test.go
+++ b/internal/projectors/action_set_test.go
@@ -430,13 +430,13 @@ func TestActionSetListener_DeleteCascadesMembersAndDefinitions(t *testing.T) {
 	// row that references our action set. Direct SQL because the
 	// definition projector is still PL/pgSQL — we don't want to
 	// couple this test to its event flow.
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		`INSERT INTO definitions_projection (id, name, member_count, created_at, created_by, projection_version)
 		 VALUES ($1, $2, 1, NOW(), '', 0)`,
 		defID, "wraps-our-set",
 	)
 	require.NoError(t, err)
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		`INSERT INTO definition_members_projection (definition_id, action_set_id, sort_order, added_at)
 		 VALUES ($1, $2, 0, NOW())`,
 		defID, setID,
@@ -452,27 +452,27 @@ func TestActionSetListener_DeleteCascadesMembersAndDefinitions(t *testing.T) {
 
 	// Set row marked deleted.
 	var isDeleted bool
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT is_deleted FROM action_sets_projection WHERE id = $1", setID,
 	).Scan(&isDeleted))
 	assert.True(t, isDeleted)
 
 	// Members wiped.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM action_set_members_projection WHERE set_id = $1", setID,
 	).Scan(&count))
 	assert.Equal(t, 0, count)
 
 	// definition_members rows for this set wiped.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM definition_members_projection WHERE action_set_id = $1", setID,
 	).Scan(&count))
 	assert.Equal(t, 0, count)
 
 	// Parent definition's member_count decremented (1 → 0).
 	var memberCount int32
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT member_count FROM definitions_projection WHERE id = $1", defID,
 	).Scan(&memberCount))
 	assert.Equal(t, int32(0), memberCount,
@@ -543,13 +543,13 @@ func TestActionSetListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 	live, err := st.Queries().GetActionSetByID(ctx, setID)
 	require.NoError(t, err)
 
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		`INSERT INTO definitions_projection (id, name, member_count, created_at, created_by, projection_version)
 		 VALUES ($1, $2, 1, NOW(), '', 0)`,
 		defID, "still-references-live-set",
 	)
 	require.NoError(t, err)
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		`INSERT INTO definition_members_projection (definition_id, action_set_id, sort_order, added_at)
 		 VALUES ($1, $2, 0, NOW())`,
 		defID, setID,
@@ -580,20 +580,20 @@ func TestActionSetListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 
 	// Member still there.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM action_set_members_projection WHERE set_id = $1", setID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale ActionSetDeleted must NOT cascade-delete members")
 
 	// definition_members row still there.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM definition_members_projection WHERE action_set_id = $1", setID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale ActionSetDeleted must NOT cascade-delete definition_members")
 
 	// Parent definition's member_count untouched.
 	var memberCount int32
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT member_count FROM definitions_projection WHERE id = $1", defID,
 	).Scan(&memberCount))
 	assert.Equal(t, int32(1), memberCount,
@@ -648,7 +648,7 @@ func TestActionSetListener_StaleMemberAddedDoesNotRecreateMembership(t *testing.
 	})
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM action_set_members_projection WHERE set_id = $1 AND action_id = $2",
 		setID, actionID,
 	).Scan(&count))

--- a/internal/projectors/action_test.go
+++ b/internal/projectors/action_test.go
@@ -298,7 +298,7 @@ func TestActionListener_RenameCascadesIntoComplianceRule(t *testing.T) {
 	}))
 
 	var actionName string
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		`SELECT action_name FROM compliance_policy_rules_projection
 		 WHERE policy_id = $1 AND action_id = $2`, policyID, actionID,
 	).Scan(&actionName))
@@ -349,13 +349,13 @@ func TestActionListener_DeletedCascadesAcrossEverything(t *testing.T) {
 	}))
 	// Plant a compliance result + an evaluation row directly so we
 	// don't have to drive the full eval engine to exercise the wipes.
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		`INSERT INTO compliance_results_projection (device_id, action_id, action_name, compliant, checked_at)
 		 VALUES ($1, $2, $3, TRUE, NOW())`,
 		deviceID, actionID, "doomed",
 	)
 	require.NoError(t, err)
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		`INSERT INTO compliance_policy_evaluation_projection (device_id, policy_id, action_id, compliant, checked_at)
 		 VALUES ($1, $2, $3, TRUE, NOW())`,
 		deviceID, policyID, actionID,
@@ -380,7 +380,7 @@ func TestActionListener_DeletedCascadesAcrossEverything(t *testing.T) {
 
 	// action_set member wiped + member_count decremented.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM action_set_members_projection WHERE action_id = $1", actionID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "action_set members for deleted action wiped")
@@ -389,7 +389,7 @@ func TestActionListener_DeletedCascadesAcrossEverything(t *testing.T) {
 	assert.Equal(t, int32(0), afterSet.MemberCount, "parent action_set member_count decremented")
 
 	// Compliance rules wiped + per-policy rule_count decremented.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_policy_rules_projection WHERE action_id = $1", actionID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "compliance rules for deleted action wiped")
@@ -398,11 +398,11 @@ func TestActionListener_DeletedCascadesAcrossEverything(t *testing.T) {
 	assert.Equal(t, int32(0), afterPolicy.RuleCount, "policy rule_count decremented")
 
 	// Evaluation + result rows wiped.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_policy_evaluation_projection WHERE action_id = $1", actionID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "evaluation rows for deleted action wiped")
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_results_projection WHERE action_id = $1", actionID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "result rows for deleted action wiped")
@@ -450,7 +450,7 @@ func TestActionListener_StaleDeleteReplayDoesNotNukeCascade(t *testing.T) {
 		},
 		ActorType: "user", ActorID: "u",
 	}))
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		`INSERT INTO compliance_results_projection (device_id, action_id, action_name, compliant, checked_at)
 		 VALUES ($1, $2, $3, TRUE, NOW())`,
 		deviceID, actionID, "live",
@@ -484,7 +484,7 @@ func TestActionListener_StaleDeleteReplayDoesNotNukeCascade(t *testing.T) {
 
 	// action_set member NOT wiped, member_count NOT decremented.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM action_set_members_projection WHERE action_id = $1", actionID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale ActionDeleted must NOT cascade-delete action_set members")
@@ -494,7 +494,7 @@ func TestActionListener_StaleDeleteReplayDoesNotNukeCascade(t *testing.T) {
 		"stale ActionDeleted must NOT decrement live action_set member_count")
 
 	// Compliance rule NOT wiped, rule_count NOT decremented.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_policy_rules_projection WHERE action_id = $1", actionID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale ActionDeleted must NOT cascade-delete compliance rules")
@@ -504,7 +504,7 @@ func TestActionListener_StaleDeleteReplayDoesNotNukeCascade(t *testing.T) {
 		"stale ActionDeleted must NOT decrement live policy rule_count")
 
 	// Compliance results NOT wiped.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_results_projection WHERE action_id = $1", actionID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale ActionDeleted must NOT cascade-delete compliance results")

--- a/internal/projectors/assignment_test.go
+++ b/internal/projectors/assignment_test.go
@@ -316,7 +316,7 @@ func TestAssignmentListener_DeleteSoftDeletes(t *testing.T) {
 
 	// But the row is still there with is_deleted=TRUE.
 	var isDeleted bool
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT is_deleted FROM assignments_projection WHERE id = $1", asnID,
 	).Scan(&isDeleted))
 	assert.True(t, isDeleted)
@@ -458,7 +458,7 @@ func TestAssignmentListener_StaleDeleteReplayDoesNotCascade(t *testing.T) {
 	// cascade DELETE is skipped on a stale replay. action_id is part
 	// of the composite PK; any value will do — the cascade DELETE
 	// scopes on (device_id, policy_id) only.
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		`INSERT INTO compliance_policy_evaluation_projection
 		   (device_id, policy_id, action_id, compliant, status)
 		 VALUES ($1, $2, $3, TRUE, 1)`,
@@ -491,7 +491,7 @@ func TestAssignmentListener_StaleDeleteReplayDoesNotCascade(t *testing.T) {
 	// Compliance evaluation row is still there — the cascade was
 	// skipped because the guarded SoftDelete returned ErrNoRows.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_policy_evaluation_projection WHERE device_id = $1 AND policy_id = $2",
 		deviceID, policyID,
 	).Scan(&count))

--- a/internal/projectors/compliance_policy_test.go
+++ b/internal/projectors/compliance_policy_test.go
@@ -503,7 +503,7 @@ func TestCompliancePolicyListener_DeleteCascadesRulesAndEvaluations(t *testing.T
 	// half of CompliancePolicyDeleted wipes it. Live evaluation rows
 	// are written by the still-PL/pgSQL eval engine; we simulate one
 	// to lock the cascade behaviour.
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		`INSERT INTO compliance_policy_evaluation_projection
 		   (device_id, policy_id, action_id, compliant, status, projection_version)
 		 VALUES ($1, $2, $3, FALSE, 0, 1)`,
@@ -519,20 +519,20 @@ func TestCompliancePolicyListener_DeleteCascadesRulesAndEvaluations(t *testing.T
 
 	// Policy row marked deleted.
 	var isDeleted bool
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT is_deleted FROM compliance_policies_projection WHERE id = $1", policyID,
 	).Scan(&isDeleted))
 	assert.True(t, isDeleted)
 
 	// Rules wiped.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_policy_rules_projection WHERE policy_id = $1", policyID,
 	).Scan(&count))
 	assert.Equal(t, 0, count)
 
 	// Evaluations wiped.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_policy_evaluation_projection WHERE policy_id = $1", policyID,
 	).Scan(&count))
 	assert.Equal(t, 0, count)
@@ -557,7 +557,7 @@ func TestCompliancePolicyListener_RuleRemovedWipesEvaluations(t *testing.T) {
 			Data:      map[string]any{"action_id": aid, "action_name": "r", "grace_period_hours": 0},
 			ActorType: "user", ActorID: "u",
 		}))
-		_, err := st.Pool().Exec(ctx,
+		_, err := st.TestingPool().Exec(ctx,
 			`INSERT INTO compliance_policy_evaluation_projection
 			   (device_id, policy_id, action_id, compliant, status, projection_version)
 			 VALUES ($1, $2, $3, FALSE, 0, 1)`,
@@ -573,13 +573,13 @@ func TestCompliancePolicyListener_RuleRemovedWipesEvaluations(t *testing.T) {
 	}))
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_policy_evaluation_projection WHERE policy_id = $1 AND action_id = $2",
 		policyID, actionA,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "RuleRemoved must wipe evaluations for the (policy, action) pair")
 
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_policy_evaluation_projection WHERE policy_id = $1 AND action_id = $2",
 		policyID, actionB,
 	).Scan(&count))
@@ -661,7 +661,7 @@ func TestCompliancePolicyListener_StaleDeleteReplayDoesNotNukeRules(t *testing.T
 
 	// Rule still there.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_policy_rules_projection WHERE policy_id = $1", policyID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale CompliancePolicyDeleted must NOT cascade-delete rules")
@@ -715,7 +715,7 @@ func TestCompliancePolicyListener_StaleRuleAddedDoesNotResurrectRemoved(t *testi
 	})
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM compliance_policy_rules_projection WHERE policy_id = $1 AND action_id = $2",
 		policyID, actionID,
 	).Scan(&count))

--- a/internal/projectors/compliance_test.go
+++ b/internal/projectors/compliance_test.go
@@ -384,7 +384,7 @@ func TestComplianceListener_StaleRemovedDoesNotWipeRevivedRow(t *testing.T) {
 	}))
 	// Capture this Removed's sequence so we can replay it later.
 	var staleRemovedSeq int64
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		`SELECT sequence_num FROM events
 		 WHERE stream_type = 'compliance' AND stream_id = $1
 		   AND event_type = 'ComplianceResultRemoved'

--- a/internal/projectors/definition_test.go
+++ b/internal/projectors/definition_test.go
@@ -332,7 +332,7 @@ func TestDefinitionListener_SynthesisedActionBranch(t *testing.T) {
 	// definitions_projection MUST NOT have a row (synthesis branch
 	// is the action-stream side; definition stream no-ops).
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM definitions_projection WHERE id = $1", id,
 	).Scan(&count))
 	assert.Equal(t, 0, count,
@@ -434,7 +434,7 @@ func TestDefinitionListener_StaleMemberAddedDoesNotRecreateMembership(t *testing
 	})
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM definition_members_projection WHERE definition_id = $1 AND action_set_id = $2",
 		defID, actionSetID,
 	).Scan(&count))
@@ -463,7 +463,7 @@ func TestDefinitionListener_IgnoresOtherStreamTypes(t *testing.T) {
 	}))
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM definitions_projection WHERE id = $1", id,
 	).Scan(&count))
 	assert.Equal(t, 0, count)

--- a/internal/projectors/device_group_test.go
+++ b/internal/projectors/device_group_test.go
@@ -408,7 +408,7 @@ func TestDeviceGroupListener_CreateLifecycle(t *testing.T) {
 	require.Error(t, err, "GetDeviceGroupByID filters is_deleted=FALSE; deleted group is gone from this query")
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "DeviceGroupDeleted cascade must wipe member rows")
@@ -471,7 +471,7 @@ func TestDeviceGroupListener_DynamicCreatedEnqueues(t *testing.T) {
 	assert.True(t, got.IsDynamic)
 
 	var reason *string
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT reason FROM dynamic_group_evaluation_queue WHERE group_id = $1", groupID,
 	).Scan(&reason))
 	require.NotNil(t, reason)
@@ -522,13 +522,13 @@ func TestDeviceGroupListener_QueryUpdatedFlipToDynamicCascade(t *testing.T) {
 	assert.Equal(t, int32(0), afterFlip.MemberCount, "flip-to-dynamic must zero member_count")
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "flip-to-dynamic must wipe every static member row")
 
 	var reason *string
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT reason FROM dynamic_group_evaluation_queue WHERE group_id = $1", groupID,
 	).Scan(&reason))
 	require.NotNil(t, reason)
@@ -561,7 +561,7 @@ func TestDeviceGroupListener_DynamicGroupRejectsMemberMutations(t *testing.T) {
 	}))
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "DeviceGroupMemberAdded against a dynamic group must be a no-op")
@@ -656,7 +656,7 @@ func TestDeviceGroupListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 
 	// Member still there.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale DeviceGroupDeleted must NOT cascade-delete members")
@@ -711,13 +711,13 @@ func TestDeviceGroupListener_StaleQueryUpdatedDoesNotNukeMembers(t *testing.T) {
 
 	// Member still there because the cascade was skipped.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale QueryUpdated must NOT cascade-wipe static members")
 
 	// No queue entry — the cascade was skipped.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM dynamic_group_evaluation_queue WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "stale QueryUpdated must NOT enqueue the group")
@@ -770,7 +770,7 @@ func TestDeviceGroupListener_StaleMemberAddedDoesNotRecreateMembership(t *testin
 	})
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1 AND device_id = $2",
 		groupID, deviceID,
 	).Scan(&count))
@@ -799,7 +799,7 @@ func TestDeviceGroupListener_QueryUpdatedSteadyStateDynamicEditPreservesMembers(
 		Data:      map[string]any{"name": "dyn", "is_dynamic": true, "dynamic_query": "(env equals \"prod\")"},
 		ActorType: "user", ActorID: "u",
 	}))
-	_, err := st.Pool().Exec(ctx, `
+	_, err := st.TestingPool().Exec(ctx, `
 		INSERT INTO device_group_members_projection (group_id, device_id, added_at, projection_version)
 		VALUES ($1, 'dev-evaluator-populated', now(), 0)`, groupID)
 	require.NoError(t, err)
@@ -811,7 +811,7 @@ func TestDeviceGroupListener_QueryUpdatedSteadyStateDynamicEditPreservesMembers(
 	}))
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM device_group_members_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "steady-state dynamic-query edit must NOT wipe evaluator-populated members")

--- a/internal/projectors/device_test.go
+++ b/internal/projectors/device_test.go
@@ -732,7 +732,7 @@ func TestDeviceListener_StaleUnassignedAfterReAssignDoesNotWipeRow(t *testing.T)
 	// reading the assignment row's projection_version + 1 — this
 	// mirrors the gap a stale event from the past carries.
 	var firstAssignVer int64
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT projection_version FROM device_assigned_users_projection WHERE device_id = $1 AND user_id = $2",
 		deviceID, userID,
 	).Scan(&firstAssignVer))

--- a/internal/projectors/identity_provider_test.go
+++ b/internal/projectors/identity_provider_test.go
@@ -212,7 +212,7 @@ func TestIdentityProviderListener_FullLifecycle(t *testing.T) {
 	require.Error(t, err, "GetIdentityProviderByID excludes is_deleted=TRUE rows")
 
 	var isDeleted, enabled, scimEnabled bool
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT is_deleted, enabled, scim_enabled FROM identity_providers_projection WHERE id = $1", idpID,
 	).Scan(&isDeleted, &enabled, &scimEnabled))
 	assert.True(t, isDeleted)
@@ -242,13 +242,13 @@ func TestIdentityProviderListener_DeleteCascadesIdentityLinksAndSCIM(t *testing.
 	}))
 
 	// Plant an identity_links row + scim_group_mapping row.
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		"INSERT INTO identity_links_projection (id, user_id, provider_id, external_id) VALUES ($1, $2, $3, $4)",
 		"link-"+testutil.NewID(), userID, idpID, "ext-1",
 	)
 	require.NoError(t, err)
 	groupID := testutil.CreateTestUserGroup(t, st, "actor", "test-group")
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		"INSERT INTO scim_group_mapping_projection (id, provider_id, scim_group_id, user_group_id) VALUES ($1, $2, $3, $4)",
 		"mapping-"+testutil.NewID(), idpID, "sg-1", groupID,
 	)
@@ -263,12 +263,12 @@ func TestIdentityProviderListener_DeleteCascadesIdentityLinksAndSCIM(t *testing.
 	}))
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM identity_links_projection WHERE provider_id = $1", idpID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "identity_links_projection rows for the deleted IdP are removed")
 
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id = $1", idpID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "scim_group_mapping_projection rows for the deleted IdP are removed")
@@ -294,7 +294,7 @@ func TestIdentityProviderListener_SCIMDisableCascadesGroupMappings(t *testing.T)
 	}))
 
 	groupID := testutil.CreateTestUserGroup(t, st, "actor", "test-group-scim")
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		"INSERT INTO scim_group_mapping_projection (id, provider_id, scim_group_id, user_group_id) VALUES ($1, $2, $3, $4)",
 		"mapping-"+testutil.NewID(), idpID, "sg-x", groupID,
 	)
@@ -308,7 +308,7 @@ func TestIdentityProviderListener_SCIMDisableCascadesGroupMappings(t *testing.T)
 	}))
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id = $1", idpID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "SCIM disable wipes group mappings for that provider")
@@ -417,13 +417,13 @@ func TestIdentityProviderListener_StaleDeleteReplay(t *testing.T) {
 	require.NoError(t, err)
 
 	// Plant a link + mapping that a stale replay would wrongly nuke.
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		"INSERT INTO identity_links_projection (id, user_id, provider_id, external_id) VALUES ($1, $2, $3, $4)",
 		"link-"+testutil.NewID(), userID, idpID, "ext-2",
 	)
 	require.NoError(t, err)
 	groupID := testutil.CreateTestUserGroup(t, st, "actor", "test-group-stale")
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		"INSERT INTO scim_group_mapping_projection (id, provider_id, scim_group_id, user_group_id) VALUES ($1, $2, $3, $4)",
 		"mapping-"+testutil.NewID(), idpID, "sg-y", groupID,
 	)
@@ -446,12 +446,12 @@ func TestIdentityProviderListener_StaleDeleteReplay(t *testing.T) {
 
 	// Identity link + SCIM mapping survive.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM identity_links_projection WHERE provider_id = $1", idpID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale IdentityProviderDeleted must NOT cascade-delete identity_links")
 
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id = $1", idpID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale IdentityProviderDeleted must NOT cascade-delete scim_group_mappings")

--- a/internal/projectors/luks_key_test.go
+++ b/internal/projectors/luks_key_test.go
@@ -518,7 +518,7 @@ func mustAppend(t *testing.T, st *store.Store, ctx context.Context, e store.Even
 // it.
 func dumpLuksKeysForAction(t *testing.T, st *store.Store, deviceID, actionID, devicePath string) []luksKeyRow {
 	t.Helper()
-	rows, err := st.Pool().Query(context.Background(),
+	rows, err := st.TestingPool().Query(context.Background(),
 		`SELECT id, passphrase, rotated_at, is_current, revocation_status FROM luks_keys_projection
 		 WHERE device_id = $1 AND action_id = $2 AND device_path = $3
 		 ORDER BY rotated_at DESC`,

--- a/internal/projectors/role_test.go
+++ b/internal/projectors/role_test.go
@@ -236,7 +236,7 @@ func TestRoleListener_DeleteCascadesUserRoles(t *testing.T) {
 	// insert (bypassing the user_role projector since #102 hasn't
 	// landed yet). The role projector only cares about cleanup, not
 	// who put them there.
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by) VALUES ($1,$2,NOW(),''),($3,$2,NOW(),'')",
 		"user-A", roleID, "user-B",
 	)
@@ -244,7 +244,7 @@ func TestRoleListener_DeleteCascadesUserRoles(t *testing.T) {
 
 	// Verify pre-delete state.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_roles_projection WHERE role_id = $1", roleID,
 	).Scan(&count))
 	require.Equal(t, 2, count)
@@ -258,13 +258,13 @@ func TestRoleListener_DeleteCascadesUserRoles(t *testing.T) {
 	// Role row marked deleted (won't show up via GetRoleByID which
 	// filters is_deleted=FALSE — query directly).
 	var isDeleted bool
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT is_deleted FROM roles_projection WHERE id = $1", roleID,
 	).Scan(&isDeleted))
 	assert.True(t, isDeleted, "RoleDeleted flips is_deleted=TRUE")
 
 	// Cascade cleared the user-role memberships.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_roles_projection WHERE role_id = $1", roleID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "user_roles_projection rows for the deleted role are removed")
@@ -337,7 +337,7 @@ func TestRoleListener_StaleDeleteReplayDoesNotNukeMemberships(t *testing.T) {
 	require.NoError(t, err)
 
 	// Plant 2 memberships.
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by) VALUES ($1,$2,NOW(),''),($3,$2,NOW(),'')",
 		"user-A", roleID, "user-B",
 	)
@@ -366,7 +366,7 @@ func TestRoleListener_StaleDeleteReplayDoesNotNukeMemberships(t *testing.T) {
 
 	// Memberships still there.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_roles_projection WHERE role_id = $1", roleID,
 	).Scan(&count))
 	assert.Equal(t, 2, count, "stale RoleDeleted replay must NOT cascade-delete live memberships")

--- a/internal/projectors/scim_group_mapping_test.go
+++ b/internal/projectors/scim_group_mapping_test.go
@@ -179,7 +179,7 @@ func TestSCIMGroupMappingListener_MapUpdateUnmap(t *testing.T) {
 
 	// Read back via direct SQL (no GetByCompositeKey query exists).
 	var displayName, userGroupID string
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT scim_display_name, user_group_id FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
 		idpID, "sg-eng",
 	).Scan(&displayName, &userGroupID))
@@ -197,7 +197,7 @@ func TestSCIMGroupMappingListener_MapUpdateUnmap(t *testing.T) {
 		},
 		ActorType: "user", ActorID: "u",
 	}))
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT scim_display_name FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
 		idpID, "sg-eng",
 	).Scan(&displayName))
@@ -214,7 +214,7 @@ func TestSCIMGroupMappingListener_MapUpdateUnmap(t *testing.T) {
 		ActorType: "user", ActorID: "u",
 	}))
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
 		idpID, "sg-eng",
 	).Scan(&count))
@@ -265,14 +265,14 @@ func TestSCIMGroupMappingListener_MapReplayIsIdempotent(t *testing.T) {
 	}))
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
 		idpID, "sg",
 	).Scan(&count))
 	assert.Equal(t, 1, count, "ON CONFLICT preserves uniqueness on (provider_id, scim_group_id)")
 
 	var displayName, ugID string
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT scim_display_name, user_group_id FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
 		idpID, "sg",
 	).Scan(&displayName, &ugID))
@@ -325,7 +325,7 @@ func TestSCIMGroupMappingListener_StaleUpdateIgnored(t *testing.T) {
 	// Capture current projection_version, then apply a stale UPDATE
 	// directly with version-5. The guard must reject it.
 	var currentVer int64
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT projection_version FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
 		idpID, "sg-stale",
 	).Scan(&currentVer))
@@ -340,7 +340,7 @@ func TestSCIMGroupMappingListener_StaleUpdateIgnored(t *testing.T) {
 
 	var displayName string
 	var afterVer int64
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT scim_display_name, projection_version FROM scim_group_mapping_projection WHERE provider_id=$1 AND scim_group_id=$2",
 		idpID, "sg-stale",
 	).Scan(&displayName, &afterVer))
@@ -366,7 +366,7 @@ func TestSCIMGroupMappingListener_IgnoresWrongStreamType(t *testing.T) {
 	}))
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM scim_group_mapping_projection WHERE provider_id=$1", idpID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "wrong-stream-type SCIMGroupMapped must NOT create a row")

--- a/internal/projectors/token_test.go
+++ b/internal/projectors/token_test.go
@@ -191,7 +191,7 @@ func TestTokenListener_CreateRenameUseDisableEnableDeleteLifecycle(t *testing.T)
 	require.Error(t, err, "GetTokenByID excludes soft-deleted rows")
 	// Confirm row still exists with is_deleted=TRUE for audit.
 	var isDeleted bool
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT is_deleted FROM tokens_projection WHERE id = $1", tokenID,
 	).Scan(&isDeleted))
 	assert.True(t, isDeleted)

--- a/internal/projectors/user_group_test.go
+++ b/internal/projectors/user_group_test.go
@@ -447,7 +447,7 @@ func TestUserGroupListener_MemberMutationsSkippedForDynamicGroup(t *testing.T) {
 
 	// The dynamic flip enqueues an evaluation row.
 	var queueCount int
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM dynamic_user_group_evaluation_queue WHERE group_id = $1", groupID,
 	).Scan(&queueCount))
 	assert.Equal(t, 1, queueCount, "UserGroupCreated for a dynamic group enqueues an evaluation row")
@@ -518,7 +518,7 @@ func TestUserGroupListener_QueryUpdatedFlipToDynamicWipesMembers(t *testing.T) {
 	assert.Empty(t, memberIDs, "flip-to-dynamic must wipe every static-membership row")
 
 	var queueCount int
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM dynamic_user_group_evaluation_queue WHERE group_id = $1", groupID,
 	).Scan(&queueCount))
 	assert.Equal(t, 1, queueCount, "flip-to-dynamic must (re-)enqueue the group for the evaluator")
@@ -626,7 +626,7 @@ func TestUserGroupListener_DeleteCascadesMembersAndRoles(t *testing.T) {
 
 	// Plant a dynamic-queue entry directly so we can confirm the
 	// cleanup half of UserGroupDeleted wipes it.
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		`INSERT INTO dynamic_user_group_evaluation_queue (group_id, queued_at, reason)
 		 VALUES ($1, NOW(), 'test-seed')
 		 ON CONFLICT (group_id) DO NOTHING`,
@@ -642,26 +642,26 @@ func TestUserGroupListener_DeleteCascadesMembersAndRoles(t *testing.T) {
 
 	// Group row marked deleted.
 	var isDeleted bool
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT is_deleted FROM user_groups_projection WHERE id = $1", groupID,
 	).Scan(&isDeleted))
 	assert.True(t, isDeleted)
 
 	// Members wiped.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_group_members_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 0, count)
 
 	// Roles wiped.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_group_roles_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 0, count)
 
 	// Dynamic-evaluation-queue row wiped.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM dynamic_user_group_evaluation_queue WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 0, count)
@@ -755,13 +755,13 @@ func TestUserGroupListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 
 	// Member still there.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_group_members_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale UserGroupDeleted must NOT cascade-delete members")
 
 	// Role still there.
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_group_roles_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale UserGroupDeleted must NOT cascade-delete role assignments")
@@ -807,7 +807,7 @@ func TestUserGroupListener_StaleMemberAddedDoesNotRecreateMembership(t *testing.
 	})
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_group_members_projection WHERE group_id = $1 AND user_id = $2",
 		groupID, userID,
 	).Scan(&count))
@@ -888,7 +888,7 @@ func TestUserGroupListener_QueryUpdatedSteadyStateDynamicEditPreservesMembers(t 
 		ActorType: "user", ActorID: "u",
 	}))
 	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@x.com", "pass", "user")
-	_, err := st.Pool().Exec(ctx, `
+	_, err := st.TestingPool().Exec(ctx, `
 		INSERT INTO user_group_members_projection (group_id, user_id, added_at, added_by, projection_version)
 		VALUES ($1, $2, now(), 'system', 0)`, groupID, userID)
 	require.NoError(t, err)
@@ -900,7 +900,7 @@ func TestUserGroupListener_QueryUpdatedSteadyStateDynamicEditPreservesMembers(t 
 	}))
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_group_members_projection WHERE group_id = $1", groupID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "steady-state dynamic-query edit must NOT wipe evaluator-populated members")
@@ -944,7 +944,7 @@ func TestUserGroupListener_StaleRoleAssignedDoesNotReinsertRevoked(t *testing.T)
 	})
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_group_roles_projection WHERE group_id = $1 AND role_id = $2",
 		groupID, roleID,
 	).Scan(&count))

--- a/internal/projectors/user_role_test.go
+++ b/internal/projectors/user_role_test.go
@@ -202,7 +202,7 @@ func TestUserRoleListener_AssignReplayIsIdempotent(t *testing.T) {
 
 	// Confirm exactly one row.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_roles_projection WHERE user_id=$1 AND role_id=$2",
 		userID, roleID,
 	).Scan(&count))

--- a/internal/projectors/user_selection_test.go
+++ b/internal/projectors/user_selection_test.go
@@ -142,7 +142,7 @@ func TestUserSelectionListener_UpsertSelectThenDeselect(t *testing.T) {
 	}))
 
 	var selected bool
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT selected FROM user_selections_projection WHERE device_id=$1 AND source_type='user' AND source_id=$2",
 		deviceID, sourceID,
 	).Scan(&selected))
@@ -158,7 +158,7 @@ func TestUserSelectionListener_UpsertSelectThenDeselect(t *testing.T) {
 		},
 		ActorType: "user", ActorID: "u",
 	}))
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT selected FROM user_selections_projection WHERE device_id=$1 AND source_type='user' AND source_id=$2",
 		deviceID, sourceID,
 	).Scan(&selected))
@@ -166,7 +166,7 @@ func TestUserSelectionListener_UpsertSelectThenDeselect(t *testing.T) {
 
 	// Confirm exactly one row (UPSERT, not duplicate insert).
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_selections_projection WHERE device_id=$1 AND source_type='user' AND source_id=$2",
 		deviceID, sourceID,
 	).Scan(&count))
@@ -195,7 +195,7 @@ func TestUserSelectionListener_PerSourceTypeScope(t *testing.T) {
 	}
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_selections_projection WHERE device_id=$1", deviceID,
 	).Scan(&count))
 	assert.Equal(t, 2, count, "different source_types must NOT collapse into one row")
@@ -233,7 +233,7 @@ func TestUserSelectionListener_StaleReplayRejected(t *testing.T) {
 
 	var currentVer int64
 	var currentSelected bool
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT projection_version, selected FROM user_selections_projection WHERE device_id=$1 AND source_type='user' AND source_id=$2",
 		deviceID, sourceID,
 	).Scan(&currentVer, &currentSelected))
@@ -255,7 +255,7 @@ func TestUserSelectionListener_StaleReplayRejected(t *testing.T) {
 
 	var afterVer int64
 	var afterSelected bool
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT projection_version, selected FROM user_selections_projection WHERE device_id=$1 AND source_type='user' AND source_id=$2",
 		deviceID, sourceID,
 	).Scan(&afterVer, &afterSelected))
@@ -280,7 +280,7 @@ func TestUserSelectionListener_IgnoresWrongStreamType(t *testing.T) {
 	}))
 
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM user_selections_projection WHERE device_id=$1", deviceID,
 	).Scan(&count))
 	assert.Equal(t, 0, count, "wrong-stream-type UserSelectionChanged must NOT create a row")

--- a/internal/projectors/user_test.go
+++ b/internal/projectors/user_test.go
@@ -735,7 +735,7 @@ func TestUserListener_StaleDeleteReplayDoesNotNukeIdentityLinks(t *testing.T) {
 	require.NoError(t, err)
 
 	// Plant an identity_link that a stale replay would wrongly nuke.
-	_, err = st.Pool().Exec(ctx,
+	_, err = st.TestingPool().Exec(ctx,
 		"INSERT INTO identity_links_projection (id, user_id, provider_id, external_id) VALUES ($1, $2, $3, $4)",
 		"link-"+testutil.NewID(), userID, idpID, "ext-stale",
 	)
@@ -765,7 +765,7 @@ func TestUserListener_StaleDeleteReplayDoesNotNukeIdentityLinks(t *testing.T) {
 	// Identity link still there — cascade was short-circuited by the
 	// SoftDelete returning n == 0.
 	count := 0
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		"SELECT count(*) FROM identity_links_projection WHERE user_id = $1", userID,
 	).Scan(&count))
 	assert.Equal(t, 1, count, "stale UserDeleted must NOT cascade-delete identity_links")

--- a/internal/store/migrations/008_seeds.sql
+++ b/internal/store/migrations/008_seeds.sql
@@ -2,55 +2,18 @@
 -- 005. pg_dump --schema-only didn't capture these so they need to be
 -- restored explicitly.
 --
--- Wave H consolidation (tracker manchtools/power-manage-server#242):
--- everything in this file is replay-safe via ON CONFLICT / IF NOT
--- EXISTS so re-running the migration after a partial apply doesn't
--- corrupt seeded state.
+-- Wave H (tracker manchtools/power-manage-server#242) moved the
+-- PL/pgSQL-only seeds — generate_ulid() and the "All Devices"
+-- DO $$...$$ block — into Go bootstrap (cmd/control/setup.go::
+-- bootstrapAllDevicesGroup) so a future non-Postgres backend doesn't
+-- need a dialect-specific seed. The Postgres role/grant block stays
+-- here because it's an operator concern, not application runtime.
+--
+-- Everything is replay-safe via ON CONFLICT / IF NOT EXISTS so
+-- re-running the migration after a partial apply doesn't corrupt
+-- seeded state.
 
 -- +goose Up
-
--- ============================================================================
--- generate_ulid() utility — used by the "All Devices" seed below.
--- ============================================================================
-
--- +goose StatementBegin
-CREATE OR REPLACE FUNCTION generate_ulid() RETURNS text
-    LANGUAGE plpgsql
-    AS $$
-DECLARE
-    timestamp_ms BIGINT;
-    random_bytes BYTEA;
-    ulid TEXT := '';
-    alphabet TEXT := '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
-    i INTEGER;
-    val BIGINT;
-BEGIN
-    timestamp_ms := (EXTRACT(EPOCH FROM clock_timestamp()) * 1000)::BIGINT;
-
-    FOR i IN REVERSE 9..0 LOOP
-        ulid := ulid || substr(alphabet, (timestamp_ms % 32)::INTEGER + 1, 1);
-        timestamp_ms := timestamp_ms / 32;
-    END LOOP;
-
-    ulid := reverse(ulid);
-
-    random_bytes := gen_random_bytes(10);
-
-    val := 0;
-    FOR i IN 0..9 LOOP
-        val := (val * 256) + get_byte(random_bytes, i);
-        IF (i + 1) % 5 = 0 THEN
-            FOR j IN REVERSE 7..0 LOOP
-                ulid := ulid || substr(alphabet, ((val >> (j * 5)) & 31)::INTEGER + 1, 1);
-            END LOOP;
-            val := 0;
-        END IF;
-    END LOOP;
-
-    RETURN ulid;
-END;
-$$;
--- +goose StatementEnd
 
 -- ============================================================================
 -- Server settings: the single 'global' row that handlers read on every
@@ -84,37 +47,23 @@ VALUES (
 ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================================
--- "All Devices" dynamic group. Emitted as a DeviceGroupCreated event so the
--- projector path takes over from here. Guarded by EXISTS so a re-run leaves
--- the existing group alone.
+-- "All Devices" dynamic group: now seeded by Go bootstrap (see
+-- cmd/control/setup.go::bootstrapAllDevicesGroup). The seed runs AFTER
+-- projectors.WireAll so the emitted DeviceGroupCreated event flows
+-- through the registered Go listener and materialises the projection
+-- row — the prior PL/pgSQL DO block bypassed AppendEvent and orphaned
+-- the event once Wave F retired the reactive triggers.
 -- ============================================================================
-
--- +goose StatementBegin
-DO $$
-DECLARE
-    group_id TEXT;
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM device_groups_projection WHERE name = 'All Devices' AND is_deleted = FALSE) THEN
-        group_id := generate_ulid();
-        INSERT INTO events (stream_type, stream_id, stream_version, event_type, data, actor_type, actor_id)
-        VALUES (
-            'device_group', group_id, 1, 'DeviceGroupCreated',
-            jsonb_build_object(
-                'name', 'All Devices',
-                'description', 'Dynamic group that matches all registered devices',
-                'is_dynamic', true,
-                'dynamic_query', ''
-            ),
-            'system', 'migration'
-        );
-    END IF;
-END;
-$$;
--- +goose StatementEnd
 
 -- ============================================================================
 -- Database roles for the read-only / indexer login. The indexer service
 -- uses pm_indexer; everything else uses the owning role.
+--
+-- This block stays in SQL because it's a Postgres-specific operator
+-- concern, not application runtime. Non-Postgres backends would
+-- implement read-only access via their own grant model and skip this
+-- migration step (e.g. via a build-tag-scoped migration file). See
+-- #242 cheap-wins note in the file header.
 -- ============================================================================
 
 -- +goose StatementBegin

--- a/internal/store/notfound.go
+++ b/internal/store/notfound.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // ErrNotFound is the canonical "no row matched" sentinel for store
@@ -25,4 +26,29 @@ func IsNotFound(err error) bool {
 		return false
 	}
 	return errors.Is(err, ErrNotFound) || errors.Is(err, pgx.ErrNoRows)
+}
+
+// ErrVersionConflict is the canonical "optimistic-concurrency lost"
+// sentinel for AppendEvent writes. The Postgres backend recognises a
+// unique-violation on (stream_type, stream_id, stream_version) as the
+// conflict signal (`pgconn.PgError.Code == "23505"`); a future MySQL /
+// SQLite backend would map ER_DUP_ENTRY 1062 / SQLITE_CONSTRAINT_UNIQUE
+// onto the same sentinel without callers needing to know.
+var ErrVersionConflict = errors.New("version conflict")
+
+// IsVersionConflict reports whether err signals a stream-version
+// collision on AppendEvent. Mirrors IsNotFound — the only intended
+// recognizer for OCC failures outside the store package.
+func IsVersionConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrVersionConflict) {
+		return true
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		return true
+	}
+	return false
 }

--- a/internal/store/projection_test.go
+++ b/internal/store/projection_test.go
@@ -47,7 +47,7 @@ func TestProjection_ActionRenameWithSoftDeletedSameName(t *testing.T) {
 
 	// Verify the rename succeeded
 	var name string
-	err = st.Pool().QueryRow(ctx,
+	err = st.TestingPool().QueryRow(ctx,
 		"SELECT name FROM actions_projection WHERE id = $1",
 		action2ID,
 	).Scan(&name)

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -37,7 +37,7 @@ func TestRebuildAll_RoundTripsThroughEventStore(t *testing.T) {
 	// Truncate the projection out from under the live pipeline,
 	// simulating an incident (manual delete, projector bug, etc.)
 	// that left the projection inconsistent with the event store.
-	_, err = st.Pool().Exec(ctx, "TRUNCATE users_projection CASCADE")
+	_, err = st.TestingPool().Exec(ctx, "TRUNCATE users_projection CASCADE")
 	require.NoError(t, err)
 
 	_, err = st.Queries().GetUserByID(ctx, userID)
@@ -71,7 +71,7 @@ func TestRebuildAll_NoArgsRebuildsEverything(t *testing.T) {
 	deviceID := testutil.CreateTestDevice(t, st, "rebuild-test-host")
 	groupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Rebuild Test Group")
 
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		`TRUNCATE users_projection CASCADE;
 		 TRUNCATE devices_projection CASCADE;
 		 TRUNCATE device_groups_projection CASCADE`)
@@ -134,7 +134,7 @@ func TestRebuildAll_PortedProjector_RoundTrip(t *testing.T) {
 	require.NoError(t, err, "role must exist after live pipeline projection")
 	assert.Equal(t, "RebuildPortedRole", before.Name)
 
-	_, err = st.Pool().Exec(ctx, "TRUNCATE roles_projection CASCADE")
+	_, err = st.TestingPool().Exec(ctx, "TRUNCATE roles_projection CASCADE")
 	require.NoError(t, err)
 
 	_, err = st.Queries().GetRoleByID(ctx, roleID)
@@ -186,7 +186,7 @@ func TestRebuildAll_PortedToken_RoundTrip(t *testing.T) {
 	require.NoError(t, err, "token must exist after live pipeline projection")
 	assert.Equal(t, "RebuildPortedToken", before.Name)
 
-	_, err = st.Pool().Exec(ctx, "TRUNCATE tokens_projection CASCADE")
+	_, err = st.TestingPool().Exec(ctx, "TRUNCATE tokens_projection CASCADE")
 	require.NoError(t, err)
 
 	_, err = st.Queries().GetTokenByID(ctx, generated.GetTokenByIDParams{ID: tokenID})
@@ -239,7 +239,7 @@ func TestRebuildAll_PortedUserSelection_RoundTrip(t *testing.T) {
 	require.NoError(t, err, "selection must exist after live pipeline projection")
 	assert.True(t, before.Selected)
 
-	_, err = st.Pool().Exec(ctx, "TRUNCATE user_selections_projection CASCADE")
+	_, err = st.TestingPool().Exec(ctx, "TRUNCATE user_selections_projection CASCADE")
 	require.NoError(t, err)
 
 	_, err = st.Queries().GetUserSelection(ctx, generated.GetUserSelectionParams{
@@ -286,7 +286,7 @@ func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
 	// production projection) is verified by reading runOneTarget,
 	// not by this test alone.
 	roleID := testutil.NewID()
-	_, err := st.Pool().Exec(ctx,
+	_, err := st.TestingPool().Exec(ctx,
 		`INSERT INTO roles_projection (id, name, description, permissions, is_system, created_at, projection_version)
 		 VALUES ($1, 'guard-canary', '', ARRAY[]::TEXT[], false, NOW(), 0)`,
 		roleID,
@@ -305,7 +305,7 @@ func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
 	// leaves the projection intact); strict pre-TRUNCATE ordering
 	// is verified by reading runOneTarget.
 	var count int
-	require.NoError(t, st.Pool().QueryRow(ctx,
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
 		`SELECT COUNT(*) FROM roles_projection WHERE id = $1`, roleID,
 	).Scan(&count))
 	assert.Equal(t, 1, count,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -5,13 +5,11 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"sync"
 
-	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // pgx database/sql driver
 	"github.com/pressly/goose/v3"
@@ -363,8 +361,17 @@ func (s *Store) Repos() *Repos {
 	return r
 }
 
-// Pool returns the underlying connection pool.
-func (s *Store) Pool() *pgxpool.Pool {
+// TestingPool returns the underlying pgx connection pool for test
+// fixtures that need to issue raw SQL outside the repo abstraction
+// (projector applies, schema introspection, raw-row asserts). Production
+// code must not call this — every backend swap on the storage-abstraction
+// tracker (#242) would have to re-implement this method, so reaching for
+// it is by definition backend-specific. New tests should prefer
+// Store.Queries() / Store.Repos() and add a query if one is missing.
+//
+// The name is deliberately backend-flavoured to make new misuse easy to
+// grep for and to keep the "this couples me to Postgres" signal visible.
+func (s *Store) TestingPool() *pgxpool.Pool {
 	return s.pool
 }
 
@@ -456,12 +463,11 @@ func (s *Store) AppendEvent(ctx context.Context, event Event) error {
 			ActorID:       event.ActorID,
 		})
 		if err != nil {
-			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			if IsVersionConflict(err) {
 				if i < maxRetries-1 {
 					continue // Retry on version conflict
 				}
-				return fmt.Errorf("version conflict after %d retries: stream was modified concurrently", maxRetries)
+				return fmt.Errorf("%w: stream was modified concurrently after %d retries", ErrVersionConflict, maxRetries)
 			}
 			return fmt.Errorf("append event: %w", err)
 		}
@@ -497,9 +503,8 @@ func (s *Store) AppendEventWithVersion(ctx context.Context, event Event, expecte
 		ActorID:       event.ActorID,
 	})
 	if err != nil {
-		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
-			return fmt.Errorf("version conflict: expected version %d but stream was modified", expectedVersion)
+		if IsVersionConflict(err) {
+			return fmt.Errorf("%w: expected version %d but stream was modified", ErrVersionConflict, expectedVersion)
 		}
 		return fmt.Errorf("append event: %w", err)
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -16,7 +16,7 @@ import (
 func TestNew_RunsMigrations(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	assert.NotNil(t, st.Queries())
-	assert.NotNil(t, st.Pool())
+	assert.NotNil(t, st.TestingPool())
 }
 
 func TestAppendEvent_Basic(t *testing.T) {
@@ -35,7 +35,7 @@ func TestAppendEvent_Basic(t *testing.T) {
 	require.NoError(t, err)
 
 	var count int64
-	err = st.Pool().QueryRow(ctx, "SELECT COUNT(*) FROM events WHERE stream_id = $1", id).Scan(&count)
+	err = st.TestingPool().QueryRow(ctx, "SELECT COUNT(*) FROM events WHERE stream_id = $1", id).Scan(&count)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
 }
@@ -58,7 +58,7 @@ func TestAppendEvent_AutoVersioning(t *testing.T) {
 	}
 
 	var maxVersion int32
-	err := st.Pool().QueryRow(ctx,
+	err := st.TestingPool().QueryRow(ctx,
 		"SELECT MAX(stream_version) FROM events WHERE stream_id = $1", id,
 	).Scan(&maxVersion)
 	require.NoError(t, err)
@@ -260,7 +260,7 @@ func TestProjection_DeviceRegistered(t *testing.T) {
 	deviceID := testutil.CreateTestDevice(t, st, "test-host")
 
 	var hostname, agentVersion string
-	err := st.Pool().QueryRow(ctx,
+	err := st.TestingPool().QueryRow(ctx,
 		"SELECT hostname, agent_version FROM devices_projection WHERE id = $1",
 		deviceID,
 	).Scan(&hostname, &agentVersion)
@@ -289,7 +289,7 @@ func TestProjection_DeviceHeartbeat(t *testing.T) {
 	require.NoError(t, err)
 
 	var agentVersion string
-	err = st.Pool().QueryRow(ctx,
+	err = st.TestingPool().QueryRow(ctx,
 		"SELECT agent_version FROM devices_projection WHERE id = $1",
 		deviceID,
 	).Scan(&agentVersion)
@@ -306,7 +306,7 @@ func TestProjection_ActionCreated(t *testing.T) {
 
 	var name string
 	var actionType int32
-	err := st.Pool().QueryRow(ctx,
+	err := st.TestingPool().QueryRow(ctx,
 		"SELECT name, action_type FROM actions_projection WHERE id = $1",
 		actionID,
 	).Scan(&name, &actionType)
@@ -338,7 +338,7 @@ func TestProjection_ActionSetWithMembers(t *testing.T) {
 	require.NoError(t, err)
 
 	var memberCount int32
-	err = st.Pool().QueryRow(ctx,
+	err = st.TestingPool().QueryRow(ctx,
 		"SELECT member_count FROM action_sets_projection WHERE id = $1",
 		setID,
 	).Scan(&memberCount)
@@ -354,7 +354,7 @@ func TestProjection_DefinitionCreated(t *testing.T) {
 	defID := testutil.CreateTestDefinition(t, st, actorID, "Full Deploy")
 
 	var name string
-	err := st.Pool().QueryRow(ctx,
+	err := st.TestingPool().QueryRow(ctx,
 		"SELECT name FROM definitions_projection WHERE id = $1",
 		defID,
 	).Scan(&name)
@@ -371,7 +371,7 @@ func TestProjection_DeviceGroupCreated(t *testing.T) {
 
 	var name string
 	var isDynamic bool
-	err := st.Pool().QueryRow(ctx,
+	err := st.TestingPool().QueryRow(ctx,
 		"SELECT name, is_dynamic FROM device_groups_projection WHERE id = $1",
 		groupID,
 	).Scan(&name, &isDynamic)
@@ -400,7 +400,7 @@ func TestProjection_DeviceLabelSet(t *testing.T) {
 	require.NoError(t, err)
 
 	var value string
-	err = st.Pool().QueryRow(ctx,
+	err = st.TestingPool().QueryRow(ctx,
 		"SELECT value FROM device_labels WHERE device_id = $1 AND key = $2",
 		deviceID, "environment",
 	).Scan(&value)
@@ -416,7 +416,7 @@ func TestProjection_TokenCreated(t *testing.T) {
 	tokenID := testutil.CreateTestToken(t, st, actorID, "Test Token", "hash123")
 
 	var name string
-	err := st.Pool().QueryRow(ctx,
+	err := st.TestingPool().QueryRow(ctx,
 		"SELECT name FROM tokens_projection WHERE id = $1",
 		tokenID,
 	).Scan(&name)
@@ -458,7 +458,7 @@ func TestProjection_ExecutionLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	var status string
-	err = st.Pool().QueryRow(ctx,
+	err = st.TestingPool().QueryRow(ctx,
 		"SELECT status FROM executions_projection WHERE id = $1",
 		execID,
 	).Scan(&status)
@@ -480,7 +480,7 @@ func TestProjection_ExecutionLifecycle(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = st.Pool().QueryRow(ctx,
+	err = st.TestingPool().QueryRow(ctx,
 		"SELECT status FROM executions_projection WHERE id = $1",
 		execID,
 	).Scan(&status)
@@ -514,7 +514,7 @@ func TestProjection_AssignmentCreated(t *testing.T) {
 	require.NoError(t, err)
 
 	var sourceType, sourceID, targetType, targetID string
-	err = st.Pool().QueryRow(ctx,
+	err = st.TestingPool().QueryRow(ctx,
 		"SELECT source_type, source_id, target_type, target_id FROM assignments_projection WHERE id = $1",
 		assignmentID,
 	).Scan(&sourceType, &sourceID, &targetType, &targetID)


### PR DESCRIPTION
## Summary

Three follow-on items from the storage-abstraction tracker (#242) that shrink the Postgres-specific surface without touching schema or regenerating sqlc.

- **H.1 — `store.IsVersionConflict` sentinel.** Mirrors Wave A's `store.IsNotFound`. `AppendEvent` / `AppendEventWithVersion` now route the `pgconn.PgError "23505"` check through `internal/store/notfound.go` and wrap conflict failures with the new exported `store.ErrVersionConflict`. A future MySQL backend can map `ER_DUP_ENTRY 1062` onto the same recognizer with no caller changes.
- **H.2 — `Store.Pool()` → `TestingPool()`.** The `*pgxpool.Pool` accessor was used only by test fixtures (22 files, 126 call sites); production code had zero callers. Renamed + flagged in the doc comment as a Postgres-specific test affordance.
- **H.3 — drop PL/pgSQL from migration 008.** Removed `generate_ulid()` and the "All Devices" `DO $$ … $$` block. The seed now runs in Go bootstrap (`cmd/control/setup.go::bootstrapAllDevicesGroup`), called from `main.go` after `projectors.WireAll` so the emitted `DeviceGroupCreated` flows through the registered listener.

**Side effect of H.3**: fixes a latent regression — the old PL/pgSQL `DO` block bypassed `AppendEvent`, so once Wave F retired the reactive triggers, fresh deployments left the "All Devices" event orphaned in the events table with no projection row.

The `pm_readonly` / `pm_indexer` `CREATE ROLE` block stays in 008 because it's deploy-time operator concern, not application runtime. Slated for build-tag extraction in a later wave.

## Out of scope

**H.4 — drop `gen_random_uuid()` defaults** was scoped but deferred. The four defaults (`events.id`, `lps_passwords_projection.id`, `luks_keys_projection.id`, `luks_tokens.id`) require sqlc query changes + regeneration, and local `sqlc v1.30.0` produces a 27-file `pgtype.Timestamptz` churn against the in-tree generated state. Out of scope for cheap wins; bundle with the sqlc version-pin work in a later wave.

## Test plan

- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/store/...` green (incl. OCC version-conflict path)
- [ ] CI: wait for full Unit + Integration + CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "All Devices" group now initializes at application startup.

* **Bug Fixes**
  * Improved version conflict detection and handling.

* **Refactor**
  * Restructured "All Devices" group initialization from database migration to application bootstrap process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->