### PR TITLE
test: phase 1 — fuzz dynamicquery + event-store invariants + bootstrap

### DIFF
--- a/cmd/control/bootstrap_test.go
+++ b/cmd/control/bootstrap_test.go
@@ -1,0 +1,70 @@
+package main
+
+// Boot-time seed tests for bootstrapAllDevicesGroup. The migration
+// 008 PL/pgSQL DO block was retired in #242 Wave H (PR #308); these
+// tests guard the Go replacement against the latent regression the
+// PL/pgSQL version carried — the seed event was written into the
+// events table but no listener was registered, so once Wave F retired
+// the reactive triggers, fresh deployments silently had no "All
+// Devices" projection row.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestBootstrapAllDevicesGroup_FreshDB asserts the seed contract:
+// on a fresh database (no prior "All Devices" group), the bootstrap
+// function emits a DeviceGroupCreated event that the registered
+// projector listener materialises into a projection row visible via
+// the standard repo lookup. This is the regression that the prior
+// PL/pgSQL DO block silently failed.
+func TestBootstrapAllDevicesGroup_FreshDB(t *testing.T) {
+	// SetupPostgres wires projectors.WireAll, matching production
+	// boot order — bootstrapAllDevicesGroup runs after WireAll so
+	// the emitted event flows through the registered listener.
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	// Pre-condition: no "All Devices" group exists on a fresh DB.
+	_, err := st.Repos().DeviceGroup.GetByName(ctx, "All Devices")
+	require.True(t, store.IsNotFound(err),
+		"fresh DB must not have the All Devices group seeded by migration")
+
+	bootstrapAllDevicesGroup(ctx, st, quietLogger())
+
+	group, err := st.Repos().DeviceGroup.GetByName(ctx, "All Devices")
+	require.NoError(t, err, "bootstrap must materialise the projection row")
+	assert.Equal(t, "All Devices", group.Name)
+	assert.True(t, group.IsDynamic,
+		"All Devices is the canonical dynamic group — the empty query matches every device")
+	assert.Equal(t, "Dynamic group that matches all registered devices", group.Description)
+}
+
+// TestBootstrapAllDevicesGroup_Idempotent asserts the re-run contract:
+// calling bootstrapAllDevicesGroup against a DB that already carries
+// the seed is a no-op. A regression that emitted a second
+// DeviceGroupCreated event would either (a) create a duplicate row
+// with a different ULID or (b) collide on the unique-name constraint
+// and crash the listener. Both are operator-visible breakages.
+func TestBootstrapAllDevicesGroup_Idempotent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	bootstrapAllDevicesGroup(ctx, st, quietLogger())
+	firstGroup, err := st.Repos().DeviceGroup.GetByName(ctx, "All Devices")
+	require.NoError(t, err)
+
+	// Second invocation must be a no-op — same row id, no new event.
+	bootstrapAllDevicesGroup(ctx, st, quietLogger())
+	secondGroup, err := st.Repos().DeviceGroup.GetByName(ctx, "All Devices")
+	require.NoError(t, err)
+	assert.Equal(t, firstGroup.ID, secondGroup.ID,
+		"second bootstrap invocation must not produce a new group — same row, same id")
+}

--- a/internal/dynamicquery/parser_fuzz_test.go
+++ b/internal/dynamicquery/parser_fuzz_test.go
@@ -1,0 +1,113 @@
+package dynamicquery_test
+
+import (
+	"testing"
+
+	"github.com/manchtools/power-manage/server/internal/dynamicquery"
+)
+
+// FuzzParse exercises the dynamic-query parser against arbitrary
+// input. The contract is "never panic": well-formed queries return an
+// AST, malformed queries return an error, and *every* input — including
+// adversarial UTF-8, deeply nested parens, unbalanced quotes, embedded
+// keywords, control characters — must do one or the other. A panic
+// here is a parser bug and a denial-of-service vector (the
+// ValidateDynamicQuery RPC is admin-only but the same parser also runs
+// inside dyngroupeval, which is invoked from the inbox worker / cron
+// loop without an explicit user trigger).
+//
+// The seed corpus covers each grammar production from the table-driven
+// happy-path test plus a handful of known boundary cases (deeply nested
+// parens, surrogate-pair UTF-8, etc.) so the fuzzer starts from
+// guidance rather than only random bytes.
+func FuzzParse(f *testing.F) {
+	for _, q := range []string{
+		``,
+		`labels.env equals "production"`,
+		`device.labels["my key"] equals "val"`,
+		`labels.a equals "1" and labels.b equals "2" or labels.c equals "3"`,
+		`(labels.a equals "1" or labels.b equals "2") and labels.c equals "3"`,
+		`not labels.role equals "broken"`,
+		`labels.environment exists`,
+		`device.group in "A,B,C"`,
+		`labels.note equals "she said \"hi\""`,
+		`user.email equals "alice@example.com"`,
+		// Adversarial seeds the parser must handle without panic.
+		`((((((((((`,
+		`not not not not not`,
+		`labels.x equals "` + "\x00\x01\x02" + `"`,
+		`labels.🚀 equals "🌍"`,
+	} {
+		f.Add(q)
+	}
+
+	f.Fuzz(func(t *testing.T, q string) {
+		// Cap the input so a pathological corpus entry doesn't burn
+		// the whole fuzz budget on one case. The handler-side validator
+		// limits queries to 10 KB; we stay well under that to keep the
+		// per-iteration budget low.
+		if len(q) > 4096 {
+			return
+		}
+		// The only contract here is "doesn't panic" — both Parse paths
+		// (returns Expr / returns error) are valid outcomes.
+		_, _ = dynamicquery.Parse(q)
+	})
+}
+
+// FuzzEvaluateDevice round-trips a fuzzed query through Parse +
+// EvaluateDevice with a fixed device context. The contract is the
+// same as FuzzParse — never panic — but adds coverage for the
+// evaluator's path: every node type that the parser can produce must
+// also be evaluable without panicking. The fixed context exercises
+// label lookups, inventory fields, and the device-group set; the
+// fuzzer varies the query string, not the context.
+func FuzzEvaluateDevice(f *testing.F) {
+	for _, q := range []string{
+		`labels.env equals "production"`,
+		`labels.team contains "platform"`,
+		`labels.role notEquals "broken"`,
+		`device.os equals "linux" and labels.env equals "prod"`,
+		`not device.os equals "windows"`,
+		`device.group in "alpha,beta"`,
+		`device.labels.region exists`,
+		`device.hostname startsWith "web-"`,
+		`device.kernel endsWith ".rt"`,
+	} {
+		f.Add(q)
+	}
+
+	inventory := map[string]string{
+		"hostname": "web-01",
+		"os":       "linux",
+		"kernel":   "6.6.0-rt",
+	}
+	ctx := dynamicquery.DeviceContext{
+		DeviceID: "01J0000000000000000000DEVICE",
+		Labels: map[string]string{
+			"env":    "production",
+			"team":   "platform infra",
+			"role":   "frontend",
+			"region": "eu-central",
+		},
+		Inventory: func(field string) (string, bool) {
+			v, ok := inventory[field]
+			return v, ok
+		},
+		GroupNames: []string{"alpha"},
+	}
+
+	f.Fuzz(func(t *testing.T, q string) {
+		if len(q) > 4096 {
+			return
+		}
+		expr, err := dynamicquery.Parse(q)
+		if err != nil {
+			return // parser-rejected inputs are not evaluator's concern
+		}
+		// The only contract here is "doesn't panic". The boolean
+		// result of evaluation is not asserted — we're fuzzing for
+		// crashes / out-of-bounds index / nil-deref, not semantics.
+		_ = dynamicquery.EvaluateDevice(expr, ctx)
+	})
+}

--- a/internal/store/listener_test.go
+++ b/internal/store/listener_test.go
@@ -1,0 +1,224 @@
+package store_test
+
+// Listener-semantics tests for the post-commit hook the projector
+// wave plumbs through Store.RegisterEventListener. The contract is
+// documented inline on EventListener in store.go:
+//
+//   - listeners fire after AppendEvent commits, in registration order
+//   - a panicking listener does not break subsequent listeners or the
+//     AppendEvent caller's success return
+//   - the persisted event row (sequence_num populated) is what
+//     listeners receive, not the in-flight Event the caller built
+//
+// These are testcontainer-backed because the listener path runs only
+// behind a real commit — fireListeners is invoked from inside
+// AppendEvent / AppendEventWithVersion after the sqlc Queries.AppendEvent
+// query returns. A mocked Queries would silently bypass the listener.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestEventListener_FiresInRegistrationOrder asserts the documented
+// contract: listeners are invoked in the order they were registered.
+// A regression here would scramble projector cascades — e.g. the
+// search-index listener depends on the projection-write listener
+// having already run.
+func TestEventListener_FiresInRegistrationOrder(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+	record := func(name string) store.EventListener {
+		return func(ctx context.Context, ev store.PersistedEvent) {
+			mu.Lock()
+			defer mu.Unlock()
+			seen = append(seen, name)
+		}
+	}
+	st.RegisterEventListener(record("first"))
+	st.RegisterEventListener(record("second"))
+	st.RegisterEventListener(record("third"))
+
+	err := st.AppendEvent(ctx, store.Event{
+		StreamType: "test",
+		StreamID:   testutil.NewID(),
+		EventType:  "OrderingProbe",
+		Data:       map[string]any{},
+		ActorType:  "system",
+		ActorID:    "test",
+	})
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"first", "second", "third"}, seen,
+		"listeners must fire in registration order — projector cascades depend on it")
+}
+
+// TestEventListener_PanicIsolation asserts the post-commit-notification
+// contract: AppendEvent returns success even when a listener panics,
+// and the panic does not stop subsequent listeners. The persisted
+// event is durable; listener failures are best-effort by design (the
+// reconciler is the safety net).
+func TestEventListener_PanicIsolation(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+
+	var afterPanic atomic.Bool
+
+	st.RegisterEventListener(func(ctx context.Context, ev store.PersistedEvent) {
+		panic("synthetic listener panic")
+	})
+	st.RegisterEventListener(func(ctx context.Context, ev store.PersistedEvent) {
+		afterPanic.Store(true)
+	})
+
+	err := st.AppendEvent(ctx, store.Event{
+		StreamType: "test",
+		StreamID:   testutil.NewID(),
+		EventType:  "PanicProbe",
+		Data:       map[string]any{},
+		ActorType:  "system",
+		ActorID:    "test",
+	})
+	require.NoError(t, err, "AppendEvent must return success even when a listener panics")
+	assert.True(t, afterPanic.Load(),
+		"listener after a panicking one must still fire — panic isolation is per-listener, not per-event")
+}
+
+// TestEventListener_ReceivesPersistedRow asserts that listeners
+// receive the row as written to the events table — sequence_num must
+// be populated (PG SERIAL value) so downstream consumers like the
+// search-index listener can use it as a stable ordering key.
+func TestEventListener_ReceivesPersistedRow(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+
+	var captured store.PersistedEvent
+	done := make(chan struct{})
+	st.RegisterEventListener(func(ctx context.Context, ev store.PersistedEvent) {
+		captured = ev
+		close(done)
+	})
+
+	streamID := testutil.NewID()
+	err := st.AppendEvent(ctx, store.Event{
+		StreamType: "test",
+		StreamID:   streamID,
+		EventType:  "PersistProbe",
+		Data:       map[string]any{"k": "v"},
+		ActorType:  "system",
+		ActorID:    "test",
+	})
+	require.NoError(t, err)
+	<-done
+
+	assert.Equal(t, "test", captured.StreamType)
+	assert.Equal(t, streamID, captured.StreamID)
+	assert.Equal(t, "PersistProbe", captured.EventType)
+	require.NotNil(t, captured.SequenceNum,
+		"persisted event must carry a non-nil SequenceNum — listeners depend on it for ordering")
+	assert.Greater(t, *captured.SequenceNum, int64(0))
+	assert.NotZero(t, captured.OccurredAt,
+		"OccurredAt is set server-side; listeners receive the persisted value, not the caller's zero time")
+}
+
+// TestAppendEventWithVersion_ConflictWrapsSentinel locks in the wave-H
+// contract: conflict failures wrap store.ErrVersionConflict so callers
+// can route through errors.Is / store.IsVersionConflict instead of
+// matching error strings. The existing TestAppendEventWithVersion_Conflict
+// only asserts the legacy substring form; this test guards the typed
+// path that Wave I+ callers (e.g. the SCIM idempotent retry layer)
+// will depend on.
+func TestAppendEventWithVersion_ConflictWrapsSentinel(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	id := testutil.NewID()
+
+	err := st.AppendEventWithVersion(ctx, store.Event{
+		StreamType: "test",
+		StreamID:   id,
+		EventType:  "TestCreated",
+		Data:       map[string]any{},
+		ActorType:  "system",
+		ActorID:    "test",
+	}, 1)
+	require.NoError(t, err)
+
+	err = st.AppendEventWithVersion(ctx, store.Event{
+		StreamType: "test",
+		StreamID:   id,
+		EventType:  "TestUpdated",
+		Data:       map[string]any{},
+		ActorType:  "system",
+		ActorID:    "test",
+	}, 1)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, store.ErrVersionConflict),
+		"conflict error must wrap store.ErrVersionConflict so callers can use errors.Is")
+	assert.True(t, store.IsVersionConflict(err),
+		"store.IsVersionConflict must classify the wrapped error")
+}
+
+// TestAppendEvent_ConflictRetriesAndRecovers asserts the inner retry
+// loop in AppendEvent (auto-versioning path) recovers from a race
+// without surfacing ErrVersionConflict to the caller — the caller
+// didn't pin an expected version, so a re-read + retry is the
+// documented behaviour. Without this guard, a regression that turned
+// retries into immediate failures would silently break every handler
+// that uses AppendEvent (most of them).
+func TestAppendEvent_ConflictRetriesAndRecovers(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+
+	id := testutil.NewID()
+
+	// Seed: one event on the stream so subsequent AppendEvent reads
+	// stream_version=1 and tries to append at version=2.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "test",
+		StreamID:   id,
+		EventType:  "Seed",
+		Data:       map[string]any{},
+		ActorType:  "system",
+		ActorID:    "test",
+	}))
+
+	const goroutines = 5
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			errs <- st.AppendEvent(ctx, store.Event{
+				StreamType: "test",
+				StreamID:   id,
+				EventType:  "RaceProbe",
+				Data:       map[string]any{},
+				ActorType:  "system",
+				ActorID:    "test",
+			})
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		assert.NoError(t, err,
+			"AppendEvent must transparently retry on version conflict — the auto-version path is the documented happy path")
+	}
+}

--- a/internal/store/notfound_test.go
+++ b/internal/store/notfound_test.go
@@ -1,0 +1,86 @@
+package store_test
+
+// Pure-Go classification tests for the store sentinels. The DB-backed
+// AppendEvent retry / conflict paths are tested in store_test.go and
+// listener_test.go; this file covers the classifiers themselves so a
+// future backend swap (MySQL, SQLite) can drop in its native error and
+// extend IsNotFound / IsVersionConflict without breaking handler-side
+// code that already routes through these recognizers.
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+func TestIsNotFound(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("boom"), false},
+		{"sentinel", store.ErrNotFound, true},
+		{"sentinel wrapped", fmt.Errorf("lookup failed: %w", store.ErrNotFound), true},
+		{"pgx.ErrNoRows", pgx.ErrNoRows, true},
+		{"pgx.ErrNoRows wrapped", fmt.Errorf("query: %w", pgx.ErrNoRows), true},
+		// pgx.ErrNoRows wraps sql.ErrNoRows (so an unwrapped pgx
+		// error still classifies), but a bare sql.ErrNoRows did NOT
+		// come from a store-backend query and intentionally falls
+		// through to false — migration code uses database/sql and
+		// must not be conflated with the repo-layer's no-rows signal.
+		{"sql.ErrNoRows direct", sql.ErrNoRows, false},
+		// IsVersionConflict's signal must not collide with IsNotFound.
+		{"version-conflict sentinel", store.ErrVersionConflict, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, store.IsNotFound(tc.err))
+		})
+	}
+}
+
+func TestIsVersionConflict(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"unrelated", errors.New("boom"), false},
+		{"sentinel", store.ErrVersionConflict, true},
+		{"sentinel wrapped", fmt.Errorf("append event: %w", store.ErrVersionConflict), true},
+		{"pgconn 23505", &pgconn.PgError{Code: "23505"}, true},
+		{"pgconn 23505 wrapped", fmt.Errorf("query: %w", &pgconn.PgError{Code: "23505"}), true},
+		{"pgconn other code", &pgconn.PgError{Code: "23503"}, false}, // foreign_key_violation
+		{"pgconn check violation", &pgconn.PgError{Code: "23514"}, false},
+		// IsNotFound's signal must not collide with IsVersionConflict.
+		{"not-found sentinel", store.ErrNotFound, false},
+		{"pgx.ErrNoRows", pgx.ErrNoRows, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, store.IsVersionConflict(tc.err))
+		})
+	}
+}
+
+// TestErrVersionConflict_UnwrapPath documents the wrap-shape callers
+// depend on: AppendEvent / AppendEventWithVersion wrap conflicts with
+// fmt.Errorf("%w: ...", ErrVersionConflict), so errors.Is + the
+// IsVersionConflict recognizer must both classify the wrapped error.
+// A regression here would silently force handler-side callers back to
+// matching error strings.
+func TestErrVersionConflict_UnwrapPath(t *testing.T) {
+	wrapped := fmt.Errorf("%w: expected version 7 but stream was modified", store.ErrVersionConflict)
+	assert.True(t, errors.Is(wrapped, store.ErrVersionConflict), "errors.Is should match wrapped sentinel")
+	assert.True(t, store.IsVersionConflict(wrapped), "IsVersionConflict should match wrapped sentinel")
+}


### PR DESCRIPTION
## Summary

First wave of test coverage post-Wave-H now that more DB logic lives in Go. Three independent angles, all additive.

- **`internal/dynamicquery/parser_fuzz_test.go`** — native `go test -fuzz` harnesses on `Parse` and `EvaluateDevice`. Seeded with one example per grammar production plus adversarial inputs (deep paren nesting, NUL bytes, surrogate-pair UTF-8, mass `not` chains). Contract: never panic. Local 10-second smoke runs executed ~7M cases each with no crash; CI runs the seed corpus on every PR.
- **`internal/store/notfound_test.go`** — pure-Go classifier tests for `IsNotFound` + `IsVersionConflict` (Wave A / H sentinels). Synthetic `pgconn.PgError` and `pgx.ErrNoRows` fixtures; no container. Locks in the wrap-shape so a future MySQL backend can drop in `ER_DUP_ENTRY 1062` without breaking handler-side code.
- **`internal/store/listener_test.go`** — testcontainer-backed event-store invariants: listeners fire in registration order, a panicking listener doesn't break later listeners or `AppendEvent`, the persisted row (non-zero `SequenceNum`) reaches listeners, conflict errors wrap `store.ErrVersionConflict`, `AppendEvent`'s auto-version retry recovers from concurrent appends.
- **`cmd/control/bootstrap_test.go`** — fresh-DB + idempotent paths for `bootstrapAllDevicesGroup` (#308). Guards the regression Wave F quietly introduced and Wave H quietly fixed.

## Phase 2 (separate PR)

Projector `*FromEvent` decoder pure-unit tests across all ~26 streams. Decoders are mechanical and warrant their own focused diff.

## Test plan

- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `go test ./internal/dynamicquery/...` (incl. fuzz seed corpus)
- [x] `go test ./internal/store/...` (sentinel + listener invariants)
- [x] `go test ./cmd/control/...` (bootstrap fresh + idempotent)
- [ ] CI: full Unit + Integration + CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added event listener integration tests covering registration order, error isolation, and conflict handling.
  * Added fuzz tests for query parsing to validate robustness under adversarial inputs.
  * Added tests for device group initialization and store error classification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->