### PR TITLE
test: phase 2 — projector decoder coverage (identity_provider + edges)

### DIFF
--- a/internal/projectors/execution_test.go
+++ b/internal/projectors/execution_test.go
@@ -589,3 +589,129 @@ func TestExecutionListener_IgnoresWrongStreamType(t *testing.T) {
 	_, err := st.Queries().GetExecutionByID(ctx, roleID)
 	require.Error(t, err, "no executions_projection row should exist for a role-stream event")
 }
+
+// TestExecutionScheduledFromEvent_TimeParseEdgeCases hardens the
+// scheduled_for parsing path. The decoder rejects malformed RFC3339
+// strings explicitly so a bad event surfaces as a wrapped error
+// instead of silently round-tripping a zero time.Time into the
+// projection (which would race with the dispatch-window guard and
+// land the row in 'scheduled' state with executed_at=epoch).
+func TestExecutionScheduledFromEvent_TimeParseEdgeCases(t *testing.T) {
+	t.Run("RFC3339 without sub-second precision is accepted", func(t *testing.T) {
+		got, err := projectors.ExecutionScheduledFromEvent(store.PersistedEvent{
+			StreamType: "execution", StreamID: "exec-1", EventType: "ExecutionScheduled",
+			ActorType: "user", ActorID: "u-1",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":     "dev-1",
+				"action_type":   1,
+				"scheduled_for": "2026-03-01T00:00:00Z",
+			}),
+		})
+		require.NoError(t, err, "RFC3339Nano parser accepts plain RFC3339")
+		assert.True(t, got.ScheduledFor.Equal(time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)))
+	})
+
+	t.Run("malformed scheduled_for is a wrapped error, not ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.ExecutionScheduledFromEvent(store.PersistedEvent{
+			StreamType: "execution", StreamID: "exec-2", EventType: "ExecutionScheduled",
+			ActorType: "user", ActorID: "u-1",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":     "dev-1",
+				"action_type":   1,
+				"scheduled_for": "not-a-timestamp",
+			}),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent),
+			"a bad timestamp must surface as a validation error, not a silent skip")
+		assert.Contains(t, err.Error(), "scheduled_for")
+	})
+
+	t.Run("Z and +00:00 round-trip identically", func(t *testing.T) {
+		gotZ, errZ := projectors.ExecutionScheduledFromEvent(store.PersistedEvent{
+			StreamType: "execution", StreamID: "exec-z", EventType: "ExecutionScheduled",
+			ActorType: "user", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":     "dev-1",
+				"action_type":   1,
+				"scheduled_for": "2026-03-01T12:34:56Z",
+			}),
+		})
+		require.NoError(t, errZ)
+		gotOffset, errOffset := projectors.ExecutionScheduledFromEvent(store.PersistedEvent{
+			StreamType: "execution", StreamID: "exec-o", EventType: "ExecutionScheduled",
+			ActorType: "user", ActorID: "u",
+			Data: jsonOrFail(t, map[string]any{
+				"device_id":     "dev-1",
+				"action_type":   1,
+				"scheduled_for": "2026-03-01T12:34:56+00:00",
+			}),
+		})
+		require.NoError(t, errOffset)
+		assert.True(t, gotZ.ScheduledFor.Equal(gotOffset.ScheduledFor),
+			"Z and +00:00 must parse to the same instant")
+	})
+}
+
+// TestExecutionCreatedFromEvent_ActionIDCoalesce hardens the
+// COALESCE(action_id, definition_id) semantics. The PL/pgSQL projector
+// wrote action_id when present, definition_id when action_id was
+// missing — used by the compliance-policy bootstrap path that
+// synthesises an action row from a definition. The decoder must
+// match: explicit action_id wins, missing action_id falls through to
+// definition_id, neither present yields nil so the projector writes
+// NULL.
+func TestExecutionCreatedFromEvent_ActionIDCoalesce(t *testing.T) {
+	mkEvent := func(payload map[string]any) store.PersistedEvent {
+		base := map[string]any{
+			"device_id":   "dev-1",
+			"action_type": 1,
+		}
+		for k, v := range payload {
+			base[k] = v
+		}
+		return store.PersistedEvent{
+			StreamType: "execution", StreamID: "exec-x", EventType: "ExecutionCreated",
+			ActorType: "user", ActorID: "u",
+			Data: jsonOrFail(t, base),
+		}
+	}
+
+	t.Run("action_id present wins over definition_id", func(t *testing.T) {
+		got, err := projectors.ExecutionCreatedFromEvent(mkEvent(map[string]any{
+			"action_id":     "act-canonical",
+			"definition_id": "def-fallback",
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, got.ActionID)
+		assert.Equal(t, "act-canonical", *got.ActionID)
+	})
+
+	t.Run("definition_id used when action_id absent", func(t *testing.T) {
+		got, err := projectors.ExecutionCreatedFromEvent(mkEvent(map[string]any{
+			"definition_id": "def-only",
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, got.ActionID)
+		assert.Equal(t, "def-only", *got.ActionID,
+			"COALESCE(action_id, definition_id) falls back to definition_id")
+	})
+
+	t.Run("neither action_id nor definition_id → ActionID nil (NULL in projection)", func(t *testing.T) {
+		got, err := projectors.ExecutionCreatedFromEvent(mkEvent(map[string]any{}))
+		require.NoError(t, err)
+		assert.Nil(t, got.ActionID,
+			"both action_id and definition_id absent must yield nil so the listener writes NULL")
+	})
+
+	t.Run("empty-string action_id falls through to definition_id", func(t *testing.T) {
+		got, err := projectors.ExecutionCreatedFromEvent(mkEvent(map[string]any{
+			"action_id":     "",
+			"definition_id": "def-via-empty",
+		}))
+		require.NoError(t, err)
+		require.NotNil(t, got.ActionID)
+		assert.Equal(t, "def-via-empty", *got.ActionID,
+			"empty-string action_id collapses to nil, then COALESCE falls back to definition_id")
+	})
+}

--- a/internal/projectors/identity_provider_test.go
+++ b/internal/projectors/identity_provider_test.go
@@ -910,7 +910,7 @@ func TestIdentityProviderCreatedFromEvent_GroupMappingDefaults(t *testing.T) {
 			"explicit empty object must round-trip as {} — indistinguishable from default")
 	})
 
-	t.Run("nested group_mapping forwards verbatim JSONB bytes", func(t *testing.T) {
+	t.Run("flat group_mapping forwards verbatim JSONB bytes", func(t *testing.T) {
 		got, err := projectors.IdentityProviderCreatedFromEvent(mkEvent(t, map[string]any{
 			"group_mapping": map[string]any{
 				"engineering": "role-eng",
@@ -923,5 +923,33 @@ func TestIdentityProviderCreatedFromEvent_GroupMappingDefaults(t *testing.T) {
 		var decoded map[string]string
 		require.NoError(t, json.Unmarshal(got.GroupMapping, &decoded))
 		assert.Equal(t, map[string]string{"engineering": "role-eng", "admins": "role-admin"}, decoded)
+	})
+
+	t.Run("nested group_mapping forwards verbatim JSONB bytes", func(t *testing.T) {
+		// The wire shape allows nested objects — e.g. an IdP that maps
+		// a SCIM claim path to a structured policy descriptor. The
+		// decoder must forward the raw bytes unmodified so the
+		// listener can write the JSONB column without re-encoding;
+		// any re-marshal would reorder keys and risk a stale-replay
+		// guard mismatching the canonical form.
+		nested := map[string]any{
+			"engineering": map[string]any{
+				"role":  "role-eng",
+				"scope": []any{"prod", "staging"},
+				"meta":  map[string]any{"source": "scim", "ttl": float64(3600)},
+			},
+			"admins": map[string]any{
+				"role": "role-admin",
+				"meta": map[string]any{"source": "manual"},
+			},
+		}
+		got, err := projectors.IdentityProviderCreatedFromEvent(mkEvent(t, map[string]any{
+			"group_mapping": nested,
+		}))
+		require.NoError(t, err)
+		var decoded map[string]any
+		require.NoError(t, json.Unmarshal(got.GroupMapping, &decoded))
+		assert.Equal(t, nested, decoded,
+			"nested object structure must round-trip without loss")
 	})
 }

--- a/internal/projectors/identity_provider_test.go
+++ b/internal/projectors/identity_provider_test.go
@@ -2,6 +2,7 @@ package projectors_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log/slog"
 	"testing"
@@ -478,4 +479,449 @@ func TestIdentityProviderListener_IgnoresWrongStreamType(t *testing.T) {
 	}))
 	_, err := st.Queries().GetIdentityProviderByID(ctx, idpID)
 	require.Error(t, err, "wrong-stream-type IdentityProviderCreated must NOT create a row")
+}
+
+// TestIdentityProviderUpdatedFromEvent_Pure exercises the partial-update
+// decoder. Pointer fields preserve the "field present" vs "field
+// omitted" distinction the listener layer relies on for COALESCE
+// preserve-on-nil semantics. client_id, client_secret_encrypted and
+// issuer_url are NULLIF-suffixed — empty-string collapses to nil so
+// the projector's COALESCE(NULLIF(payload, ""), existing) preserves
+// the existing column rather than blanking it.
+func TestIdentityProviderUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with every field", func(t *testing.T) {
+		got, err := projectors.IdentityProviderUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "idp-1",
+			EventType: "IdentityProviderUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"name":                        "Renamed",
+				"enabled":                     true,
+				"client_id":                   "client-new",
+				"client_secret_encrypted":     "ENC:rotated",
+				"issuer_url":                  "https://new.example.com",
+				"authorization_url":           "https://oauth/auth2",
+				"token_url":                   "https://oauth/token2",
+				"userinfo_url":                "https://oauth/userinfo2",
+				"scopes":                      []string{"openid", "groups"},
+				"auto_create_users":           true,
+				"auto_link_by_email":          false,
+				"default_role_id":             "role-2",
+				"disable_password_for_linked": true,
+				"group_claim":                 "groups",
+				"group_mapping":               map[string]string{"admins": "role-admin"},
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "idp-1", got.ID)
+		require.NotNil(t, got.Name)
+		assert.Equal(t, "Renamed", *got.Name)
+		require.NotNil(t, got.Enabled)
+		assert.True(t, *got.Enabled)
+		require.NotNil(t, got.ClientID)
+		assert.Equal(t, "client-new", *got.ClientID)
+		require.NotNil(t, got.ClientSecretEncrypted)
+		assert.Equal(t, "ENC:rotated", *got.ClientSecretEncrypted)
+		require.NotNil(t, got.IssuerURL)
+		assert.Equal(t, "https://new.example.com", *got.IssuerURL)
+		require.NotNil(t, got.Scopes)
+		assert.Equal(t, []string{"openid", "groups"}, *got.Scopes)
+		require.NotNil(t, got.DefaultRoleID)
+		assert.Equal(t, "role-2", *got.DefaultRoleID)
+		assert.NotEmpty(t, got.GroupMapping, "group_mapping JSONB bytes forwarded")
+	})
+
+	t.Run("empty payload yields zero-value (preserves all columns)", func(t *testing.T) {
+		got, err := projectors.IdentityProviderUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "idp-2",
+			EventType: "IdentityProviderUpdated",
+			Data:      nil,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "idp-2", got.ID)
+		assert.Nil(t, got.Name)
+		assert.Nil(t, got.Enabled)
+		assert.Nil(t, got.ClientID)
+		assert.Nil(t, got.GroupMapping,
+			"absent group_mapping must yield nil bytes — listener writes NULL")
+	})
+
+	t.Run("partial update only sets present fields", func(t *testing.T) {
+		got, err := projectors.IdentityProviderUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "idp-3",
+			EventType: "IdentityProviderUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"name":    "OnlyName",
+				"enabled": false,
+			}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Name)
+		assert.Equal(t, "OnlyName", *got.Name)
+		require.NotNil(t, got.Enabled)
+		assert.False(t, *got.Enabled)
+		assert.Nil(t, got.ClientID, "absent field stays nil — listener preserves the column")
+		assert.Nil(t, got.IssuerURL)
+		assert.Nil(t, got.Scopes)
+	})
+
+	t.Run("NULLIF semantics: empty-string client_id/secret/issuer collapse to nil", func(t *testing.T) {
+		got, err := projectors.IdentityProviderUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "idp-4",
+			EventType: "IdentityProviderUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"client_id":               "",
+				"client_secret_encrypted": "",
+				"issuer_url":              "",
+				// authorization_url is NOT NULLIF-semantic — empty-string survives.
+				"authorization_url": "",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got.ClientID, "empty client_id collapses to nil (NULLIF)")
+		assert.Nil(t, got.ClientSecretEncrypted, "empty secret collapses to nil (NULLIF)")
+		assert.Nil(t, got.IssuerURL, "empty issuer_url collapses to nil (NULLIF)")
+		require.NotNil(t, got.AuthorizationURL,
+			"authorization_url is NOT NULLIF-semantic — empty-string passes through to the listener")
+		assert.Equal(t, "", *got.AuthorizationURL)
+	})
+
+	t.Run("invalid JSON returns wrapped error", func(t *testing.T) {
+		_, err := projectors.IdentityProviderUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "idp-5",
+			EventType: "IdentityProviderUpdated",
+			Data:      []byte("{not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "IdentityProviderUpdated")
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.IdentityProviderUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "IdentityProviderUpdated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.IdentityProviderUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", EventType: "IdentityProviderCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestIdentityLinkedFromEvent_Pure covers the link-projection write
+// for the IdentityLinked event. UserID / ProviderID / ExternalID are
+// the composite key — all three required. ExternalEmail / ExternalName
+// are optional and present-empty collapses to "".
+func TestIdentityLinkedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path with all fields", func(t *testing.T) {
+		got, err := projectors.IdentityLinkedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "link-1",
+			EventType: "IdentityLinked",
+			Data: jsonOrFail(t, map[string]any{
+				"user_id":        "user-1",
+				"provider_id":    "idp-1",
+				"external_id":    "ext-1",
+				"external_email": "alice@example.com",
+				"external_name":  "Alice",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "link-1", got.ID)
+		assert.Equal(t, "user-1", got.UserID)
+		assert.Equal(t, "idp-1", got.ProviderID)
+		assert.Equal(t, "ext-1", got.ExternalID)
+		assert.Equal(t, "alice@example.com", got.ExternalEmail)
+		assert.Equal(t, "Alice", got.ExternalName)
+	})
+
+	t.Run("optional fields absent → empty strings", func(t *testing.T) {
+		got, err := projectors.IdentityLinkedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "link-2",
+			EventType: "IdentityLinked",
+			Data: jsonOrFail(t, map[string]any{
+				"user_id":     "user-2",
+				"provider_id": "idp-2",
+				"external_id": "ext-2",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, got.ExternalEmail)
+		assert.Empty(t, got.ExternalName)
+	})
+
+	t.Run("required fields enforced", func(t *testing.T) {
+		base := map[string]any{"user_id": "u", "provider_id": "p", "external_id": "e"}
+		for _, drop := range []string{"user_id", "provider_id", "external_id"} {
+			t.Run("missing "+drop, func(t *testing.T) {
+				payload := map[string]any{}
+				for k, v := range base {
+					if k == drop {
+						continue
+					}
+					payload[k] = v
+				}
+				_, err := projectors.IdentityLinkedFromEvent(store.PersistedEvent{
+					StreamType: "identity_provider", StreamID: "link-x",
+					EventType: "IdentityLinked",
+					Data:      jsonOrFail(t, payload),
+				})
+				require.Error(t, err)
+				assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+				assert.Contains(t, err.Error(), drop)
+			})
+		}
+	})
+
+	t.Run("empty payload returns error (not ErrIgnoredEvent)", func(t *testing.T) {
+		_, err := projectors.IdentityLinkedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "link-empty",
+			EventType: "IdentityLinked",
+			Data:      nil,
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		assert.Contains(t, err.Error(), "empty")
+	})
+
+	t.Run("invalid JSON returns wrapped error", func(t *testing.T) {
+		_, err := projectors.IdentityLinkedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "link-bad",
+			EventType: "IdentityLinked",
+			Data:      []byte("not json"),
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.IdentityLinkedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "IdentityLinked",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.IdentityLinkedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", EventType: "IdentityProviderCreated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestIdentityLinkLoginUpdatedFromEvent_Pure covers the login-update
+// projection write. ProviderID + ExternalID are the lookup key (both
+// required). ExternalEmail / ExternalName are read as plain string
+// (NOT pointer) so the listener layer applies NULLIF semantics on
+// write — the decoder forwards whatever was on the wire, including
+// the empty-string case.
+func TestIdentityLinkLoginUpdatedFromEvent_Pure(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.IdentityLinkLoginUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "link-1",
+			EventType: "IdentityLinkLoginUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"provider_id":    "idp-1",
+				"external_id":    "ext-1",
+				"external_email": "alice@new.example.com",
+				"external_name":  "Alice New",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "link-1", got.ID)
+		assert.Equal(t, "idp-1", got.ProviderID)
+		assert.Equal(t, "ext-1", got.ExternalID)
+		assert.Equal(t, "alice@new.example.com", got.ExternalEmail)
+		assert.Equal(t, "Alice New", got.ExternalName)
+		assert.Empty(t, got.UserID, "UserID is not set by LoginUpdated — the projection uses the existing row")
+	})
+
+	t.Run("empty external_email/name forwarded as empty strings", func(t *testing.T) {
+		got, err := projectors.IdentityLinkLoginUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "link-2",
+			EventType: "IdentityLinkLoginUpdated",
+			Data: jsonOrFail(t, map[string]any{
+				"provider_id":    "idp-2",
+				"external_id":    "ext-2",
+				"external_email": "",
+				"external_name":  "",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, got.ExternalEmail,
+			"empty external_email is passed through — the listener applies NULLIF semantics on write")
+		assert.Empty(t, got.ExternalName)
+	})
+
+	t.Run("required key fields enforced", func(t *testing.T) {
+		for _, drop := range []string{"provider_id", "external_id"} {
+			t.Run("missing "+drop, func(t *testing.T) {
+				base := map[string]any{"provider_id": "p", "external_id": "e"}
+				payload := map[string]any{}
+				for k, v := range base {
+					if k == drop {
+						continue
+					}
+					payload[k] = v
+				}
+				_, err := projectors.IdentityLinkLoginUpdatedFromEvent(store.PersistedEvent{
+					StreamType: "identity_provider", StreamID: "link-x",
+					EventType: "IdentityLinkLoginUpdated",
+					Data:      jsonOrFail(t, payload),
+				})
+				require.Error(t, err)
+				assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+				assert.Contains(t, err.Error(), drop)
+			})
+		}
+	})
+
+	t.Run("empty payload returns error", func(t *testing.T) {
+		_, err := projectors.IdentityLinkLoginUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "link-empty",
+			EventType: "IdentityLinkLoginUpdated",
+			Data:      nil,
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("wrong stream/event type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.IdentityLinkLoginUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "IdentityLinkLoginUpdated",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		_, err = projectors.IdentityLinkLoginUpdatedFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", EventType: "IdentityLinked",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestSCIMTokenFromEvent_Pure exercises the shared decoder used by
+// both IdentityProviderSCIMEnabled and IdentityProviderSCIMTokenRotated.
+// The decoder takes an extra eventType parameter — caller passes the
+// expected event-type string so a single decoder serves both events
+// without duplicating the wire shape.
+func TestSCIMTokenFromEvent_Pure(t *testing.T) {
+	for _, et := range []string{"IdentityProviderSCIMEnabled", "IdentityProviderSCIMTokenRotated"} {
+		t.Run(et+": happy path", func(t *testing.T) {
+			got, err := projectors.SCIMTokenFromEvent(store.PersistedEvent{
+				StreamType: "identity_provider", StreamID: "idp-1",
+				EventType: et,
+				Data: jsonOrFail(t, map[string]any{
+					"scim_token_hash": "bcrypt:$2y$abcd",
+				}),
+			}, et)
+			require.NoError(t, err)
+			assert.Equal(t, "idp-1", got.ID)
+			assert.Equal(t, "bcrypt:$2y$abcd", got.ScimTokenHash)
+		})
+
+		t.Run(et+": missing scim_token_hash → error", func(t *testing.T) {
+			_, err := projectors.SCIMTokenFromEvent(store.PersistedEvent{
+				StreamType: "identity_provider", StreamID: "idp-2",
+				EventType: et,
+				Data:      jsonOrFail(t, map[string]any{}),
+			}, et)
+			require.Error(t, err)
+			assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+			assert.Contains(t, err.Error(), "scim_token_hash")
+			assert.Contains(t, err.Error(), et,
+				"error message must name the event type so logs identify which decoder rejected the payload")
+		})
+
+		t.Run(et+": empty payload → error", func(t *testing.T) {
+			_, err := projectors.SCIMTokenFromEvent(store.PersistedEvent{
+				StreamType: "identity_provider", StreamID: "idp-3",
+				EventType: et,
+				Data:      nil,
+			}, et)
+			require.Error(t, err)
+			assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+			assert.Contains(t, err.Error(), "empty")
+		})
+
+		t.Run(et+": invalid JSON → wrapped error", func(t *testing.T) {
+			_, err := projectors.SCIMTokenFromEvent(store.PersistedEvent{
+				StreamType: "identity_provider", StreamID: "idp-4",
+				EventType: et,
+				Data:      []byte("{bad"),
+			}, et)
+			require.Error(t, err)
+			assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+		})
+	}
+
+	t.Run("wrong stream type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.SCIMTokenFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "IdentityProviderSCIMEnabled",
+		}, "IdentityProviderSCIMEnabled")
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("event-type mismatch with caller-supplied eventType → ErrIgnoredEvent", func(t *testing.T) {
+		// Persisted row is IdentityProviderSCIMEnabled but the caller
+		// dispatched it as IdentityProviderSCIMTokenRotated — the
+		// decoder must NOT decode under the wrong event-type label.
+		_, err := projectors.SCIMTokenFromEvent(store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "idp-x",
+			EventType: "IdentityProviderSCIMEnabled",
+			Data:      jsonOrFail(t, map[string]any{"scim_token_hash": "x"}),
+		}, "IdentityProviderSCIMTokenRotated")
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
+// TestIdentityProviderCreatedFromEvent_GroupMappingDefaults pins the
+// JSONB defaulting behaviour for the group_mapping column. The
+// projector writes []byte("{}") when the payload omits the field
+// (matches the PL/pgSQL default for the JSONB column) and forwards
+// the raw bytes verbatim when present, so a future schema change that
+// drifted away from the "{}" default would be caught here rather than
+// silently surfaced as a NULL row in the projection.
+func TestIdentityProviderCreatedFromEvent_GroupMappingDefaults(t *testing.T) {
+	mkEvent := func(t *testing.T, extra map[string]any) store.PersistedEvent {
+		base := map[string]any{
+			"name":       "Bare",
+			"slug":       "bare",
+			"client_id":  "c",
+			"issuer_url": "https://example.com",
+		}
+		for k, v := range extra {
+			base[k] = v
+		}
+		return store.PersistedEvent{
+			StreamType: "identity_provider", StreamID: "idp-gm",
+			EventType: "IdentityProviderCreated", ActorID: "u",
+			Data: jsonOrFail(t, base),
+		}
+	}
+
+	t.Run("absent group_mapping defaults to {}", func(t *testing.T) {
+		got, err := projectors.IdentityProviderCreatedFromEvent(mkEvent(t, nil))
+		require.NoError(t, err)
+		require.NotEmpty(t, got.GroupMapping, "absent group_mapping must default to {} bytes")
+		assert.JSONEq(t, "{}", string(got.GroupMapping))
+	})
+
+	t.Run("explicit empty group_mapping {} round-trips", func(t *testing.T) {
+		got, err := projectors.IdentityProviderCreatedFromEvent(mkEvent(t, map[string]any{
+			"group_mapping": map[string]any{},
+		}))
+		require.NoError(t, err)
+		assert.JSONEq(t, "{}", string(got.GroupMapping),
+			"explicit empty object must round-trip as {} — indistinguishable from default")
+	})
+
+	t.Run("nested group_mapping forwards verbatim JSONB bytes", func(t *testing.T) {
+		got, err := projectors.IdentityProviderCreatedFromEvent(mkEvent(t, map[string]any{
+			"group_mapping": map[string]any{
+				"engineering": "role-eng",
+				"admins":      "role-admin",
+			},
+		}))
+		require.NoError(t, err)
+		// Decode to a generic map to assert key set without depending
+		// on JSON key ordering.
+		var decoded map[string]string
+		require.NoError(t, json.Unmarshal(got.GroupMapping, &decoded))
+		assert.Equal(t, map[string]string{"engineering": "role-eng", "admins": "role-admin"}, decoded)
+	})
 }


### PR DESCRIPTION
## Summary

Phase 2 of the testing push (#242). Audit confirmed 98/102 projector `*FromEvent` decoders already had `_Pure` unit tests; the four in `internal/projectors/identity_provider.go` were exercised only via the listener Apply path. Closes that gap, plus picks up the moderate-priority edge cases the audit flagged.

## New pure-Go decoder tests

In `internal/projectors/identity_provider_test.go`:

- `TestIdentityProviderUpdatedFromEvent_Pure` — 13 optional fields, partial-update preserve-on-nil contract, **NULLIF semantics** on `client_id` / `client_secret_encrypted` / `issuer_url` (empty collapses to nil so the listener's `COALESCE(NULLIF(payload, ""), existing)` preserves the column rather than blanking it), invalid-JSON + wrong-event-type rejection, `group_mapping` JSONB forwarding.
- `TestIdentityLinkedFromEvent_Pure` — `user_id` / `provider_id` / `external_id` required (composite key), optional fields, empty-payload returns error (not `ErrIgnoredEvent`).
- `TestIdentityLinkLoginUpdatedFromEvent_Pure` — `provider_id` + `external_id` are the lookup key (both required), email/name forwarded as plain string so the listener applies NULLIF on write.
- `TestSCIMTokenFromEvent_Pure` — shared decoder for `SCIMEnabled` + `SCIMTokenRotated`, exercised with both event-type values as the caller-supplied parameter, includes the **event-type-mismatch guard** (persisted `SCIMEnabled` but caller passed `SCIMTokenRotated` → must be ignored).

## Moderate-priority edge cases

- `TestExecutionScheduledFromEvent_TimeParseEdgeCases` — RFC3339 without sub-second precision accepted, malformed `scheduled_for` surfaces as wrapped error (not `ErrIgnoredEvent`), `Z` and `+00:00` round-trip identically.
- `TestExecutionCreatedFromEvent_ActionIDCoalesce` — locks down the PL/pgSQL `COALESCE(action_id, definition_id)` semantics across four cases including empty-string fallthrough.
- `TestIdentityProviderCreatedFromEvent_GroupMappingDefaults` — absent `group_mapping` defaults to `{}` bytes (matches JSONB column default), explicit `{}` round-trips, nested object forwards verbatim.

## Coverage

Decoder layer is now **102/102 covered** by pure-Go tests. All new cases run sub-second without testcontainers.

## Test plan

- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go test ./internal/projectors/...` green (all new cases pass)
- [ ] CI: full Unit + Integration + CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded unit test coverage for event decoding and validation: more timestamp parsing edge-cases, stricter handling of action ID coalescing, comprehensive identity-provider and identity-link decoding scenarios (pointer vs omission semantics, NULLIF-style empty-string collapsing, required-key enforcement, SCIM token validation, and JSON group-mapping defaults).

**Note:** Internal testing improvements with no direct user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->