### PR TITLE
sec: address 12 findings from SECURITY_AUDIT.md batch 1

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -280,11 +279,15 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Add health check endpoint.
+	// Public health endpoint — minimal response so unauthenticated
+	// callers cannot enumerate server versions for vulnerability
+	// scanning (audit F-26). The version is still reachable via
+	// authenticated control RPCs (GetServerVersion equivalent) and
+	// via the mTLS-protected internal /health below for operator
+	// scrape tools.
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{"status":"ok","version":%q}`, version)
+		_, _ = w.Write([]byte("ok"))
 	})
 
 	// Mount InternalService on a separate mTLS-protected listener.

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -89,12 +89,28 @@ services:
     restart: unless-stopped
     volumes:
       - ./data/valkey:/data:z
-    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${VALKEY_PASSWORD}", "--loadmodule", "/opt/redis-stack/lib/redisearch.so"]
+      # valkey.conf is rendered from valkey.conf.template at setup
+      # time with VALKEY_PASSWORD substituted in. Mounted read-only
+      # so a runtime container compromise can't tamper with it.
+      - ./valkey.conf:/etc/valkey/valkey.conf:ro,z
+    # Secrets-in-cmdline hardening (audit F-03): the password used
+    # to live in `--requirepass ${VALKEY_PASSWORD}` here, which made
+    # it readable to anything with PID-namespace access via
+    # /proc/<pid>/cmdline. Now the password is in /etc/valkey/valkey.conf
+    # (file permissions enforced by the bind-mount), and the health
+    # check authenticates via REDISCLI_AUTH so the cmdline of the
+    # one-shot redis-cli probe stays clean too.
+    command: ["redis-server", "/etc/valkey/valkey.conf"]
     healthcheck:
-      test: ["CMD", "redis-cli", "-a", "${VALKEY_PASSWORD}", "ping"]
+      test: ["CMD-SHELL", "REDISCLI_AUTH=\"$$VALKEY_PASSWORD\" redis-cli ping"]
       interval: 5s
       timeout: 3s
       retries: 3
+    environment:
+      # Exposed to the container so the healthcheck shell can read
+      # REDISCLI_AUTH. The password is NOT a cmdline arg here, and the
+      # env var is namespace-isolated to this container.
+      - VALKEY_PASSWORD=${VALKEY_PASSWORD}
     networks:
       - internal
 

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -660,7 +660,29 @@ main() {
     chmod 755 "$DATA_DIR/postgres" "$DATA_DIR/valkey" "$DATA_DIR/traefik"
     log_info "Created data directories: $DATA_DIR/{postgres,valkey,traefik}"
 
+    render_valkey_config
+
     show_instructions
+}
+
+# render_valkey_config writes the deployment's valkey.conf from the
+# template (deploy/valkey.conf.template) with VALKEY_PASSWORD
+# substituted in. The rendered file is read-only-mounted into the
+# pm-valkey container so the password no longer appears in
+# /proc/<pid>/cmdline (audit F-03).
+render_valkey_config() {
+    local template="$SCRIPT_DIR/valkey.conf.template"
+    local rendered="$SCRIPT_DIR/valkey.conf"
+    if [[ ! -f "$template" ]]; then
+        log_error "valkey.conf.template missing at $template"
+        return 1
+    fi
+    # Use awk so a password containing &, \, /, or | doesn't get
+    # interpreted by sed's replacement syntax.
+    awk -v pw="$VALKEY_PASSWORD" '{ gsub(/__VALKEY_PASSWORD__/, pw); print }' \
+        "$template" > "$rendered"
+    chmod 0400 "$rendered"
+    log_info "Rendered valkey.conf (mode 0400) from template"
 }
 
 # Run main only when executed directly. When this file is `source`d

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -677,12 +677,40 @@ render_valkey_config() {
         log_error "valkey.conf.template missing at $template"
         return 1
     fi
-    # Use awk so a password containing &, \, /, or | doesn't get
-    # interpreted by sed's replacement syntax.
-    awk -v pw="$VALKEY_PASSWORD" '{ gsub(/__VALKEY_PASSWORD__/, pw); print }' \
-        "$template" > "$rendered"
-    chmod 0400 "$rendered"
-    log_info "Rendered valkey.conf (mode 0400) from template"
+    # Literal substitution via a split-and-concatenate loop. Every
+    # other approach we tried interprets `&` as the matched text
+    # (awk's gsub, bash's ${var//pat/rep}, sed's s/// — all of
+    # them). Splitting the template at the placeholder and using
+    # ${pw} as the joiner keeps the password truly literal, so a
+    # password containing &, \, /, |, $, or newlines lands in the
+    # rendered config exactly as the operator generated it.
+    local template_contents
+    template_contents="$(<"$template")"
+    local rendered_contents=""
+    local remaining="$template_contents"
+    while [[ "$remaining" == *__VALKEY_PASSWORD__* ]]; do
+        rendered_contents+="${remaining%%__VALKEY_PASSWORD__*}${VALKEY_PASSWORD}"
+        remaining="${remaining#*__VALKEY_PASSWORD__}"
+    done
+    rendered_contents+="$remaining"
+    # Write atomically: render to a temp, fsync via mv. Use printf
+    # rather than echo so a password starting with `-` is not
+    # interpreted as a flag.
+    local tmp
+    tmp="$(mktemp "${rendered}.tmp.XXXXXX")"
+    printf '%s' "$rendered_contents" > "$tmp"
+    # 0644 keeps the file readable by the redis user inside the
+    # container (uid 999 in the redis-stack-server image) without
+    # needing the operator to chown to a specific uid. The bind-
+    # mount carries `ro,z` so the container cannot tamper, and the
+    # password is already on disk in .env (same protection level),
+    # so 0644 doesn't materially widen exposure beyond the existing
+    # secret-handling model. The audit-F-03 fix is the cmdline /
+    # /proc/cmdline scrubbing, which holds regardless of the
+    # rendered file's mode.
+    chmod 0644 "$tmp"
+    mv "$tmp" "$rendered"
+    log_info "Rendered valkey.conf from template"
 }
 
 # Run main only when executed directly. When this file is `source`d

--- a/deploy/valkey.conf.template
+++ b/deploy/valkey.conf.template
@@ -1,0 +1,36 @@
+# Valkey/Redis-stack server configuration (audit F-03).
+#
+# Rendered to ./valkey.conf at setup time by setup.sh — the only
+# value substituted in is ${VALKEY_PASSWORD}. The rendered file is
+# bind-mounted read-only into the pm-valkey container at
+# /etc/valkey/valkey.conf. Keeping the password in a file (with
+# operator-controlled permissions) rather than the command line
+# stops /proc/<pid>/cmdline from leaking the credential to anything
+# sharing the PID namespace.
+#
+# Permissions on the rendered file should be 0400 on the host so
+# only the user that owns the deployment can read it; the bind-mount
+# carries those bits into the container.
+
+# Module loading (RediSearch ships in the redis-stack-server image at
+# the path below; keep this in sync with the image's --loadmodule arg).
+loadmodule /opt/redis-stack/lib/redisearch.so
+
+# Authentication. setup.sh replaces __VALKEY_PASSWORD__ with the
+# operator-generated password from .env.
+requirepass __VALKEY_PASSWORD__
+
+# Durability — match the previous --appendonly yes flag.
+appendonly yes
+
+# Bind/listen — Compose's internal network already gates access to
+# the valkey service from outside the compose project, so the default
+# bind is sufficient. Explicit here so it's reviewable.
+bind 0.0.0.0 -::*
+port 6379
+
+# Protected mode is OFF because requirepass is set; turning it back
+# on would block the legitimate cross-container access path from
+# control, gateway, indexer, and traefik. The password is the only
+# auth gate.
+protected-mode no

--- a/internal/api/audit_handler.go
+++ b/internal/api/audit_handler.go
@@ -121,27 +121,38 @@ var eventRedactionSchemas = map[string]map[string]redactionSchema{
 // actionRedactionSchemas maps an action's `params.type` value to the
 // redactionSchema that should be applied to its `params:` subtree.
 // The action-emit shape is `{ type: "...", name: "...", params: { ... } }`,
-// so each path is rooted at `params.`.
+// and `params:` is produced by serializeProtoParams (protojson with
+// UseProtoNames=false), so the path segments are camelCase to match
+// the wire format — NOT the proto field's snake_case schema name.
+// A path that uses snake_case here will silently miss the field in
+// production (audit F-34 — the prior schema had this exact bug for
+// every secret-bearing action type, leaking customConfig, gpgKey, and
+// presharedKey through the audit log).
 //
 // One schema per action type that carries secret-bearing parameters:
 //
-//   - SHELL  -> params.script (full shell body)
-//   - FILE   -> params.content (file body, may contain secrets)
-//   - SUDO   -> params.unit_content (sudoers fragment)
-//   - REPOSITORY -> params.gpg_key (GPG signing key material)
-//   - LPS    -> params.password / params.preshared_key (rotation seed)
-//   - LUKS   -> params.passphrase / params.preshared_key
+//   - SHELL        -> params.script + params.detectionScript
+//     (both can hold full shell bodies)
+//   - FILE         -> params.content (file body, may contain secrets)
+//   - ADMIN_POLICY -> params.customConfig (sudoers / doas.conf fragment;
+//     proto field renamed from unit_content)
+//   - REPOSITORY   -> params.gpgKey (GPG signing key material; URL form
+//     params.gpgKeyUrl is intentionally NOT scrubbed)
+//   - ENCRYPTION   -> params.presharedKey (LUKS bootstrap entropy)
 //
 // Action types not in this map have no params secrets to scrub
 // (PACKAGE, UPDATE, REBOOT, SYNC, USER, GROUP, SSH, SSHD,
-// SYSTEMD/SERVICE, DIRECTORY, APP_IMAGE, DEB, RPM, FLATPAK).
+// SYSTEMD/SERVICE, DIRECTORY, APP_IMAGE, DEB, RPM, FLATPAK, LPS).
+// LpsParams in particular looks like a hit but is not — the actual
+// rotated password is generated agent-side and surfaces via the
+// LpsPasswordRotated event (covered by eventRedactionSchemas), not
+// via the dispatch action_params.
 var actionRedactionSchemas = map[string]redactionSchema{
-	"ACTION_TYPE_SHELL":        {paths: []string{"params.script"}},
+	"ACTION_TYPE_SHELL":        {paths: []string{"params.script", "params.detectionScript"}},
 	"ACTION_TYPE_FILE":         {paths: []string{"params.content"}},
-	"ACTION_TYPE_ADMIN_POLICY": {paths: []string{"params.unit_content"}},
-	"ACTION_TYPE_REPOSITORY":   {paths: []string{"params.gpg_key"}},
-	"ACTION_TYPE_LPS":          {paths: []string{"params.password", "params.preshared_key"}},
-	"ACTION_TYPE_ENCRYPTION":   {paths: []string{"params.passphrase", "params.preshared_key"}},
+	"ACTION_TYPE_ADMIN_POLICY": {paths: []string{"params.customConfig"}},
+	"ACTION_TYPE_REPOSITORY":   {paths: []string{"params.gpgKey"}},
+	"ACTION_TYPE_ENCRYPTION":   {paths: []string{"params.presharedKey"}},
 }
 
 // redactEventData removes sensitive fields from a serialized event

--- a/internal/api/audit_redactor_internal_test.go
+++ b/internal/api/audit_redactor_internal_test.go
@@ -11,11 +11,16 @@ import (
 
 // TestRedactEventData_ActionParams locks the schema-aware contract:
 // each action type has its own redaction schema rooted at `params.`.
-// A SHELL action's `script`, a FILE action's `content`, a SUDO action's
-// `unit_content`, etc. must NOT appear verbatim in the redacted output.
+// A SHELL action's `script`, a FILE action's `content`, an
+// ADMIN_POLICY action's `customConfig`, etc. must NOT appear verbatim
+// in the redacted output.
 //
-// The test uses the action emit shape (`{name, type, params}`) that
-// every emit site in `internal/api/action_handler.go` produces.
+// The fixtures here use the **camelCase** keys the production wire
+// format actually produces — see audit F-34. Earlier versions of this
+// test used snake_case keys that matched a (broken) snake_case
+// schema, masking the production leak. The fixtures match what
+// `serializeProtoParams` in internal/api/action_params.go emits via
+// protojson (`UseProtoNames=false`).
 func TestRedactEventData_ActionParams(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -24,12 +29,13 @@ func TestRedactEventData_ActionParams(t *testing.T) {
 		secrets    []string
 	}{
 		{
-			name:       "SHELL params.script",
+			name:       "SHELL params.script + params.detectionScript",
 			actionType: "ACTION_TYPE_SHELL",
 			params: map[string]any{
-				"script": "echo SENTINEL_SHELL",
+				"script":          "echo SENTINEL_SHELL",
+				"detectionScript": "echo SENTINEL_DETECT",
 			},
-			secrets: []string{"SENTINEL_SHELL"},
+			secrets: []string{"SENTINEL_SHELL", "SENTINEL_DETECT"},
 		},
 		{
 			name:       "FILE params.content",
@@ -41,41 +47,30 @@ func TestRedactEventData_ActionParams(t *testing.T) {
 			secrets: []string{"SENTINEL_FILE"},
 		},
 		{
-			name:       "ADMIN_POLICY params.unit_content",
+			name:       "ADMIN_POLICY params.customConfig",
 			actionType: "ACTION_TYPE_ADMIN_POLICY",
 			params: map[string]any{
-				"unit_content": "SENTINEL_SUDO",
+				"customConfig": "SENTINEL_SUDO",
 			},
 			secrets: []string{"SENTINEL_SUDO"},
 		},
 		{
-			name:       "REPOSITORY params.gpg_key",
+			name:       "REPOSITORY params.gpgKey",
 			actionType: "ACTION_TYPE_REPOSITORY",
 			params: map[string]any{
-				"url":     "https://example.com/repo",
-				"gpg_key": "SENTINEL_GPG",
+				"url":    "https://example.com/repo",
+				"gpgKey": "SENTINEL_GPG",
 			},
 			secrets: []string{"SENTINEL_GPG"},
 		},
 		{
-			name:       "LPS params.password + params.preshared_key",
-			actionType: "ACTION_TYPE_LPS",
-			params: map[string]any{
-				"username":      "alice",
-				"password":      "SENTINEL_LPS_PWD",
-				"preshared_key": "SENTINEL_LPS_PSK",
-			},
-			secrets: []string{"SENTINEL_LPS_PWD", "SENTINEL_LPS_PSK"},
-		},
-		{
-			name:       "ENCRYPTION (LUKS) params.passphrase + params.preshared_key",
+			name:       "ENCRYPTION (LUKS) params.presharedKey",
 			actionType: "ACTION_TYPE_ENCRYPTION",
 			params: map[string]any{
-				"device_path":   "/dev/sda1",
-				"passphrase":    "SENTINEL_LUKS_PWD",
-				"preshared_key": "SENTINEL_LUKS_PSK",
+				"devicePath":   "/dev/sda1",
+				"presharedKey": "SENTINEL_LUKS_PSK",
 			},
-			secrets: []string{"SENTINEL_LUKS_PWD", "SENTINEL_LUKS_PSK"},
+			secrets: []string{"SENTINEL_LUKS_PSK"},
 		},
 	}
 

--- a/internal/api/audit_redactor_paths_test.go
+++ b/internal/api/audit_redactor_paths_test.go
@@ -1,0 +1,148 @@
+package api
+
+// Audit F-34 — schema-vs-wire validator.
+//
+// `actionRedactionSchemas` claims to scrub specific paths under
+// `params.<name>` for each action type. The wire format of `params`
+// is produced by serializeProtoParams via protojson with
+// `UseProtoNames=false` (camelCase JSON keys). A schema path that
+// names a snake_case field — or a field that doesn't exist on the
+// underlying proto at all — silently misses the secret. The prior
+// schema had exactly that bug for every secret-bearing action type
+// (`unit_content`, `gpg_key`, `preshared_key`, the phantom
+// `passphrase` / LPS `password`), and the existing tests masked it
+// by passing snake_case fixtures matching the broken schema.
+//
+// This test fails fast on any future schema drift by checking that
+// every action-redaction path resolves to a real field on a
+// fully-populated emit of the corresponding proto message. If the
+// proto field is renamed and the schema isn't updated in lock-step,
+// CI catches it.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
+)
+
+// fullyPopulatedParamsFor returns one of each secret-bearing
+// action's proto message, populated with non-zero values on every
+// field that should appear in the protojson emit. We don't try to
+// be smart about defaults — protojson's `EmitUnpopulated=false`
+// drops zero-value fields, but we set every field to a distinct
+// sentinel so the wire emit definitely contains it.
+func fullyPopulatedParamsFor(t *testing.T, actionType string) proto.Message {
+	t.Helper()
+	switch actionType {
+	case "ACTION_TYPE_SHELL":
+		return &pm.ShellParams{
+			Script:           "S",
+			DetectionScript:  "D",
+			Interpreter:      "/bin/bash",
+			RunAsRoot:        true,
+			Environment:      map[string]string{"K": "V"},
+			WorkingDirectory: "/tmp",
+		}
+	case "ACTION_TYPE_FILE":
+		return &pm.FileParams{
+			Path:    "/etc/x",
+			Content: "C",
+			Owner:   "root",
+			Group:   "root",
+			Mode:    "0644",
+		}
+	case "ACTION_TYPE_ADMIN_POLICY":
+		return &pm.AdminPolicyParams{
+			AccessLevel:  pm.AdminAccessLevel(3),
+			Users:        []string{"alice"},
+			CustomConfig: "C",
+		}
+	case "ACTION_TYPE_REPOSITORY":
+		return &pm.AptRepository{
+			Url:          "https://example.com",
+			Distribution: "stable",
+			Components:   []string{"main"},
+			GpgKey:       "K",
+			GpgKeyUrl:    "https://example.com/key.asc",
+		}
+	case "ACTION_TYPE_ENCRYPTION":
+		return &pm.EncryptionParams{
+			PresharedKey:         "P",
+			RotationIntervalDays: 30,
+		}
+	}
+	return nil
+}
+
+func TestActionRedactionSchemas_PathsMatchWireFormat(t *testing.T) {
+	for actionType, schema := range actionRedactionSchemas {
+		actionType, schema := actionType, schema
+		t.Run(actionType, func(t *testing.T) {
+			msg := fullyPopulatedParamsFor(t, actionType)
+			require.NotNil(t, msg,
+				"redaction schema names action type %s but the test fixture has no proto for it — add one to fullyPopulatedParamsFor", actionType)
+
+			raw, err := actionparams.MarshalActionParams(msg)
+			require.NoError(t, err)
+
+			var params map[string]any
+			require.NoError(t, json.Unmarshal(raw, &params))
+
+			// Wrap in the {name, type, params} envelope so the path
+			// `params.X` resolves the same way the redactor walks it.
+			envelope := map[string]any{
+				"name":   "test",
+				"type":   actionType,
+				"params": params,
+			}
+
+			for _, path := range schema.paths {
+				if path == "" {
+					continue
+				}
+				resolved, ok := resolveJSONPath(envelope, path)
+				require.True(t, ok,
+					"redaction schema %s claims to scrub %q but that path does not exist on the wire emit of %T (got keys: %v)",
+					actionType, path, msg, sortedKeys(params))
+				_, isString := resolved.(string)
+				require.True(t, isString,
+					"redaction schema %s path %q resolves to %T, not a string — redactor only knows how to scrub string fields",
+					actionType, path, resolved)
+			}
+		})
+	}
+}
+
+// resolveJSONPath walks a dotted path through a decoded JSON map and
+// returns the leaf value. Returns (nil, false) if any segment is
+// missing or refers to a non-map.
+func resolveJSONPath(root any, path string) (any, bool) {
+	segs := strings.Split(path, ".")
+	cur := root
+	for _, s := range segs {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		v, ok := m[s]
+		if !ok {
+			return nil, false
+		}
+		cur = v
+	}
+	return cur, true
+}
+
+func sortedKeys(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/api/certificate_handler.go
+++ b/internal/api/certificate_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/subtle"
 	"log/slog"
 	"time"
 
@@ -63,7 +64,13 @@ func (h *CertificateHandler) RenewCertificate(ctx context.Context, req *connect.
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to compute fingerprint")
 	}
-	if device.CertFingerprint == nil || *device.CertFingerprint != currentFP {
+	// Use a constant-time comparison so a co-located attacker can't
+	// extract the stored fingerprint byte-by-byte via response-timing
+	// (audit F-04). The fingerprints are equal-length hex strings on
+	// the happy path; the nil-pointer short-circuit handles the
+	// "device never had a cert" case before we reach the compare.
+	if device.CertFingerprint == nil ||
+		subtle.ConstantTimeCompare([]byte(*device.CertFingerprint), []byte(currentFP)) != 1 {
 		h.logger.Warn("certificate fingerprint mismatch",
 			"device_id", deviceID,
 			"presented", currentFP,

--- a/internal/api/idp_handler.go
+++ b/internal/api/idp_handler.go
@@ -67,17 +67,26 @@ func (h *IDPHandler) CreateIdentityProvider(ctx context.Context, req *connect.Re
 		StreamID:   id,
 		EventType:  string(eventtypes.IdentityProviderCreated),
 		Data: payloads.IdentityProviderCreated{
-			Name:                     req.Msg.Name,
-			Slug:                     req.Msg.Slug,
-			ProviderType:             identityProviderTypeToString(req.Msg.ProviderType),
-			ClientID:                 req.Msg.ClientId,
-			ClientSecretEncrypted:    encryptedSecret,
-			IssuerURL:                req.Msg.IssuerUrl,
-			AuthorizationURL:         req.Msg.AuthorizationUrl,
-			TokenURL:                 req.Msg.TokenUrl,
-			UserinfoURL:              req.Msg.UserinfoUrl,
-			Scopes:                   req.Msg.Scopes,
-			AutoCreateUsers:          req.Msg.AutoCreateUsers,
+			Name:                  req.Msg.Name,
+			Slug:                  req.Msg.Slug,
+			ProviderType:          identityProviderTypeToString(req.Msg.ProviderType),
+			ClientID:              req.Msg.ClientId,
+			ClientSecretEncrypted: encryptedSecret,
+			IssuerURL:             req.Msg.IssuerUrl,
+			AuthorizationURL:      req.Msg.AuthorizationUrl,
+			TokenURL:              req.Msg.TokenUrl,
+			UserinfoURL:           req.Msg.UserinfoUrl,
+			Scopes:                req.Msg.Scopes,
+			AutoCreateUsers:       req.Msg.AutoCreateUsers,
+			// AutoLinkByEmail defaults to FALSE for new providers
+			// (proto bool default) and must be explicitly enabled
+			// by the operator (audit F-28). Enabling it makes the
+			// IdP's email-verification policy a hard dependency
+			// for the local-account trust boundary — an IdP that
+			// returns unverified emails would let an attacker hijack
+			// a local user by signing into the IdP with the
+			// victim's email address. Document this in operator
+			// guidance before flipping the default.
 			AutoLinkByEmail:          req.Msg.AutoLinkByEmail,
 			DefaultRoleID:            req.Msg.DefaultRoleId,
 			DisablePasswordForLinked: req.Msg.DisablePasswordForLinked,

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -3,7 +3,10 @@ package api
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"net"
+	"net/url"
 	"time"
 
 	"connectrpc.com/connect"
@@ -18,6 +21,64 @@ import (
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
+
+// validateSSORedirectURL enforces a server-side allowlist on the
+// client-supplied redirect URL (audit F-15). The OIDC provider also
+// validates `redirect_uri` against its own registered list, but
+// relying solely on the IdP's check is fragile — a misconfigured
+// provider (or an IdP CVE) would otherwise let an attacker pass
+// `https://evil.com/callback` and complete an OIDC dance that mints a
+// session bound to a redirect they control.
+//
+// Accept:
+//   - empty string (server falls back to callbackBaseURL)
+//   - same origin as callbackBaseURL (scheme + host + port match)
+//   - loopback URLs (http://127.0.0.1:* / http://localhost:* /
+//     http://[::1]:*) — pm-enroll CLI uses this to receive the
+//     callback on a local port
+//
+// Reject everything else with InvalidArgument.
+func validateSSORedirectURL(redirectURL, callbackBaseURL string) error {
+	if redirectURL == "" {
+		return nil
+	}
+	u, err := url.Parse(redirectURL)
+	if err != nil {
+		return fmt.Errorf("malformed redirect_url: %w", err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("redirect_url scheme must be http or https, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("redirect_url missing host")
+	}
+	// Loopback hosts are accepted for CLI flows. net.ParseIP catches
+	// IPv4/IPv6 literals; the string "localhost" is the conventional
+	// hostname for the same purpose.
+	host := u.Hostname()
+	if host == "localhost" {
+		return nil
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return nil
+	}
+	// Same-origin match against the configured base URL. The base is
+	// required to be configured for any non-loopback redirect — a
+	// deployment without callbackBaseURL refuses non-loopback clients
+	// by construction.
+	if callbackBaseURL == "" {
+		return fmt.Errorf("redirect_url not permitted: CONTROL_SSO_CALLBACK_BASE_URL is not configured")
+	}
+	base, err := url.Parse(callbackBaseURL)
+	if err != nil {
+		return fmt.Errorf("server-side callback base URL is malformed: %w", err)
+	}
+	if u.Scheme != base.Scheme || u.Host != base.Host {
+		return fmt.Errorf("redirect_url origin %q does not match server callback base %q",
+			u.Scheme+"://"+u.Host, base.Scheme+"://"+base.Host)
+	}
+	return nil
+}
 
 // SSOHandler handles SSO authentication flow RPCs.
 type SSOHandler struct {
@@ -102,6 +163,10 @@ func (h *SSOHandler) ListAuthMethods(ctx context.Context, req *connect.Request[p
 func (h *SSOHandler) GetSSOLoginURL(ctx context.Context, req *connect.Request[pm.GetSSOLoginURLRequest]) (*connect.Response[pm.GetSSOLoginURLResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
+	}
+
+	if err := validateSSORedirectURL(req.Msg.RedirectUrl, h.callbackBaseURL); err != nil {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, err.Error())
 	}
 
 	provider, err := h.store.Repos().IdentityProvider.GetBySlug(ctx, req.Msg.Slug)

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -110,6 +110,20 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 	// reads from the device projection. Pre-fix this was hardcoded
 	// to userCtx.ID, which masked admin access to bulk-enrolled
 	// (unassigned) devices.
+	//
+	// Security note (audit F-27): the unscoped StartTerminal
+	// permission deliberately grants cross-user terminal access — an
+	// admin can open a session that runs as ANY device user's TTY
+	// account, not only their own (subject to the caller having a
+	// linux_username configured on their own profile, which becomes
+	// the TTY user inside the session). This is the intended admin
+	// behaviour for incident response; the audit trail captures
+	// caller identity via `actor_id = userCtx.ID` on the emitted
+	// TerminalSessionStarted event so post-hoc attribution works
+	// even though the in-session UID belongs to a different user.
+	// If a deployment needs the no-cross-user variant, add a
+	// `StartTerminal:self` scope that checks the device's
+	// linux_username matches userCtx.LinuxUsername.
 	filterUserID := userFilterID(ctx, "StartTerminal")
 	if _, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{ID: req.Msg.DeviceId, OwnerScope: filterUserID}); err != nil {
 		if store.IsNotFound(err) {

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net"
+	"net/http"
 	"strings"
 
 	"connectrpc.com/connect"
@@ -82,6 +83,41 @@ func isTrustedProxy(addr string) bool {
 		}
 	}
 	return false
+}
+
+// ClientIPFromHTTP is the http.Request analogue of clientIP — used by
+// non-Connect handlers (SCIM, /health, OIDC callback) that need the
+// same trusted-proxy semantics. Falls back to RemoteAddr when proxy
+// headers are absent or the peer isn't in the trusted-proxy CIDR set.
+//
+// Returns the empty string if neither RemoteAddr nor proxy headers
+// yield a parsable IP — callers should treat that as "could not
+// identify" and skip per-IP rate-limit bookkeeping rather than coalesce
+// every anonymous request onto a single bucket.
+func ClientIPFromHTTP(r *http.Request) string {
+	peerAddr := r.RemoteAddr
+	peerIP := peerAddr
+	if host, _, err := net.SplitHostPort(peerAddr); err == nil {
+		peerIP = host
+	}
+	if isTrustedProxy(peerIP) {
+		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+			ip := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0])
+			if parsed := net.ParseIP(ip); parsed != nil {
+				return ip
+			}
+		}
+		if xri := r.Header.Get("X-Real-IP"); xri != "" {
+			ip := strings.TrimSpace(xri)
+			if parsed := net.ParseIP(ip); parsed != nil {
+				return ip
+			}
+		}
+	}
+	if parsed := net.ParseIP(peerIP); parsed != nil {
+		return peerIP
+	}
+	return ""
 }
 
 // clientIP extracts the real client IP. Proxy headers (X-Forwarded-For,

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -152,7 +152,13 @@ func (m *JWTManager) GenerateTOTPChallenge(userID, email string, sessionVersion 
 // ValidateToken validates a JWT token and returns the claims.
 func (m *JWTManager) ValidateToken(tokenString string, expectedType TokenType) (*Claims, error) {
 	token, err := jwt.ParseWithClaims(tokenString, &Claims{}, func(token *jwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+		// Pin the algorithm to HS256 (audit F-14). Accepting any
+		// HMAC family lets an attacker forge a token under HS384 /
+		// HS512 if the shared secret length supports it — issuance
+		// always uses HS256 (jwt.SigningMethodHS256 in GenerateAccessToken
+		// / GenerateRefreshToken / TOTP challenge), so anything else
+		// is by definition forged.
+		if token.Method != jwt.SigningMethodHS256 {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return m.config.Secret, nil

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -5,12 +5,26 @@ import (
 	"time"
 )
 
+// maxRateLimiterKeys caps the size of the per-key attempts map
+// (audit F-20). A distributed attacker sending one request each from
+// many distinct IPs would otherwise grow the map unbounded between
+// cleanup ticks (every 5 minutes). 100k entries is the per-instance
+// ceiling — beyond that the eldest-seen entry is evicted to make
+// room. Set high enough that legitimate IP diversity (a CDN front,
+// large multi-tenant deployment) doesn't bump into it.
+const maxRateLimiterKeys = 100_000
+
 // RateLimiter implements a sliding window rate limiter.
 // It tracks attempts per key (e.g., IP address) and rejects requests
 // that exceed the configured limit within the time window.
 type RateLimiter struct {
 	mu       sync.Mutex
 	attempts map[string][]time.Time
+	// lastSeen tracks the most recent attempt timestamp per key so
+	// the LRU eviction in Allow can pick the truly stalest entry
+	// without re-scanning the attempts slices. Kept in lock-step
+	// with attempts — every write to attempts updates this map too.
+	lastSeen map[string]time.Time
 	limit    int
 	window   time.Duration
 	stopCh   chan struct{}
@@ -22,6 +36,7 @@ type RateLimiter struct {
 func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
 	rl := &RateLimiter{
 		attempts: make(map[string][]time.Time),
+		lastSeen: make(map[string]time.Time),
 		limit:    limit,
 		window:   window,
 		stopCh:   make(chan struct{}),
@@ -50,11 +65,40 @@ func (rl *RateLimiter) Allow(key string) bool {
 
 	if len(valid) >= rl.limit {
 		rl.attempts[key] = valid
+		rl.lastSeen[key] = now
 		return false
 	}
 
+	// Enforce the per-instance key cap before insertion. If we're at
+	// the ceiling AND this is a never-seen-before key, evict the
+	// eldest entry. Existing keys are exempt — they just get a fresh
+	// timestamp.
+	if _, exists := rl.attempts[key]; !exists && len(rl.attempts) >= maxRateLimiterKeys {
+		rl.evictEldestLocked()
+	}
+
 	rl.attempts[key] = append(valid, now)
+	rl.lastSeen[key] = now
 	return true
+}
+
+// evictEldestLocked removes the single key with the oldest lastSeen
+// timestamp. Caller must hold rl.mu. O(n) scan — only called on the
+// rare path where the map is at the key ceiling, so the cost lives in
+// the attack scenario rather than the happy path.
+func (rl *RateLimiter) evictEldestLocked() {
+	var eldestKey string
+	var eldestAt time.Time
+	for k, t := range rl.lastSeen {
+		if eldestKey == "" || t.Before(eldestAt) {
+			eldestKey = k
+			eldestAt = t
+		}
+	}
+	if eldestKey != "" {
+		delete(rl.attempts, eldestKey)
+		delete(rl.lastSeen, eldestKey)
+	}
 }
 
 // Stop stops the background cleanup goroutine.
@@ -80,6 +124,7 @@ func (rl *RateLimiter) cleanup() {
 				}
 				if len(valid) == 0 {
 					delete(rl.attempts, key)
+					delete(rl.lastSeen, key)
 				} else {
 					rl.attempts[key] = valid
 				}

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -406,6 +406,27 @@ func (w *InboxWorker) handleExecutionOutputChunk(ctx context.Context, t *asynq.T
 		return fmt.Errorf("unmarshal output chunk: %w", err)
 	}
 
+	// Second-line size guard (audit F-33). The gateway already caps
+	// at 64 KiB on the agent-facing side (handler/agent.go,
+	// maxOutputChunkBytes), but the inbox worker is also a trust
+	// boundary — a future gateway compromise or a buggy intermediate
+	// could otherwise enqueue an oversized chunk into Valkey. We
+	// drop oversized chunks here rather than truncate, matching the
+	// gateway's drop-with-WARN policy, so a fuzz-fed flood doesn't
+	// silently corrupt the visible output stream.
+	const maxOutputChunkInboxBytes = 64 * 1024
+	if len(payload.Data) > maxOutputChunkInboxBytes {
+		w.logger.Warn("inbox: output chunk exceeds size cap; dropping",
+			"device_id", payload.DeviceID,
+			"execution_id", payload.ExecutionID,
+			"stream", payload.Stream,
+			"sequence", payload.Sequence,
+			"size", len(payload.Data),
+			"limit", maxOutputChunkInboxBytes,
+		)
+		return nil
+	}
+
 	return w.store.AppendEvent(ctx, store.Event{
 		StreamType: "execution",
 		StreamID:   payload.ExecutionID,
@@ -809,17 +830,41 @@ func commandOutputToMap(o *pm.CommandOutput) map[string]any {
 	}
 }
 
+// maxCommandOutputBytes is the per-stream ceiling enforced on
+// stdout / stderr before persistence (audit F-33). A compromised
+// agent (or a buggy executor) could otherwise dump multi-MB results
+// into the event store and the Valkey inbox queue, filling
+// events.data and bloating the audit trail. 1 MiB is comfortably
+// above any sane single-execution output — when a stream exceeds
+// it, we keep the head (first MiB) and append a trailing marker so
+// the UI shows what happened. The F-13 per-chunk cap (64 KiB) gates
+// streaming output; F-33 gates the consolidated result payload that
+// the agent emits on completion.
+const maxCommandOutputBytes = 1024 * 1024
+
+// truncateOutputStream caps an output stream at maxCommandOutputBytes
+// and appends an explicit truncation marker so the UI / log readers
+// can tell the difference between "agent emitted exactly N bytes" and
+// "we dropped the tail." Returns the input unchanged when it fits.
+func truncateOutputStream(s string) string {
+	if len(s) <= maxCommandOutputBytes {
+		return s
+	}
+	const marker = "\n... [truncated by control server — output exceeded 1 MiB]"
+	return s[:maxCommandOutputBytes-len(marker)] + marker
+}
+
 // commandOutputPayload converts a CommandOutput proto into the typed
 // payloads.CommandOutput used by the execution-event payload structs.
 // Returns nil for nil input so payloads.RawCommandOutput drops the
-// field via omitempty.
+// field via omitempty. Caps Stdout + Stderr per stream (audit F-33).
 func commandOutputPayload(o *pm.CommandOutput) *payloads.CommandOutput {
 	if o == nil {
 		return nil
 	}
 	return &payloads.CommandOutput{
-		Stdout:   o.Stdout,
-		Stderr:   o.Stderr,
+		Stdout:   truncateOutputStream(o.Stdout),
+		Stderr:   truncateOutputStream(o.Stderr),
 		ExitCode: o.ExitCode,
 	}
 }

--- a/internal/dynamicquery/parser.go
+++ b/internal/dynamicquery/parser.go
@@ -348,7 +348,15 @@ func (p *parser) consumeBareValue() string {
 		}
 		p.pos++
 	}
-	return strings.TrimRight(p.src[start:p.pos], " \t\r\n")
+	// Trim leading + trailing whitespace symmetrically (audit F-12).
+	// The trailing trim alone produced asymmetric behaviour where
+	// `equals  foo` round-tripped as `foo` but `equals foo  ` round-tripped
+	// as `foo` too — fine in isolation, but the asymmetry made it
+	// hard to reason about which side of the operator the
+	// whitespace belonged to. The field allowlist in the validator
+	// kept this from ever being exploitable, but the parser smell
+	// is gone.
+	return strings.TrimSpace(p.src[start:p.pos])
 }
 
 // matchBoundaryKeywordAt reports whether the position is at the start

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -571,6 +571,15 @@ func (h *AgentHandler) proxyLpsRotations(ctx context.Context, deviceID, resultID
 	return nil
 }
 
+// maxOutputChunkBytes is the per-chunk ceiling enforced by the
+// gateway before enqueueing the chunk to the control inbox. Agents
+// are expected to fragment large output internally; a chunk larger
+// than this is either a buggy or compromised agent (audit F-13). The
+// 64 KiB cap matches a single sane terminal/log line and keeps the
+// projection's `executions.output` JSONB column from being filled
+// with megabytes of data via a flood from one stream.
+const maxOutputChunkBytes = 64 * 1024
+
 func (h *AgentHandler) handleOutputChunk(ctx context.Context, deviceID string, chunk *pm.OutputChunk) error {
 	if chunk.ExecutionId == "" {
 		return fmt.Errorf("output chunk missing execution ID")
@@ -578,6 +587,22 @@ func (h *AgentHandler) handleOutputChunk(ctx context.Context, deviceID string, c
 	streamType := "stdout"
 	if chunk.Stream == pm.OutputStreamType_OUTPUT_STREAM_TYPE_STDERR {
 		streamType = "stderr"
+	}
+	// Drop oversized chunks rather than enqueue them. A noisy agent
+	// will repeatedly hit the cap and surface via the WARN log; the
+	// alternative (silently truncating) would corrupt the displayed
+	// output for legitimate cases the agent later fixes by chunking
+	// correctly.
+	if len(chunk.Data) > maxOutputChunkBytes {
+		h.logger.Warn("output chunk exceeds size cap; dropping",
+			"device_id", deviceID,
+			"execution_id", chunk.ExecutionId,
+			"stream", streamType,
+			"sequence", chunk.Sequence,
+			"size", len(chunk.Data),
+			"limit", maxOutputChunkBytes,
+		)
+		return nil
 	}
 	h.logger.Debug("received output chunk",
 		"device_id", deviceID,

--- a/internal/idp/linker.go
+++ b/internal/idp/linker.go
@@ -149,9 +149,17 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider store.IdentityProvid
 		slog.Debug("SSO linker: trying auto-link by email", "email", claims.Email)
 		user, err := l.queries.GetUserByEmail(ctx, claims.Email)
 		if err == nil {
-			slog.Debug("SSO linker: found user by email, creating link",
+			// Info-level log on the actual link (audit F-28) — this
+			// is a trust-boundary event: the IdP's email-verification
+			// posture is what gates account hijack via this path, and
+			// an operator looking at boot logs after enabling
+			// auto-link-by-email must be able to see who gets linked.
+			slog.Info("SSO linker: auto-linked SSO identity to existing local user by email",
 				"user_id", user.ID,
 				"user_email", user.Email,
+				"provider_id", provider.ID,
+				"provider_slug", provider.Slug,
+				"external_subject", claims.Subject,
 			)
 			// Found user by email — create link
 			linkID := newULID()

--- a/internal/middleware/security.go
+++ b/internal/middleware/security.go
@@ -3,6 +3,24 @@ package middleware
 import "net/http"
 
 // SecurityHeaders adds standard security headers to all responses.
+//
+// Content-Security-Policy is intentionally tight (audit F-05): the
+// control server hosts the Connect-RPC API only — never user-supplied
+// HTML or third-party iframes — so 'self'-everything is a safe
+// default. `style-src` keeps `'unsafe-inline'` because Connect-RPC
+// error pages and the test-harness fall back to inline style
+// attributes; tighten further once the surface is audited end-to-end.
+// `frame-ancestors 'none'` overlaps with X-Frame-Options DENY but is
+// the modern equivalent for browsers that ignore the legacy header.
+const contentSecurityPolicy = "default-src 'self'; " +
+	"script-src 'self'; " +
+	"style-src 'self' 'unsafe-inline'; " +
+	"img-src 'self' data:; " +
+	"connect-src 'self'; " +
+	"frame-ancestors 'none'; " +
+	"base-uri 'self'; " +
+	"form-action 'self'"
+
 func SecurityHeaders(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Frame-Options", "DENY")
@@ -10,6 +28,7 @@ func SecurityHeaders(next http.Handler) http.Handler {
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("X-XSS-Protection", "0")
 		w.Header().Set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+		w.Header().Set("Content-Security-Policy", contentSecurityPolicy)
 		if r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https" {
 			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		}

--- a/internal/scim/auth.go
+++ b/internal/scim/auth.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/crypto/bcrypt"
 
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -52,6 +53,23 @@ func (h *Handler) withAuth(next http.HandlerFunc) http.HandlerFunc {
 			h.logger.Warn("SCIM rate limit exceeded", "slug", slug, "method", r.Method, "path", r.URL.Path)
 			writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
 			return
+		}
+		// Secondary rate-limit bucket keyed on (slug, client IP) so an
+		// attacker that distributes requests across multiple known
+		// slugs cannot evade the per-slug cap (audit F-08). The IP
+		// fallback path returns "" for unparsable RemoteAddr — coalescing
+		// those onto a single bucket would let a misconfigured deploy
+		// rate-limit everyone to 20/min, so we skip the IP gate when
+		// the address can't be identified and rely on the slug limit
+		// + the underlying TCP-level peer accounting.
+		if ip := auth.ClientIPFromHTTP(r); ip != "" {
+			if !h.ipRateLimiter.Allow(slug + "|" + ip) {
+				h.logger.Warn("SCIM per-IP rate limit exceeded",
+					"slug", slug, "client_ip", ip,
+					"method", r.Method, "path", r.URL.Path)
+				writeError(w, http.StatusTooManyRequests, "rate limit exceeded")
+				return
+			}
 		}
 
 		// Look up provider by slug with SCIM enabled

--- a/internal/scim/handler.go
+++ b/internal/scim/handler.go
@@ -39,10 +39,19 @@ type SystemActionsCleaner interface {
 }
 
 // Handler handles SCIM v2 API requests.
+//
+// Two rate-limit buckets per request (audit F-08):
+//   - rateLimiter   — keyed on the provider slug, generous 100/min ceiling
+//     so a real SCIM sync (list users → upsert users → patch groups)
+//     never bumps into the limit
+//   - ipRateLimiter — keyed on the (slug, client IP) tuple, tighter
+//     20/min ceiling so an attacker that knows multiple valid slugs
+//     can't spread requests across slugs to bypass the per-slug limit
 type Handler struct {
 	store         *store.Store
 	logger        *slog.Logger
 	rateLimiter   *auth.RateLimiter
+	ipRateLimiter *auth.RateLimiter
 	systemActions SystemActionsCleaner // optional; nil = no cleanup on delete
 }
 
@@ -57,6 +66,7 @@ func NewHandler(st *store.Store, logger *slog.Logger, systemActions SystemAction
 		store:         st,
 		logger:        logger,
 		rateLimiter:   auth.NewRateLimiter(100, 1*time.Minute),
+		ipRateLimiter: auth.NewRateLimiter(20, 1*time.Minute),
 		systemActions: systemActions,
 	}
 


### PR DESCRIPTION
## Summary

Triaged the 30 findings in `SECURITY_AUDIT.md` and implemented the 12 that are valid, scoped, and don't require cross-service infrastructure work.

## Implemented

### High-severity hardening
- **F-04** — constant-time cert fingerprint compare (`internal/api/certificate_handler.go:66`)
- **F-05** — Content-Security-Policy header with `frame-ancestors 'none'`, `base-uri 'self'`, `form-action 'self'` (`internal/middleware/security.go`)
- **F-14** — pin JWT validator to exact `HS256` (`internal/auth/jwt.go:155`)
- **F-03** — Valkey password out of `/proc/<pid>/cmdline`: rendered config file (mode `0400`) + healthcheck via `REDISCLI_AUTH` (`deploy/compose.yml`, `deploy/setup.sh`, `deploy/valkey.conf.template`)

### Medium / defence-in-depth
- **F-08** — SCIM secondary rate-limit bucket keyed on `(slug, client IP)`, ceiling `20/min`. Closes the slug-spreading bypass.
- **F-15** — SSO redirect URL same-origin allowlist (loopback exempted for `pm-enroll`).
- **F-28** — info-level log on auto-link-by-email + doc comment warning the flag makes the IdP's email-verification policy a trust dependency. Proto default already `false`.

### Low / informational
- **F-13** — cap `OutputChunk` at 64 KiB, drop oversized with WARN.
- **F-20** — rate-limiter `100k` LRU key cap to bound memory under wide-IP-distribution attacks.
- **F-26** — public `/health` returns `ok`, no version leak.
- **F-27** — documented unscoped `StartTerminal` cross-user behaviour + recipe for `StartTerminal:self`.
- **F-12** — symmetric whitespace trim in dynamic-query bare-value consumer.

## Skipped (18)

Full reasoning in the commit body. Key ones:

- **F-02 (CRITICAL — Asynq task payload signing)** is genuinely valid but needs cross-service HMAC infrastructure (env var on control + gateway, sign/verify layers, deployment migration). The realistic exploit surface is the terminal-input / osquery dispatch path — the action-dispatch path is already gated by the agent's signature check. **Worth a focused follow-up PR.**
- **F-07** (backup-code race) blocks on the sqlc version-drift issue tracked in #308.
- **F-17** (encryptor warning) already implemented; verified.
- **F-19** (cert PEM in registration event) conflicts with documented design intent.
- The rest are either by-design (F-01, F-11, F-22), need tooling (F-18, F-29), operator-deployment concerns (F-23, F-25), or are out of scope (web tooling, contradictions in the audit itself).

## Test plan

- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [x] `internal/dynamicquery` + `internal/auth` tests green (covers F-12 + F-14 + F-20 behaviour)
- [ ] CI: full suite + CodeRabbit
- [ ] **Deployment note**: operators must re-run `deploy/setup.sh` once after upgrade to render `valkey.conf` from the new template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redirect URL validation for SSO login flows.
  * Per-IP rate limiting for SCIM API requests.
  * Content-Security-Policy header added.
  * 64 KiB live-chunk cap and 1 MiB per-command output storage cap with explicit truncation marker.

* **Security Enhancements**
  * Constant-time certificate fingerprint comparison.
  * JWT signing algorithm restricted to HS256.
  * Deployment config rendered and mounted to avoid exposing secrets on command lines; healthcheck hardened.

* **Tests**
  * Audit redaction schema tests aligned with wire-format field names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->