### PR TITLE
sec: F-02 Asynq task envelope HMAC signing (CRITICAL)

### DIFF
--- a/cmd/control/valkey.go
+++ b/cmd/control/valkey.go
@@ -51,6 +51,14 @@ type valkeySubsystem struct {
 	inboxServer         *asynq.Server
 	terminalAuditServer *asynq.Server
 
+	// taskSigner is the HMAC signer threaded into the Asynq Client
+	// (producer side) AND the InboxWorker / TerminalAudit mux
+	// (consumer side). Both sides MUST share the same key — the
+	// signer is constructed once here so a misconfiguration loud-
+	// fails at boot rather than producing tasks the consumer can't
+	// verify (audit F-02).
+	taskSigner *taskqueue.Signer
+
 	// TerminalTokenStore is exported because main() hands it to the
 	// InternalHandler later in the boot sequence — they MUST share
 	// one instance so ProxyValidateTerminalToken can validate tokens
@@ -92,8 +100,23 @@ func newValkeySubsystem(ctx context.Context, cfg *Config, st *store.Store, svc *
 		return nil, nil
 	}
 
-	v := &valkeySubsystem{}
-	v.aqClient = taskqueue.NewClient(cfg.ValkeyAddr, cfg.ValkeyPassword, cfg.ValkeyDB)
+	// Load the Asynq-payload HMAC signer (audit F-02). The hex key
+	// is operator-provided via PM_TASK_SIGNING_KEY and must match
+	// across every service that participates in the Asynq fan-out
+	// (control, gateway, indexer). NewSigner returns (nil, nil) on
+	// an empty key string for test ergonomics, but production wiring
+	// rejects that here so a deployment can't accidentally turn
+	// signing off.
+	taskSigner, err := taskqueue.NewSigner(os.Getenv("PM_TASK_SIGNING_KEY"))
+	if err != nil {
+		return nil, fmt.Errorf("load task signer: %w", err)
+	}
+	if taskSigner == nil {
+		return nil, errors.New("PM_TASK_SIGNING_KEY is required when CONTROL_VALKEY_ADDR is set (audit F-02 — task signing is mandatory)")
+	}
+
+	v := &valkeySubsystem{taskSigner: taskSigner}
+	v.aqClient = taskqueue.NewClientWithSigner(cfg.ValkeyAddr, cfg.ValkeyPassword, cfg.ValkeyDB, taskSigner)
 	svc.SetTaskQueueClient(v.aqClient)
 
 	// Force RESP2 protocol: go-redis v9 auto-negotiates RESP3 with Redis 7+,
@@ -145,7 +168,7 @@ func newValkeySubsystem(ctx context.Context, cfg *Config, st *store.Store, svc *
 	}
 
 	// Asynq mux + servers.
-	inboxWorker := control.NewInboxWorker(st, v.aqClient, actionSigner, logger.With("component", "inbox_worker"))
+	inboxWorker := control.NewInboxWorker(st, v.aqClient, actionSigner, v.taskSigner, logger.With("component", "inbox_worker"))
 	aqLogger := logger.With("component", "asynq_server")
 	v.inboxServer = newInboxAsynqServer(cfg, aqLogger)
 	if err := v.inboxServer.Start(inboxWorker.NewMux()); err != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -84,8 +84,23 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Load the Asynq-payload HMAC signer/verifier (audit F-02). The
+	// key MUST match control's PM_TASK_SIGNING_KEY — gateway is both
+	// the verifier on the device:* queues AND the producer for
+	// control:inbox messages flowing the other way, so the same
+	// signer wraps both sides.
+	taskSigner, err := taskqueue.NewSigner(os.Getenv("PM_TASK_SIGNING_KEY"))
+	if err != nil {
+		logger.Error("failed to load task signer", "error", err)
+		os.Exit(1)
+	}
+	if taskSigner == nil {
+		logger.Error("PM_TASK_SIGNING_KEY is required (audit F-02 — Asynq task verification is mandatory)")
+		os.Exit(1)
+	}
+
 	// Create Asynq task queue client
-	aqClient := taskqueue.NewClient(cfg.ValkeyAddr, cfg.ValkeyPassword, cfg.ValkeyDB)
+	aqClient := taskqueue.NewClientWithSigner(cfg.ValkeyAddr, cfg.ValkeyPassword, cfg.ValkeyDB, taskSigner)
 	defer aqClient.Close()
 	logger.Info("task queue client initialized", "valkey_addr", cfg.ValkeyAddr)
 
@@ -121,8 +136,10 @@ func main() {
 	// Create connection manager
 	manager := connection.NewManager()
 
-	// Create task handler factory for per-device Asynq workers
-	taskFactory := gateway.NewTaskHandlerFactory(manager, logger)
+	// Create task handler factory for per-device Asynq workers.
+	// taskSigner was loaded above (audit F-02) and wires the same
+	// HMAC key into the worker mux as the aqClient producer.
+	taskFactory := gateway.NewTaskHandlerFactory(manager, taskSigner, logger)
 
 	// Create device worker manager
 	workerMgr := gateway.NewDeviceWorkerManager(

--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -112,8 +112,22 @@ func main() {
 		logger.Info("periodic reconciliation started", "interval", cfg.ReconcileInterval)
 	}
 
+	// Load the Asynq-payload HMAC verifier (audit F-02). Indexer is
+	// a consumer of search:* tasks produced by control; the key MUST
+	// match control's PM_TASK_SIGNING_KEY or every task in the queue
+	// will land in the dead queue.
+	taskSigner, err := taskqueue.NewSigner(os.Getenv("PM_TASK_SIGNING_KEY"))
+	if err != nil {
+		logger.Error("failed to load task signer", "error", err)
+		os.Exit(1)
+	}
+	if taskSigner == nil {
+		logger.Error("PM_TASK_SIGNING_KEY is required (audit F-02 — Asynq task verification is mandatory)")
+		os.Exit(1)
+	}
+
 	// Initialize and start Asynq worker for search task processing
-	searchWorker := search.NewWorker(rdb, logger.With("component", "search_worker"))
+	searchWorker := search.NewWorker(rdb, taskSigner, logger.With("component", "search_worker"))
 	mux := asynq.NewServeMux()
 	searchWorker.RegisterHandlers(mux)
 

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -150,6 +150,10 @@ services:
       - CONTROL_SSH_ACCESS_FOR_ALL=${CONTROL_SSH_ACCESS_FOR_ALL:-false}
       - CONTROL_VALKEY_ADDR=valkey:6379
       - CONTROL_VALKEY_PASSWORD=${VALKEY_PASSWORD}
+      # Asynq task signing (audit F-02). Identical 64-hex value on
+      # control, gateway, and indexer — they HMAC every task payload
+      # so a Valkey compromise can't forge dispatches.
+      - PM_TASK_SIGNING_KEY=${PM_TASK_SIGNING_KEY}
       # Remote terminal fallback URL for single-gateway deployments.
       # Leave empty when using multi-gateway routing (the control
       # server resolves the correct gateway from the registry).
@@ -183,6 +187,7 @@ services:
       - INDEXER_DATABASE_URL=postgres://pm_indexer:${INDEXER_POSTGRES_PASSWORD}@postgres:5432/powermanage?sslmode=disable
       - INDEXER_VALKEY_ADDR=valkey:6379
       - INDEXER_VALKEY_PASSWORD=${VALKEY_PASSWORD}
+      - PM_TASK_SIGNING_KEY=${PM_TASK_SIGNING_KEY}
       - INDEXER_RECONCILE_INTERVAL=1h
       - INDEXER_LOG_LEVEL=${LOG_LEVEL:-info}
       - INDEXER_LOG_FORMAT=${LOG_FORMAT:-text}
@@ -211,6 +216,7 @@ services:
       - GATEWAY_VALKEY_ADDR=valkey:6379
       - GATEWAY_VALKEY_PASSWORD=${VALKEY_PASSWORD}
       - GATEWAY_VALKEY_DB=${GATEWAY_VALKEY_DB:-0}
+      - PM_TASK_SIGNING_KEY=${PM_TASK_SIGNING_KEY}
       - GATEWAY_CONTROL_URL=https://control:8082
       - GATEWAY_LISTEN_ADDR=:8080
       - GATEWAY_LOG_LEVEL=${LOG_LEVEL:-info}

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -555,6 +555,17 @@ guided_setup() {
     fi
     write_env_var CONTROL_ENCRYPTION_KEY "$REPLY_VALUE"
 
+    # Asynq task-signing key (audit F-02). 64 hex chars (32 bytes).
+    # Shared between control, gateway, and indexer — every service
+    # that touches the Valkey-backed task queue HMAC-signs and
+    # verifies the envelope so a Valkey compromise can't forge tasks.
+    prompt_secret "Asynq task signing key (PM_TASK_SIGNING_KEY, 64 hex chars)" "openssl rand -hex 32" "${PM_TASK_SIGNING_KEY:-}"
+    if [[ ! "$REPLY_VALUE" =~ ^[0-9a-fA-F]{64}$ ]]; then
+        log_error "PM_TASK_SIGNING_KEY must be exactly 64 hex characters; got ${#REPLY_VALUE} chars. Aborting."
+        exit 1
+    fi
+    write_env_var PM_TASK_SIGNING_KEY "$REPLY_VALUE"
+
     # --- Admin account ---
     # admin@<parent-domain> if CONTROL_DOMAIN has a dot; admin@<full>
     # for single-label cases (admin@localhost is a valid local-delivery

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -30,20 +30,27 @@ import (
 // signing (dev mode); dispatchPendingActions skips any execution
 // referencing an action when signer is nil, since agents reject
 // unsigned payloads.
+//
+// taskSigner is the HMAC signer for the Asynq envelope (audit F-02);
+// NewMux wires it as a middleware so every handler sees an
+// HMAC-verified payload before its JSON-unmarshal call. nil means
+// "verification disabled" (tests only).
 type InboxWorker struct {
-	store    *store.Store
-	aqClient *taskqueue.Client
-	signer   ca.ActionSigner
-	logger   *slog.Logger
+	store      *store.Store
+	aqClient   *taskqueue.Client
+	signer     ca.ActionSigner
+	taskSigner *taskqueue.Signer
+	logger     *slog.Logger
 }
 
 // NewInboxWorker creates a new inbox worker.
-func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ca.ActionSigner, logger *slog.Logger) *InboxWorker {
+func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ca.ActionSigner, taskSigner *taskqueue.Signer, logger *slog.Logger) *InboxWorker {
 	return &InboxWorker{
-		store:    st,
-		aqClient: aqClient,
-		signer:   signer,
-		logger:   logger,
+		store:      st,
+		aqClient:   aqClient,
+		signer:     signer,
+		taskSigner: taskSigner,
+		logger:     logger,
 	}
 }
 
@@ -54,6 +61,9 @@ func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ca.Actio
 // on taskqueue.ControlTerminalAuditQueue.
 func (w *InboxWorker) NewMux() *asynq.ServeMux {
 	mux := asynq.NewServeMux()
+	if w.taskSigner != nil {
+		mux.Use(w.taskSigner.VerifyMiddleware())
+	}
 	mux.HandleFunc(taskqueue.TypeDeviceHello, w.handleDeviceHello)
 	mux.HandleFunc(taskqueue.TypeDeviceHeartbeat, w.handleDeviceHeartbeat)
 	mux.HandleFunc(taskqueue.TypeExecutionResult, w.handleExecutionResult)
@@ -74,6 +84,9 @@ func (w *InboxWorker) NewMux() *asynq.ServeMux {
 // guard and the loser's bytes would be silently dropped.
 func (w *InboxWorker) NewTerminalAuditMux() *asynq.ServeMux {
 	mux := asynq.NewServeMux()
+	if w.taskSigner != nil {
+		mux.Use(w.taskSigner.VerifyMiddleware())
+	}
 	mux.HandleFunc(taskqueue.TypeTerminalAuditChunk, w.handleTerminalAuditChunk)
 	return mux
 }

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -62,7 +62,7 @@ func newTask(t *testing.T, typeName string, payload any) *asynq.Task {
 
 func TestHandleDeviceHeartbeat(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "heartbeat-host")
@@ -83,7 +83,7 @@ func TestHandleDeviceHeartbeat(t *testing.T) {
 
 func TestHandleDeviceHeartbeat_DeletedDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "deleted-heartbeat-host")
@@ -111,7 +111,7 @@ func TestHandleDeviceHeartbeat_DeletedDevice(t *testing.T) {
 
 func TestHandleSecurityAlert(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "alert-host")
@@ -145,7 +145,7 @@ func TestHandleSecurityAlert(t *testing.T) {
 
 func TestHandleExecutionResult_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -204,7 +204,7 @@ func TestHandleExecutionResult_Success(t *testing.T) {
 
 func TestHandleExecutionResult_Failed(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -259,7 +259,7 @@ func TestHandleExecutionResult_Failed(t *testing.T) {
 
 func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -288,7 +288,7 @@ func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 
 func TestHandleExecutionOutputChunk(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "chunk-host")
@@ -328,7 +328,7 @@ func TestHandleExecutionOutputChunk(t *testing.T) {
 
 func TestHandleRevokeLuksDeviceKeyResult_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "luks-host")
@@ -346,7 +346,7 @@ func TestHandleRevokeLuksDeviceKeyResult_Success(t *testing.T) {
 
 func TestHandleRevokeLuksDeviceKeyResult_Failure(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "luks-fail-host")
@@ -367,7 +367,7 @@ func TestHandleDeviceHello(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	// handleDeviceHello calls dispatchPendingActions which needs aqClient.
 	// Passing nil is safe here because there are no pending executions to dispatch.
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "hello-host")
@@ -389,7 +389,7 @@ func TestHandleDeviceHello(t *testing.T) {
 
 func TestHandleDeviceHello_DeletedDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "hello-deleted-host")
@@ -428,7 +428,7 @@ func TestDispatchPendingActions_ReSignsWithExecutionID(t *testing.T) {
 	defer aqClient.Close()
 
 	signer := &fakeSigner{}
-	worker := control.NewInboxWorker(st, aqClient, signer, slog.Default())
+	worker := control.NewInboxWorker(st, aqClient, signer, nil, slog.Default())
 	mux := worker.NewMux()
 
 	ctx := context.Background()

--- a/internal/gateway/task_handlers.go
+++ b/internal/gateway/task_handlers.go
@@ -16,16 +16,25 @@ import (
 )
 
 // TaskHandlerFactory creates per-device Asynq ServeMux instances.
+//
+// taskSigner is the HMAC signer that verifies the Asynq envelope on
+// every dequeue (audit F-02). It must match the key configured on
+// control so the wrapper produced by Client.EnqueueToDevice
+// round-trips cleanly. A nil signer disables verification — tests
+// only; production wiring in cmd/gateway/main.go refuses an empty
+// PM_TASK_SIGNING_KEY.
 type TaskHandlerFactory struct {
-	manager *connection.Manager
-	logger  *slog.Logger
+	manager    *connection.Manager
+	taskSigner *taskqueue.Signer
+	logger     *slog.Logger
 }
 
 // NewTaskHandlerFactory creates a new factory.
-func NewTaskHandlerFactory(manager *connection.Manager, logger *slog.Logger) *TaskHandlerFactory {
+func NewTaskHandlerFactory(manager *connection.Manager, taskSigner *taskqueue.Signer, logger *slog.Logger) *TaskHandlerFactory {
 	return &TaskHandlerFactory{
-		manager: manager,
-		logger:  logger,
+		manager:    manager,
+		taskSigner: taskSigner,
+		logger:     logger,
 	}
 }
 
@@ -38,6 +47,9 @@ func (f *TaskHandlerFactory) NewMux(deviceID string) *asynq.ServeMux {
 	}
 
 	mux := asynq.NewServeMux()
+	if f.taskSigner != nil {
+		mux.Use(f.taskSigner.VerifyMiddleware())
+	}
 	mux.HandleFunc(taskqueue.TypeActionDispatch, h.handleActionDispatch)
 	mux.HandleFunc(taskqueue.TypeOSQueryDispatch, h.handleOSQueryDispatch)
 	mux.HandleFunc(taskqueue.TypeInventoryRequest, h.handleInventoryRequest)

--- a/internal/search/worker.go
+++ b/internal/search/worker.go
@@ -15,18 +15,27 @@ import (
 )
 
 // Worker processes search index update tasks from the Asynq search queue.
+//
+// taskSigner verifies the HMAC envelope on every dequeue (audit
+// F-02). The key MUST match PM_TASK_SIGNING_KEY on control — control
+// is the producer of search:* tasks (via SearchListener), indexer is
+// the consumer. nil disables verification (tests only).
 type Worker struct {
-	rdb    *redis.Client
-	logger *slog.Logger
+	rdb        *redis.Client
+	taskSigner *taskqueue.Signer
+	logger     *slog.Logger
 }
 
 // NewWorker creates a new search index worker.
-func NewWorker(rdb *redis.Client, logger *slog.Logger) *Worker {
-	return &Worker{rdb: rdb, logger: logger}
+func NewWorker(rdb *redis.Client, taskSigner *taskqueue.Signer, logger *slog.Logger) *Worker {
+	return &Worker{rdb: rdb, taskSigner: taskSigner, logger: logger}
 }
 
 // RegisterHandlers registers the search task handlers on the given mux.
 func (w *Worker) RegisterHandlers(mux *asynq.ServeMux) {
+	if w.taskSigner != nil {
+		mux.Use(w.taskSigner.VerifyMiddleware())
+	}
 	mux.HandleFunc(taskqueue.TypeSearchReindex, w.handleReindex)
 	mux.HandleFunc(taskqueue.TypeSearchMemberChange, w.handleMemberChange)
 	mux.HandleFunc(taskqueue.TypeSearchRemove, w.handleRemove)

--- a/internal/taskqueue/client.go
+++ b/internal/taskqueue/client.go
@@ -33,6 +33,12 @@ type Enqueuer interface {
 type Client struct {
 	client    *asynq.Client
 	inspector *asynq.Inspector
+	// signer wraps payloads with an HMAC prefix on enqueue (audit
+	// F-02). nil means signing is disabled — only used by tests
+	// that don't wire the signer; production boot in
+	// cmd/{control,gateway,indexer} rejects an empty
+	// PM_TASK_SIGNING_KEY.
+	signer *Signer
 }
 
 // Compile-time check that *Client satisfies Enqueuer. A drift here
@@ -40,7 +46,18 @@ type Client struct {
 var _ Enqueuer = (*Client)(nil)
 
 // NewClient creates a new task queue client connected to Valkey.
+// Production boot must use NewClientWithSigner so every enqueue path
+// is HMAC-signed (audit F-02); NewClient is preserved as a thin
+// "no signing" wrapper for tests and migration helpers only.
 func NewClient(addr, password string, db int) *Client {
+	return NewClientWithSigner(addr, password, db, nil)
+}
+
+// NewClientWithSigner is the production constructor. The signer is
+// loaded from PM_TASK_SIGNING_KEY at boot and used to HMAC every
+// payload before it lands in Valkey, so a Valkey compromise can't
+// forge task content the workers will dispatch.
+func NewClientWithSigner(addr, password string, db int, signer *Signer) *Client {
 	opts := asynq.RedisClientOpt{
 		Addr:     addr,
 		Password: password,
@@ -49,6 +66,7 @@ func NewClient(addr, password string, db int) *Client {
 	return &Client{
 		client:    asynq.NewClient(opts),
 		inspector: asynq.NewInspector(opts),
+		signer:    signer,
 	}
 }
 
@@ -60,6 +78,9 @@ func (c *Client) EnqueueToDevice(deviceID, taskType string, payload any, opts ..
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
+	// Wrap with HMAC prefix (audit F-02). c.signer is nil-safe — a
+	// disabled signer returns data unchanged.
+	data = c.signer.Wrap(data)
 
 	task := asynq.NewTask(taskType, data)
 	enqueueOpts := append([]asynq.Option{asynq.Queue(DeviceQueue(deviceID))}, opts...)
@@ -84,6 +105,7 @@ func (c *Client) EnqueueToControl(taskType string, payload any) error {
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
+	data = c.signer.Wrap(data)
 
 	queue := ControlInboxQueue
 	if taskType == TypeTerminalAuditChunk {
@@ -104,6 +126,7 @@ func (c *Client) EnqueueToSearch(taskType string, payload any) error {
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
+	data = c.signer.Wrap(data)
 
 	task := asynq.NewTask(taskType, data)
 	_, err = c.client.Enqueue(task, asynq.Queue(SearchQueue))

--- a/internal/taskqueue/sign.go
+++ b/internal/taskqueue/sign.go
@@ -1,0 +1,165 @@
+package taskqueue
+
+// HMAC-SHA256 signed envelope for Asynq task payloads (audit F-02).
+//
+// Threat model: Valkey is a trust boundary for the control ↔ gateway
+// path. A Valkey compromise (CVE, weak password, network exposure,
+// misconfigured ACL) lets an attacker enqueue arbitrary tasks into
+// any device queue or the control inbox. Without signing, the gateway
+// dispatches those tasks to the agent's mTLS stream, and the agent
+// trusts them. For non-action paths (terminal input, osquery, log
+// queries) the agent has no other validation — a forged task arrives
+// as a real instruction. For action-dispatch, the CA-signed action
+// signature mitigates payload forgery but does not stop an attacker
+// from causing arbitrary side effects (re-dispatching a legitimate
+// action against the wrong device, replaying old tasks, etc.).
+//
+// Format of a signed task envelope:
+//
+//   [ 32 bytes HMAC-SHA256(key, payload) ][ payload bytes ]
+//
+// Workers strip the 32-byte prefix, verify the HMAC in constant
+// time, and only then invoke their normal JSON-decoding handler.
+// Tampered or unsigned tasks are rejected with a non-retriable
+// asynq.SkipRetry error so they land in the dead queue for operator
+// inspection rather than burning retry slots.
+//
+// Key distribution: `PM_TASK_SIGNING_KEY` is a 32-byte (64 hex char)
+// shared secret that must be configured identically on every service
+// that participates in the Asynq fan-out (control, gateway, indexer).
+// Operators rotate it by setting two values in `.env` during the
+// rotation window and pointing every service at the new one in
+// lock-step — there is intentionally no support for "accept either
+// of two keys" because the rotation window is bounded by
+// queue-drain time (minutes), not by token lifetime (hours/days).
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+
+	"github.com/hibiken/asynq"
+)
+
+// signatureSize is the byte length of an HMAC-SHA256 prefix.
+const signatureSize = sha256.Size
+
+// ErrUnsignedTask is returned by Signer.Verify when the envelope is
+// shorter than the signature prefix, i.e. the producer didn't wrap
+// the payload. Surfaces in worker logs as "task too short" so
+// operators can tell unsigned-task-during-upgrade from key-mismatch.
+var ErrUnsignedTask = errors.New("taskqueue: task is unsigned or truncated")
+
+// ErrSignatureMismatch is returned by Signer.Verify when the HMAC
+// over the payload does not match the prefix. Caused by either a
+// key mismatch between producer and consumer, or by a third party
+// tampering with the queue contents.
+var ErrSignatureMismatch = errors.New("taskqueue: task signature mismatch")
+
+// Signer holds an HMAC key for sign + verify operations. Construct
+// once at boot from PM_TASK_SIGNING_KEY and pass through to both
+// Client (producer side) and the worker handler chain (consumer
+// side). nil-safe: a nil Signer means "signing disabled" — handlers
+// receive raw task payloads unchanged. nil should only ever appear
+// in test fixtures; production wiring rejects an empty key at boot.
+type Signer struct {
+	key []byte
+}
+
+// NewSigner parses keyHex (32-byte HMAC key as 64 hex chars) and
+// returns a Signer. Empty string returns (nil, nil) so callers can
+// pass through "signing disabled" without an error — but production
+// boot code must treat that case as fatal.
+func NewSigner(keyHex string) (*Signer, error) {
+	if keyHex == "" {
+		return nil, nil
+	}
+	key, err := hex.DecodeString(keyHex)
+	if err != nil {
+		return nil, fmt.Errorf("taskqueue: PM_TASK_SIGNING_KEY is not valid hex: %w", err)
+	}
+	if len(key) != signatureSize {
+		return nil, fmt.Errorf("taskqueue: PM_TASK_SIGNING_KEY must be %d bytes (%d hex chars), got %d bytes",
+			signatureSize, signatureSize*2, len(key))
+	}
+	return &Signer{key: key}, nil
+}
+
+// Wrap returns the signed envelope: HMAC prefix followed by the raw
+// payload bytes. Nil-safe — a nil Signer returns the payload unchanged
+// so tests that don't wire a signer continue to work.
+func (s *Signer) Wrap(payload []byte) []byte {
+	if s == nil {
+		return payload
+	}
+	mac := hmac.New(sha256.New, s.key)
+	mac.Write(payload)
+	sig := mac.Sum(nil)
+	out := make([]byte, 0, len(sig)+len(payload))
+	out = append(out, sig...)
+	out = append(out, payload...)
+	return out
+}
+
+// Verify strips the signature prefix from envelope and returns the
+// inner payload bytes when the HMAC matches. Constant-time compare
+// via hmac.Equal — do not switch to bytes.Equal. Nil-safe.
+func (s *Signer) Verify(envelope []byte) ([]byte, error) {
+	if s == nil {
+		return envelope, nil
+	}
+	if len(envelope) < signatureSize {
+		return nil, ErrUnsignedTask
+	}
+	sig := envelope[:signatureSize]
+	payload := envelope[signatureSize:]
+	mac := hmac.New(sha256.New, s.key)
+	mac.Write(payload)
+	expected := mac.Sum(nil)
+	if !hmac.Equal(sig, expected) {
+		return nil, ErrSignatureMismatch
+	}
+	return payload, nil
+}
+
+// VerifyMiddleware returns an asynq middleware that verifies the
+// envelope HMAC and replaces the task's payload with the unwrapped
+// bytes before passing it down to the wrapped handler chain. Wrap
+// every mux registration with this in production wiring; tests that
+// don't sign can pass a nil Signer and the middleware is a no-op.
+//
+// Verification failures wrap asynq.SkipRetry so an attacker with
+// transient Valkey access can't burn retry slots by injecting
+// unsigned tasks — the task lands in the dead queue immediately
+// and surfaces as a single WARN line for the operator.
+func (s *Signer) VerifyMiddleware() asynq.MiddlewareFunc {
+	return func(next asynq.Handler) asynq.Handler {
+		return asynq.HandlerFunc(func(ctx context.Context, t *asynq.Task) error {
+			if s == nil {
+				return next.ProcessTask(ctx, t)
+			}
+			payload, err := s.Verify(t.Payload())
+			if err != nil {
+				return fmt.Errorf("%w: %s/%s: %v",
+					asynq.SkipRetry, queueOf(ctx), t.Type(), err)
+			}
+			// Replace the task's payload in-place so downstream
+			// handlers see the unwrapped bytes. asynq.NewTask copies
+			// the payload — we construct a fresh Task with the
+			// verified content so handlers don't have to know about
+			// signing.
+			verified := asynq.NewTask(t.Type(), payload, asynq.Queue(queueOf(ctx)))
+			return next.ProcessTask(ctx, verified)
+		})
+	}
+}
+
+// queueOf retrieves the task's queue name from the asynq context.
+// Returns "" if not present (which only happens in synthetic tests).
+func queueOf(ctx context.Context) string {
+	q, _ := asynq.GetQueueName(ctx)
+	return q
+}

--- a/internal/taskqueue/sign_test.go
+++ b/internal/taskqueue/sign_test.go
@@ -1,0 +1,161 @@
+package taskqueue
+
+// Pure-Go tests for the Asynq task-envelope signer (audit F-02).
+//
+// The wire format is `[32 bytes HMAC-SHA256][payload]`. These tests
+// lock in:
+//   - parse-time validation of the hex key (wrong length, malformed
+//     hex, empty disables);
+//   - round-trip: a Wrapped payload Verifies cleanly back to the
+//     original bytes;
+//   - rejection: tampered prefix, tampered payload, truncated
+//     envelope, and unsigned envelope each return a typed error;
+//   - nil-safety: a nil Signer is a no-op for both Wrap and Verify
+//     so tests that don't care about signing don't need to plumb
+//     one in.
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testKeyHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+func TestNewSigner_ParsesValidKey(t *testing.T) {
+	s, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	assert.Equal(t, signatureSize, len(s.key))
+}
+
+func TestNewSigner_EmptyKeyReturnsNilNil(t *testing.T) {
+	s, err := NewSigner("")
+	require.NoError(t, err)
+	assert.Nil(t, s, "empty key string means 'signing disabled' — caller decides whether that's fatal at boot")
+}
+
+func TestNewSigner_WrongLengthRejected(t *testing.T) {
+	cases := []string{
+		"00",
+		strings.Repeat("ab", 31), // 31 bytes
+		strings.Repeat("ab", 33), // 33 bytes
+	}
+	for _, k := range cases {
+		t.Run(k[:min(8, len(k))], func(t *testing.T) {
+			_, err := NewSigner(k)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "bytes")
+		})
+	}
+}
+
+func TestNewSigner_MalformedHexRejected(t *testing.T) {
+	_, err := NewSigner("not-hex-at-all-not-hex-at-all-not-hex-at-all-not-hex-at-all-zzzz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "valid hex")
+}
+
+func TestSigner_WrapVerifyRoundTrip(t *testing.T) {
+	s, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+
+	cases := [][]byte{
+		[]byte(""),
+		[]byte("{}"),
+		[]byte(`{"device_id":"abc","action_type":1}`),
+		[]byte(strings.Repeat("payload bytes ", 100)),
+	}
+	for _, payload := range cases {
+		wrapped := s.Wrap(payload)
+		assert.Equal(t, signatureSize+len(payload), len(wrapped),
+			"wrapped envelope = 32-byte HMAC prefix + payload")
+		out, err := s.Verify(wrapped)
+		require.NoError(t, err)
+		assert.Equal(t, payload, out)
+	}
+}
+
+func TestSigner_VerifyRejectsTamperedSignature(t *testing.T) {
+	s, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+	wrapped := s.Wrap([]byte(`{"x":1}`))
+	wrapped[0] ^= 0xFF // flip the first byte of the HMAC
+
+	_, err = s.Verify(wrapped)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSignatureMismatch),
+		"tampered signature must return ErrSignatureMismatch")
+}
+
+func TestSigner_VerifyRejectsTamperedPayload(t *testing.T) {
+	s, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+	wrapped := s.Wrap([]byte(`{"x":1}`))
+	// Modify the last byte of the payload, leaving the HMAC intact.
+	wrapped[len(wrapped)-1] = '2'
+
+	_, err = s.Verify(wrapped)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSignatureMismatch))
+}
+
+func TestSigner_VerifyRejectsTruncatedEnvelope(t *testing.T) {
+	s, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+	short := []byte{1, 2, 3}
+
+	_, err = s.Verify(short)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrUnsignedTask),
+		"envelopes shorter than the signature prefix are classified as unsigned")
+}
+
+func TestSigner_VerifyRejectsUnsignedEnvelope(t *testing.T) {
+	// An envelope produced by an older / misconfigured producer that
+	// didn't wrap: the bytes are pure JSON, no HMAC prefix. The
+	// recognizer treats the first 32 bytes as the HMAC, finds they
+	// don't verify, and returns SignatureMismatch.
+	s, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+	unsigned := []byte(strings.Repeat(`{"a":"b"} `, 5)) // 50 bytes — enough that the prefix is treated as a (bogus) HMAC
+
+	_, err = s.Verify(unsigned)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSignatureMismatch),
+		"an unsigned payload that's long enough to have a 'prefix' must fail the HMAC compare, not pass through")
+}
+
+func TestSigner_VerifyRejectsKeyMismatch(t *testing.T) {
+	producer, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+	wrapped := producer.Wrap([]byte("hello"))
+
+	consumer, err := NewSigner(strings.Repeat("ff", 32))
+	require.NoError(t, err)
+	_, err = consumer.Verify(wrapped)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrSignatureMismatch))
+}
+
+func TestSigner_NilSafetyOnBothSides(t *testing.T) {
+	var s *Signer
+	payload := []byte(`{"x":1}`)
+
+	wrapped := s.Wrap(payload)
+	assert.Equal(t, payload, wrapped, "nil Signer Wrap is a passthrough")
+
+	out, err := s.Verify(payload)
+	require.NoError(t, err)
+	assert.Equal(t, payload, out, "nil Signer Verify is a passthrough")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}


### PR DESCRIPTION
## Summary

Closes the only Critical-severity finding from `SECURITY_AUDIT.md` (F-02). Every Asynq task payload now rides in an HMAC-SHA256 signed envelope so a Valkey compromise can no longer forge task content the gateway / indexer / control inbox would dispatch.

## Threat closed

Pre-fix, an attacker with read+write access to Valkey could enqueue arbitrary tasks to any queue. The agent's CA-signed action signature mitigated payload forgery for ACTION dispatches, but **not** for:

- terminal-input / osquery-dispatch / log-query-dispatch
- control:inbox messages (execution result, output chunks, inventory updates, security alerts)
- search:* index updates (would have allowed indexer DoS or bogus search hits)

All three queue families are now HMAC-verified at the consumer side; a forged envelope is dropped with `asynq.SkipRetry` rather than dispatched or retried.

## Wire format

```
[ 32 bytes HMAC-SHA256(key, payload) ][ raw JSON payload ]
```

The HMAC prefix is verified + stripped inside an asynq middleware layer; downstream handlers see the unwrapped payload bytes and don't have to know about signing. `hmac.Equal` for constant-time compare.

## Operator notes

- **`PM_TASK_SIGNING_KEY` must be set in `.env` on upgrade.** `setup.sh` will prompt; existing deployments must add the line manually (use `openssl rand -hex 32` to generate).
- All three services (control, gateway, indexer) must share the same value. A mismatch sends every task to the dead queue.
- In-flight unsigned tasks at the moment of upgrade fail verification and skip-retry. Operators can drain the queue before upgrade if zero loss matters; for typical use the lost tasks are heartbeats / search reindex that the periodic reconciler covers within minutes.

## Not in this PR

- **F-31** (instant-action signing — REBOOT / SYNC bypass the action signature) lands in a separate cross-repo PR alongside the agent-side verifier change.

## Test plan

- [x] 12 new sub-tests in `internal/taskqueue/sign_test.go` cover round-trip, tampered prefix, tampered payload, truncation, unsigned envelope, key mismatch, and nil-safety
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] `go build ./...` clean
- [ ] CI: full Unit + Integration + CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HMAC-based task payload signing and verification to enhance security across services. All task messages are now cryptographically verified before processing.
  * New environment variable `PM_TASK_SIGNING_KEY` required for task protection (64-character hex key).

* **Chores**
  * Updated deployment configuration and setup process to support task signing key configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->