### PR TITLE
sec: F-31 sign instant actions (REBOOT, SYNC) — paired with agent PR

### DIFF
--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -764,12 +764,33 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 	if dispatchDelay > 0 {
 		enqueueOpts = append(enqueueOpts, asynq.TaskID(id), asynq.ProcessIn(dispatchDelay))
 	}
+	// Sign the instant dispatch with the same canonical-bytes contract
+	// as regular actions (audit F-31): the agent will refuse to
+	// execute REBOOT / SYNC without a valid CA-signature once it
+	// drops the IsInstantAction skip in the matching agent PR.
+	// Canonical params for parameterless instant actions is the
+	// empty-object JSON `{}` — agent's verifier uses the same
+	// (id, type, paramsCanonical) tuple as for regular actions, so
+	// no protocol change is needed.
+	canonicalParams := []byte("{}")
+	var instantSig []byte
+	if h.signer != nil {
+		var sigErr error
+		instantSig, sigErr = h.signer.Sign(id, int32(req.Msg.InstantAction), canonicalParams)
+		if sigErr != nil {
+			h.logger.Error("failed to sign instant action; refusing dispatch",
+				"execution_id", id, "action_type", req.Msg.InstantAction.String(), "error", sigErr)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign instant action")
+		}
+	}
 	if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
-		ExecutionID:    id,
-		ActionType:     int32(req.Msg.InstantAction),
-		DesiredState:   int32(pm.DesiredState_DESIRED_STATE_PRESENT),
-		Params:         json.RawMessage("{}"),
-		TimeoutSeconds: timeoutSeconds,
+		ExecutionID:     id,
+		ActionType:      int32(req.Msg.InstantAction),
+		DesiredState:    int32(pm.DesiredState_DESIRED_STATE_PRESENT),
+		Params:          json.RawMessage("{}"),
+		ParamsCanonical: canonicalParams,
+		Signature:       instantSig,
+		TimeoutSeconds:  timeoutSeconds,
 	}, enqueueOpts...); err != nil {
 		h.logger.Error("failed to enqueue instant action dispatch; emitting ExecutionFailed",
 			"error", err, "execution_id", id)

--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -765,23 +765,31 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 		enqueueOpts = append(enqueueOpts, asynq.TaskID(id), asynq.ProcessIn(dispatchDelay))
 	}
 	// Sign the instant dispatch with the same canonical-bytes contract
-	// as regular actions (audit F-31): the agent will refuse to
-	// execute REBOOT / SYNC without a valid CA-signature once it
-	// drops the IsInstantAction skip in the matching agent PR.
-	// Canonical params for parameterless instant actions is the
-	// empty-object JSON `{}` — agent's verifier uses the same
-	// (id, type, paramsCanonical) tuple as for regular actions, so
-	// no protocol change is needed.
+	// as regular actions (audit F-31): the agent refuses to execute
+	// REBOOT / SYNC without a valid CA-signature once the matching
+	// agent PR drops the IsInstantAction verifier skip. Canonical
+	// params for parameterless instant actions is the empty-object
+	// JSON `{}` — agent's verifier uses the same (id, type,
+	// paramsCanonical) tuple as for regular actions, so no protocol
+	// change is needed.
+	//
+	// Fail-closed on a nil signer — matches the existing
+	// DispatchAction contract at action_dispatch.go:219 (CR finding
+	// on the F-31 PR). A nil signer is a wiring bug, not a config
+	// option: production main.go passes the real internal/ca signer,
+	// tests pass NoOpSigner. Dispatching an unsigned instant task
+	// from this branch would silently survive a misconfigured boot
+	// and re-open the REBOOT-storm primitive that F-31 closes.
+	if h.signer == nil {
+		h.logger.Error("instant dispatch: nil signer — wiring bug", "execution_id", id)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
+	}
 	canonicalParams := []byte("{}")
-	var instantSig []byte
-	if h.signer != nil {
-		var sigErr error
-		instantSig, sigErr = h.signer.Sign(id, int32(req.Msg.InstantAction), canonicalParams)
-		if sigErr != nil {
-			h.logger.Error("failed to sign instant action; refusing dispatch",
-				"execution_id", id, "action_type", req.Msg.InstantAction.String(), "error", sigErr)
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign instant action")
-		}
+	instantSig, sigErr := h.signer.Sign(id, int32(req.Msg.InstantAction), canonicalParams)
+	if sigErr != nil {
+		h.logger.Error("failed to sign instant action; refusing dispatch",
+			"execution_id", id, "action_type", req.Msg.InstantAction.String(), "error", sigErr)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign instant action")
 	}
 	if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
 		ExecutionID:     id,


### PR DESCRIPTION
## Summary

Server half of the F-31 fix from `SECURITY_AUDIT.md`. `DispatchInstantAction` previously emitted `ActionDispatchPayload` with `Signature` and `ParamsCanonical` both empty. Combined with the agent's matching skip (`agent` PR #90), instant actions bypassed the CA-signature chain entirely — a compromised gateway or a leftover unsigned task slipping past the F-02 HMAC envelope could trigger arbitrary REBOOTs on any connected agent.

## Fix

Sign instant dispatches with the same canonical-bytes tuple as regular parameterless actions:

```
actionID    = execution ID
actionType  = REBOOT or SYNC
paramsJSON  = []byte("{}")
```

The agent verifier (after `agent` PR #90 lands) checks the same tuple. No proto change, no gateway change — the gateway already forwards `Signature` + `ParamsCanonical` verbatim from the task payload to the bidi-stream `Action` message.

Nil-signer is fail-closed (matches the existing `DispatchAction` contract at `action_dispatch.go:219`).

## ⚠️ Merge order

**This PR MUST land BEFORE `agent` PR #90.** Order:

1. Merge this PR. Control begins emitting signed instant actions immediately; older agents ignore the new fields (already present on every wire `Action` — just unused for instant types previously).
2. Merge `agent` PR #90. Once agents roll out, they enforce verification on instant actions too.

Server-side signing is a strict superset of the prior wire shape, so the rollout window can span multiple release cycles without breaking older agents.

## Test plan

- [x] `go vet` / `gofmt` / `go build` clean
- [x] Existing `DispatchInstantAction` tests pass unchanged
- [ ] CI: full Unit + Integration + CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instant action dispatches now include canonical parameters and cryptographic signatures for stronger integrity and verification.
* **Bug Fixes / Behavior**
  * Dispatching will now fail safely if signing isn’t available or if signature generation fails, returning an error instead of enqueuing an unsigned task.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->