### PR TITLE
fix: bootstrap ordering vs WireAll + install-script hardening for rc2

### DIFF
--- a/cmd/control/bootstrap_test.go
+++ b/cmd/control/bootstrap_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/manchtools/power-manage/server/internal/projectors"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
@@ -67,4 +68,53 @@ func TestBootstrapAllDevicesGroup_Idempotent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, firstGroup.ID, secondGroup.ID,
 		"second bootstrap invocation must not produce a new group — same row, same id")
+}
+
+// TestEnsureAdminUser_RequiresWireAllFirst guards against the #317
+// regression: ensureAdminUser emits a UserCreatedWithRoles event which
+// only materialises into users_projection when UserListener is already
+// registered. Production startup wires WireAll inside wireSystemActions
+// (cmd/control/main.go); ensureAdminUser must run AFTER that.
+//
+// The test uses SetupPostgresWithoutProjectors so the test fixture
+// doesn't paper over the production ordering — SetupPostgres's
+// auto-wire is what masked the original bug from CI for rc1.
+func TestEnsureAdminUser_RequiresWireAllFirst(t *testing.T) {
+	ctx := context.Background()
+	logger := quietLogger()
+
+	t.Run("CorrectOrder_WireAllThenEnsureAdmin", func(t *testing.T) {
+		st := testutil.SetupPostgresWithoutProjectors(t)
+		// Production order as of #317: listeners registered first.
+		projectors.WireAll(st, logger)
+
+		err := ensureAdminUser(ctx, st, "admin@example.com", "test-password", logger)
+		require.NoError(t, err, "ensureAdminUser succeeds")
+
+		user, err := st.Repos().User.GetByEmail(ctx, "admin@example.com")
+		require.NoError(t, err,
+			"with WireAll wired first, UserListener writes users_projection during AppendEvent")
+		assert.Equal(t, "admin@example.com", user.Email)
+		require.NotNil(t, user.PasswordHash)
+		assert.NotEmpty(t, *user.PasswordHash,
+			"projector must persist the bcrypt hash so Login can verify against it")
+	})
+
+	t.Run("BrokenOrder_EnsureAdminBeforeWireAll", func(t *testing.T) {
+		// Documents the rc1 broken order: with no listener registered
+		// at AppendEvent time, the event lands in `events` but the
+		// projection write is silently skipped — GetByEmail then misses.
+		// If main.go regresses to the pre-#317 ordering, this branch
+		// would pass and the production-correct branch above would fail.
+		st := testutil.SetupPostgresWithoutProjectors(t)
+
+		err := ensureAdminUser(ctx, st, "admin@example.com", "test-password", logger)
+		require.NoError(t, err,
+			"AppendEvent succeeds — the bug is the silent projection skip, not the emit")
+
+		_, err = st.Repos().User.GetByEmail(ctx, "admin@example.com")
+		require.True(t, store.IsNotFound(err),
+			"without WireAll first, the projection row never materialises; "+
+				"this is the rc1 race that left users_projection empty for the bootstrap admin")
+	})
 }

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -122,13 +122,12 @@ func main() {
 	st.SetRepos(postgres.NewRepos(st.Queries()))
 	logger.Info("database initialized", "url", maskDatabaseURL(cfg.DatabaseURL))
 
-	// Create admin user if specified and not exists
-	if cfg.AdminEmail != "" && cfg.AdminPassword != "" {
-		if err := ensureAdminUser(ctx, st, cfg.AdminEmail, cfg.AdminPassword, logger); err != nil {
-			logger.Error("failed to create admin user", "error", err)
-			os.Exit(1)
-		}
-	}
+	// NOTE: bootstrap event emissions (ensureAdminUser, seedSSHAccessForAll,
+	// bootstrapAllDevicesGroup) live AFTER wireSystemActions below. Tracker
+	// #107 / #317: Go-side projector listeners only fire for new events, so
+	// any AppendEvent before WireAll silently skips the projection write —
+	// the canonical case being a fresh install where the admin user lands
+	// in events but not in users_projection, and login then fails.
 
 	// Initialize CA
 	certAuth, err := ca.New(cfg.CACertPath, cfg.CAKeyPath, cfg.CertValidity)
@@ -202,10 +201,9 @@ func main() {
 		SCIMBaseURL:         cfg.SCIMBaseURL,
 	})
 
-	// One-shot env-driven seed of the global SSH-access-for-all flag.
-	seedSSHAccessForAll(ctx, st, logger)
-
-	// Reconcile system roles (Admin/User) with current permission definitions
+	// Reconcile system roles (Admin/User) with current permission definitions.
+	// Bypasses the event store (direct UPDATE on roles_projection via sqlc),
+	// so the ordering vs WireAll doesn't matter for this call.
 	if err := auth.ReconcileSystemRoles(ctx, st.Queries(), logger); err != nil {
 		logger.Error("failed to reconcile system roles", "error", err)
 	}
@@ -213,7 +211,24 @@ func main() {
 	// rc11 #77: derived-projection wiring for system actions —
 	// projectors.WireAll + startup sweep + post-commit listener +
 	// periodic reconciler. See setup.go for the full rationale.
+	//
+	// Every bootstrap helper that emits events MUST run AFTER this call
+	// (#317). Go-side listeners are only registered here; an AppendEvent
+	// before WireAll persists the event but skips the projection write.
 	wireSystemActions(ctx, st, svc, cfg, logger)
+
+	// Bootstrap admin user (event-sourced via UserCreatedWithRoles).
+	// Runs after WireAll so UserListener materialises users_projection.
+	if cfg.AdminEmail != "" && cfg.AdminPassword != "" {
+		if err := ensureAdminUser(ctx, st, cfg.AdminEmail, cfg.AdminPassword, logger); err != nil {
+			logger.Error("failed to create admin user", "error", err)
+			os.Exit(1)
+		}
+	}
+
+	// One-shot env-driven seed of the global SSH-access-for-all flag.
+	// Emits ServerSettingUpdated; needs ServerSettingsListener registered.
+	seedSSHAccessForAll(ctx, st, logger)
 
 	// Boot-time seed of the "All Devices" dynamic group. Runs AFTER
 	// WireAll so the DeviceGroupCreated event flows through the

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -105,6 +105,15 @@ CONTROL_ENCRYPTION_KEY=
 # which makes the control server refuse to start without CONTROL_ENCRYPTION_KEY.
 # CONTROL_ENCRYPTION_KEY_REQUIRED=false
 
+# HMAC key shared between control, gateway, and indexer for the Asynq
+# task-queue envelope. Every service that touches the Valkey-backed
+# queue signs outbound and verifies inbound tasks so a Valkey
+# compromise can't forge work. Must be exactly 64 hex chars (32 bytes).
+# Generate with: openssl rand -hex 32
+# setup.sh's guided mode will generate this; the placeholder is here so
+# compose's variable-substitution doesn't warn 3× on first up.
+PM_TASK_SIGNING_KEY=CHANGE_ME_generate_a_64_hex_char_key
+
 # =============================================================================
 # Optional — uncomment and set as needed
 # =============================================================================

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -33,7 +33,12 @@ GITHUB_REPO="manchtools/power-manage-server"
 # expands an out-of-scope name once the function returns, exploding
 # the trap with "tmpdir: unbound variable" — the rc1 install bug.
 PM_INSTALL_TMPDIR=""
-trap 'rm -rf "${PM_INSTALL_TMPDIR:-}"' EXIT
+# Guarded `rm` so an early exit (before download_deploy_tree assigned
+# a tempdir) doesn't trigger `rm -rf ""`, which on GNU rm errors with
+# "cannot remove '': No such file or directory" and overrides the
+# script's real exit status. The :+ test only fires `rm` when the var
+# is set AND non-empty.
+trap 'if [[ -n "${PM_INSTALL_TMPDIR:-}" ]]; then rm -rf "$PM_INSTALL_TMPDIR"; fi' EXIT
 
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -27,6 +27,14 @@ RELEASE_TAG="${RELEASE_TAG:-latest-rc}"
 NO_PROMPT="${NO_PROMPT:-0}"
 GITHUB_REPO="manchtools/power-manage-server"
 
+# Holds the mktemp -d path used by download_deploy_tree so the EXIT
+# trap can clean it up. Declared at script scope (not `local` inside
+# the function) because `set -u` + a function-local trap reference
+# expands an out-of-scope name once the function returns, exploding
+# the trap with "tmpdir: unbound variable" — the rc1 install bug.
+PM_INSTALL_TMPDIR=""
+trap 'rm -rf "${PM_INSTALL_TMPDIR:-}"' EXIT
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -35,6 +43,69 @@ NC='\033[0m'
 log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
 log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
+
+# resolve_release_tag turns the floating-tag aliases :latest-rc and
+# :latest (the container-image contract names) into the actual git
+# tag they point at, by hitting the GitHub Releases API. The previous
+# code path treated them as git refs directly and failed with
+# "Could not resolve as tag or branch" because no such ref exists.
+#
+# An explicit tag (vYYYY.MM[-rcN]) is left untouched.
+resolve_release_tag() {
+    case "$RELEASE_TAG" in
+        latest-rc)
+            local api_url="https://api.github.com/repos/${GITHUB_REPO}/releases?per_page=30"
+            local resolved
+            resolved="$(curl -fsSL "$api_url" | _first_prerelease_tag)" || true
+            ;;
+        latest)
+            local api_url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
+            local resolved
+            resolved="$(curl -fsSL "$api_url" | _release_tag_name)" || true
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+    if [[ -z "${resolved:-}" || "$resolved" == "null" ]]; then
+        log_error "Could not resolve $RELEASE_TAG via the GitHub releases API on $GITHUB_REPO."
+        log_error "  Pass an explicit tag instead, e.g.: RELEASE_TAG=v2026.06-rc1 ./install.sh"
+        exit 1
+    fi
+    log_info "  Resolved $RELEASE_TAG → $resolved"
+    RELEASE_TAG="$resolved"
+}
+
+# JSON parsing helpers — python3 is the primary path (preinstalled on
+# every supported distro); jq is the fallback if the operator has
+# stripped python; failure mode is a clear "install one or pass an
+# explicit RELEASE_TAG" rather than a silent empty resolve.
+_first_prerelease_tag() {
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import json,sys
+data=json.load(sys.stdin)
+for r in data:
+    if r.get("prerelease") and not r.get("draft"):
+        print(r["tag_name"]); break'
+    elif command -v jq >/dev/null 2>&1; then
+        jq -r 'map(select(.prerelease==true and .draft==false))[0].tag_name'
+    else
+        log_error "Neither python3 nor jq is installed; cannot parse the GitHub releases API."
+        log_error "  Install one, or set an explicit RELEASE_TAG (e.g. v2026.06-rc1)."
+        exit 1
+    fi
+}
+
+_release_tag_name() {
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import json,sys; print(json.load(sys.stdin).get("tag_name",""))'
+    elif command -v jq >/dev/null 2>&1; then
+        jq -r '.tag_name // empty'
+    else
+        log_error "Neither python3 nor jq is installed; cannot parse the GitHub releases API."
+        exit 1
+    fi
+}
 
 ###############################################################################
 # Step 1 — preflight
@@ -96,14 +167,17 @@ preflight() {
 # tarball-download endpoint which accepts both.
 ###############################################################################
 download_deploy_tree() {
+    # Map :latest / :latest-rc to a real git tag before trying to
+    # download the source tarball.
+    resolve_release_tag
+
     log_info "Fetching deploy tree from $GITHUB_REPO@$RELEASE_TAG…"
 
-    local tmpdir
-    tmpdir="$(mktemp -d)"
-    # Single-quote so $tmpdir is expanded at trap-fire time, not now —
-    # SC2064. Works either way today (the var isn't reassigned), but
-    # the deferred-expansion form is the documented intent.
-    trap 'rm -rf "$tmpdir"' EXIT
+    # Use the script-scope var so the EXIT trap at the top of the
+    # script can clean it up without referencing an out-of-scope
+    # local. See PM_INSTALL_TMPDIR declaration up top.
+    PM_INSTALL_TMPDIR="$(mktemp -d)"
+    local tmpdir="$PM_INSTALL_TMPDIR"
 
     local tarball="$tmpdir/source.tar.gz"
 
@@ -209,6 +283,26 @@ run_setup() {
 ###############################################################################
 start_stack() {
     cd "$INSTALL_DIR"
+
+    # Defense-in-depth against the dockerd bind-mount footgun:
+    # compose.yml mounts ./valkey.conf into pm-valkey, and if the
+    # host path doesn't exist when compose runs, dockerd silently
+    # creates it as a DIRECTORY. Valkey then loads with no config,
+    # `requirepass` is unset, and every downstream auth fails with
+    # "AUTH called without any password configured". setup.sh
+    # render_valkey_config writes the real file, but if it failed
+    # or was skipped, surface that here rather than letting docker
+    # paper over it.
+    if [[ -d valkey.conf ]]; then
+        log_error "valkey.conf exists as a directory — docker auto-created the bind-mount source on a prior partial run."
+        log_error "  Remove it and re-run setup.sh: rm -rf valkey.conf && ./setup.sh --no-prompt"
+        exit 1
+    fi
+    if [[ ! -f valkey.conf ]]; then
+        log_error "valkey.conf is missing — setup.sh did not render it."
+        log_error "  Run: ./setup.sh   (or ./setup.sh --no-prompt for non-interactive mode)"
+        exit 1
+    fi
 
     log_info "Pulling images…"
     docker compose pull

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -75,6 +75,32 @@ check_env() {
         missing=1
     fi
 
+    # AES-256-GCM key for at-rest secret encryption. Must be exactly
+    # 64 hex chars (32 bytes). Interactive mode's prompt_secret already
+    # length-checks this; the check_env mirror is what catches a
+    # --no-prompt run against a malformed .env. Empty is allowed only
+    # when the operator explicitly opted out via
+    # CONTROL_ENCRYPTION_KEY_REQUIRED=false (handled at control-server
+    # boot, not here).
+    if [[ -n "${CONTROL_ENCRYPTION_KEY:-}" ]] && [[ ! "$CONTROL_ENCRYPTION_KEY" =~ ^[0-9a-fA-F]{64}$ ]]; then
+        log_error "CONTROL_ENCRYPTION_KEY must be exactly 64 hex characters when set"
+        missing=1
+    fi
+
+    # Asynq task-signing key — must be 64 hex chars (32 bytes). Without
+    # this, compose substitutes blank and HMAC verification fails
+    # silently across control/gateway/indexer. The placeholder in
+    # .env.example is intentionally not a valid hex string so this
+    # check fires loudly on a non-interactive run that forgot to
+    # generate one.
+    if [[ -z "${PM_TASK_SIGNING_KEY:-}" ]] || [[ "$PM_TASK_SIGNING_KEY" == "CHANGE_ME"* ]]; then
+        log_error "PM_TASK_SIGNING_KEY must be set in .env (generate with: openssl rand -hex 32)"
+        missing=1
+    elif [[ ! "$PM_TASK_SIGNING_KEY" =~ ^[0-9a-fA-F]{64}$ ]]; then
+        log_error "PM_TASK_SIGNING_KEY must be exactly 64 hex characters"
+        missing=1
+    fi
+
     if [[ -z "$ADMIN_EMAIL" ]]; then
         log_error "ADMIN_EMAIL must be set in .env"
         missing=1

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -585,7 +585,11 @@ guided_setup() {
     # the prompt loop ran (empty on a fresh install).
     ADMIN_EMAIL="$REPLY_VALUE"
 
-    prompt_secret "Bootstrap admin password (ADMIN_PASSWORD)" "openssl rand -base64 24" "${ADMIN_PASSWORD:-}"
+    # Use hex (not base64) so the generated password is safe to paste
+    # into a web form. base64 emits '+' and '/' — '+' decodes as space
+    # under application/x-www-form-urlencoded so the bootstrap admin
+    # could not sign in through the UI without manual URL encoding.
+    prompt_secret "Bootstrap admin password (ADMIN_PASSWORD)" "openssl rand -hex 24" "${ADMIN_PASSWORD:-}"
     write_env_var ADMIN_PASSWORD "$REPLY_VALUE"
     local admin_pass="$REPLY_VALUE"
     local admin_pass_generated="$REPLY_GENERATED"
@@ -687,6 +691,17 @@ render_valkey_config() {
     if [[ ! -f "$template" ]]; then
         log_error "valkey.conf.template missing at $template"
         return 1
+    fi
+    # Docker bind-mount footgun: if compose ever starts before this
+    # function has rendered the file, dockerd silently creates the
+    # host-side path as a DIRECTORY (because the source of the bind
+    # mount doesn't exist). Valkey then loads without a config —
+    # `requirepass` not set, indexer's AUTH gets "no password
+    # configured", auth fails everywhere. Surface and fix the dir
+    # so the operator doesn't chase it through the indexer logs.
+    if [[ -d "$rendered" ]]; then
+        log_warn "valkey.conf is a directory (docker auto-created the bind-mount source); removing and re-rendering."
+        rm -rf "$rendered"
     fi
     # Literal substitution via a split-and-concatenate loop. Every
     # other approach we tried interprets `&` as the matched text


### PR DESCRIPTION
## Summary

Closes #317. Bundles two classes of bug found cutting `v2026.06-rc1` and walking a fresh install end-to-end.

### 1. Bootstrap startup-ordering (the real blocker)

`cmd/control/main.go` invoked `ensureAdminUser` and `seedSSHAccessForAll` **before** `wireSystemActions()` runs `projectors.WireAll`. The Go-side listeners are registered inside `WireAll`; `AppendEvent` fires synchronous listeners only — historical events emitted earlier are silently skipped on the projection side. On a fresh install the admin user lands in `events` but `users_projection` stays empty, and Login then fails with `invalid_credentials`.

The PL/pgSQL projector the 2026.06 Go listener port (tracker #107) replaced survived this because the DB trigger fired on the `events` INSERT regardless of any Go-side wiring.

**Fix:** move the three bootstrap helpers that emit events (`ensureAdminUser`, `seedSSHAccessForAll`, `bootstrapAllDevicesGroup`) to **after** `wireSystemActions`. `ReconcileSystemRoles` stays early — it bypasses the event store entirely.

**Regression test** in `cmd/control/bootstrap_test.go` covers both the fixed and broken orders against an unwired store (`testutil.SetupPostgresWithoutProjectors`) so the test fixture's auto-wire doesn't paper over the production race — the gap that let this bug ship in rc1.

### 2. Install-script hardening (the cuts walking the rc1 install)

`deploy/install.sh`:

- `local tmpdir` + global EXIT trap → `tmpdir: unbound variable` under `set -u`. Lifted to a script-scope `PM_INSTALL_TMPDIR` declared up top; trap references it with `${PM_INSTALL_TMPDIR:-}`.
- `RELEASE_TAG=latest-rc` default was tried as a git ref (it's a container-image floating tag — never existed as a git ref). Added `resolve_release_tag()` that hits the GitHub releases API: `latest-rc` → latest non-draft prerelease, `latest` → latest stable. python3-first with jq fallback; clean error if neither is installed.
- `start_stack()` pre-checks `valkey.conf` is a regular file before compose runs. Catches the docker bind-mount footgun where dockerd silently creates the host-side mount source as a DIRECTORY when setup.sh hasn't rendered it yet — valkey then loads with no config, `requirepass` is unset, indexer auth-fails through the chain.

`deploy/setup.sh`:

- `ADMIN_PASSWORD` generator switched from `openssl rand -base64 24` to `openssl rand -hex 24`. base64 emits `+/=` which round-trip wrong through web-form encoders (`+` decodes to space under `application/x-www-form-urlencoded`), so the bootstrap admin couldn't sign in through the UI without manual URL escaping. Hex pastes safely, same byte entropy.
- `render_valkey_config()` removes `valkey.conf` if it exists as a directory and re-renders. Mirrors the `install.sh` pre-check from the other side of the install path.

`deploy/.env.example`:

- Added `PM_TASK_SIGNING_KEY` placeholder. `compose.yml` references it on control, gateway, and indexer; without it compose warned 3× and fell back to blank, breaking HMAC verification across the queue. `setup.sh`'s guided mode generates it correctly; the env template just keeps compose quiet on first up.

## Test plan

- [x] `go build ./cmd/control ./cmd/gateway ./cmd/indexer` clean locally
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `bash -n deploy/install.sh && bash -n deploy/setup.sh` clean
- [x] `_first_prerelease_tag` against the live GitHub API resolves to `v2026.06-rc1`; `_release_tag_name` resolves `latest` to `v2026.05`
- [x] Full `cmd/control/...` test suite green (32s, including the two new regression tests)
- [x] Local `cr review` — no findings
- [ ] CI (unit + integration + lint + govulncheck)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added task-signing configuration (PM_TASK_SIGNING_KEY) for secure task-queue envelopes.
  * Installer resolves floating release tags (e.g., latest, latest-rc) with robust tag resolution.

* **Bug Fixes**
  * Ensured projector wiring before admin user bootstrapping.
  * Improved installer temp-dir cleanup and exit handling.
  * Added validation for valkey.conf and stricter secret-format checks; generated admin password now hex.

* **Tests**
  * Added test verifying admin user creation requires projectors to be wired first.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manchtools/power-manage-server/pull/318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->