### PR TITLE
feat(deploy): cut over from redis-stack-server to valkey-bundle 9.1.0

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -82,9 +82,12 @@ services:
 
   valkey:
     # Pinned to avoid silent upstream upgrades. Bump deliberately when
-    # you've verified the RediSearch module + data format still work
-    # for your deployment.
-    image: docker.io/redis/redis-stack-server:7.4.0-v0
+    # you've verified the valkey-search module + data format still
+    # work for your deployment. The bundle image carries valkey-server
+    # plus the search / json / bloom / ldap modules under
+    # /usr/lib/valkey/; its entrypoint auto-loads any .so it finds
+    # there that isn't already loaded by the config file.
+    image: docker.io/valkey/valkey-bundle:9.1.0
     container_name: pm-valkey
     restart: unless-stopped
     volumes:
@@ -99,10 +102,14 @@ services:
     # /proc/<pid>/cmdline. Now the password is in /etc/valkey/valkey.conf
     # (file permissions enforced by the bind-mount), and the health
     # check authenticates via REDISCLI_AUTH so the cmdline of the
-    # one-shot redis-cli probe stays clean too.
-    command: ["redis-server", "/etc/valkey/valkey.conf"]
+    # one-shot valkey-cli probe stays clean too.
+    #
+    # Command must invoke `valkey-server` (not its `redis-server`
+    # symlink) so the bundle's entrypoint takes the module-autoload
+    # branch — see bundle-docker-entrypoint.sh.
+    command: ["valkey-server", "/etc/valkey/valkey.conf"]
     healthcheck:
-      test: ["CMD-SHELL", "REDISCLI_AUTH=\"$$VALKEY_PASSWORD\" redis-cli ping"]
+      test: ["CMD-SHELL", "REDISCLI_AUTH=\"$$VALKEY_PASSWORD\" valkey-cli ping"]
       interval: 5s
       timeout: 3s
       retries: 3

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -751,8 +751,8 @@ render_valkey_config() {
     local tmp
     tmp="$(mktemp "${rendered}.tmp.XXXXXX")"
     printf '%s' "$rendered_contents" > "$tmp"
-    # 0644 keeps the file readable by the redis user inside the
-    # container (uid 999 in the redis-stack-server image) without
+    # 0644 keeps the file readable by the valkey user inside the
+    # container (uid 999 in the valkey-bundle image) without
     # needing the operator to chown to a specific uid. The bind-
     # mount carries `ro,z` so the container cannot tamper, and the
     # password is already on disk in .env (same protection level),

--- a/deploy/valkey.conf.template
+++ b/deploy/valkey.conf.template
@@ -1,4 +1,4 @@
-# Valkey/Redis-stack server configuration (audit F-03).
+# Valkey server configuration (audit F-03).
 #
 # Rendered to ./valkey.conf at setup time by setup.sh — the only
 # value substituted in is ${VALKEY_PASSWORD}. The rendered file is
@@ -12,9 +12,13 @@
 # only the user that owns the deployment can read it; the bind-mount
 # carries those bits into the container.
 
-# Module loading (RediSearch ships in the redis-stack-server image at
-# the path below; keep this in sync with the image's --loadmodule arg).
-loadmodule /opt/redis-stack/lib/redisearch.so
+# Module loading: handled by the valkey-bundle entrypoint, not here.
+# `bundle-docker-entrypoint.sh` auto-discovers every .so under
+# /usr/lib/valkey/ (search, json, bloom, ldap) and appends them as
+# --loadmodule args at start. Adding an explicit `loadmodule` line
+# for one of them would make the entrypoint skip its auto-append for
+# that module (idempotent) — only add one to pin to a non-bundled
+# module path.
 
 # Authentication. setup.sh replaces __VALKEY_PASSWORD__ with the
 # operator-generated password from .env.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/alicebob/miniredis/v2 v2.37.0
 	github.com/coder/websocket v1.8.14
 	github.com/coreos/go-oidc/v3 v3.17.0
-	github.com/go-jose/go-jose/v4 v4.1.3
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/gabriel-vasile/mimetype v1.4.12 h1:e9hWvmLYvtp846tLHam2o++qitpguFiYCKbn0w9jyqw=
 github.com/gabriel-vasile/mimetype v1.4.12/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -132,7 +132,7 @@ func (idx *Index) FlushSearchData(ctx context.Context) error {
 	return nil
 }
 
-// EnsureIndexes creates the RediSearch FT indexes if they don't already exist.
+// EnsureIndexes creates the FT search indexes if they don't already exist.
 func (idx *Index) EnsureIndexes(ctx context.Context) error {
 	indexes := []struct {
 		name   string
@@ -264,7 +264,13 @@ func (idx *Index) EnsureIndexes(ctx context.Context) error {
 		args = append(args, ix.schema...)
 		err := idx.rdb.Do(ctx, args...).Err()
 		if err != nil {
-			if strings.Contains(err.Error(), "Index already exists") {
+			// "already exists" substring covers both backends used during
+			// the redis-stack → valkey-bundle cutover (#319). RediSearch
+			// emits "Index already exists"; valkey-search 1.2+ emits
+			// "Index <name> in database 0 already exists." — both
+			// contain the same anchor word, so a single substring
+			// works without per-backend branching.
+			if strings.Contains(err.Error(), "already exists") {
 				continue
 			}
 			return fmt.Errorf("create index %s: %w", ix.name, err)

--- a/internal/search/indexer_test.go
+++ b/internal/search/indexer_test.go
@@ -18,15 +18,18 @@ import (
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
-// setupRedis starts a Redis Stack container with RediSearch module and returns
-// a connected go-redis client. The container is stopped when the test completes.
+// setupRedis starts a valkey-bundle container (valkey-search module
+// auto-loaded by the bundle entrypoint) and returns a connected
+// go-redis client. The container is stopped when the test completes.
+// Image swap from redis-stack-server is part of #319 — test logic
+// itself is unchanged so a clean run validates the cutover.
 func setupRedis(t *testing.T) *redis.Client {
 	t.Helper()
 	ctx := context.Background()
 
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:        "redis/redis-stack-server:latest",
+			Image:        "valkey/valkey-bundle:9.1.0",
 			ExposedPorts: []string{"6379/tcp"},
 			WaitingFor:   wait.ForLog("Ready to accept connections").WithStartupTimeout(30 * time.Second),
 		},

--- a/internal/terminal/valkey_backend.go
+++ b/internal/terminal/valkey_backend.go
@@ -55,7 +55,8 @@ func (b *ValkeyBackend) Delete(ctx context.Context, sessionID string) error {
 
 // GetAndDelete atomically returns the payload and removes the key in a
 // single Valkey/Redis round-trip using GETDEL (available since Redis
-// 6.2; redis-stack-server ships well past that). This is the primitive
+// 6.2; both valkey-bundle and the legacy redis-stack-server image
+// ship well past that). This is the primitive
 // that makes terminal tokens single-use — two concurrent validators
 // cannot both observe the payload.
 func (b *ValkeyBackend) GetAndDelete(ctx context.Context, sessionID string) ([]byte, error) {


### PR DESCRIPTION
Closes manchtools/power-manage-server#319.

The compose stack was pinned to `redis/redis-stack-server:7.4.0-v0` because earlier valkey-search builds were missing TEXT field support (and `FT.DROPINDEX DD`, though we don't depend on it). Both gaps are resolved upstream in valkey-search 1.2+, which ships in `valkey/valkey-bundle:9.1.0` (and `unstable`). This PR cuts over so we drop the Redis Inc. dependency on redis-stack.

## Summary

- `deploy/compose.yml` — image swap to `docker.io/valkey/valkey-bundle:9.1.0`. `command` flips to `valkey-server` (the bundle entrypoint's auto-loadmodule branch only fires on the canonical name, not the `redis-server` symlink). Healthcheck flips to `valkey-cli ping`. Comments refreshed.
- `deploy/valkey.conf.template` — dropped the explicit `loadmodule /opt/redis-stack/lib/redisearch.so` line. The bundle entrypoint (`bundle-docker-entrypoint.sh`) auto-discovers every `.so` under `/usr/lib/valkey/` and appends them as `--loadmodule` args at start. Comments rewritten to document that behaviour.
- `deploy/setup.sh` — comment correction (uid 999 is now the `valkey` user, not the `redis` user).
- `internal/search/index.go` — broadened the `EnsureIndexes` idempotency check from `Index already exists` (RediSearch) to `already exists` so it covers valkey-search 1.2's verbose `Index <name> in database 0 already exists.` wording. The drop-index handler at `index.go:107` and `search_handler.go:194` already cover both backends via the existing `not found` substring; verified empirically against the bundle.
- `internal/search/indexer_test.go` — testcontainer image swap to `valkey/valkey-bundle:9.1.0`. **Test logic unchanged** — the existing suite passes against the new container.
- `internal/terminal/valkey_backend.go` — stale `redis-stack-server` reference in a doc comment updated to call out both backends.

## Why bundle 9.1.0 specifically?

The `9.0.3` tag ships valkey-search **1.0.0** (module ver `10000`), which still doesn't support TEXT fields. The `9.1.0` tag (2026-05-27) and `unstable` both ship valkey-search **1.2** (module ver `66048`). 9.1.0 is the lowest tagged stable bundle that satisfies #319's requirement.

Sibling-swept the codebase for other RediSearch error-string matches:
- `internal/search/index.go:107` (drop) — `"not found"` substring already covers valkey-search 1.2 (`Index with name 'X' not found in database 0`). No change needed.
- `internal/api/search_handler.go:194` (search) — same.

## Validation

- [x] `go build ./...` clean.
- [x] `internal/search` package suite green against `valkey-bundle:9.1.0` (`go test -count=1 ./internal/search/...` → 62s, all green).
- [x] Search-touching `internal/api` tests green (`go test -run 'Search|search' ./internal/api/...` → 80s, all green).
- [x] `internal/terminal`, `internal/gateway/...`, `internal/handler` all green.
- [x] Local compose smoke: `docker compose up -d valkey` healthy in ~8s; modules load (json/search/bloom/ldap); `FT.CREATE idx:smoke ... SCHEMA name TEXT created_at NUMERIC SORTABLE` succeeds via `valkey-cli ping` with the bind-mounted password file.
- [x] `cr review` returned no findings.
- [ ] Soak on staging for ≥1 week before tagging 2026.07-rc1 (per #319's plan).

## Migration notes for operators

- mTLS certs, control / gateway configs, Postgres data — **all unaffected**.
- Existing `deploy/data/valkey/` AOF + RDB carry over. Both images use UID 999 for their service user, so no host-side chown is required.
- On first boot under the new image, the search-index schema is identical (we already use the TEXT+TAG+NUMERIC+SORTABLE shapes valkey-search 1.2 supports). The `EnsureIndexes` idempotency path is the only behaviour difference between backends, and it's covered. For an abundance-of-caution rebuild, hit **Settings → Search → Rebuild index** in the web UI after the cutover.

## Rollback

Revert the image tag in `compose.yml` to `redis/redis-stack-server:7.4.0-v0` and the command to `["redis-server", "/etc/valkey/valkey.conf"]`. The data directory remains compatible. The `internal/search/index.go` substring broadening is forward- and backward-compatible (RediSearch's `Index already exists` still contains `already exists`), so the code change does not need reverting.

## Test plan

- [ ] Single-node staging install soak (≥1 week).
- [ ] Multi-host staging install soak (≥1 week, multiple gateways against the same control + valkey).
- [ ] `RebuildSearchIndex` RPC on a populated install — verify it completes cleanly and all 10 indexes report `last_indexing_finished_time` post-rebuild.
- [ ] Operator-facing search box hits every index scope and returns expected results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Migrated underlying infrastructure from Redis Stack Server 7.4.0 to Valkey 9.1.0 for improved performance and maintainability.
  * Updated Go dependencies for enhanced security and stability.
  * Updated configuration templates to align with new deployment architecture.

* **Bug Fixes**
  * Improved error handling in search index creation to support multiple search backend variants with better error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->