### PR TITLE
feat(api): boundary validation interceptor + coverage fill + test-suite hardening

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -271,6 +271,7 @@ func main() {
 	interceptors := connect.WithInterceptors(
 		api.NewLoggingInterceptor(logger),
 		auth.NewAuthInterceptor(logger, jwtManager, rateLimiters),
+		api.NewValidationInterceptor(),
 		auth.NewAuthzInterceptor(),
 	)
 
@@ -314,7 +315,10 @@ func main() {
 		// ProxyValidateTerminalToken.
 		internalHandler.SetTerminalTokenStore(valkey.TerminalTokenStore)
 	}
-	internalPath, internalH := pmv1connect.NewInternalServiceHandler(internalHandler)
+	internalPath, internalH := pmv1connect.NewInternalServiceHandler(
+		internalHandler,
+		connect.WithInterceptors(api.NewValidationInterceptor()),
+	)
 
 	// Peer-class gate: InternalService handles credential-bearing
 	// proxy calls (LUKS keys, LPS passwords). A compromised agent

--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -136,6 +136,10 @@ func (h *ActionHandler) GetAction(ctx context.Context, req *connect.Request[pm.G
 
 // ListActions returns a paginated list of actions.
 func (h *ActionHandler) ListActions(ctx context.Context, req *connect.Request[pm.ListActionsRequest]) (*connect.Response[pm.ListActionsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -611,6 +611,10 @@ func (h *ActionHandler) GetExecution(ctx context.Context, req *connect.Request[p
 
 // ListExecutions returns a paginated list of executions.
 func (h *ActionHandler) ListExecutions(ctx context.Context, req *connect.Request[pm.ListExecutionsRequest]) (*connect.Response[pm.ListExecutionsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -111,6 +111,10 @@ func (h *ActionSetHandler) GetActionSet(ctx context.Context, req *connect.Reques
 
 // ListActionSets returns a paginated list of action sets.
 func (h *ActionSetHandler) ListActionSets(ctx context.Context, req *connect.Request[pm.ListActionSetsRequest]) (*connect.Response[pm.ListActionSetsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -196,6 +196,10 @@ func (h *AssignmentHandler) DeleteAssignment(ctx context.Context, req *connect.R
 
 // ListAssignments returns a paginated list of assignments.
 func (h *AssignmentHandler) ListAssignments(ctx context.Context, req *connect.Request[pm.ListAssignmentsRequest]) (*connect.Response[pm.ListAssignmentsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/audit_handler.go
+++ b/internal/api/audit_handler.go
@@ -28,6 +28,10 @@ func NewAuditHandler(st *store.Store, logger *slog.Logger) *AuditHandler {
 
 // ListAuditEvents returns a paginated list of audit events.
 func (h *AuditHandler) ListAuditEvents(ctx context.Context, req *connect.Request[pm.ListAuditEventsRequest]) (*connect.Response[pm.ListAuditEventsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -233,6 +233,10 @@ func (h *AuthHandler) Logout(ctx context.Context, req *connect.Request[pm.Logout
 
 // GetCurrentUser returns the current authenticated user.
 func (h *AuthHandler) GetCurrentUser(ctx context.Context, req *connect.Request[pm.GetCurrentUserRequest]) (*connect.Response[pm.GetCurrentUserResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/api/compliance_handler.go
+++ b/internal/api/compliance_handler.go
@@ -28,6 +28,10 @@ func NewComplianceHandler(st *store.Store, logger *slog.Logger) *ComplianceHandl
 
 // GetDeviceCompliance returns the compliance status and individual check results for a device.
 func (h *ComplianceHandler) GetDeviceCompliance(ctx context.Context, req *connect.Request[pm.GetDeviceComplianceRequest]) (*connect.Response[pm.GetDeviceComplianceResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	deviceID := req.Msg.DeviceId
 
 	results, err := h.store.Repos().Compliance.DeviceResults(ctx, deviceID)

--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -91,6 +91,10 @@ func (h *CompliancePolicyHandler) GetCompliancePolicy(ctx context.Context, req *
 
 // ListCompliancePolicies returns a paginated list of compliance policies.
 func (h *CompliancePolicyHandler) ListCompliancePolicies(ctx context.Context, req *connect.Request[pm.ListCompliancePoliciesRequest]) (*connect.Response[pm.ListCompliancePoliciesResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/control_boundary_test.go
+++ b/internal/api/control_boundary_test.go
@@ -1,0 +1,117 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/middleware"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+type controlRPCFixture struct {
+	client      pmv1connect.ControlServiceClient
+	server      *httptest.Server
+	jwtManager  *auth.JWTManager
+	accessToken string
+	store       *store.Store
+}
+
+func newControlRPCFixture(t *testing.T) *controlRPCFixture {
+	t.Helper()
+
+	st := testutil.SetupPostgres(t)
+	jwtManager := testutil.NewJWTManager()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	svc := api.NewControlService(
+		st,
+		jwtManager,
+		api.NoOpSigner{},
+		nil,
+		"https://gateway.test",
+		logger,
+		testutil.NewEncryptor(t),
+		api.ControlServiceConfig{
+			PasswordAuthEnabled: true,
+			SSOCallbackBaseURL:  "https://app.example.com",
+			SCIMBaseURL:         "https://control.example.com/scim/v2",
+		},
+	)
+
+	path, h := pmv1connect.NewControlServiceHandler(
+		svc,
+		connect.WithInterceptors(
+			api.NewLoggingInterceptor(logger),
+			auth.NewAuthInterceptor(logger, jwtManager, auth.RateLimiters{}),
+			api.NewValidationInterceptor(),
+			auth.NewAuthzInterceptor(),
+		),
+	)
+	mux := http.NewServeMux()
+	mux.Handle(path, h)
+	srv := httptest.NewServer(middleware.RequestID(mux))
+	t.Cleanup(srv.Close)
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	tokens, err := jwtManager.GenerateTokens(userID, "admin@example.com", auth.AdminPermissions(), 0)
+	require.NoError(t, err)
+
+	return &controlRPCFixture{
+		client:      pmv1connect.NewControlServiceClient(srv.Client(), srv.URL),
+		server:      srv,
+		jwtManager:  jwtManager,
+		accessToken: tokens.AccessToken,
+		store:       st,
+	}
+}
+
+func TestControlRPCBoundaryValidationRejectsInvalidRequestBeforeHandler(t *testing.T) {
+	f := newControlRPCFixture(t)
+
+	req := connect.NewRequest(&pm.ListDevicesRequest{PageSize: 201})
+	req.Header().Set("Authorization", "Bearer "+f.accessToken)
+	_, err := f.client.ListDevices(context.Background(), req)
+
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.NotEmpty(t, errorDetailRequestID(t, err), "boundary validation errors must carry request correlation IDs")
+}
+
+func TestControlRPCBoundaryAuthzStillRunsAfterValidation(t *testing.T) {
+	f := newControlRPCFixture(t)
+	limited, err := f.jwtManager.GenerateTokens("user-no-device-list", "limited@example.com", []string{"GetCurrentUser"}, 0)
+	require.NoError(t, err)
+
+	req := connect.NewRequest(&pm.ListDevicesRequest{PageSize: 1})
+	req.Header().Set("Authorization", "Bearer "+limited.AccessToken)
+	_, err = f.client.ListDevices(context.Background(), req)
+
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	assert.NotEmpty(t, errorDetailRequestID(t, err), "authz errors must carry request correlation IDs")
+}
+
+func errorDetailRequestID(t *testing.T, err error) string {
+	t.Helper()
+	var connectErr *connect.Error
+	require.True(t, errors.As(err, &connectErr))
+	require.NotEmpty(t, connectErr.Details())
+	value, detailErr := connectErr.Details()[0].Value()
+	require.NoError(t, detailErr)
+	detail, ok := value.(*pm.ErrorDetail)
+	require.True(t, ok)
+	return detail.RequestId
+}

--- a/internal/api/definition_handler.go
+++ b/internal/api/definition_handler.go
@@ -109,6 +109,10 @@ func (h *DefinitionHandler) GetDefinition(ctx context.Context, req *connect.Requ
 
 // ListDefinitions returns a paginated list of definitions.
 func (h *DefinitionHandler) ListDefinitions(ctx context.Context, req *connect.Request[pm.ListDefinitionsRequest]) (*connect.Response[pm.ListDefinitionsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -122,6 +122,10 @@ func (h *DeviceGroupHandler) GetDeviceGroup(ctx context.Context, req *connect.Re
 
 // ListDeviceGroups returns a paginated list of device groups.
 func (h *DeviceGroupHandler) ListDeviceGroups(ctx context.Context, req *connect.Request[pm.ListDeviceGroupsRequest]) (*connect.Response[pm.ListDeviceGroupsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -41,6 +41,10 @@ func NewDeviceHandler(st *store.Store, enc *crypto.Encryptor, logger *slog.Logge
 // ListDevices returns a paginated list of devices.
 // Admins see all devices; regular users see only their assigned devices.
 func (h *DeviceHandler) ListDevices(ctx context.Context, req *connect.Request[pm.ListDevicesRequest]) (*connect.Response[pm.ListDevicesResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/identity_link_handler.go
+++ b/internal/api/identity_link_handler.go
@@ -27,6 +27,10 @@ func NewIdentityLinkHandler(st *store.Store, logger *slog.Logger) *IdentityLinkH
 
 // ListIdentityLinks returns the current user's linked identities.
 func (h *IdentityLinkHandler) ListIdentityLinks(ctx context.Context, req *connect.Request[pm.ListIdentityLinksRequest]) (*connect.Response[pm.ListIdentityLinksResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/api/idp_handler.go
+++ b/internal/api/idp_handler.go
@@ -127,6 +127,10 @@ func (h *IDPHandler) GetIdentityProvider(ctx context.Context, req *connect.Reque
 
 // ListIdentityProviders returns a paginated list of identity providers.
 func (h *IDPHandler) ListIdentityProviders(ctx context.Context, req *connect.Request[pm.ListIdentityProvidersRequest]) (*connect.Response[pm.ListIdentityProvidersResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -60,6 +60,10 @@ func (h *InternalHandler) SetTerminalTokenStore(s *terminal.TokenStore) {
 // VerifyDevice checks that a device exists and is not deleted.
 // Called by the gateway before registering an agent connection.
 func (h *InternalHandler) VerifyDevice(ctx context.Context, req *connect.Request[pm.VerifyDeviceRequest]) (*connect.Response[pm.VerifyDeviceResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	deviceID := req.Msg.DeviceId
 	if deviceID == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id is required")
@@ -76,6 +80,10 @@ func (h *InternalHandler) VerifyDevice(ctx context.Context, req *connect.Request
 
 // ProxySyncActions resolves all assigned actions for a device.
 func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Request[pm.InternalSyncActionsRequest]) (*connect.Response[pm.SyncActionsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	deviceID := req.Msg.DeviceId
 	if deviceID == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id is required")
@@ -241,6 +249,10 @@ func dbActionToWireAction(a db.ActionsProjection) *pm.Action {
 
 // ProxyValidateLuksToken validates and consumes a one-time LUKS token.
 func (h *InternalHandler) ProxyValidateLuksToken(ctx context.Context, req *connect.Request[pm.InternalValidateLuksTokenRequest]) (*connect.Response[pm.ValidateLuksTokenResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	if req.Msg.DeviceId == "" || req.Msg.Token == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id and token are required")
 	}
@@ -269,6 +281,10 @@ func (h *InternalHandler) ProxyValidateLuksToken(ctx context.Context, req *conne
 
 // ProxyGetLuksKey retrieves and decrypts the current LUKS key for a device+action.
 func (h *InternalHandler) ProxyGetLuksKey(ctx context.Context, req *connect.Request[pm.InternalGetLuksKeyRequest]) (*connect.Response[pm.GetLuksKeyResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	if req.Msg.DeviceId == "" || req.Msg.ActionId == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id and action_id are required")
 	}
@@ -290,6 +306,10 @@ func (h *InternalHandler) ProxyGetLuksKey(ctx context.Context, req *connect.Requ
 
 // ProxyStoreLuksKey encrypts and stores a new LUKS key.
 func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Request[pm.InternalStoreLuksKeyRequest]) (*connect.Response[pm.StoreLuksKeyResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	if req.Msg.DeviceId == "" || req.Msg.ActionId == "" || req.Msg.Passphrase == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id, action_id, and passphrase are required")
 	}
@@ -327,6 +347,10 @@ func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Re
 
 // ProxyStoreLpsPasswords encrypts and stores LPS password rotation entries.
 func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *connect.Request[pm.InternalStoreLpsPasswordsRequest]) (*connect.Response[pm.InternalStoreLpsPasswordsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	if req.Msg.DeviceId == "" || req.Msg.ActionId == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id and action_id are required")
 	}
@@ -460,6 +484,10 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 // store not configured' is Unavailable — operator misconfiguration,
 // not a client bug.
 func (h *InternalHandler) ProxyValidateTerminalToken(ctx context.Context, req *connect.Request[pm.InternalValidateTerminalTokenRequest]) (*connect.Response[pm.InternalValidateTerminalTokenResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	if h.terminalTokenStore == nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable,
 			"remote terminal sessions are not configured on this control instance")

--- a/internal/api/internal_handler_test.go
+++ b/internal/api/internal_handler_test.go
@@ -345,8 +345,19 @@ func TestProxyValidateTerminalToken_IsSingleUse(t *testing.T) {
 func TestProxyValidateTerminalToken_UnknownSession(t *testing.T) {
 	h, _ := newInternalHandlerWithTokenStore(t)
 
+	// The probe-distinguishability defense protects against an
+	// attacker learning whether a session *exists*, not whether the
+	// session_id string is a syntactically valid ULID. A malformed
+	// session_id is rejected by the validation interceptor + the
+	// handler-level Validate() call with InvalidArgument before the
+	// token-store lookup, which is the right shape: anyone can tell
+	// a malformed input from "no session here" without probing. Use
+	// a valid-format-but-unminted ULID so the request reaches the
+	// token check and the comparison below pins the equal-message
+	// contract for the cases where it actually matters.
+	unknownSessionID := testutil.NewID()
 	_, err := h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
-		SessionId: "no-such-session",
+		SessionId: unknownSessionID,
 		Token:     "anything",
 	}))
 	require.Error(t, err)
@@ -416,11 +427,17 @@ func TestProxyValidateTerminalToken_StoreNotConfigured(t *testing.T) {
 	// instance running without TerminalGatewayURL), the RPC must
 	// return Unavailable so the gateway can degrade gracefully
 	// instead of returning a confusing 'method not found'.
+	//
+	// The session_id must be a syntactically valid ULID — the new
+	// boundary validation rejects malformed inputs with
+	// InvalidArgument before the store-not-configured check fires,
+	// which would hide the behavior we want to pin. Use a freshly
+	// minted ULID here.
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
 
 	_, err := h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
-		SessionId: "01ABC",
+		SessionId: testutil.NewID(),
 		Token:     "tok",
 	}))
 	require.Error(t, err)

--- a/internal/api/logs_handler.go
+++ b/internal/api/logs_handler.go
@@ -32,6 +32,10 @@ func NewLogsHandler(st *store.Store, logger *slog.Logger) *LogsHandler {
 
 // QueryDeviceLogs dispatches a journalctl log query to a connected device.
 func (h *LogsHandler) QueryDeviceLogs(ctx context.Context, req *connect.Request[pm.QueryDeviceLogsRequest]) (*connect.Response[pm.QueryDeviceLogsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	msg := req.Msg
 
 	// Verify device exists
@@ -95,6 +99,10 @@ func (h *LogsHandler) QueryDeviceLogs(ctx context.Context, req *connect.Request[
 
 // GetDeviceLogResult polls for the result of a dispatched log query.
 func (h *LogsHandler) GetDeviceLogResult(ctx context.Context, req *connect.Request[pm.GetDeviceLogResultRequest]) (*connect.Response[pm.GetDeviceLogResultResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	result, err := h.store.Repos().Logs.GetQueryResult(ctx, req.Msg.QueryId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrQueryResultNotFound, connect.CodeNotFound, "log query result not found")

--- a/internal/api/logs_handler_test.go
+++ b/internal/api/logs_handler_test.go
@@ -21,7 +21,11 @@ func TestQueryDeviceLogs_DeviceNotFound(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	_, err := h.QueryDeviceLogs(ctx, connect.NewRequest(&pm.QueryDeviceLogsRequest{
-		DeviceId: "nonexistent-device",
+		// Valid-format ULID that isn't in the devices_projection.
+		// Boundary validation accepts the request, the existence
+		// lookup returns NotFound — which is the contract this
+		// test pins.
+		DeviceId: testutil.NewID(),
 		Lines:    100,
 	}))
 	require.Error(t, err)
@@ -61,7 +65,8 @@ func TestGetDeviceLogResult_NotFound(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	_, err := h.GetDeviceLogResult(ctx, connect.NewRequest(&pm.GetDeviceLogResultRequest{
-		QueryId: "nonexistent-query-id",
+		// Valid-format ULID that isn't in the log_queries projection.
+		QueryId: testutil.NewID(),
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))

--- a/internal/api/missing_rpc_coverage_test.go
+++ b/internal/api/missing_rpc_coverage_test.go
@@ -1,0 +1,704 @@
+package api_test
+
+// Coverage tests for RPCs that previously had no dedicated handler test.
+// Each test exercises one RPC with assertions on its actual return
+// shape — not just "no error". File is split into single-RPC tests so
+// failures point at the exact code path that regressed; conjoined
+// "TestFooAndBarAndBaz" functions were rejected on review.
+//
+// Each test calls testutil.SetupPostgres(t), which spawns a fresh
+// Postgres testcontainer per test. That matches the rest of the
+// codebase but is expensive in aggregate. A shared per-package fixture
+// would help; it's tracked separately because changing the pattern
+// here only would diverge from house style.
+
+import (
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// =============================================================================
+// UserHandler — profile + provisioning + Linux username + SSH key + SSH settings
+// =============================================================================
+
+func TestUserHandler_UpdateUserProfile_AppliesAllProfileFields(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.UpdateUserProfile(ctx, connect.NewRequest(&pm.UpdateUserProfileRequest{
+		Id:                userID,
+		DisplayName:       "Alice Example",
+		GivenName:         "Alice",
+		FamilyName:        "Example",
+		PreferredUsername: "alice",
+		Locale:            "en-US",
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.User)
+	got := resp.Msg.User
+	assert.Equal(t, userID, got.Id)
+	assert.Equal(t, "Alice Example", got.DisplayName)
+	assert.Equal(t, "Alice", got.GivenName)
+	assert.Equal(t, "Example", got.FamilyName)
+	assert.Equal(t, "alice", got.PreferredUsername)
+	assert.Equal(t, "en-US", got.Locale)
+}
+
+func TestUserHandler_SetUserProvisioningEnabled_FlipsFlag(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	ctx := testutil.AdminContext(adminID)
+
+	on, err := h.SetUserProvisioningEnabled(ctx, connect.NewRequest(&pm.SetUserProvisioningEnabledRequest{
+		UserId:  userID,
+		Enabled: true,
+	}))
+	require.NoError(t, err)
+	assert.True(t, on.Msg.User.UserProvisioningEnabled, "true must persist")
+
+	off, err := h.SetUserProvisioningEnabled(ctx, connect.NewRequest(&pm.SetUserProvisioningEnabledRequest{
+		UserId:  userID,
+		Enabled: false,
+	}))
+	require.NoError(t, err)
+	assert.False(t, off.Msg.User.UserProvisioningEnabled, "false must also persist — the field must be a real toggle, not a one-way switch")
+}
+
+func TestUserHandler_UpdateUserLinuxUsername_PersistsValue(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.UpdateUserLinuxUsername(ctx, connect.NewRequest(&pm.UpdateUserLinuxUsernameRequest{
+		UserId:        userID,
+		LinuxUsername: "alice-linux",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "alice-linux", resp.Msg.User.LinuxUsername)
+	assert.Equal(t, userID, resp.Msg.User.Id, "response must echo the same user id it was asked to update")
+}
+
+func TestUserHandler_AddAndRemoveUserSshKey_RoundTrip(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	ctx := testutil.AdminContext(adminID)
+
+	add, err := h.AddUserSshKey(ctx, connect.NewRequest(&pm.AddUserSshKeyRequest{
+		UserId:    userID,
+		PublicKey: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJ3validtestkey alice@example",
+		Comment:   "laptop",
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, add.Msg.Key)
+	keyID := add.Msg.Key.Id
+	assert.NotEmpty(t, keyID, "the server must mint a key id")
+	assert.Equal(t, "laptop", add.Msg.Key.Comment, "the comment must round-trip")
+
+	_, err = h.RemoveUserSshKey(ctx, connect.NewRequest(&pm.RemoveUserSshKeyRequest{
+		UserId: userID,
+		KeyId:  keyID,
+	}))
+	require.NoError(t, err)
+}
+
+func TestUserHandler_UpdateUserSshSettings_AppliesAllFlags(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.UpdateUserSshSettings(ctx, connect.NewRequest(&pm.UpdateUserSshSettingsRequest{
+		UserId:           userID,
+		SshAccessEnabled: true,
+		SshAllowPubkey:   true,
+		SshAllowPassword: false,
+	}))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.User)
+	got := resp.Msg.User
+	assert.True(t, got.SshAccessEnabled, "ssh_access_enabled must persist")
+	assert.True(t, got.SshAllowPubkey, "ssh_allow_pubkey must persist")
+	assert.False(t, got.SshAllowPassword, "ssh_allow_password=false must persist (not silently flipped to true)")
+}
+
+// =============================================================================
+// DeviceGroupHandler — list-for-device, dynamic query, evaluation
+// =============================================================================
+
+func TestDeviceGroupHandler_ListDeviceGroupsForDevice_ReturnsOnlyGroupsContainingDevice(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "list-host")
+	memberGroupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Member Group")
+	otherGroupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Other Group")
+	testutil.AddDeviceToTestGroup(t, st, adminID, memberGroupID, deviceID)
+
+	resp, err := h.ListDeviceGroupsForDevice(ctx, connect.NewRequest(&pm.ListDeviceGroupsForDeviceRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Groups, 1, "must only return groups containing the device")
+	assert.Equal(t, memberGroupID, resp.Msg.Groups[0].Id)
+	for _, g := range resp.Msg.Groups {
+		assert.NotEqual(t, otherGroupID, g.Id, "groups the device is not a member of must not leak into the response")
+	}
+}
+
+func TestDeviceGroupHandler_UpdateDeviceGroupQuery_FlipsToDynamicAndPersistsQuery(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	created, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{Name: "To Become Dynamic"}))
+	require.NoError(t, err)
+	require.False(t, created.Msg.Group.IsDynamic, "fresh groups must default to static")
+
+	updated, err := h.UpdateDeviceGroupQuery(ctx, connect.NewRequest(&pm.UpdateDeviceGroupQueryRequest{
+		Id:           created.Msg.Group.Id,
+		IsDynamic:    true,
+		DynamicQuery: `(device.hostname equals "dyn-host")`,
+	}))
+	require.NoError(t, err)
+	assert.True(t, updated.Msg.Group.IsDynamic, "is_dynamic must persist")
+	assert.Equal(t, `(device.hostname equals "dyn-host")`, updated.Msg.Group.DynamicQuery, "the query string must round-trip verbatim")
+}
+
+func TestDeviceGroupHandler_EvaluateDynamicGroup_CountsMatchingDevices(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	testutil.CreateTestDevice(t, st, "dyn-host")          // matching
+	testutil.CreateTestDevice(t, st, "non-matching-host") // not matching
+	group, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{Name: "Dyn"}))
+	require.NoError(t, err)
+	_, err = h.UpdateDeviceGroupQuery(ctx, connect.NewRequest(&pm.UpdateDeviceGroupQueryRequest{
+		Id:           group.Msg.Group.Id,
+		IsDynamic:    true,
+		DynamicQuery: `(device.hostname equals "dyn-host")`,
+	}))
+	require.NoError(t, err)
+
+	evaluated, err := h.EvaluateDynamicGroup(ctx, connect.NewRequest(&pm.EvaluateDynamicGroupRequest{
+		Id: group.Msg.Group.Id,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), evaluated.Msg.Group.MemberCount, "evaluation must select exactly the one matching device, not zero and not both")
+}
+
+// =============================================================================
+// ActionHandler — five dispatch fan-out variants
+// =============================================================================
+
+func newDispatchFixture(t *testing.T) (*api.ActionHandler, *api.NoOpEnqueuer, string, string, string, string, string, string) {
+	t.Helper()
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	queue := &api.NoOpEnqueuer{}
+	h.SetTaskQueueClient(queue)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	deviceA := testutil.CreateTestDevice(t, st, "fanout-a")
+	deviceB := testutil.CreateTestDevice(t, st, "fanout-b")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Fanout Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Fanout Set")
+	testutil.AddActionToTestSet(t, st, adminID, setID, actionID, 1)
+	definitionID := testutil.CreateTestDefinition(t, st, adminID, "Fanout Definition")
+	testutil.AddActionSetToTestDefinition(t, st, adminID, definitionID, setID, 1)
+	groupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Fanout Group")
+	testutil.AddDeviceToTestGroup(t, st, adminID, groupID, deviceA)
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceA, int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
+
+	return h, queue, adminID, deviceA, deviceB, actionID, setID, definitionID
+}
+
+func TestActionHandler_DispatchToMultiple_CreatesOneExecutionPerDevice(t *testing.T) {
+	h, _, adminID, deviceA, deviceB, actionID, _, _ := newDispatchFixture(t)
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.DispatchToMultiple(ctx, connect.NewRequest(&pm.DispatchToMultipleRequest{
+		DeviceIds: []string{deviceA, deviceB},
+		ActionSource: &pm.DispatchToMultipleRequest_ActionId{
+			ActionId: actionID,
+		},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Executions, 2, "exactly one execution per target device")
+
+	gotDevices := map[string]bool{}
+	for _, e := range resp.Msg.Executions {
+		gotDevices[e.DeviceId] = true
+		assert.NotEmpty(t, e.Id, "every execution must carry a server-minted id")
+	}
+	assert.True(t, gotDevices[deviceA] && gotDevices[deviceB], "both devices must appear in the executions list")
+}
+
+func TestActionHandler_DispatchAssignedActions_DispatchesEveryAssignedAction(t *testing.T) {
+	h, _, adminID, deviceA, _, _, _, _ := newDispatchFixture(t)
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.DispatchAssignedActions(ctx, connect.NewRequest(&pm.DispatchAssignedActionsRequest{DeviceId: deviceA}))
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Msg.Executions, "the device has an assigned action — at least one execution must be dispatched")
+	for _, e := range resp.Msg.Executions {
+		assert.Equal(t, deviceA, e.DeviceId, "every dispatched execution must target the requested device")
+	}
+}
+
+func TestActionHandler_DispatchActionSet_DispatchesEverySetMember(t *testing.T) {
+	h, _, adminID, deviceA, _, actionID, setID, _ := newDispatchFixture(t)
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.DispatchActionSet(ctx, connect.NewRequest(&pm.DispatchActionSetRequest{
+		DeviceId:    deviceA,
+		ActionSetId: setID,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Executions, 1, "the set has one action; the response must contain exactly one execution per member")
+	assert.Equal(t, actionID, resp.Msg.Executions[0].ActionId, "the execution must reference the set's member action")
+}
+
+func TestActionHandler_DispatchDefinition_DispatchesAllUnderlyingActions(t *testing.T) {
+	h, _, adminID, deviceA, _, actionID, _, definitionID := newDispatchFixture(t)
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.DispatchDefinition(ctx, connect.NewRequest(&pm.DispatchDefinitionRequest{
+		DeviceId:     deviceA,
+		DefinitionId: definitionID,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Executions, 1, "the definition has one set with one action — exactly one execution")
+	assert.Equal(t, actionID, resp.Msg.Executions[0].ActionId, "the resolved execution must point at the action under the definition")
+}
+
+func TestActionHandler_DispatchToGroup_FansOutAcrossEveryGroupMember(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	queue := &api.NoOpEnqueuer{}
+	h.SetTaskQueueClient(queue)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	deviceA := testutil.CreateTestDevice(t, st, "group-fanout-a")
+	deviceB := testutil.CreateTestDevice(t, st, "group-fanout-b")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Fanout Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+	groupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Fanout Group")
+	testutil.AddDeviceToTestGroup(t, st, adminID, groupID, deviceA)
+	testutil.AddDeviceToTestGroup(t, st, adminID, groupID, deviceB)
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.DispatchToGroup(ctx, connect.NewRequest(&pm.DispatchToGroupRequest{
+		GroupId: groupID,
+		ActionSource: &pm.DispatchToGroupRequest_ActionId{
+			ActionId: actionID,
+		},
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Executions, 2, "every device in the group must receive an execution")
+
+	deviceSeen := map[string]bool{}
+	for _, e := range resp.Msg.Executions {
+		deviceSeen[e.DeviceId] = true
+	}
+	assert.True(t, deviceSeen[deviceA] && deviceSeen[deviceB], "both group members must appear in the executions")
+	assert.GreaterOrEqual(t, len(queue.DeviceCalls), 2, "each execution must enqueue at least one device task")
+}
+
+// =============================================================================
+// DeviceHandler — LPS, LUKS history, LUKS token mint
+// =============================================================================
+
+func TestDeviceHandler_GetDeviceLpsPasswords_EmptyForNewDevice(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "lps-device")
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
+	ctx := testutil.UserContext(userID)
+
+	resp, err := h.GetDeviceLpsPasswords(ctx, connect.NewRequest(&pm.GetDeviceLpsPasswordsRequest{DeviceId: deviceID}))
+	require.NoError(t, err)
+	assert.Empty(t, resp.Msg.Current, "a device with no LPS rotation history must report empty current state")
+	assert.Empty(t, resp.Msg.History, "a device with no LPS rotation history must report empty history")
+}
+
+func TestDeviceHandler_GetDeviceLuksKeys_EmptyForNewDevice(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "luks-device")
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
+	ctx := testutil.UserContext(userID)
+
+	resp, err := h.GetDeviceLuksKeys(ctx, connect.NewRequest(&pm.GetDeviceLuksKeysRequest{DeviceId: deviceID}))
+	require.NoError(t, err)
+	assert.Empty(t, resp.Msg.Current, "a device with no LUKS rotation history must report empty current state")
+	assert.Empty(t, resp.Msg.History, "a device with no LUKS rotation history must report empty history")
+}
+
+func TestDeviceHandler_CreateLuksToken_ReturnsTokenAndCliCommand(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "luks-device")
+	actionID := testutil.CreateTestAction(t, st, userID, "Encrypt Disk", int(pm.ActionType_ACTION_TYPE_ENCRYPTION))
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
+	ctx := testutil.UserContext(userID)
+
+	resp, err := h.CreateLuksToken(ctx, connect.NewRequest(&pm.CreateLuksTokenRequest{
+		DeviceId: deviceID,
+		ActionId: actionID,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Token, 64, "the token must be a fixed-width 64-char identifier — operator-readability + collision-resistance contract")
+	assert.Contains(t, resp.Msg.CliCommand, resp.Msg.Token, "the CLI command must embed the same token that was returned")
+}
+
+// =============================================================================
+// CompliancePolicyHandler — add rule, update rule, device status
+// =============================================================================
+
+func TestCompliancePolicyHandler_AddCompliancePolicyRule_AppendsRuleToPolicy(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewCompliancePolicyHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	// AddCompliancePolicyRule rejects actions whose params don't carry
+	// is_compliance=true (compliance_policy_handler.go:267). Use the
+	// existing test helper that builds a SHELL action with that flag.
+	actionID := createComplianceShellAction(t, st, adminID, "Compliance Action")
+	policy, err := h.CreateCompliancePolicy(ctx, connect.NewRequest(&pm.CreateCompliancePolicyRequest{Name: "Baseline"}))
+	require.NoError(t, err)
+	require.Empty(t, policy.Msg.Policy.Rules, "a freshly-created policy must have no rules")
+
+	resp, err := h.AddCompliancePolicyRule(ctx, connect.NewRequest(&pm.AddCompliancePolicyRuleRequest{
+		PolicyId:         policy.Msg.Policy.Id,
+		ActionId:         actionID,
+		GracePeriodHours: 1,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Policy.Rules, 1, "AddCompliancePolicyRule must append exactly one rule")
+	rule := resp.Msg.Policy.Rules[0]
+	assert.Equal(t, actionID, rule.ActionId, "the rule must reference the action we asked for")
+	assert.Equal(t, int32(1), rule.GracePeriodHours, "the grace_period_hours we passed in must persist as-is")
+}
+
+func TestCompliancePolicyHandler_UpdateCompliancePolicyRule_UpdatesGracePeriod(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewCompliancePolicyHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	actionID := createComplianceShellAction(t, st, adminID, "Compliance Action")
+	policy, err := h.CreateCompliancePolicy(ctx, connect.NewRequest(&pm.CreateCompliancePolicyRequest{Name: "Baseline"}))
+	require.NoError(t, err)
+	_, err = h.AddCompliancePolicyRule(ctx, connect.NewRequest(&pm.AddCompliancePolicyRuleRequest{
+		PolicyId:         policy.Msg.Policy.Id,
+		ActionId:         actionID,
+		GracePeriodHours: 1,
+	}))
+	require.NoError(t, err)
+
+	resp, err := h.UpdateCompliancePolicyRule(ctx, connect.NewRequest(&pm.UpdateCompliancePolicyRuleRequest{
+		PolicyId:         policy.Msg.Policy.Id,
+		ActionId:         actionID,
+		GracePeriodHours: 24,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Policy.Rules, 1, "update must not change the rule count — only the grace period")
+	assert.Equal(t, int32(24), resp.Msg.Policy.Rules[0].GracePeriodHours, "grace_period_hours must reflect the new value")
+}
+
+func TestCompliancePolicyHandler_GetDeviceCompliancePolicyStatus_UnknownForDeviceWithoutEvaluations(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewCompliancePolicyHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "compliance-device")
+
+	resp, err := h.GetDeviceCompliancePolicyStatus(ctx, connect.NewRequest(&pm.GetDeviceCompliancePolicyStatusRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, pm.ComplianceStatus_COMPLIANCE_STATUS_UNKNOWN, resp.Msg.OverallStatus,
+		"a device that has never reported a compliance evaluation must surface as UNKNOWN (never as a misleading PASSING/FAILING default)")
+}
+
+// =============================================================================
+// TerminalHandler — list active sessions
+// =============================================================================
+//
+// TODO: TestTerminalHandler_ListActiveTerminalSessions — the admin
+// terminal RPCs (ListActiveTerminalSessions, TerminateTerminalSession)
+// require a fully-configured handler with both a gateway registry and
+// the internal HTTP client wired in. The existing newTerminalHandler
+// in terminal_handler_test.go intentionally passes nil for both so
+// the StartTerminal happy-path tests can run without that fixture.
+// terminal_handler_test.go:254 has a parallel TODO noting the same
+// gap. Add a `newAdminTerminalHandler` helper (registry + http client)
+// before re-introducing this test — otherwise it surfaces as an opaque
+// "registry not configured" failure instead of testing the RPC.
+
+// =============================================================================
+// Description updates — one test per entity (uniform shape, separate failures)
+// =============================================================================
+
+func TestActionHandler_UpdateActionDescription_PersistsValue(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	actionID := testutil.CreateTestAction(t, st, adminID, "Describe Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+
+	resp, err := h.UpdateActionDescription(ctx, connect.NewRequest(&pm.UpdateActionDescriptionRequest{
+		Id:          actionID,
+		Description: "action description",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, actionID, resp.Msg.Action.Id)
+	assert.Equal(t, "action description", resp.Msg.Action.Description)
+}
+
+func TestActionSetHandler_UpdateActionSetDescription_PersistsValue(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionSetHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Describe Set")
+
+	resp, err := h.UpdateActionSetDescription(ctx, connect.NewRequest(&pm.UpdateActionSetDescriptionRequest{
+		Id:          setID,
+		Description: "set description",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, setID, resp.Msg.Set.Id)
+	assert.Equal(t, "set description", resp.Msg.Set.Description)
+}
+
+func TestDefinitionHandler_UpdateDefinitionDescription_PersistsValue(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDefinitionHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	definitionID := testutil.CreateTestDefinition(t, st, adminID, "Describe Definition")
+
+	resp, err := h.UpdateDefinitionDescription(ctx, connect.NewRequest(&pm.UpdateDefinitionDescriptionRequest{
+		Id:          definitionID,
+		Description: "definition description",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, definitionID, resp.Msg.Definition.Id)
+	assert.Equal(t, "definition description", resp.Msg.Definition.Description)
+}
+
+func TestDeviceGroupHandler_UpdateDeviceGroupDescription_PersistsValue(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	groupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Describe Device Group")
+
+	resp, err := h.UpdateDeviceGroupDescription(ctx, connect.NewRequest(&pm.UpdateDeviceGroupDescriptionRequest{
+		Id:          groupID,
+		Description: "device group description",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, groupID, resp.Msg.Group.Id)
+	assert.Equal(t, "device group description", resp.Msg.Group.Description)
+}
+
+func TestCompliancePolicyHandler_UpdateCompliancePolicyDescription_PersistsValue(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewCompliancePolicyHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	policy, err := h.CreateCompliancePolicy(ctx, connect.NewRequest(&pm.CreateCompliancePolicyRequest{Name: "Describe Policy"}))
+	require.NoError(t, err)
+
+	resp, err := h.UpdateCompliancePolicyDescription(ctx, connect.NewRequest(&pm.UpdateCompliancePolicyDescriptionRequest{
+		Id:          policy.Msg.Policy.Id,
+		Description: "policy description",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, policy.Msg.Policy.Id, resp.Msg.Policy.Id)
+	assert.Equal(t, "policy description", resp.Msg.Policy.Description)
+}
+
+// =============================================================================
+// DefinitionHandler — set membership: reorder + remove
+// =============================================================================
+
+func TestDefinitionHandler_ReorderActionSetInDefinition_ReturnsSameDefinition(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDefinitionHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Set")
+	definitionID := testutil.CreateTestDefinition(t, st, adminID, "Definition")
+	testutil.AddActionSetToTestDefinition(t, st, adminID, definitionID, setID, 1)
+
+	resp, err := h.ReorderActionSetInDefinition(ctx, connect.NewRequest(&pm.ReorderActionSetInDefinitionRequest{
+		DefinitionId: definitionID,
+		ActionSetId:  setID,
+		NewOrder:     2,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, definitionID, resp.Msg.Definition.Id, "the response must echo the definition that was reordered")
+}
+
+func TestDefinitionHandler_RemoveActionSetFromDefinition_ReturnsDefinitionWithoutSet(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDefinitionHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Set")
+	definitionID := testutil.CreateTestDefinition(t, st, adminID, "Definition")
+	testutil.AddActionSetToTestDefinition(t, st, adminID, definitionID, setID, 1)
+
+	resp, err := h.RemoveActionSetFromDefinition(ctx, connect.NewRequest(&pm.RemoveActionSetFromDefinitionRequest{
+		DefinitionId: definitionID,
+		ActionSetId:  setID,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, definitionID, resp.Msg.Definition.Id)
+}
+
+// =============================================================================
+// DeviceHandler — ListDeviceAssignees
+// =============================================================================
+
+func TestDeviceHandler_ListDeviceAssignees_ListsAssignedUser(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "assignee-host")
+	testutil.AssignDeviceToUser(t, st, adminID, deviceID, userID)
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.ListDeviceAssignees(ctx, connect.NewRequest(&pm.ListDeviceAssigneesRequest{DeviceId: deviceID}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Assignees, 1, "exactly one user is assigned — must be the one we assigned")
+	assert.Equal(t, userID, resp.Msg.Assignees[0].Id)
+}
+
+// =============================================================================
+// UserGroupHandler — dynamic query + query validation
+// =============================================================================
+
+func TestUserGroupHandler_UpdateUserGroupQuery_FlipsToDynamicAndPersistsQuery(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	groupID := testutil.CreateTestUserGroup(t, st, adminID, "Dynamic Users")
+
+	resp, err := h.UpdateUserGroupQuery(ctx, connect.NewRequest(&pm.UpdateUserGroupQueryRequest{
+		Id:           groupID,
+		IsDynamic:    true,
+		DynamicQuery: `(user.email contains "@user.com")`,
+	}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.Group.IsDynamic)
+	assert.Equal(t, `(user.email contains "@user.com")`, resp.Msg.Group.DynamicQuery, "the query string must round-trip verbatim")
+}
+
+func TestUserGroupHandler_ValidateUserGroupQuery_AcceptsValidSyntax(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.ValidateUserGroupQuery(ctx, connect.NewRequest(&pm.ValidateUserGroupQueryRequest{
+		Query: `(user.email contains "@")`,
+	}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.Valid, "a syntactically valid query must report valid=true")
+}
+
+// =============================================================================
+// TOTPHandler — admin force-disable
+// =============================================================================
+
+func TestTOTPHandler_AdminDisableUserTOTP_DisablesUsersTOTP(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	ctx := testutil.AdminContext(adminID)
+
+	testutil.SetupTOTP(t, st, enc, userID, "totp-user@example.com")
+	h := api.NewTOTPHandler(st, slog.Default(), testutil.NewJWTManager(), enc, "Test")
+
+	_, err := h.AdminDisableUserTOTP(ctx, connect.NewRequest(&pm.AdminDisableUserTOTPRequest{UserId: userID}))
+	require.NoError(t, err, "an admin acting on a user with TOTP set up must be allowed to force-disable it")
+}
+
+// =============================================================================
+// SearchHandler + RoleHandler — utility RPCs
+// =============================================================================
+
+func TestSearchHandler_RebuildSearchIndex_UnavailableWhenIndexNotConfigured(t *testing.T) {
+	h := api.NewSearchHandler(slog.Default())
+	adminID := testutil.NewID()
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.RebuildSearchIndex(ctx, connect.NewRequest(&pm.RebuildSearchIndexRequest{}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err),
+		"calling RebuildSearchIndex without a configured index must surface as Unavailable (the operator-readable signal that this control replica isn't the indexer-bearing one), not a generic Internal")
+}
+
+func TestRoleHandler_ListPermissions_ReturnsTheBuiltinPermissionCatalog(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.ListPermissions(ctx, connect.NewRequest(&pm.ListPermissionsRequest{}))
+	require.NoError(t, err)
+	assert.NotEmpty(t, resp.Msg.Permissions, "the built-in permission catalog must surface to admins — empty would be a serious RBAC regression")
+}

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -114,6 +114,10 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 
 // GetOSQueryResult polls for the result of a dispatched osquery.
 func (h *OSQueryHandler) GetOSQueryResult(ctx context.Context, req *connect.Request[pm.GetOSQueryResultRequest]) (*connect.Response[pm.GetOSQueryResultResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	result, err := h.store.Repos().OSQuery.GetResult(ctx, req.Msg.QueryId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrQueryResultNotFound, connect.CodeNotFound, "query result not found")
@@ -152,6 +156,10 @@ func (h *OSQueryHandler) GetOSQueryResult(ctx context.Context, req *connect.Requ
 
 // GetDeviceInventory returns cached inventory data for a device.
 func (h *OSQueryHandler) GetDeviceInventory(ctx context.Context, req *connect.Request[pm.GetDeviceInventoryRequest]) (*connect.Response[pm.GetDeviceInventoryResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	msg := req.Msg
 
 	var rows []store.InventoryTable
@@ -189,6 +197,10 @@ func (h *OSQueryHandler) GetDeviceInventory(ctx context.Context, req *connect.Re
 
 // RefreshDeviceInventory requests the agent to re-collect and send inventory.
 func (h *OSQueryHandler) RefreshDeviceInventory(ctx context.Context, req *connect.Request[pm.RefreshDeviceInventoryRequest]) (*connect.Response[pm.RefreshDeviceInventoryResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	msg := req.Msg
 
 	// Verify device exists

--- a/internal/api/osquery_handler_test.go
+++ b/internal/api/osquery_handler_test.go
@@ -192,7 +192,8 @@ func TestGetOSQueryResult_NotFound(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	_, err := h.GetOSQueryResult(ctx, connect.NewRequest(&pm.GetOSQueryResultRequest{
-		QueryId: "nonexistent",
+		// Valid-format ULID that isn't in the osquery_results projection.
+		QueryId: testutil.NewID(),
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
@@ -320,7 +321,8 @@ func TestRefreshDeviceInventory_DeviceNotFound(t *testing.T) {
 	ctx := testutil.AdminContext(adminID)
 
 	_, err := h.RefreshDeviceInventory(ctx, connect.NewRequest(&pm.RefreshDeviceInventoryRequest{
-		DeviceId: "nonexistent",
+		// Valid-format ULID that isn't in the devices_projection.
+		DeviceId: testutil.NewID(),
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))

--- a/internal/api/registration_handler.go
+++ b/internal/api/registration_handler.go
@@ -120,6 +120,10 @@ func NewRegistrationHandler(st *store.Store, certAuth *ca.CA, gatewayURL string,
 // Register handles agent registration requests synchronously.
 // Validates the registration token, signs the CSR, emits events, and returns credentials.
 func (h *RegistrationHandler) Register(ctx context.Context, req *connect.Request[pm.RegisterRequest]) (*connect.Response[pm.RegisterResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	logger := h.logger.With("hostname", req.Msg.Hostname, "agent_version", req.Msg.AgentVersion)
 	logger.Info("processing registration request")
 

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -118,6 +118,10 @@ func (h *RoleHandler) GetRole(ctx context.Context, req *connect.Request[pm.GetRo
 
 // ListRoles returns a paginated list of roles.
 func (h *RoleHandler) ListRoles(ctx context.Context, req *connect.Request[pm.ListRolesRequest]) (*connect.Response[pm.ListRolesResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err
@@ -403,6 +407,10 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 
 // ListPermissions returns all available permissions.
 func (h *RoleHandler) ListPermissions(ctx context.Context, req *connect.Request[pm.ListPermissionsRequest]) (*connect.Response[pm.ListPermissionsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	allPerms := auth.AllPermissions()
 	protoPerms := make([]*pm.PermissionInfo, len(allPerms))
 	for i, p := range allPerms {

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -108,6 +108,10 @@ func searchScopeFromString(s string) pm.SearchScope {
 }
 
 func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.SearchRequest]) (*connect.Response[pm.SearchResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	if h.searchIdx == nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable, "search index is not configured on this control instance")
 	}
@@ -216,6 +220,10 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 }
 
 func (h *SearchHandler) RebuildSearchIndex(ctx context.Context, req *connect.Request[pm.RebuildSearchIndexRequest]) (*connect.Response[pm.RebuildSearchIndexResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	if h.searchIdx == nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable, "search index is not configured on this control instance")
 	}

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -32,6 +32,10 @@ func NewSettingsHandler(st *store.Store, logger *slog.Logger, systemActions *Sys
 
 // GetServerSettings returns the current server settings.
 func (h *SettingsHandler) GetServerSettings(ctx context.Context, req *connect.Request[pm.GetServerSettingsRequest]) (*connect.Response[pm.GetServerSettingsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	settings, err := h.store.Repos().Settings.GetServer(ctx)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get server settings")
@@ -47,6 +51,10 @@ func (h *SettingsHandler) GetServerSettings(ctx context.Context, req *connect.Re
 
 // UpdateServerSettings updates global server settings and triggers a full resync.
 func (h *SettingsHandler) UpdateServerSettings(ctx context.Context, req *connect.Request[pm.UpdateServerSettingsRequest]) (*connect.Response[pm.UpdateServerSettingsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "server_settings",
 		StreamID:   "global",

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -104,6 +104,10 @@ func NewSSOHandler(st *store.Store, logger *slog.Logger, jwtManager *auth.JWTMan
 
 // ListAuthMethods returns the available authentication methods.
 func (h *SSOHandler) ListAuthMethods(ctx context.Context, req *connect.Request[pm.ListAuthMethodsRequest]) (*connect.Response[pm.ListAuthMethodsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	resp := &pm.ListAuthMethodsResponse{
 		PasswordEnabled: h.passwordAuthEnabled,
 	}

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -80,6 +80,10 @@ func NewTerminalHandler(st *store.Store, tokenStore *terminal.TokenStore, reg *r
 // key is "StartTerminal" — same convention as every other handler),
 // so this method only runs for callers that already hold it.
 func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Request[pm.StartTerminalRequest]) (*connect.Response[pm.StartTerminalResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	userCtx, ok := auth.UserFromContext(ctx)
 	if !ok {
 		return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, "not authenticated")
@@ -383,6 +387,10 @@ func (h *TerminalHandler) resolveGatewayURL(ctx context.Context, deviceID string
 // This matches the contract documented above StopTerminalRequest in
 // the SDK proto.
 func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request[pm.StopTerminalRequest]) (*connect.Response[pm.StopTerminalResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	userCtx, ok := auth.UserFromContext(ctx)
 	if !ok {
 		return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, "not authenticated")
@@ -468,6 +476,10 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 // session snapshot; the control enriches with user/device metadata
 // from the database and returns the merged list.
 func (h *TerminalHandler) ListActiveTerminalSessions(ctx context.Context, req *connect.Request[pm.ListActiveTerminalSessionsRequest]) (*connect.Response[pm.ListActiveTerminalSessionsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	if h.registry == nil || h.internalHTTPClient == nil {
 		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
 			"terminal admin RPCs require a configured registry and internal HTTP client")
@@ -529,6 +541,10 @@ func (h *TerminalHandler) ListActiveTerminalSessions(ctx context.Context, req *c
 // (via the token store's device_id → registry lookup) and calls
 // TerminateGatewayTerminalSession on that gateway.
 func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *connect.Request[pm.TerminateTerminalSessionRequest]) (*connect.Response[pm.TerminateTerminalSessionResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	// Explicit auth check at the handler boundary, matching the pattern
 	// used by StartTerminal and StopTerminal above. The auth interceptor
 	// also enforces admin access to this RPC, but a missing auth context

--- a/internal/api/terminal_handler_test.go
+++ b/internal/api/terminal_handler_test.go
@@ -149,7 +149,8 @@ func TestStartTerminal_DeviceNotFound(t *testing.T) {
 	setLinuxUsername(t, st, userID, "alice")
 
 	_, err := h.StartTerminal(authedCtx(userID), connect.NewRequest(&pm.StartTerminalRequest{
-		DeviceId: "non-existent-device",
+		// Valid-format ULID that isn't in the devices_projection.
+		DeviceId: testutil.NewID(),
 	}))
 	require.Error(t, err)
 	var connectErr *connect.Error
@@ -263,7 +264,8 @@ func TestStopTerminal_UnknownSessionIsIdempotent(t *testing.T) {
 	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 
 	resp, err := h.StopTerminal(authedCtx(userID), connect.NewRequest(&pm.StopTerminalRequest{
-		SessionId: "no-such-session",
+		// Valid-format ULID that no session has minted.
+		SessionId: testutil.NewID(),
 	}))
 	require.NoError(t, err)
 	require.NotNil(t, resp)
@@ -274,7 +276,12 @@ func TestStopTerminal_NotAuthenticated(t *testing.T) {
 	h, _ := newTerminalHandler(t, st)
 
 	_, err := h.StopTerminal(context.Background(), connect.NewRequest(&pm.StopTerminalRequest{
-		SessionId: "any",
+		// Valid-format ULID — the test asserts the auth gate fires
+		// before any session-store lookup, so the request only needs
+		// to pass boundary validation. A malformed value would short-
+		// circuit at InvalidArgument and hide the auth check we're
+		// pinning.
+		SessionId: testutil.NewID(),
 	}))
 	require.Error(t, err)
 	var connectErr *connect.Error
@@ -296,7 +303,10 @@ func TestTerminateTerminalSession_NotAuthenticated(t *testing.T) {
 	h, _ := newTerminalHandler(t, st)
 
 	_, err := h.TerminateTerminalSession(context.Background(), connect.NewRequest(&pm.TerminateTerminalSessionRequest{
-		SessionId: "any",
+		// Valid-format ULID for the same reason as
+		// TestStopTerminal_NotAuthenticated above — the test is
+		// about the auth gate firing first, not the session lookup.
+		SessionId: testutil.NewID(),
 		Reason:    "test",
 	}))
 	require.Error(t, err)

--- a/internal/api/token_handler.go
+++ b/internal/api/token_handler.go
@@ -136,6 +136,10 @@ func (h *TokenHandler) GetToken(ctx context.Context, req *connect.Request[pm.Get
 
 // ListTokens returns a paginated list of tokens.
 func (h *TokenHandler) ListTokens(ctx context.Context, req *connect.Request[pm.ListTokensRequest]) (*connect.Response[pm.ListTokensResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -42,6 +42,10 @@ func NewTOTPHandler(st *store.Store, logger *slog.Logger, jwtManager *auth.JWTMa
 
 // SetupTOTP generates a new TOTP secret and backup codes for the current user.
 func (h *TOTPHandler) SetupTOTP(ctx context.Context, req *connect.Request[pm.SetupTOTPRequest]) (*connect.Response[pm.SetupTOTPResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
@@ -228,6 +232,10 @@ func (h *TOTPHandler) AdminDisableUserTOTP(ctx context.Context, req *connect.Req
 
 // GetTOTPStatus returns whether TOTP is enabled and how many backup codes remain.
 func (h *TOTPHandler) GetTOTPStatus(ctx context.Context, req *connect.Request[pm.GetTOTPStatusRequest]) (*connect.Response[pm.GetTOTPStatusResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -136,6 +136,10 @@ func (h *UserGroupHandler) GetUserGroup(ctx context.Context, req *connect.Reques
 
 // ListUserGroups returns a paginated list of user groups.
 func (h *UserGroupHandler) ListUserGroups(ctx context.Context, req *connect.Request[pm.ListUserGroupsRequest]) (*connect.Response[pm.ListUserGroupsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -227,6 +227,10 @@ func (h *UserHandler) GetUser(ctx context.Context, req *connect.Request[pm.GetUs
 
 // ListUsers returns a paginated list of users.
 func (h *UserHandler) ListUsers(ctx context.Context, req *connect.Request[pm.ListUsersRequest]) (*connect.Response[pm.ListUsersResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err

--- a/internal/api/validation_interceptor.go
+++ b/internal/api/validation_interceptor.go
@@ -1,0 +1,60 @@
+package api
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+)
+
+// ValidationInterceptor runs Validate on every inbound Connect-RPC
+// request before it reaches the handler. Wire it into the production
+// interceptor chain after the auth interceptor and before authz, so
+// authz still sees a well-formed message but doesn't waste cycles on
+// requests that can't pass validation.
+//
+// Why every handler ALSO calls Validate(ctx, req.Msg) at its
+// top-of-function:
+//   - The interceptor only sees requests that traverse the configured
+//     interceptor chain. Direct handler calls from tests or from
+//     in-process callers (e.g. a future internal RPC bridge that bypasses
+//     the chain) would skip it.
+//   - Defense in depth — the cost is one map lookup + a fast-path bool
+//     check inside Validate; the benefit is that adding the interceptor
+//     can't accidentally silently disable validation if it's ever
+//     removed from cmd/control/main.go's chain.
+//
+// Validation here covers the proto-level rules (protovalidate tags).
+// Handlers still own their own semantic checks — authz, cross-field
+// invariants, target-existence — those are *not* a job for this
+// interceptor.
+type ValidationInterceptor struct{}
+
+// NewValidationInterceptor creates a Connect-RPC interceptor for
+// boundary validation. See ValidationInterceptor's doc comment for the
+// chain ordering and the rationale for the redundant handler-level
+// Validate calls.
+func NewValidationInterceptor() *ValidationInterceptor {
+	return &ValidationInterceptor{}
+}
+
+// WrapUnary implements connect.Interceptor.
+func (i *ValidationInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
+	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+		if err := Validate(ctx, req.Any()); err != nil {
+			return nil, err
+		}
+		return next(ctx, req)
+	}
+}
+
+// WrapStreamingClient implements connect.Interceptor.
+func (i *ValidationInterceptor) WrapStreamingClient(next connect.StreamingClientFunc) connect.StreamingClientFunc {
+	return next
+}
+
+// WrapStreamingHandler implements connect.Interceptor.
+func (i *ValidationInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
+	return next
+}
+
+var _ connect.Interceptor = (*ValidationInterceptor)(nil)

--- a/internal/api/validation_interceptor_test.go
+++ b/internal/api/validation_interceptor_test.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type validationInterceptorFixture struct {
+	ID string `validate:"required,ulid"`
+}
+
+func TestValidationInterceptor_RejectsInvalidUnaryRequestBeforeHandler(t *testing.T) {
+	interceptor := NewValidationInterceptor()
+	called := false
+
+	next := func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		called = true
+		return connect.NewResponse(&validationInterceptorFixture{}), nil
+	}
+
+	_, err := interceptor.WrapUnary(next)(context.Background(), connect.NewRequest(&validationInterceptorFixture{ID: "not-a-ulid"}))
+
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.False(t, called, "invalid boundary input must not reach the RPC handler")
+}
+
+func TestValidationInterceptor_AllowsValidUnaryRequest(t *testing.T) {
+	interceptor := NewValidationInterceptor()
+	called := false
+
+	next := func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+		called = true
+		return connect.NewResponse(&validationInterceptorFixture{}), nil
+	}
+
+	_, err := interceptor.WrapUnary(next)(context.Background(), connect.NewRequest(&validationInterceptorFixture{ID: "01ARZ3NDEKTSV4RRFFQ69G5FAV"}))
+
+	require.NoError(t, err)
+	assert.True(t, called)
+}

--- a/internal/gateway/task_handlers.go
+++ b/internal/gateway/task_handlers.go
@@ -23,8 +23,12 @@ import (
 // round-trips cleanly. A nil signer disables verification — tests
 // only; production wiring in cmd/gateway/main.go refuses an empty
 // PM_TASK_SIGNING_KEY.
+type messageSender interface {
+	Send(deviceID string, msg *pm.ServerMessage) error
+}
+
 type TaskHandlerFactory struct {
-	manager    *connection.Manager
+	manager    messageSender
 	taskSigner *taskqueue.Signer
 	logger     *slog.Logger
 }
@@ -61,7 +65,7 @@ func (f *TaskHandlerFactory) NewMux(deviceID string) *asynq.ServeMux {
 // deviceTaskHandler processes tasks from a specific device's queue.
 type deviceTaskHandler struct {
 	deviceID string
-	manager  *connection.Manager
+	manager  messageSender
 	logger   *slog.Logger
 }
 

--- a/internal/gateway/task_handlers_test.go
+++ b/internal/gateway/task_handlers_test.go
@@ -1,9 +1,13 @@
 package gateway
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	"testing"
 
+	"github.com/hibiken/asynq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -233,29 +237,54 @@ func TestLogQueryDispatchPayloadRoundtrip(t *testing.T) {
 	assert.Equal(t, original.Kernel, decoded.Kernel)
 }
 
+type recordingMessageSender struct {
+	deviceID string
+	messages []*pm.ServerMessage
+	err      error
+}
+
+func (r *recordingMessageSender) Send(deviceID string, msg *pm.ServerMessage) error {
+	if r.err != nil {
+		return r.err
+	}
+	r.deviceID = deviceID
+	r.messages = append(r.messages, msg)
+	return nil
+}
+
 func TestDeviceTaskHandler_BuildsActionMessage(t *testing.T) {
-	// Directly test the action building logic by constructing the Action
-	// exactly as handleActionDispatch does (minus the Send call).
 	payload := taskqueue.ActionDispatchPayload{
-		ExecutionID:    "exec-001",
-		ActionType:     int32(pm.ActionType_ACTION_TYPE_PACKAGE),
-		DesiredState:   int32(pm.DesiredState_DESIRED_STATE_PRESENT),
-		Params:         json.RawMessage(`{"name":"htop"}`),
-		TimeoutSeconds: 600,
+		ExecutionID:     "exec-001",
+		ActionType:      int32(pm.ActionType_ACTION_TYPE_PACKAGE),
+		DesiredState:    int32(pm.DesiredState_DESIRED_STATE_PRESENT),
+		Params:          json.RawMessage(`{"name":"htop"}`),
+		TimeoutSeconds:  600,
+		Signature:       []byte("sig"),
+		ParamsCanonical: []byte(`{"name":"htop"}`),
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	sender := &recordingMessageSender{}
+	h := &deviceTaskHandler{
+		deviceID: "device-1",
+		manager:  sender,
+		logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
-	action := &pm.Action{
-		Id:             &pm.ActionId{Value: payload.ExecutionID},
-		Type:           pm.ActionType(payload.ActionType),
-		DesiredState:   pm.DesiredState(payload.DesiredState),
-		TimeoutSeconds: payload.TimeoutSeconds,
-	}
-	actionparams.PopulateAction(action, payload.ActionType, payload.Params)
+	err = h.handleActionDispatch(context.Background(), asynq.NewTask(taskqueue.TypeActionDispatch, data))
+	require.NoError(t, err)
 
+	require.Len(t, sender.messages, 1)
+	assert.Equal(t, "device-1", sender.deviceID)
+	action := sender.messages[0].GetAction().GetAction()
+	require.NotNil(t, action)
 	assert.Equal(t, "exec-001", action.Id.Value)
 	assert.Equal(t, pm.ActionType_ACTION_TYPE_PACKAGE, action.Type)
 	assert.Equal(t, pm.DesiredState_DESIRED_STATE_PRESENT, action.DesiredState)
 	assert.Equal(t, int32(600), action.TimeoutSeconds)
+	assert.Equal(t, []byte("sig"), action.Signature)
+	assert.Equal(t, []byte(`{"name":"htop"}`), action.ParamsCanonical)
 	require.NotNil(t, action.GetPackage())
 	assert.Equal(t, "htop", action.GetPackage().Name)
 }

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -18,7 +18,6 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage/server/internal/connection"
-	"github.com/manchtools/power-manage/server/internal/gateway"
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/mtls"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
@@ -32,6 +31,13 @@ const (
 	DeviceIDContextKey contextKey = "device_id"
 )
 
+const registryDetachTimeout = 5 * time.Second
+
+type deviceWorkerManager interface {
+	StartWorker(deviceID string) error
+	StopWorker(deviceID string)
+}
+
 // AgentHandler implements the AgentService.
 type AgentHandler struct {
 	pmv1connect.UnimplementedAgentServiceHandler
@@ -43,7 +49,7 @@ type AgentHandler struct {
 	// implements the interface.
 	aqClient          taskqueue.Enqueuer
 	controlProxy      *ControlProxy
-	workerMgr         *gateway.DeviceWorkerManager
+	workerMgr         deviceWorkerManager
 	logger            *slog.Logger
 	serverVersion     string
 	heartbeatInterval time.Duration
@@ -70,7 +76,7 @@ func NewAgentHandler(
 	manager *connection.Manager,
 	aqClient taskqueue.Enqueuer,
 	controlProxy *ControlProxy,
-	workerMgr *gateway.DeviceWorkerManager,
+	workerMgr deviceWorkerManager,
 	serverVersion string,
 	heartbeatInterval time.Duration,
 	logger *slog.Logger,
@@ -92,7 +98,7 @@ func NewAgentHandlerWithTLS(
 	manager *connection.Manager,
 	aqClient taskqueue.Enqueuer,
 	controlProxy *ControlProxy,
-	workerMgr *gateway.DeviceWorkerManager,
+	workerMgr deviceWorkerManager,
 	serverVersion string,
 	heartbeatInterval time.Duration,
 	logger *slog.Logger,
@@ -354,10 +360,13 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 			// Detach from the registry too. Same race-aware pattern:
 			// only delete if we're still the current connection,
 			// otherwise we'd evict a freshly-attached entry from a
-			// reconnect that already happened. Use Background ctx
-			// because the request ctx is being torn down.
+			// reconnect that already happened. The detach context is
+			// derived from the stream context but detached from its
+			// cancellation so cleanup can finish after the RPC ends.
 			if h.registry != nil {
-				if err := h.registry.DetachDevice(context.Background(), deviceID, h.gatewayID); err != nil {
+				detachCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), registryDetachTimeout)
+				defer cancel()
+				if err := h.registry.DetachDevice(detachCtx, deviceID, h.gatewayID); err != nil {
 					h.logger.Warn("failed to remove device→gateway mapping",
 						"device_id", deviceID, "error", err)
 				}

--- a/internal/handler/agent_stream_test.go
+++ b/internal/handler/agent_stream_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -27,11 +26,8 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"crypto/tls"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/http2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
@@ -122,10 +118,14 @@ func newStreamFixture(t *testing.T, requireTLS bool) *streamFixture {
 		requireTLS:        requireTLS,
 	}
 
-	// 3) AgentService over h2c httptest server. h2c.NewHandler was
-	// deprecated in x/net v0.55 in favour of http.Server.Protocols; the
-	// Go 1.24+ replacement is to set Protocols.UnencryptedHTTP2 on the
-	// underlying Server before Start.
+	// 3) AgentService over h2c httptest server. Both server and
+	// client opt into UnencryptedHTTP2 via http.Protocols (Go 1.24+
+	// first-party h2c support). Mixing the new server-side opt-in
+	// with the deprecated x/net http2.Transport on the client side
+	// produced trailer-less terminations that the client wrapped as
+	// CodeUnknown "EOF" on clean shutdown — using the same primitive
+	// on both ends lets the client see plain io.EOF when the
+	// handler's Stream() returns nil.
 	mux := http.NewServeMux()
 	path, hh := pmv1connect.NewAgentServiceHandler(h)
 	mux.Handle(path, hh)
@@ -137,15 +137,13 @@ func newStreamFixture(t *testing.T, requireTLS bool) *streamFixture {
 	t.Cleanup(srv.Close)
 
 	httpClient := &http.Client{
-		Transport: &http2.Transport{
-			AllowHTTP: true,
-			DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-				var d net.Dialer
-				return d.DialContext(ctx, network, addr)
-			},
+		Transport: &http.Transport{
+			Protocols: protocols,
 		},
 	}
-	client := pmv1connect.NewAgentServiceClient(httpClient, srv.URL, connect.WithGRPC())
+	// No protocol option → defaults to Connect, matching the
+	// production agent's NewAgentServiceClient call.
+	client := pmv1connect.NewAgentServiceClient(httpClient, srv.URL)
 
 	return &streamFixture{
 		client:      client,
@@ -159,7 +157,9 @@ func newStreamFixture(t *testing.T, requireTLS bool) *streamFixture {
 // recvErr drives the bidi stream's Receive loop until it returns the
 // terminal error from the server's Stream() return — the BidiStream
 // API surfaces server-side errors only on the next Receive after the
-// handler has returned.
+// handler has returned. Clean shutdown is io.EOF; anything else
+// (including Connect-wrapped errors with the handler's actual reason)
+// is propagated to the caller.
 func recvErr(stream interface {
 	Receive() (*pm.ServerMessage, error)
 }) error {
@@ -280,6 +280,14 @@ func TestStream_HappyPathRegistersStartsWorkerAndSendsWelcome(t *testing.T) {
 	assert.Empty(t, stopped)
 
 	require.NoError(t, stream.CloseRequest())
+	// Drain the response side so the handler's Stream() goroutine
+	// observes the request-side EOF and unwinds before we snapshot
+	// worker state below. The terminal error itself is not asserted
+	// here — Connect-Go v1.18.1 wraps a clean bidi stream shutdown
+	// over httptest as *connect.Error{CodeUnknown, "EOF"} instead
+	// of plain io.EOF (see #331 for the open investigation). The
+	// load-bearing assertion is the worker.stopped check below,
+	// which proves Stream() returned and ran its cleanup.
 	_ = recvErr(stream)
 
 	_, stopped = f.worker.snapshot()

--- a/internal/handler/agent_stream_test.go
+++ b/internal/handler/agent_stream_test.go
@@ -10,12 +10,9 @@ package handler
 //
 // Strategy: stand up a real Connect-RPC handler over h2c (HTTP/2 over
 // cleartext) on httptest.Server, and exercise it through a real
-// AgentServiceClient bidi stream. workerMgr is left nil on the handler —
-// every test case in here bails BEFORE Stream's manager.Register +
-// workerMgr.StartWorker block, so a nil workerMgr is safe for these
-// paths. A test that exercises the post-Register path would either
-// need workerMgr to become an interface or stand up miniredis; both
-// are out of scope here.
+// AgentServiceClient bidi stream. The fixture uses recording fakes for
+// the task queue and per-device worker manager so the post-register
+// happy path is covered without depending on Valkey.
 
 import (
 	"context"
@@ -62,6 +59,31 @@ func (r *recordingControlForStream) VerifyDevice(_ context.Context, req *connect
 	return connect.NewResponse(&pm.VerifyDeviceResponse{}), nil
 }
 
+type fakeStreamWorkerManager struct {
+	mu      sync.Mutex
+	started []string
+	stopped []string
+}
+
+func (f *fakeStreamWorkerManager) StartWorker(deviceID string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.started = append(f.started, deviceID)
+	return nil
+}
+
+func (f *fakeStreamWorkerManager) StopWorker(deviceID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.stopped = append(f.stopped, deviceID)
+}
+
+func (f *fakeStreamWorkerManager) snapshot() (started, stopped []string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.started...), append([]string(nil), f.stopped...)
+}
+
 // streamFixture wires AgentHandler into an h2c httptest.Server and
 // returns an AgentServiceClient pointed at it, plus the recording
 // control stub so tests can flip the VerifyDevice outcome.
@@ -69,6 +91,7 @@ type streamFixture struct {
 	client      pmv1connect.AgentServiceClient
 	internalSrv *httptest.Server
 	control     *recordingControlForStream
+	worker      *fakeStreamWorkerManager
 	server      *httptest.Server
 }
 
@@ -83,12 +106,16 @@ func newStreamFixture(t *testing.T, requireTLS bool) *streamFixture {
 	internalSrv := httptest.NewServer(internalMux)
 	t.Cleanup(internalSrv.Close)
 
-	// 2) Real ControlProxy + connection.Manager + nil workerMgr.
+	// 2) Real ControlProxy + connection.Manager + recording fakes for
+	// the queue and per-device worker manager.
 	proxy := NewControlProxy(internalSrv.Client(), internalSrv.URL)
 	mgr := connection.NewManager()
+	worker := &fakeStreamWorkerManager{}
 	h := &AgentHandler{
 		manager:           mgr,
+		aqClient:          &fakeEnqueuer{},
 		controlProxy:      proxy,
+		workerMgr:         worker,
 		logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
 		serverVersion:     "test",
 		heartbeatInterval: 30 * time.Second,
@@ -124,6 +151,7 @@ func newStreamFixture(t *testing.T, requireTLS bool) *streamFixture {
 		client:      client,
 		internalSrv: internalSrv,
 		control:     control,
+		worker:      worker,
 		server:      srv,
 	}
 }
@@ -227,17 +255,8 @@ func TestStream_VerifyDeviceFailureRejectsConnection(t *testing.T) {
 		"VerifyDevice must be called with the Hello-supplied device_id")
 }
 
-func TestStream_HelloDeviceIDForwardedToVerifyDevice(t *testing.T) {
-	// Happy-path through VerifyDevice: the gate succeeds, but with
-	// workerMgr=nil the next call (h.workerMgr.StartWorker) panics.
-	// This is fine — recovering inside Stream() turns the panic into
-	// CodeInternal, which is what the test asserts. The point of the
-	// test is that VerifyDevice was called with the right ID, proving
-	// the Hello → VerifyDevice plumbing works.
+func TestStream_HappyPathRegistersStartsWorkerAndSendsWelcome(t *testing.T) {
 	f := newStreamFixture(t, false)
-	// VerifyDevice succeeds (no err). manager.Register is real, but
-	// workerMgr is nil so StartWorker will panic — Stream's defer
-	// recovers and surfaces CodeInternal.
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -249,13 +268,20 @@ func TestStream_HelloDeviceIDForwardedToVerifyDevice(t *testing.T) {
 			AgentVersion: "happy",
 		}},
 	}))
-	require.NoError(t, stream.CloseRequest())
 
-	// We don't assert on the connection.Manager state because Register
-	// happens AFTER VerifyDevice but BEFORE the panic — the recovered
-	// error path doesn't unregister, so observed state would be racy.
-	// The point is the VerifyDevice call landed.
+	msg, err := stream.Receive()
+	require.NoError(t, err)
+	require.NotNil(t, msg.GetWelcome(), "successful stream setup must send Welcome to the agent")
+	assert.Equal(t, "test", msg.GetWelcome().ServerVersion)
+	assert.Equal(t, "01HZX9DEFGH000000000000000", f.control.lastVerifyDevice)
+
+	started, stopped := f.worker.snapshot()
+	assert.Equal(t, []string{"01HZX9DEFGH000000000000000"}, started)
+	assert.Empty(t, stopped)
+
+	require.NoError(t, stream.CloseRequest())
 	_ = recvErr(stream)
-	assert.Equal(t, "01HZX9DEFGH000000000000000", f.control.lastVerifyDevice,
-		"VerifyDevice MUST be called with the Hello device_id, even on the happy path")
+
+	_, stopped = f.worker.snapshot()
+	assert.Equal(t, []string{"01HZX9DEFGH000000000000000"}, stopped)
 }

--- a/internal/search/worker_test.go
+++ b/internal/search/worker_test.go
@@ -1,0 +1,118 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/hibiken/asynq"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/taskqueue"
+)
+
+const workerTestKeyHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+type workerFixture struct {
+	ctx    context.Context
+	rdb    *redis.Client
+	signer *taskqueue.Signer
+	mux    *asynq.ServeMux
+}
+
+func newWorkerFixture(t *testing.T) *workerFixture {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, rdb.Close()) })
+
+	signer, err := taskqueue.NewSigner(workerTestKeyHex)
+	require.NoError(t, err)
+	worker := NewWorker(rdb, signer, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	mux := asynq.NewServeMux()
+	worker.RegisterHandlers(mux)
+
+	return &workerFixture{ctx: context.Background(), rdb: rdb, signer: signer, mux: mux}
+}
+
+func (f *workerFixture) signedTask(t *testing.T, taskType string, payload any) *asynq.Task {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return asynq.NewTask(taskType, f.signer.Wrap(data), asynq.Queue(taskqueue.SearchQueue))
+}
+
+func TestWorker_ReindexRequiresSignedTaskAndWritesHash(t *testing.T) {
+	f := newWorkerFixture(t)
+
+	payload := taskqueue.SearchReindexPayload{
+		Scope: ScopeAction,
+		ID:    "act-1",
+		Data: &taskqueue.SearchEntityData{
+			Name:        "Install Nginx",
+			Description: "package install",
+			Type:        100,
+		},
+	}
+	require.NoError(t, f.mux.ProcessTask(f.ctx, f.signedTask(t, taskqueue.TypeSearchReindex, payload)))
+
+	fields, err := f.rdb.HGetAll(f.ctx, prefixAction+"act-1").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "Install Nginx", fields["name"])
+	assert.Equal(t, "package install", fields["description"])
+	assert.Equal(t, "100", fields["type"])
+}
+
+func TestWorker_MemberChangeUpdatesMembershipAndRebuildsParent(t *testing.T) {
+	f := newWorkerFixture(t)
+	require.NoError(t, f.rdb.HSet(f.ctx, prefixAction+"act-1", map[string]any{"name": "Install Nginx"}).Err())
+
+	payload := taskqueue.SearchMemberChangePayload{
+		ParentScope: ScopeActionSet,
+		ParentID:    "set-1",
+		ChildScope:  ScopeAction,
+		ChildID:     "act-1",
+		Action:      "add",
+	}
+	require.NoError(t, f.mux.ProcessTask(f.ctx, f.signedTask(t, taskqueue.TypeSearchMemberChange, payload)))
+
+	isMember, err := f.rdb.SIsMember(f.ctx, prefixMembersActionSet+"set-1", "act-1").Result()
+	require.NoError(t, err)
+	assert.True(t, isMember)
+	parents, err := f.rdb.SMembers(f.ctx, prefixReverseAction+"act-1").Result()
+	require.NoError(t, err)
+	assert.Equal(t, []string{"set-1"}, parents)
+	fields, err := f.rdb.HGetAll(f.ctx, prefixActionSet+"set-1").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "Install Nginx", fields["action_names"])
+	assert.Equal(t, "1", fields["member_count"])
+}
+
+func TestWorker_RemoveDeletesEntityKeys(t *testing.T) {
+	f := newWorkerFixture(t)
+	require.NoError(t, f.rdb.HSet(f.ctx, prefixAction+"act-1", map[string]any{"name": "Install Nginx"}).Err())
+	require.NoError(t, f.rdb.SAdd(f.ctx, prefixReverseAction+"act-1", "set-1").Err())
+
+	payload := taskqueue.SearchRemovePayload{Scope: ScopeAction, ID: "act-1"}
+	require.NoError(t, f.mux.ProcessTask(f.ctx, f.signedTask(t, taskqueue.TypeSearchRemove, payload)))
+
+	exists, err := f.rdb.Exists(f.ctx, prefixAction+"act-1", prefixReverseAction+"act-1").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists)
+}
+
+func TestWorker_UnsignedTaskIsRejected(t *testing.T) {
+	f := newWorkerFixture(t)
+	payload := taskqueue.SearchReindexPayload{Scope: ScopeAction, ID: "act-1", Data: &taskqueue.SearchEntityData{Name: "x"}}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	err = f.mux.ProcessTask(f.ctx, asynq.NewTask(taskqueue.TypeSearchReindex, data))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "task signature")
+}

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -312,18 +312,36 @@ func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
 		"projection must survive the failed rebuild; finding zero rows means either the guard ran too late or the outer transaction failed to roll back a destructive op")
 }
 
-// TestRebuildAll_TransactionalAtomicity — if the projector function
-// fails partway through replay, the whole rebuild must roll back so
-// the projection is not left half-replayed against a TRUNCATE'd
-// table. We force a failure by swapping out the events table briefly,
-// then verify the projection returns to its pre-rebuild state.
-//
-// Skipped for now: the cleanest way to force a projector failure is
-// to inject a malformed event row, which requires write access to
-// the events table mid-test. Documented here as a follow-up since
-// the contract is critical but the test is fragile to set up.
+// TestRebuildAll_TransactionalAtomicity forces the roles applier to
+// fail after the target's TRUNCATE has executed. The outer rebuild
+// transaction must roll that destructive statement back, leaving the
+// pre-existing projection row intact.
 func TestRebuildAll_TransactionalAtomicity(t *testing.T) {
-	t.Skip("follow-up: inject a malformed event to force projector failure mid-replay")
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	roleID := testutil.CreateTestRole(t, st, actorID, "atomic-role-"+testutil.NewID(), []string{"GetDevice"})
+
+	var before int
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		`SELECT COUNT(*) FROM roles_projection WHERE id = $1`, roleID,
+	).Scan(&before))
+	require.Equal(t, 1, before)
+
+	st.RegisterRebuildApply("roles", func(context.Context, *store.Queries, store.PersistedEvent) error {
+		return errors.New("forced roles replay failure")
+	})
+
+	_, err := st.RebuildAll(ctx, "roles")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "forced roles replay failure")
+
+	var after int
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		`SELECT COUNT(*) FROM roles_projection WHERE id = $1`, roleID,
+	).Scan(&after))
+	assert.Equal(t, 1, after, "failed rebuild must roll back target TRUNCATE")
 }
 
 // TestRebuildAll_UserGroupsRebuildPreservesSCIMMappings pins the

--- a/internal/taskqueue/client_test.go
+++ b/internal/taskqueue/client_test.go
@@ -72,6 +72,13 @@ func TestClient_EnqueueToControlRoutesTerminalAuditToSerialQueue(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, auditTasks, 1)
 	assert.Equal(t, TypeTerminalAuditChunk, auditTasks[0].Type)
-	_, err = signer.Verify(auditTasks[0].Payload)
+	verified, err := signer.Verify(auditTasks[0].Payload)
 	require.NoError(t, err)
+	var got TerminalAuditChunkPayload
+	require.NoError(t, json.Unmarshal(verified, &got))
+	assert.Equal(t, "sess-1", got.SessionID)
+	assert.Equal(t, "device-1", got.DeviceID)
+	assert.Equal(t, "user-1", got.UserID)
+	assert.Equal(t, int64(1), got.Sequence)
+	assert.Equal(t, []byte("whoami\n"), got.Data)
 }

--- a/internal/taskqueue/client_test.go
+++ b/internal/taskqueue/client_test.go
@@ -1,0 +1,77 @@
+package taskqueue
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_EnqueueToDeviceSignsPayloadAndUsesDeviceQueue(t *testing.T) {
+	mr := miniredis.RunT(t)
+	signer, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+
+	client := NewClientWithSigner(mr.Addr(), "", 0, signer)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	payload := OSQueryDispatchPayload{QueryID: "query-1", Table: "processes", Columns: []string{"pid"}, Limit: 10}
+	require.NoError(t, client.EnqueueToDevice("device-1", TypeOSQueryDispatch, payload))
+
+	inspector := asynq.NewInspector(asynq.RedisClientOpt{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, inspector.Close()) })
+
+	tasks, err := inspector.ListPendingTasks(DeviceQueue("device-1"))
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, TypeOSQueryDispatch, tasks[0].Type)
+	assert.NotEqual(t, []byte(`{"QueryID":"query-1"}`), tasks[0].Payload, "payload must be HMAC wrapped before it is stored in Valkey")
+
+	verified, err := signer.Verify(tasks[0].Payload)
+	require.NoError(t, err)
+	var got OSQueryDispatchPayload
+	require.NoError(t, json.Unmarshal(verified, &got))
+	assert.Equal(t, payload.QueryID, got.QueryID)
+	assert.Equal(t, payload.Table, got.Table)
+	assert.Equal(t, payload.Columns, got.Columns)
+	assert.Equal(t, payload.Limit, got.Limit)
+}
+
+func TestClient_EnqueueToControlRoutesTerminalAuditToSerialQueue(t *testing.T) {
+	mr := miniredis.RunT(t)
+	signer, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+
+	client := NewClientWithSigner(mr.Addr(), "", 0, signer)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	require.NoError(t, client.EnqueueToControl(TypeTerminalAuditChunk, TerminalAuditChunkPayload{
+		SessionID: "sess-1",
+		DeviceID:  "device-1",
+		UserID:    "user-1",
+		Sequence:  1,
+		Data:      []byte("whoami\n"),
+	}))
+
+	inspector := asynq.NewInspector(asynq.RedisClientOpt{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, inspector.Close()) })
+
+	mainQueueTasks, err := inspector.ListPendingTasks(ControlInboxQueue)
+	if errors.Is(err, asynq.ErrQueueNotFound) {
+		mainQueueTasks = nil
+	} else {
+		require.NoError(t, err)
+	}
+	assert.Empty(t, mainQueueTasks)
+
+	auditTasks, err := inspector.ListPendingTasks(ControlTerminalAuditQueue)
+	require.NoError(t, err)
+	require.Len(t, auditTasks, 1)
+	assert.Equal(t, TypeTerminalAuditChunk, auditTasks[0].Type)
+	_, err = signer.Verify(auditTasks[0].Payload)
+	require.NoError(t, err)
+}

--- a/internal/terminal/valkey_backend_test.go
+++ b/internal/terminal/valkey_backend_test.go
@@ -1,0 +1,151 @@
+package terminal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+func newValkeyBackendForTest(t *testing.T) (*ValkeyBackend, context.Context) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Fatalf("close redis client: %v", err)
+		}
+	})
+	return NewValkeyBackend(client), context.Background()
+}
+
+func TestValkeyBackend_SetGetDeleteRoundTrip(t *testing.T) {
+	backend, ctx := newValkeyBackendForTest(t)
+
+	if err := backend.Set(ctx, "session-1", []byte(`{"user_id":"u1"}`), time.Minute); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	payload, err := backend.Get(ctx, "session-1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if string(payload) != `{"user_id":"u1"}` {
+		t.Fatalf("payload = %q", payload)
+	}
+	if err := backend.Delete(ctx, "session-1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := backend.Get(ctx, "session-1"); !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("get after delete error = %v, want ErrTokenNotFound", err)
+	}
+}
+
+func TestValkeyBackend_GetAndDeleteIsSingleUse(t *testing.T) {
+	backend, ctx := newValkeyBackendForTest(t)
+
+	if err := backend.Set(ctx, "session-1", []byte("payload"), time.Minute); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	payload, err := backend.GetAndDelete(ctx, "session-1")
+	if err != nil {
+		t.Fatalf("getdel: %v", err)
+	}
+	if string(payload) != "payload" {
+		t.Fatalf("payload = %q", payload)
+	}
+	if _, err := backend.GetAndDelete(ctx, "session-1"); !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("second getdel error = %v, want ErrTokenNotFound", err)
+	}
+}
+
+func TestValkeyBackend_ValkeyBundleGetAndDeleteRoundTrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping valkey-bundle integration test in short mode")
+	}
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "valkey/valkey-bundle:9.1.0",
+			ExposedPorts: []string{"6379/tcp"},
+			WaitingFor:   wait.ForLog("Ready to accept connections").WithStartupTimeout(30 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("start valkey-bundle container: %v", err)
+	}
+	t.Cleanup(func() {
+		termCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := container.Terminate(termCtx); err != nil {
+			t.Logf("terminate valkey-bundle container: %v", err)
+		}
+	})
+	host, err := container.Host(ctx)
+	if err != nil {
+		t.Fatalf("container host: %v", err)
+	}
+	port, err := container.MappedPort(ctx, "6379")
+	if err != nil {
+		t.Fatalf("container port: %v", err)
+	}
+	client := redis.NewClient(&redis.Options{Addr: fmt.Sprintf("%s:%s", host, port.Port())})
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Fatalf("close redis client: %v", err)
+		}
+	})
+	backend := NewValkeyBackend(client)
+
+	if err := backend.Set(ctx, "bundle-session", []byte("payload"), time.Minute); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	payload, err := backend.GetAndDelete(ctx, "bundle-session")
+	if err != nil {
+		t.Fatalf("getdel: %v", err)
+	}
+	if string(payload) != "payload" {
+		t.Fatalf("payload = %q", payload)
+	}
+	if _, err := backend.Get(ctx, "bundle-session"); !errors.Is(err, ErrTokenNotFound) {
+		t.Fatalf("get after getdel error = %v, want ErrTokenNotFound", err)
+	}
+}
+
+func TestValkeyBackend_GetAndDeleteAllowsOnlyOneConcurrentReader(t *testing.T) {
+	backend, ctx := newValkeyBackendForTest(t)
+
+	if err := backend.Set(ctx, "session-1", []byte("payload"), time.Minute); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	var successes int32
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			payload, err := backend.GetAndDelete(ctx, "session-1")
+			if err == nil && string(payload) == "payload" {
+				atomic.AddInt32(&successes, 1)
+				return
+			}
+			if err != nil && !errors.Is(err, ErrTokenNotFound) {
+				t.Errorf("unexpected getdel error: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if successes != 1 {
+		t.Fatalf("successful GetAndDelete calls = %d, want 1", successes)
+	}
+}

--- a/internal/terminal/valkey_backend_test.go
+++ b/internal/terminal/valkey_backend_test.go
@@ -70,6 +70,12 @@ func TestValkeyBackend_ValkeyBundleGetAndDeleteRoundTrip(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping valkey-bundle integration test in short mode")
 	}
+	// Gracefully skip when Docker / the testcontainers provider isn't
+	// available so this test doesn't fail-stop the unit-test job on
+	// CI hosts that lack a healthy Docker daemon (or where docker.io
+	// rate-limits the image pull). The integration suite still runs
+	// this in environments that have Docker.
+	testcontainers.SkipIfProviderIsNotHealthy(t)
 	ctx := context.Background()
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{


### PR DESCRIPTION
## Summary

Three things in one PR; they depend on each other.

### 1. ValidationInterceptor — protovalidate at the RPC boundary

\`internal/api/validation_interceptor.go\` wraps every Connect-RPC request in a \`Validate()\` call before it reaches the handler. Wired into both the \`ControlService\` and \`InternalService\` chains in \`cmd/control/main.go\` between auth and authz (\`logging → auth → validation → authz\`).

Every handler also calls \`Validate(ctx, req.Msg)\` at its top-of-function. **Intentional defense in depth** — the interceptor catches the production wire path; the per-handler calls catch direct-call paths (tests, future in-process callers) that bypass the chain.

Tests: \`control_boundary_test.go\` stands up a real h2c httptest server with the full chain and verifies (a) invalid input is rejected before the handler runs, (b) authz still runs after validation, (c) both error paths carry \`ErrorDetail.RequestId\` for correlation. \`validation_interceptor_test.go\` unit-tests the interceptor in isolation.

### 2. Coverage fill (split + strengthen)

\`internal/api/missing_rpc_coverage_test.go\` — ~30 previously-untested RPCs across user / device-group / action-dispatch / device LUKS+LPS / compliance / description-update / definition-membership / user-group / TOTP-admin / search / role surfaces. Each test names exactly the RPC it pins (the old \`TestFooAndBarAndBaz\` conjoined pattern is gone; failure attribution is 1:1 with the test name).

### 3. Test-suite hardening on existing files

- \`internal/store/rebuild_test.go\` — \`TestRebuildAll_TransactionalAtomicity\` was previously \`t.Skip\`'d. Now implemented via the new \`RegisterRebuildApply\` hook: forces a roles applier failure, asserts the outer rebuild transaction rolled back the target TRUNCATE so the pre-existing projection row survived.
- \`internal/handler/agent_stream_test.go\` — \`TestStream_HelloDeviceIDForwardedToVerifyDevice\` previously only proved the Hello → VerifyDevice plumbing; now asserts the actual device-id arrives intact.

## Code review notes (from prep on this branch)

Before pushing, I reviewed the diff against my own changes and surfaced these:

### Bug fixes added on top (10 tests)

The new boundary validation rejects malformed-ULID inputs with \`CodeInvalidArgument\` *before* the handlers' own existence / auth / state checks fire. Ten existing tests had been sending short literals like \`"nonexistent-device"\` / \`"no-such-session"\` / \`"any"\` to exercise those downstream checks; after the boundary validation lands, they get \`InvalidArgument\` instead of the \`NotFound\` / \`Unauthenticated\` / \`Unavailable\` they're trying to pin.

Fixed each by minting a syntactically valid ULID via \`testutil.NewID()\` that happens not to exist in the projection, so the request reaches the actual check under test. Where the substitution non-obviously preserves a security property (\`TestProxyValidateTerminalToken_UnknownSession\` — the probe-distinguishability defense only applies to syntactically valid inputs), the comment spells out why.

See commit \`7f97fe4 fix(test): …\` on this branch.

### Design observation — Validate-vs-auth ordering

Handlers don't consistently order top-of-function \`Validate\` vs the auth check:

- \`RevokeLuksDeviceKey\` does auth first, then validate.
- \`StopTerminal\` / \`TerminateTerminalSession\` do validate first, then auth.

Both orderings are defensible:

- **Auth-first** doesn't waste \`Validate\` cycles on unauthenticated requests, and is consistent with "fail fast on auth."
- **Validate-first** doesn't let malformed requests learn anything about auth state — a marginally stronger probe-distinguishability story.

Not changing in this PR — this is a design call worth deciding deliberately, not flipping under cover of a test-suite hardening PR. Suggest a follow-up issue to pin a canonical order.

## Test plan

- [x] \`go vet ./...\` clean
- [x] \`gofmt -l .\` empty
- [x] Targeted runs on the 10 previously-failing tests — all green after the fix
- [x] Targeted runs on \`TestValidationInterceptor*\`, \`TestProxyValidate*\`, \`TestControlRPCBoundary*\` — all green
- [x] Local \`cr review\` — no findings
- [ ] CI green

Refs the long-standing testing-coverage commitment and the boundary-validation security-audit finding.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive request validation across all API handlers to reject malformed requests early with proper error messages.

* **Tests**
  * Added extensive integration and unit test coverage for validation behavior, handler operations, and edge cases across multiple API endpoints and services.

* **Refactoring**
  * Refactored internal dependencies and test fixtures to improve modularity and enable better testability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->