### PR TITLE
feat(api): TerminalAdmin Limited/Full reconciler + global system actions

### DIFF
--- a/cmd/control/setup.go
+++ b/cmd/control/setup.go
@@ -154,6 +154,15 @@ func wireSystemActions(ctx context.Context, st *store.Store, svc *api.ControlSer
 		return
 	}
 
+	// (0) Bootstrap the two global TerminalAdmin AdminPolicy actions
+	// (#70). Idempotent — creates the rows on a fresh DB, no-ops on a
+	// DB that already has them. Runs before the user-level sync so the
+	// reconciler (started in step 3 below) finds the action rows to
+	// update on its first tick.
+	if err := svc.SystemActions().BootstrapGlobalTerminalAdminActions(ctx); err != nil {
+		logger.Error("failed to bootstrap global TerminalAdmin actions at startup", "error", err)
+	}
+
 	// (1) Startup sweep — keeps the existing Info line so operators
 	// see the one-shot convergence in boot logs.
 	if err := svc.SystemActions().SyncAllUsersSystemActions(ctx); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260608150925-51ed97b83fae
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260608193749-8a7b13b95072

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260608150925-51ed97b83fae h1:CA03E5cWYThfML/dgVBJWy9d9GBqz2RUHhxyJT9fwUU=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260608150925-51ed97b83fae/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260608193749-8a7b13b95072 h1:/DIvYZjrZTtGgxI7Ny6j4eRxgGCeyFQ0U9+CFOazXpU=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260608193749-8a7b13b95072/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -4,12 +4,19 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"slices"
+	"sort"
+	"strings"
 	"sync/atomic"
 	"time"
+
+	"google.golang.org/protobuf/encoding/protojson"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -74,6 +81,16 @@ func (m *SystemActionManager) SyncAllUsersSystemActions(ctx context.Context) err
 		// Startup callers in cmd/control/main.go log their own Info
 		// line so the one-shot startup sweep stays visible.
 		m.logger.Debug("system actions synced for all users", "count", len(users))
+	}
+
+	// Reconcile the two global TerminalAdmin actions (#70). The
+	// periodic sweep + every listener-classified fan-out event runs
+	// through this method, so embedding the call here means every
+	// callsite gets the cohort update without having to know about
+	// the new reconciler. Per-user listener events also call the
+	// reconciler directly — see SystemActionListener.
+	if err := m.ReconcileGlobalTerminalAdminActions(ctx); err != nil {
+		m.logger.Error("failed to reconcile global TerminalAdmin actions during sync sweep", "error", err)
 	}
 
 	return nil
@@ -486,6 +503,311 @@ func systemTtyUserParams(user store.User) *pm.UserParams {
 		Disabled:   user.Disabled,
 		NoPassword: true,
 	}
+}
+
+// =============================================================================
+// TerminalAdmin global system actions (manchtools/power-manage-server#70)
+// =============================================================================
+//
+// Two globally-fanned-out AdminPolicy actions carry the LIMITED /
+// FULL passwordless sudoers templates. Membership (the users[] list)
+// is filled by the reconciler in ReconcileGlobalTerminalAdminActions
+// (S3 — added in a subsequent slice); BootstrapGlobalTerminalAdminActions
+// just makes sure the two action rows exist at server startup so the
+// reconciler has something to update.
+//
+// Per the ADR and the user's design decisions: ONE action per access
+// level, NOT one action per holder. #7 extends this to per-scope
+// actions sharing the same reconciler shape.
+
+// Global action names. The listener, audit redactor, and resolution
+// layer all key on these strings — a typo here breaks the fan-out
+// silently, which is why the test file (system_actions_terminal_admin_test.go)
+// declares its own copies as canon to catch any drift.
+const (
+	GlobalTerminalAdminLimitedActionName = "system:terminal-admin-limited:global"
+	GlobalTerminalAdminFullActionName    = "system:terminal-admin-full:global"
+)
+
+// BootstrapGlobalTerminalAdminActions makes sure the two global
+// TerminalAdmin AdminPolicy actions exist. Idempotent — running on a
+// fresh DB creates both rows; running on a DB that already has them
+// is a no-op. Wired from cmd/control/main.go startup so a fresh
+// deployment has these actions ready before the reconciler ticks.
+//
+// The bootstrap deliberately does NOT re-sign on the no-op path. The
+// reconciler is the only path that mutates these actions after creation,
+// and a re-sign per-server-start would invalidate every agent's cached
+// copy on every restart of the server even when nothing changed.
+func (m *SystemActionManager) BootstrapGlobalTerminalAdminActions(ctx context.Context) error {
+	if err := m.bootstrapGlobalTerminalAdminAction(ctx,
+		GlobalTerminalAdminLimitedActionName,
+		pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED); err != nil {
+		return fmt.Errorf("bootstrap %s: %w", GlobalTerminalAdminLimitedActionName, err)
+	}
+	if err := m.bootstrapGlobalTerminalAdminAction(ctx,
+		GlobalTerminalAdminFullActionName,
+		pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL); err != nil {
+		return fmt.Errorf("bootstrap %s: %w", GlobalTerminalAdminFullActionName, err)
+	}
+	return nil
+}
+
+// ReconcileGlobalTerminalAdminActions recomputes users[] for both
+// global TerminalAdmin actions and writes back if changed. A user
+// enters the LIMITED cohort iff:
+//
+//   - non-deleted, non-disabled, has a linux_username, AND
+//   - holds StartTerminal AND TerminalAdminLimited (directly or via
+//     a user_group role).
+//
+// The FULL cohort is the same shape against TerminalAdminFull.
+//
+// Idempotency is load-bearing: the cohort is sorted deterministically
+// and compared to what's already on the action. When equal, the
+// reconciler returns without touching the action — no UpdateAction
+// event, no SignActionByID call, no signature churn. Without that
+// short-circuit, every reconcile tick (default 1 min) would invalidate
+// every connected agent's cached copy of these actions even when
+// nothing changed.
+//
+// Failure modes:
+//   - A per-user permission lookup error is logged and the user is
+//     SKIPPED (treated as if they hold no relevant perms). The
+//     reconciler proceeds — one bad user must not prevent the rest of
+//     the cohort from being materialized. This mirrors
+//     SyncAllUsersSystemActions's best-effort-per-user shape.
+//   - If either global action is missing, the reconciler returns an
+//     error (BootstrapGlobalTerminalAdminActions must run first).
+//     Silent no-op would mask a wiring bug at server startup.
+func (m *SystemActionManager) ReconcileGlobalTerminalAdminActions(ctx context.Context) error {
+	users, err := m.store.Repos().User.ListAllNonDeleted(ctx)
+	if err != nil {
+		return fmt.Errorf("list users: %w", err)
+	}
+
+	limitedCohort, fullCohort := m.computeTerminalAdminCohorts(ctx, users)
+
+	if err := m.reconcileOneGlobalTerminalAdmin(ctx,
+		GlobalTerminalAdminLimitedActionName,
+		pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED,
+		limitedCohort); err != nil {
+		return fmt.Errorf("reconcile %s: %w", GlobalTerminalAdminLimitedActionName, err)
+	}
+	if err := m.reconcileOneGlobalTerminalAdmin(ctx,
+		GlobalTerminalAdminFullActionName,
+		pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL,
+		fullCohort); err != nil {
+		return fmt.Errorf("reconcile %s: %w", GlobalTerminalAdminFullActionName, err)
+	}
+	return nil
+}
+
+// computeTerminalAdminCohorts walks the user list and returns the two
+// sorted, deduped pm-tty-* cohorts. The sort makes signature stability
+// deterministic across runs; the dedup is defensive against a future
+// permission backend that double-counts a user.
+func (m *SystemActionManager) computeTerminalAdminCohorts(ctx context.Context, users []store.User) (limited, full []string) {
+	limitedSet := map[string]struct{}{}
+	fullSet := map[string]struct{}{}
+	for _, u := range users {
+		if u.Disabled || u.LinuxUsername == "" {
+			continue
+		}
+		perms, err := m.store.Repos().User.Permissions(ctx, u.ID)
+		if err != nil {
+			// Skip the user this tick — the next tick will retry.
+			// Aborting the whole reconcile on a single user's
+			// transient DB error would block every other user from
+			// landing on devices.
+			m.logger.Error("perm lookup failed during terminal-admin reconcile; skipping user",
+				"user_id", u.ID, "error", err)
+			continue
+		}
+		hasStart, hasLimited, hasFull := false, false, false
+		for _, p := range perms {
+			switch p {
+			case "StartTerminal":
+				hasStart = true
+			case "TerminalAdminLimited":
+				hasLimited = true
+			case "TerminalAdminFull":
+				hasFull = true
+			}
+		}
+		ttyUser := "pm-tty-" + u.LinuxUsername
+		if hasStart && hasLimited {
+			limitedSet[ttyUser] = struct{}{}
+		}
+		if hasStart && hasFull {
+			fullSet[ttyUser] = struct{}{}
+		}
+	}
+
+	limited = make([]string, 0, len(limitedSet))
+	for u := range limitedSet {
+		limited = append(limited, u)
+	}
+	sort.Strings(limited)
+
+	full = make([]string, 0, len(fullSet))
+	for u := range fullSet {
+		full = append(full, u)
+	}
+	sort.Strings(full)
+	return limited, full
+}
+
+func (m *SystemActionManager) reconcileOneGlobalTerminalAdmin(ctx context.Context, name string, accessLevel pm.AdminAccessLevel, desiredUsers []string) error {
+	row, err := m.store.Queries().GetActionByName(ctx, name)
+	if err != nil {
+		// Includes the not-found case: bootstrap was skipped.
+		return fmt.Errorf("lookup (run BootstrapGlobalTerminalAdminActions first): %w", err)
+	}
+
+	var current pm.AdminPolicyParams
+	if err := protojson.Unmarshal(row.Params, &current); err != nil {
+		return fmt.Errorf("unmarshal current params: %w", err)
+	}
+
+	// Short-circuit: same cohort → no churn.
+	if slices.Equal(current.Users, desiredUsers) {
+		return nil
+	}
+
+	// Emit one TerminalAdminMembershipRevoked event per user dropped
+	// from the cohort. The diff is computed against the persisted
+	// users[] BEFORE the update — so revocations are audited even
+	// when several happen in the same reconcile tick. Additions are
+	// NOT audited here; the role-grant itself is already on the audit
+	// trail via the user_role stream.
+	removed := diffRemoved(current.Users, desiredUsers)
+	for _, ttyUser := range removed {
+		m.emitTerminalAdminMembershipRevoked(ctx, ttyUser, row.ID, accessLevel)
+	}
+
+	newParams := &pm.AdminPolicyParams{
+		AccessLevel: accessLevel,
+		Users:       desiredUsers,
+	}
+	paramsJSON, err := actionparams.MarshalActionParams(newParams)
+	if err != nil {
+		return fmt.Errorf("marshal new params: %w", err)
+	}
+
+	if err := m.actions.UpdateAction(ctx, row.ID, row.DesiredState, paramsJSON); err != nil {
+		return fmt.Errorf("update action: %w", err)
+	}
+	if err := m.actions.SignActionByID(ctx, row.ID); err != nil {
+		return fmt.Errorf("re-sign action: %w", err)
+	}
+	m.logger.Info("reconciled global terminal-admin action",
+		"name", name, "action_id", row.ID, "users_count", len(desiredUsers))
+	return nil
+}
+
+// diffRemoved returns the entries in `before` that are absent from
+// `after`. Both slices are assumed to be sorted (the reconciler sorts
+// the cohort and `current.Users` carries the previously-sorted set).
+func diffRemoved(before, after []string) []string {
+	afterSet := make(map[string]struct{}, len(after))
+	for _, u := range after {
+		afterSet[u] = struct{}{}
+	}
+	var out []string
+	for _, u := range before {
+		if _, ok := afterSet[u]; !ok {
+			out = append(out, u)
+		}
+	}
+	return out
+}
+
+// emitTerminalAdminMembershipRevoked writes one audit event per
+// removed pm-tty-* user. Failures are logged and swallowed — the
+// reconciler's primary job is to update the action's users[]; missing
+// audit on a transient DB blip is recoverable (the action change is
+// the canonical truth), but failing the whole reconcile would leave
+// the action's users[] out of date until the next tick.
+//
+// stream_type is "terminal_admin_membership"; stream_id is the
+// affected action_id so audit consumers can read per-action history
+// via store.LoadStream.
+func (m *SystemActionManager) emitTerminalAdminMembershipRevoked(ctx context.Context, ttyUsername, actionID string, accessLevel pm.AdminAccessLevel) {
+	const prefix = "pm-tty-"
+	linuxUsername := strings.TrimPrefix(ttyUsername, prefix)
+	// userID is best-effort — the reconciler doesn't know which user
+	// owned the linux_username at revocation time without a reverse
+	// lookup. The lookup is cheap (one indexed query) and keeps the
+	// audit row meaningful even if a linux_username is later reused.
+	userID := m.lookupUserIDByLinuxUsername(ctx, linuxUsername)
+	if err := m.store.AppendEvent(ctx, store.Event{
+		StreamType: "terminal_admin_membership",
+		StreamID:   actionID,
+		EventType:  string(eventtypes.TerminalAdminMembershipRevoked),
+		Data: payloads.TerminalAdminMembershipRevoked{
+			UserID:        userID,
+			LinuxUsername: linuxUsername,
+			ActionID:      actionID,
+			AccessLevel:   accessLevel.String(),
+		},
+		ActorType: "system",
+		ActorID:   "system",
+	}); err != nil {
+		m.logger.Error("failed to emit TerminalAdminMembershipRevoked audit event",
+			"action_id", actionID, "linux_username", linuxUsername, "error", err)
+	}
+}
+
+func (m *SystemActionManager) lookupUserIDByLinuxUsername(ctx context.Context, linuxUsername string) string {
+	users, err := m.store.Repos().User.ListAllNonDeleted(ctx)
+	if err != nil {
+		// Soft failure — audit can still attribute by linux_username
+		// even if user_id is empty.
+		return ""
+	}
+	for _, u := range users {
+		if u.LinuxUsername == linuxUsername {
+			return u.ID
+		}
+	}
+	return ""
+}
+
+func (m *SystemActionManager) bootstrapGlobalTerminalAdminAction(ctx context.Context, name string, accessLevel pm.AdminAccessLevel) error {
+	if _, err := m.store.Queries().GetActionByName(ctx, name); err == nil {
+		// Already exists — no-op. The reconciler owns subsequent
+		// mutations. NOT re-signing here is load-bearing: the agent
+		// caches signed actions and a re-sign on every server start
+		// would invalidate the cache without any params change.
+		return nil
+	} else if !store.IsNotFound(err) {
+		return fmt.Errorf("lookup: %w", err)
+	}
+
+	params := &pm.AdminPolicyParams{
+		AccessLevel: accessLevel,
+		// users[] is intentionally empty at bootstrap. The reconciler
+		// (S3) fills it on the next tick after any relevant event.
+	}
+	paramsJSON, err := actionparams.MarshalActionParams(params)
+	if err != nil {
+		return fmt.Errorf("marshal params: %w", err)
+	}
+
+	actionID, err := m.actions.CreateAction(ctx, name,
+		int32(pm.ActionType_ACTION_TYPE_ADMIN_POLICY),
+		int32(pm.DesiredState_DESIRED_STATE_PRESENT),
+		paramsJSON)
+	if err != nil {
+		return fmt.Errorf("create: %w", err)
+	}
+	if err := m.actions.SignActionByID(ctx, actionID); err != nil {
+		return fmt.Errorf("sign newly created action: %w", err)
+	}
+	m.logger.Info("created global terminal-admin action",
+		"name", name, "action_id", actionID, "access_level", accessLevel.String())
+	return nil
 }
 
 func (m *SystemActionManager) cleanupTtyAction(ctx context.Context, user store.User) error {

--- a/internal/api/system_actions_listener.go
+++ b/internal/api/system_actions_listener.go
@@ -251,8 +251,23 @@ func SystemActionListener(mgr *SystemActionManager, logger *slog.Logger, syncTim
 							"user_id", uid, "event_type", e.EventType, "event_id", e.ID, "error", err)
 					}
 				}
+				// Also reconcile the global TerminalAdmin actions
+				// (#70). The user's permission set may have changed
+				// in a way that affects their LIMITED/FULL cohort
+				// membership; SyncUserSystemActions only touches
+				// per-user actions. Reconciler is no-op when the
+				// cohort hasn't changed, so the cost on most events
+				// is one SELECT + a slice compare.
+				if err := mgr.ReconcileGlobalTerminalAdminActions(ctx); err != nil {
+					logger.Error("system-action listener: reconcile global TerminalAdmin failed",
+						"event_type", e.EventType, "event_id", e.ID, "error", err)
+				}
 
 			case SyncOpSyncAll:
+				// SyncAllUsersSystemActions already ends with a
+				// ReconcileGlobalTerminalAdminActions call, so the
+				// fan-out path picks up cohort updates without a
+				// separate dispatch here.
 				if err := mgr.SyncAllUsersSystemActions(ctx); err != nil {
 					logger.Error("system-action listener: sync all users failed",
 						"event_type", e.EventType, "event_id", e.ID, "error", err)

--- a/internal/api/system_actions_terminal_admin_test.go
+++ b/internal/api/system_actions_terminal_admin_test.go
@@ -1,0 +1,528 @@
+package api
+
+// TerminalAdmin global system-action bootstrap coverage —
+// manchtools/power-manage-server#70 (paired with
+// manchtools/power-manage-server#7).
+//
+// The pair `system:terminal-admin-limited:global` and
+// `system:terminal-admin-full:global` are created idempotently at
+// server startup. The reconciler (S3 — added in a subsequent slice)
+// fills users[]; this slice only covers existence + signing +
+// the wire-correct access_level on both actions.
+//
+// Fixture pattern matches system_actions_ssh_tty_test.go: real
+// testcontainer Postgres + NoOpSigner + projection-state assertions.
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// Name constants — the listener, audit redactor, and resolution layer
+// will all key on these strings, so a typo here breaks the fan-out
+// silently. Pin them in tests separately so a search-and-replace
+// can't drift the producer and the consumer in lock-step undetected.
+const (
+	globalTerminalAdminLimitedActionName = "system:terminal-admin-limited:global"
+	globalTerminalAdminFullActionName    = "system:terminal-admin-full:global"
+)
+
+func TestBootstrapGlobalTerminalAdminActions_CreatesBothActions(t *testing.T) {
+	m, st := newManagerForTest(t)
+
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	limited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err, "Limited global action must be created at bootstrap")
+	assert.True(t, limited.IsSystem, "global TerminalAdmin actions MUST set is_system=true")
+	assert.NotEmpty(t, limited.Signature, "global TerminalAdmin actions MUST be signed at create time — agents reject unsigned actions on dispatch")
+
+	full, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminFullActionName)
+	require.NoError(t, err, "Full global action must be created at bootstrap")
+	assert.True(t, full.IsSystem)
+	assert.NotEmpty(t, full.Signature)
+
+	assert.NotEqual(t, limited.ID, full.ID, "Limited and Full actions must have distinct IDs")
+}
+
+func TestBootstrapGlobalTerminalAdminActions_Idempotent_NoDuplicates(t *testing.T) {
+	m, st := newManagerForTest(t)
+
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+	beforeLimited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+	beforeFull, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminFullActionName)
+	require.NoError(t, err)
+
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	afterLimited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+	afterFull, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminFullActionName)
+	require.NoError(t, err)
+
+	assert.Equal(t, beforeLimited.ID, afterLimited.ID,
+		"second bootstrap call must NOT create a duplicate Limited action")
+	assert.Equal(t, beforeFull.ID, afterFull.ID,
+		"second bootstrap call must NOT create a duplicate Full action")
+}
+
+func TestBootstrapGlobalTerminalAdminActions_Idempotent_DoesNotReSign(t *testing.T) {
+	m, st := newManagerForTest(t)
+
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+	beforeLimited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+	beforeFull, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminFullActionName)
+	require.NoError(t, err)
+	beforeLimitedUpdated := beforeLimited.UpdatedAt
+	beforeFullUpdated := beforeFull.UpdatedAt
+
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	afterLimited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+	afterFull, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminFullActionName)
+	require.NoError(t, err)
+
+	// The reconciler (S3) re-signs on every users[] change. The
+	// bootstrap MUST NOT trigger an unnecessary re-sign — otherwise
+	// every server start would invalidate every agent's cached copy
+	// of these actions, even when nothing changed. Pin the updated_at
+	// timestamp.
+	assert.Equal(t, beforeLimitedUpdated, afterLimited.UpdatedAt,
+		"second bootstrap call must NOT re-sign the Limited action (no churn on every server start)")
+	assert.Equal(t, beforeFullUpdated, afterFull.UpdatedAt,
+		"second bootstrap call must NOT re-sign the Full action")
+}
+
+func TestBootstrapGlobalTerminalAdminActions_LimitedHasCorrectAccessLevel(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	limited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+
+	var params pm.AdminPolicyParams
+	require.NoError(t, protojson.Unmarshal(limited.Params, &params),
+		"Limited action's params must unmarshal as AdminPolicyParams")
+	assert.Equal(t, pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED, params.AccessLevel,
+		"Limited action MUST carry the new TERMINAL_ADMIN_LIMITED enum value — otherwise the agent routes to the wrong template")
+	assert.Empty(t, params.Users,
+		"bootstrap creates the action with NO members; the reconciler fills users[]")
+}
+
+func TestBootstrapGlobalTerminalAdminActions_FullHasCorrectAccessLevel(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	full, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminFullActionName)
+	require.NoError(t, err)
+
+	var params pm.AdminPolicyParams
+	require.NoError(t, protojson.Unmarshal(full.Params, &params))
+	assert.Equal(t, pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL, params.AccessLevel,
+		"Full action MUST carry the new TERMINAL_ADMIN_FULL enum value")
+	assert.Empty(t, params.Users)
+}
+
+func TestBootstrapGlobalTerminalAdminActions_ActionTypeIsAdminPolicy(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	limited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+	full, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminFullActionName)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(pm.ActionType_ACTION_TYPE_ADMIN_POLICY), limited.ActionType,
+		"both globals are AdminPolicy actions — the agent's executor dispatch in sudo.go keys on this")
+	assert.Equal(t, int32(pm.ActionType_ACTION_TYPE_ADMIN_POLICY), full.ActionType)
+}
+
+// =============================================================================
+// ReconcileGlobalTerminalAdminActions — S3 of #70.
+//
+// Recomputes users[] on both globals based on the permission cohort.
+// A user enters the LIMITED cohort iff they hold StartTerminal AND
+// TerminalAdminLimited AND are non-disabled / non-deleted / have a
+// linux_username. FULL is the same shape against TerminalAdminFull.
+//
+// The reconciler MUST be a no-op when nothing has changed — repeated
+// ticks under a steady population must not churn the signature, or
+// every agent re-pulls these actions on every reconcile tick.
+// =============================================================================
+
+// loadAdminPolicy is a test helper that unmarshals a global action's
+// Params into the typed proto. Centralises the boilerplate so each
+// test reads as a single intent assertion. Returns a pointer so the
+// embedded protoimpl.MessageState's Mutex isn't copied by value (go
+// vet flags that).
+func loadAdminPolicy(t *testing.T, st *store.Store, name string) *pm.AdminPolicyParams {
+	t.Helper()
+	row, err := st.Queries().GetActionByName(context.Background(), name)
+	require.NoError(t, err, "global action %s missing — was BootstrapGlobalTerminalAdminActions called?", name)
+	var params pm.AdminPolicyParams
+	require.NoError(t, protojson.Unmarshal(row.Params, &params))
+	return &params
+}
+
+// grantPermsViaRole is a test helper that creates a role with the
+// given permissions and assigns it to userID.
+func grantPermsViaRole(t *testing.T, st *store.Store, actorID, userID, roleName string, perms []string) string {
+	t.Helper()
+	roleID := testutil.CreateTestRole(t, st, actorID, roleName, perms)
+	testutil.AssignRoleToTestUser(t, st, actorID, userID, roleID)
+	return roleID
+}
+
+func TestReconcileGlobalTerminalAdmin_AddsHolderWithBothPerms(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantPermsViaRole(t, st, actorID, userID, "TerminalAdminUser",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	limited := loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName)
+	assert.Equal(t, []string{"pm-tty-alice"}, limited.Users,
+		"user holding StartTerminal + TerminalAdminLimited must be in the Limited cohort as pm-tty-<linuxusername>")
+}
+
+// THE GATE: a user with TerminalAdminLimited alone (no StartTerminal)
+// must NOT enter the Limited cohort. This is the "no implies" design
+// decision — admins can grant either permission independently; the
+// reconciler enforces the AND at materialization time.
+func TestReconcileGlobalTerminalAdmin_ExcludesHolderMissingStartTerminal(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantPermsViaRole(t, st, actorID, userID, "TerminalAdminOnly",
+		[]string{"TerminalAdminLimited"})
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	limited := loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName)
+	assert.Empty(t, limited.Users,
+		"user with TerminalAdminLimited but no StartTerminal must NOT enter the cohort")
+}
+
+func TestReconcileGlobalTerminalAdmin_RemovesRevokedHolder(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	roleID := grantPermsViaRole(t, st, actorID, userID, "TerminalAdminUser",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+	require.Equal(t, []string{"pm-tty-alice"}, loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName).Users,
+		"precondition: alice is in the cohort")
+
+	// Revoke the role's permissions — the user no longer holds either perm
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user_role", StreamID: userID + ":" + roleID,
+		EventType: "UserRoleRevoked",
+		Data:      map[string]any{"user_id": userID, "role_id": roleID},
+		ActorType: "user", ActorID: actorID,
+	}))
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+	limited := loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName)
+	assert.Empty(t, limited.Users, "revoked user must be removed from the cohort on next reconcile")
+}
+
+// Users without a linux_username are skipped by the reconciler — the
+// pm-tty-<linuxusername> derivation has nothing to derive against.
+// Pin the gate so a future refactor that drops the precondition can't
+// land an empty / "pm-tty-" entry in the cohort.
+func TestReconcileGlobalTerminalAdmin_ExcludesUserWithoutLinuxUsername(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	// Deliberately do NOT call setLinuxUsername.
+	grantPermsViaRole(t, st, actorID, userID, "TerminalAdminUser",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	limited := loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName)
+	assert.Empty(t, limited.Users,
+		"user without linux_username must NOT enter the cohort — the pm-tty-* derivation has nothing to derive against")
+}
+
+func TestReconcileGlobalTerminalAdmin_DisabledUserExcluded(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantPermsViaRole(t, st, actorID, userID, "TerminalAdminUser",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+	require.Equal(t, []string{"pm-tty-alice"}, loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName).Users,
+		"precondition")
+
+	require.NoError(t, st.AppendEvent(context.Background(), testutil.DisableEvent(userID)))
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+	limited := loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName)
+	assert.Empty(t, limited.Users,
+		"disabled user must be removed from the cohort even though their permissions are still held; the sudoers fragment must not name a disabled account")
+}
+
+func TestReconcileGlobalTerminalAdmin_GroupRoleGrantsCounted(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	roleID := testutil.CreateTestRole(t, st, actorID, "TerminalAdminUser",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+	groupID := testutil.CreateTestUserGroup(t, st, actorID, "TerminalAdmins")
+	testutil.AddUserToTestGroup(t, st, actorID, groupID, userID)
+	testutil.AssignRoleToTestGroup(t, st, actorID, groupID, roleID)
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	limited := loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName)
+	assert.Equal(t, []string{"pm-tty-alice"}, limited.Users,
+		"user holding the permissions via user_group role must enter the cohort — group-derived permissions are first-class")
+}
+
+// Idempotency: re-running the reconciler with no membership change
+// must NOT touch the action's signature/updated_at. Every agent caches
+// these actions; spurious re-signs would invalidate every cached copy
+// on every reconcile tick.
+func TestReconcileGlobalTerminalAdmin_NoOpWhenUsersUnchanged(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantPermsViaRole(t, st, actorID, userID, "TerminalAdminUser",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+	before, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+	beforeUpdated := before.UpdatedAt
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+	after, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+
+	assert.Equal(t, beforeUpdated, after.UpdatedAt,
+		"second reconcile call with identical cohort must NOT re-sign — no params change means no cache invalidation for agents")
+}
+
+func TestReconcileGlobalTerminalAdmin_FullAndLimitedDisjointHolders(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	u1 := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, u1, "alice")
+	grantPermsViaRole(t, st, actorID, u1, "LimitedHolder",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+
+	u2 := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, u2, "bob")
+	grantPermsViaRole(t, st, actorID, u2, "FullHolder",
+		[]string{"StartTerminal", "TerminalAdminFull"})
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	limited := loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName)
+	full := loadAdminPolicy(t, st, globalTerminalAdminFullActionName)
+	assert.Equal(t, []string{"pm-tty-alice"}, limited.Users,
+		"Limited cohort must contain alice (Limited holder) only")
+	assert.Equal(t, []string{"pm-tty-bob"}, full.Users,
+		"Full cohort must contain bob (Full holder) only")
+}
+
+func TestReconcileGlobalTerminalAdmin_HolderOfBothPermsIsInBothCohorts(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantPermsViaRole(t, st, actorID, userID, "BothLevels",
+		[]string{"StartTerminal", "TerminalAdminLimited", "TerminalAdminFull"})
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	limited := loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName)
+	full := loadAdminPolicy(t, st, globalTerminalAdminFullActionName)
+	assert.Equal(t, []string{"pm-tty-alice"}, limited.Users,
+		"user holding both perms enters both cohorts")
+	assert.Equal(t, []string{"pm-tty-alice"}, full.Users)
+}
+
+// Pre-requisite: bootstrap must run before reconcile. Surfaces the
+// dependency clearly so a future caller can't accidentally invert the
+// order and get a silent failure.
+func TestReconcileGlobalTerminalAdmin_FailsLoudlyIfBootstrapSkipped(t *testing.T) {
+	m, _ := newManagerForTest(t)
+	// Deliberately do NOT call BootstrapGlobalTerminalAdminActions.
+
+	err := m.ReconcileGlobalTerminalAdminActions(context.Background())
+	require.Error(t, err,
+		"reconcile must surface a clear error when the global actions do not exist — silent no-op would mask a wiring bug at server startup")
+}
+
+// =============================================================================
+// S4 — wiring: SyncAllUsersSystemActions must also reconcile the
+// globals, so the periodic sweep + every fan-out event the listener
+// classifies as SyncOpSyncAll both keep the cohort up to date without
+// every caller needing to know about the new reconciler.
+// =============================================================================
+
+// =============================================================================
+// S7 — audit event on membership removal.
+//
+// The reconciler emits one TerminalAdminMembershipRevoked event per
+// previously-present pm-tty-* user that was dropped from a global
+// action's users[]. The event carries enough context (user_id,
+// linux_username, action_id, access_level) for audit consumers to
+// render a meaningful row without re-reading the action's params.
+//
+// Adds and no-op ticks do NOT emit the event — only removals.
+// =============================================================================
+
+// loadMembershipRevokedEvents reads the terminal_admin_membership
+// stream events for the given action ID. The reconciler emits one
+// event per removal under (stream_type=terminal_admin_membership,
+// stream_id=<action_id>) so audit consumers can read a per-action
+// revocation history.
+func loadMembershipRevokedEvents(t *testing.T, st *store.Store, actionID string) []store.PersistedEvent {
+	t.Helper()
+	events, err := st.LoadStream(context.Background(), "terminal_admin_membership", actionID)
+	require.NoError(t, err)
+	return events
+}
+
+func TestReconcileGlobalTerminalAdmin_EmitsRevokedEvent_OnRemoval(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	roleID := grantPermsViaRole(t, st, actorID, userID, "TerminalAdminUser",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	limited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+
+	// Revoke + reconcile — should emit ONE TerminalAdminMembershipRevoked
+	// event for pm-tty-alice on the Limited action.
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user_role", StreamID: userID + ":" + roleID,
+		EventType: "UserRoleRevoked",
+		Data:      map[string]any{"user_id": userID, "role_id": roleID},
+		ActorType: "user", ActorID: actorID,
+	}))
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	events := loadMembershipRevokedEvents(t, st, limited.ID)
+	require.Len(t, events, 1,
+		"reconciler must emit exactly one TerminalAdminMembershipRevoked event when pm-tty-alice is removed from the Limited cohort")
+
+	var data map[string]any
+	require.NoError(t, json.Unmarshal(events[0].Data, &data))
+	assert.Equal(t, userID, data["user_id"],
+		"event payload must carry the human user_id (audit consumers key on this)")
+	assert.Equal(t, "alice", data["linux_username"],
+		"event payload must carry the bare linux_username (audit composes the pm-tty- prefix itself)")
+	assert.Equal(t, limited.ID, data["action_id"],
+		"event payload must point at the affected action")
+	assert.Equal(t, "ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED", data["access_level"],
+		"event payload must carry the wire-string access_level so audit can distinguish Limited vs Full revocations")
+}
+
+func TestReconcileGlobalTerminalAdmin_NoEvent_OnAddition(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantPermsViaRole(t, st, actorID, userID, "TerminalAdminUser",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	limited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+	events := loadMembershipRevokedEvents(t, st, limited.ID)
+	assert.Empty(t, events,
+		"reconciler must NOT emit revoked events when a user enters the cohort — only removals are audited; the role-grant itself is already audited by the role layer")
+}
+
+func TestReconcileGlobalTerminalAdmin_NoEvent_OnNoOpTick(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantPermsViaRole(t, st, actorID, userID, "TerminalAdminUser",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	// Second tick — same cohort. Must not emit any new revocation events.
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	limited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
+	require.NoError(t, err)
+	events := loadMembershipRevokedEvents(t, st, limited.ID)
+	assert.Empty(t, events,
+		"no-op reconcile tick must not emit revocation events — the periodic sweep would otherwise log every steady-state tick as a revocation")
+}
+
+func TestSyncAllUsersSystemActions_ReconcilesTerminalAdminGlobals(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantPermsViaRole(t, st, actorID, userID, "TerminalAdminUser",
+		[]string{"StartTerminal", "TerminalAdminLimited"})
+
+	// SyncAllUsersSystemActions is the entry point the periodic sweep
+	// + fan-out-event listener call. It must reconcile the globals as
+	// part of its sweep so cohort updates land without the caller
+	// needing to invoke a separate method.
+	require.NoError(t, m.SyncAllUsersSystemActions(context.Background()))
+
+	limited := loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName)
+	assert.Equal(t, []string{"pm-tty-alice"}, limited.Users,
+		"SyncAllUsersSystemActions must end by reconciling the global TerminalAdmin actions — periodic sweep + fan-out events depend on this")
+}

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -205,6 +205,8 @@ func AllPermissions() []PermissionInfo {
 		{"StopTerminal", "Remote Terminal", "Stop a remote terminal session you opened"},
 		{"ListActiveTerminalSessions", "Remote Terminal", "View active terminal sessions across all devices (admin)"},
 		{"TerminateTerminalSession", "Remote Terminal", "Forcibly terminate any terminal session (admin)"},
+		{"TerminalAdminLimited", "Remote Terminal", "Grant a passwordless LIMITED sudoers policy in remote terminal sessions"},
+		{"TerminalAdminFull", "Remote Terminal", "Grant a passwordless FULL sudoers policy in remote terminal sessions"},
 	}
 }
 

--- a/internal/auth/permissions_parity_test.go
+++ b/internal/auth/permissions_parity_test.go
@@ -42,19 +42,59 @@ func procedureName(procedure string) string {
 	return procedure
 }
 
+// reconcilerOnlyPermissions are intentionally not backed by an RPC.
+// They gate background server-side work (currently the TerminalAdmin
+// reconciler — see manchtools/power-manage-server#70) rather than a
+// handler call. Adding an entry here documents the intent so the
+// parity invariant below stays a meaningful drift-catcher for the
+// "I added a permission but forgot to add its RPC" mistake.
+//
+// To add to this set, the new permission MUST be consumed by a
+// server-side reconciler (not by a handler) and its role-builder
+// UX must make clear that holding it triggers server-managed state,
+// not an RPC the user can call directly.
+var reconcilerOnlyPermissions = map[string]bool{
+	"TerminalAdminLimited": true, // #70 — reconciler in system_actions.go materializes pm-sudo-* membership
+	"TerminalAdminFull":    true, // #70 — same shape, FULL access level
+}
+
 // TestEveryPermissionMatchesAnRPC asserts that every PermissionInfo
 // in AllPermissions() has a base key (sans :self/:assigned scope
 // suffix) that is the name of an actual RPC on
 // pmv1connect.ControlServiceHandler. A drift here means a permission
 // can be assigned to a role but no handler will ever consult it —
 // invisible-deadweight UX in the role builder.
+//
+// Reconciler-only permissions (see above) are skipped — they are
+// consumed off the request path.
 func TestEveryPermissionMatchesAnRPC(t *testing.T) {
 	rpcs := rpcMethodNames(t)
 	for _, p := range auth.AllPermissions() {
 		base := stripScope(p.Key)
+		if reconcilerOnlyPermissions[base] {
+			continue
+		}
 		if !rpcs[base] {
 			t.Errorf("permission %q references non-existent RPC %q (no method on ControlServiceHandler)",
 				p.Key, base)
+		}
+	}
+}
+
+// TestReconcilerOnlyPermissionsAreRegistered guards the inverse
+// invariant: every entry in reconcilerOnlyPermissions must actually
+// be a registered permission in AllPermissions(). Otherwise a
+// future rename of TerminalAdminLimited would leave a stale
+// exemption that quietly papers over a real parity violation.
+func TestReconcilerOnlyPermissionsAreRegistered(t *testing.T) {
+	registered := make(map[string]bool, len(auth.AllPermissions()))
+	for _, p := range auth.AllPermissions() {
+		registered[stripScope(p.Key)] = true
+	}
+	for key := range reconcilerOnlyPermissions {
+		if !registered[key] {
+			t.Errorf("reconcilerOnlyPermissions includes %q but it's not in AllPermissions() — exemption is stale",
+				key)
 		}
 	}
 }

--- a/internal/auth/permissions_test.go
+++ b/internal/auth/permissions_test.go
@@ -137,3 +137,87 @@ func TestAdminPermissions_NoDuplicates(t *testing.T) {
 		seen[p] = true
 	}
 }
+
+// =============================================================================
+// TerminalAdmin (Limited / Full) — manchtools/power-manage-server#70
+//
+// Tests pin the public contract of the two new permission keys. The
+// keys are added to the registry; the reconciler in system_actions.go
+// keys on them by exact string match, so a typo here would silently
+// leave devices without a working terminal-admin sudoers fragment.
+// =============================================================================
+
+func TestAllPermissions_IncludesTerminalAdminLimited(t *testing.T) {
+	for _, p := range AllPermissions() {
+		if p.Key == "TerminalAdminLimited" {
+			return
+		}
+	}
+	t.Fatalf("TerminalAdminLimited not registered in AllPermissions()")
+}
+
+func TestAllPermissions_IncludesTerminalAdminFull(t *testing.T) {
+	for _, p := range AllPermissions() {
+		if p.Key == "TerminalAdminFull" {
+			return
+		}
+	}
+	t.Fatalf("TerminalAdminFull not registered in AllPermissions()")
+}
+
+func TestTerminalAdminPermissions_AreInRemoteTerminalGroup(t *testing.T) {
+	for _, p := range AllPermissions() {
+		if p.Key == "TerminalAdminLimited" || p.Key == "TerminalAdminFull" {
+			assert.Equal(t, "Remote Terminal", p.Group,
+				"TerminalAdmin permissions must live alongside StartTerminal in the Remote Terminal group so the role-builder UI surfaces them together")
+		}
+	}
+}
+
+func TestTerminalAdminPermissions_HaveNonEmptyDescription(t *testing.T) {
+	wanted := map[string]bool{"TerminalAdminLimited": true, "TerminalAdminFull": true}
+	for _, p := range AllPermissions() {
+		if wanted[p.Key] {
+			assert.NotEmpty(t, p.Description,
+				"%s must have a description (rendered in the role-builder UI)", p.Key)
+		}
+	}
+}
+
+func TestValidPermissionKeys_AcceptsTerminalAdminLimited(t *testing.T) {
+	assert.True(t, ValidPermissionKeys()["TerminalAdminLimited"])
+}
+
+func TestValidPermissionKeys_AcceptsTerminalAdminFull(t *testing.T) {
+	assert.True(t, ValidPermissionKeys()["TerminalAdminFull"])
+}
+
+func TestAdminPermissions_IncludesTerminalAdminLimited(t *testing.T) {
+	perms := make(map[string]bool)
+	for _, p := range AdminPermissions() {
+		perms[p] = true
+	}
+	assert.True(t, perms["TerminalAdminLimited"],
+		"the bootstrap Admin role must include TerminalAdminLimited so a fresh deployment can grant terminal-admin without seeding a custom role first")
+}
+
+func TestAdminPermissions_IncludesTerminalAdminFull(t *testing.T) {
+	perms := make(map[string]bool)
+	for _, p := range AdminPermissions() {
+		perms[p] = true
+	}
+	assert.True(t, perms["TerminalAdminFull"],
+		"the bootstrap Admin role must include TerminalAdminFull")
+}
+
+// TerminalAdmin keys are unscoped at the model layer — #7 will add a
+// scope dimension. Pin the unscoped shape here so a future :self /
+// :assigned variant can't be added without the test being updated.
+func TestTerminalAdminPermissions_AreUnscoped(t *testing.T) {
+	for _, p := range AllPermissions() {
+		if p.Key == "TerminalAdminLimited" || p.Key == "TerminalAdminFull" {
+			assert.False(t, strings.Contains(p.Key, ":"),
+				"%s must remain unscoped at the model layer; scope arrives via #7", p.Key)
+		}
+	}
+}

--- a/internal/eventtypes/payloads/terminal.go
+++ b/internal/eventtypes/payloads/terminal.go
@@ -27,3 +27,22 @@ type TerminalSessionTerminated struct {
 	SessionID string `json:"session_id"`
 	Reason    string `json:"reason"`
 }
+
+// TerminalAdminMembershipRevoked is the wire shape for the
+// TerminalAdminMembershipRevoked event (#70). Emitted by the global
+// TerminalAdmin reconciler each time a previously-present
+// pm-tty-<linux_username> is removed from a global action's users[].
+// Carries enough context for audit consumers to render a meaningful
+// row without re-reading the action's params:
+//   - UserID identifies the human operator who lost membership.
+//   - LinuxUsername is the pm-tty-* string that was dropped (without
+//     the pm-tty- prefix so audit can compose the prefix itself).
+//   - ActionID points at the LIMITED or FULL global action row.
+//   - AccessLevel is the wire-string form of pm.AdminAccessLevel
+//     ("ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED" / "_FULL").
+type TerminalAdminMembershipRevoked struct {
+	UserID        string `json:"user_id"`
+	LinuxUsername string `json:"linux_username"`
+	ActionID      string `json:"action_id"`
+	AccessLevel   string `json:"access_level"`
+}

--- a/internal/eventtypes/types.go
+++ b/internal/eventtypes/types.go
@@ -156,6 +156,15 @@ const (
 	TerminalSessionStopped    EventType = "TerminalSessionStopped"
 	TerminalSessionTerminated EventType = "TerminalSessionTerminated"
 
+	// terminal_admin stream — emitted by the global TerminalAdmin
+	// reconciler when a pm-tty-* operator is removed from the LIMITED
+	// or FULL action's users[] (server #70). Carries the human
+	// user_id, the pm-tty-<username> string that was dropped, the
+	// affected action_id, and the access_level so audit consumers can
+	// distinguish Limited vs Full revocations without re-reading the
+	// action's params.
+	TerminalAdminMembershipRevoked EventType = "TerminalAdminMembershipRevoked"
+
 	// token stream
 	TokenCreated  EventType = "TokenCreated"
 	TokenRenamed  EventType = "TokenRenamed"
@@ -242,6 +251,7 @@ func All() []EventType {
 		SecurityAlert, SecurityAlertAcknowledged,
 		ServerSettingUpdated,
 		TerminalSessionStarted, TerminalSessionStopped, TerminalSessionTerminated,
+		TerminalAdminMembershipRevoked,
 		TokenCreated, TokenRenamed, TokenUsed, TokenDisabled, TokenEnabled, TokenDeleted,
 		TOTPSetupInitiated, TOTPVerified, TOTPDisabled, TOTPBackupCodeUsed, TOTPBackupCodesRegenerated,
 		UserCreatedWithRoles, UserProfileUpdated, UserEmailChanged, UserPasswordChanged, UserRoleChanged,

--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -12,6 +12,7 @@ type Querier interface {
 	ListDeviceLayerExcludedActionIDs(ctx context.Context, targetID string) ([]string, error)
 	ListUserLayerResolvedActionsForDevice(ctx context.Context, id string) ([]db.ListUserLayerResolvedActionsForDeviceRow, error)
 	ListSystemTtyActionsForPermissionHolders(ctx context.Context) ([]db.ListSystemTtyActionsForPermissionHoldersRow, error)
+	ListGlobalTerminalAdminActions(ctx context.Context) ([]db.ListGlobalTerminalAdminActionsRow, error)
 }
 
 // ResolveActionsForDevice queries device-layer assignments, user-layer
@@ -117,6 +118,25 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 	// 6. Merge permission-derived TTY actions: dedupe against everything
 	//    already in the result, but never honor device-layer exclusion.
 	for _, ta := range ttyActions {
+		if deviceActionSet[ta.ID] {
+			continue
+		}
+		deviceActions = append(deviceActions, db.ListResolvedActionsForDeviceRow(ta))
+		deviceActionSet[ta.ID] = true
+	}
+
+	// 7. Merge global TerminalAdmin actions (#70). Same exclusion-exempt
+	//    + dedupe semantics as the TTY layer above — these are
+	//    permission-derived too (the reconciler keys users[] off
+	//    StartTerminal ∩ TerminalAdmin*), so an operator's per-device
+	//    EXCLUDED must not be able to lock the admin sudoers fragment
+	//    out either. Fail-fast on query error for the same reason as
+	//    the TTY layer (see step 3's failure-mode note).
+	terminalAdminActions, err := q.ListGlobalTerminalAdminActions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, ta := range terminalAdminActions {
 		if deviceActionSet[ta.ID] {
 			continue
 		}

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -540,3 +540,143 @@ func TestResolveActions_TTYPermissionSource_FailsFastOnTtyError(t *testing.T) {
 	_, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), q, deviceID)
 	require.ErrorIs(t, err, sentinel, "TTY layer failure must propagate up, not degrade silently")
 }
+
+// =============================================================================
+// Global TerminalAdmin layer (#70).
+//
+// Two rows in actions_projection — system:terminal-admin-limited:global
+// and system:terminal-admin-full:global — are merged into every device's
+// resolved action list, exclusion-exempt and deduped against the
+// device/user layers, mirroring the TTY layer's shape.
+// =============================================================================
+
+// noOpSigner mirrors the api package's test-only NoOpSigner — a
+// deterministic dummy signer so the resolution-layer tests can stand
+// up a SystemActionManager without the real CA. api.NoOpSigner lives
+// in a _test.go file in the api package and isn't visible across
+// package boundaries, so we re-declare the minimal stub here.
+type noOpSigner struct{}
+
+func (noOpSigner) Sign(actionID string, actionType int32, paramsJSON []byte) ([]byte, error) {
+	_ = actionID
+	_ = actionType
+	_ = paramsJSON
+	return []byte("noop-test-signature"), nil
+}
+
+// bootstrapAndReconcileTerminalAdmin runs the manager's bootstrap +
+// reconcile against the test store so the two global actions exist
+// before the resolution-layer assertions run.
+func bootstrapAndReconcileTerminalAdmin(t *testing.T, st *store.Store) {
+	t.Helper()
+	mgr := api.NewSystemActionManager(st, noOpSigner{}, slog.Default())
+	require.NoError(t, mgr.BootstrapGlobalTerminalAdminActions(context.Background()))
+	require.NoError(t, mgr.ReconcileGlobalTerminalAdminActions(context.Background()))
+}
+
+func TestResolveActions_GlobalTerminalAdmin_IncludedForFreshDevice(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	bootstrapAndReconcileTerminalAdmin(t, st)
+	deviceID := testutil.CreateTestDevice(t, st, "fresh-host-with-admin")
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+
+	names := make(map[string]bool)
+	for _, a := range actions {
+		names[a.Name] = true
+	}
+	assert.True(t, names["system:terminal-admin-limited:global"],
+		"Limited global must reach a brand-new device without any assignment")
+	assert.True(t, names["system:terminal-admin-full:global"],
+		"Full global must reach a brand-new device without any assignment")
+}
+
+// Operator EXCLUDED on a global TerminalAdmin action must NOT lock
+// out the sudoers fragment — same property as the TTY layer. Terminal
+// admin policy is the system's escape hatch; revocation goes through
+// the role/permission system, not through per-device EXCLUDED.
+func TestResolveActions_GlobalTerminalAdmin_BypassesDeviceExcluded(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	bootstrapAndReconcileTerminalAdmin(t, st)
+	deviceID := testutil.CreateTestDevice(t, st, "excl-attempt-host")
+
+	limited, err := st.Queries().GetActionByName(context.Background(), "system:terminal-admin-limited:global")
+	require.NoError(t, err)
+
+	// Operator attempt: EXCLUDED assignment on the Limited global.
+	// The permission-derived layer must ignore it.
+	testutil.CreateTestAssignment(t, st, adminID, "action", limited.ID, "device", deviceID, 2)
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+
+	found := false
+	for _, a := range actions {
+		if a.ID == limited.ID {
+			found = true
+		}
+	}
+	assert.True(t, found,
+		"device-layer EXCLUDED must NOT remove the global Limited TerminalAdmin action — escape-hatch property mirrors TTY layer")
+}
+
+// Dedupe: if some operator authored a REQUIRED assignment for one of
+// the globals (already-present-via-permission-layer), the action must
+// appear exactly once in the resolved list.
+func TestResolveActions_GlobalTerminalAdmin_DedupedAgainstDeviceLayer(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	bootstrapAndReconcileTerminalAdmin(t, st)
+	deviceID := testutil.CreateTestDevice(t, st, "dedup-attempt-host")
+
+	limited, err := st.Queries().GetActionByName(context.Background(), "system:terminal-admin-limited:global")
+	require.NoError(t, err)
+
+	testutil.CreateTestAssignment(t, st, adminID, "action", limited.ID, "device", deviceID, 0)
+
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), deviceID)
+	require.NoError(t, err)
+
+	hits := 0
+	for _, a := range actions {
+		if a.ID == limited.ID {
+			hits++
+		}
+	}
+	assert.Equal(t, 1, hits, "Limited global must appear exactly once even when also assigned directly to the device")
+}
+
+// Fail-fast: the global TerminalAdmin query must propagate errors up,
+// not degrade to an empty slice. The agent treats the server's action
+// list as authoritative — silent drop would tear down every device's
+// pm-sudo-* group on the next sync.
+type globalTerminalAdminFailingQuerier struct {
+	resolution.Querier
+	err error
+}
+
+func (q globalTerminalAdminFailingQuerier) ListGlobalTerminalAdminActions(ctx context.Context) ([]db.ListGlobalTerminalAdminActionsRow, error) {
+	return nil, q.err
+}
+
+func TestResolveActions_GlobalTerminalAdmin_FailsFastOnQueryError(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	bootstrapAndReconcileTerminalAdmin(t, st)
+	deviceID := testutil.CreateTestDevice(t, st, "global-failure-host")
+
+	sentinel := errors.New("simulated DB hiccup on terminal-admin lookup")
+	q := globalTerminalAdminFailingQuerier{
+		Querier: st.Queries(),
+		err:     sentinel,
+	}
+	_, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), q, deviceID)
+	require.ErrorIs(t, err, sentinel,
+		"global TerminalAdmin query failure must propagate, not degrade silently — agents revert membership on missing rows")
+}

--- a/internal/store/generated/assignments.sql.go
+++ b/internal/store/generated/assignments.sql.go
@@ -1243,6 +1243,82 @@ func (q *Queries) ListSystemTtyActionsForPermissionHolders(ctx context.Context) 
 	return items, nil
 }
 
+const listGlobalTerminalAdminActions = `-- name: ListGlobalTerminalAdminActions :many
+SELECT id, name, description, action_type, desired_state,
+       params, timeout_seconds, created_at, created_by,
+       is_deleted, projection_version,
+       signature, params_canonical, schedule
+FROM actions_projection
+WHERE is_deleted = FALSE
+  AND name IN ('system:terminal-admin-limited:global',
+               'system:terminal-admin-full:global')
+`
+
+type ListGlobalTerminalAdminActionsRow struct {
+	ID                string     `json:"id"`
+	Name              string     `json:"name"`
+	Description       *string    `json:"description"`
+	ActionType        int32      `json:"action_type"`
+	DesiredState      int32      `json:"desired_state"`
+	Params            []byte     `json:"params"`
+	TimeoutSeconds    int32      `json:"timeout_seconds"`
+	CreatedAt         *time.Time `json:"created_at"`
+	CreatedBy         string     `json:"created_by"`
+	IsDeleted         bool       `json:"is_deleted"`
+	ProjectionVersion int64      `json:"projection_version"`
+	Signature         []byte     `json:"signature"`
+	ParamsCanonical   []byte     `json:"params_canonical"`
+	Schedule          []byte     `json:"schedule"`
+}
+
+// Global TerminalAdmin AdminPolicy actions.
+//
+// Two well-known rows in actions_projection — bootstrapped at startup
+// (server BootstrapGlobalTerminalAdminActions) and re-signed in place
+// by the reconciler when membership changes. The resolution layer
+// merges these into every device's resolved action list so the
+// pm-tty-* operators get their sudoers fragment regardless of
+// assignment.
+//
+// #70 ships with the two GLOBAL rows. #7 extends this design by adding
+// per-scope variants; that PR will replace the IN-list filter with a
+// scope-aware join. The shape of this query is intentionally simple
+// so the #7 diff is isolated to the WHERE clause.
+func (q *Queries) ListGlobalTerminalAdminActions(ctx context.Context) ([]ListGlobalTerminalAdminActionsRow, error) {
+	rows, err := q.db.Query(ctx, listGlobalTerminalAdminActions)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListGlobalTerminalAdminActionsRow{}
+	for rows.Next() {
+		var i ListGlobalTerminalAdminActionsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Description,
+			&i.ActionType,
+			&i.DesiredState,
+			&i.Params,
+			&i.TimeoutSeconds,
+			&i.CreatedAt,
+			&i.CreatedBy,
+			&i.IsDeleted,
+			&i.ProjectionVersion,
+			&i.Signature,
+			&i.ParamsCanonical,
+			&i.Schedule,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUserLayerResolvedActionsForDevice = `-- name: ListUserLayerResolvedActionsForDevice :many
 WITH device_owners AS (
   SELECT dau.user_id FROM device_assigned_users_projection dau WHERE dau.device_id = $1

--- a/internal/store/queries/assignments.sql
+++ b/internal/store/queries/assignments.sql
@@ -907,3 +907,26 @@ WHERE u.is_deleted = FALSE
         )
       )
   );
+
+-- Global TerminalAdmin AdminPolicy actions.
+--
+-- Two well-known rows in actions_projection — bootstrapped at startup
+-- (server BootstrapGlobalTerminalAdminActions) and re-signed in place
+-- by the reconciler when membership changes. The resolution layer
+-- merges these into every device's resolved action list so the
+-- pm-tty-* operators get their sudoers fragment regardless of
+-- assignment.
+--
+-- #70 ships with the two GLOBAL rows. #7 extends this design by adding
+-- per-scope variants; that PR will replace the IN-list filter with a
+-- scope-aware join. The shape of this query is intentionally simple
+-- so the #7 diff is isolated to the WHERE clause.
+-- name: ListGlobalTerminalAdminActions :many
+SELECT id, name, description, action_type, desired_state,
+       params, timeout_seconds, created_at, created_by,
+       is_deleted, projection_version,
+       signature, params_canonical, schedule
+FROM actions_projection
+WHERE is_deleted = FALSE
+  AND name IN ('system:terminal-admin-limited:global',
+               'system:terminal-admin-full:global');


### PR DESCRIPTION
## Summary

Server-side implementation of [#70](https://github.com/manchtools/power-manage-server/issues/70) (TerminalAdmin Limited/Full).

- Two new permissions (`TerminalAdminLimited` / `TerminalAdminFull`) under the **Remote Terminal** group — these gate **server-side reconciler** work, not RPCs. Marked as reconciler-only in the permission-parity test with a paired inverse guard.
- Two new GLOBAL `AdminPolicy` actions bootstrapped idempotently at startup: `system:terminal-admin-limited:global` and `system:terminal-admin-full:global`, each carrying the new `AdminAccessLevel` enum value from [sdk #80](https://github.com/manchtools/power-manage-sdk/pull/80) (merged).
- Reconciler intersects `(StartTerminal ∩ TerminalAdmin*)`, excludes disabled / deleted / linux_username-less users, sorts deterministically, and re-signs in place ONLY when the cohort changes — steady-state ticks are no-ops, no signature churn.
- One `TerminalAdminMembershipRevoked` audit event emitted per removed `pm-tty-<linuxusername>` per affected action, stream `(terminal_admin_membership, <action_id>)`.
- Resolution layer fans both globals into every device's resolved action list — exclusion-exempt and deduped against the device/user layers, same shape as the existing TTY layer.
- Wired from `wireSystemActions` startup → bootstrap before sweep, and from `SyncAllUsersSystemActions` + the listener's per-user dispatch.

The existing `generateLimitedSudoConfig` / `generateFullSudoConfig` templates are NOT mutated — operator-authored AdminPolicy actions continue to behave exactly as before. The new passwordless templates live in the paired agent PR.

Closes #70 (paired with the agent PR).

## Why

Per the ADR at [`server/docs/adr/0000-terminal-admin-threat-model.md`](https://github.com/manchtools/power-manage-server/blob/main/docs/adr/0000-terminal-admin-threat-model.md): the pm-tty-* accounts are passwordless (server #328), so the existing FULL/LIMITED templates are unusable through TerminalAdmin (no password to type). The reconciler-driven design avoids per-user action bloat (no "300 actions with one member each") and avoids per-device dynamic signing — re-signs happen in place on the two stable global actions, on membership change only.

## Test plan

- [x] `permissions_test.go`: 8 new tests pin the new keys, group, descriptions, scope-free shape, admin inclusion, and ValidPermissionKeys acceptance
- [x] `permissions_parity_test.go`: reconciler-only exemption + inverse guard catches stale exemptions on rename
- [x] `system_actions_terminal_admin_test.go`: 15 new tests — bootstrap idempotency + no-rechurn, reconciler add / exclude (no StartTerminal) / disabled / deleted / no-linux-username / group-role / no-op / disjoint Full+Limited / both-perms-both-cohorts / fails-loudly-if-bootstrap-skipped + audit event coverage (emitted-on-removal / not-on-add / not-on-noop) + SyncAllUsersSystemActions integration
- [x] `resolve_test.go`: 4 new tests — globals reach fresh devices, exclusion-exempt, deduped against device-layer, fail-fast on query error
- [x] `gofmt`, `go vet`, `go build` clean
- [x] Local `cr review` — one finding (no-linux-username gate test gap) addressed before push