### PR TITLE
feat(auth): #7 S1 — group permission split + TargetKind + ProcedureAlternatives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260608193749-8a7b13b95072
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260609134833-73a636cdf6a3

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260608193749-8a7b13b95072 h1:/DIvYZjrZTtGgxI7Ny6j4eRxgGCeyFQ0U9+CFOazXpU=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260608193749-8a7b13b95072/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260609134833-73a636cdf6a3 h1:UWd+f3FfnaUdHR6NE3vTF05GHl3DvKOyO/oy1qYm/Jg=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260609134833-73a636cdf6a3/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -50,6 +50,19 @@ func (h *DeviceGroupHandler) CreateDeviceGroup(ctx context.Context, req *connect
 		return nil, err
 	}
 
+	// Reject the (IsDynamic=true, DynamicQuery="") combination
+	// BEFORE the permission narrowing: without this guard the
+	// `wantsDynamic` predicate below would compute false (because
+	// DynamicQuery is empty), letting a holder of
+	// CreateStaticDeviceGroup pass the static-perm check while the
+	// event still persists IsDynamic=true with an empty query —
+	// an empty query is treated as match-all at evaluation time,
+	// so the resulting "static" group would actually scoop up every
+	// device. T-S2 bypass; flagged in #333 review.
+	if req.Msg.IsDynamic && req.Msg.DynamicQuery == "" {
+		return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "is_dynamic=true requires a non-empty dynamic_query")
+	}
+
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
@@ -420,6 +433,14 @@ func (h *DeviceGroupHandler) RemoveDeviceFromGroup(ctx context.Context, req *con
 func (h *DeviceGroupHandler) UpdateDeviceGroupQuery(ctx context.Context, req *connect.Request[pm.UpdateDeviceGroupQueryRequest]) (*connect.Response[pm.UpdateDeviceGroupQueryResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
+	}
+
+	// Same T-S2 bypass guard as CreateDeviceGroup: empty dynamic
+	// query evaluates as match-all, so an IsDynamic=true with an
+	// empty query would persist a group that scoops up every
+	// device. Reject at the boundary. Flagged in #333 review.
+	if req.Msg.IsDynamic && req.Msg.DynamicQuery == "" {
+		return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "is_dynamic=true requires a non-empty dynamic_query")
 	}
 
 	userCtx, err := requireAuth(ctx)

--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -10,6 +10,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/go/maintenance"
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/dynamicquery"
 	"github.com/manchtools/power-manage/server/internal/dyngroupeval"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -35,6 +36,15 @@ func NewDeviceGroupHandler(st *store.Store, logger *slog.Logger) *DeviceGroupHan
 }
 
 // CreateDeviceGroup creates a new device group.
+//
+// Permission dispatch (server #7 T-S2): the AuthzInterceptor passes
+// the caller through if they hold EITHER CreateStaticDeviceGroup or
+// CreateDynamicDeviceGroup (per ProcedureAlternatives). The handler
+// then narrows to the specific permission against the request
+// shape: a dynamic-query request requires the dynamic permission, a
+// non-dynamic request requires the static permission. Without this
+// narrowing, a static-only admin could create dynamic groups and
+// perturb other actors' scopes.
 func (h *DeviceGroupHandler) CreateDeviceGroup(ctx context.Context, req *connect.Request[pm.CreateDeviceGroupRequest]) (*connect.Response[pm.CreateDeviceGroupResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
@@ -45,10 +55,19 @@ func (h *DeviceGroupHandler) CreateDeviceGroup(ctx context.Context, req *connect
 		return nil, err
 	}
 
+	wantsDynamic := req.Msg.IsDynamic && req.Msg.DynamicQuery != ""
+	requiredPerm := "CreateStaticDeviceGroup"
+	if wantsDynamic {
+		requiredPerm = "CreateDynamicDeviceGroup"
+	}
+	if !auth.HasPermission(ctx, requiredPerm) {
+		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "missing required permission for the requested device group shape")
+	}
+
 	id := ulid.Make().String()
 
 	// Validate dynamic query if provided
-	if req.Msg.IsDynamic && req.Msg.DynamicQuery != "" {
+	if wantsDynamic {
 		if len(req.Msg.DynamicQuery) > maxDynamicQueryLength {
 			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "dynamic_query exceeds maximum length")
 		}
@@ -388,6 +407,16 @@ func (h *DeviceGroupHandler) RemoveDeviceFromGroup(ctx context.Context, req *con
 }
 
 // UpdateDeviceGroupQuery updates a device group's dynamic query.
+//
+// Defensive check (server #7 T-S2 update pathway): the target group
+// MUST currently be dynamic. This RPC does NOT promote a static
+// group to dynamic — that would let a holder of
+// UpdateDynamicDeviceGroupQuery silently convert a static group
+// into a dynamic one, bypassing the CreateDynamicDeviceGroup gate.
+// A separate (future) RPC owns the convert operation if anyone
+// needs it. Permission gating (via ProcedureAlternatives) is
+// already exclusively UpdateDynamicDeviceGroupQuery, so this check
+// belt-and-suspenders against accidental misuse.
 func (h *DeviceGroupHandler) UpdateDeviceGroupQuery(ctx context.Context, req *connect.Request[pm.UpdateDeviceGroupQueryRequest]) (*connect.Response[pm.UpdateDeviceGroupQueryResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
@@ -396,6 +425,16 @@ func (h *DeviceGroupHandler) UpdateDeviceGroupQuery(ctx context.Context, req *co
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Defensive: the target group must already be dynamic.
+	current, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
+	}
+	if !current.IsDynamic {
+		return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeFailedPrecondition,
+			"cannot apply UpdateDeviceGroupQuery to a static device group; use a dedicated convert operation if you need to change the group's kind")
 	}
 
 	// Validate dynamic query if provided

--- a/internal/api/device_group_handler_test.go
+++ b/internal/api/device_group_handler_test.go
@@ -362,6 +362,79 @@ func TestUpdateDeviceGroupQuery_RejectsStaticGroup_FailedPrecondition(t *testing
 		"applying UpdateDeviceGroupQuery to a static group must FailedPrecondition — no implicit promotion (T-S2 update pathway)")
 }
 
+// =============================================================================
+// CR-#333 regression: reject `IsDynamic=true` with an empty
+// `DynamicQuery`. Without this guard the handler's wantsDynamic
+// predicate evaluates false (because DynamicQuery is empty), letting
+// a holder of CreateStaticDeviceGroup pass the static permission
+// check while the event still persists IsDynamic=true with an empty
+// query. Empty queries match every device at evaluation time, so
+// the resulting group would scoop up the entire fleet — a T-S2
+// bypass in disguise.
+// =============================================================================
+
+func TestCreateDeviceGroup_IsDynamicTrueWithEmptyQuery_Rejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name:         "Suspicious",
+		IsDynamic:    true,
+		DynamicQuery: "",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
+		"is_dynamic=true with empty dynamic_query must be rejected at the boundary — CR #333 T-S2 bypass guard")
+}
+
+func TestCreateDeviceGroup_IsDynamicTrueWithEmptyQuery_StaticOnlyActor_NotElevated(t *testing.T) {
+	// Threat lens: even a static-only admin must NOT be able to
+	// slip a `IsDynamic=true, DynamicQuery=""` payload past the
+	// permission check. The bypass guard rejects BEFORE the
+	// permission narrowing runs.
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AuthContext(userID, "static-only@test.com", []string{"CreateStaticDeviceGroup"})
+
+	_, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name:         "Bypass Attempt",
+		IsDynamic:    true,
+		DynamicQuery: "",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
+		"the bypass guard must fire BEFORE the permission narrowing — invalid request shape is rejected ahead of authz")
+}
+
+func TestUpdateDeviceGroupQuery_IsDynamicTrueWithEmptyQuery_Rejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	created, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name:         "Existing Dyn",
+		IsDynamic:    true,
+		DynamicQuery: `(device.labels.x equals "y")`,
+	}))
+	require.NoError(t, err)
+
+	_, err = h.UpdateDeviceGroupQuery(ctx, connect.NewRequest(&pm.UpdateDeviceGroupQueryRequest{
+		Id:           created.Msg.Group.Id,
+		IsDynamic:    true,
+		DynamicQuery: "",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
+		"clearing the dynamic query on an existing dynamic group via IsDynamic=true must be rejected — same all-devices-match bypass")
+}
+
 func TestUpdateDeviceGroupQuery_AcceptsDynamicGroup(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewDeviceGroupHandler(st, slog.Default())

--- a/internal/api/device_group_handler_test.go
+++ b/internal/api/device_group_handler_test.go
@@ -230,3 +230,159 @@ func TestValidateDynamicQuery(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, resp.Msg.Valid)
 }
+
+// =============================================================================
+// CreateDeviceGroup / UpdateDeviceGroupQuery handler dispatch
+// (server #7 T-S2 — static/dynamic permission narrowing)
+//
+// Tests drive the actual handler with hand-built UserContexts that
+// hold ONLY the specific split permission under test, NOT a full
+// admin grant. That's the load-bearing assertion: the handler MUST
+// narrow on request shape, not rely on either permission being held
+// (which the interceptor already does via ProcedureAlternatives).
+//
+// Wrong-data is sourced from intent (the T-S2 design: a static-only
+// admin must be unable to author or modify dynamic groups), NOT
+// from the artifact under test.
+// =============================================================================
+
+func TestCreateDeviceGroup_StaticRequest_StaticPermOnly_Succeeds(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AuthContext(userID, "static-only@test.com", []string{"CreateStaticDeviceGroup"})
+
+	resp, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name: "Static Group",
+	}))
+	require.NoError(t, err)
+	assert.False(t, resp.Msg.Group.IsDynamic, "static-only path must produce a static group")
+}
+
+func TestCreateDeviceGroup_DynamicRequest_StaticPermOnly_Denied(t *testing.T) {
+	// T-S2: static-only admin must NOT be able to create a dynamic
+	// group. The interceptor would let them through (alternatives
+	// map: holding CreateStaticDeviceGroup is sufficient to ENTER
+	// the RPC), but the handler narrows to CreateDynamicDeviceGroup
+	// once it sees the dynamic-query request shape.
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AuthContext(userID, "static-only@test.com", []string{"CreateStaticDeviceGroup"})
+
+	_, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name:         "Sneaky Dynamic",
+		IsDynamic:    true,
+		DynamicQuery: `(device.labels.environment equals "prod")`,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err),
+		"static-only admin must be denied when request asks for dynamic — T-S2 mitigation")
+}
+
+func TestCreateDeviceGroup_DynamicRequest_DynamicPermOnly_Succeeds(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AuthContext(userID, "dynamic-only@test.com", []string{"CreateDynamicDeviceGroup"})
+
+	resp, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name:         "Dynamic Group",
+		IsDynamic:    true,
+		DynamicQuery: `(device.labels.environment equals "prod")`,
+	}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.Group.IsDynamic, "dynamic-only path must produce a dynamic group")
+}
+
+func TestCreateDeviceGroup_StaticRequest_DynamicPermOnly_Denied(t *testing.T) {
+	// Symmetric — dynamic-only admin must NOT be able to create a
+	// static group. This is the inverse asymmetry guard so a
+	// future PR can't accidentally collapse the dispatch to "any
+	// split perm satisfies".
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AuthContext(userID, "dynamic-only@test.com", []string{"CreateDynamicDeviceGroup"})
+
+	_, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name: "Static Attempt",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err),
+		"dynamic-only admin must be denied when request asks for static — asymmetry guard")
+}
+
+func TestCreateDeviceGroup_DynamicRequest_BothPermsHeld_Succeeds(t *testing.T) {
+	// Admin tier — both split perms held — covers either request
+	// shape. Sanity check on the typical admin flow.
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AuthContext(userID, "both@test.com", []string{
+		"CreateStaticDeviceGroup",
+		"CreateDynamicDeviceGroup",
+	})
+
+	resp, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name:         "Either",
+		IsDynamic:    true,
+		DynamicQuery: `(device.labels.x equals "y")`,
+	}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.Group.IsDynamic)
+}
+
+func TestUpdateDeviceGroupQuery_RejectsStaticGroup_FailedPrecondition(t *testing.T) {
+	// Defensive: applying UpdateDeviceGroupQuery to a static group
+	// would silently promote it to dynamic, bypassing the
+	// CreateDynamicDeviceGroup gate. Must fail with
+	// FailedPrecondition (not InvalidArgument) so callers can
+	// distinguish "I sent a bad request" from "the resource isn't
+	// in the expected state".
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	staticGroupID := testutil.CreateTestDeviceGroup(t, st, adminID, "Static Target")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.UpdateDeviceGroupQuery(ctx, connect.NewRequest(&pm.UpdateDeviceGroupQueryRequest{
+		Id:           staticGroupID,
+		IsDynamic:    true,
+		DynamicQuery: `(device.labels.env equals "prod")`,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err),
+		"applying UpdateDeviceGroupQuery to a static group must FailedPrecondition — no implicit promotion (T-S2 update pathway)")
+}
+
+func TestUpdateDeviceGroupQuery_AcceptsDynamicGroup(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	// Create a dynamic group first
+	created, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name:         "Dyn Target",
+		IsDynamic:    true,
+		DynamicQuery: `(device.labels.env equals "stage")`,
+	}))
+	require.NoError(t, err)
+
+	resp, err := h.UpdateDeviceGroupQuery(ctx, connect.NewRequest(&pm.UpdateDeviceGroupQueryRequest{
+		Id:           created.Msg.Group.Id,
+		IsDynamic:    true,
+		DynamicQuery: `(device.labels.env equals "prod")`,
+	}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.Group.IsDynamic)
+	assert.Contains(t, resp.Msg.Group.DynamicQuery, "prod")
+}

--- a/internal/api/missing_rpc_coverage_test.go
+++ b/internal/api/missing_rpc_coverage_test.go
@@ -170,15 +170,29 @@ func TestDeviceGroupHandler_ListDeviceGroupsForDevice_ReturnsOnlyGroupsContainin
 	}
 }
 
-func TestDeviceGroupHandler_UpdateDeviceGroupQuery_FlipsToDynamicAndPersistsQuery(t *testing.T) {
+// TestDeviceGroupHandler_UpdateDeviceGroupQuery_UpdatesQueryOnDynamicGroup
+// pins the post-#7 contract: UpdateDeviceGroupQuery only operates on
+// groups that are ALREADY dynamic. The previous name
+// `FlipsToDynamicAndPersistsQuery` described the looser pre-#7
+// behaviour where the same RPC promoted static groups to dynamic —
+// that path was closed in #7 S1 to prevent a holder of
+// UpdateDynamicDeviceGroupQuery from silently bypassing the
+// CreateDynamicDeviceGroup gate (T-S2 update pathway). The static
+// rejection contract is pinned by the sibling test
+// TestUpdateDeviceGroupQuery_RejectsStaticGroup_FailedPrecondition.
+func TestDeviceGroupHandler_UpdateDeviceGroupQuery_UpdatesQueryOnDynamicGroup(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewDeviceGroupHandler(st, slog.Default())
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
-	created, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{Name: "To Become Dynamic"}))
+	created, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name:         "Born Dynamic",
+		IsDynamic:    true,
+		DynamicQuery: `(device.hostname equals "initial-host")`,
+	}))
 	require.NoError(t, err)
-	require.False(t, created.Msg.Group.IsDynamic, "fresh groups must default to static")
+	require.True(t, created.Msg.Group.IsDynamic)
 
 	updated, err := h.UpdateDeviceGroupQuery(ctx, connect.NewRequest(&pm.UpdateDeviceGroupQueryRequest{
 		Id:           created.Msg.Group.Id,
@@ -198,10 +212,8 @@ func TestDeviceGroupHandler_EvaluateDynamicGroup_CountsMatchingDevices(t *testin
 	ctx := testutil.AdminContext(adminID)
 	testutil.CreateTestDevice(t, st, "dyn-host")          // matching
 	testutil.CreateTestDevice(t, st, "non-matching-host") // not matching
-	group, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{Name: "Dyn"}))
-	require.NoError(t, err)
-	_, err = h.UpdateDeviceGroupQuery(ctx, connect.NewRequest(&pm.UpdateDeviceGroupQueryRequest{
-		Id:           group.Msg.Group.Id,
+	group, err := h.CreateDeviceGroup(ctx, connect.NewRequest(&pm.CreateDeviceGroupRequest{
+		Name:         "Dyn",
 		IsDynamic:    true,
 		DynamicQuery: `(device.hostname equals "dyn-host")`,
 	}))
@@ -626,16 +638,26 @@ func TestDeviceHandler_ListDeviceAssignees_ListsAssignedUser(t *testing.T) {
 // UserGroupHandler — dynamic query + query validation
 // =============================================================================
 
-func TestUserGroupHandler_UpdateUserGroupQuery_FlipsToDynamicAndPersistsQuery(t *testing.T) {
+// TestUserGroupHandler_UpdateUserGroupQuery_UpdatesQueryOnDynamicGroup
+// — symmetric with the device-group rename. Renamed from
+// `FlipsToDynamicAndPersistsQuery` for the same reason: #7 S1
+// closed the static→dynamic promotion path through this RPC.
+func TestUserGroupHandler_UpdateUserGroupQuery_UpdatesQueryOnDynamicGroup(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewUserGroupHandler(st, slog.Default())
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
 	ctx := testutil.AdminContext(adminID)
-	groupID := testutil.CreateTestUserGroup(t, st, adminID, "Dynamic Users")
+	created, err := h.CreateUserGroup(ctx, connect.NewRequest(&pm.CreateUserGroupRequest{
+		Name:         "Born Dynamic Users",
+		IsDynamic:    true,
+		DynamicQuery: `(user.email contains "@old.com")`,
+	}))
+	require.NoError(t, err)
+	require.True(t, created.Msg.Group.IsDynamic)
 
 	resp, err := h.UpdateUserGroupQuery(ctx, connect.NewRequest(&pm.UpdateUserGroupQueryRequest{
-		Id:           groupID,
+		Id:           created.Msg.Group.Id,
 		IsDynamic:    true,
 		DynamicQuery: `(user.email contains "@user.com")`,
 	}))

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -418,12 +418,26 @@ func (h *RoleHandler) ListPermissions(ctx context.Context, req *connect.Request[
 			Key:         p.Key,
 			Group:       p.Group,
 			Description: p.Description,
+			TargetKind:  targetKindToProto(p.TargetKind),
 		}
 	}
 
 	return connect.NewResponse(&pm.ListPermissionsResponse{
 		Permissions: protoPerms,
 	}), nil
+}
+
+// targetKindToProto maps the auth-package PermissionTargetKind to
+// its proto wire form. server #7.
+func targetKindToProto(k auth.PermissionTargetKind) pm.PermissionTargetKind {
+	switch k {
+	case auth.TargetDevice:
+		return pm.PermissionTargetKind_PERMISSION_TARGET_KIND_DEVICE
+	case auth.TargetUser:
+		return pm.PermissionTargetKind_PERMISSION_TARGET_KIND_USER
+	default:
+		return pm.PermissionTargetKind_PERMISSION_TARGET_KIND_UNSPECIFIED
+	}
 }
 
 // bumpUserSessionVersion increments a user's session_version to

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -48,6 +48,22 @@ func (h *UserGroupHandler) CreateUserGroup(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
+	// Same T-S2 bypass guard as CreateDeviceGroup — see comment
+	// there. Flagged in #333 review.
+	if req.Msg.IsDynamic && req.Msg.DynamicQuery == "" {
+		return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "is_dynamic=true requires a non-empty dynamic_query")
+	}
+
+	// Authenticate BEFORE the permission narrowing and DB access.
+	// An unauthenticated caller should see Unauthenticated, not
+	// PermissionDenied (which would misclassify them as authenticated
+	// but unauthorized), and they should not even hit the
+	// name-uniqueness query. Matches the CreateDeviceGroup pattern.
+	userCtx, err := requireAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	wantsDynamic := req.Msg.IsDynamic && req.Msg.DynamicQuery != ""
 	requiredPerm := "CreateStaticUserGroup"
 	if wantsDynamic {
@@ -60,17 +76,12 @@ func (h *UserGroupHandler) CreateUserGroup(ctx context.Context, req *connect.Req
 	// Check name uniqueness — distinguishing NotFound from a transient
 	// DB error matters: silently treating any error as "name available"
 	// would let a concurrent CreateUserGroup succeed twice on a flaky DB.
-	_, err := h.store.Repos().UserGroup.GetByName(ctx, req.Msg.Name)
+	_, err = h.store.Repos().UserGroup.GetByName(ctx, req.Msg.Name)
 	if err == nil {
 		return nil, apiErrorCtx(ctx, ErrUserGroupNameExists, connect.CodeAlreadyExists, "user group name already exists")
 	}
 	if !store.IsNotFound(err) {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check user group name uniqueness")
-	}
-
-	userCtx, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
 	}
 
 	id := ulid.Make().String()
@@ -622,6 +633,12 @@ func (h *UserGroupHandler) ListUserGroupsForUser(ctx context.Context, req *conne
 func (h *UserGroupHandler) UpdateUserGroupQuery(ctx context.Context, req *connect.Request[pm.UpdateUserGroupQueryRequest]) (*connect.Response[pm.UpdateUserGroupQueryResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
+	}
+
+	// Same T-S2 bypass guard as CreateDeviceGroup. Flagged in
+	// #333 review.
+	if req.Msg.IsDynamic && req.Msg.DynamicQuery == "" {
+		return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "is_dynamic=true requires a non-empty dynamic_query")
 	}
 
 	userCtx, err := requireAuth(ctx)

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -37,9 +37,24 @@ func NewUserGroupHandler(st *store.Store, logger *slog.Logger) *UserGroupHandler
 }
 
 // CreateUserGroup creates a new user group.
+//
+// Permission dispatch (server #7 T-S2): symmetric with
+// CreateDeviceGroup. The interceptor passes the caller if they hold
+// either CreateStaticUserGroup or CreateDynamicUserGroup; the
+// handler narrows to the specific permission against the request
+// shape.
 func (h *UserGroupHandler) CreateUserGroup(ctx context.Context, req *connect.Request[pm.CreateUserGroupRequest]) (*connect.Response[pm.CreateUserGroupResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
+	}
+
+	wantsDynamic := req.Msg.IsDynamic && req.Msg.DynamicQuery != ""
+	requiredPerm := "CreateStaticUserGroup"
+	if wantsDynamic {
+		requiredPerm = "CreateDynamicUserGroup"
+	}
+	if !auth.HasPermission(ctx, requiredPerm) {
+		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "missing required permission for the requested user group shape")
 	}
 
 	// Check name uniqueness — distinguishing NotFound from a transient
@@ -61,7 +76,7 @@ func (h *UserGroupHandler) CreateUserGroup(ctx context.Context, req *connect.Req
 	id := ulid.Make().String()
 
 	// Validate dynamic query if provided
-	if req.Msg.IsDynamic && req.Msg.DynamicQuery != "" {
+	if wantsDynamic {
 		if len(req.Msg.DynamicQuery) > maxDynamicQueryLength {
 			return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeInvalidArgument, "dynamic_query exceeds maximum length")
 		}
@@ -600,6 +615,10 @@ func (h *UserGroupHandler) ListUserGroupsForUser(ctx context.Context, req *conne
 }
 
 // UpdateUserGroupQuery updates the dynamic query settings for a user group.
+//
+// Defensive check (server #7 T-S2 update pathway): symmetric with
+// UpdateDeviceGroupQuery. Target group MUST already be dynamic; no
+// implicit static→dynamic promotion through this RPC.
 func (h *UserGroupHandler) UpdateUserGroupQuery(ctx context.Context, req *connect.Request[pm.UpdateUserGroupQueryRequest]) (*connect.Response[pm.UpdateUserGroupQueryResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
@@ -608,6 +627,16 @@ func (h *UserGroupHandler) UpdateUserGroupQuery(ctx context.Context, req *connec
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Defensive: the target group must already be dynamic.
+	current, err := h.store.Repos().UserGroup.Get(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, handleGetError(ctx, err, ErrUserGroupNotFound, "user group not found")
+	}
+	if !current.IsDynamic {
+		return nil, apiErrorCtx(ctx, ErrInvalidQuery, connect.CodeFailedPrecondition,
+			"cannot apply UpdateUserGroupQuery to a static user group; use a dedicated convert operation if you need to change the group's kind")
 	}
 
 	// Validate dynamic query if provided

--- a/internal/api/user_group_handler_test.go
+++ b/internal/api/user_group_handler_test.go
@@ -506,3 +506,111 @@ func TestEvaluateDynamicUserGroup_NotAuthenticated(t *testing.T) {
 	require.True(t, errors.As(err, &connectErr))
 	assert.Equal(t, connect.CodeUnauthenticated, connectErr.Code())
 }
+
+// =============================================================================
+// CreateUserGroup / UpdateUserGroupQuery handler dispatch — symmetric
+// with the device-group split. server #7 T-S2.
+// =============================================================================
+
+func TestCreateUserGroup_StaticRequest_StaticPermOnly_Succeeds(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AuthContext(userID, "static-only@test.com", []string{"CreateStaticUserGroup"})
+
+	resp, err := h.CreateUserGroup(ctx, connect.NewRequest(&pm.CreateUserGroupRequest{
+		Name: "Static UG",
+	}))
+	require.NoError(t, err)
+	assert.False(t, resp.Msg.Group.IsDynamic)
+}
+
+func TestCreateUserGroup_DynamicRequest_StaticPermOnly_Denied(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AuthContext(userID, "static-only@test.com", []string{"CreateStaticUserGroup"})
+
+	_, err := h.CreateUserGroup(ctx, connect.NewRequest(&pm.CreateUserGroupRequest{
+		Name:         "Sneaky Dyn UG",
+		IsDynamic:    true,
+		DynamicQuery: `(user.email contains "@corp.com")`,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err),
+		"static-only admin must be denied when request asks for dynamic — T-S2 mitigation, user-group side")
+}
+
+func TestCreateUserGroup_DynamicRequest_DynamicPermOnly_Succeeds(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AuthContext(userID, "dynamic-only@test.com", []string{"CreateDynamicUserGroup"})
+
+	resp, err := h.CreateUserGroup(ctx, connect.NewRequest(&pm.CreateUserGroupRequest{
+		Name:         "Dyn UG",
+		IsDynamic:    true,
+		DynamicQuery: `(user.email contains "@corp.com")`,
+	}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.Group.IsDynamic)
+}
+
+func TestCreateUserGroup_StaticRequest_DynamicPermOnly_Denied(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.AuthContext(userID, "dynamic-only@test.com", []string{"CreateDynamicUserGroup"})
+
+	_, err := h.CreateUserGroup(ctx, connect.NewRequest(&pm.CreateUserGroupRequest{
+		Name: "Static UG Attempt",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+func TestUpdateUserGroupQuery_RejectsStaticGroup_FailedPrecondition(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	staticUGID := testutil.CreateTestUserGroup(t, st, adminID, "Static User Group Target")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.UpdateUserGroupQuery(ctx, connect.NewRequest(&pm.UpdateUserGroupQueryRequest{
+		Id:           staticUGID,
+		IsDynamic:    true,
+		DynamicQuery: `(user.email contains "@corp.com")`,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err),
+		"applying UpdateUserGroupQuery to a static user group must FailedPrecondition — no implicit promotion (T-S2 update pathway)")
+}
+
+func TestUpdateUserGroupQuery_AcceptsDynamicGroup(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	created, err := h.CreateUserGroup(ctx, connect.NewRequest(&pm.CreateUserGroupRequest{
+		Name:         "Dyn UG Target",
+		IsDynamic:    true,
+		DynamicQuery: `(user.email contains "@old.com")`,
+	}))
+	require.NoError(t, err)
+
+	resp, err := h.UpdateUserGroupQuery(ctx, connect.NewRequest(&pm.UpdateUserGroupQueryRequest{
+		Id:           created.Msg.Group.Id,
+		IsDynamic:    true,
+		DynamicQuery: `(user.email contains "@corp.com")`,
+	}))
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.Group.IsDynamic)
+	assert.Contains(t, resp.Msg.Group.DynamicQuery, "corp")
+}

--- a/internal/api/user_group_handler_test.go
+++ b/internal/api/user_group_handler_test.go
@@ -591,6 +591,51 @@ func TestUpdateUserGroupQuery_RejectsStaticGroup_FailedPrecondition(t *testing.T
 		"applying UpdateUserGroupQuery to a static user group must FailedPrecondition — no implicit promotion (T-S2 update pathway)")
 }
 
+// =============================================================================
+// CR-#333 regression: reject `IsDynamic=true` with an empty
+// `DynamicQuery` — symmetric with the device-group guard.
+// =============================================================================
+
+func TestCreateUserGroup_IsDynamicTrueWithEmptyQuery_Rejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.CreateUserGroup(ctx, connect.NewRequest(&pm.CreateUserGroupRequest{
+		Name:         "Suspicious",
+		IsDynamic:    true,
+		DynamicQuery: "",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
+		"is_dynamic=true with empty dynamic_query must be rejected at the boundary — CR #333 T-S2 bypass guard, user-group side")
+}
+
+func TestUpdateUserGroupQuery_IsDynamicTrueWithEmptyQuery_Rejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	created, err := h.CreateUserGroup(ctx, connect.NewRequest(&pm.CreateUserGroupRequest{
+		Name:         "Existing Dyn UG",
+		IsDynamic:    true,
+		DynamicQuery: `(user.email contains "@x.com")`,
+	}))
+	require.NoError(t, err)
+
+	_, err = h.UpdateUserGroupQuery(ctx, connect.NewRequest(&pm.UpdateUserGroupQueryRequest{
+		Id:           created.Msg.Group.Id,
+		IsDynamic:    true,
+		DynamicQuery: "",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
 func TestUpdateUserGroupQuery_AcceptsDynamicGroup(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewUserGroupHandler(st, slog.Default())

--- a/internal/auth/authorizer_test.go
+++ b/internal/auth/authorizer_test.go
@@ -36,7 +36,7 @@ func TestAuthorize_AdminPermissionsAllowAll(t *testing.T) {
 		"CreateToken", "DeleteToken",
 		"CreateAction", "DispatchAction",
 		"CreateDefinition", "DeleteDefinition",
-		"CreateDeviceGroup", "DeleteDeviceGroup",
+		"CreateStaticDeviceGroup", "CreateDynamicDeviceGroup", "DeleteDeviceGroup",
 		"CreateAssignment", "DeleteAssignment",
 		"ListAuditEvents",
 		"CreateRole", "UpdateRole", "DeleteRole",

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -36,7 +36,7 @@ var PublicProcedures = map[string]bool{
 	"/pm.v1.ControlService/SSOCallback":      true,
 }
 
-// ProcedureAlternatives maps a Connect-RPC procedure path to the
+// procedureAlternatives maps a Connect-RPC procedure path to the
 // set of permission keys that can authorize it. The AuthzInterceptor
 // passes the procedure if the actor holds ANY of the listed
 // alternatives — handler-level dispatch then narrows to the specific
@@ -52,13 +52,17 @@ var PublicProcedures = map[string]bool{
 // Lookup precedence inside WrapUnary:
 //  1. PublicProcedures (bypass)
 //  2. Device context (separate authz path)
-//  3. ProcedureAlternatives (this map) — if a procedure has an
+//  3. procedureAlternatives (this map) — if a procedure has an
 //     entry, ONLY the alternatives are checked. The default
 //     base-key Authorize path is NOT a fallback.
 //  4. Default: Authorize with action derived from procedure name.
 //
-// server #7 T-S2.
-var ProcedureAlternatives = map[string][]string{
+// Unexported by design: an exported mutable map of authorization
+// rules is a runtime-tampering surface. Out-of-package callers use
+// ProcedureAlternativesSnapshot for read-only access. Concurrent
+// reads inside WrapUnary are safe because the map is set once at
+// package init and never mutated. server #7 T-S2.
+var procedureAlternatives = map[string][]string{
 	// CreateDeviceGroup splits authorization on req.IsDynamic.
 	"/pm.v1.ControlService/CreateDeviceGroup": {
 		"CreateStaticDeviceGroup",
@@ -81,15 +85,27 @@ var ProcedureAlternatives = map[string][]string{
 	},
 }
 
+// ProcedureAlternativesSnapshot returns a deep copy of the
+// procedure-alternatives map for read-only inspection by tests and
+// out-of-package callers. The returned value is freshly allocated;
+// mutating it does NOT affect the live authorization policy.
+func ProcedureAlternativesSnapshot() map[string][]string {
+	out := make(map[string][]string, len(procedureAlternatives))
+	for k, v := range procedureAlternatives {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
+}
+
 // proceduresAcceptingAlternative builds the inverse of
-// ProcedureAlternatives: a permission key → true map of every
+// procedureAlternatives: a permission key → true map of every
 // permission that appears as an alternative for SOME procedure.
 // Used by the parity tests to recognize split / renamed permissions
 // (CreateStaticDeviceGroup etc.) as RPC-backed via the alternatives
 // map even though no RPC has that literal name.
 func proceduresAcceptingAlternative() map[string]bool {
 	out := make(map[string]bool)
-	for _, alts := range ProcedureAlternatives {
+	for _, alts := range procedureAlternatives {
 		for _, perm := range alts {
 			out[perm] = true
 		}
@@ -98,7 +114,7 @@ func proceduresAcceptingAlternative() map[string]bool {
 }
 
 // PermissionIsAlternative returns true if the given permission key
-// appears in ProcedureAlternatives as a satisfying alternative for
+// appears in procedureAlternatives as a satisfying alternative for
 // some procedure. Exported for parity-test consumption.
 func PermissionIsAlternative(permKey string) bool {
 	return proceduresAcceptingAlternative()[permKey]
@@ -413,13 +429,13 @@ func (i *AuthzInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 
 		// Procedures whose authorization depends on the request
 		// shape (e.g. CreateDeviceGroup → static vs dynamic) consult
-		// the ProcedureAlternatives map: ANY of the listed perms
+		// the procedureAlternatives map: ANY of the listed perms
 		// admits the caller. The handler then narrows to the
 		// specific permission against the request shape. The
 		// default Authorize path is NOT a fallback here — a
 		// procedure in the alternatives map is exclusively gated by
 		// that list. server #7 T-S2.
-		if alts, hasAlt := ProcedureAlternatives[procedure]; hasAlt {
+		if alts, hasAlt := procedureAlternatives[procedure]; hasAlt {
 			for _, alt := range alts {
 				for _, perm := range userCtx.Permissions {
 					if perm == alt {

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -36,6 +36,74 @@ var PublicProcedures = map[string]bool{
 	"/pm.v1.ControlService/SSOCallback":      true,
 }
 
+// ProcedureAlternatives maps a Connect-RPC procedure path to the
+// set of permission keys that can authorize it. The AuthzInterceptor
+// passes the procedure if the actor holds ANY of the listed
+// alternatives — handler-level dispatch then narrows to the specific
+// permission based on the request shape.
+//
+// Used for RPCs whose authorization depends on a runtime property
+// of the request (e.g. CreateDeviceGroup is satisfied by either
+// CreateStaticDeviceGroup or CreateDynamicDeviceGroup depending on
+// whether the request carries a dynamic query). The handler MUST
+// re-check the specific permission against the request shape — the
+// interceptor only guarantees "actor holds at least one of these".
+//
+// Lookup precedence inside WrapUnary:
+//  1. PublicProcedures (bypass)
+//  2. Device context (separate authz path)
+//  3. ProcedureAlternatives (this map) — if a procedure has an
+//     entry, ONLY the alternatives are checked. The default
+//     base-key Authorize path is NOT a fallback.
+//  4. Default: Authorize with action derived from procedure name.
+//
+// server #7 T-S2.
+var ProcedureAlternatives = map[string][]string{
+	// CreateDeviceGroup splits authorization on req.IsDynamic.
+	"/pm.v1.ControlService/CreateDeviceGroup": {
+		"CreateStaticDeviceGroup",
+		"CreateDynamicDeviceGroup",
+	},
+	"/pm.v1.ControlService/CreateUserGroup": {
+		"CreateStaticUserGroup",
+		"CreateDynamicUserGroup",
+	},
+	// UpdateDeviceGroupQuery is dynamic-only. The legacy permission
+	// name was renamed to UpdateDynamicDeviceGroupQuery; the RPC
+	// name stays for backward compat. Static-only admins cannot
+	// satisfy this procedure because only the dynamic-update perm
+	// is listed.
+	"/pm.v1.ControlService/UpdateDeviceGroupQuery": {
+		"UpdateDynamicDeviceGroupQuery",
+	},
+	"/pm.v1.ControlService/UpdateUserGroupQuery": {
+		"UpdateDynamicUserGroupQuery",
+	},
+}
+
+// proceduresAcceptingAlternative builds the inverse of
+// ProcedureAlternatives: a permission key → true map of every
+// permission that appears as an alternative for SOME procedure.
+// Used by the parity tests to recognize split / renamed permissions
+// (CreateStaticDeviceGroup etc.) as RPC-backed via the alternatives
+// map even though no RPC has that literal name.
+func proceduresAcceptingAlternative() map[string]bool {
+	out := make(map[string]bool)
+	for _, alts := range ProcedureAlternatives {
+		for _, perm := range alts {
+			out[perm] = true
+		}
+	}
+	return out
+}
+
+// PermissionIsAlternative returns true if the given permission key
+// appears in ProcedureAlternatives as a satisfying alternative for
+// some procedure. Exported for parity-test consumption.
+func PermissionIsAlternative(permKey string) bool {
+	return proceduresAcceptingAlternative()[permKey]
+}
+
 // TrustedProxies is the set of IP addresses/CIDRs trusted to set
 // X-Forwarded-For / X-Real-IP headers. If empty, proxy headers are ignored
 // and the direct peer address is always used.
@@ -341,6 +409,25 @@ func (i *AuthzInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		userCtx, ok := UserFromContext(ctx)
 		if !ok {
 			return nil, authErrorCtx(ctx, errNotAuthenticated, connect.CodeUnauthenticated, "not authenticated")
+		}
+
+		// Procedures whose authorization depends on the request
+		// shape (e.g. CreateDeviceGroup → static vs dynamic) consult
+		// the ProcedureAlternatives map: ANY of the listed perms
+		// admits the caller. The handler then narrows to the
+		// specific permission against the request shape. The
+		// default Authorize path is NOT a fallback here — a
+		// procedure in the alternatives map is exclusively gated by
+		// that list. server #7 T-S2.
+		if alts, hasAlt := ProcedureAlternatives[procedure]; hasAlt {
+			for _, alt := range alts {
+				for _, perm := range userCtx.Permissions {
+					if perm == alt {
+						return next(ctx, req)
+					}
+				}
+			}
+			return nil, authErrorCtx(ctx, errPermissionDenied, connect.CodePermissionDenied, "permission denied")
 		}
 
 		input := AuthzInput{

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -418,3 +418,151 @@ func TestAuthInterceptor_LogoutWithoutLimiter_PassesThrough(t *testing.T) {
 		require.NoError(t, err, "with no Logout limiter configured, every call must pass through")
 	}
 }
+
+// =============================================================================
+// AuthzInterceptor — ProcedureAlternatives path (server #7 T-S2).
+//
+// Drive both interceptors (auth + authz) against a real procedure
+// that's in the alternatives map. Tests prove the interceptor accepts
+// ANY alternative, rejects when none are held, and does NOT fall
+// through to the default Authorize path for a procedure in the map.
+// =============================================================================
+
+// setupAlternativesInterceptorTest wires AuthInterceptor +
+// AuthzInterceptor against the CreateDeviceGroup procedure, which
+// is in the ProcedureAlternatives map. Returns the server URL +
+// JWT manager so each test mints its own token with custom perms.
+func setupAlternativesInterceptorTest(t *testing.T) (string, *JWTManager) {
+	t.Helper()
+
+	jwtMgr := NewJWTManager(JWTConfig{
+		Secret:            []byte("test-secret-alternatives"),
+		AccessTokenExpiry: 15 * time.Minute,
+	})
+	authIc := NewAuthInterceptor(testLogger, jwtMgr, RateLimiters{})
+	authzIc := NewAuthzInterceptor()
+
+	mux := http.NewServeMux()
+	procedure := "/pm.v1.ControlService/CreateDeviceGroup"
+	handler := connect.NewUnaryHandler(
+		procedure,
+		func(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+			return connect.NewResponse(&emptypb.Empty{}), nil
+		},
+		connect.WithInterceptors(authIc, authzIc),
+	)
+	mux.Handle(procedure, handler)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return server.URL, jwtMgr
+}
+
+func TestAuthzInterceptor_AlternativesPath_StaticAltOnly_Accepts(t *testing.T) {
+	serverURL, jwtMgr := setupAlternativesInterceptorTest(t)
+	tokens, err := jwtMgr.GenerateTokens("u1", "alice@test", []string{"CreateStaticDeviceGroup"}, 1)
+	require.NoError(t, err)
+
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](
+		http.DefaultClient, serverURL+"/pm.v1.ControlService/CreateDeviceGroup",
+	)
+	req := connect.NewRequest(&emptypb.Empty{})
+	req.Header().Set("Authorization", "Bearer "+tokens.AccessToken)
+
+	_, err = client.CallUnary(context.Background(), req)
+	require.NoError(t, err,
+		"holding ONE of the alternatives is sufficient to pass the interceptor — handler narrows on request shape")
+}
+
+func TestAuthzInterceptor_AlternativesPath_DynamicAltOnly_Accepts(t *testing.T) {
+	serverURL, jwtMgr := setupAlternativesInterceptorTest(t)
+	tokens, err := jwtMgr.GenerateTokens("u1", "alice@test", []string{"CreateDynamicDeviceGroup"}, 1)
+	require.NoError(t, err)
+
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](
+		http.DefaultClient, serverURL+"/pm.v1.ControlService/CreateDeviceGroup",
+	)
+	req := connect.NewRequest(&emptypb.Empty{})
+	req.Header().Set("Authorization", "Bearer "+tokens.AccessToken)
+
+	_, err = client.CallUnary(context.Background(), req)
+	require.NoError(t, err,
+		"the OTHER alternative is also sufficient — symmetry")
+}
+
+func TestAuthzInterceptor_AlternativesPath_NeitherAltHeld_Denied(t *testing.T) {
+	// Threat lens: even a user with a HUGE permission set that
+	// happens to omit BOTH split alternatives must be rejected. A
+	// future regression where the interceptor accidentally falls
+	// through to the default Authorize path would let through any
+	// permission whose base equals "CreateDeviceGroup" — but no
+	// such permission is registered post-#7. Belt-and-suspenders
+	// with the registry tests.
+	serverURL, jwtMgr := setupAlternativesInterceptorTest(t)
+	tokens, err := jwtMgr.GenerateTokens("u1", "alice@test", []string{
+		// A grab-bag of unrelated perms — none satisfy the split.
+		"GetUser", "ListUsers", "GetDevice", "ListDevices",
+		"CreateAction", "RebuildSearchIndex",
+	}, 1)
+	require.NoError(t, err)
+
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](
+		http.DefaultClient, serverURL+"/pm.v1.ControlService/CreateDeviceGroup",
+	)
+	req := connect.NewRequest(&emptypb.Empty{})
+	req.Header().Set("Authorization", "Bearer "+tokens.AccessToken)
+
+	_, err = client.CallUnary(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "permission denied")
+}
+
+// TestAuthzInterceptor_AlternativesPath_LegacyKeyAlone_Denied pins
+// that holding the LEGACY base-key (e.g. "CreateDeviceGroup")
+// without any of the split alternatives does NOT satisfy a procedure
+// in the alternatives map. Forged-token threat: even if an attacker
+// somehow forged a JWT with the legacy claim, the interceptor's
+// alternatives-only gate refuses to fall through. Pins the
+// "alternatives are exclusive" contract for this procedure.
+func TestAuthzInterceptor_AlternativesPath_LegacyKeyAlone_Denied(t *testing.T) {
+	serverURL, jwtMgr := setupAlternativesInterceptorTest(t)
+	// Mint a token claiming the legacy "CreateDeviceGroup" perm —
+	// not registered post-#7, but a forged or stale token might
+	// carry it.
+	tokens, err := jwtMgr.GenerateTokens("u1", "alice@test", []string{"CreateDeviceGroup"}, 1)
+	require.NoError(t, err)
+
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](
+		http.DefaultClient, serverURL+"/pm.v1.ControlService/CreateDeviceGroup",
+	)
+	req := connect.NewRequest(&emptypb.Empty{})
+	req.Header().Set("Authorization", "Bearer "+tokens.AccessToken)
+
+	_, err = client.CallUnary(context.Background(), req)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err),
+		"legacy CreateDeviceGroup key alone (no alternatives held) must be rejected — alternatives are exclusive for procedures in the map")
+}
+
+func TestPermissionIsAlternative_KnownAlt(t *testing.T) {
+	assert.True(t, PermissionIsAlternative("CreateStaticDeviceGroup"))
+	assert.True(t, PermissionIsAlternative("CreateDynamicDeviceGroup"))
+	assert.True(t, PermissionIsAlternative("CreateStaticUserGroup"))
+	assert.True(t, PermissionIsAlternative("CreateDynamicUserGroup"))
+	assert.True(t, PermissionIsAlternative("UpdateDynamicDeviceGroupQuery"))
+	assert.True(t, PermissionIsAlternative("UpdateDynamicUserGroupQuery"))
+}
+
+func TestPermissionIsAlternative_UnknownAlt(t *testing.T) {
+	// Negative case — a permission that is NOT in the alternatives
+	// map must NOT pass this check. A regression that lets
+	// PermissionIsAlternative return true for arbitrary keys would
+	// silently widen the parity test exemptions.
+	assert.False(t, PermissionIsAlternative("GetUser"))
+	assert.False(t, PermissionIsAlternative("CreateAction"))
+	assert.False(t, PermissionIsAlternative(""))
+	assert.False(t, PermissionIsAlternative("CreateDeviceGroup"),
+		"the legacy single-key permission MUST NOT register as an alternative — it was removed by #7")
+}

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -1,212 +1,281 @@
 package auth
 
+// PermissionTargetKind classifies the target kind a permission acts
+// on, which determines whether (and how) it can be scoped on a role
+// grant (manchtools/power-manage-server#7).
+//
+// Fail-closed semantic: a permission that does not explicitly
+// declare a target kind stays at the zero value (TargetUnspecified)
+// and is NOT scopable. Granting it with any scope_kind is rejected
+// by the role-assignment handler. New permissions added without an
+// explicit kind silently land at the safe default — the inverse
+// (default-scopable) is the classic stale-allowlist failure mode.
+//
+// Use TargetDevice / TargetUser only when the permission's
+// authorization decision can be expressed as "scope-id matches a
+// group containing this device/user". Org-tier permissions
+// (CreateRole, server settings, IDP/SCIM, audit) and permissions
+// that can perturb other actors' scopes (dynamic-group ops, labels)
+// stay TargetUnspecified.
+type PermissionTargetKind int
+
+const (
+	// TargetUnspecified — not scopable. The zero value is the safe
+	// default for any permission that hasn't been explicitly
+	// classified.
+	TargetUnspecified PermissionTargetKind = iota
+	// TargetDevice — scopable with
+	// RoleGrantScopeKind=DEVICE_GROUP only.
+	TargetDevice
+	// TargetUser — scopable with
+	// RoleGrantScopeKind=USER_GROUP only.
+	TargetUser
+)
+
 // PermissionInfo describes a single permission.
 type PermissionInfo struct {
 	Key         string // e.g. "CreateAction", "GetUser:self"
 	Group       string // UI group: "Users", "Devices", etc.
 	Description string
+	// TargetKind classifies what kind of target this permission
+	// acts on, used by the role-assignment handler to gate scoped
+	// grants. TargetUnspecified (zero value) means the permission
+	// is not scopable. server #7.
+	TargetKind PermissionTargetKind
 }
 
 // AllPermissions returns every available permission with metadata.
 func AllPermissions() []PermissionInfo {
 	return []PermissionInfo{
 		// Users
-		{"GetCurrentUser", "Users", "View own profile"},
-		{"GetUser", "Users", "View any user"},
-		{"GetUser:self", "Users", "View own profile only"},
-		{"ListUsers", "Users", "List all users"},
-		{"CreateUser", "Users", "Create users"},
-		{"UpdateUserEmail", "Users", "Change any user's email"},
-		{"UpdateUserEmail:self", "Users", "Change own email"},
-		{"UpdateUserPassword", "Users", "Change any user's password"},
-		{"UpdateUserPassword:self", "Users", "Change own password"},
-		{"SetUserDisabled", "Users", "Disable/enable users"},
-		{"UpdateUserProfile", "Users", "Update any user's profile"},
-		{"UpdateUserProfile:self", "Users", "Update own profile"},
-		{"DeleteUser", "Users", "Delete users"},
-		{"UpdateUserSshSettings", "Users", "Update any user's SSH settings"},
-		{"UpdateUserSshSettings:self", "Users", "Update own SSH settings"},
-		{"UpdateUserLinuxUsername", "Users", "Change any user's linux username"},
-		{"UpdateUserLinuxUsername:self", "Users", "Change own linux username"},
-		{"AddUserSshKey", "Users", "Add SSH key to any user"},
-		{"AddUserSshKey:self", "Users", "Add own SSH key"},
-		{"RemoveUserSshKey", "Users", "Remove SSH key from any user"},
-		{"RemoveUserSshKey:self", "Users", "Remove own SSH key"},
+		{"GetCurrentUser", "Users", "View own profile", TargetUnspecified},
+		{"GetUser", "Users", "View any user", TargetUser},
+		{"GetUser:self", "Users", "View own profile only", TargetUnspecified},
+		{"ListUsers", "Users", "List all users", TargetUser},
+		{"CreateUser", "Users", "Create users", TargetUnspecified},
+		{"UpdateUserEmail", "Users", "Change any user's email", TargetUser},
+		{"UpdateUserEmail:self", "Users", "Change own email", TargetUnspecified},
+		{"UpdateUserPassword", "Users", "Change any user's password", TargetUser},
+		{"UpdateUserPassword:self", "Users", "Change own password", TargetUnspecified},
+		{"SetUserDisabled", "Users", "Disable/enable users", TargetUser},
+		{"UpdateUserProfile", "Users", "Update any user's profile", TargetUser},
+		{"UpdateUserProfile:self", "Users", "Update own profile", TargetUnspecified},
+		{"DeleteUser", "Users", "Delete users", TargetUser},
+		{"UpdateUserSshSettings", "Users", "Update any user's SSH settings", TargetUser},
+		{"UpdateUserSshSettings:self", "Users", "Update own SSH settings", TargetUnspecified},
+		{"UpdateUserLinuxUsername", "Users", "Change any user's linux username", TargetUser},
+		{"UpdateUserLinuxUsername:self", "Users", "Change own linux username", TargetUnspecified},
+		{"AddUserSshKey", "Users", "Add SSH key to any user", TargetUser},
+		{"AddUserSshKey:self", "Users", "Add own SSH key", TargetUnspecified},
+		{"RemoveUserSshKey", "Users", "Remove SSH key from any user", TargetUser},
+		{"RemoveUserSshKey:self", "Users", "Remove own SSH key", TargetUnspecified},
 		// Devices
-		{"ListDevices", "Devices", "List all devices"},
-		{"ListDevices:assigned", "Devices", "List own assigned devices"},
-		{"GetDevice", "Devices", "View any device"},
-		{"GetDevice:assigned", "Devices", "View own assigned devices"},
-		{"SetDeviceLabel", "Devices", "Set device labels"},
-		{"RemoveDeviceLabel", "Devices", "Remove device labels"},
-		{"AssignDevice", "Devices", "Assign devices to users or groups"},
-		{"UnassignDevice", "Devices", "Unassign devices from users or groups"},
-		{"ListDeviceAssignees", "Devices", "List device assignees"},
-		{"SetDeviceSyncInterval", "Devices", "Set device sync interval"},
-		{"DeleteDevice", "Devices", "Delete devices"},
+		{"ListDevices", "Devices", "List all devices", TargetDevice},
+		{"ListDevices:assigned", "Devices", "List own assigned devices", TargetUnspecified},
+		{"GetDevice", "Devices", "View any device", TargetDevice},
+		{"GetDevice:assigned", "Devices", "View own assigned devices", TargetUnspecified},
+		// SetDeviceLabel / RemoveDeviceLabel are intentionally NOT
+		// scopable: labels feed dynamic device-group queries, so
+		// scoping the labels permission would let a scope-confined
+		// admin perturb OTHER admins' dynamic-group scopes. T-S2.
+		{"SetDeviceLabel", "Devices", "Set device labels", TargetUnspecified},
+		{"RemoveDeviceLabel", "Devices", "Remove device labels", TargetUnspecified},
+		// AssignDevice / UnassignDevice manage the device-user
+		// relationship; scoping them creates cross-kind semantics
+		// that V1 explicitly excludes per kinds-don't-mix. Org-tier
+		// for V1.
+		{"AssignDevice", "Devices", "Assign devices to users or groups", TargetUnspecified},
+		{"UnassignDevice", "Devices", "Unassign devices from users or groups", TargetUnspecified},
+		{"ListDeviceAssignees", "Devices", "List device assignees", TargetUnspecified},
+		{"SetDeviceSyncInterval", "Devices", "Set device sync interval", TargetDevice},
+		{"DeleteDevice", "Devices", "Delete devices", TargetDevice},
 		// Tokens
-		{"CreateToken", "Tokens", "Create registration tokens"},
-		{"CreateToken:self", "Tokens", "Create one-time token for self"},
-		{"GetToken", "Tokens", "View tokens"},
-		{"ListTokens", "Tokens", "List tokens"},
-		{"RenameToken", "Tokens", "Rename tokens"},
-		{"SetTokenDisabled", "Tokens", "Disable/enable tokens"},
-		{"DeleteToken", "Tokens", "Delete tokens"},
-		// Actions
-		{"CreateAction", "Actions", "Create actions"},
-		{"GetAction", "Actions", "View actions"},
-		{"ListActions", "Actions", "List actions"},
-		{"RenameAction", "Actions", "Rename actions"},
-		{"UpdateActionDescription", "Actions", "Update action descriptions"},
-		{"UpdateActionParams", "Actions", "Update action parameters"},
-		{"DeleteAction", "Actions", "Delete actions"},
-		// Action Sets
-		{"CreateActionSet", "Action Sets", "Create action sets"},
-		{"GetActionSet", "Action Sets", "View action sets"},
-		{"ListActionSets", "Action Sets", "List action sets"},
-		{"RenameActionSet", "Action Sets", "Rename action sets"},
-		{"UpdateActionSetDescription", "Action Sets", "Update action set descriptions"},
-		{"UpdateActionSetSchedule", "Action Sets", "Update action set schedule"},
-		{"DeleteActionSet", "Action Sets", "Delete action sets"},
-		{"AddActionToSet", "Action Sets", "Add actions to sets"},
-		{"RemoveActionFromSet", "Action Sets", "Remove actions from sets"},
-		{"ReorderActionInSet", "Action Sets", "Reorder actions in sets"},
-		// Definitions
-		{"CreateDefinition", "Definitions", "Create definitions"},
-		{"GetDefinition", "Definitions", "View definitions"},
-		{"ListDefinitions", "Definitions", "List definitions"},
-		{"RenameDefinition", "Definitions", "Rename definitions"},
-		{"UpdateDefinitionDescription", "Definitions", "Update definition descriptions"},
-		{"UpdateDefinitionSchedule", "Definitions", "Update definition schedule"},
-		{"DeleteDefinition", "Definitions", "Delete definitions"},
-		{"AddActionSetToDefinition", "Definitions", "Add action sets to definitions"},
-		{"RemoveActionSetFromDefinition", "Definitions", "Remove action sets from definitions"},
-		{"ReorderActionSetInDefinition", "Definitions", "Reorder action sets in definitions"},
+		{"CreateToken", "Tokens", "Create registration tokens", TargetUnspecified},
+		{"CreateToken:self", "Tokens", "Create one-time token for self", TargetUnspecified},
+		{"GetToken", "Tokens", "View tokens", TargetUnspecified},
+		{"ListTokens", "Tokens", "List tokens", TargetUnspecified},
+		{"RenameToken", "Tokens", "Rename tokens", TargetUnspecified},
+		{"SetTokenDisabled", "Tokens", "Disable/enable tokens", TargetUnspecified},
+		{"DeleteToken", "Tokens", "Delete tokens", TargetUnspecified},
+		// Actions — org-tier objects (authored once, dispatched
+		// per-device); scoping happens on the dispatch RPCs, not
+		// the action CRUD.
+		{"CreateAction", "Actions", "Create actions", TargetUnspecified},
+		{"GetAction", "Actions", "View actions", TargetUnspecified},
+		{"ListActions", "Actions", "List actions", TargetUnspecified},
+		{"RenameAction", "Actions", "Rename actions", TargetUnspecified},
+		{"UpdateActionDescription", "Actions", "Update action descriptions", TargetUnspecified},
+		{"UpdateActionParams", "Actions", "Update action parameters", TargetUnspecified},
+		{"DeleteAction", "Actions", "Delete actions", TargetUnspecified},
+		// Action Sets — org-tier objects
+		{"CreateActionSet", "Action Sets", "Create action sets", TargetUnspecified},
+		{"GetActionSet", "Action Sets", "View action sets", TargetUnspecified},
+		{"ListActionSets", "Action Sets", "List action sets", TargetUnspecified},
+		{"RenameActionSet", "Action Sets", "Rename action sets", TargetUnspecified},
+		{"UpdateActionSetDescription", "Action Sets", "Update action set descriptions", TargetUnspecified},
+		{"UpdateActionSetSchedule", "Action Sets", "Update action set schedule", TargetUnspecified},
+		{"DeleteActionSet", "Action Sets", "Delete action sets", TargetUnspecified},
+		{"AddActionToSet", "Action Sets", "Add actions to sets", TargetUnspecified},
+		{"RemoveActionFromSet", "Action Sets", "Remove actions from sets", TargetUnspecified},
+		{"ReorderActionInSet", "Action Sets", "Reorder actions in sets", TargetUnspecified},
+		// Definitions — org-tier objects
+		{"CreateDefinition", "Definitions", "Create definitions", TargetUnspecified},
+		{"GetDefinition", "Definitions", "View definitions", TargetUnspecified},
+		{"ListDefinitions", "Definitions", "List definitions", TargetUnspecified},
+		{"RenameDefinition", "Definitions", "Rename definitions", TargetUnspecified},
+		{"UpdateDefinitionDescription", "Definitions", "Update definition descriptions", TargetUnspecified},
+		{"UpdateDefinitionSchedule", "Definitions", "Update definition schedule", TargetUnspecified},
+		{"DeleteDefinition", "Definitions", "Delete definitions", TargetUnspecified},
+		{"AddActionSetToDefinition", "Definitions", "Add action sets to definitions", TargetUnspecified},
+		{"RemoveActionSetFromDefinition", "Definitions", "Remove action sets from definitions", TargetUnspecified},
+		{"ReorderActionSetInDefinition", "Definitions", "Reorder action sets in definitions", TargetUnspecified},
 		// Device Groups
-		{"CreateDeviceGroup", "Device Groups", "Create device groups"},
-		{"GetDeviceGroup", "Device Groups", "View device groups"},
-		{"ListDeviceGroups", "Device Groups", "List device groups"},
-		{"ListDeviceGroupsForDevice", "Device Groups", "List device groups for a device"},
-		{"RenameDeviceGroup", "Device Groups", "Rename device groups"},
-		{"UpdateDeviceGroupDescription", "Device Groups", "Update device group descriptions"},
-		{"UpdateDeviceGroupQuery", "Device Groups", "Update device group queries"},
-		{"DeleteDeviceGroup", "Device Groups", "Delete device groups"},
-		{"AddDeviceToGroup", "Device Groups", "Add devices to groups"},
-		{"RemoveDeviceFromGroup", "Device Groups", "Remove devices from groups"},
-		{"ValidateDynamicQuery", "Device Groups", "Validate dynamic queries"},
-		{"EvaluateDynamicGroup", "Device Groups", "Evaluate dynamic groups"},
-		{"SetDeviceGroupSyncInterval", "Device Groups", "Set device group sync interval"},
-		{"SetDeviceGroupMaintenanceWindow", "Device Groups", "Set device group maintenance window"},
+		//
+		// CreateDeviceGroup was split into a static and a dynamic
+		// variant in server #7. Static-group creation is safe to
+		// scope (the scoped admin can only organize devices already
+		// within their scope into sub-groups). Dynamic-group
+		// creation stays unscopable because the query language
+		// matches arbitrary device sets and could perturb other
+		// actors' scopes — see T-S2 in the #7 design.
+		{"CreateStaticDeviceGroup", "Device Groups", "Create static device groups", TargetDevice},
+		{"CreateDynamicDeviceGroup", "Device Groups", "Create dynamic device groups", TargetUnspecified},
+		{"GetDeviceGroup", "Device Groups", "View device groups", TargetDevice},
+		{"ListDeviceGroups", "Device Groups", "List device groups", TargetDevice},
+		{"ListDeviceGroupsForDevice", "Device Groups", "List device groups for a device", TargetDevice},
+		{"RenameDeviceGroup", "Device Groups", "Rename device groups", TargetDevice},
+		{"UpdateDeviceGroupDescription", "Device Groups", "Update device group descriptions", TargetDevice},
+		{"UpdateDynamicDeviceGroupQuery", "Device Groups", "Update dynamic device group queries", TargetUnspecified},
+		{"DeleteDeviceGroup", "Device Groups", "Delete device groups", TargetDevice},
+		{"AddDeviceToGroup", "Device Groups", "Add devices to groups", TargetDevice},
+		{"RemoveDeviceFromGroup", "Device Groups", "Remove devices from groups", TargetDevice},
+		{"ValidateDynamicQuery", "Device Groups", "Validate dynamic queries", TargetUnspecified},
+		{"EvaluateDynamicGroup", "Device Groups", "Evaluate dynamic groups", TargetUnspecified},
+		{"SetDeviceGroupSyncInterval", "Device Groups", "Set device group sync interval", TargetDevice},
+		{"SetDeviceGroupMaintenanceWindow", "Device Groups", "Set device group maintenance window", TargetDevice},
 		// Assignments
-		{"CreateAssignment", "Assignments", "Create assignments"},
-		{"DeleteAssignment", "Assignments", "Delete assignments"},
-		{"ListAssignments", "Assignments", "List assignments"},
-		{"GetDeviceAssignments", "Assignments", "View device assignments"},
-		{"GetUserAssignments", "Assignments", "View user assignments"},
+		{"CreateAssignment", "Assignments", "Create assignments", TargetUnspecified},
+		{"DeleteAssignment", "Assignments", "Delete assignments", TargetUnspecified},
+		{"ListAssignments", "Assignments", "List assignments", TargetUnspecified},
+		{"GetDeviceAssignments", "Assignments", "View device assignments", TargetUnspecified},
+		{"GetUserAssignments", "Assignments", "View user assignments", TargetUnspecified},
 		// User Selections
-		{"SetUserSelection", "User Selections", "Manage user selections"},
-		{"ListAvailableActions", "User Selections", "List available actions"},
+		{"SetUserSelection", "User Selections", "Manage user selections", TargetUnspecified},
+		{"ListAvailableActions", "User Selections", "List available actions", TargetUnspecified},
 		// Dispatch
-		{"DispatchAction", "Dispatch", "Dispatch single action"},
-		{"DispatchToMultiple", "Dispatch", "Dispatch to multiple devices"},
-		{"DispatchAssignedActions", "Dispatch", "Sync assigned actions to device"},
-		{"DispatchActionSet", "Dispatch", "Dispatch action set"},
-		{"DispatchDefinition", "Dispatch", "Dispatch definition"},
-		{"DispatchToGroup", "Dispatch", "Dispatch to device group"},
-		{"DispatchInstantAction", "Dispatch", "Dispatch instant action"},
+		{"DispatchAction", "Dispatch", "Dispatch single action", TargetDevice},
+		{"DispatchToMultiple", "Dispatch", "Dispatch to multiple devices", TargetDevice},
+		{"DispatchAssignedActions", "Dispatch", "Sync assigned actions to device", TargetDevice},
+		{"DispatchActionSet", "Dispatch", "Dispatch action set", TargetDevice},
+		{"DispatchDefinition", "Dispatch", "Dispatch definition", TargetDevice},
+		{"DispatchToGroup", "Dispatch", "Dispatch to device group", TargetDevice},
+		{"DispatchInstantAction", "Dispatch", "Dispatch instant action", TargetDevice},
 		// Executions
-		{"GetExecution", "Executions", "View executions"},
-		{"ListExecutions", "Executions", "List executions"},
-		{"CancelExecution", "Executions", "Cancel pending executions"},
+		{"GetExecution", "Executions", "View executions", TargetDevice},
+		{"ListExecutions", "Executions", "List executions", TargetDevice},
+		{"CancelExecution", "Executions", "Cancel pending executions", TargetDevice},
 		// OSQuery
-		{"DispatchOSQuery", "OSQuery", "Run OSQuery on device"},
-		{"GetOSQueryResult", "OSQuery", "View OSQuery results"},
-		{"GetDeviceInventory", "OSQuery", "View device inventory"},
-		{"RefreshDeviceInventory", "OSQuery", "Refresh device inventory"},
+		{"DispatchOSQuery", "OSQuery", "Run OSQuery on device", TargetDevice},
+		{"GetOSQueryResult", "OSQuery", "View OSQuery results", TargetDevice},
+		{"GetDeviceInventory", "OSQuery", "View device inventory", TargetDevice},
+		{"RefreshDeviceInventory", "OSQuery", "Refresh device inventory", TargetDevice},
 		// Device Logs
-		{"QueryDeviceLogs", "Device Logs", "Query device logs"},
-		{"GetDeviceLogResult", "Device Logs", "View device log results"},
+		{"QueryDeviceLogs", "Device Logs", "Query device logs", TargetDevice},
+		{"GetDeviceLogResult", "Device Logs", "View device log results", TargetDevice},
 		// Compliance
-		{"GetDeviceCompliance", "Compliance", "View device compliance"},
-		{"GetDeviceCompliance:assigned", "Compliance", "View compliance for assigned devices"},
-		// Compliance Policies
-		{"CreateCompliancePolicy", "Compliance Policies", "Create compliance policies"},
-		{"GetCompliancePolicy", "Compliance Policies", "View compliance policies"},
-		{"ListCompliancePolicies", "Compliance Policies", "List compliance policies"},
-		{"RenameCompliancePolicy", "Compliance Policies", "Rename compliance policies"},
-		{"UpdateCompliancePolicyDescription", "Compliance Policies", "Update compliance policy descriptions"},
-		{"DeleteCompliancePolicy", "Compliance Policies", "Delete compliance policies"},
-		{"AddCompliancePolicyRule", "Compliance Policies", "Add rules to compliance policies"},
-		{"RemoveCompliancePolicyRule", "Compliance Policies", "Remove rules from compliance policies"},
-		{"UpdateCompliancePolicyRule", "Compliance Policies", "Update compliance policy rules"},
-		{"GetDeviceCompliancePolicyStatus", "Compliance Policies", "View device compliance policy status"},
-		{"GetDeviceCompliancePolicyStatus:assigned", "Compliance Policies", "View compliance policy status for assigned devices"},
-		// Audit
-		{"ListAuditEvents", "Audit", "View audit log"},
-		// LPS
-		{"GetDeviceLpsPasswords", "LPS", "View LPS passwords"},
-		// LUKS
-		{"GetDeviceLuksKeys", "LUKS", "View LUKS keys"},
-		{"CreateLuksToken", "LUKS", "Create LUKS recovery token"},
-		{"RevokeLuksDeviceKey", "LUKS", "Revoke LUKS device key"},
+		{"GetDeviceCompliance", "Compliance", "View device compliance", TargetDevice},
+		{"GetDeviceCompliance:assigned", "Compliance", "View compliance for assigned devices", TargetUnspecified},
+		// Compliance Policies — org-tier
+		{"CreateCompliancePolicy", "Compliance Policies", "Create compliance policies", TargetUnspecified},
+		{"GetCompliancePolicy", "Compliance Policies", "View compliance policies", TargetUnspecified},
+		{"ListCompliancePolicies", "Compliance Policies", "List compliance policies", TargetUnspecified},
+		{"RenameCompliancePolicy", "Compliance Policies", "Rename compliance policies", TargetUnspecified},
+		{"UpdateCompliancePolicyDescription", "Compliance Policies", "Update compliance policy descriptions", TargetUnspecified},
+		{"DeleteCompliancePolicy", "Compliance Policies", "Delete compliance policies", TargetUnspecified},
+		{"AddCompliancePolicyRule", "Compliance Policies", "Add rules to compliance policies", TargetUnspecified},
+		{"RemoveCompliancePolicyRule", "Compliance Policies", "Remove rules from compliance policies", TargetUnspecified},
+		{"UpdateCompliancePolicyRule", "Compliance Policies", "Update compliance policy rules", TargetUnspecified},
+		{"GetDeviceCompliancePolicyStatus", "Compliance Policies", "View device compliance policy status", TargetDevice},
+		{"GetDeviceCompliancePolicyStatus:assigned", "Compliance Policies", "View compliance policy status for assigned devices", TargetUnspecified},
+		// Audit — org-tier (V2 may revisit)
+		{"ListAuditEvents", "Audit", "View audit log", TargetUnspecified},
+		// LPS — security-sensitive, org-tier
+		{"GetDeviceLpsPasswords", "LPS", "View LPS passwords", TargetUnspecified},
+		// LUKS — security-sensitive, org-tier
+		{"GetDeviceLuksKeys", "LUKS", "View LUKS keys", TargetUnspecified},
+		{"CreateLuksToken", "LUKS", "Create LUKS recovery token", TargetUnspecified},
+		{"RevokeLuksDeviceKey", "LUKS", "Revoke LUKS device key", TargetUnspecified},
 		// TOTP
-		{"SetupTOTP", "Authentication", "Set up TOTP 2FA"},
-		{"VerifyTOTP", "Authentication", "Verify TOTP setup"},
-		{"DisableTOTP", "Authentication", "Disable TOTP 2FA"},
-		{"AdminDisableUserTOTP", "Users", "Disable TOTP for any user"},
-		{"GetTOTPStatus", "Authentication", "View TOTP status"},
-		{"RegenerateBackupCodes", "Authentication", "Regenerate backup codes"},
-		// Roles
-		{"CreateRole", "Roles", "Create roles"},
-		{"GetRole", "Roles", "View roles"},
-		{"ListRoles", "Roles", "List roles"},
-		{"UpdateRole", "Roles", "Update roles"},
-		{"DeleteRole", "Roles", "Delete roles"},
-		{"AssignRoleToUser", "Roles", "Assign roles to users"},
-		{"RevokeRoleFromUser", "Roles", "Revoke roles from users"},
-		{"ListPermissions", "Roles", "List available permissions"},
+		{"SetupTOTP", "Authentication", "Set up TOTP 2FA", TargetUnspecified},
+		{"VerifyTOTP", "Authentication", "Verify TOTP setup", TargetUnspecified},
+		{"DisableTOTP", "Authentication", "Disable TOTP 2FA", TargetUnspecified},
+		{"AdminDisableUserTOTP", "Users", "Disable TOTP for any user", TargetUser},
+		{"GetTOTPStatus", "Authentication", "View TOTP status", TargetUnspecified},
+		{"RegenerateBackupCodes", "Authentication", "Regenerate backup codes", TargetUnspecified},
+		// Roles — org-tier. AssignRoleScope grants the authority to
+		// attach a scope to a role grant (paired-or-neither
+		// scope_kind+scope_id). server #7.
+		{"CreateRole", "Roles", "Create roles", TargetUnspecified},
+		{"GetRole", "Roles", "View roles", TargetUnspecified},
+		{"ListRoles", "Roles", "List roles", TargetUnspecified},
+		{"UpdateRole", "Roles", "Update roles", TargetUnspecified},
+		{"DeleteRole", "Roles", "Delete roles", TargetUnspecified},
+		{"AssignRoleToUser", "Roles", "Assign roles to users", TargetUnspecified},
+		{"RevokeRoleFromUser", "Roles", "Revoke roles from users", TargetUnspecified},
+		{"AssignRoleScope", "Roles", "Attach a scope (device group / user group) to a role grant", TargetUnspecified},
+		{"ListPermissions", "Roles", "List available permissions", TargetUnspecified},
 		// User Groups
-		{"CreateUserGroup", "User Groups", "Create user groups"},
-		{"GetUserGroup", "User Groups", "View user groups"},
-		{"ListUserGroups", "User Groups", "List user groups"},
-		{"UpdateUserGroup", "User Groups", "Update user groups"},
-		{"DeleteUserGroup", "User Groups", "Delete user groups"},
-		{"AddUserToGroup", "User Groups", "Add users to groups"},
-		{"RemoveUserFromGroup", "User Groups", "Remove users from groups"},
-		{"AssignRoleToUserGroup", "User Groups", "Assign roles to user groups"},
-		{"RevokeRoleFromUserGroup", "User Groups", "Revoke roles from user groups"},
-		{"ListUserGroupsForUser", "User Groups", "List user groups for a user"},
-		{"UpdateUserGroupQuery", "User Groups", "Update user group queries"},
-		{"ValidateUserGroupQuery", "User Groups", "Validate user group queries"},
-		{"EvaluateDynamicUserGroup", "User Groups", "Evaluate dynamic user groups"},
-		{"SetUserGroupMaintenanceWindow", "User Groups", "Set user group maintenance window"},
-		// Identity Providers
-		{"CreateIdentityProvider", "Identity Providers", "Create identity providers"},
-		{"GetIdentityProvider", "Identity Providers", "View identity providers"},
-		{"ListIdentityProviders", "Identity Providers", "List identity providers"},
-		{"UpdateIdentityProvider", "Identity Providers", "Update identity providers"},
-		{"DeleteIdentityProvider", "Identity Providers", "Delete identity providers"},
-		{"EnableSCIM", "Identity Providers", "Enable SCIM provisioning"},
-		{"DisableSCIM", "Identity Providers", "Disable SCIM provisioning"},
-		{"RotateSCIMToken", "Identity Providers", "Rotate SCIM token"},
+		//
+		// CreateUserGroup split into static + dynamic variants in
+		// server #7, same rationale as CreateDeviceGroup. T-S2.
+		{"CreateStaticUserGroup", "User Groups", "Create static user groups", TargetUser},
+		{"CreateDynamicUserGroup", "User Groups", "Create dynamic user groups", TargetUnspecified},
+		{"GetUserGroup", "User Groups", "View user groups", TargetUser},
+		{"ListUserGroups", "User Groups", "List user groups", TargetUser},
+		{"UpdateUserGroup", "User Groups", "Update user groups", TargetUser},
+		{"DeleteUserGroup", "User Groups", "Delete user groups", TargetUser},
+		{"AddUserToGroup", "User Groups", "Add users to groups", TargetUser},
+		{"RemoveUserFromGroup", "User Groups", "Remove users from groups", TargetUser},
+		{"AssignRoleToUserGroup", "User Groups", "Assign roles to user groups", TargetUnspecified},
+		{"RevokeRoleFromUserGroup", "User Groups", "Revoke roles from user groups", TargetUnspecified},
+		{"ListUserGroupsForUser", "User Groups", "List user groups for a user", TargetUser},
+		{"UpdateDynamicUserGroupQuery", "User Groups", "Update dynamic user group queries", TargetUnspecified},
+		{"ValidateUserGroupQuery", "User Groups", "Validate user group queries", TargetUnspecified},
+		{"EvaluateDynamicUserGroup", "User Groups", "Evaluate dynamic user groups", TargetUnspecified},
+		{"SetUserGroupMaintenanceWindow", "User Groups", "Set user group maintenance window", TargetUser},
+		// Identity Providers — org-tier
+		{"CreateIdentityProvider", "Identity Providers", "Create identity providers", TargetUnspecified},
+		{"GetIdentityProvider", "Identity Providers", "View identity providers", TargetUnspecified},
+		{"ListIdentityProviders", "Identity Providers", "List identity providers", TargetUnspecified},
+		{"UpdateIdentityProvider", "Identity Providers", "Update identity providers", TargetUnspecified},
+		{"DeleteIdentityProvider", "Identity Providers", "Delete identity providers", TargetUnspecified},
+		{"EnableSCIM", "Identity Providers", "Enable SCIM provisioning", TargetUnspecified},
+		{"DisableSCIM", "Identity Providers", "Disable SCIM provisioning", TargetUnspecified},
+		{"RotateSCIMToken", "Identity Providers", "Rotate SCIM token", TargetUnspecified},
 		// Identity Links
-		{"ListIdentityLinks", "Authentication", "View own linked identities"},
-		{"UnlinkIdentity", "Authentication", "Unlink own identity"},
-		// Search
-		{"Search", "Search", "Search across entities"},
-		{"RebuildSearchIndex", "Search", "Force rebuild search index"},
-		// Server Settings
-		{"GetServerSettings", "Server Settings", "View server settings"},
-		{"UpdateServerSettings", "Server Settings", "Update server settings"},
+		{"ListIdentityLinks", "Authentication", "View own linked identities", TargetUnspecified},
+		{"UnlinkIdentity", "Authentication", "Unlink own identity", TargetUnspecified},
+		// Search — single gate-only permission; per-facet scope
+		// inherits from ListDevices / ListUsers / ListActions
+		// already in the actor's JWT. Search itself stays
+		// TargetUnspecified so the kind-matching invariant doesn't
+		// constrain it. See #7 Valkey-search section.
+		{"Search", "Search", "Search across entities", TargetUnspecified},
+		{"RebuildSearchIndex", "Search", "Force rebuild search index", TargetUnspecified},
+		// Server Settings — org-tier
+		{"GetServerSettings", "Server Settings", "View server settings", TargetUnspecified},
+		{"UpdateServerSettings", "Server Settings", "Update server settings", TargetUnspecified},
 		// User Provisioning
-		{"SetUserProvisioningEnabled", "Users", "Toggle user provisioning per user"},
-		// Remote Terminal
-		{"StartTerminal", "Remote Terminal", "Open a remote terminal session on a device"},
-		{"StopTerminal", "Remote Terminal", "Stop a remote terminal session you opened"},
-		{"ListActiveTerminalSessions", "Remote Terminal", "View active terminal sessions across all devices (admin)"},
-		{"TerminateTerminalSession", "Remote Terminal", "Forcibly terminate any terminal session (admin)"},
-		{"TerminalAdminLimited", "Remote Terminal", "Grant a passwordless LIMITED sudoers policy in remote terminal sessions"},
-		{"TerminalAdminFull", "Remote Terminal", "Grant a passwordless FULL sudoers policy in remote terminal sessions"},
+		{"SetUserProvisioningEnabled", "Users", "Toggle user provisioning per user", TargetUser},
+		// Remote Terminal — the V1 user-facing consumer of scoping.
+		// TerminalAdmin* per-scope grants drive the cohort
+		// computation in the reconciler (#7 S6).
+		{"StartTerminal", "Remote Terminal", "Open a remote terminal session on a device", TargetDevice},
+		{"StopTerminal", "Remote Terminal", "Stop a remote terminal session you opened", TargetDevice},
+		{"ListActiveTerminalSessions", "Remote Terminal", "View active terminal sessions across all devices (admin)", TargetDevice},
+		{"TerminateTerminalSession", "Remote Terminal", "Forcibly terminate any terminal session (admin)", TargetDevice},
+		{"TerminalAdminLimited", "Remote Terminal", "Grant a passwordless LIMITED sudoers policy in remote terminal sessions", TargetDevice},
+		{"TerminalAdminFull", "Remote Terminal", "Grant a passwordless FULL sudoers policy in remote terminal sessions", TargetDevice},
 	}
 }
 

--- a/internal/auth/permissions_parity_test.go
+++ b/internal/auth/permissions_parity_test.go
@@ -154,7 +154,7 @@ func TestEveryRPCIsCoveredByPermissionOrPublic(t *testing.T) {
 	for procedure := range auth.PublicProcedures {
 		covered[procedureName(procedure)] = true
 	}
-	for procedure := range auth.ProcedureAlternatives {
+	for procedure := range auth.ProcedureAlternativesSnapshot() {
 		covered[procedureName(procedure)] = true
 	}
 	for _, p := range auth.AllPermissions() {
@@ -195,11 +195,12 @@ func TestProcedureAlternatives_Exact(t *testing.T) {
 			"UpdateDynamicUserGroupQuery",
 		},
 	}
-	if len(expected) != len(auth.ProcedureAlternatives) {
-		t.Fatalf("ProcedureAlternatives length drifted: have %d, expected %d", len(auth.ProcedureAlternatives), len(expected))
+	live := auth.ProcedureAlternativesSnapshot()
+	if len(expected) != len(live) {
+		t.Fatalf("ProcedureAlternatives length drifted: have %d, expected %d", len(live), len(expected))
 	}
 	for proc, wantAlts := range expected {
-		gotAlts, ok := auth.ProcedureAlternatives[proc]
+		gotAlts, ok := live[proc]
 		if !ok {
 			t.Errorf("ProcedureAlternatives missing entry for %q", proc)
 			continue
@@ -216,17 +217,60 @@ func TestProcedureAlternatives_Exact(t *testing.T) {
 	}
 }
 
+// TestProcedureAlternativesSnapshot_IsIndependentCopy guards the
+// hardening done in #333 review: a snapshot caller must not be able
+// to mutate the live authorization policy by writing into the
+// returned map. The interceptor reads `procedureAlternatives`
+// directly, so the snapshot must be a deep copy. Without this guard
+// the public accessor would be a thin alias on the policy and the
+// "immutability" benefit of unexporting the var would be lost.
+func TestProcedureAlternativesSnapshot_IsIndependentCopy(t *testing.T) {
+	first := auth.ProcedureAlternativesSnapshot()
+	// Pick any existing key for the smoke check; if the map is
+	// empty the matches-zero guard below catches it.
+	if len(first) == 0 {
+		t.Fatal("ProcedureAlternativesSnapshot returned empty — matches-zero guard")
+	}
+	var pickedProc string
+	for k := range first {
+		pickedProc = k
+		break
+	}
+	// Mutate the snapshot.
+	first[pickedProc] = append(first[pickedProc], "AttackerInjectedPermission")
+	first["/pm.v1.ControlService/Forged"] = []string{"AttackerInjectedPermission"}
+
+	// Re-snapshot and compare.
+	second := auth.ProcedureAlternativesSnapshot()
+	if len(second) != len(first)-1 {
+		t.Fatalf("snapshot accessor shared state with live policy: second size %d unexpectedly differs from first-1 size %d", len(second), len(first)-1)
+	}
+	if _, leaked := second["/pm.v1.ControlService/Forged"]; leaked {
+		t.Errorf("forged procedure leaked into the live policy via snapshot mutation")
+	}
+	for _, alt := range second[pickedProc] {
+		if alt == "AttackerInjectedPermission" {
+			t.Errorf("attacker-injected permission leaked into live policy on procedure %q via snapshot mutation", pickedProc)
+		}
+	}
+}
+
 // TestProcedureAlternatives_EveryAlternativeIsARegisteredPermission
 // pins that every permission listed as an alternative actually
 // exists in AllPermissions(). A typo here would silently leave the
 // procedure ungated for users who hold the typo'd permission name
 // (i.e. zero users) — effectively closed but invisible.
+//
+// Uses EXACT key matching (not stripScope) per #333 review: a
+// scoped variant like `Foo:self` must not satisfy a lookup for the
+// unscoped base `Foo`. The alternatives must reference the literal
+// permission key the actor would hold in their JWT.
 func TestProcedureAlternatives_EveryAlternativeIsARegisteredPermission(t *testing.T) {
 	registered := make(map[string]bool, len(auth.AllPermissions()))
 	for _, p := range auth.AllPermissions() {
-		registered[stripScope(p.Key)] = true
+		registered[p.Key] = true
 	}
-	for proc, alts := range auth.ProcedureAlternatives {
+	for proc, alts := range auth.ProcedureAlternativesSnapshot() {
 		for _, alt := range alts {
 			if !registered[alt] {
 				t.Errorf("ProcedureAlternatives[%q] lists permission %q which is not in AllPermissions()", proc, alt)
@@ -237,12 +281,19 @@ func TestProcedureAlternatives_EveryAlternativeIsARegisteredPermission(t *testin
 
 // TestProcedureAlternatives_EveryKeyIsAnRPC pins that the procedure
 // path on the LHS of the alternatives map actually corresponds to
-// an RPC on the generated handler. A typo here would silently leave
-// the alternatives override inactive for the real procedure (which
-// would fall through to the default Authorize path).
+// an RPC on the generated handler. A typo in the trailing method
+// name OR the service prefix would silently leave the alternatives
+// override inactive for the real procedure (which would fall through
+// to the default Authorize path). Per #333 review, both pieces are
+// asserted.
 func TestProcedureAlternatives_EveryKeyIsAnRPC(t *testing.T) {
 	rpcs := rpcMethodNames(t)
-	for proc := range auth.ProcedureAlternatives {
+	const wantPrefix = "/pm.v1.ControlService/"
+	for proc := range auth.ProcedureAlternativesSnapshot() {
+		if !strings.HasPrefix(proc, wantPrefix) {
+			t.Errorf("ProcedureAlternatives key %q does not start with the canonical Connect prefix %q", proc, wantPrefix)
+			continue
+		}
 		method := procedureName(proc)
 		if !rpcs[method] {
 			t.Errorf("ProcedureAlternatives key %q references non-existent RPC %q", proc, method)

--- a/internal/auth/permissions_parity_test.go
+++ b/internal/auth/permissions_parity_test.go
@@ -42,20 +42,25 @@ func procedureName(procedure string) string {
 	return procedure
 }
 
-// reconcilerOnlyPermissions are intentionally not backed by an RPC.
-// They gate background server-side work (currently the TerminalAdmin
-// reconciler — see manchtools/power-manage-server#70) rather than a
-// handler call. Adding an entry here documents the intent so the
-// parity invariant below stays a meaningful drift-catcher for the
-// "I added a permission but forgot to add its RPC" mistake.
+// nonRPCBackedPermissions are intentionally not gated by an RPC of
+// the same name. Two sub-categories live here:
 //
-// To add to this set, the new permission MUST be consumed by a
-// server-side reconciler (not by a handler) and its role-builder
-// UX must make clear that holding it triggers server-managed state,
-// not an RPC the user can call directly.
-var reconcilerOnlyPermissions = map[string]bool{
-	"TerminalAdminLimited": true, // #70 — reconciler in system_actions.go materializes pm-sudo-* membership
-	"TerminalAdminFull":    true, // #70 — same shape, FULL access level
+//   - **Reconciler-only**: gate background server-side work
+//     (TerminalAdmin* — #70 reconciler in system_actions.go
+//     materializes pm-sudo-* membership). The reconciler reads the
+//     projection; no handler check fires.
+//   - **Gate-authority**: consulted as a precondition by ANOTHER
+//     permission's handler, not by an RPC of the same name
+//     (AssignRoleScope — #7 gates the scope_kind/scope_id args on
+//     AssignRoleToUser / AssignRoleToUserGroup).
+//
+// Adding an entry here documents the intent so the parity
+// invariant below stays a meaningful drift-catcher for the
+// "I added a permission but forgot to add its RPC" mistake.
+var nonRPCBackedPermissions = map[string]bool{
+	"TerminalAdminLimited": true, // #70 — reconciler-only
+	"TerminalAdminFull":    true, // #70 — reconciler-only
+	"AssignRoleScope":      true, // #7 — gate-authority for scoped grants
 }
 
 // TestEveryPermissionMatchesAnRPC asserts that every PermissionInfo
@@ -65,35 +70,41 @@ var reconcilerOnlyPermissions = map[string]bool{
 // can be assigned to a role but no handler will ever consult it —
 // invisible-deadweight UX in the role builder.
 //
-// Reconciler-only permissions (see above) are skipped — they are
-// consumed off the request path.
+// Three exemption paths:
+//   - nonRPCBackedPermissions (reconciler-only or gate-authority).
+//   - ProcedureAlternatives: a split / renamed permission that
+//     gates a procedure whose name differs (CreateStaticDeviceGroup
+//     gates /CreateDeviceGroup via the alternatives map).
 func TestEveryPermissionMatchesAnRPC(t *testing.T) {
 	rpcs := rpcMethodNames(t)
 	for _, p := range auth.AllPermissions() {
 		base := stripScope(p.Key)
-		if reconcilerOnlyPermissions[base] {
+		if nonRPCBackedPermissions[base] {
+			continue
+		}
+		if auth.PermissionIsAlternative(base) {
 			continue
 		}
 		if !rpcs[base] {
-			t.Errorf("permission %q references non-existent RPC %q (no method on ControlServiceHandler)",
+			t.Errorf("permission %q references non-existent RPC %q (no method on ControlServiceHandler, no alternatives entry, not in nonRPCBackedPermissions)",
 				p.Key, base)
 		}
 	}
 }
 
-// TestReconcilerOnlyPermissionsAreRegistered guards the inverse
-// invariant: every entry in reconcilerOnlyPermissions must actually
+// TestNonRPCBackedPermissionsAreRegistered guards the inverse
+// invariant: every entry in nonRPCBackedPermissions must actually
 // be a registered permission in AllPermissions(). Otherwise a
 // future rename of TerminalAdminLimited would leave a stale
 // exemption that quietly papers over a real parity violation.
-func TestReconcilerOnlyPermissionsAreRegistered(t *testing.T) {
+func TestNonRPCBackedPermissionsAreRegistered(t *testing.T) {
 	registered := make(map[string]bool, len(auth.AllPermissions()))
 	for _, p := range auth.AllPermissions() {
 		registered[stripScope(p.Key)] = true
 	}
-	for key := range reconcilerOnlyPermissions {
+	for key := range nonRPCBackedPermissions {
 		if !registered[key] {
-			t.Errorf("reconcilerOnlyPermissions includes %q but it's not in AllPermissions() — exemption is stale",
+			t.Errorf("nonRPCBackedPermissions includes %q but it's not in AllPermissions() — exemption is stale",
 				key)
 		}
 	}
@@ -123,10 +134,14 @@ func TestEveryPublicProcedureIsAnRPC(t *testing.T) {
 }
 
 // TestEveryRPCIsCoveredByPermissionOrPublic is the inverse of the
-// two checks above: for every RPC on the generated handler, EITHER
-// it's listed in PublicProcedures (auth bypass) OR there's at least
-// one permission whose base key matches it. Catches new RPCs added
-// without permission wiring.
+// two checks above: for every RPC on the generated handler, the RPC
+// must be covered by ONE of:
+//   - PublicProcedures (auth bypass)
+//   - A permission whose base key matches the RPC name
+//   - An entry in ProcedureAlternatives (one or more permissions
+//     gate the procedure via the alternatives map)
+//
+// Catches new RPCs added without permission wiring.
 func TestEveryRPCIsCoveredByPermissionOrPublic(t *testing.T) {
 	rpcs := rpcMethodNames(t)
 
@@ -137,6 +152,9 @@ func TestEveryRPCIsCoveredByPermissionOrPublic(t *testing.T) {
 	}
 
 	for procedure := range auth.PublicProcedures {
+		covered[procedureName(procedure)] = true
+	}
+	for procedure := range auth.ProcedureAlternatives {
 		covered[procedureName(procedure)] = true
 	}
 	for _, p := range auth.AllPermissions() {
@@ -150,6 +168,84 @@ func TestEveryRPCIsCoveredByPermissionOrPublic(t *testing.T) {
 		}
 	}
 	if len(uncovered) > 0 {
-		t.Errorf("RPCs with no permission and not in PublicProcedures (drift hazard — every new RPC needs one or the other): %v", uncovered)
+		t.Errorf("RPCs with no permission, not in PublicProcedures, and not in ProcedureAlternatives (drift hazard — every new RPC needs one of the three): %v", uncovered)
+	}
+}
+
+// TestProcedureAlternatives_Exact pins the exact set of procedures
+// gated via the alternatives map. Adding to or removing from this
+// map is intentional but consequential (it changes the interceptor
+// gating semantics), so the assertion lists the expected set
+// verbatim — a future PR that wants to widen the alternatives must
+// update this test consciously.
+func TestProcedureAlternatives_Exact(t *testing.T) {
+	expected := map[string][]string{
+		"/pm.v1.ControlService/CreateDeviceGroup": {
+			"CreateStaticDeviceGroup",
+			"CreateDynamicDeviceGroup",
+		},
+		"/pm.v1.ControlService/CreateUserGroup": {
+			"CreateStaticUserGroup",
+			"CreateDynamicUserGroup",
+		},
+		"/pm.v1.ControlService/UpdateDeviceGroupQuery": {
+			"UpdateDynamicDeviceGroupQuery",
+		},
+		"/pm.v1.ControlService/UpdateUserGroupQuery": {
+			"UpdateDynamicUserGroupQuery",
+		},
+	}
+	if len(expected) != len(auth.ProcedureAlternatives) {
+		t.Fatalf("ProcedureAlternatives length drifted: have %d, expected %d", len(auth.ProcedureAlternatives), len(expected))
+	}
+	for proc, wantAlts := range expected {
+		gotAlts, ok := auth.ProcedureAlternatives[proc]
+		if !ok {
+			t.Errorf("ProcedureAlternatives missing entry for %q", proc)
+			continue
+		}
+		if len(gotAlts) != len(wantAlts) {
+			t.Errorf("ProcedureAlternatives[%q] length mismatch: got %d, want %d", proc, len(gotAlts), len(wantAlts))
+			continue
+		}
+		for i, w := range wantAlts {
+			if gotAlts[i] != w {
+				t.Errorf("ProcedureAlternatives[%q][%d] = %q, want %q", proc, i, gotAlts[i], w)
+			}
+		}
+	}
+}
+
+// TestProcedureAlternatives_EveryAlternativeIsARegisteredPermission
+// pins that every permission listed as an alternative actually
+// exists in AllPermissions(). A typo here would silently leave the
+// procedure ungated for users who hold the typo'd permission name
+// (i.e. zero users) — effectively closed but invisible.
+func TestProcedureAlternatives_EveryAlternativeIsARegisteredPermission(t *testing.T) {
+	registered := make(map[string]bool, len(auth.AllPermissions()))
+	for _, p := range auth.AllPermissions() {
+		registered[stripScope(p.Key)] = true
+	}
+	for proc, alts := range auth.ProcedureAlternatives {
+		for _, alt := range alts {
+			if !registered[alt] {
+				t.Errorf("ProcedureAlternatives[%q] lists permission %q which is not in AllPermissions()", proc, alt)
+			}
+		}
+	}
+}
+
+// TestProcedureAlternatives_EveryKeyIsAnRPC pins that the procedure
+// path on the LHS of the alternatives map actually corresponds to
+// an RPC on the generated handler. A typo here would silently leave
+// the alternatives override inactive for the real procedure (which
+// would fall through to the default Authorize path).
+func TestProcedureAlternatives_EveryKeyIsAnRPC(t *testing.T) {
+	rpcs := rpcMethodNames(t)
+	for proc := range auth.ProcedureAlternatives {
+		method := procedureName(proc)
+		if !rpcs[method] {
+			t.Errorf("ProcedureAlternatives key %q references non-existent RPC %q", proc, method)
+		}
 	}
 }

--- a/internal/auth/permissions_test.go
+++ b/internal/auth/permissions_test.go
@@ -210,14 +210,429 @@ func TestAdminPermissions_IncludesTerminalAdminFull(t *testing.T) {
 		"the bootstrap Admin role must include TerminalAdminFull")
 }
 
-// TerminalAdmin keys are unscoped at the model layer — #7 will add a
-// scope dimension. Pin the unscoped shape here so a future :self /
-// :assigned variant can't be added without the test being updated.
-func TestTerminalAdminPermissions_AreUnscoped(t *testing.T) {
+// TerminalAdmin keys carry NO `:self` / `:assigned` suffix — those
+// describe the older subject-scope mechanism (own-record vs any).
+// #7's group-anchored scope arrives via PermissionInfo.TargetKind
+// (DEVICE for these two), not via a key suffix. Pin the bare key
+// shape here so a future `:self` variant can't be added silently —
+// the group-anchored scope and the subject-scope mechanisms must
+// stay orthogonal at the registry layer.
+func TestTerminalAdminPermissions_HaveNoSubjectScopeSuffix(t *testing.T) {
 	for _, p := range AllPermissions() {
 		if p.Key == "TerminalAdminLimited" || p.Key == "TerminalAdminFull" {
 			assert.False(t, strings.Contains(p.Key, ":"),
-				"%s must remain unscoped at the model layer; scope arrives via #7", p.Key)
+				"%s must remain free of `:self`/`:assigned` suffix; group-anchored scope lives on TargetKind, not the key", p.Key)
 		}
 	}
+}
+
+// =============================================================================
+// PermissionTargetKind classification — manchtools/power-manage-server#7.
+//
+// Tests pin the V1 curated scopable / non-scopable sets so a future
+// PR can't accidentally flip a permission's scopability. Self-
+// discovering against the registry with a matches-zero guard per
+// ~/.claude/skills/test-quality.md rule #4 — a registry rename or
+// removal surfaces immediately rather than failing open.
+//
+// Wrong-data is sourced from intent (the locked design's threat
+// model T-S2 and the V1 curated table), NOT from the artifact under
+// test, per the global TDD rule #3.
+// =============================================================================
+
+// v1ScopableDeviceTargeted is the curated set of permissions that
+// MUST carry TargetKind=TargetDevice in V1. Sourced from the locked
+// #7 design's V1 curated scopable device-targeted table — every
+// permission whose authorization decision is "does scope_id resolve
+// to a device group containing the request's device target?"
+//
+// Adding to this list is a deliberate registry change; removing is
+// a security regression unless the permission was also removed.
+var v1ScopableDeviceTargeted = []string{
+	"StartTerminal",
+	"StopTerminal",
+	"ListActiveTerminalSessions",
+	"TerminateTerminalSession",
+	"TerminalAdminLimited",
+	"TerminalAdminFull",
+	"GetDevice",
+	"ListDevices",
+	"DeleteDevice",
+	"SetDeviceSyncInterval",
+	"RefreshDeviceInventory",
+	"QueryDeviceLogs",
+	"GetDeviceLogResult",
+	"DispatchAction",
+	"DispatchActionSet",
+	"DispatchDefinition",
+	"DispatchInstantAction",
+	"DispatchAssignedActions",
+	"DispatchToMultiple",
+	"DispatchToGroup",
+	"GetExecution",
+	"ListExecutions",
+	"CancelExecution",
+	"DispatchOSQuery",
+	"GetOSQueryResult",
+	"GetDeviceInventory",
+	"GetDeviceCompliance",
+	"GetDeviceCompliancePolicyStatus",
+	"AddDeviceToGroup",
+	"RemoveDeviceFromGroup",
+	"CreateStaticDeviceGroup",
+	"RenameDeviceGroup",
+	"UpdateDeviceGroupDescription",
+	"DeleteDeviceGroup",
+	"SetDeviceGroupSyncInterval",
+	"SetDeviceGroupMaintenanceWindow",
+	"ListDeviceGroupsForDevice",
+	"GetDeviceGroup",
+	"ListDeviceGroups",
+}
+
+// v1ScopableUserTargeted is the curated set of permissions that
+// MUST carry TargetKind=TargetUser. Same rationale as device.
+var v1ScopableUserTargeted = []string{
+	"GetUser",
+	"ListUsers",
+	"UpdateUserEmail",
+	"UpdateUserPassword",
+	"UpdateUserProfile",
+	"SetUserDisabled",
+	"DeleteUser",
+	"UpdateUserSshSettings",
+	"UpdateUserLinuxUsername",
+	"AddUserSshKey",
+	"RemoveUserSshKey",
+	"AddUserToGroup",
+	"RemoveUserFromGroup",
+	"CreateStaticUserGroup",
+	"UpdateUserGroup",
+	"DeleteUserGroup",
+	"SetUserGroupMaintenanceWindow",
+	"GetUserGroup",
+	"ListUserGroups",
+	"ListUserGroupsForUser",
+	"AdminDisableUserTOTP",
+	"SetUserProvisioningEnabled",
+}
+
+// v1NonScopableDangerous is the curated set of permissions that
+// MUST stay TargetKind=TargetUnspecified because granting them with
+// scope would either:
+//   - silently perturb OTHER actors' scopes (labels, dynamic queries
+//     — T-S2 transitive privilege escalation), or
+//   - hand the holder cross-scope authority (AssignRoleScope itself
+//     — T-S7 scope-authority sprawl).
+//
+// A future PR that flips one of these to scopable fails this test
+// loudly. Together with v1ScopableDeviceTargeted +
+// v1ScopableUserTargeted the three lists pin scopability in BOTH
+// directions, which closes the silent-allowlist gap (test-quality
+// skill rule #4).
+var v1NonScopableDangerous = []string{
+	// Label perms feed dynamic-query device groups
+	"SetDeviceLabel",
+	"RemoveDeviceLabel",
+	// Dynamic-group ops let the holder match arbitrary devices /
+	// users, which would perturb other actors' scopes
+	"CreateDynamicDeviceGroup",
+	"UpdateDynamicDeviceGroupQuery",
+	"EvaluateDynamicGroup",
+	"ValidateDynamicQuery",
+	"CreateDynamicUserGroup",
+	"UpdateDynamicUserGroupQuery",
+	"EvaluateDynamicUserGroup",
+	"ValidateUserGroupQuery",
+	// Scope-authority itself is org-tier — V1 stance per T-S7
+	"AssignRoleScope",
+	// Role management is org-tier
+	"CreateRole", "UpdateRole", "DeleteRole",
+	"AssignRoleToUser", "RevokeRoleFromUser",
+	"AssignRoleToUserGroup", "RevokeRoleFromUserGroup",
+	// Server settings, IDP, SCIM, audit are org-tier
+	"GetServerSettings", "UpdateServerSettings",
+	"CreateIdentityProvider", "DeleteIdentityProvider",
+	"EnableSCIM", "DisableSCIM", "RotateSCIMToken",
+	"ListAuditEvents",
+	// Search is the gate-only single permission; per-facet scope
+	// inherits from ListDevices / ListUsers in the JWT
+	"Search",
+	// Security-sensitive credential views — org-tier
+	"GetDeviceLpsPasswords",
+	"GetDeviceLuksKeys",
+	"CreateLuksToken",
+	"RevokeLuksDeviceKey",
+}
+
+// indexAllByKey returns a key→PermissionInfo map for self-
+// discovering registry queries. Used by every TargetKind test below.
+func indexAllByKey(t *testing.T) map[string]PermissionInfo {
+	t.Helper()
+	out := make(map[string]PermissionInfo, len(AllPermissions()))
+	for _, p := range AllPermissions() {
+		out[p.Key] = p
+	}
+	return out
+}
+
+func TestPermissionTargetKind_UnspecifiedIsZeroValue(t *testing.T) {
+	// Zero value invariant: a PermissionInfo literal with no
+	// explicit TargetKind must default to TargetUnspecified. Closes
+	// the fail-closed contract — new permission entries that forget
+	// to classify themselves land at the safe default. T-S2.
+	var zero PermissionInfo
+	assert.Equal(t, TargetUnspecified, zero.TargetKind,
+		"zero-value TargetKind must be TargetUnspecified — fail-closed default")
+}
+
+func TestAllPermissions_EveryEntry_HasKnownTargetKind(t *testing.T) {
+	// Every registered permission must carry a known TargetKind
+	// enum value (Unspecified / Device / User). A future PR that
+	// adds a fourth value here would be visible from this test
+	// failing rather than from a runtime mystery rejection.
+	for _, p := range AllPermissions() {
+		switch p.TargetKind {
+		case TargetUnspecified, TargetDevice, TargetUser:
+			// known
+		default:
+			t.Errorf("permission %q has unknown TargetKind %v — extend the enum or fix the entry", p.Key, p.TargetKind)
+		}
+	}
+}
+
+// -----------------------------------------------------------------
+// AssignRoleScope — the scope-authority gate
+// -----------------------------------------------------------------
+
+func TestAllPermissions_IncludesAssignRoleScope(t *testing.T) {
+	_, ok := indexAllByKey(t)["AssignRoleScope"]
+	assert.True(t, ok, "AssignRoleScope must be registered — it gates scope-authority for #7")
+}
+
+func TestAssignRoleScope_IsInRolesGroup(t *testing.T) {
+	info, ok := indexAllByKey(t)["AssignRoleScope"]
+	require.True(t, ok)
+	assert.Equal(t, "Roles", info.Group,
+		"AssignRoleScope belongs in the Roles UI group alongside AssignRoleToUser so the role-builder surfaces them together")
+}
+
+func TestAssignRoleScope_IsOrgTier_NotScopable(t *testing.T) {
+	// T-S7: AssignRoleScope itself is unscoped/org-tier in V1. A
+	// flip to scopable would create a two-tier scope-authority
+	// delegation that this design explicitly defers.
+	info, ok := indexAllByKey(t)["AssignRoleScope"]
+	require.True(t, ok)
+	assert.Equal(t, TargetUnspecified, info.TargetKind,
+		"AssignRoleScope must stay TargetUnspecified — V1 stance per T-S7 scope-authority sprawl")
+}
+
+func TestAdminPermissions_IncludesAssignRoleScope(t *testing.T) {
+	perms := make(map[string]bool, len(AdminPermissions()))
+	for _, p := range AdminPermissions() {
+		perms[p] = true
+	}
+	assert.True(t, perms["AssignRoleScope"],
+		"the bootstrap Admin role must include AssignRoleScope so a fresh deployment can attach scopes without seeding a custom role first")
+}
+
+// -----------------------------------------------------------------
+// Static/Dynamic group permission splits (server #7 T-S2 mitigation)
+// -----------------------------------------------------------------
+
+func TestAllPermissions_IncludesGroupCreationSplits(t *testing.T) {
+	idx := indexAllByKey(t)
+	for _, key := range []string{
+		"CreateStaticDeviceGroup",
+		"CreateDynamicDeviceGroup",
+		"CreateStaticUserGroup",
+		"CreateDynamicUserGroup",
+	} {
+		_, ok := idx[key]
+		assert.True(t, ok, "split permission %q must be registered", key)
+	}
+}
+
+func TestAllPermissions_RemovesLegacyCreateAndUpdateKeys(t *testing.T) {
+	// The static/dynamic split removed the old single-key
+	// `CreateDeviceGroup` / `CreateUserGroup` and renamed the old
+	// `Update…GroupQuery` permissions to be explicitly "Dynamic" so
+	// a scope-confined admin holding only the Static variant can
+	// neither create NOR update dynamic groups (T-S2 update
+	// pathway). Old names MUST be gone — leaving them as aliases
+	// silently bypasses the split.
+	idx := indexAllByKey(t)
+	for _, legacy := range []string{
+		"CreateDeviceGroup",
+		"CreateUserGroup",
+		"UpdateDeviceGroupQuery",
+		"UpdateUserGroupQuery",
+	} {
+		_, ok := idx[legacy]
+		assert.False(t, ok,
+			"legacy permission %q must be removed by #7 split; presence as alias would bypass T-S2 update pathway", legacy)
+	}
+}
+
+func TestCreateStaticDeviceGroup_TargetsDevice(t *testing.T) {
+	info, ok := indexAllByKey(t)["CreateStaticDeviceGroup"]
+	require.True(t, ok)
+	assert.Equal(t, TargetDevice, info.TargetKind,
+		"CreateStaticDeviceGroup must be TargetDevice so a scope-confined admin can organize their scoped devices into sub-groups")
+}
+
+func TestCreateDynamicDeviceGroup_NotScopable(t *testing.T) {
+	info, ok := indexAllByKey(t)["CreateDynamicDeviceGroup"]
+	require.True(t, ok)
+	assert.Equal(t, TargetUnspecified, info.TargetKind,
+		"CreateDynamicDeviceGroup must stay unscopable — dynamic queries can match arbitrary devices and perturb other scopes (T-S2)")
+}
+
+func TestCreateStaticUserGroup_TargetsUser(t *testing.T) {
+	info, ok := indexAllByKey(t)["CreateStaticUserGroup"]
+	require.True(t, ok)
+	assert.Equal(t, TargetUser, info.TargetKind,
+		"CreateStaticUserGroup must be TargetUser, symmetric with the device-group split")
+}
+
+func TestCreateDynamicUserGroup_NotScopable(t *testing.T) {
+	info, ok := indexAllByKey(t)["CreateDynamicUserGroup"]
+	require.True(t, ok)
+	assert.Equal(t, TargetUnspecified, info.TargetKind,
+		"CreateDynamicUserGroup must stay unscopable, symmetric with the device-group case")
+}
+
+func TestUpdateDynamicDeviceGroupQuery_NotScopable(t *testing.T) {
+	info, ok := indexAllByKey(t)["UpdateDynamicDeviceGroupQuery"]
+	require.True(t, ok)
+	assert.Equal(t, TargetUnspecified, info.TargetKind,
+		"UpdateDynamicDeviceGroupQuery must stay unscopable — modifying a query is equivalent to authoring a fresh one (T-S2 update pathway)")
+}
+
+func TestUpdateDynamicUserGroupQuery_NotScopable(t *testing.T) {
+	info, ok := indexAllByKey(t)["UpdateDynamicUserGroupQuery"]
+	require.True(t, ok)
+	assert.Equal(t, TargetUnspecified, info.TargetKind,
+		"UpdateDynamicUserGroupQuery must stay unscopable, symmetric")
+}
+
+func TestAdminPermissions_IncludesAllGroupSplits(t *testing.T) {
+	perms := make(map[string]bool, len(AdminPermissions()))
+	for _, p := range AdminPermissions() {
+		perms[p] = true
+	}
+	for _, key := range []string{
+		"CreateStaticDeviceGroup",
+		"CreateDynamicDeviceGroup",
+		"CreateStaticUserGroup",
+		"CreateDynamicUserGroup",
+		"UpdateDynamicDeviceGroupQuery",
+		"UpdateDynamicUserGroupQuery",
+	} {
+		assert.True(t, perms[key], "Admin role must include split key %q", key)
+	}
+}
+
+// -----------------------------------------------------------------
+// TerminalAdmin classification (V1 user-facing scope demo)
+// -----------------------------------------------------------------
+
+func TestTerminalAdminLimited_TargetsDevice(t *testing.T) {
+	info, ok := indexAllByKey(t)["TerminalAdminLimited"]
+	require.True(t, ok)
+	assert.Equal(t, TargetDevice, info.TargetKind,
+		"TerminalAdminLimited is the V1 user-facing scope demo — must be TargetDevice so the reconciler can compute per-scope cohorts")
+}
+
+func TestTerminalAdminFull_TargetsDevice(t *testing.T) {
+	info, ok := indexAllByKey(t)["TerminalAdminFull"]
+	require.True(t, ok)
+	assert.Equal(t, TargetDevice, info.TargetKind,
+		"TerminalAdminFull must be TargetDevice, symmetric with Limited")
+}
+
+// -----------------------------------------------------------------
+// Self-discovering V1 curated set asserts (T-S2)
+// -----------------------------------------------------------------
+
+func TestV1ScopableDeviceTargeted_CuratedSet_AllPresentAndClassified(t *testing.T) {
+	// Matches-zero guard: if the curated list shrinks to empty,
+	// the test fails loudly so a future PR can't silently delete
+	// the scopable set and pass.
+	require.NotEmpty(t, v1ScopableDeviceTargeted,
+		"v1ScopableDeviceTargeted curated list is empty — guard against vacuous pass")
+
+	idx := indexAllByKey(t)
+	for _, key := range v1ScopableDeviceTargeted {
+		info, ok := idx[key]
+		require.True(t, ok, "curated key %q is not registered — registry drift", key)
+		assert.Equalf(t, TargetDevice, info.TargetKind,
+			"curated device-targeted permission %q must be TargetDevice; found %v", key, info.TargetKind)
+	}
+}
+
+func TestV1ScopableUserTargeted_CuratedSet_AllPresentAndClassified(t *testing.T) {
+	require.NotEmpty(t, v1ScopableUserTargeted,
+		"v1ScopableUserTargeted curated list is empty — guard against vacuous pass")
+
+	idx := indexAllByKey(t)
+	for _, key := range v1ScopableUserTargeted {
+		info, ok := idx[key]
+		require.True(t, ok, "curated key %q is not registered — registry drift", key)
+		assert.Equalf(t, TargetUser, info.TargetKind,
+			"curated user-targeted permission %q must be TargetUser; found %v", key, info.TargetKind)
+	}
+}
+
+func TestV1NonScopableDangerous_CuratedSet_AllStayUnspecified(t *testing.T) {
+	// The inverse guard — pins the "must stay unscopable" set so
+	// a future PR can't flip a label perm / dynamic-group op /
+	// AssignRoleScope to scopable without this test failing.
+	require.NotEmpty(t, v1NonScopableDangerous,
+		"v1NonScopableDangerous curated list is empty — guard against vacuous pass")
+
+	idx := indexAllByKey(t)
+	for _, key := range v1NonScopableDangerous {
+		info, ok := idx[key]
+		require.True(t, ok, "curated key %q is not registered — registry drift", key)
+		assert.Equalf(t, TargetUnspecified, info.TargetKind,
+			"curated non-scopable permission %q must be TargetUnspecified; flipping it scopable bypasses T-S2 / T-S7", key)
+	}
+}
+
+// -----------------------------------------------------------------
+// Subject-scope (':self'/':assigned') × group-scope (TargetKind)
+// invariant: the two scope mechanisms are orthogonal at the
+// registry layer. Subject-scoped permissions are NEVER scopable in
+// the group-anchored sense — they describe a self-record gate, not
+// a group-membership gate.
+// -----------------------------------------------------------------
+
+func TestSelfScopedPermissions_AreNeverGroupScopable(t *testing.T) {
+	found := 0
+	for _, p := range AllPermissions() {
+		if !strings.Contains(p.Key, ":") {
+			continue
+		}
+		found++
+		assert.Equalf(t, TargetUnspecified, p.TargetKind,
+			"subject-scoped permission %q (key with `:self`/`:assigned`) must stay TargetUnspecified — the two scope mechanisms don't mix", p.Key)
+	}
+	// Matches-zero guard.
+	require.Greater(t, found, 0, "no subject-scoped (`:self`/`:assigned`) permissions found — the registry must still carry them")
+}
+
+// -----------------------------------------------------------------
+// Search permission is the single gate-only entry; per-facet scope
+// inherits from ListDevices / ListUsers via JWT-baked grants per
+// the locked Valkey-search section of #7. Search itself MUST stay
+// unscopable so the kinds-don't-mix invariant doesn't constrain
+// its dispatch shape.
+// -----------------------------------------------------------------
+
+func TestSearchPermission_IsGateOnly_NotScopable(t *testing.T) {
+	info, ok := indexAllByKey(t)["Search"]
+	require.True(t, ok)
+	assert.Equal(t, TargetUnspecified, info.TargetKind,
+		"Search is the gate-only single permission; per-facet scope inherits from ListDevices / ListUsers via JWT")
 }

--- a/internal/store/migrations/009_role_permission_split_7.sql
+++ b/internal/store/migrations/009_role_permission_split_7.sql
@@ -1,0 +1,101 @@
+-- manchtools/power-manage-server#7 — permission registry split for
+-- group-anchored RBAC scoping. Renames legacy permission keys in
+-- existing roles_projection rows so custom roles created against
+-- the pre-#7 registry keep working:
+--
+--   CreateDeviceGroup      → CreateStaticDeviceGroup
+--                            (+ CreateDynamicDeviceGroup appended,
+--                             preserving the old key's combined
+--                             static-OR-dynamic capability)
+--   CreateUserGroup        → CreateStaticUserGroup
+--                            (+ CreateDynamicUserGroup appended)
+--   UpdateDeviceGroupQuery → UpdateDynamicDeviceGroupQuery
+--                            (no append — the old key was already
+--                             dynamic-only by RPC semantics)
+--   UpdateUserGroupQuery   → UpdateDynamicUserGroupQuery
+--
+-- The bootstrap Admin role is overwritten on next server startup by
+-- internal/auth.ReconcileSystemRoles, which always syncs to
+-- AdminPermissions() — so the seed-installed Admin gets the
+-- AssignRoleScope key without further migration. This migration
+-- exists to cover custom roles in the projection that
+-- ReconcileSystemRoles does NOT touch.
+--
+-- +goose Up
+-- +goose StatementBegin
+DO $$
+BEGIN
+    -- Rename the legacy single-key Create permissions; append the
+    -- dynamic counterpart so combined capability is preserved.
+    UPDATE roles_projection
+       SET permissions =
+           CASE
+               WHEN NOT ('CreateDynamicDeviceGroup' = ANY(permissions))
+                   THEN array_append(
+                       array_replace(permissions, 'CreateDeviceGroup', 'CreateStaticDeviceGroup'),
+                       'CreateDynamicDeviceGroup'
+                   )
+               ELSE array_replace(permissions, 'CreateDeviceGroup', 'CreateStaticDeviceGroup')
+           END
+     WHERE 'CreateDeviceGroup' = ANY(permissions);
+
+    UPDATE roles_projection
+       SET permissions =
+           CASE
+               WHEN NOT ('CreateDynamicUserGroup' = ANY(permissions))
+                   THEN array_append(
+                       array_replace(permissions, 'CreateUserGroup', 'CreateStaticUserGroup'),
+                       'CreateDynamicUserGroup'
+                   )
+               ELSE array_replace(permissions, 'CreateUserGroup', 'CreateStaticUserGroup')
+           END
+     WHERE 'CreateUserGroup' = ANY(permissions);
+
+    -- Rename the legacy Update*Query permissions in place. The old
+    -- keys were dynamic-only by RPC semantics, so no append needed.
+    UPDATE roles_projection
+       SET permissions = array_replace(permissions, 'UpdateDeviceGroupQuery', 'UpdateDynamicDeviceGroupQuery')
+     WHERE 'UpdateDeviceGroupQuery' = ANY(permissions);
+
+    UPDATE roles_projection
+       SET permissions = array_replace(permissions, 'UpdateUserGroupQuery', 'UpdateDynamicUserGroupQuery')
+     WHERE 'UpdateUserGroupQuery' = ANY(permissions);
+END $$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    -- Reverse the rename. The split-vs-combined re-collapse drops
+    -- the explicit dynamic permission and replaces the static one
+    -- with the legacy key. Loses information (a role granted ONLY
+    -- the dynamic capability post-#7 would collapse to the legacy
+    -- "both" key on downgrade) — acceptable for an undo of an
+    -- additive migration with no deployed callers.
+
+    UPDATE roles_projection
+       SET permissions = array_remove(
+               array_replace(permissions, 'CreateStaticDeviceGroup', 'CreateDeviceGroup'),
+               'CreateDynamicDeviceGroup'
+           )
+     WHERE 'CreateStaticDeviceGroup' = ANY(permissions)
+        OR 'CreateDynamicDeviceGroup' = ANY(permissions);
+
+    UPDATE roles_projection
+       SET permissions = array_remove(
+               array_replace(permissions, 'CreateStaticUserGroup', 'CreateUserGroup'),
+               'CreateDynamicUserGroup'
+           )
+     WHERE 'CreateStaticUserGroup' = ANY(permissions)
+        OR 'CreateDynamicUserGroup' = ANY(permissions);
+
+    UPDATE roles_projection
+       SET permissions = array_replace(permissions, 'UpdateDynamicDeviceGroupQuery', 'UpdateDeviceGroupQuery')
+     WHERE 'UpdateDynamicDeviceGroupQuery' = ANY(permissions);
+
+    UPDATE roles_projection
+       SET permissions = array_replace(permissions, 'UpdateDynamicUserGroupQuery', 'UpdateUserGroupQuery')
+     WHERE 'UpdateDynamicUserGroupQuery' = ANY(permissions);
+END $$;
+-- +goose StatementEnd

--- a/internal/store/migrations/009_role_permission_split_7.sql
+++ b/internal/store/migrations/009_role_permission_split_7.sql
@@ -67,26 +67,50 @@ END $$;
 -- +goose StatementBegin
 DO $$
 BEGIN
-    -- Reverse the rename. The split-vs-combined re-collapse drops
-    -- the explicit dynamic permission and replaces the static one
-    -- with the legacy key. Loses information (a role granted ONLY
-    -- the dynamic capability post-#7 would collapse to the legacy
-    -- "both" key on downgrade) — acceptable for an undo of an
-    -- additive migration with no deployed callers.
+    -- Collapse the static/dynamic split back to the legacy single
+    -- key. Three cases per role:
+    --   1. Holds both Static AND Dynamic — replace Static with the
+    --      legacy key, drop the Dynamic key.
+    --   2. Holds only Static — replace Static with the legacy key.
+    --   3. Holds only Dynamic — replace Dynamic with the legacy key
+    --      (do NOT drop it; otherwise the role loses ALL create
+    --      capability, which is information loss).
+    --
+    -- Flagged in #333 review: the prior "unconditionally remove
+    -- Dynamic" shape silently stripped roles whose only create
+    -- capability was the dynamic variant.
 
     UPDATE roles_projection
-       SET permissions = array_remove(
-               array_replace(permissions, 'CreateStaticDeviceGroup', 'CreateDeviceGroup'),
-               'CreateDynamicDeviceGroup'
-           )
+       SET permissions =
+           CASE
+               WHEN 'CreateStaticDeviceGroup' = ANY(permissions) AND 'CreateDynamicDeviceGroup' = ANY(permissions) THEN
+                   array_remove(
+                       array_replace(permissions, 'CreateStaticDeviceGroup', 'CreateDeviceGroup'),
+                       'CreateDynamicDeviceGroup'
+                   )
+               WHEN 'CreateStaticDeviceGroup' = ANY(permissions) THEN
+                   array_replace(permissions, 'CreateStaticDeviceGroup', 'CreateDeviceGroup')
+               WHEN 'CreateDynamicDeviceGroup' = ANY(permissions) THEN
+                   array_replace(permissions, 'CreateDynamicDeviceGroup', 'CreateDeviceGroup')
+               ELSE permissions
+           END
      WHERE 'CreateStaticDeviceGroup' = ANY(permissions)
         OR 'CreateDynamicDeviceGroup' = ANY(permissions);
 
     UPDATE roles_projection
-       SET permissions = array_remove(
-               array_replace(permissions, 'CreateStaticUserGroup', 'CreateUserGroup'),
-               'CreateDynamicUserGroup'
-           )
+       SET permissions =
+           CASE
+               WHEN 'CreateStaticUserGroup' = ANY(permissions) AND 'CreateDynamicUserGroup' = ANY(permissions) THEN
+                   array_remove(
+                       array_replace(permissions, 'CreateStaticUserGroup', 'CreateUserGroup'),
+                       'CreateDynamicUserGroup'
+                   )
+               WHEN 'CreateStaticUserGroup' = ANY(permissions) THEN
+                   array_replace(permissions, 'CreateStaticUserGroup', 'CreateUserGroup')
+               WHEN 'CreateDynamicUserGroup' = ANY(permissions) THEN
+                   array_replace(permissions, 'CreateDynamicUserGroup', 'CreateUserGroup')
+               ELSE permissions
+           END
      WHERE 'CreateStaticUserGroup' = ANY(permissions)
         OR 'CreateDynamicUserGroup' = ANY(permissions);
 


### PR DESCRIPTION
## Summary

First slice of manchtools/power-manage-server#7 (scoped device-group RBAC). Lands the permission-registry edits, interceptor machinery, and handler dispatch that S2/S2b/S5 build on. No scope grant/wiring yet — additive plumbing only.

- `auth.PermissionInfo.TargetKind` (fail-closed default UNSPECIFIED). Surfaced on `ListPermissions` for the web role-builder.
- New `AssignRoleScope` permission (org-tier scope-authority gate, used by S5 handlers).
- T-S2 mitigation split:
  - `CreateDeviceGroup` → `CreateStaticDeviceGroup` (TargetDevice) + `CreateDynamicDeviceGroup` (UNSPECIFIED)
  - `CreateUserGroup` → `CreateStaticUserGroup` (TargetUser) + `CreateDynamicUserGroup` (UNSPECIFIED)
  - `UpdateDeviceGroupQuery` → `UpdateDynamicDeviceGroupQuery` (UNSPECIFIED — RPC name unchanged)
  - `UpdateUserGroupQuery` → `UpdateDynamicUserGroupQuery` (same shape)
- `ProcedureAlternatives` map on the AuthzInterceptor: per-RPC list of satisfying perms. Interceptor passes if ANY held; handler narrows on `req.IsDynamic`. Map is exclusive — no fall-through to default Authorize for procedures in it.
- Defensive: `UpdateDeviceGroupQuery` / `UpdateUserGroupQuery` reject `FailedPrecondition` when target group is static (no implicit static→dynamic promotion).
- Migration 009 array_replaces legacy keys in `roles_projection.permissions`. Bootstrap Admin role is auto-rebuilt by `ReconcileSystemRoles` on startup — the migration is for custom roles created against the pre-#7 registry.
- `permissions_parity_test` now recognizes alternatives + the new `nonRPCBackedPermissions` set (renamed from `reconcilerOnlyPermissions` to also cover `AssignRoleScope` as gate-authority).

## Test plan

Tests ship with implementation per the project's policy:

- [x] `internal/auth` — full sweep green. New tests: PermissionTargetKind fail-closed, AssignRoleScope shape, split keys + curated V1 scopable/non-scopable sets with matches-zero guards, ProcedureAlternatives integration tests against a wired httptest harness (static-alt + dynamic-alt accept, neither denies, legacy-key alone denies).
- [x] `internal/api` (focused) — handler dispatch tests with hand-built UserContexts holding ONLY one split perm; UpdateDeviceGroupQuery / UpdateUserGroupQuery `FailedPrecondition` on static target.
- [x] Local `cr review`: no findings.
- [x] `go vet ./...` clean.
- [x] `gofmt -l .` clean.

## Follow-ups (S2 onward)

S2: schema (`scope_kind` / `scope_id` columns on user_roles_projection + user_group_roles_projection) + event payload + projector wiring. S2b: JWT `ScopedGrants` claim + `UserRepo.ScopedGrants` + `EnforceDeviceScope` / `EnforceUserScope` / `DeviceScopeFilterFor` / `UserScopeFilterFor` helpers. S5: `AssignRoleToUser*` / `RevokeRoleFromUser*` accept `scope_kind` + `scope_id` with paired-or-neither validation + scope-authority gate + kind-matching.

Closes part of manchtools/power-manage-server#7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Split create permissions into static vs dynamic variants and added shape-based permission checks.
  * Permission target scoping introduced (device vs user).

* **Bug Fixes**
  * Blocked invalid static→dynamic promotions and reject dynamic requests with empty queries.

* **Tests**
  * Expanded authorization and dynamic-group boundary test coverage and added regression tests.

* **Chores**
  * Updated SDK dependency and migrated legacy permission keys via a database migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->