### PR TITLE
feat(store+projectors): #7 S2 — scope columns + event payloads + projector wiring

### DIFF
--- a/internal/eventtypes/payloads/payloads_test.go
+++ b/internal/eventtypes/payloads/payloads_test.go
@@ -679,10 +679,76 @@ func TestRoundtrip_UserRoleAssigned(t *testing.T) {
 	assert.Equal(t, in, out)
 }
 
+func TestRoundtrip_UserRoleAssigned_WithScope(t *testing.T) {
+	// server #7 S2: scoped grants carry both ScopeKind + ScopeID
+	// on the wire. The pointers must round-trip identically.
+	kind := "device_group"
+	id := "01H..."
+	in := payloads.UserRoleAssigned{
+		UserID:    "user-1",
+		RoleID:    "role-1",
+		ScopeKind: &kind,
+		ScopeID:   &id,
+	}
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+	var out payloads.UserRoleAssigned
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, in, out)
+	// Pin that nil pointers round-trip as nil (not zero-value
+	// pointer-to-empty-string) so the omitempty contract works.
+	assert.Equal(t, "device_group", *out.ScopeKind)
+	assert.Equal(t, "01H...", *out.ScopeID)
+}
+
+func TestRoundtrip_UserRoleAssigned_LegacyEventWithoutScopeFields(t *testing.T) {
+	// Backward-compatibility guard: an event emitted before #7 has
+	// no scope_kind / scope_id keys in its JSON. Decoding it must
+	// produce nil pointers — NOT empty strings — so the projector
+	// classifies it as an unscoped grant.
+	raw := []byte(`{"user_id":"u1","role_id":"r1"}`)
+	var out payloads.UserRoleAssigned
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, "u1", out.UserID)
+	assert.Equal(t, "r1", out.RoleID)
+	assert.Nil(t, out.ScopeKind, "legacy events must decode to nil ScopeKind, not a pointer to empty string")
+	assert.Nil(t, out.ScopeID)
+}
+
+func TestRoundtrip_UserRoleAssigned_NoScope_OmitsKeysOnWire(t *testing.T) {
+	// omitempty contract: an unscoped grant must NOT write the
+	// scope keys to the wire, so a legacy decoder that doesn't
+	// know about scope still sees the historical shape.
+	in := payloads.UserRoleAssigned{UserID: "u1", RoleID: "r1"}
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+	var asMap map[string]any
+	require.NoError(t, json.Unmarshal(raw, &asMap))
+	assert.NotContains(t, asMap, "scope_kind", "unscoped grant must omit scope_kind from the wire JSON")
+	assert.NotContains(t, asMap, "scope_id", "unscoped grant must omit scope_id from the wire JSON")
+}
+
 func TestRoundtrip_UserRoleRevoked(t *testing.T) {
 	in := payloads.UserRoleRevoked{
 		UserID: "user-1",
 		RoleID: "role-1",
+	}
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+	var out payloads.UserRoleRevoked
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, in, out)
+}
+
+func TestRoundtrip_UserRoleRevoked_WithScope(t *testing.T) {
+	// server #7 S5 4-tuple revoke grammar.
+	kind := "user_group"
+	id := "01HXY..."
+	in := payloads.UserRoleRevoked{
+		UserID:    "user-1",
+		RoleID:    "role-1",
+		ScopeKind: &kind,
+		ScopeID:   &id,
 	}
 	raw, err := json.Marshal(in)
 	require.NoError(t, err)
@@ -759,6 +825,58 @@ func TestRoundtrip_UserGroupRoleAssignedRevoked(t *testing.T) {
 	var outR payloads.UserGroupRoleRevoked
 	require.NoError(t, json.Unmarshal(rawR, &outR))
 	assert.Equal(t, r, outR)
+}
+
+func TestRoundtrip_UserGroupRoleAssigned_WithScope(t *testing.T) {
+	kind := "device_group"
+	id := "01HXY..."
+	in := payloads.UserGroupRoleAssigned{
+		GroupID:   "g-1",
+		RoleID:    "r-1",
+		ScopeKind: &kind,
+		ScopeID:   &id,
+	}
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+	var out payloads.UserGroupRoleAssigned
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, in, out)
+}
+
+func TestRoundtrip_UserGroupRoleAssigned_NoScope_OmitsKeys(t *testing.T) {
+	in := payloads.UserGroupRoleAssigned{GroupID: "g-1", RoleID: "r-1"}
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+	var asMap map[string]any
+	require.NoError(t, json.Unmarshal(raw, &asMap))
+	assert.NotContains(t, asMap, "scope_kind")
+	assert.NotContains(t, asMap, "scope_id")
+}
+
+func TestRoundtrip_UserGroupRoleAssigned_LegacyEventDecodesAsUnscoped(t *testing.T) {
+	raw := []byte(`{"group_id":"g1","role_id":"r1"}`)
+	var out payloads.UserGroupRoleAssigned
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, "g1", out.GroupID)
+	assert.Equal(t, "r1", out.RoleID)
+	assert.Nil(t, out.ScopeKind)
+	assert.Nil(t, out.ScopeID)
+}
+
+func TestRoundtrip_UserGroupRoleRevoked_WithScope(t *testing.T) {
+	kind := "user_group"
+	id := "01HXY..."
+	in := payloads.UserGroupRoleRevoked{
+		GroupID:   "g-1",
+		RoleID:    "r-1",
+		ScopeKind: &kind,
+		ScopeID:   &id,
+	}
+	raw, err := json.Marshal(in)
+	require.NoError(t, err)
+	var out payloads.UserGroupRoleRevoked
+	require.NoError(t, json.Unmarshal(raw, &out))
+	assert.Equal(t, in, out)
 }
 
 func TestRoundtrip_UserGroupQueryUpdated(t *testing.T) {

--- a/internal/eventtypes/payloads/role.go
+++ b/internal/eventtypes/payloads/role.go
@@ -35,18 +35,34 @@ type RoleUpdated struct {
 	Permissions []string `json:"permissions"`
 }
 
-// UserRoleAssigned is the wire shape for UserRoleAssigned. Both
-// fields are required — they are the composite-key columns of the
-// user_roles_projection row this event projects.
+// UserRoleAssigned is the wire shape for UserRoleAssigned. UserID
+// and RoleID are required — they are the composite-key columns of
+// the user_roles_projection row this event projects.
+//
+// ScopeKind and ScopeID are paired optional fields added in
+// server #7 S2. Both nil means an unscoped/global grant
+// (backward-compatible with every pre-#7 event). Both populated
+// means the grant is constrained to the named group. Half-set is
+// invalid and rejected by the projector and the DB CHECK.
+// Pointer types preserve the absent-vs-empty distinction across
+// JSON round-trips so the projector can tell a legacy event from
+// one with an intentionally-empty scope value.
 type UserRoleAssigned struct {
-	UserID string `json:"user_id"`
-	RoleID string `json:"role_id"`
+	UserID    string  `json:"user_id"`
+	RoleID    string  `json:"role_id"`
+	ScopeKind *string `json:"scope_kind,omitempty"`
+	ScopeID   *string `json:"scope_id,omitempty"`
 }
 
 // UserRoleRevoked is the wire shape for UserRoleRevoked. Same
-// composite-key shape as UserRoleAssigned; the projector deletes the
-// matching row.
+// composite-key shape as UserRoleAssigned plus the optional
+// (ScopeKind, ScopeID) pair from #7 S5's 4-tuple revoke grammar.
+// Both nil = revoke the unscoped grant; both set = revoke the
+// matching scoped grant. The projector dispatches via
+// IS NOT DISTINCT FROM.
 type UserRoleRevoked struct {
-	UserID string `json:"user_id"`
-	RoleID string `json:"role_id"`
+	UserID    string  `json:"user_id"`
+	RoleID    string  `json:"role_id"`
+	ScopeKind *string `json:"scope_kind,omitempty"`
+	ScopeID   *string `json:"scope_id,omitempty"`
 }

--- a/internal/eventtypes/payloads/user_group.go
+++ b/internal/eventtypes/payloads/user_group.go
@@ -44,15 +44,21 @@ type UserGroupMemberRemoved struct {
 }
 
 // UserGroupRoleAssigned / UserGroupRoleRevoked share the same
-// (group_id, role_id) composite-key shape.
+// (group_id, role_id) composite-key shape plus the optional scope
+// tuple added in server #7 S2 / S5 (paired-or-neither, both nil =
+// unscoped grant for backward compat).
 type UserGroupRoleAssigned struct {
-	GroupID string `json:"group_id"`
-	RoleID  string `json:"role_id"`
+	GroupID   string  `json:"group_id"`
+	RoleID    string  `json:"role_id"`
+	ScopeKind *string `json:"scope_kind,omitempty"`
+	ScopeID   *string `json:"scope_id,omitempty"`
 }
 
 type UserGroupRoleRevoked struct {
-	GroupID string `json:"group_id"`
-	RoleID  string `json:"role_id"`
+	GroupID   string  `json:"group_id"`
+	RoleID    string  `json:"role_id"`
+	ScopeKind *string `json:"scope_kind,omitempty"`
+	ScopeID   *string `json:"scope_id,omitempty"`
 }
 
 // UserGroupQueryUpdated toggles a static group to dynamic (or back).

--- a/internal/projectors/user_group.go
+++ b/internal/projectors/user_group.go
@@ -251,16 +251,21 @@ func decodeUserGroupMember(e store.PersistedEvent, eventName string) (UserGroupM
 
 // UserGroupRolePayload covers UserGroupRoleAssigned and
 // UserGroupRoleRevoked. Both events carry the same (group_id, role_id)
-// pair from the payload (the projector indexes off `event.data->>...`
-// rather than the stream id, mirroring how the handler emits them).
+// pair from the payload, plus the optional (ScopeKind, ScopeID)
+// tuple from server #7 S2 / S5 for scoped grants and the 4-tuple
+// revoke grammar.
 type UserGroupRolePayload struct {
-	GroupID string
-	RoleID  string
+	GroupID   string
+	RoleID    string
+	ScopeKind *string
+	ScopeID   *string
 }
 
 type userGroupRoleRaw struct {
-	GroupID string `json:"group_id"`
-	RoleID  string `json:"role_id"`
+	GroupID   string  `json:"group_id"`
+	RoleID    string  `json:"role_id"`
+	ScopeKind *string `json:"scope_kind,omitempty"`
+	ScopeID   *string `json:"scope_id,omitempty"`
 }
 
 // UserGroupRoleAssignedFromEvent decodes UserGroupRoleAssigned.
@@ -292,6 +297,9 @@ func decodeUserGroupRole(e store.PersistedEvent, eventName string) (UserGroupRol
 		return UserGroupRolePayload{}, fmt.Errorf("projector: %s requires group_id", eventName)
 	case raw.RoleID == "":
 		return UserGroupRolePayload{}, fmt.Errorf("projector: %s requires role_id", eventName)
+	}
+	if err := validateScopePair(raw.ScopeKind, raw.ScopeID, eventName); err != nil {
+		return UserGroupRolePayload{}, err
 	}
 	return UserGroupRolePayload(raw), nil
 }

--- a/internal/projectors/user_group_listener.go
+++ b/internal/projectors/user_group_listener.go
@@ -392,6 +392,8 @@ func applyUserGroupRoleAssigned(ctx context.Context, q *store.Queries, e store.P
 	return q.InsertUserGroupRole(ctx, db.InsertUserGroupRoleParams{
 		GroupID:           payload.GroupID,
 		RoleID:            payload.RoleID,
+		ScopeKind:         payload.ScopeKind,
+		ScopeID:           payload.ScopeID,
 		AssignedAt:        e.OccurredAt,
 		AssignedBy:        e.ActorID,
 		ProjectionVersion: deref(e.SequenceNum),
@@ -418,8 +420,10 @@ func applyUserGroupRoleRevoked(ctx context.Context, q *store.Queries, e store.Pe
 		return nil
 	}
 	return q.DeleteUserGroupRole(ctx, db.DeleteUserGroupRoleParams{
-		GroupID: payload.GroupID,
-		RoleID:  payload.RoleID,
+		GroupID:   payload.GroupID,
+		RoleID:    payload.RoleID,
+		ScopeKind: payload.ScopeKind,
+		ScopeID:   payload.ScopeID,
 	})
 }
 

--- a/internal/projectors/user_role.go
+++ b/internal/projectors/user_role.go
@@ -9,19 +9,28 @@ import (
 )
 
 // UserRoleAssignedPayload is the decoded shape of a UserRoleAssigned
-// event. Both fields are required — they're the (composite-key)
-// columns of the row this projector inserts.
+// event. UserID and RoleID are required — they're the
+// composite-key columns of the row this projector inserts.
+// ScopeKind and ScopeID are paired optional (server #7 S2): both
+// nil means an unscoped/global grant, both set means a scoped grant.
+// Half-set is rejected at decode time as defense-in-depth on top
+// of the DB CHECK constraint.
 type UserRoleAssignedPayload struct {
-	UserID     string `json:"user_id"`
-	RoleID     string `json:"role_id"`
-	AssignedBy string // populated from event.actor_id, not the JSON payload
+	UserID     string  `json:"user_id"`
+	RoleID     string  `json:"role_id"`
+	ScopeKind  *string `json:"scope_kind,omitempty"`
+	ScopeID    *string `json:"scope_id,omitempty"`
+	AssignedBy string  // populated from event.actor_id, not the JSON payload
 }
 
-// UserRoleRevokedPayload mirrors the assigned shape; same composite
-// key, same required-field semantics.
+// UserRoleRevokedPayload mirrors the assigned shape — same
+// composite-key requirements plus the optional scope tuple for the
+// 4-tuple revoke grammar (server #7 S5).
 type UserRoleRevokedPayload struct {
-	UserID string `json:"user_id"`
-	RoleID string `json:"role_id"`
+	UserID    string  `json:"user_id"`
+	RoleID    string  `json:"role_id"`
+	ScopeKind *string `json:"scope_kind,omitempty"`
+	ScopeID   *string `json:"scope_id,omitempty"`
 }
 
 // UserRoleAssignedFromEvent decodes UserRoleAssigned. Returns
@@ -43,6 +52,9 @@ func UserRoleAssignedFromEvent(e store.PersistedEvent) (UserRoleAssignedPayload,
 		return UserRoleAssignedPayload{}, fmt.Errorf("projector: UserRoleAssigned requires user_id")
 	case p.RoleID == "":
 		return UserRoleAssignedPayload{}, fmt.Errorf("projector: UserRoleAssigned requires role_id")
+	}
+	if err := validateScopePair(p.ScopeKind, p.ScopeID, "UserRoleAssigned"); err != nil {
+		return UserRoleAssignedPayload{}, err
 	}
 	p.AssignedBy = e.ActorID
 	return p, nil
@@ -67,5 +79,33 @@ func UserRoleRevokedFromEvent(e store.PersistedEvent) (UserRoleRevokedPayload, e
 	case p.RoleID == "":
 		return UserRoleRevokedPayload{}, fmt.Errorf("projector: UserRoleRevoked requires role_id")
 	}
+	if err := validateScopePair(p.ScopeKind, p.ScopeID, "UserRoleRevoked"); err != nil {
+		return UserRoleRevokedPayload{}, err
+	}
 	return p, nil
+}
+
+// validateScopePair enforces the paired-or-neither + known-kind
+// invariant on the (scope_kind, scope_id) tuple. Mirrors the DB
+// CHECK constraints from migration 010 so a misbehaving emit-site
+// can't slip a half-scoped event past the projector even if the
+// DB layer is bypassed (e.g. raw event-store inspection). Empty-
+// string scope values are treated as malformed: a present field
+// must carry a non-empty string. server #7 S2 T-S3.
+func validateScopePair(scopeKind, scopeID *string, eventName string) error {
+	switch {
+	case scopeKind == nil && scopeID == nil:
+		return nil // unscoped grant — backward-compatible shape
+	case scopeKind == nil && scopeID != nil:
+		return fmt.Errorf("projector: %s carries scope_id without scope_kind (paired-or-neither)", eventName)
+	case scopeKind != nil && scopeID == nil:
+		return fmt.Errorf("projector: %s carries scope_kind without scope_id (paired-or-neither)", eventName)
+	case *scopeKind == "":
+		return fmt.Errorf("projector: %s carries an empty scope_kind", eventName)
+	case *scopeID == "":
+		return fmt.Errorf("projector: %s carries an empty scope_id", eventName)
+	case *scopeKind != "device_group" && *scopeKind != "user_group":
+		return fmt.Errorf("projector: %s carries unknown scope_kind %q", eventName, *scopeKind)
+	}
+	return nil
 }

--- a/internal/projectors/user_role_listener.go
+++ b/internal/projectors/user_role_listener.go
@@ -49,6 +49,8 @@ func applyUserRoleAssigned(ctx context.Context, st *store.Store, logger *slog.Lo
 	if err := st.Queries().InsertUserRoleProjection(ctx, db.InsertUserRoleProjectionParams{
 		UserID:            payload.UserID,
 		RoleID:            payload.RoleID,
+		ScopeKind:         payload.ScopeKind,
+		ScopeID:           payload.ScopeID,
 		AssignedAt:        e.OccurredAt,
 		AssignedBy:        payload.AssignedBy,
 		ProjectionVersion: deref(e.SequenceNum),
@@ -72,8 +74,10 @@ func applyUserRoleRevoked(ctx context.Context, st *store.Store, logger *slog.Log
 		return
 	}
 	if err := st.Queries().DeleteUserRoleProjection(ctx, db.DeleteUserRoleProjectionParams{
-		UserID: payload.UserID,
-		RoleID: payload.RoleID,
+		UserID:    payload.UserID,
+		RoleID:    payload.RoleID,
+		ScopeKind: payload.ScopeKind,
+		ScopeID:   payload.ScopeID,
 	}); err != nil {
 		logger.Warn("user_role projector: failed to delete user_roles_projection row",
 			"event_id", e.ID,

--- a/internal/projectors/user_role_test.go
+++ b/internal/projectors/user_role_test.go
@@ -260,3 +260,585 @@ func TestUserRoleListener_IgnoresWrongStreamType(t *testing.T) {
 func dbUserHasRoleParams(userID, roleID string) db.UserHasRoleParams {
 	return db.UserHasRoleParams{UserID: userID, RoleID: roleID}
 }
+
+// =============================================================================
+// server #7 S2 — scope decoding + projector wiring (T-S3 / T-S4).
+//
+// Tests pin the (scope_kind, scope_id) contract end-to-end:
+//   - both nil  → unscoped grant (backward-compat with pre-#7 events)
+//   - both set → scoped grant; values round-trip verbatim into the
+//                projection (T-S3 no-remapping invariant)
+//   - half-set → projector rejects at decode (T-S4 defense in depth
+//                on top of the DB CHECK)
+//   - unknown scope_kind → projector rejects
+//   - multiple scoped grants of (user, role) at different scopes
+//     coexist in the projection (the partial unique index allows it)
+// =============================================================================
+
+func TestUserRoleAssignedFromEvent_AcceptsScopedPayload(t *testing.T) {
+	got, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+		StreamType: "user_role",
+		EventType:  "UserRoleAssigned",
+		ActorID:    "actor-1",
+		Data: jsonOrFail(t, map[string]any{
+			"user_id":    "u",
+			"role_id":    "r",
+			"scope_kind": "device_group",
+			"scope_id":   "g1",
+		}),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, got.ScopeKind)
+	require.NotNil(t, got.ScopeID)
+	assert.Equal(t, "device_group", *got.ScopeKind)
+	assert.Equal(t, "g1", *got.ScopeID)
+}
+
+func TestUserRoleAssignedFromEvent_RejectsScopeKindWithoutScopeID(t *testing.T) {
+	_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+		StreamType: "user_role", EventType: "UserRoleAssigned",
+		Data: jsonOrFail(t, map[string]any{
+			"user_id":    "u",
+			"role_id":    "r",
+			"scope_kind": "device_group",
+		}),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope_id")
+}
+
+func TestUserRoleAssignedFromEvent_RejectsScopeIDWithoutScopeKind(t *testing.T) {
+	_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+		StreamType: "user_role", EventType: "UserRoleAssigned",
+		Data: jsonOrFail(t, map[string]any{
+			"user_id":  "u",
+			"role_id":  "r",
+			"scope_id": "g1",
+		}),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope_kind")
+}
+
+func TestUserRoleAssignedFromEvent_RejectsEmptyScopeStrings(t *testing.T) {
+	t.Run("empty scope_kind", func(t *testing.T) {
+		_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+			StreamType: "user_role", EventType: "UserRoleAssigned",
+			Data: jsonOrFail(t, map[string]any{
+				"user_id":    "u",
+				"role_id":    "r",
+				"scope_kind": "",
+				"scope_id":   "g1",
+			}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scope_kind")
+	})
+	t.Run("empty scope_id", func(t *testing.T) {
+		_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+			StreamType: "user_role", EventType: "UserRoleAssigned",
+			Data: jsonOrFail(t, map[string]any{
+				"user_id":    "u",
+				"role_id":    "r",
+				"scope_kind": "device_group",
+				"scope_id":   "",
+			}),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scope_id")
+	})
+}
+
+func TestUserRoleAssignedFromEvent_RejectsUnknownScopeKind(t *testing.T) {
+	_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+		StreamType: "user_role", EventType: "UserRoleAssigned",
+		Data: jsonOrFail(t, map[string]any{
+			"user_id":    "u",
+			"role_id":    "r",
+			"scope_kind": "garbage_kind",
+			"scope_id":   "g1",
+		}),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown scope_kind")
+}
+
+// TestUserRoleAssignedFromEvent_LegacyEventDecodesAsUnscoped pins
+// the backward-compat contract: an event JSON without scope keys
+// decodes to nil pointers (an unscoped grant).
+func TestUserRoleAssignedFromEvent_LegacyEventDecodesAsUnscoped(t *testing.T) {
+	got, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+		StreamType: "user_role",
+		EventType:  "UserRoleAssigned",
+		Data:       jsonOrFail(t, map[string]any{"user_id": "u", "role_id": "r"}),
+	})
+	require.NoError(t, err)
+	assert.Nil(t, got.ScopeKind)
+	assert.Nil(t, got.ScopeID)
+}
+
+// TestUserRoleListener_WritesScopeFields drives the full pipeline:
+// an UserRoleAssigned event with scope fields lands in the
+// projection with EXACTLY the emitted scope_kind + scope_id. T-S3
+// no-remapping invariant.
+func TestUserRoleListener_WritesScopeFields(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	roleID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	scopeID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data:      map[string]any{"name": "tmp", "permissions": []string{"x"}},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":" + scopeID,
+		EventType:  "UserRoleAssigned",
+		Data: map[string]any{
+			"user_id":    userID,
+			"role_id":    roleID,
+			"scope_kind": "device_group",
+			"scope_id":   scopeID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	var (
+		gotKind *string
+		gotID   *string
+	)
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		"SELECT scope_kind, scope_id FROM user_roles_projection WHERE user_id=$1 AND role_id=$2 AND scope_id=$3",
+		userID, roleID, scopeID,
+	).Scan(&gotKind, &gotID))
+	require.NotNil(t, gotKind)
+	require.NotNil(t, gotID)
+	assert.Equal(t, "device_group", *gotKind, "T-S3: projector must write exactly the event's scope_kind, no remapping")
+	assert.Equal(t, scopeID, *gotID, "T-S3: projector must write exactly the event's scope_id")
+}
+
+// TestUserRoleListener_UnscopedAndScopedGrantsCoexist proves that
+// the new partial-unique-index scheme lets ONE unscoped grant +
+// MULTIPLE scoped grants of the same (user, role) coexist in the
+// projection. The previous PK (user_id, role_id) would have made
+// this impossible.
+func TestUserRoleListener_UnscopedAndScopedGrantsCoexist(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	roleID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	scopeAID := testutil.NewID()
+	scopeBID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data:      map[string]any{"name": "tmp", "permissions": []string{"x"}},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Unscoped grant.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":global",
+		EventType:  "UserRoleAssigned",
+		Data: map[string]any{
+			"user_id": userID,
+			"role_id": roleID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	// Scoped grant A.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":" + scopeAID,
+		EventType:  "UserRoleAssigned",
+		Data: map[string]any{
+			"user_id":    userID,
+			"role_id":    roleID,
+			"scope_kind": "device_group",
+			"scope_id":   scopeAID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+	// Scoped grant B.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":" + scopeBID,
+		EventType:  "UserRoleAssigned",
+		Data: map[string]any{
+			"user_id":    userID,
+			"role_id":    roleID,
+			"scope_kind": "device_group",
+			"scope_id":   scopeBID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	var count int
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		"SELECT count(*) FROM user_roles_projection WHERE user_id=$1 AND role_id=$2",
+		userID, roleID,
+	).Scan(&count))
+	assert.Equal(t, 3, count, "one unscoped + two scoped grants must all coexist (partial unique indexes)")
+}
+
+// TestUserRoleListener_RevokeScoped_LeavesOtherScopesIntact pins
+// the 4-tuple revoke grammar (server #7 S5): revoking ONE scoped
+// grant leaves the other scoped grants and the unscoped grant
+// intact.
+func TestUserRoleListener_RevokeScoped_LeavesOtherScopesIntact(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	roleID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	scopeA := testutil.NewID()
+	scopeB := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data:      map[string]any{"name": "tmp", "permissions": []string{"x"}},
+		ActorType: "user", ActorID: "u",
+	}))
+	for _, e := range []map[string]any{
+		{"user_id": userID, "role_id": roleID},
+		{"user_id": userID, "role_id": roleID, "scope_kind": "device_group", "scope_id": scopeA},
+		{"user_id": userID, "role_id": roleID, "scope_kind": "device_group", "scope_id": scopeB},
+	} {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "user_role",
+			StreamID:   userID + ":" + roleID + ":mixed",
+			EventType:  "UserRoleAssigned",
+			Data:       e,
+			ActorType:  "user", ActorID: "u",
+		}))
+	}
+
+	// Revoke ONLY scope A.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":mixed",
+		EventType:  "UserRoleRevoked",
+		Data: map[string]any{
+			"user_id":    userID,
+			"role_id":    roleID,
+			"scope_kind": "device_group",
+			"scope_id":   scopeA,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// scope A gone, unscoped + scope B intact.
+	var remaining int
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		"SELECT count(*) FROM user_roles_projection WHERE user_id=$1 AND role_id=$2",
+		userID, roleID,
+	).Scan(&remaining))
+	assert.Equal(t, 2, remaining, "after revoking scope A, unscoped + scope B must remain")
+
+	var scopeAStillThere bool
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM user_roles_projection WHERE user_id=$1 AND role_id=$2 AND scope_id=$3)",
+		userID, roleID, scopeA,
+	).Scan(&scopeAStillThere))
+	assert.False(t, scopeAStillThere, "scope A grant must be gone")
+}
+
+// TestUserRoleListener_RevokeUnscoped_LeavesScopedIntact mirrors
+// the previous test for the reverse direction: revoking the
+// unscoped grant must not touch scoped grants. Tests the
+// IS NOT DISTINCT FROM NULL targeting.
+func TestUserRoleListener_RevokeUnscoped_LeavesScopedIntact(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	roleID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	scopeA := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data:      map[string]any{"name": "tmp", "permissions": []string{"x"}},
+		ActorType: "user", ActorID: "u",
+	}))
+	for _, e := range []map[string]any{
+		{"user_id": userID, "role_id": roleID},
+		{"user_id": userID, "role_id": roleID, "scope_kind": "device_group", "scope_id": scopeA},
+	} {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "user_role",
+			StreamID:   userID + ":" + roleID + ":mixed",
+			EventType:  "UserRoleAssigned",
+			Data:       e,
+			ActorType:  "user", ActorID: "u",
+		}))
+	}
+
+	// Revoke ONLY the unscoped grant (no scope fields).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":mixed",
+		EventType:  "UserRoleRevoked",
+		Data: map[string]any{
+			"user_id": userID,
+			"role_id": roleID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// scope A intact, unscoped gone.
+	var unscopedStillThere bool
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM user_roles_projection WHERE user_id=$1 AND role_id=$2 AND scope_id IS NULL)",
+		userID, roleID,
+	).Scan(&unscopedStillThere))
+	assert.False(t, unscopedStillThere, "unscoped grant must be gone after the unscoped revoke")
+
+	var scopedStillThere bool
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM user_roles_projection WHERE user_id=$1 AND role_id=$2 AND scope_id=$3)",
+		userID, roleID, scopeA,
+	).Scan(&scopedStillThere))
+	assert.True(t, scopedStillThere, "scoped grant must remain — unscoped revoke targets scope_id IS NULL specifically")
+}
+
+// =============================================================================
+// Schema-level CHECK constraints (migration 010).
+//
+// These tests hit the projection directly with raw SQL so the DB
+// constraint behaviour is pinned independent of the projector. T-S4
+// defense in depth: even if a future projector regression let
+// half-scoped data through, the DB CHECK still rejects.
+// =============================================================================
+
+func TestSchema_ScopeCheckConstraint_BothNull_Accepted(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	roleID := plantTestRole(t, st, ctx)
+
+	_, err := st.TestingPool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by, projection_version, scope_kind, scope_id) VALUES ($1, $2, NOW(), 'u', 0, NULL, NULL)",
+		userID, roleID,
+	)
+	require.NoError(t, err, "both-NULL must satisfy the paired-or-neither CHECK")
+}
+
+func TestSchema_ScopeCheckConstraint_BothSet_Accepted(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	roleID := plantTestRole(t, st, ctx)
+
+	_, err := st.TestingPool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by, projection_version, scope_kind, scope_id) VALUES ($1, $2, NOW(), 'u', 0, 'device_group', $3)",
+		userID, roleID, testutil.NewID(),
+	)
+	require.NoError(t, err, "both-set with a valid kind must satisfy both CHECKs")
+}
+
+func TestSchema_ScopeCheckConstraint_OnlyKind_Rejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	roleID := plantTestRole(t, st, ctx)
+
+	_, err := st.TestingPool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by, projection_version, scope_kind, scope_id) VALUES ($1, $2, NOW(), 'u', 0, 'device_group', NULL)",
+		userID, roleID,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user_roles_scope_pair_or_neither")
+}
+
+func TestSchema_ScopeCheckConstraint_OnlyID_Rejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	roleID := plantTestRole(t, st, ctx)
+
+	_, err := st.TestingPool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by, projection_version, scope_kind, scope_id) VALUES ($1, $2, NOW(), 'u', 0, NULL, $3)",
+		userID, roleID, testutil.NewID(),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user_roles_scope_pair_or_neither")
+}
+
+func TestSchema_ScopeKindValidConstraint_RejectsGarbage(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	roleID := plantTestRole(t, st, ctx)
+
+	_, err := st.TestingPool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by, projection_version, scope_kind, scope_id) VALUES ($1, $2, NOW(), 'u', 0, 'random_thing', $3)",
+		userID, roleID, testutil.NewID(),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user_roles_scope_kind_valid")
+}
+
+// TestSchema_UnscopedUniqueIndex_OneRowOnly pins the partial unique
+// index for unscoped grants: only ONE unscoped grant per
+// (user, role) pair is allowed.
+func TestSchema_UnscopedUniqueIndex_OneRowOnly(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	roleID := plantTestRole(t, st, ctx)
+
+	_, err := st.TestingPool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by, projection_version) VALUES ($1, $2, NOW(), 'u', 0)",
+		userID, roleID,
+	)
+	require.NoError(t, err)
+	_, err = st.TestingPool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, assigned_at, assigned_by, projection_version) VALUES ($1, $2, NOW(), 'u', 1)",
+		userID, roleID,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user_roles_unscoped_unique",
+		"the partial unique index must reject a second unscoped grant of (user, role)")
+}
+
+// TestSchema_ScopedUniqueIndex_OneRowPerScope pins the scoped
+// partial unique index: at most ONE row per (user, role, scope-tuple).
+func TestSchema_ScopedUniqueIndex_OneRowPerScope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	roleID := plantTestRole(t, st, ctx)
+	scopeID := testutil.NewID()
+
+	_, err := st.TestingPool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, scope_kind, scope_id, assigned_at, assigned_by, projection_version) VALUES ($1, $2, 'device_group', $3, NOW(), 'u', 0)",
+		userID, roleID, scopeID,
+	)
+	require.NoError(t, err)
+	_, err = st.TestingPool().Exec(ctx,
+		"INSERT INTO user_roles_projection (user_id, role_id, scope_kind, scope_id, assigned_at, assigned_by, projection_version) VALUES ($1, $2, 'device_group', $3, NOW(), 'u', 1)",
+		userID, roleID, scopeID,
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "user_roles_scoped_unique",
+		"the scoped partial unique index must reject a second grant of the same (user, role, scope) tuple")
+}
+
+// TestProjector_AcceptsExactlyKnownScopeKinds is the self-
+// discovering coverage guard: any new lowercase string kind added
+// to the DB CHECK constraint MUST also be accepted by the projector
+// validator (and vice versa). The two lists are kept in sync here.
+// A drift means a future kind value silently rejects at one layer
+// or the other.
+func TestProjector_AcceptsExactlyKnownScopeKinds(t *testing.T) {
+	knownAccepted := []string{"device_group", "user_group"}
+	knownRejected := []string{"", "unknown_kind", "device", "user", "Device_Group"}
+
+	require.NotEmpty(t, knownAccepted, "matches-zero guard: accepted-set must not be empty")
+	require.NotEmpty(t, knownRejected, "matches-zero guard: rejected-set must not be empty")
+
+	for _, kind := range knownAccepted {
+		t.Run("accept_"+kind, func(t *testing.T) {
+			_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+				StreamType: "user_role", EventType: "UserRoleAssigned",
+				Data: jsonOrFail(t, map[string]any{
+					"user_id":    "u",
+					"role_id":    "r",
+					"scope_kind": kind,
+					"scope_id":   "g1",
+				}),
+			})
+			require.NoError(t, err, "kind %q must be accepted (drift vs DB CHECK)", kind)
+		})
+	}
+	for _, kind := range knownRejected {
+		t.Run("reject_"+kind, func(t *testing.T) {
+			_, err := projectors.UserRoleAssignedFromEvent(store.PersistedEvent{
+				StreamType: "user_role", EventType: "UserRoleAssigned",
+				Data: jsonOrFail(t, map[string]any{
+					"user_id":    "u",
+					"role_id":    "r",
+					"scope_kind": kind,
+					"scope_id":   "g1",
+				}),
+			})
+			require.Error(t, err, "kind %q must be rejected (drift vs DB CHECK)", kind)
+		})
+	}
+}
+
+// TestUserGroupRoleListener_WritesScopeFields — symmetric with the
+// user_role version, covers the user-group → role projection.
+func TestUserGroupRoleListener_WritesScopeFields(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	groupID := testutil.NewID()
+	roleID := plantTestRole(t, st, ctx)
+	scopeID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_group", StreamID: groupID, EventType: "UserGroupCreated",
+		Data:      map[string]any{"name": "ug-" + groupID, "description": "x"},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_group",
+		StreamID:   groupID,
+		EventType:  "UserGroupRoleAssigned",
+		Data: map[string]any{
+			"group_id":   groupID,
+			"role_id":    roleID,
+			"scope_kind": "user_group",
+			"scope_id":   scopeID,
+		},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	var (
+		gotKind *string
+		gotID   *string
+	)
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		"SELECT scope_kind, scope_id FROM user_group_roles_projection WHERE group_id=$1 AND role_id=$2 AND scope_id=$3",
+		groupID, roleID, scopeID,
+	).Scan(&gotKind, &gotID))
+	require.NotNil(t, gotKind)
+	require.NotNil(t, gotID)
+	assert.Equal(t, "user_group", *gotKind)
+	assert.Equal(t, scopeID, *gotID)
+}
+
+func TestUserGroupRoleDecoder_RejectsPartialScope(t *testing.T) {
+	_, err := projectors.UserGroupRoleAssignedFromEvent(store.PersistedEvent{
+		StreamType: "user_group",
+		EventType:  "UserGroupRoleAssigned",
+		Data: jsonOrFail(t, map[string]any{
+			"group_id":   "g",
+			"role_id":    "r",
+			"scope_kind": "device_group",
+			// scope_id intentionally missing
+		}),
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "scope_id")
+}
+
+func plantTestRole(t *testing.T, st *store.Store, ctx context.Context) string {
+	t.Helper()
+	id := testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: id, EventType: "RoleCreated",
+		Data:      map[string]any{"name": "tmp-" + id, "permissions": []string{"x"}},
+		ActorType: "user", ActorID: "u",
+	}))
+	return id
+}

--- a/internal/store/generated/roles.sql.go
+++ b/internal/store/generated/roles.sql.go
@@ -36,18 +36,31 @@ const deleteUserRoleProjection = `-- name: DeleteUserRoleProjection :exec
 DELETE FROM user_roles_projection
 WHERE user_id = $1
   AND role_id = $2
+  AND scope_kind IS NOT DISTINCT FROM $3::TEXT
+  AND scope_id   IS NOT DISTINCT FROM $4::TEXT
 `
 
 type DeleteUserRoleProjectionParams struct {
-	UserID string `json:"user_id"`
-	RoleID string `json:"role_id"`
+	UserID    string  `json:"user_id"`
+	RoleID    string  `json:"role_id"`
+	ScopeKind *string `json:"scope_kind"`
+	ScopeID   *string `json:"scope_id"`
 }
 
-// UserRoleRevoked handler. Plain DELETE — silently no-op on a miss
-// matches the PL/pgSQL projector's behaviour under repeated revoke
-// events.
+// UserRoleRevoked handler — 4-tuple revoke grammar (server #7 S5).
+// IS NOT DISTINCT FROM gives NULL-aware equality: when the caller
+// passes NULL for both scope_kind and scope_id the WHERE matches
+// the row whose scope columns are also both NULL (the unscoped
+// grant); when the caller passes concrete values it targets the
+// specific scoped row. A miss is a silent no-op, matching the
+// prior projector behaviour.
 func (q *Queries) DeleteUserRoleProjection(ctx context.Context, arg DeleteUserRoleProjectionParams) error {
-	_, err := q.db.Exec(ctx, deleteUserRoleProjection, arg.UserID, arg.RoleID)
+	_, err := q.db.Exec(ctx, deleteUserRoleProjection,
+		arg.UserID,
+		arg.RoleID,
+		arg.ScopeKind,
+		arg.ScopeID,
+	)
 	return err
 }
 
@@ -210,9 +223,15 @@ func (q *Queries) InsertRoleProjection(ctx context.Context, arg InsertRoleProjec
 
 const insertUserRoleProjection = `-- name: InsertUserRoleProjection :exec
 INSERT INTO user_roles_projection (
-    user_id, role_id, assigned_at, assigned_by, projection_version
-) VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (user_id, role_id) DO NOTHING
+    user_id, role_id, scope_kind, scope_id,
+    assigned_at, assigned_by, projection_version
+) VALUES (
+    $1, $2,
+    $6::TEXT,
+    $7::TEXT,
+    $3, $4, $5
+)
+ON CONFLICT DO NOTHING
 `
 
 type InsertUserRoleProjectionParams struct {
@@ -221,11 +240,16 @@ type InsertUserRoleProjectionParams struct {
 	AssignedAt        time.Time `json:"assigned_at"`
 	AssignedBy        string    `json:"assigned_by"`
 	ProjectionVersion int64     `json:"projection_version"`
+	ScopeKind         *string   `json:"scope_kind"`
+	ScopeID           *string   `json:"scope_id"`
 }
 
-// UserRoleAssigned handler. ON CONFLICT (user_id, role_id) DO NOTHING
-// preserves the PL/pgSQL projector's idempotency under reconciler
-// replays.
+// UserRoleAssigned handler. Scope columns (scope_kind, scope_id)
+// are NULL together for unscoped grants and both set for scoped
+// grants (paired-or-neither, enforced by the DB CHECK as well as
+// the projector). ON CONFLICT DO NOTHING (no target) catches both
+// partial unique indexes — unscoped_unique and scoped_unique — so
+// a reconciler replay of either shape no-ops cleanly. server #7 S2.
 func (q *Queries) InsertUserRoleProjection(ctx context.Context, arg InsertUserRoleProjectionParams) error {
 	_, err := q.db.Exec(ctx, insertUserRoleProjection,
 		arg.UserID,
@@ -233,6 +257,8 @@ func (q *Queries) InsertUserRoleProjection(ctx context.Context, arg InsertUserRo
 		arg.AssignedAt,
 		arg.AssignedBy,
 		arg.ProjectionVersion,
+		arg.ScopeKind,
+		arg.ScopeID,
 	)
 	return err
 }

--- a/internal/store/generated/user_groups.sql.go
+++ b/internal/store/generated/user_groups.sql.go
@@ -192,17 +192,27 @@ const deleteUserGroupRole = `-- name: DeleteUserGroupRole :exec
 DELETE FROM user_group_roles_projection
 WHERE group_id = $1
   AND role_id = $2
+  AND scope_kind IS NOT DISTINCT FROM $3::TEXT
+  AND scope_id   IS NOT DISTINCT FROM $4::TEXT
 `
 
 type DeleteUserGroupRoleParams struct {
-	GroupID string `json:"group_id"`
-	RoleID  string `json:"role_id"`
+	GroupID   string  `json:"group_id"`
+	RoleID    string  `json:"role_id"`
+	ScopeKind *string `json:"scope_kind"`
+	ScopeID   *string `json:"scope_id"`
 }
 
-// UserGroupRoleRevoked handler. Plain DELETE — silently no-op on a
-// miss matches the PL/pgSQL projector's behaviour.
+// UserGroupRoleRevoked handler — 4-tuple revoke grammar.
+// IS NOT DISTINCT FROM gives NULL-aware equality. See
+// DeleteUserRoleProjection for the dispatch contract.
 func (q *Queries) DeleteUserGroupRole(ctx context.Context, arg DeleteUserGroupRoleParams) error {
-	_, err := q.db.Exec(ctx, deleteUserGroupRole, arg.GroupID, arg.RoleID)
+	_, err := q.db.Exec(ctx, deleteUserGroupRole,
+		arg.GroupID,
+		arg.RoleID,
+		arg.ScopeKind,
+		arg.ScopeID,
+	)
 	return err
 }
 
@@ -487,9 +497,15 @@ func (q *Queries) InsertUserGroupProjection(ctx context.Context, arg InsertUserG
 
 const insertUserGroupRole = `-- name: InsertUserGroupRole :exec
 INSERT INTO user_group_roles_projection (
-    group_id, role_id, assigned_at, assigned_by, projection_version
-) VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (group_id, role_id) DO NOTHING
+    group_id, role_id, scope_kind, scope_id,
+    assigned_at, assigned_by, projection_version
+) VALUES (
+    $1, $2,
+    $6::TEXT,
+    $7::TEXT,
+    $3, $4, $5
+)
+ON CONFLICT DO NOTHING
 `
 
 type InsertUserGroupRoleParams struct {
@@ -498,12 +514,13 @@ type InsertUserGroupRoleParams struct {
 	AssignedAt        time.Time `json:"assigned_at"`
 	AssignedBy        string    `json:"assigned_by"`
 	ProjectionVersion int64     `json:"projection_version"`
+	ScopeKind         *string   `json:"scope_kind"`
+	ScopeID           *string   `json:"scope_id"`
 }
 
-// UserGroupRoleAssigned handler. ON CONFLICT DO NOTHING preserves the
-// PL/pgSQL projector's idempotency under reconciler replays. The
-// composite PK (group_id, role_id) makes this safe. No parent-row
-// update — role assignments are independent of member_count.
+// UserGroupRoleAssigned handler. Scope-aware shape symmetric with
+// InsertUserRoleProjection — see that query for the paired-or-
+// neither + ON CONFLICT semantics. server #7 S2.
 func (q *Queries) InsertUserGroupRole(ctx context.Context, arg InsertUserGroupRoleParams) error {
 	_, err := q.db.Exec(ctx, insertUserGroupRole,
 		arg.GroupID,
@@ -511,6 +528,8 @@ func (q *Queries) InsertUserGroupRole(ctx context.Context, arg InsertUserGroupRo
 		arg.AssignedAt,
 		arg.AssignedBy,
 		arg.ProjectionVersion,
+		arg.ScopeKind,
+		arg.ScopeID,
 	)
 	return err
 }

--- a/internal/store/migrations/010_role_grant_scope_7.sql
+++ b/internal/store/migrations/010_role_grant_scope_7.sql
@@ -1,0 +1,173 @@
+-- manchtools/power-manage-server#7 S2 — scope columns on the
+-- role-grant projections.
+--
+-- Adds (scope_kind, scope_id) to user_roles_projection and
+-- user_group_roles_projection. Paired-or-neither: both NULL means an
+-- unscoped/global grant (backward-compatible with every pre-#7
+-- row), both set means the grant is constrained to the named
+-- group's members. The CHECK constraints enforce the invariant at
+-- the DB layer so a misbehaving projector (or a crafted event)
+-- can't write a half-scoped row.
+--
+-- Uniqueness model:
+--   * Drop the existing 2-tuple primary key (user_id, role_id) and
+--     replace it with two PARTIAL UNIQUE indexes:
+--       - one (user_id, role_id) WHERE scope_id IS NULL    — at
+--         most ONE unscoped grant per (user, role).
+--       - one (user_id, role_id, scope_kind, scope_id) WHERE
+--         scope_id IS NOT NULL — at most one scoped grant per
+--         (user, role, scope-tuple).
+--   * Symmetric shape for user_group_roles_projection.
+--
+-- Why partial indexes (not a single 4-column UNIQUE): NULLs are
+-- treated as distinct in PostgreSQL <15 ordinary unique indexes, so
+-- a single 4-column unique would let multiple unscoped grants
+-- coexist for the same (user, role). NULLS NOT DISTINCT (pg ≥ 15)
+-- would also work but the partial-index shape is portable across
+-- versions.
+--
+-- Index for scope-targeted queries (the reconciler in S6 reads
+-- scoped grants by (scope_kind, scope_id) to compute per-scope
+-- cohorts): a separate btree index on the scope tuple, filtered to
+-- rows with a scope set.
+--
+-- +goose Up
+-- +goose StatementBegin
+DO $$
+BEGIN
+    -- =========================================================
+    -- user_roles_projection
+    -- =========================================================
+    ALTER TABLE public.user_roles_projection
+        ADD COLUMN scope_kind TEXT NULL,
+        ADD COLUMN scope_id   TEXT NULL;
+
+    ALTER TABLE public.user_roles_projection
+        ADD CONSTRAINT user_roles_scope_pair_or_neither
+        CHECK ((scope_kind IS NULL) = (scope_id IS NULL));
+
+    ALTER TABLE public.user_roles_projection
+        ADD CONSTRAINT user_roles_scope_kind_valid
+        CHECK (
+            scope_kind IS NULL
+            OR scope_kind IN ('device_group', 'user_group')
+        );
+
+    -- Swap the primary key for the two partial unique indexes.
+    ALTER TABLE public.user_roles_projection
+        DROP CONSTRAINT user_roles_projection_pkey;
+
+    CREATE UNIQUE INDEX user_roles_unscoped_unique
+        ON public.user_roles_projection (user_id, role_id)
+        WHERE scope_id IS NULL;
+
+    CREATE UNIQUE INDEX user_roles_scoped_unique
+        ON public.user_roles_projection (user_id, role_id, scope_kind, scope_id)
+        WHERE scope_id IS NOT NULL;
+
+    -- Reconciler/lookup index for scoped grants only.
+    CREATE INDEX user_roles_scope_lookup
+        ON public.user_roles_projection (scope_kind, scope_id)
+        WHERE scope_id IS NOT NULL;
+
+    -- =========================================================
+    -- user_group_roles_projection — symmetric shape
+    -- =========================================================
+    ALTER TABLE public.user_group_roles_projection
+        ADD COLUMN scope_kind TEXT NULL,
+        ADD COLUMN scope_id   TEXT NULL;
+
+    ALTER TABLE public.user_group_roles_projection
+        ADD CONSTRAINT user_group_roles_scope_pair_or_neither
+        CHECK ((scope_kind IS NULL) = (scope_id IS NULL));
+
+    ALTER TABLE public.user_group_roles_projection
+        ADD CONSTRAINT user_group_roles_scope_kind_valid
+        CHECK (
+            scope_kind IS NULL
+            OR scope_kind IN ('device_group', 'user_group')
+        );
+
+    ALTER TABLE public.user_group_roles_projection
+        DROP CONSTRAINT user_group_roles_projection_pkey;
+
+    CREATE UNIQUE INDEX user_group_roles_unscoped_unique
+        ON public.user_group_roles_projection (group_id, role_id)
+        WHERE scope_id IS NULL;
+
+    CREATE UNIQUE INDEX user_group_roles_scoped_unique
+        ON public.user_group_roles_projection (group_id, role_id, scope_kind, scope_id)
+        WHERE scope_id IS NOT NULL;
+
+    CREATE INDEX user_group_roles_scope_lookup
+        ON public.user_group_roles_projection (scope_kind, scope_id)
+        WHERE scope_id IS NOT NULL;
+END $$;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    -- Drop the new indexes + constraints, then restore the original
+    -- 2-tuple primary keys. Any rows holding a scope tuple are
+    -- collapsed back to the unscoped shape (scope columns dropped).
+    -- A scoped grant + the original PK aren't compatible (two scoped
+    -- grants of the same (user, role) at different scopes), so the
+    -- down here is necessarily lossy for any actor who held more
+    -- than one scoped grant of the same (user, role) at downgrade
+    -- time — acceptable because the up shape is the new product
+    -- behaviour and downgrade is an emergency operation.
+
+    -- =========================================================
+    -- user_group_roles_projection
+    -- =========================================================
+    DROP INDEX IF EXISTS public.user_group_roles_scope_lookup;
+    DROP INDEX IF EXISTS public.user_group_roles_scoped_unique;
+    DROP INDEX IF EXISTS public.user_group_roles_unscoped_unique;
+
+    ALTER TABLE public.user_group_roles_projection
+        DROP CONSTRAINT IF EXISTS user_group_roles_scope_pair_or_neither,
+        DROP CONSTRAINT IF EXISTS user_group_roles_scope_kind_valid;
+
+    -- Collapse duplicates so the 2-tuple PK fits.
+    DELETE FROM public.user_group_roles_projection a
+    USING public.user_group_roles_projection b
+    WHERE  a.group_id = b.group_id
+      AND  a.role_id  = b.role_id
+      AND  a.ctid     > b.ctid;
+
+    ALTER TABLE public.user_group_roles_projection
+        DROP COLUMN IF EXISTS scope_kind,
+        DROP COLUMN IF EXISTS scope_id;
+
+    ALTER TABLE public.user_group_roles_projection
+        ADD CONSTRAINT user_group_roles_projection_pkey
+        PRIMARY KEY (group_id, role_id);
+
+    -- =========================================================
+    -- user_roles_projection
+    -- =========================================================
+    DROP INDEX IF EXISTS public.user_roles_scope_lookup;
+    DROP INDEX IF EXISTS public.user_roles_scoped_unique;
+    DROP INDEX IF EXISTS public.user_roles_unscoped_unique;
+
+    ALTER TABLE public.user_roles_projection
+        DROP CONSTRAINT IF EXISTS user_roles_scope_pair_or_neither,
+        DROP CONSTRAINT IF EXISTS user_roles_scope_kind_valid;
+
+    DELETE FROM public.user_roles_projection a
+    USING public.user_roles_projection b
+    WHERE  a.user_id = b.user_id
+      AND  a.role_id = b.role_id
+      AND  a.ctid    > b.ctid;
+
+    ALTER TABLE public.user_roles_projection
+        DROP COLUMN IF EXISTS scope_kind,
+        DROP COLUMN IF EXISTS scope_id;
+
+    ALTER TABLE public.user_roles_projection
+        ADD CONSTRAINT user_roles_projection_pkey
+        PRIMARY KEY (user_id, role_id);
+END $$;
+-- +goose StatementEnd

--- a/internal/store/queries/roles.sql
+++ b/internal/store/queries/roles.sql
@@ -84,18 +84,33 @@ WHERE id = $1
 DELETE FROM user_roles_projection WHERE role_id = $1;
 
 -- name: InsertUserRoleProjection :exec
--- UserRoleAssigned handler. ON CONFLICT (user_id, role_id) DO NOTHING
--- preserves the PL/pgSQL projector's idempotency under reconciler
--- replays.
+-- UserRoleAssigned handler. Scope columns (scope_kind, scope_id)
+-- are NULL together for unscoped grants and both set for scoped
+-- grants (paired-or-neither, enforced by the DB CHECK as well as
+-- the projector). ON CONFLICT DO NOTHING (no target) catches both
+-- partial unique indexes — unscoped_unique and scoped_unique — so
+-- a reconciler replay of either shape no-ops cleanly. server #7 S2.
 INSERT INTO user_roles_projection (
-    user_id, role_id, assigned_at, assigned_by, projection_version
-) VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (user_id, role_id) DO NOTHING;
+    user_id, role_id, scope_kind, scope_id,
+    assigned_at, assigned_by, projection_version
+) VALUES (
+    $1, $2,
+    sqlc.narg('scope_kind')::TEXT,
+    sqlc.narg('scope_id')::TEXT,
+    $3, $4, $5
+)
+ON CONFLICT DO NOTHING;
 
 -- name: DeleteUserRoleProjection :exec
--- UserRoleRevoked handler. Plain DELETE — silently no-op on a miss
--- matches the PL/pgSQL projector's behaviour under repeated revoke
--- events.
+-- UserRoleRevoked handler — 4-tuple revoke grammar (server #7 S5).
+-- IS NOT DISTINCT FROM gives NULL-aware equality: when the caller
+-- passes NULL for both scope_kind and scope_id the WHERE matches
+-- the row whose scope columns are also both NULL (the unscoped
+-- grant); when the caller passes concrete values it targets the
+-- specific scoped row. A miss is a silent no-op, matching the
+-- prior projector behaviour.
 DELETE FROM user_roles_projection
 WHERE user_id = $1
-  AND role_id = $2;
+  AND role_id = $2
+  AND scope_kind IS NOT DISTINCT FROM sqlc.narg('scope_kind')::TEXT
+  AND scope_id   IS NOT DISTINCT FROM sqlc.narg('scope_id')::TEXT;

--- a/internal/store/queries/user_groups.sql
+++ b/internal/store/queries/user_groups.sql
@@ -367,18 +367,26 @@ WHERE group_id = $1
   AND user_id = $2;
 
 -- name: InsertUserGroupRole :exec
--- UserGroupRoleAssigned handler. ON CONFLICT DO NOTHING preserves the
--- PL/pgSQL projector's idempotency under reconciler replays. The
--- composite PK (group_id, role_id) makes this safe. No parent-row
--- update — role assignments are independent of member_count.
+-- UserGroupRoleAssigned handler. Scope-aware shape symmetric with
+-- InsertUserRoleProjection — see that query for the paired-or-
+-- neither + ON CONFLICT semantics. server #7 S2.
 INSERT INTO user_group_roles_projection (
-    group_id, role_id, assigned_at, assigned_by, projection_version
-) VALUES ($1, $2, $3, $4, $5)
-ON CONFLICT (group_id, role_id) DO NOTHING;
+    group_id, role_id, scope_kind, scope_id,
+    assigned_at, assigned_by, projection_version
+) VALUES (
+    $1, $2,
+    sqlc.narg('scope_kind')::TEXT,
+    sqlc.narg('scope_id')::TEXT,
+    $3, $4, $5
+)
+ON CONFLICT DO NOTHING;
 
 -- name: DeleteUserGroupRole :exec
--- UserGroupRoleRevoked handler. Plain DELETE — silently no-op on a
--- miss matches the PL/pgSQL projector's behaviour.
+-- UserGroupRoleRevoked handler — 4-tuple revoke grammar.
+-- IS NOT DISTINCT FROM gives NULL-aware equality. See
+-- DeleteUserRoleProjection for the dispatch contract.
 DELETE FROM user_group_roles_projection
 WHERE group_id = $1
-  AND role_id = $2;
+  AND role_id = $2
+  AND scope_kind IS NOT DISTINCT FROM sqlc.narg('scope_kind')::TEXT
+  AND scope_id   IS NOT DISTINCT FROM sqlc.narg('scope_id')::TEXT;


### PR DESCRIPTION
## Summary

Second slice of manchtools/power-manage-server#7 — schema, event payloads, and projector wiring for the (scope_kind, scope_id) tuple on role grants. Purely additive plumbing: every existing grant projects as unscoped, and the new tuple is opt-in. Handler consumers land in S5.

- **Migration 010**: nullable `scope_kind` + `scope_id` on `user_roles_projection` + `user_group_roles_projection`. Paired-or-neither CHECK constraint, scope_kind value-set CHECK. The 2-tuple PKs are replaced by two partial unique indexes (one for `scope_id IS NULL`, one for `scope_id IS NOT NULL`) so one unscoped + many scoped grants of the same (user, role) coexist. Reconciler-lookup btree index on (scope_kind, scope_id).
- **Payloads**: `UserRoleAssigned`/`UserRoleRevoked` and `UserGroupRoleAssigned`/`UserGroupRoleRevoked` gain optional `ScopeKind` + `ScopeID` pointer fields with `omitempty`. Legacy events (no scope keys) decode to nil pointers (unscoped).
- **Projectors**: Decoders enforce paired-or-neither + known-kind at decode time via a shared `validateScopePair` helper (defense in depth on top of the DB CHECK). Listeners pass the tuple through to sqlc params.
- **sqlc**: Insert queries take nullable scope params and use bare `ON CONFLICT DO NOTHING` to catch both partial unique indexes. Delete queries use `IS NOT DISTINCT FROM` for NULL-aware 4-tuple revoke targeting.
- **Generated code edited manually for the four changed queries only** — avoids the wholesale sqlc-regen rewrite from `project_rebuildall_vs_go_projector_bug`.

## Test plan

- [x] `go vet ./...` + `gofmt -l .` clean.
- [x] `internal/eventtypes/payloads` + `internal/projectors` test sweep green (112s testcontainer Postgres). ~20 new tests:
  - Payload round-trip with/without scope, omitempty contract, legacy-event-decodes-as-unscoped backward-compat for both UserRole and UserGroupRole.
  - Projector decoder: accepts scoped payload, rejects partial scope (kind-only / id-only), rejects empty scope strings, rejects unknown scope_kind.
  - Projector listener writes scope_kind + scope_id verbatim into the projection (T-S3 no-remapping).
  - Multiple scoped grants of (user, role) at different scopes coexist with one unscoped grant.
  - 4-tuple revoke targets ONE scoped grant; leaves other scopes + unscoped grant intact. Inverse case (unscoped revoke leaves scoped intact).
  - Raw-SQL schema tests pin each CHECK branch (both NULL, both set, kind-only, id-only, garbage kind) plus the two partial unique indexes.
  - Self-discovering "accepted scope_kind set must match DB CHECK" with matches-zero guard.
- [x] Local `cr review`: no findings.

## Follow-ups (S2b onward)

S2b — JWT `ScopedGrants` claim + `UserRepo.ScopedGrants` + `EnforceDeviceScope`/`EnforceUserScope`/`DeviceScopeFilterFor`/`UserScopeFilterFor` helpers. S5 — `AssignRoleTo*` / `RevokeRoleFrom*` accept and validate the scope tuple end-to-end.

Closes part of manchtools/power-manage-server#7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Roles can now be assigned and revoked with optional scope context, enabling role grants within specific device groups or user groups
  * Multiple scoped and unscoped role grants can coexist for the same user or group
  * Full backward compatibility with legacy role events lacking scope information

* **Tests**
  * Added comprehensive test coverage for scoped role operations, validation rules, and database constraints
  * Added schema validation tests for uniqueness and scope pair constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->