### PR TITLE
feat: #7 S2b — scope resolution + enforcement primitives (JWT sgrants, Enforce*/Filter* helpers)

### DIFF
--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -93,13 +93,17 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 		}), nil
 	}
 
-	// Resolve permissions from DB and embed in JWT
+	// Resolve permissions + scoped grants from DB and embed in JWT
 	permissions, err := h.store.Repos().User.Permissions(ctx, user.ID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve permissions")
 	}
+	scopedGrants, err := resolveScopedGrants(ctx, h.store.Repos().User, user.ID)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve scoped grants")
+	}
 
-	tokens, err := h.jwtManager.GenerateTokens(user.ID, user.Email, permissions, user.SessionVersion)
+	tokens, err := h.jwtManager.GenerateTokens(user.ID, user.Email, permissions, scopedGrants, user.SessionVersion)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to generate tokens")
 	}
@@ -195,9 +199,13 @@ func (h *AuthHandler) RefreshToken(ctx context.Context, req *connect.Request[pm.
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve permissions")
 	}
+	scopedGrants, err := resolveScopedGrants(ctx, h.store.Repos().User, result.Claims.UserID)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve scoped grants")
+	}
 
-	// Generate new token pair with fresh permissions
-	tokens, err := h.jwtManager.GenerateTokens(result.Claims.UserID, result.Claims.Email, permissions, result.Claims.SessionVersion)
+	// Generate new token pair with fresh permissions + scoped grants
+	tokens, err := h.jwtManager.GenerateTokens(result.Claims.UserID, result.Claims.Email, permissions, scopedGrants, result.Claims.SessionVersion)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to generate tokens")
 	}
@@ -258,4 +266,20 @@ func (h *AuthHandler) GetCurrentUser(ctx context.Context, req *connect.Request[p
 	return connect.NewResponse(&pm.GetCurrentUserResponse{
 		User: protoUser,
 	}), nil
+}
+
+// resolveScopedGrants resolves the user's (permission, scope) grants and
+// maps them to the auth-layer ScopedGrant shape embedded in the JWT
+// `sgrants` claim. Empty result (no scoped grants) is fine — the claim
+// is omitempty, so an unscoped user's token is unchanged (#7 S2b).
+func resolveScopedGrants(ctx context.Context, users store.UserRepo, userID string) ([]auth.ScopedGrant, error) {
+	grants, err := users.ScopedGrants(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]auth.ScopedGrant, len(grants))
+	for i, g := range grants {
+		out[i] = auth.ScopedGrant{Permission: g.Permission, ScopeKind: g.ScopeKind, ScopeID: g.ScopeID}
+	}
+	return out, nil
 }

--- a/internal/api/control_boundary_test.go
+++ b/internal/api/control_boundary_test.go
@@ -66,7 +66,7 @@ func newControlRPCFixture(t *testing.T) *controlRPCFixture {
 	t.Cleanup(srv.Close)
 
 	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
-	tokens, err := jwtManager.GenerateTokens(userID, "admin@example.com", auth.AdminPermissions(), 0)
+	tokens, err := jwtManager.GenerateTokens(userID, "admin@example.com", auth.AdminPermissions(), nil, 0)
 	require.NoError(t, err)
 
 	return &controlRPCFixture{
@@ -92,7 +92,7 @@ func TestControlRPCBoundaryValidationRejectsInvalidRequestBeforeHandler(t *testi
 
 func TestControlRPCBoundaryAuthzStillRunsAfterValidation(t *testing.T) {
 	f := newControlRPCFixture(t)
-	limited, err := f.jwtManager.GenerateTokens("user-no-device-list", "limited@example.com", []string{"GetCurrentUser"}, 0)
+	limited, err := f.jwtManager.GenerateTokens("user-no-device-list", "limited@example.com", []string{"GetCurrentUser"}, nil, 0)
 	require.NoError(t, err)
 
 	req := connect.NewRequest(&pm.ListDevicesRequest{PageSize: 1})

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -434,8 +434,12 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve permissions")
 	}
+	scopedGrants, err := resolveScopedGrants(ctx, h.store.Repos().User, user.ID)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve scoped grants")
+	}
 
-	tokens, err := h.jwtManager.GenerateTokens(user.ID, user.Email, permissions, user.SessionVersion)
+	tokens, err := h.jwtManager.GenerateTokens(user.ID, user.Email, permissions, scopedGrants, user.SessionVersion)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to generate tokens")
 	}

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -466,13 +466,17 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 		return nil, apiErrorCtx(ctx, ErrTokenExpired, connect.CodeUnauthenticated, "session invalidated, please log in again")
 	}
 
-	// Resolve permissions and generate real tokens
+	// Resolve permissions + scoped grants and generate real tokens
 	permissions, err := h.store.Repos().User.Permissions(ctx, claims.UserID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve permissions")
 	}
+	scopedGrants, err := resolveScopedGrants(ctx, h.store.Repos().User, claims.UserID)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve scoped grants")
+	}
 
-	tokens, err := h.jwtManager.GenerateTokens(claims.UserID, claims.Email, permissions, claims.SessionVersion)
+	tokens, err := h.jwtManager.GenerateTokens(claims.UserID, claims.Email, permissions, scopedGrants, claims.SessionVersion)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to generate tokens")
 	}

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -19,6 +19,7 @@ type UserContext struct {
 	ID             string
 	Email          string
 	Permissions    []string
+	ScopedGrants   []ScopedGrant
 	SessionVersion int32
 }
 

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -358,11 +358,12 @@ func (i *AuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			return nil, authErrorCtx(ctx, errNotAuthenticated, connect.CodeUnauthenticated, "invalid token")
 		}
 
-		// Add user context with permissions from JWT
+		// Add user context with permissions + scoped grants from JWT
 		userCtx := &UserContext{
 			ID:             claims.UserID,
 			Email:          claims.Email,
 			Permissions:    claims.Permissions,
+			ScopedGrants:   claims.ScopedGrants,
 			SessionVersion: claims.SessionVersion,
 		}
 		ctx = WithUser(ctx, userCtx)

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -156,7 +156,7 @@ func setupInterceptorTest(t *testing.T) (string, *JWTManager) {
 func TestAuthInterceptor_BearerTokenAccepted(t *testing.T) {
 	serverURL, jwtMgr := setupInterceptorTest(t)
 
-	tokens, err := jwtMgr.GenerateTokens("user123", "test@example.com", []string{"GetUser"}, 1)
+	tokens, err := jwtMgr.GenerateTokens("user123", "test@example.com", []string{"GetUser"}, nil, 1)
 	require.NoError(t, err)
 
 	client := connect.NewClient[emptypb.Empty, emptypb.Empty](
@@ -217,7 +217,7 @@ func TestAuthInterceptor_InvalidToken(t *testing.T) {
 func TestAuthInterceptor_CookieNoLongerAccepted(t *testing.T) {
 	serverURL, jwtMgr := setupInterceptorTest(t)
 
-	tokens, err := jwtMgr.GenerateTokens("user123", "test@example.com", []string{"GetUser"}, 1)
+	tokens, err := jwtMgr.GenerateTokens("user123", "test@example.com", []string{"GetUser"}, nil, 1)
 	require.NoError(t, err)
 
 	client := connect.NewClient[emptypb.Empty, emptypb.Empty](
@@ -288,7 +288,7 @@ func TestAuthInterceptor_ExpiredToken(t *testing.T) {
 		AccessTokenExpiry: -1 * time.Second, // Already expired
 	})
 
-	tokens, err := expiredMgr.GenerateTokens("user123", "test@example.com", []string{"GetUser"}, 1)
+	tokens, err := expiredMgr.GenerateTokens("user123", "test@example.com", []string{"GetUser"}, nil, 1)
 	require.NoError(t, err)
 
 	serverURL, _ := setupInterceptorTest(t)
@@ -317,7 +317,7 @@ func TestAuthInterceptor_WrongSecret(t *testing.T) {
 		Secret:            []byte("other-secret-key"),
 		AccessTokenExpiry: 15 * time.Minute,
 	})
-	tokens, err := otherMgr.GenerateTokens("user123", "test@example.com", []string{"GetUser"}, 1)
+	tokens, err := otherMgr.GenerateTokens("user123", "test@example.com", []string{"GetUser"}, nil, 1)
 	require.NoError(t, err)
 
 	serverURL, _ := setupInterceptorTest(t)
@@ -461,7 +461,7 @@ func setupAlternativesInterceptorTest(t *testing.T) (string, *JWTManager) {
 
 func TestAuthzInterceptor_AlternativesPath_StaticAltOnly_Accepts(t *testing.T) {
 	serverURL, jwtMgr := setupAlternativesInterceptorTest(t)
-	tokens, err := jwtMgr.GenerateTokens("u1", "alice@test", []string{"CreateStaticDeviceGroup"}, 1)
+	tokens, err := jwtMgr.GenerateTokens("u1", "alice@test", []string{"CreateStaticDeviceGroup"}, nil, 1)
 	require.NoError(t, err)
 
 	client := connect.NewClient[emptypb.Empty, emptypb.Empty](
@@ -477,7 +477,7 @@ func TestAuthzInterceptor_AlternativesPath_StaticAltOnly_Accepts(t *testing.T) {
 
 func TestAuthzInterceptor_AlternativesPath_DynamicAltOnly_Accepts(t *testing.T) {
 	serverURL, jwtMgr := setupAlternativesInterceptorTest(t)
-	tokens, err := jwtMgr.GenerateTokens("u1", "alice@test", []string{"CreateDynamicDeviceGroup"}, 1)
+	tokens, err := jwtMgr.GenerateTokens("u1", "alice@test", []string{"CreateDynamicDeviceGroup"}, nil, 1)
 	require.NoError(t, err)
 
 	client := connect.NewClient[emptypb.Empty, emptypb.Empty](
@@ -504,7 +504,7 @@ func TestAuthzInterceptor_AlternativesPath_NeitherAltHeld_Denied(t *testing.T) {
 		// A grab-bag of unrelated perms — none satisfy the split.
 		"GetUser", "ListUsers", "GetDevice", "ListDevices",
 		"CreateAction", "RebuildSearchIndex",
-	}, 1)
+	}, nil, 1)
 	require.NoError(t, err)
 
 	client := connect.NewClient[emptypb.Empty, emptypb.Empty](
@@ -531,7 +531,7 @@ func TestAuthzInterceptor_AlternativesPath_LegacyKeyAlone_Denied(t *testing.T) {
 	// Mint a token claiming the legacy "CreateDeviceGroup" perm —
 	// not registered post-#7, but a forged or stale token might
 	// carry it.
-	tokens, err := jwtMgr.GenerateTokens("u1", "alice@test", []string{"CreateDeviceGroup"}, 1)
+	tokens, err := jwtMgr.GenerateTokens("u1", "alice@test", []string{"CreateDeviceGroup"}, nil, 1)
 	require.NoError(t, err)
 
 	client := connect.NewClient[emptypb.Empty, emptypb.Empty](

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -23,11 +23,12 @@ const (
 // Claims represents the JWT claims for user authentication.
 type Claims struct {
 	jwt.RegisteredClaims
-	UserID         string    `json:"uid"`
-	Email          string    `json:"email"`
-	Permissions    []string  `json:"perms,omitempty"`
-	TokenType      TokenType `json:"type"`
-	SessionVersion int32     `json:"sv,omitempty"`
+	UserID         string        `json:"uid"`
+	Email          string        `json:"email"`
+	Permissions    []string      `json:"perms,omitempty"`
+	ScopedGrants   []ScopedGrant `json:"sgrants,omitempty"`
+	TokenType      TokenType     `json:"type"`
+	SessionVersion int32         `json:"sv,omitempty"`
 }
 
 // JWTConfig holds JWT configuration.
@@ -79,8 +80,9 @@ type TokenPair struct {
 }
 
 // GenerateTokens creates a new access/refresh token pair.
-// Permissions are only embedded in the access token, not the refresh token.
-func (m *JWTManager) GenerateTokens(userID, email string, permissions []string, sessionVersion int32) (*TokenPair, error) {
+// Permissions and scoped grants are only embedded in the access token,
+// not the refresh token.
+func (m *JWTManager) GenerateTokens(userID, email string, permissions []string, scopedGrants []ScopedGrant, sessionVersion int32) (*TokenPair, error) {
 	now := time.Now()
 	accessExpiry := now.Add(m.config.AccessTokenExpiry)
 	entropy := ulid.Monotonic(rand.Reader, 0)
@@ -97,6 +99,7 @@ func (m *JWTManager) GenerateTokens(userID, email string, permissions []string, 
 		UserID:         userID,
 		Email:          email,
 		Permissions:    permissions,
+		ScopedGrants:   scopedGrants,
 		TokenType:      TokenTypeAccess,
 		SessionVersion: sessionVersion,
 	}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -1,12 +1,26 @@
 package auth
 
 import (
+	"encoding/base64"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// decodeJWTPayload base64url-decodes the claims segment of a JWT so a
+// test can assert on the raw wire shape (e.g. an omitempty claim's
+// absence), not just the parsed struct.
+func decodeJWTPayload(t *testing.T, token string) string {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	return string(payload)
+}
 
 func newTestJWTManager() *JWTManager {
 	return NewJWTManager(JWTConfig{
@@ -31,7 +45,7 @@ func TestNewJWTManager_Defaults(t *testing.T) {
 func TestGenerateTokens(t *testing.T) {
 	m := newTestJWTManager()
 
-	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices", "GetUser:self"}, 0)
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices", "GetUser:self"}, nil, 0)
 	require.NoError(t, err)
 
 	assert.NotEmpty(t, pair.AccessToken)
@@ -45,7 +59,7 @@ func TestValidateToken_Access(t *testing.T) {
 	m := newTestJWTManager()
 
 	perms := []string{"ListDevices", "GetUser:self"}
-	pair, err := m.GenerateTokens("user-1", "a@b.com", perms, 5)
+	pair, err := m.GenerateTokens("user-1", "a@b.com", perms, nil, 5)
 	require.NoError(t, err)
 
 	claims, err := m.ValidateToken(pair.AccessToken, TokenTypeAccess)
@@ -61,10 +75,55 @@ func TestValidateToken_Access(t *testing.T) {
 	assert.NotEmpty(t, claims.ID)
 }
 
+func TestValidateToken_ScopedGrantsRoundTrip(t *testing.T) {
+	m := newTestJWTManager()
+
+	grants := []ScopedGrant{
+		{Permission: "StartTerminal"}, // global
+		{Permission: "StartTerminal", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"}, // scoped
+		{Permission: "GetUser", ScopeKind: ScopeKindUserGroup, ScopeID: "ug2"},
+	}
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"StartTerminal", "GetUser"}, grants, 0)
+	require.NoError(t, err)
+
+	claims, err := m.ValidateToken(pair.AccessToken, TokenTypeAccess)
+	require.NoError(t, err)
+	assert.Equal(t, grants, claims.ScopedGrants, "scoped grants must round-trip through the access token")
+}
+
+// An unscoped user (no scoped grants) gets a token with the claim
+// omitted entirely — backward compatible with pre-#7 tokens.
+func TestValidateToken_NoScopedGrantsOmitsClaim(t *testing.T) {
+	m := newTestJWTManager()
+
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, nil, 0)
+	require.NoError(t, err)
+	assert.NotContains(t, decodeJWTPayload(t, pair.AccessToken), "sgrants",
+		"the sgrants claim must be omitted when there are no scoped grants")
+
+	claims, err := m.ValidateToken(pair.AccessToken, TokenTypeAccess)
+	require.NoError(t, err)
+	assert.Nil(t, claims.ScopedGrants)
+}
+
+// Scoped grants, like permissions, must NOT be embedded in the refresh
+// token.
+func TestValidateToken_RefreshHasNoScopedGrants(t *testing.T) {
+	m := newTestJWTManager()
+
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"StartTerminal"},
+		[]ScopedGrant{{Permission: "StartTerminal", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"}}, 0)
+	require.NoError(t, err)
+
+	claims, err := m.ValidateToken(pair.RefreshToken, TokenTypeRefresh)
+	require.NoError(t, err)
+	assert.Nil(t, claims.ScopedGrants, "refresh token must not carry scoped grants")
+}
+
 func TestValidateToken_RefreshHasNoPermissions(t *testing.T) {
 	m := newTestJWTManager()
 
-	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, 0)
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, nil, 0)
 	require.NoError(t, err)
 
 	claims, err := m.ValidateToken(pair.RefreshToken, TokenTypeRefresh)
@@ -78,7 +137,7 @@ func TestValidateToken_RefreshHasNoPermissions(t *testing.T) {
 func TestValidateToken_WrongType(t *testing.T) {
 	m := newTestJWTManager()
 
-	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, 0)
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, nil, 0)
 	require.NoError(t, err)
 
 	// Access token validated as refresh should fail
@@ -96,7 +155,7 @@ func TestValidateToken_WrongSecret(t *testing.T) {
 	m1 := newTestJWTManager()
 	m2 := NewJWTManager(JWTConfig{Secret: []byte("different-secret")})
 
-	pair, err := m1.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, 0)
+	pair, err := m1.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, nil, 0)
 	require.NoError(t, err)
 
 	_, err = m2.ValidateToken(pair.AccessToken, TokenTypeAccess)
@@ -110,7 +169,7 @@ func TestValidateToken_Expired(t *testing.T) {
 		RefreshTokenExpiry: 1 * time.Millisecond,
 	})
 
-	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, 0)
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, nil, 0)
 	require.NoError(t, err)
 
 	time.Sleep(10 * time.Millisecond)
@@ -132,7 +191,7 @@ func TestValidateToken_Garbage(t *testing.T) {
 func TestValidateRefreshToken_Success(t *testing.T) {
 	m := newTestJWTManager()
 
-	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, 3)
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, nil, 3)
 	require.NoError(t, err)
 
 	neverRevoked := func(jti string) (bool, error) { return false, nil }
@@ -149,7 +208,7 @@ func TestValidateRefreshToken_Success(t *testing.T) {
 func TestValidateRefreshToken_Revoked(t *testing.T) {
 	m := newTestJWTManager()
 
-	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, 0)
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, nil, 0)
 	require.NoError(t, err)
 
 	alwaysRevoked := func(jti string) (bool, error) { return true, nil }
@@ -162,7 +221,7 @@ func TestValidateRefreshToken_Revoked(t *testing.T) {
 func TestValidateRefreshToken_WithAccessToken(t *testing.T) {
 	m := newTestJWTManager()
 
-	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, 0)
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, nil, 0)
 	require.NoError(t, err)
 
 	neverRevoked := func(jti string) (bool, error) { return false, nil }
@@ -174,7 +233,7 @@ func TestValidateRefreshToken_WithAccessToken(t *testing.T) {
 func TestValidateRefreshToken_NilCallback(t *testing.T) {
 	m := newTestJWTManager()
 
-	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, 0)
+	pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, nil, 0)
 	require.NoError(t, err)
 
 	result, err := m.ValidateRefreshToken(pair.RefreshToken, nil)
@@ -187,7 +246,7 @@ func TestGenerateTokens_UniqueJTIs(t *testing.T) {
 
 	jtis := make(map[string]bool)
 	for i := 0; i < 10; i++ {
-		pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, 0)
+		pair, err := m.GenerateTokens("user-1", "a@b.com", []string{"ListDevices"}, nil, 0)
 		require.NoError(t, err)
 
 		accessClaims, err := m.ValidateToken(pair.AccessToken, TokenTypeAccess)

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+)
+
+// Scope kinds. A grant carries at most one. Empty = unscoped (global).
+const (
+	ScopeKindDeviceGroup = "device_group"
+	ScopeKindUserGroup   = "user_group"
+)
+
+// ScopedGrant is one (permission, scope) tuple the caller holds.
+// ScopeKind/ScopeID are empty together for an unscoped (global) grant.
+// When set, ScopeKind is ScopeKindDeviceGroup or ScopeKindUserGroup and
+// ScopeID is the group's id. The permission is constrained to that
+// scope. Carried in the JWT `sgrants` claim and the UserContext (#7).
+type ScopedGrant struct {
+	Permission string `json:"p"`
+	ScopeKind  string `json:"k,omitempty"`
+	ScopeID    string `json:"i,omitempty"`
+}
+
+// ScopeFilter describes how a permission is scoped for the caller, for
+// list/query narrowing. Global means the caller holds the permission
+// unscoped, so no row filtering applies. Otherwise GroupIDs is the set
+// of scope-group ids (device_group ids for device targets, user_group
+// ids for user targets) the caller is limited to; an empty GroupIDs
+// with Global=false means the caller holds the permission only via
+// irrelevant scopes (or not at all) and may see nothing.
+type ScopeFilter struct {
+	Global   bool
+	GroupIDs []string
+}
+
+// ScopeResolver answers group-membership questions the scope helpers
+// need. Implemented over the device-group / user-group projections at
+// the call site; kept as an interface so the helpers stay free
+// functions (mirroring EnforceSelfScope) and are unit-testable with a
+// fake.
+type ScopeResolver interface {
+	// DeviceGroupsForDevice returns the ids of every device group the
+	// device belongs to (static + dynamic-materialized).
+	DeviceGroupsForDevice(ctx context.Context, deviceID string) ([]string, error)
+	// UserGroupsForUser returns the ids of every user group the user
+	// belongs to.
+	UserGroupsForUser(ctx context.Context, userID string) ([]string, error)
+}
+
+// scopeFilterFor reduces the caller's scoped grants for `permission` to
+// a ScopeFilter, considering only grants whose ScopeKind matches
+// wantKind (the kind relevant to the target type) plus unscoped grants.
+// A grant of `permission` under a different scope kind grants no access
+// to this target type and is therefore ignored.
+func scopeFilterFor(ctx context.Context, permission, wantKind string) ScopeFilter {
+	user, ok := UserFromContext(ctx)
+	if !ok {
+		return ScopeFilter{}
+	}
+	var groupIDs []string
+	for _, g := range user.ScopedGrants {
+		if g.Permission != permission {
+			continue
+		}
+		if g.ScopeKind == "" {
+			// An unscoped grant of the permission is fleet-wide.
+			return ScopeFilter{Global: true}
+		}
+		if g.ScopeKind == wantKind {
+			groupIDs = append(groupIDs, g.ScopeID)
+		}
+	}
+	return ScopeFilter{Global: false, GroupIDs: groupIDs}
+}
+
+// DeviceScopeFilterFor returns the device-group scoping for a
+// device-target permission. Global=true ⇒ no device narrowing;
+// otherwise restrict device queries to GroupIDs.
+func DeviceScopeFilterFor(ctx context.Context, permission string) ScopeFilter {
+	return scopeFilterFor(ctx, permission, ScopeKindDeviceGroup)
+}
+
+// UserScopeFilterFor returns the user-group scoping for a user-target
+// permission. Global=true ⇒ no user narrowing; otherwise restrict user
+// queries to GroupIDs.
+func UserScopeFilterFor(ctx context.Context, permission string) ScopeFilter {
+	return scopeFilterFor(ctx, permission, ScopeKindUserGroup)
+}
+
+// EnforceDeviceScope authorizes a device-target action. It allows when
+// the caller holds `permission` unscoped (global) OR scoped to a device
+// group that contains deviceID; otherwise it denies. Self-contained:
+// when the caller holds no relevant grant for `permission` (including
+// holding it only via a user_group scope, which grants no device
+// access), it denies.
+func EnforceDeviceScope(ctx context.Context, resolver ScopeResolver, permission, deviceID string) error {
+	if _, ok := UserFromContext(ctx); !ok {
+		return connect.NewError(connect.CodeUnauthenticated, errors.New("not authenticated"))
+	}
+	f := DeviceScopeFilterFor(ctx, permission)
+	if f.Global {
+		return nil
+	}
+	if len(f.GroupIDs) == 0 {
+		return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+	}
+	deviceGroups, err := resolver.DeviceGroupsForDevice(ctx, deviceID)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, errors.New("scope resolution failed"))
+	}
+	if intersects(f.GroupIDs, deviceGroups) {
+		return nil
+	}
+	return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+}
+
+// EnforceUserScope authorizes a user-target action. It allows when the
+// caller holds `permission` unscoped OR scoped to a user group that
+// contains targetUserID; otherwise it denies.
+func EnforceUserScope(ctx context.Context, resolver ScopeResolver, permission, targetUserID string) error {
+	if _, ok := UserFromContext(ctx); !ok {
+		return connect.NewError(connect.CodeUnauthenticated, errors.New("not authenticated"))
+	}
+	f := UserScopeFilterFor(ctx, permission)
+	if f.Global {
+		return nil
+	}
+	if len(f.GroupIDs) == 0 {
+		return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+	}
+	userGroups, err := resolver.UserGroupsForUser(ctx, targetUserID)
+	if err != nil {
+		return connect.NewError(connect.CodeInternal, errors.New("scope resolution failed"))
+	}
+	if intersects(f.GroupIDs, userGroups) {
+		return nil
+	}
+	return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+}
+
+// intersects reports whether a and b share any element.
+func intersects(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, x := range a {
+		set[x] = struct{}{}
+	}
+	for _, y := range b {
+		if _, ok := set[y]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/auth/scope_test.go
+++ b/internal/auth/scope_test.go
@@ -1,0 +1,166 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeResolver answers membership from in-memory maps and can be forced
+// to error.
+type fakeResolver struct {
+	deviceGroups map[string][]string // deviceID -> group ids
+	userGroups   map[string][]string // userID -> group ids
+	err          error
+}
+
+func (f *fakeResolver) DeviceGroupsForDevice(_ context.Context, deviceID string) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.deviceGroups[deviceID], nil
+}
+
+func (f *fakeResolver) UserGroupsForUser(_ context.Context, userID string) ([]string, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.userGroups[userID], nil
+}
+
+func ctxWithGrants(grants ...ScopedGrant) context.Context {
+	return WithUser(context.Background(), &UserContext{ID: "caller", ScopedGrants: grants})
+}
+
+func codeOf(err error) connect.Code {
+	return connect.CodeOf(err)
+}
+
+func TestDeviceScopeFilterFor(t *testing.T) {
+	t.Run("unscoped grant is global", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p"})
+		f := DeviceScopeFilterFor(ctx, "p")
+		assert.True(t, f.Global)
+		assert.Empty(t, f.GroupIDs)
+	})
+
+	t.Run("device_group grants collect their group ids", func(t *testing.T) {
+		ctx := ctxWithGrants(
+			ScopedGrant{Permission: "p", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"},
+			ScopedGrant{Permission: "p", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg2"},
+		)
+		f := DeviceScopeFilterFor(ctx, "p")
+		assert.False(t, f.Global)
+		assert.ElementsMatch(t, []string{"dg1", "dg2"}, f.GroupIDs)
+	})
+
+	t.Run("any unscoped grant wins over scoped ones (global)", func(t *testing.T) {
+		ctx := ctxWithGrants(
+			ScopedGrant{Permission: "p", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"},
+			ScopedGrant{Permission: "p"},
+		)
+		assert.True(t, DeviceScopeFilterFor(ctx, "p").Global)
+	})
+
+	t.Run("a user_group-scoped grant of a device permission grants no device access", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		f := DeviceScopeFilterFor(ctx, "p")
+		assert.False(t, f.Global)
+		assert.Empty(t, f.GroupIDs, "cross-kind scope must be ignored for device targets")
+	})
+
+	t.Run("a different permission's scope does not leak", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "other", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		f := DeviceScopeFilterFor(ctx, "p")
+		assert.False(t, f.Global)
+		assert.Empty(t, f.GroupIDs)
+	})
+}
+
+func TestEnforceDeviceScope(t *testing.T) {
+	res := &fakeResolver{deviceGroups: map[string][]string{
+		"devA": {"dg1", "dg9"},
+		"devB": {"dg2"},
+	}}
+
+	t.Run("unauthenticated", func(t *testing.T) {
+		err := EnforceDeviceScope(context.Background(), res, "p", "devA")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnauthenticated, codeOf(err))
+	})
+
+	t.Run("global grant allows any device", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p"})
+		assert.NoError(t, EnforceDeviceScope(ctx, res, "p", "devA"))
+		assert.NoError(t, EnforceDeviceScope(ctx, res, "p", "devB"))
+	})
+
+	t.Run("device inside a scoped group is allowed", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		assert.NoError(t, EnforceDeviceScope(ctx, res, "p", "devA"))
+	})
+
+	t.Run("device outside the scoped group is denied", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		err := EnforceDeviceScope(ctx, res, "p", "devB")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("permission held only via user_group scope is denied for devices", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		err := EnforceDeviceScope(ctx, res, "p", "devA")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("no grant for the permission is denied", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "other"})
+		err := EnforceDeviceScope(ctx, res, "p", "devA")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("resolver error surfaces as internal, not allow", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		boom := &fakeResolver{err: errors.New("db down")}
+		err := EnforceDeviceScope(ctx, boom, "p", "devA")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInternal, codeOf(err))
+	})
+}
+
+func TestEnforceUserScope(t *testing.T) {
+	res := &fakeResolver{userGroups: map[string][]string{
+		"userX": {"ug1"},
+		"userY": {"ug2"},
+	}}
+
+	t.Run("global grant allows any user target", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p"})
+		assert.NoError(t, EnforceUserScope(ctx, res, "p", "userX"))
+	})
+
+	t.Run("target user inside a scoped user-group is allowed", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		assert.NoError(t, EnforceUserScope(ctx, res, "p", "userX"))
+	})
+
+	t.Run("target user outside the scoped user-group is denied", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		err := EnforceUserScope(ctx, res, "p", "userY")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("a device_group-scoped grant grants no user access", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "p", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		err := EnforceUserScope(ctx, res, "p", "userX")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+}

--- a/internal/projectors/scoped_grants_resolution_test.go
+++ b/internal/projectors/scoped_grants_resolution_test.go
@@ -1,0 +1,170 @@
+package projectors_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// plantRoleWithPerms creates a role granting the given permissions and
+// returns its id.
+func plantRoleWithPerms(t *testing.T, st *store.Store, ctx context.Context, perms ...string) string {
+	t.Helper()
+	id := testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: id, EventType: "RoleCreated",
+		Data:      map[string]any{"name": "role-" + id, "permissions": perms},
+		ActorType: "user", ActorID: "u",
+	}))
+	return id
+}
+
+func assignUserRole(t *testing.T, st *store.Store, ctx context.Context, userID, roleID string, scope map[string]any) {
+	t.Helper()
+	data := map[string]any{"user_id": userID, "role_id": roleID}
+	for k, v := range scope {
+		data[k] = v
+	}
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role", StreamID: userID + ":" + roleID + scopeSuffix(scope),
+		EventType: "UserRoleAssigned", Data: data, ActorType: "user", ActorID: "u",
+	}))
+}
+
+func scopeSuffix(scope map[string]any) string {
+	if id, ok := scope["scope_id"].(string); ok {
+		return ":" + id
+	}
+	return ""
+}
+
+// grantKey renders a (permission, scope) tuple for set comparison.
+func grantKey(g store.ScopedGrant) string {
+	return g.Permission + "|" + g.ScopeKind + "|" + g.ScopeID
+}
+
+func grantKeys(grants []store.ScopedGrant) map[string]bool {
+	out := make(map[string]bool, len(grants))
+	for _, g := range grants {
+		out[grantKey(g)] = true
+	}
+	return out
+}
+
+// countPerm counts grants for a specific permission, so assertions are
+// robust against any unrelated grants the test-user factory plants.
+func countPerm(grants []store.ScopedGrant, perm string) int {
+	n := 0
+	for _, g := range grants {
+		if g.Permission == perm {
+			n++
+		}
+	}
+	return n
+}
+
+// TestScopedGrantsResolution exercises User.ScopedGrants — the
+// hand-maintained GetUserScopedGrants query that drives the JWT sgrants
+// claim (#7 S2b). One container, a user per scenario.
+func TestScopedGrantsResolution(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	t.Run("direct unscoped grant has empty scope", func(t *testing.T) {
+		uid := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pw", "user")
+		role := plantRoleWithPerms(t, st, ctx, "perm.a", "perm.b")
+		assignUserRole(t, st, ctx, uid, role, nil)
+
+		grants, err := st.Repos().User.ScopedGrants(ctx, uid)
+		require.NoError(t, err)
+		keys := grantKeys(grants)
+		assert.True(t, keys["perm.a||"], "unscoped grant must carry empty scope")
+		assert.True(t, keys["perm.b||"])
+		assert.Equal(t, 1, countPerm(grants, "perm.a"))
+		assert.Equal(t, 1, countPerm(grants, "perm.b"))
+	})
+
+	t.Run("direct device_group-scoped grant carries the scope tuple", func(t *testing.T) {
+		uid := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pw", "user")
+		role := plantRoleWithPerms(t, st, ctx, "perm.c")
+		assignUserRole(t, st, ctx, uid, role, map[string]any{"scope_kind": "device_group", "scope_id": "dg-1"})
+
+		grants, err := st.Repos().User.ScopedGrants(ctx, uid)
+		require.NoError(t, err)
+		require.Equal(t, 1, countPerm(grants, "perm.c"))
+		assert.Contains(t, grants, store.ScopedGrant{Permission: "perm.c", ScopeKind: "device_group", ScopeID: "dg-1"})
+	})
+
+	t.Run("grant inherited via user-group membership is resolved with its scope", func(t *testing.T) {
+		uid := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pw", "user")
+		role := plantRoleWithPerms(t, st, ctx, "perm.d")
+		gid := testutil.NewID()
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "user_group", StreamID: gid, EventType: "UserGroupCreated",
+			Data: map[string]any{"name": "ug-" + gid, "description": "x"}, ActorType: "user", ActorID: "u",
+		}))
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "user_group", StreamID: gid, EventType: "UserGroupMemberAdded",
+			Data: map[string]any{"group_id": gid, "user_id": uid}, ActorType: "user", ActorID: "u",
+		}))
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "user_group", StreamID: gid, EventType: "UserGroupRoleAssigned",
+			Data:      map[string]any{"group_id": gid, "role_id": role, "scope_kind": "device_group", "scope_id": "dg-2"},
+			ActorType: "user", ActorID: "u",
+		}))
+
+		grants, err := st.Repos().User.ScopedGrants(ctx, uid)
+		require.NoError(t, err)
+		require.Equal(t, 1, countPerm(grants, "perm.d"))
+		assert.Contains(t, grants, store.ScopedGrant{Permission: "perm.d", ScopeKind: "device_group", ScopeID: "dg-2"})
+	})
+
+	t.Run("user_group scope kind is preserved", func(t *testing.T) {
+		uid := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pw", "user")
+		role := plantRoleWithPerms(t, st, ctx, "perm.e")
+		assignUserRole(t, st, ctx, uid, role, map[string]any{"scope_kind": "user_group", "scope_id": "ug-9"})
+
+		grants, err := st.Repos().User.ScopedGrants(ctx, uid)
+		require.NoError(t, err)
+		require.Equal(t, 1, countPerm(grants, "perm.e"))
+		assert.Contains(t, grants, store.ScopedGrant{Permission: "perm.e", ScopeKind: "user_group", ScopeID: "ug-9"})
+	})
+
+	t.Run("same permission at the same scope via two roles is deduped", func(t *testing.T) {
+		uid := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pw", "user")
+		r1 := plantRoleWithPerms(t, st, ctx, "perm.dup")
+		r2 := plantRoleWithPerms(t, st, ctx, "perm.dup")
+		assignUserRole(t, st, ctx, uid, r1, map[string]any{"scope_kind": "device_group", "scope_id": "dg-3"})
+		assignUserRole(t, st, ctx, uid, r2, map[string]any{"scope_kind": "device_group", "scope_id": "dg-3"})
+
+		grants, err := st.Repos().User.ScopedGrants(ctx, uid)
+		require.NoError(t, err)
+		assert.Equal(t, 1, countPerm(grants, "perm.dup"), "DISTINCT must collapse the same (permission, scope) from two roles")
+	})
+
+	t.Run("scoped and unscoped grants of the same permission coexist", func(t *testing.T) {
+		uid := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pw", "user")
+		role := plantRoleWithPerms(t, st, ctx, "perm.both")
+		assignUserRole(t, st, ctx, uid, role, nil)
+		assignUserRole(t, st, ctx, uid, role, map[string]any{"scope_kind": "device_group", "scope_id": "dg-4"})
+
+		grants, err := st.Repos().User.ScopedGrants(ctx, uid)
+		require.NoError(t, err)
+		keys := grantKeys(grants)
+		assert.True(t, keys["perm.both||"], "unscoped (global) grant present")
+		assert.True(t, keys["perm.both|device_group|dg-4"], "scoped grant present")
+		assert.Equal(t, 2, countPerm(grants, "perm.both"))
+	})
+
+	t.Run("no grants returns empty, not error", func(t *testing.T) {
+		uid := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pw", "user")
+		grants, err := st.Repos().User.ScopedGrants(ctx, uid)
+		require.NoError(t, err)
+		assert.Empty(t, grants)
+	})
+}

--- a/internal/store/generated/roles.sql.go
+++ b/internal/store/generated/roles.sql.go
@@ -147,6 +147,59 @@ func (q *Queries) GetUserPermissions(ctx context.Context, userID string) ([]stri
 	return items, nil
 }
 
+// NOTE: GetUserScopedGrants is HAND-MAINTAINED. sqlc cannot generate it
+// because migration 010 adds scope_kind/scope_id inside a `DO $$` block,
+// which sqlc's schema parser does not read, so it can't resolve those
+// columns as SELECT outputs (sqlc generate errors "column scope_kind
+// does not exist"). sqlc IS lenient on INSERT/DELETE column references
+// (the S2 hand-edited queries), but a SELECT output needs the column
+// type from the catalog. Keep this in sync with the GetUserScopedGrants
+// query in queries/roles.sql by hand. #7 S2b.
+const getUserScopedGrants = `-- name: GetUserScopedGrants :many
+SELECT grants.permission, grants.scope_kind, grants.scope_id FROM (
+    SELECT perm.permission::TEXT AS permission, ur.scope_kind, ur.scope_id
+    FROM roles_projection r
+    JOIN user_roles_projection ur ON ur.role_id = r.id
+    CROSS JOIN LATERAL unnest(r.permissions) AS perm(permission)
+    WHERE ur.user_id = $1 AND r.is_deleted = FALSE
+    UNION
+    SELECT perm.permission::TEXT AS permission, ugr.scope_kind, ugr.scope_id
+    FROM roles_projection r
+    JOIN user_group_roles_projection ugr ON ugr.role_id = r.id
+    JOIN user_group_members_projection ugm ON ugm.group_id = ugr.group_id
+    CROSS JOIN LATERAL unnest(r.permissions) AS perm(permission)
+    WHERE ugm.user_id = $1 AND r.is_deleted = FALSE
+) grants
+`
+
+// GetUserScopedGrantsRow is one (permission, scope) tuple. ScopeKind and
+// ScopeID are nil together for an unscoped (global) grant.
+type GetUserScopedGrantsRow struct {
+	Permission string  `json:"permission"`
+	ScopeKind  *string `json:"scope_kind"`
+	ScopeID    *string `json:"scope_id"`
+}
+
+func (q *Queries) GetUserScopedGrants(ctx context.Context, userID string) ([]GetUserScopedGrantsRow, error) {
+	rows, err := q.db.Query(ctx, getUserScopedGrants, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetUserScopedGrantsRow{}
+	for rows.Next() {
+		var i GetUserScopedGrantsRow
+		if err := rows.Scan(&i.Permission, &i.ScopeKind, &i.ScopeID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getUserRoles = `-- name: GetUserRoles :many
 SELECT r.id, r.name, r.description, r.permissions, r.is_system, r.created_at, r.created_by, r.updated_at, r.is_deleted, r.projection_version FROM roles_projection r
 JOIN user_roles_projection ur ON ur.role_id = r.id

--- a/internal/store/postgres/user.go
+++ b/internal/store/postgres/user.go
@@ -67,6 +67,33 @@ func (u *User) Permissions(ctx context.Context, userID string) ([]string, error)
 	return perms, nil
 }
 
+func (u *User) ScopedGrants(ctx context.Context, userID string) ([]store.ScopedGrant, error) {
+	rows, err := u.q.GetUserScopedGrants(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("user: scoped grants: %w", err)
+	}
+	grants := make([]store.ScopedGrant, len(rows))
+	for i, r := range rows {
+		grants[i] = store.ScopedGrant{
+			Permission: r.Permission,
+			ScopeKind:  derefString(r.ScopeKind),
+			ScopeID:    derefString(r.ScopeID),
+		}
+	}
+	return grants, nil
+}
+
+// derefString returns the pointed-to string, or "" when the pointer is
+// nil. The scope columns are nullable TEXT (NULL = unscoped/global), and
+// the store contract represents that as an empty string rather than a
+// pointer.
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
 func (u *User) NextLinuxUID(ctx context.Context) (int32, error) {
 	uid, err := u.q.GetNextLinuxUID(ctx)
 	if err != nil {

--- a/internal/store/queries/roles.sql
+++ b/internal/store/queries/roles.sql
@@ -21,6 +21,30 @@ SELECT DISTINCT unnest(r.permissions)::TEXT AS permission FROM roles_projection 
 JOIN user_roles_projection ur ON ur.role_id = r.id
 WHERE ur.user_id = $1 AND r.is_deleted = FALSE;
 
+-- name: GetUserScopedGrants :many
+-- Returns every (permission, scope) tuple the user holds — from direct
+-- role grants AND grants inherited via user-group membership — carrying
+-- the grant's (scope_kind, scope_id). Both are NULL for an unscoped
+-- (global) grant. DISTINCT collapses the same permission held at the
+-- same scope via multiple roles. Drives the JWT `sgrants` claim and the
+-- scope-enforcement primitives (#7 S2b). The cascade is a property of
+-- the GRANT: every permission a grant materializes inherits the grant's
+-- scope.
+SELECT grants.permission, grants.scope_kind, grants.scope_id FROM (
+    SELECT perm.permission::TEXT AS permission, ur.scope_kind, ur.scope_id
+    FROM roles_projection r
+    JOIN user_roles_projection ur ON ur.role_id = r.id
+    CROSS JOIN LATERAL unnest(r.permissions) AS perm(permission)
+    WHERE ur.user_id = $1 AND r.is_deleted = FALSE
+    UNION
+    SELECT perm.permission::TEXT AS permission, ugr.scope_kind, ugr.scope_id
+    FROM roles_projection r
+    JOIN user_group_roles_projection ugr ON ugr.role_id = r.id
+    JOIN user_group_members_projection ugm ON ugm.group_id = ugr.group_id
+    CROSS JOIN LATERAL unnest(r.permissions) AS perm(permission)
+    WHERE ugm.user_id = $1 AND r.is_deleted = FALSE
+) grants;
+
 -- name: CountUsersWithRole :one
 SELECT count(*) FROM user_roles_projection WHERE role_id = $1;
 

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -69,6 +69,16 @@ type ListUsersFilter struct {
 	Offset int32
 }
 
+// ScopedGrant is one (permission, scope) tuple a user holds. ScopeKind
+// and ScopeID are empty together for an unscoped (global) grant; when
+// set, ScopeKind is one of "device_group" / "user_group" and ScopeID is
+// the group's id. The permission is constrained to that scope (#7 S2b).
+type ScopedGrant struct {
+	Permission string
+	ScopeKind  string
+	ScopeID    string
+}
+
 // UserRepo reads user-projection state. Writes flow through events
 // (UserCreated / UserUpdated / UserDeleted / UserPasswordChanged /
 // UserDisabled / etc.) — there are no Set / Update / Delete methods
@@ -90,6 +100,15 @@ type UserRepo interface {
 	// user, combining direct role permissions with permissions
 	// inherited from user_group memberships.
 	Permissions(ctx context.Context, userID string) ([]string, error)
+
+	// ScopedGrants returns every (permission, scope) tuple the user
+	// holds — from direct role grants AND grants inherited via
+	// user-group membership — carrying each grant's scope. A grant with
+	// no scope (ScopeKind/ScopeID empty) is global. The cascade is a
+	// property of the GRANT: every permission a grant materializes
+	// inherits the grant's scope. Drives the JWT `sgrants` claim and the
+	// auth scope-enforcement primitives (#7 S2b).
+	ScopedGrants(ctx context.Context, userID string) ([]ScopedGrant, error)
 
 	// NextLinuxUID returns the next available Linux UID for new
 	// user provisioning. The underlying query is a SERIAL-style


### PR DESCRIPTION
Third slice of manchtools/power-manage-server#7 — the scope **resolution + enforcement primitives** S5's handlers will consume. Purely additive: no existing handler changes its behavior, and an unscoped user's JWT is byte-identical to before. Builds on S2 (#334)'s `(scope_kind, scope_id)` columns.

## Store
- `UserRepo.ScopedGrants(ctx, userID)` + `GetUserScopedGrants`: unnests role permissions across **both** direct `user_role` grants and grants inherited via user-group membership, carrying each grant's `(scope_kind, scope_id)`. NULL scope = unscoped/global. `DISTINCT` collapses the same `(permission, scope)` from multiple roles. The cascade is a property of the grant — every permission a grant materializes inherits its scope.
- The generated method is **hand-maintained**: migration 010 adds the scope columns inside a `DO $$` block that sqlc's schema parser doesn't read, so it can't resolve them as SELECT outputs (sqlc is lenient on INSERT/DELETE column refs — why S2's writes generate — but a SELECT output needs the column type from the catalog). The `.sql` query is the source of truth; a `NOTE` in the generated file documents the sync contract.

## Auth primitives (gate-then-narrow)
- `ScopedGrant` / `ScopeFilter` types + `UserContext.ScopedGrants`.
- `ScopeResolver` interface (`DeviceGroupsForDevice` / `UserGroupsForUser`) so the `Enforce*` helpers stay free functions (like `EnforceSelfScope`) and unit-test with a fake.
- `DeviceScopeFilterFor` / `UserScopeFilterFor`: reduce the caller's grants for a permission to `{Global | GroupIDs}` for list/query narrowing. An unscoped grant ⇒ Global; a cross-kind scope (e.g. a `user_group` scope on a device permission) grants no access to that target type.
- `EnforceDeviceScope` / `EnforceUserScope`: allow when the permission is held unscoped OR scoped to a group containing the target; deny otherwise. Self-contained (no relevant grant ⇒ deny); resolver errors fail **closed** as `Internal`.

## JWT
- `Claims.ScopedGrants` (`sgrants`, omitempty), embedded in the **access** token only (like permissions); the interceptor populates `UserContext.ScopedGrants`. The 4 token-gen sites (login / refresh / TOTP / SSO) resolve and embed via a shared `resolveScopedGrants` helper. Omitempty ⇒ an unscoped user's token is unchanged (backward compatible).

## Tests
- Store (testcontainer): direct/unscoped, direct device_group-scoped, inherited-via-user-group, user_group kind, `DISTINCT` dedup, scoped+unscoped coexistence, empty case.
- Auth (unit): global / in-scope / out-of-scope / cross-kind / no-grant / resolver-error + the filter reductions.
- JWT: scoped grants round-trip the access token, the claim is omitted when empty, and the refresh token carries neither permissions nor scoped grants.
- `go vet ./...`, `gofmt`, full auth suite, and `internal/api` (562s testcontainer) green. Local CodeRabbit: no findings.

## Follow-ups
S5 — `AssignRoleTo*` / `RevokeRoleFrom*` accept and validate the scope tuple end-to-end, and per-device/-user handlers call these `Enforce*` helpers (the `ScopeResolver` is wired to the device-group/user-group projections at that point).

Closes part of manchtools/power-manage-server#7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced scoped permissions system enabling administrators to assign permissions limited to specific device groups or user groups, rather than globally to users.
  * Access tokens now carry scope information to enforce fine-grained authorization at runtime.

* **Improvements**
  * Authorization checks now validate both permission and scope boundaries during request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->