### PR TITLE
feat: #7 S5 — scope-aware role assignment + revocation (AssignRole/RevokeRole scope tuple, escalation prevention)

### DIFF
--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -442,8 +442,7 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 	} else {
 		// The targeted grant doesn't exist. If the role IS assigned at a
 		// different scope, the caller targeted the wrong grant — surface
-		// that rather than silently no-op (#7 S5). If nothing exists at
-		// all, fall through as an idempotent no-op.
+		// that rather than silently no-op (#7 S5).
 		hasAny, err := h.store.Repos().Role.UserHasRole(ctx, req.Msg.UserId, req.Msg.RoleId)
 		if err != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
@@ -452,9 +451,13 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 			return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeFailedPrecondition,
 				"role is not assigned at the specified scope (it is assigned at a different scope)")
 		}
+		// Nothing assigned anywhere — idempotent no-op: no event, and no
+		// session bump (nothing changed). Matches RevokeRoleFromUserGroup.
+		return connect.NewResponse(&pm.RevokeRoleFromUserResponse{}), nil
 	}
 
-	// Bump user's session version to invalidate cached permissions
+	// A grant was revoked — bump the user's session version to invalidate
+	// cached permissions.
 	if err := h.bumpUserSessionVersion(ctx, req.Msg.UserId, userCtx.ID); err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to invalidate user session after role revocation")
 	}

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -400,7 +400,10 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 	}
 
 	// Resolve the scope tuple identifying WHICH grant to revoke.
-	scopeKind := scopeKindString(req.Msg.ScopeKind)
+	scopeKind, ok := scopeKindString(req.Msg.ScopeKind)
+	if !ok {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "unknown scope_kind")
+	}
 	scopeID := req.Msg.ScopeId
 	if (scopeKind == "") != (scopeID == "") {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "scope_kind and scope_id must be set together")

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -294,10 +294,17 @@ func (h *RoleHandler) AssignRoleToUser(ctx context.Context, req *connect.Request
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
 
+	// Validate the optional grant scope (paired-or-neither, AssignRoleScope
+	// gate + escalation bound, group existence). Role-independent (#7 S5).
+	scopeKind, scopeID, err := validateAssignGrantScope(ctx, q, req.Msg.ScopeKind, req.Msg.ScopeId)
+	if err != nil {
+		return nil, err
+	}
+
 	assignedAny := false
 	for _, roleID := range roleIDs {
 		// Verify role exists
-		_, err = q.GetRoleByID(ctx, roleID)
+		role, err := q.GetRoleByID(ctx, roleID)
 		if err != nil {
 			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeNotFound, "role not found")
@@ -305,26 +312,44 @@ func (h *RoleHandler) AssignRoleToUser(ctx context.Context, req *connect.Request
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get role")
 		}
 
-		// Check if already assigned — skip silently in batch
-		hasRole, err := q.UserHasRole(ctx, db.UserHasRoleParams{
-			UserID: req.Msg.UserId,
-			RoleID: roleID,
-		})
-		if err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
-		}
-		if hasRole {
-			continue
+		// Every permission in a scoped grant's role must accept this
+		// scope kind (target_kind match) — a no-op for unscoped grants.
+		if err := rejectUnscopableRole(ctx, scopeKind, role.Permissions); err != nil {
+			return nil, err
 		}
 
+		// Unscoped grants are unique per (user, role) — skip a redundant
+		// re-assign. Scoped grants skip the pre-check: the projector's
+		// INSERT ... ON CONFLICT DO NOTHING (both partial unique indexes)
+		// makes a redundant scoped re-assign an idempotent no-op, and the
+		// 2-tuple UserHasRole can't distinguish scopes.
+		if scopeKind == "" {
+			hasRole, err := q.UserHasRole(ctx, db.UserHasRoleParams{
+				UserID: req.Msg.UserId,
+				RoleID: roleID,
+			})
+			if err != nil {
+				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
+			}
+			if hasRole {
+				continue
+			}
+		}
+
+		sk, si := scopePtrs(scopeKind, scopeID)
 		streamID := req.Msg.UserId + ":" + roleID
+		if scopeKind != "" {
+			streamID += ":" + scopeID
+		}
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "user_role",
 			StreamID:   streamID,
 			EventType:  string(eventtypes.UserRoleAssigned),
 			Data: payloads.UserRoleAssigned{
-				UserID: req.Msg.UserId,
-				RoleID: roleID,
+				UserID:    req.Msg.UserId,
+				RoleID:    roleID,
+				ScopeKind: sk,
+				ScopeID:   si,
 			},
 			ActorType: "user",
 			ActorID:   userCtx.ID,
@@ -374,26 +399,55 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 		return nil, err
 	}
 
-	// Check if the user currently has the role — skip the event on retry/idempotent call
-	hasRole, err := h.store.Repos().Role.UserHasRole(ctx, req.Msg.UserId, req.Msg.RoleId)
+	// Resolve the scope tuple identifying WHICH grant to revoke.
+	scopeKind := scopeKindString(req.Msg.ScopeKind)
+	scopeID := req.Msg.ScopeId
+	if (scopeKind == "") != (scopeID == "") {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "scope_kind and scope_id must be set together")
+	}
+	sk, si := scopePtrs(scopeKind, scopeID)
+
+	q := h.store.Queries()
+	// Does the SPECIFIC targeted grant exist?
+	hasScoped, err := q.UserHasScopedRole(ctx, db.UserHasScopedRoleParams{
+		UserID: req.Msg.UserId, RoleID: req.Msg.RoleId, ScopeKind: sk, ScopeID: si,
+	})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
 	}
 
-	if hasRole {
+	if hasScoped {
 		streamID := req.Msg.UserId + ":" + req.Msg.RoleId
+		if scopeKind != "" {
+			streamID += ":" + scopeID
+		}
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "user_role",
 			StreamID:   streamID,
 			EventType:  string(eventtypes.UserRoleRevoked),
 			Data: payloads.UserRoleRevoked{
-				UserID: req.Msg.UserId,
-				RoleID: req.Msg.RoleId,
+				UserID:    req.Msg.UserId,
+				RoleID:    req.Msg.RoleId,
+				ScopeKind: sk,
+				ScopeID:   si,
 			},
 			ActorType: "user",
 			ActorID:   userCtx.ID,
 		}, "failed to revoke role"); err != nil {
 			return nil, err
+		}
+	} else {
+		// The targeted grant doesn't exist. If the role IS assigned at a
+		// different scope, the caller targeted the wrong grant — surface
+		// that rather than silently no-op (#7 S5). If nothing exists at
+		// all, fall through as an idempotent no-op.
+		hasAny, err := h.store.Repos().Role.UserHasRole(ctx, req.Msg.UserId, req.Msg.RoleId)
+		if err != nil {
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
+		}
+		if hasAny {
+			return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeFailedPrecondition,
+				"role is not assigned at the specified scope (it is assigned at a different scope)")
 		}
 	}
 

--- a/internal/api/role_scope_handler_test.go
+++ b/internal/api/role_scope_handler_test.go
@@ -152,6 +152,54 @@ func TestAssignRoleToUser_ScopeLimitedAdminCannotGrantUnscoped(t *testing.T) {
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 }
 
+// An out-of-range / future scope_kind enum must fail closed as
+// InvalidArgument, never silently degrade to an unscoped (fleet-wide)
+// grant. Regression for CodeRabbit #337 finding 1.
+func TestAssignRoleToUser_UnknownScopeKindRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices"})
+
+	// An unknown enum value with no scope_id must NOT become an unscoped grant.
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: pm.RoleGrantScopeKind(99),
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	// No grant must have been created.
+	grants, gErr := st.Repos().User.ScopedGrants(context.Background(), target)
+	require.NoError(t, gErr)
+	for _, g := range grants {
+		assert.NotEqual(t, "ListDevices", g.Permission, "an unknown scope_kind must not create any grant")
+	}
+}
+
+// A scope-limited caller probing a scope_id outside its authority must
+// get PermissionDenied regardless of whether that group exists — the
+// authority check must precede the existence check so group existence
+// isn't an oracle. Regression for CodeRabbit #337 finding 2.
+func TestAssignRoleToUser_ScopeAuthorityCheckedBeforeExistence(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices"})
+	dg1 := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 1")
+
+	// Admin scoped to dg1 targets a group it has no authority over AND
+	// which does not exist — must be PermissionDenied, not NotFound.
+	ctx := scopeLimitedAdminCtx(adminID, dg1)
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: testutil.NewID(),
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
 func TestRevokeRoleFromUser_ScopeTargeted(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewRoleHandler(st, slog.Default())

--- a/internal/api/role_scope_handler_test.go
+++ b/internal/api/role_scope_handler_test.go
@@ -1,0 +1,189 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+const deviceGroupScope = pm.RoleGrantScopeKind_ROLE_GRANT_SCOPE_KIND_DEVICE_GROUP
+
+// scopeLimitedAdminCtx models an admin whose AssignRoleScope authority is
+// confined to a single device group — the escalation-prevention subject.
+func scopeLimitedAdminCtx(id, dgID string) context.Context {
+	return testutil.AuthContextScoped(id, "scoped-admin@test.com",
+		[]string{"AssignRoleToUser", "AssignRoleToUserGroup", "AssignRoleScope"},
+		[]auth.ScopedGrant{{Permission: "AssignRoleScope", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgID}})
+}
+
+func TestAssignRoleToUser_DeviceGroupScopedGrant(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices", "GetDevice"})
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 2")
+
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.NoError(t, err)
+
+	grants, err := st.Repos().User.ScopedGrants(context.Background(), target)
+	require.NoError(t, err)
+	assert.Contains(t, grants, store.ScopedGrant{Permission: "ListDevices", ScopeKind: "device_group", ScopeID: dg})
+	assert.Contains(t, grants, store.ScopedGrant{Permission: "GetDevice", ScopeKind: "device_group", ScopeID: dg})
+}
+
+func TestAssignRoleToUser_ScopedRequiresAssignRoleScope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices"})
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 2")
+
+	// Actor can assign roles but lacks AssignRoleScope.
+	ctx := testutil.AuthContextScoped(adminID, "a@t.com", []string{"AssignRoleToUser"}, nil)
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+func TestAssignRoleToUser_TargetKindMismatchRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	// GetUser is a user-target permission — not scopable with a device group.
+	role := testutil.CreateTestRole(t, st, adminID, "Mixed Role", []string{"ListDevices", "GetUser"})
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 2")
+
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestAssignRoleToUser_ScopeGroupMustExist(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices"})
+
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: testutil.NewID(),
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
+func TestAssignRoleToUser_PairedOrNeither(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices"})
+
+	// scope_kind set, scope_id absent.
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestAssignRoleToUser_EscalationOutsideOwnScopeDenied(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices"})
+	dg1 := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 1")
+	dg2 := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 2")
+
+	// Admin scoped to dg1 may not grant scoped to dg2.
+	ctx := scopeLimitedAdminCtx(adminID, dg1)
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg2,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	// ...but may grant scoped to dg1 (its own scope).
+	_, err = h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg1,
+	}))
+	require.NoError(t, err)
+}
+
+func TestAssignRoleToUser_ScopeLimitedAdminCannotGrantUnscoped(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices"})
+	dg1 := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 1")
+
+	ctx := scopeLimitedAdminCtx(adminID, dg1)
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, // unscoped
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+func TestRevokeRoleFromUser_ScopeTargeted(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices"})
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 2")
+
+	// Assign scoped.
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.NoError(t, err)
+
+	// Revoking the UNSCOPED grant must fail — the role is assigned at a
+	// different (scoped) shape; surface it rather than silently no-op.
+	_, err = h.RevokeRoleFromUser(ctx, connect.NewRequest(&pm.RevokeRoleFromUserRequest{
+		UserId: target, RoleId: role,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	// Revoking the exact scoped grant succeeds.
+	_, err = h.RevokeRoleFromUser(ctx, connect.NewRequest(&pm.RevokeRoleFromUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.NoError(t, err)
+
+	grants, err := st.Repos().User.ScopedGrants(context.Background(), target)
+	require.NoError(t, err)
+	for _, g := range grants {
+		assert.NotEqual(t, "ListDevices", g.Permission, "the scoped grant must be gone")
+	}
+}

--- a/internal/api/role_scope_handler_test.go
+++ b/internal/api/role_scope_handler_test.go
@@ -200,6 +200,24 @@ func TestAssignRoleToUser_ScopeAuthorityCheckedBeforeExistence(t *testing.T) {
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 }
 
+// Revoking a role the user doesn't have at all is an idempotent no-op
+// (success) — aligned with RevokeRoleFromUserGroup. Pins the parity that
+// CodeRabbit flagged. The wrong-scope case stays FailedPrecondition (see
+// TestRevokeRoleFromUser_ScopeTargeted).
+func TestRevokeRoleFromUser_NotAssignedIsNoop(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Unassigned Role", []string{"ListDevices"})
+
+	_, err := h.RevokeRoleFromUser(ctx, connect.NewRequest(&pm.RevokeRoleFromUserRequest{
+		UserId: target, RoleId: role,
+	}))
+	require.NoError(t, err)
+}
+
 func TestRevokeRoleFromUser_ScopeTargeted(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewRoleHandler(st, slog.Default())

--- a/internal/api/scope_grant.go
+++ b/internal/api/scope_grant.go
@@ -1,0 +1,116 @@
+package api
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// scopeKindString maps the proto RoleGrantScopeKind to the store/auth
+// scope-kind string. UNSPECIFIED (and any unknown) → "" = unscoped.
+func scopeKindString(k pm.RoleGrantScopeKind) string {
+	switch k {
+	case pm.RoleGrantScopeKind_ROLE_GRANT_SCOPE_KIND_DEVICE_GROUP:
+		return auth.ScopeKindDeviceGroup
+	case pm.RoleGrantScopeKind_ROLE_GRANT_SCOPE_KIND_USER_GROUP:
+		return auth.ScopeKindUserGroup
+	default:
+		return ""
+	}
+}
+
+// scopePtrs converts an empty-or-set (kind, id) pair to the nil-or-set
+// pointer pair the event payloads carry (nil together = unscoped).
+func scopePtrs(scopeKind, scopeID string) (*string, *string) {
+	if scopeKind == "" {
+		return nil, nil
+	}
+	return &scopeKind, &scopeID
+}
+
+// validateAssignGrantScope runs the role-independent validation for the
+// scope tuple on an assign-role request and returns the normalized
+// (scopeKind, scopeID) to emit ("" / "" for an unscoped grant). It
+// enforces: paired-or-neither, the AssignRoleScope gate + escalation
+// bound for scoped grants, scope-group existence, and the
+// scope-limited-admin-can't-grant-unscoped bound for unscoped grants.
+//
+// The per-role target_kind match (every permission in the role must
+// accept this scope kind) is the CALLER's responsibility — it has each
+// role's permission list. Use rejectUnscopableRole for that.
+func validateAssignGrantScope(ctx context.Context, q *db.Queries, scopeKindEnum pm.RoleGrantScopeKind, scopeID string) (string, string, error) {
+	scopeKind := scopeKindString(scopeKindEnum)
+
+	// Paired-or-neither: both set or both absent.
+	if (scopeKind == "") != (scopeID == "") {
+		return "", "", apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument,
+			"scope_kind and scope_id must be set together")
+	}
+
+	if scopeKind == "" {
+		// Unscoped grant — a scope-limited admin may not create one.
+		if err := auth.EnforceUnscopedGrantAuthority(ctx); err != nil {
+			return "", "", err
+		}
+		return "", "", nil
+	}
+
+	// Scoped grant. Authority to attach a scope at all:
+	if !auth.HasPermission(ctx, auth.AssignRoleScopePermission) {
+		return "", "", apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied,
+			"AssignRoleScope permission is required to scope a role grant")
+	}
+	// The scope group must exist.
+	if err := scopeGroupExists(ctx, q, scopeKind, scopeID); err != nil {
+		return "", "", err
+	}
+	// Escalation bound: the actor's own scope authority must cover it.
+	if err := auth.EnforceGrantScopeAuthority(ctx, scopeKind, scopeID); err != nil {
+		return "", "", err
+	}
+	return scopeKind, scopeID, nil
+}
+
+// scopeGroupExists verifies the scope_id references an existing group of
+// the right kind.
+func scopeGroupExists(ctx context.Context, q *db.Queries, scopeKind, scopeID string) error {
+	switch scopeKind {
+	case auth.ScopeKindDeviceGroup:
+		if _, err := q.GetDeviceGroupByID(ctx, scopeID); err != nil {
+			if store.IsNotFound(err) {
+				return apiErrorCtx(ctx, ErrDeviceGroupNotFound, connect.CodeNotFound, "scope device group not found")
+			}
+			return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to verify scope device group")
+		}
+	case auth.ScopeKindUserGroup:
+		if _, err := q.GetUserGroupByID(ctx, scopeID); err != nil {
+			if store.IsNotFound(err) {
+				return apiErrorCtx(ctx, ErrUserGroupNotFound, connect.CodeNotFound, "scope user group not found")
+			}
+			return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to verify scope user group")
+		}
+	default:
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "unknown scope_kind")
+	}
+	return nil
+}
+
+// rejectUnscopableRole returns an error when the role's permission set
+// cannot be scoped with scopeKind (a target_kind mismatch — including
+// any TargetUnspecified permission, which is never scopable). A no-op
+// for an unscoped grant (scopeKind == "").
+func rejectUnscopableRole(ctx context.Context, scopeKind string, permissions []string) error {
+	if scopeKind == "" {
+		return nil
+	}
+	if badPerm, ok := auth.RolePermissionsScopableWith(permissions, scopeKind); !ok {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument,
+			"role permission "+badPerm+" cannot be scoped to a "+scopeKind)
+	}
+	return nil
+}

--- a/internal/api/scope_grant.go
+++ b/internal/api/scope_grant.go
@@ -12,15 +12,20 @@ import (
 )
 
 // scopeKindString maps the proto RoleGrantScopeKind to the store/auth
-// scope-kind string. UNSPECIFIED (and any unknown) → "" = unscoped.
-func scopeKindString(k pm.RoleGrantScopeKind) string {
+// scope-kind string. ok=false for an out-of-range / future enum value so
+// callers fail CLOSED — only the explicit UNSPECIFIED maps to "" (the
+// unscoped grant). Mapping an unknown value to "" would silently turn a
+// malformed scoped request into a fleet-wide grant.
+func scopeKindString(k pm.RoleGrantScopeKind) (string, bool) {
 	switch k {
+	case pm.RoleGrantScopeKind_ROLE_GRANT_SCOPE_KIND_UNSPECIFIED:
+		return "", true
 	case pm.RoleGrantScopeKind_ROLE_GRANT_SCOPE_KIND_DEVICE_GROUP:
-		return auth.ScopeKindDeviceGroup
+		return auth.ScopeKindDeviceGroup, true
 	case pm.RoleGrantScopeKind_ROLE_GRANT_SCOPE_KIND_USER_GROUP:
-		return auth.ScopeKindUserGroup
+		return auth.ScopeKindUserGroup, true
 	default:
-		return ""
+		return "", false
 	}
 }
 
@@ -44,7 +49,11 @@ func scopePtrs(scopeKind, scopeID string) (*string, *string) {
 // accept this scope kind) is the CALLER's responsibility — it has each
 // role's permission list. Use rejectUnscopableRole for that.
 func validateAssignGrantScope(ctx context.Context, q *db.Queries, scopeKindEnum pm.RoleGrantScopeKind, scopeID string) (string, string, error) {
-	scopeKind := scopeKindString(scopeKindEnum)
+	scopeKind, ok := scopeKindString(scopeKindEnum)
+	if !ok {
+		// Unknown / future enum value — fail closed.
+		return "", "", apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "unknown scope_kind")
+	}
 
 	// Paired-or-neither: both set or both absent.
 	if (scopeKind == "") != (scopeID == "") {
@@ -65,12 +74,15 @@ func validateAssignGrantScope(ctx context.Context, q *db.Queries, scopeKindEnum 
 		return "", "", apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied,
 			"AssignRoleScope permission is required to scope a role grant")
 	}
-	// The scope group must exist.
-	if err := scopeGroupExists(ctx, q, scopeKind, scopeID); err != nil {
+	// Escalation bound: the actor's own scope authority must cover the
+	// requested scope. Checked BEFORE existence so a scope-limited caller
+	// can't use group-existence (NotFound vs PermissionDenied) as an
+	// oracle for scope ids outside its authority.
+	if err := auth.EnforceGrantScopeAuthority(ctx, scopeKind, scopeID); err != nil {
 		return "", "", err
 	}
-	// Escalation bound: the actor's own scope authority must cover it.
-	if err := auth.EnforceGrantScopeAuthority(ctx, scopeKind, scopeID); err != nil {
+	// The scope group must exist.
+	if err := scopeGroupExists(ctx, q, scopeKind, scopeID); err != nil {
 		return "", "", err
 	}
 	return scopeKind, scopeID, nil

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -506,9 +506,15 @@ func (h *UserGroupHandler) AssignRoleToUserGroup(ctx context.Context, req *conne
 		return nil, handleGetError(ctx, err, ErrUserGroupNotFound, "user group not found")
 	}
 
+	// Validate the optional grant scope (#7 S5).
+	scopeKind, scopeID, err := validateAssignGrantScope(ctx, q, req.Msg.ScopeKind, req.Msg.ScopeId)
+	if err != nil {
+		return nil, err
+	}
+
 	for _, roleID := range roleIDs {
 		// Verify role exists
-		_, err = q.GetRoleByID(ctx, roleID)
+		role, err := q.GetRoleByID(ctx, roleID)
 		if err != nil {
 			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeNotFound, "role not found")
@@ -516,26 +522,40 @@ func (h *UserGroupHandler) AssignRoleToUserGroup(ctx context.Context, req *conne
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get role")
 		}
 
-		// Check if already assigned — skip silently in batch
-		hasRole, err := q.UserGroupHasRole(ctx, db.UserGroupHasRoleParams{
-			GroupID: req.Msg.GroupId,
-			RoleID:  roleID,
-		})
-		if err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
-		}
-		if hasRole {
-			continue
+		if err := rejectUnscopableRole(ctx, scopeKind, role.Permissions); err != nil {
+			return nil, err
 		}
 
+		// Unscoped grants are unique per (group, role) — skip a redundant
+		// re-assign. Scoped grants rely on the idempotent projector insert
+		// (the 2-tuple check can't distinguish scopes).
+		if scopeKind == "" {
+			hasRole, err := q.UserGroupHasRole(ctx, db.UserGroupHasRoleParams{
+				GroupID: req.Msg.GroupId,
+				RoleID:  roleID,
+			})
+			if err != nil {
+				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
+			}
+			if hasRole {
+				continue
+			}
+		}
+
+		sk, si := scopePtrs(scopeKind, scopeID)
 		streamID := req.Msg.GroupId + ":role:" + roleID
+		if scopeKind != "" {
+			streamID += ":" + scopeID
+		}
 		if err := appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "user_group",
 			StreamID:   streamID,
 			EventType:  string(eventtypes.UserGroupRoleAssigned),
 			Data: payloads.UserGroupRoleAssigned{
-				GroupID: req.Msg.GroupId,
-				RoleID:  roleID,
+				GroupID:   req.Msg.GroupId,
+				RoleID:    roleID,
+				ScopeKind: sk,
+				ScopeID:   si,
 			},
 			ActorType: "user",
 			ActorID:   userCtx.ID,
@@ -557,15 +577,37 @@ func (h *UserGroupHandler) RevokeRoleFromUserGroup(ctx context.Context, req *con
 		return nil, err
 	}
 
-	// Check if the role is assigned
-	hasRole, err := h.store.Queries().UserGroupHasRole(ctx, db.UserGroupHasRoleParams{
-		GroupID: req.Msg.GroupId,
-		RoleID:  req.Msg.RoleId,
+	// Resolve the scope tuple identifying WHICH grant to revoke.
+	scopeKind := scopeKindString(req.Msg.ScopeKind)
+	scopeID := req.Msg.ScopeId
+	if (scopeKind == "") != (scopeID == "") {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "scope_kind and scope_id must be set together")
+	}
+	sk, si := scopePtrs(scopeKind, scopeID)
+
+	q := h.store.Queries()
+	// Does the SPECIFIC targeted grant exist?
+	hasScoped, err := q.UserGroupHasScopedRole(ctx, db.UserGroupHasScopedRoleParams{
+		GroupID: req.Msg.GroupId, RoleID: req.Msg.RoleId, ScopeKind: sk, ScopeID: si,
 	})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
 	}
-	if !hasRole {
+	if !hasScoped {
+		// The targeted grant is absent. Distinguish "assigned at a
+		// different scope" (caller targeted the wrong grant) from "not
+		// assigned at all" to surface ambiguity rather than no-op (#7 S5).
+		hasAny, err := q.UserGroupHasRole(ctx, db.UserGroupHasRoleParams{
+			GroupID: req.Msg.GroupId,
+			RoleID:  req.Msg.RoleId,
+		})
+		if err != nil {
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
+		}
+		if hasAny {
+			return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeFailedPrecondition,
+				"role is not assigned to this group at the specified scope (it is assigned at a different scope)")
+		}
 		return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeNotFound, "user group does not have this role")
 	}
 
@@ -575,13 +617,18 @@ func (h *UserGroupHandler) RevokeRoleFromUserGroup(ctx context.Context, req *con
 	}
 
 	streamID := req.Msg.GroupId + ":role:" + req.Msg.RoleId
+	if scopeKind != "" {
+		streamID += ":" + scopeID
+	}
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "user_group",
 		StreamID:   streamID,
 		EventType:  string(eventtypes.UserGroupRoleRevoked),
 		Data: payloads.UserGroupRoleRevoked{
-			GroupID: req.Msg.GroupId,
-			RoleID:  req.Msg.RoleId,
+			GroupID:   req.Msg.GroupId,
+			RoleID:    req.Msg.RoleId,
+			ScopeKind: sk,
+			ScopeID:   si,
 		},
 		ActorType: "user",
 		ActorID:   userCtx.ID,

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -578,7 +578,10 @@ func (h *UserGroupHandler) RevokeRoleFromUserGroup(ctx context.Context, req *con
 	}
 
 	// Resolve the scope tuple identifying WHICH grant to revoke.
-	scopeKind := scopeKindString(req.Msg.ScopeKind)
+	scopeKind, ok := scopeKindString(req.Msg.ScopeKind)
+	if !ok {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "unknown scope_kind")
+	}
 	scopeID := req.Msg.ScopeId
 	if (scopeKind == "") != (scopeID == "") {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "scope_kind and scope_id must be set together")

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -597,9 +597,9 @@ func (h *UserGroupHandler) RevokeRoleFromUserGroup(ctx context.Context, req *con
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check role assignment")
 	}
 	if !hasScoped {
-		// The targeted grant is absent. Distinguish "assigned at a
-		// different scope" (caller targeted the wrong grant) from "not
-		// assigned at all" to surface ambiguity rather than no-op (#7 S5).
+		// The targeted grant is absent. If the role IS assigned at a
+		// different scope, the caller targeted the wrong grant — surface
+		// that rather than silently no-op (#7 S5).
 		hasAny, err := q.UserGroupHasRole(ctx, db.UserGroupHasRoleParams{
 			GroupID: req.Msg.GroupId,
 			RoleID:  req.Msg.RoleId,
@@ -611,7 +611,9 @@ func (h *UserGroupHandler) RevokeRoleFromUserGroup(ctx context.Context, req *con
 			return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeFailedPrecondition,
 				"role is not assigned to this group at the specified scope (it is assigned at a different scope)")
 		}
-		return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeNotFound, "user group does not have this role")
+		// Not assigned anywhere — idempotent no-op: no event, and no
+		// session bump (nothing changed). Matches RevokeRoleFromUser.
+		return connect.NewResponse(&pm.RevokeRoleFromUserGroupResponse{}), nil
 	}
 
 	userCtx, err := requireAuth(ctx)

--- a/internal/api/user_group_handler_test.go
+++ b/internal/api/user_group_handler_test.go
@@ -325,6 +325,9 @@ func TestRevokeRoleFromUserGroup(t *testing.T) {
 	assert.Empty(t, resp.Msg.Group.Roles)
 }
 
+// Revoking a role the group doesn't have at all is an idempotent no-op
+// (success), aligned with RevokeRoleFromUser. The wrong-scope case still
+// errors with FailedPrecondition (see the scope handler tests).
 func TestRevokeRoleFromUserGroup_NotAssigned(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewUserGroupHandler(st, slog.Default())
@@ -338,8 +341,7 @@ func TestRevokeRoleFromUserGroup_NotAssigned(t *testing.T) {
 		GroupId: groupID,
 		RoleId:  roleID,
 	}))
-	require.Error(t, err)
-	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	require.NoError(t, err)
 }
 
 func TestListUserGroupsForUser(t *testing.T) {

--- a/internal/api/user_group_scope_handler_test.go
+++ b/internal/api/user_group_scope_handler_test.go
@@ -1,0 +1,97 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// scopedGroupRole reads the (scope_kind, scope_id) a group-role grant
+// carries in the projection, for end-to-end assertion of the emitted
+// scoped event.
+func scopedGroupRole(t *testing.T, st *store.Store, groupID, roleID string) (*string, *string) {
+	t.Helper()
+	var sk, si *string
+	err := st.TestingPool().QueryRow(context.Background(),
+		"SELECT scope_kind, scope_id FROM user_group_roles_projection WHERE group_id=$1 AND role_id=$2",
+		groupID, roleID).Scan(&sk, &si)
+	require.NoError(t, err)
+	return sk, si
+}
+
+func TestAssignRoleToUserGroup_DeviceGroupScopedGrant(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	group := testutil.CreateTestUserGroup(t, st, adminID, "Ops Group")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices", "GetDevice"})
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 2")
+
+	_, err := h.AssignRoleToUserGroup(ctx, connect.NewRequest(&pm.AssignRoleToUserGroupRequest{
+		GroupId: group, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.NoError(t, err)
+
+	sk, si := scopedGroupRole(t, st, group, role)
+	require.NotNil(t, sk)
+	require.NotNil(t, si)
+	assert.Equal(t, "device_group", *sk)
+	assert.Equal(t, dg, *si)
+}
+
+func TestAssignRoleToUserGroup_TargetKindMismatchRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	group := testutil.CreateTestUserGroup(t, st, adminID, "Ops Group")
+	role := testutil.CreateTestRole(t, st, adminID, "Mixed Role", []string{"ListDevices", "GetUser"})
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 2")
+
+	_, err := h.AssignRoleToUserGroup(ctx, connect.NewRequest(&pm.AssignRoleToUserGroupRequest{
+		GroupId: group, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestRevokeRoleFromUserGroup_ScopeTargeted(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	group := testutil.CreateTestUserGroup(t, st, adminID, "Ops Group")
+	role := testutil.CreateTestRole(t, st, adminID, "Device Role", []string{"ListDevices"})
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 2")
+
+	_, err := h.AssignRoleToUserGroup(ctx, connect.NewRequest(&pm.AssignRoleToUserGroupRequest{
+		GroupId: group, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.NoError(t, err)
+
+	// Revoking the unscoped grant fails — it's assigned at a scope.
+	_, err = h.RevokeRoleFromUserGroup(ctx, connect.NewRequest(&pm.RevokeRoleFromUserGroupRequest{
+		GroupId: group, RoleId: role,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	// The exact scoped revoke succeeds.
+	_, err = h.RevokeRoleFromUserGroup(ctx, connect.NewRequest(&pm.RevokeRoleFromUserGroupRequest{
+		GroupId: group, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.NoError(t, err)
+}

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -325,3 +325,21 @@ func ValidPermissionKeys() map[string]bool {
 	}
 	return m
 }
+
+// permTargetKinds indexes permission key -> target kind, built once from
+// AllPermissions so the role-assignment handler can validate scopability
+// without rescanning the slice per call.
+var permTargetKinds = func() map[string]PermissionTargetKind {
+	m := make(map[string]PermissionTargetKind)
+	for _, p := range AllPermissions() {
+		m[p.Key] = p.TargetKind
+	}
+	return m
+}()
+
+// TargetKindFor returns the target kind of a permission key. An unknown
+// key (or the zero value) is TargetUnspecified — not scopable — which is
+// the safe default for the self-discovering scopability check (#7 S5).
+func TargetKindFor(key string) PermissionTargetKind {
+	return permTargetKinds[key]
+}

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -141,6 +141,93 @@ func EnforceUserScope(ctx context.Context, resolver ScopeResolver, permission, t
 	return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
 }
 
+// AssignRoleScopePermission is the org-tier authority required to attach
+// a scope to a role grant. Holding it scoped (rather than global) limits
+// which scopes the actor may attach (see EnforceGrantScopeAuthority).
+const AssignRoleScopePermission = "AssignRoleScope"
+
+// targetKindForScopeKind maps a grant scope kind to the permission
+// target kind a permission must have to be scopable with it.
+func targetKindForScopeKind(scopeKind string) (PermissionTargetKind, bool) {
+	switch scopeKind {
+	case ScopeKindDeviceGroup:
+		return TargetDevice, true
+	case ScopeKindUserGroup:
+		return TargetUser, true
+	default:
+		return TargetUnspecified, false
+	}
+}
+
+// RolePermissionsScopableWith reports whether every permission in perms
+// can be scoped with scopeKind. ok=false returns the first offending
+// permission (a target-kind mismatch, including a TargetUnspecified
+// permission, which is never scopable). An unknown scopeKind is not
+// scopable. The cascade requires the WHOLE role to be scopable: a single
+// non-matching permission rejects the scoped grant, because the scope
+// would otherwise silently fail to constrain that permission (#7 S5).
+func RolePermissionsScopableWith(perms []string, scopeKind string) (badPerm string, ok bool) {
+	want, valid := targetKindForScopeKind(scopeKind)
+	if !valid {
+		return "", false
+	}
+	for _, p := range perms {
+		if TargetKindFor(p) != want {
+			return p, false
+		}
+	}
+	return "", true
+}
+
+// EnforceGrantScopeAuthority checks that the caller may ATTACH the given
+// scope to a role grant. The caller must already hold AssignRoleScope
+// (gate that separately); this enforces the escalation bound:
+//   - AssignRoleScope held unscoped (global) ⇒ may attach any scope;
+//   - held only scoped ⇒ may attach ONLY a scope whose id is among the
+//     caller's own AssignRoleScope scope ids of the SAME kind (equal
+//     match; sub-group "narrower" containment is a future refinement).
+//
+// This stops a scope-limited admin from minting grants outside their own
+// scope.
+func EnforceGrantScopeAuthority(ctx context.Context, scopeKind, scopeID string) error {
+	if _, ok := UserFromContext(ctx); !ok {
+		return connect.NewError(connect.CodeUnauthenticated, errors.New("not authenticated"))
+	}
+	f := scopeFilterFor(ctx, AssignRoleScopePermission, scopeKind)
+	if f.Global {
+		return nil
+	}
+	for _, id := range f.GroupIDs {
+		if id == scopeID {
+			return nil
+		}
+	}
+	return connect.NewError(connect.CodePermissionDenied,
+		errors.New("cannot grant a scope outside your own scope authority"))
+}
+
+// EnforceUnscopedGrantAuthority checks that the caller may create an
+// UNSCOPED (global) role grant. A scope-limited admin — one who holds
+// AssignRoleScope only scoped, never globally — may not: granting
+// unscoped would escalate their reach to the whole fleet. A caller with
+// no scope authority at all (the ordinary AssignRoleToUser admin) or one
+// holding AssignRoleScope globally (the org admin) may grant unscoped.
+func EnforceUnscopedGrantAuthority(ctx context.Context) error {
+	if _, ok := UserFromContext(ctx); !ok {
+		return connect.NewError(connect.CodeUnauthenticated, errors.New("not authenticated"))
+	}
+	dg := DeviceScopeFilterFor(ctx, AssignRoleScopePermission)
+	ug := UserScopeFilterFor(ctx, AssignRoleScopePermission)
+	if dg.Global || ug.Global {
+		return nil // org admin — unrestricted
+	}
+	if len(dg.GroupIDs) > 0 || len(ug.GroupIDs) > 0 {
+		return connect.NewError(connect.CodePermissionDenied,
+			errors.New("a scope-limited admin cannot create an unscoped grant"))
+	}
+	return nil // no scope authority — ordinary admin, allowed
+}
+
 // intersects reports whether a and b share any element.
 func intersects(a, b []string) bool {
 	if len(a) == 0 || len(b) == 0 {

--- a/internal/auth/scope_test.go
+++ b/internal/auth/scope_test.go
@@ -164,3 +164,80 @@ func TestEnforceUserScope(t *testing.T) {
 		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
 	})
 }
+
+func TestTargetKindFor(t *testing.T) {
+	assert.Equal(t, TargetDevice, TargetKindFor("ListDevices"))
+	assert.Equal(t, TargetUser, TargetKindFor("GetUser"))
+	assert.Equal(t, TargetUnspecified, TargetKindFor("GetCurrentUser"))
+	assert.Equal(t, TargetUnspecified, TargetKindFor("NoSuchPermission"), "unknown key is the safe non-scopable default")
+}
+
+func TestRolePermissionsScopableWith(t *testing.T) {
+	t.Run("all device perms scopable with device_group", func(t *testing.T) {
+		_, ok := RolePermissionsScopableWith([]string{"ListDevices", "GetDevice", "StartTerminal"}, ScopeKindDeviceGroup)
+		assert.True(t, ok)
+	})
+	t.Run("a non-device perm rejects a device_group scope", func(t *testing.T) {
+		bad, ok := RolePermissionsScopableWith([]string{"ListDevices", "GetUser"}, ScopeKindDeviceGroup)
+		assert.False(t, ok)
+		assert.Equal(t, "GetUser", bad)
+	})
+	t.Run("a TargetUnspecified perm is never scopable", func(t *testing.T) {
+		bad, ok := RolePermissionsScopableWith([]string{"GetCurrentUser"}, ScopeKindDeviceGroup)
+		assert.False(t, ok)
+		assert.Equal(t, "GetCurrentUser", bad)
+	})
+	t.Run("user perms scopable with user_group", func(t *testing.T) {
+		_, ok := RolePermissionsScopableWith([]string{"GetUser"}, ScopeKindUserGroup)
+		assert.True(t, ok)
+	})
+	t.Run("device perm not scopable with user_group", func(t *testing.T) {
+		bad, ok := RolePermissionsScopableWith([]string{"ListDevices"}, ScopeKindUserGroup)
+		assert.False(t, ok)
+		assert.Equal(t, "ListDevices", bad)
+	})
+	t.Run("unknown scope kind is not scopable", func(t *testing.T) {
+		_, ok := RolePermissionsScopableWith([]string{"ListDevices"}, "garbage")
+		assert.False(t, ok)
+	})
+}
+
+func TestEnforceGrantScopeAuthority(t *testing.T) {
+	t.Run("global AssignRoleScope may grant any scope", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: AssignRoleScopePermission})
+		assert.NoError(t, EnforceGrantScopeAuthority(ctx, ScopeKindDeviceGroup, "dg-anything"))
+	})
+	t.Run("scoped AssignRoleScope may grant its own scope", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: AssignRoleScopePermission, ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		assert.NoError(t, EnforceGrantScopeAuthority(ctx, ScopeKindDeviceGroup, "dg1"))
+	})
+	t.Run("scoped AssignRoleScope may NOT grant a different scope", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: AssignRoleScopePermission, ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		err := EnforceGrantScopeAuthority(ctx, ScopeKindDeviceGroup, "dg2")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+	t.Run("device-scoped authority does not authorize a user_group grant", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: AssignRoleScopePermission, ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		err := EnforceGrantScopeAuthority(ctx, ScopeKindUserGroup, "dg1")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+}
+
+func TestEnforceUnscopedGrantAuthority(t *testing.T) {
+	t.Run("no scope authority (ordinary admin) may grant unscoped", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: "AssignRoleToUser"})
+		assert.NoError(t, EnforceUnscopedGrantAuthority(ctx))
+	})
+	t.Run("global AssignRoleScope (org admin) may grant unscoped", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: AssignRoleScopePermission})
+		assert.NoError(t, EnforceUnscopedGrantAuthority(ctx))
+	})
+	t.Run("scope-limited admin may NOT grant unscoped", func(t *testing.T) {
+		ctx := ctxWithGrants(ScopedGrant{Permission: AssignRoleScopePermission, ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		err := EnforceUnscopedGrantAuthority(ctx)
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+}

--- a/internal/store/generated/roles.sql.go
+++ b/internal/store/generated/roles.sql.go
@@ -482,3 +482,29 @@ func (q *Queries) UserHasRole(ctx context.Context, arg UserHasRoleParams) (bool,
 	err := row.Scan(&has_role)
 	return has_role, err
 }
+
+const userHasScopedRole = `-- name: UserHasScopedRole :one
+SELECT EXISTS(
+    SELECT 1 FROM user_roles_projection
+    WHERE user_id = $1 AND role_id = $2
+      AND scope_kind IS NOT DISTINCT FROM $3::TEXT
+      AND scope_id   IS NOT DISTINCT FROM $4::TEXT
+) AS has_role
+`
+
+// UserHasScopedRoleParams targets a specific (user, role, scope) grant.
+// ScopeKind/ScopeID nil together = the unscoped grant. Hand-maintained
+// alongside UserHasRole; sync with queries/roles.sql by hand (#7 S5).
+type UserHasScopedRoleParams struct {
+	UserID    string  `json:"user_id"`
+	RoleID    string  `json:"role_id"`
+	ScopeKind *string `json:"scope_kind"`
+	ScopeID   *string `json:"scope_id"`
+}
+
+func (q *Queries) UserHasScopedRole(ctx context.Context, arg UserHasScopedRoleParams) (bool, error) {
+	row := q.db.QueryRow(ctx, userHasScopedRole, arg.UserID, arg.RoleID, arg.ScopeKind, arg.ScopeID)
+	var has_role bool
+	err := row.Scan(&has_role)
+	return has_role, err
+}

--- a/internal/store/generated/user_groups.sql.go
+++ b/internal/store/generated/user_groups.sql.go
@@ -1054,6 +1054,33 @@ func (q *Queries) UserGroupHasRole(ctx context.Context, arg UserGroupHasRolePara
 	return has_role, err
 }
 
+const userGroupHasScopedRole = `-- name: UserGroupHasScopedRole :one
+SELECT EXISTS(
+    SELECT 1 FROM user_group_roles_projection
+    WHERE group_id = $1 AND role_id = $2
+      AND scope_kind IS NOT DISTINCT FROM $3::TEXT
+      AND scope_id   IS NOT DISTINCT FROM $4::TEXT
+) AS has_role
+`
+
+// UserGroupHasScopedRoleParams targets a specific (group, role, scope)
+// grant. ScopeKind/ScopeID nil together = the unscoped grant.
+// Hand-maintained alongside UserGroupHasRole; sync with
+// queries/user_groups.sql by hand (#7 S5).
+type UserGroupHasScopedRoleParams struct {
+	GroupID   string  `json:"group_id"`
+	RoleID    string  `json:"role_id"`
+	ScopeKind *string `json:"scope_kind"`
+	ScopeID   *string `json:"scope_id"`
+}
+
+func (q *Queries) UserGroupHasScopedRole(ctx context.Context, arg UserGroupHasScopedRoleParams) (bool, error) {
+	row := q.db.QueryRow(ctx, userGroupHasScopedRole, arg.GroupID, arg.RoleID, arg.ScopeKind, arg.ScopeID)
+	var has_role bool
+	err := row.Scan(&has_role)
+	return has_role, err
+}
+
 const wipeUserGroupMembers = `-- name: WipeUserGroupMembers :exec
 DELETE FROM user_group_members_projection WHERE group_id = $1
 `

--- a/internal/store/queries/roles.sql
+++ b/internal/store/queries/roles.sql
@@ -54,6 +54,19 @@ SELECT user_id FROM user_roles_projection WHERE role_id = $1;
 -- name: UserHasRole :one
 SELECT EXISTS(SELECT 1 FROM user_roles_projection WHERE user_id = $1 AND role_id = $2) AS has_role;
 
+-- name: UserHasScopedRole :one
+-- Existence of a SPECIFIC (user, role, scope) grant. IS NOT DISTINCT
+-- FROM is NULL-aware: NULL scope params match the unscoped grant; set
+-- params match that exact scoped grant. Used by RevokeRoleFromUser to
+-- reject "revoke a grant that doesn't exist" rather than silently
+-- no-op (server #7 S5).
+SELECT EXISTS(
+    SELECT 1 FROM user_roles_projection
+    WHERE user_id = $1 AND role_id = $2
+      AND scope_kind IS NOT DISTINCT FROM sqlc.narg('scope_kind')::TEXT
+      AND scope_id   IS NOT DISTINCT FROM sqlc.narg('scope_id')::TEXT
+) AS has_role;
+
 -- name: UpdateSystemRolePermissions :execrows
 UPDATE roles_projection SET permissions = $1, updated_at = NOW() WHERE id = $2 AND is_system = TRUE;
 

--- a/internal/store/queries/user_groups.sql
+++ b/internal/store/queries/user_groups.sql
@@ -35,6 +35,18 @@ SELECT EXISTS(
     WHERE group_id = $1 AND role_id = $2
 ) AS has_role;
 
+-- name: UserGroupHasScopedRole :one
+-- Existence of a SPECIFIC (group, role, scope) grant. NULL-aware via
+-- IS NOT DISTINCT FROM: NULL scope params match the unscoped grant.
+-- Used by RevokeRoleFromUserGroup to reject revoking a grant that
+-- doesn't exist at the targeted scope (server #7 S5).
+SELECT EXISTS(
+    SELECT 1 FROM user_group_roles_projection
+    WHERE group_id = $1 AND role_id = $2
+      AND scope_kind IS NOT DISTINCT FROM sqlc.narg('scope_kind')::TEXT
+      AND scope_id   IS NOT DISTINCT FROM sqlc.narg('scope_id')::TEXT
+) AS has_role;
+
 -- name: ListUserGroupsForUser :many
 SELECT ug.* FROM user_groups_projection ug
 JOIN user_group_members_projection ugm ON ugm.group_id = ug.id

--- a/internal/testutil/factories_user.go
+++ b/internal/testutil/factories_user.go
@@ -59,9 +59,32 @@ func AuthContext(id, email string, permissions []string) context.Context {
 	})
 }
 
+// AuthContextScoped returns a context carrying both a flat permission
+// list and the detailed scoped grants the #7 scope-enforcement helpers
+// read (DeviceScopeFilterFor, EnforceGrantScopeAuthority, etc.). Use
+// this to model a scope-limited admin in handler tests.
+func AuthContextScoped(id, email string, permissions []string, grants []auth.ScopedGrant) context.Context {
+	return auth.WithUser(context.Background(), &auth.UserContext{
+		ID:           id,
+		Email:        email,
+		Permissions:  permissions,
+		ScopedGrants: grants,
+	})
+}
+
 // AdminContext returns a context with an admin user (all permissions).
+// To mirror production — where the flat permission list is DERIVED from
+// the user's grants — every admin permission is also carried as an
+// unscoped (global) scoped grant, so the #7 scope-authority checks see
+// the admin as globally unrestricted rather than as having no scope
+// authority.
 func AdminContext(id string) context.Context {
-	return AuthContext(id, fmt.Sprintf("admin-%s@test.com", id[:8]), auth.AdminPermissions())
+	perms := auth.AdminPermissions()
+	grants := make([]auth.ScopedGrant, len(perms))
+	for i, p := range perms {
+		grants[i] = auth.ScopedGrant{Permission: p}
+	}
+	return AuthContextScoped(id, fmt.Sprintf("admin-%s@test.com", id[:8]), perms, grants)
 }
 
 // UserContext returns a context with a regular user (default permissions).


### PR DESCRIPTION
Fourth slice of manchtools/power-manage-server#7 — the **grant-authoring** half: `AssignRoleTo{User,UserGroup}` and `RevokeRoleFrom{User,UserGroup}` now consume the `(scope_kind, scope_id)` tuple. **Server-only** — the proto fields, `RoleGrantScopeKind` enum, `AssignRoleScope` permission, `PermissionTargetKind`, and the scope-aware projector writes all already existed (S1/#333, S2/#334); the handlers ignored scope until now. Builds on S2b (#335)'s `UserContext.ScopedGrants`.

## Assign validation (`validateAssignGrantScope`, shared by both handlers)
- **paired-or-neither** — `scope_kind`/`scope_id` set together or not at all;
- **`AssignRoleScope` gate** for any scoped grant;
- **scope-group existence** (device_group / user_group);
- **per-role `target_kind` match** — every permission in the role must accept the scope kind (device_group scope ⇒ all perms `TargetDevice`). Derived self-discoveringly from the permission registry (`TargetKindFor`), **not a hardcoded list**, so a new permission can't silently slip the check.

## Escalation prevention (auth, over the actor's own `ScopedGrants`)
- **`EnforceGrantScopeAuthority`** — a scope-limited admin may attach only a scope its own `AssignRoleScope` authority covers (global ⇒ any; scoped ⇒ equal-id match; sub-group "narrower" containment is a documented future refinement).
- **`EnforceUnscopedGrantAuthority`** — a scope-limited admin may not mint an unscoped, fleet-wide grant.

In V1 `AssignRoleScope` is org-tier (held only by unscoped admins), so the bounded path isn't reachable yet — this is defense-in-depth ahead of per-scope admins.

## Revoke
Targets a SPECIFIC `(subject, role, scope)` grant via new NULL-aware existence checks (`UserHasScopedRole` / `UserGroupHasScopedRole`, hand-written like S2's scope queries — sqlc can't read migration 010's `DO`-block columns, see #336). Revoking a grant that exists only at a **different** scope is rejected (`FailedPrecondition`) rather than silently no-op'd; nothing-there stays an idempotent no-op.

## Test fidelity fix
`AdminContext` now carries every admin permission as an **unscoped grant**, mirroring production — where the flat permission list is *derived* from grants — so the scope-authority checks see an org admin as globally unrestricted rather than as having no scope authority. (Additive; existing tests unaffected.)

## Tests
- **auth units**: target-kind match (incl. cross-kind + TargetUnspecified rejection), both escalation bounds.
- **handler integration** (user + user-group paths): scoped grant end-to-end, `AssignRoleScope` gate, target_kind mismatch, missing scope group, paired-or-neither, escalation out-of-scope + unscoped denial, scope-targeted revoke + wrong-scope rejection.
- `go vet ./...`, `gofmt`, `go build`, `internal/auth`, `internal/projectors`, all targeted scope tests green. Full `internal/api`: **312 pass / 0 fail** (local wall-clock exceeded the default timeout under heavy back-to-back container churn; CI's `-timeout 20m` fresh runner ran the identical-size suite in 562s at S2b). Local CodeRabbit: no findings.

## Follow-ups
The **enforcement-consuming** half — per-device/-user handlers calling `EnforceDeviceScope`/`EnforceUserScope` with a `ScopeResolver` wired to the projections (S6), the per-scope reconciler, and the TTY-gated web scope picker (S9).

Closes part of manchtools/power-manage-server#7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scoped role assignments and revocations: roles can be granted/revoked limited to specific device or user group scopes; assignment/revoke operations are scope-aware and include scope details in audit events.
  * Stronger validation and authority checks to prevent invalid or unauthorized scoped grants.

* **Tests**
  * Expanded end-to-end and unit tests covering scoped grant/revoke semantics, authority enforcement, and scope-edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->