### PR TITLE
feat: #7 — decouple TerminalAdmin sudo cohort from StartTerminal (Model Y, PR1/2)

### DIFF
--- a/docs/adr/0000-terminal-admin-threat-model.md
+++ b/docs/adr/0000-terminal-admin-threat-model.md
@@ -37,10 +37,22 @@ already in production:
 
 **What #70 actually adds** is the role-driven layer that connects
 them: when a user holds the new `TerminalAdminLimited` (or `Full`)
-permission, their `pm-tty-<username>` account is automatically added
-to the LIMITED (or FULL) system-managed AdminPolicy action's
-`users` list on every device they have `StartTerminal` on. Same
+permission, their `pm-tty-<username>` account is added to the LIMITED
+(or FULL) system-managed AdminPolicy action's `users` list. Same
 fan-out shape as the existing tty-user action.
+
+> **#7 model update (2026-06-10, "Model Y"):** the sudo cohort is
+> driven by `TerminalAdmin{Limited,Full}` **alone** — `StartTerminal`
+> is **not** required. `StartTerminal` drives the separate `pm-tty`
+> account; the LIMITED/FULL sudo policy is harmless/inert on a device
+> where the account doesn't exist (group rule, empty membership; the
+> agent SKIPs gracefully). Each permission is scoped independently —
+> the LIMITED/FULL action reaches a device when the holder's
+> `TerminalAdmin*` scope covers it; the account reaches a device when
+> the holder's `StartTerminal` scope covers it. This replaces the
+> earlier `StartTerminal ∩ TerminalAdmin` cohort. (PR1 decoupled the
+> global cohort; PR2 adds the per-scope actions + scope-aware
+> delivery.)
 
 The catch is one small but load-bearing detail: **the existing
 LIMITED/FULL templates require a password**, and `pm-tty-*` accounts
@@ -69,7 +81,8 @@ mitigations are small additions to existing files.
 │   TerminalAdminLimited / TerminalAdminFull                      │
 │   Held by user U → resolution layer adds "pm-tty-U" to the      │
 │   users list of the LIMITED/FULL system action on each device   │
-│   where U has StartTerminal AND is in scope.                    │
+│   in U's TerminalAdmin* scope (StartTerminal NOT required —      │
+│   it drives the separate pm-tty account; #7 Model Y).           │
 └─────────────────────────────────────────────────────────────────┘
                               ▲
 ┌─────────────────────────────────────────────────────────────────┐
@@ -442,9 +455,12 @@ can do.
 - #70's PR may not merge while any `GAP` marker above is unresolved.
 - **Two new permissions** land in
   [`server/internal/auth/permissions.go`](../../../server/internal/auth/permissions.go):
-  `TerminalAdminLimited` and `TerminalAdminFull`. Each implies
-  `StartTerminal` (so the resolution layer's existing `pm-tty-*`
-  fan-out still fires for these holders).
+  `TerminalAdminLimited` and `TerminalAdminFull`. They do **not** imply
+  `StartTerminal` (#7 Model Y, 2026-06-10) — the sudo cohort is driven
+  by `TerminalAdmin*` alone, while `StartTerminal` independently drives
+  the `pm-tty` account. A holder without `StartTerminal` gets the sudo
+  policy listed but inert (no account), which the agent SKIPs
+  gracefully.
 - **Two new system-managed AdminPolicy actions** delivered the same
   way the existing `system:tty-user:*` actions are delivered — one
   for LIMITED, one for FULL. Their `users` list is computed by a

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -604,9 +604,20 @@ func (m *SystemActionManager) ReconcileGlobalTerminalAdminActions(ctx context.Co
 }
 
 // computeTerminalAdminCohorts walks the user list and returns the two
-// sorted, deduped pm-tty-* cohorts. The sort makes signature stability
-// deterministic across runs; the dedup is defensive against a future
-// permission backend that double-counts a user.
+// sorted, deduped pm-tty-* cohorts for the GLOBAL LIMITED/FULL sudo
+// actions. The sort makes signature stability deterministic across runs;
+// the dedup is defensive against a future permission backend that
+// double-counts a user.
+//
+// #7 model (Model Y): the sudo cohort is driven by TerminalAdmin{Limited,
+// Full} ALONE — StartTerminal is NO LONGER required (it drives the
+// pm-tty account, a separate concern; the agent's sudo policy is inert
+// and harmless when no account exists). This walks the user's scoped
+// grants and counts only UNSCOPED (global) TerminalAdmin grants here;
+// device-group-scoped grants drive the per-scope actions added in a
+// follow-up and are intentionally ignored by the global cohort. A
+// user_group-scoped TerminalAdmin grant has no device meaning and is
+// ignored everywhere.
 func (m *SystemActionManager) computeTerminalAdminCohorts(ctx context.Context, users []store.User) (limited, full []string) {
 	limitedSet := map[string]struct{}{}
 	fullSet := map[string]struct{}{}
@@ -614,33 +625,30 @@ func (m *SystemActionManager) computeTerminalAdminCohorts(ctx context.Context, u
 		if u.Disabled || u.LinuxUsername == "" {
 			continue
 		}
-		perms, err := m.store.Repos().User.Permissions(ctx, u.ID)
+		grants, err := m.store.Repos().User.ScopedGrants(ctx, u.ID)
 		if err != nil {
 			// Skip the user this tick — the next tick will retry.
 			// Aborting the whole reconcile on a single user's
 			// transient DB error would block every other user from
 			// landing on devices.
-			m.logger.Error("perm lookup failed during terminal-admin reconcile; skipping user",
+			m.logger.Error("scoped-grant lookup failed during terminal-admin reconcile; skipping user",
 				"user_id", u.ID, "error", err)
 			continue
 		}
-		hasStart, hasLimited, hasFull := false, false, false
-		for _, p := range perms {
-			switch p {
-			case "StartTerminal":
-				hasStart = true
-			case "TerminalAdminLimited":
-				hasLimited = true
-			case "TerminalAdminFull":
-				hasFull = true
-			}
-		}
 		ttyUser := "pm-tty-" + u.LinuxUsername
-		if hasStart && hasLimited {
-			limitedSet[ttyUser] = struct{}{}
-		}
-		if hasStart && hasFull {
-			fullSet[ttyUser] = struct{}{}
+		for _, g := range grants {
+			// Only UNSCOPED (global) grants feed the global actions.
+			// scope_kind != "" ⇒ a per-scope grant, handled by the
+			// per-scope reconciler (follow-up).
+			if g.ScopeKind != "" {
+				continue
+			}
+			switch g.Permission {
+			case "TerminalAdminLimited":
+				limitedSet[ttyUser] = struct{}{}
+			case "TerminalAdminFull":
+				fullSet[ttyUser] = struct{}{}
+			}
 		}
 	}
 

--- a/internal/api/system_actions_terminal_admin_test.go
+++ b/internal/api/system_actions_terminal_admin_test.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
@@ -153,9 +154,12 @@ func TestBootstrapGlobalTerminalAdminActions_ActionTypeIsAdminPolicy(t *testing.
 // ReconcileGlobalTerminalAdminActions — S3 of #70.
 //
 // Recomputes users[] on both globals based on the permission cohort.
-// A user enters the LIMITED cohort iff they hold StartTerminal AND
-// TerminalAdminLimited AND are non-disabled / non-deleted / have a
-// linux_username. FULL is the same shape against TerminalAdminFull.
+// #7 Model Y: a user enters the LIMITED cohort iff they hold an UNSCOPED
+// TerminalAdminLimited grant AND are non-disabled / non-deleted / have a
+// linux_username. StartTerminal is NOT required — it drives the pm-tty
+// account (a separate concern); the sudo policy is inert/harmless when
+// no account exists. FULL is the same shape against TerminalAdminFull.
+// (Device-group-scoped grants drive the per-scope actions, not these.)
 //
 // The reconciler MUST be a no-op when nothing has changed — repeated
 // ticks under a steady population must not churn the signature, or
@@ -202,11 +206,12 @@ func TestReconcileGlobalTerminalAdmin_AddsHolderWithBothPerms(t *testing.T) {
 		"user holding StartTerminal + TerminalAdminLimited must be in the Limited cohort as pm-tty-<linuxusername>")
 }
 
-// THE GATE: a user with TerminalAdminLimited alone (no StartTerminal)
-// must NOT enter the Limited cohort. This is the "no implies" design
-// decision — admins can grant either permission independently; the
-// reconciler enforces the AND at materialization time.
-func TestReconcileGlobalTerminalAdmin_ExcludesHolderMissingStartTerminal(t *testing.T) {
+// #7 Model Y: a user with TerminalAdminLimited alone (no StartTerminal)
+// MUST enter the Limited cohort — the sudo cohort is driven by
+// TerminalAdmin alone (StartTerminal drives only the pm-tty account, a
+// separate concern). The sudo policy is harmless/inert on devices where
+// the account doesn't exist. This reverses the pre-#7 intersection gate.
+func TestReconcileGlobalTerminalAdmin_IncludesHolderWithoutStartTerminal(t *testing.T) {
 	m, st := newManagerForTest(t)
 	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
 
@@ -219,8 +224,54 @@ func TestReconcileGlobalTerminalAdmin_ExcludesHolderMissingStartTerminal(t *test
 	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
 
 	limited := loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName)
-	assert.Empty(t, limited.Users,
-		"user with TerminalAdminLimited but no StartTerminal must NOT enter the cohort")
+	assert.Equal(t, []string{"pm-tty-alice"}, limited.Users,
+		"user with TerminalAdminLimited (even without StartTerminal) must enter the cohort")
+}
+
+// A user with StartTerminal alone (no TerminalAdmin*) must NOT enter any
+// sudo cohort — StartTerminal grants the account/session, not sudo.
+func TestReconcileGlobalTerminalAdmin_ExcludesStartTerminalOnly(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantPermsViaRole(t, st, actorID, userID, "TerminalOnly", []string{"StartTerminal"})
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	assert.Empty(t, loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName).Users,
+		"StartTerminal alone grants no sudo cohort membership")
+	assert.Empty(t, loadAdminPolicy(t, st, globalTerminalAdminFullActionName).Users)
+}
+
+// A device-group-SCOPED TerminalAdmin grant must NOT enter the GLOBAL
+// cohort — it drives the per-scope action (follow-up). Only unscoped
+// (global) grants feed the global actions.
+func TestReconcileGlobalTerminalAdmin_ExcludesScopedGrant(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	roleID := testutil.CreateTestRole(t, st, actorID, "ScopedTA", []string{"TerminalAdminLimited"})
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":dg-1",
+		EventType:  string(eventtypes.UserRoleAssigned),
+		Data: map[string]any{
+			"user_id": userID, "role_id": roleID,
+			"scope_kind": "device_group", "scope_id": "dg-1",
+		},
+		ActorType: "user", ActorID: actorID,
+	}))
+
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+
+	assert.Empty(t, loadAdminPolicy(t, st, globalTerminalAdminLimitedActionName).Users,
+		"a device-group-scoped TerminalAdmin grant must NOT enter the global cohort")
 }
 
 func TestReconcileGlobalTerminalAdmin_RemovesRevokedHolder(t *testing.T) {


### PR DESCRIPTION
First of two PRs implementing #7's **TTY/TerminalAdmin** scope enforcement (the authoritative V1 consumer). This one is the **global decouple**; PR2 adds per-scope actions + scope-aware delivery + the StartTerminal scope gate.

## Model (confirmed with the user — "Model Y, independent + graceful")
`StartTerminal` and `TerminalAdmin{Limited,Full}` are **independent**:
- `StartTerminal` → the per-user `pm-tty-<linux_username>` account (a session must run as it).
- `TerminalAdmin{Limited,Full}` → the LIMITED/FULL sudo policy that account carries.

The agent **SKIPs gracefully** when a sudo policy references a missing account (group rule, empty membership, inert — verified in `agent/internal/executor/helpers.go:56-58`; `visudo -c` doesn't validate members). So a TerminalAdmin grant without an account is harmless. We therefore **drop** #332's `StartTerminal ∩ TerminalAdmin` cohort intersection and do **not** auto-create accounts from TerminalAdmin (an account is useless without a session).

## This PR
- `computeTerminalAdminCohorts` now keys the LIMITED/FULL sudo cohort on **`TerminalAdmin{Limited,Full}` alone** (StartTerminal dropped), and sources from `User.ScopedGrants` (scope-carrying) instead of the scope-blind `User.Permissions`. Only **unscoped** TerminalAdmin grants feed the global actions — device-group-scoped grants drive the per-scope actions in PR2 and are ignored here; `user_group`-scoped TerminalAdmin grants have no device meaning and are ignored everywhere.
- `ReconcileGlobalTerminalAdminActions` is otherwise unchanged (same signature/short-circuit/audit).

## Tests
- `TerminalAdmin`-without-`StartTerminal` holder → **now in** the cohort (reverses the old gate).
- `StartTerminal`-alone → in **no** sudo cohort (account only).
- device-group-scoped grant → **not** in the global cohort.
- existing both-perms / revocation / idempotency cases stay green.
- ADR `0000-terminal-admin-threat-model.md` updated: TerminalAdmin no longer "implies StartTerminal"; cohort is TerminalAdmin-alone; the per-scope / GAP-A work is marked for PR2.

`go vet ./...`, `gofmt`, full `internal/api` TerminalAdmin suite green. Local CodeRabbit: no findings.

## Follow-up (PR2)
Per-scope reconciler (`system:terminal-admin-{limited,full}:<dgID>` from `User.ScopedGrants`, GAP-A), scope-aware account + sudo delivery in `resolution.go`, and the `EnforceDeviceScope` gate on `StartTerminal`.

Refs manchtools/power-manage-server#7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal admin permissions (`TerminalAdminLimited` and `TerminalAdminFull`) are now decoupled from prerequisite permissions, providing greater flexibility in permission assignment and enforcement.

* **Documentation**
  * Updated threat model and architecture documentation to reflect the revised terminal admin permission model and its operational behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->