### PR TITLE
feat: #7 — per-scope TerminalAdmin reconciler (Model Y, PR2/3)

### DIFF
--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -92,6 +92,11 @@ func (m *SystemActionManager) SyncAllUsersSystemActions(ctx context.Context) err
 	if err := m.ReconcileGlobalTerminalAdminActions(ctx); err != nil {
 		m.logger.Error("failed to reconcile global TerminalAdmin actions during sync sweep", "error", err)
 	}
+	// Per-scope TerminalAdmin actions (#7) — same shape, keyed by
+	// device-group scope.
+	if err := m.ReconcileScopedTerminalAdminActions(ctx); err != nil {
+		m.logger.Error("failed to reconcile scoped TerminalAdmin actions during sync sweep", "error", err)
+	}
 
 	return nil
 }
@@ -540,12 +545,12 @@ const (
 // and a re-sign per-server-start would invalidate every agent's cached
 // copy on every restart of the server even when nothing changed.
 func (m *SystemActionManager) BootstrapGlobalTerminalAdminActions(ctx context.Context) error {
-	if err := m.bootstrapGlobalTerminalAdminAction(ctx,
+	if err := m.bootstrapTerminalAdminAction(ctx,
 		GlobalTerminalAdminLimitedActionName,
 		pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED); err != nil {
 		return fmt.Errorf("bootstrap %s: %w", GlobalTerminalAdminLimitedActionName, err)
 	}
-	if err := m.bootstrapGlobalTerminalAdminAction(ctx,
+	if err := m.bootstrapTerminalAdminAction(ctx,
 		GlobalTerminalAdminFullActionName,
 		pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL); err != nil {
 		return fmt.Errorf("bootstrap %s: %w", GlobalTerminalAdminFullActionName, err)
@@ -586,18 +591,20 @@ func (m *SystemActionManager) ReconcileGlobalTerminalAdminActions(ctx context.Co
 		return fmt.Errorf("list users: %w", err)
 	}
 
-	limitedCohort, fullCohort := m.computeTerminalAdminCohorts(ctx, users)
+	cohorts := m.computeTerminalAdminCohorts(ctx, users)
 
-	if err := m.reconcileOneGlobalTerminalAdmin(ctx,
+	// The global actions consume only the unscoped (Scope=="") cohorts;
+	// per-scope cohorts are materialized by ReconcileScopedTerminalAdminActions.
+	if err := m.reconcileOneTerminalAdmin(ctx,
 		GlobalTerminalAdminLimitedActionName,
 		pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED,
-		limitedCohort); err != nil {
+		cohorts[cohortKey{Level: pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED}]); err != nil {
 		return fmt.Errorf("reconcile %s: %w", GlobalTerminalAdminLimitedActionName, err)
 	}
-	if err := m.reconcileOneGlobalTerminalAdmin(ctx,
+	if err := m.reconcileOneTerminalAdmin(ctx,
 		GlobalTerminalAdminFullActionName,
 		pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL,
-		fullCohort); err != nil {
+		cohorts[cohortKey{Level: pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL}]); err != nil {
 		return fmt.Errorf("reconcile %s: %w", GlobalTerminalAdminFullActionName, err)
 	}
 	return nil
@@ -618,9 +625,14 @@ func (m *SystemActionManager) ReconcileGlobalTerminalAdminActions(ctx context.Co
 // follow-up and are intentionally ignored by the global cohort. A
 // user_group-scoped TerminalAdmin grant has no device meaning and is
 // ignored everywhere.
-func (m *SystemActionManager) computeTerminalAdminCohorts(ctx context.Context, users []store.User) (limited, full []string) {
-	limitedSet := map[string]struct{}{}
-	fullSet := map[string]struct{}{}
+func (m *SystemActionManager) computeTerminalAdminCohorts(ctx context.Context, users []store.User) map[cohortKey][]string {
+	sets := map[cohortKey]map[string]struct{}{}
+	add := func(k cohortKey, ttyUser string) {
+		if sets[k] == nil {
+			sets[k] = map[string]struct{}{}
+		}
+		sets[k][ttyUser] = struct{}{}
+	}
 	for _, u := range users {
 		if u.Disabled || u.LinuxUsername == "" {
 			continue
@@ -637,36 +649,32 @@ func (m *SystemActionManager) computeTerminalAdminCohorts(ctx context.Context, u
 		}
 		ttyUser := "pm-tty-" + u.LinuxUsername
 		for _, g := range grants {
-			// Only UNSCOPED (global) grants feed the global actions.
-			// scope_kind != "" ⇒ a per-scope grant, handled by the
-			// per-scope reconciler (follow-up).
-			if g.ScopeKind != "" {
-				continue
+			scope, ok := terminalAdminScopeKey(g)
+			if !ok {
+				continue // user_group / unknown scope — no device meaning
 			}
 			switch g.Permission {
 			case "TerminalAdminLimited":
-				limitedSet[ttyUser] = struct{}{}
+				add(cohortKey{Level: pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED, Scope: scope}, ttyUser)
 			case "TerminalAdminFull":
-				fullSet[ttyUser] = struct{}{}
+				add(cohortKey{Level: pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL, Scope: scope}, ttyUser)
 			}
 		}
 	}
 
-	limited = make([]string, 0, len(limitedSet))
-	for u := range limitedSet {
-		limited = append(limited, u)
+	out := make(map[cohortKey][]string, len(sets))
+	for k, set := range sets {
+		cohort := make([]string, 0, len(set))
+		for u := range set {
+			cohort = append(cohort, u)
+		}
+		sort.Strings(cohort)
+		out[k] = cohort
 	}
-	sort.Strings(limited)
-
-	full = make([]string, 0, len(fullSet))
-	for u := range fullSet {
-		full = append(full, u)
-	}
-	sort.Strings(full)
-	return limited, full
+	return out
 }
 
-func (m *SystemActionManager) reconcileOneGlobalTerminalAdmin(ctx context.Context, name string, accessLevel pm.AdminAccessLevel, desiredUsers []string) error {
+func (m *SystemActionManager) reconcileOneTerminalAdmin(ctx context.Context, name string, accessLevel pm.AdminAccessLevel, desiredUsers []string) error {
 	row, err := m.store.Queries().GetActionByName(ctx, name)
 	if err != nil {
 		// Includes the not-found case: bootstrap was skipped.
@@ -709,7 +717,7 @@ func (m *SystemActionManager) reconcileOneGlobalTerminalAdmin(ctx context.Contex
 	if err := m.actions.SignActionByID(ctx, row.ID); err != nil {
 		return fmt.Errorf("re-sign action: %w", err)
 	}
-	m.logger.Info("reconciled global terminal-admin action",
+	m.logger.Info("reconciled terminal-admin action",
 		"name", name, "action_id", row.ID, "users_count", len(desiredUsers))
 	return nil
 }
@@ -782,7 +790,7 @@ func (m *SystemActionManager) lookupUserIDByLinuxUsername(ctx context.Context, l
 	return ""
 }
 
-func (m *SystemActionManager) bootstrapGlobalTerminalAdminAction(ctx context.Context, name string, accessLevel pm.AdminAccessLevel) error {
+func (m *SystemActionManager) bootstrapTerminalAdminAction(ctx context.Context, name string, accessLevel pm.AdminAccessLevel) error {
 	if _, err := m.store.Queries().GetActionByName(ctx, name); err == nil {
 		// Already exists — no-op. The reconciler owns subsequent
 		// mutations. NOT re-signing here is load-bearing: the agent
@@ -813,7 +821,7 @@ func (m *SystemActionManager) bootstrapGlobalTerminalAdminAction(ctx context.Con
 	if err := m.actions.SignActionByID(ctx, actionID); err != nil {
 		return fmt.Errorf("sign newly created action: %w", err)
 	}
-	m.logger.Info("created global terminal-admin action",
+	m.logger.Info("created terminal-admin action",
 		"name", name, "action_id", actionID, "access_level", accessLevel.String())
 	return nil
 }

--- a/internal/api/system_actions_listener.go
+++ b/internal/api/system_actions_listener.go
@@ -262,6 +262,12 @@ func SystemActionListener(mgr *SystemActionManager, logger *slog.Logger, syncTim
 					logger.Error("system-action listener: reconcile global TerminalAdmin failed",
 						"event_type", e.EventType, "event_id", e.ID, "error", err)
 				}
+				// Same for the per-scope TerminalAdmin actions (#7): a
+				// scoped grant change recomputes the per-scope cohorts.
+				if err := mgr.ReconcileScopedTerminalAdminActions(ctx); err != nil {
+					logger.Error("system-action listener: reconcile scoped TerminalAdmin failed",
+						"event_type", e.EventType, "event_id", e.ID, "error", err)
+				}
 
 			case SyncOpSyncAll:
 				// SyncAllUsersSystemActions already ends with a

--- a/internal/api/system_actions_scoped.go
+++ b/internal/api/system_actions_scoped.go
@@ -1,0 +1,128 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// Per-scope TerminalAdmin actions (#7). The global reconciler in
+// system_actions.go handles the two `:global` actions; this file adds the
+// per-device-group actions `system:terminal-admin-{limited,full}:<dgID>`,
+// sharing the same cohort computation and reconcile body.
+
+// cohortKey identifies one (access level, scope) sudo cohort. Scope is
+// "" for the global action, or a device_group id for a per-scope action.
+type cohortKey struct {
+	Level pm.AdminAccessLevel
+	Scope string
+}
+
+// Per-scope action name prefixes. A per-scope name is the prefix + the
+// device-group id (a ULID — colon-free, so the suffix is unambiguous).
+const (
+	scopedTerminalAdminPrefixLimited = "system:terminal-admin-limited:"
+	scopedTerminalAdminPrefixFull    = "system:terminal-admin-full:"
+)
+
+// terminalAdminScopeKey reduces a scoped grant to its cohort scope:
+//   - unscoped/global grant       → ("", true)   → the :global action
+//   - device_group-scoped grant   → (groupID, true) → the per-scope action
+//   - user_group-scoped / unknown → ("", false)  → ignored (TerminalAdmin
+//     is a device-target permission; a user_group scope grants no device
+//     reach).
+func terminalAdminScopeKey(g store.ScopedGrant) (scope string, ok bool) {
+	switch g.ScopeKind {
+	case "":
+		return "", true
+	case auth.ScopeKindDeviceGroup:
+		return g.ScopeID, true
+	default:
+		return "", false
+	}
+}
+
+// scopedTerminalAdminActionName builds the per-scope action name for a
+// (level, device-group) pair.
+func scopedTerminalAdminActionName(level pm.AdminAccessLevel, deviceGroupID string) string {
+	if level == pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL {
+		return scopedTerminalAdminPrefixFull + deviceGroupID
+	}
+	return scopedTerminalAdminPrefixLimited + deviceGroupID
+}
+
+// levelFromScopedActionName parses the access level back out of a
+// per-scope action name. ok=false for the :global actions or any name
+// that isn't a per-scope terminal-admin action.
+func levelFromScopedActionName(name string) (pm.AdminAccessLevel, bool) {
+	switch {
+	case name == GlobalTerminalAdminLimitedActionName || name == GlobalTerminalAdminFullActionName:
+		return 0, false
+	case strings.HasPrefix(name, scopedTerminalAdminPrefixFull):
+		return pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL, true
+	case strings.HasPrefix(name, scopedTerminalAdminPrefixLimited):
+		return pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED, true
+	default:
+		return 0, false
+	}
+}
+
+// ReconcileScopedTerminalAdminActions recomputes users[] for every
+// per-device-group TerminalAdmin action. For each (level, device-group)
+// cohort that has ≥1 holder it lazily creates the action (idempotent,
+// signed once on create) and reconciles its membership; for any
+// pre-existing per-scope action whose cohort is now empty it reconciles
+// the membership to [] (the row is LEFT in place — an empty AdminPolicy
+// is inert and the agent SKIPs it; deleting would churn the action id
+// across grant flapping).
+//
+// GAP-A (over-revocation safety): each (level × scope) is exactly one
+// action with its own users[] derived from exactly the grants of that
+// level at that scope, so revoking Limited:dgX recomputes only
+// system:terminal-admin-limited:<dgX> and cannot touch
+// system:terminal-admin-full:<dgY>.
+func (m *SystemActionManager) ReconcileScopedTerminalAdminActions(ctx context.Context) error {
+	users, err := m.store.Repos().User.ListAllNonDeleted(ctx)
+	if err != nil {
+		return fmt.Errorf("list users: %w", err)
+	}
+	cohorts := m.computeTerminalAdminCohorts(ctx, users)
+
+	wanted := map[string]struct{}{}
+	for k, cohort := range cohorts {
+		if k.Scope == "" {
+			continue // global actions are owned by the global reconciler
+		}
+		name := scopedTerminalAdminActionName(k.Level, k.Scope)
+		wanted[name] = struct{}{}
+		if err := m.bootstrapTerminalAdminAction(ctx, name, k.Level); err != nil {
+			return fmt.Errorf("bootstrap %s: %w", name, err)
+		}
+		if err := m.reconcileOneTerminalAdmin(ctx, name, k.Level, cohort); err != nil {
+			return fmt.Errorf("reconcile %s: %w", name, err)
+		}
+	}
+
+	// Empty the cohort of any per-scope action that no longer has holders.
+	existing, err := m.store.Queries().ListScopedTerminalAdminActionNames(ctx)
+	if err != nil {
+		return fmt.Errorf("list scoped terminal-admin action names: %w", err)
+	}
+	for _, name := range existing {
+		if _, ok := wanted[name]; ok {
+			continue
+		}
+		level, ok := levelFromScopedActionName(name)
+		if !ok {
+			continue // defensive — query already excludes non-per-scope names
+		}
+		if err := m.reconcileOneTerminalAdmin(ctx, name, level, nil); err != nil {
+			return fmt.Errorf("clear empty scope %s: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/internal/api/system_actions_scoped_terminal_admin_test.go
+++ b/internal/api/system_actions_scoped_terminal_admin_test.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+const (
+	limitedLevel = pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_LIMITED
+	fullLevel    = pm.AdminAccessLevel_ADMIN_ACCESS_LEVEL_TERMINAL_ADMIN_FULL
+)
+
+// grantScopedTerminalAdmin grants `perm` to userID scoped to device
+// group dgID (a device_group-scoped role grant). Returns the role id.
+func grantScopedTerminalAdmin(t *testing.T, st *store.Store, actorID, userID, perm, dgID string) string {
+	t.Helper()
+	roleID := testutil.CreateTestRole(t, st, actorID, "scoped-"+perm+"-"+dgID, []string{perm})
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":" + dgID,
+		EventType:  string(eventtypes.UserRoleAssigned),
+		Data: map[string]any{
+			"user_id": userID, "role_id": roleID,
+			"scope_kind": "device_group", "scope_id": dgID,
+		},
+		ActorType: "user", ActorID: actorID,
+	}))
+	return roleID
+}
+
+func revokeScopedRole(t *testing.T, st *store.Store, actorID, userID, roleID, dgID string) {
+	t.Helper()
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":" + dgID,
+		EventType:  string(eventtypes.UserRoleRevoked),
+		Data: map[string]any{
+			"user_id": userID, "role_id": roleID,
+			"scope_kind": "device_group", "scope_id": dgID,
+		},
+		ActorType: "user", ActorID: actorID,
+	}))
+}
+
+func TestReconcileScoped_MaterializesPerScopeCohort(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantScopedTerminalAdmin(t, st, actorID, userID, "TerminalAdminFull", "dg-X")
+
+	require.NoError(t, m.ReconcileScopedTerminalAdminActions(context.Background()))
+
+	scoped := loadAdminPolicy(t, st, scopedTerminalAdminActionName(fullLevel, "dg-X"))
+	assert.Equal(t, []string{"pm-tty-alice"}, scoped.Users,
+		"a TerminalAdminFull:scope=dg-X holder must be in the per-scope FULL action")
+	assert.Equal(t, fullLevel, scoped.AccessLevel)
+
+	// The global FULL action must NOT contain the scoped holder.
+	require.NoError(t, m.ReconcileGlobalTerminalAdminActions(context.Background()))
+	assert.Empty(t, loadAdminPolicy(t, st, globalTerminalAdminFullActionName).Users,
+		"a scoped grant must not leak into the global cohort")
+}
+
+// GAP-A: revoking Limited:dgX must not affect Full:dgY.
+func TestReconcileScoped_GAPA_RevokeLimitedKeepsFull(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	limitedRole := grantScopedTerminalAdmin(t, st, actorID, userID, "TerminalAdminLimited", "dg-X")
+	grantScopedTerminalAdmin(t, st, actorID, userID, "TerminalAdminFull", "dg-Y")
+
+	require.NoError(t, m.ReconcileScopedTerminalAdminActions(context.Background()))
+	require.Equal(t, []string{"pm-tty-alice"}, loadAdminPolicy(t, st, scopedTerminalAdminActionName(limitedLevel, "dg-X")).Users)
+	require.Equal(t, []string{"pm-tty-alice"}, loadAdminPolicy(t, st, scopedTerminalAdminActionName(fullLevel, "dg-Y")).Users)
+
+	// Revoke ONLY the Limited:dg-X grant.
+	revokeScopedRole(t, st, actorID, userID, limitedRole, "dg-X")
+	require.NoError(t, m.ReconcileScopedTerminalAdminActions(context.Background()))
+
+	assert.Empty(t, loadAdminPolicy(t, st, scopedTerminalAdminActionName(limitedLevel, "dg-X")).Users,
+		"revoked Limited:dg-X cohort must be emptied")
+	assert.Equal(t, []string{"pm-tty-alice"}, loadAdminPolicy(t, st, scopedTerminalAdminActionName(fullLevel, "dg-Y")).Users,
+		"Full:dg-Y must be untouched by the Limited:dg-X revoke (GAP-A)")
+}
+
+// When a scope loses its last holder, the action row persists with an
+// empty users[] (inert) rather than being deleted.
+func TestReconcileScoped_EmptyScopeCleanup(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	roleID := grantScopedTerminalAdmin(t, st, actorID, userID, "TerminalAdminLimited", "dg-X")
+	require.NoError(t, m.ReconcileScopedTerminalAdminActions(context.Background()))
+
+	name := scopedTerminalAdminActionName(limitedLevel, "dg-X")
+	require.NotEmpty(t, loadAdminPolicy(t, st, name).Users)
+
+	revokeScopedRole(t, st, actorID, userID, roleID, "dg-X")
+	require.NoError(t, m.ReconcileScopedTerminalAdminActions(context.Background()))
+
+	// Row still exists (GetActionByName succeeds in loadAdminPolicy) with empty users.
+	assert.Empty(t, loadAdminPolicy(t, st, name).Users,
+		"emptied scope keeps the action row with no members")
+}
+
+// A user_group-scoped TerminalAdmin grant has no device meaning and must
+// materialize no per-scope action.
+func TestReconcileScoped_IgnoresUserGroupScope(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	roleID := testutil.CreateTestRole(t, st, actorID, "ug-scoped", []string{"TerminalAdminLimited"})
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":ug-1",
+		EventType:  string(eventtypes.UserRoleAssigned),
+		Data: map[string]any{
+			"user_id": userID, "role_id": roleID,
+			"scope_kind": "user_group", "scope_id": "ug-1",
+		},
+		ActorType: "user", ActorID: actorID,
+	}))
+
+	require.NoError(t, m.ReconcileScopedTerminalAdminActions(context.Background()))
+
+	names, err := st.Queries().ListScopedTerminalAdminActionNames(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, names, "a user_group-scoped TerminalAdmin grant must create no per-scope action")
+}
+
+func TestReconcileScoped_Idempotent_NoReSign(t *testing.T) {
+	m, st := newManagerForTest(t)
+	require.NoError(t, m.BootstrapGlobalTerminalAdminActions(context.Background()))
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "viewer")
+	setLinuxUsername(t, st, userID, "alice")
+	grantScopedTerminalAdmin(t, st, actorID, userID, "TerminalAdminLimited", "dg-X")
+	require.NoError(t, m.ReconcileScopedTerminalAdminActions(context.Background()))
+
+	name := scopedTerminalAdminActionName(limitedLevel, "dg-X")
+	before, err := st.Queries().GetActionByName(context.Background(), name)
+	require.NoError(t, err)
+
+	require.NoError(t, m.ReconcileScopedTerminalAdminActions(context.Background()))
+	after, err := st.Queries().GetActionByName(context.Background(), name)
+	require.NoError(t, err)
+
+	assert.Equal(t, before.Signature, after.Signature,
+		"a steady scoped cohort must not re-sign on a no-op reconcile tick")
+}

--- a/internal/store/generated/assignments.sql.go
+++ b/internal/store/generated/assignments.sql.go
@@ -1319,6 +1319,35 @@ func (q *Queries) ListGlobalTerminalAdminActions(ctx context.Context) ([]ListGlo
 	return items, nil
 }
 
+const listScopedTerminalAdminActionNames = `-- name: ListScopedTerminalAdminActionNames :many
+SELECT name FROM actions_projection
+WHERE is_deleted = FALSE
+  AND (name LIKE 'system:terminal-admin-limited:%'
+       OR name LIKE 'system:terminal-admin-full:%')
+  AND name NOT IN ('system:terminal-admin-limited:global',
+                   'system:terminal-admin-full:global')
+`
+
+func (q *Queries) ListScopedTerminalAdminActionNames(ctx context.Context) ([]string, error) {
+	rows, err := q.db.Query(ctx, listScopedTerminalAdminActionNames)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		items = append(items, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listUserLayerResolvedActionsForDevice = `-- name: ListUserLayerResolvedActionsForDevice :many
 WITH device_owners AS (
   SELECT dau.user_id FROM device_assigned_users_projection dau WHERE dau.device_id = $1

--- a/internal/store/queries/assignments.sql
+++ b/internal/store/queries/assignments.sql
@@ -930,3 +930,15 @@ FROM actions_projection
 WHERE is_deleted = FALSE
   AND name IN ('system:terminal-admin-limited:global',
                'system:terminal-admin-full:global');
+
+-- name: ListScopedTerminalAdminActionNames :many
+-- Names of every PER-SCOPE terminal-admin action (excluding the two
+-- :global actions), so the per-scope reconciler can empty the cohort of
+-- any scope that no longer has a holder. Names are
+-- system:terminal-admin-{limited,full}:<deviceGroupID> (#7).
+SELECT name FROM actions_projection
+WHERE is_deleted = FALSE
+  AND (name LIKE 'system:terminal-admin-limited:%'
+       OR name LIKE 'system:terminal-admin-full:%')
+  AND name NOT IN ('system:terminal-admin-limited:global',
+                   'system:terminal-admin-full:global');


### PR DESCRIPTION
Second of the #7 TTY/TerminalAdmin scope PRs (after #340 decoupled the global cohort). This adds the **per-scope reconciler** — the per-device-group sudo actions. The scope-aware **delivery** (account + sudo to devices) and the **StartTerminal scope gate** are the next PR; until then these per-scope rows are inert (created but not delivered), which is harmless.

## What this adds
- `computeTerminalAdminCohorts` now returns `map[cohortKey{Level,Scope}][]string`, sourced from `User.ScopedGrants`: unscoped grants feed the two `:global` actions (the global reconciler reads `Scope==""`), device-group-scoped grants feed per-scope actions, `user_group`-scoped grants are ignored (no device meaning).
- `ReconcileScopedTerminalAdminActions` lazily creates `system:terminal-admin-{limited,full}:<deviceGroupID>` on first grant (idempotent, signed once), reconciles membership via the now name-agnostic `reconcileOneTerminalAdmin`, and empties (does **not** delete) the `users[]` of a scope that loses its last holder — an empty AdminPolicy is inert and the agent SKIPs it; deleting would churn the action id across grant flapping. `ListScopedTerminalAdminActionNames` finds the rows to clean.
- Wired into the periodic sweep and the per-user listener branch.

## GAP-A (over-revocation safety)
Each `(level × scope)` is exactly one action with its own `users[]` derived from exactly that grant. Revoking `Limited:dgX` recomputes only `…limited:<dgX>` and structurally cannot touch `…full:<dgY>` — the executable form of the ADR's T6.GAP-A.

## Tests
Per-scope cohort materialization (global unaffected), **GAP-A** (revoke Limited keeps Full), empty-scope cleanup (row persists, inert), `user_group` scope ignored, idempotent no-re-sign. Full TerminalAdmin suite green; `go vet`, `gofmt`, build clean. Local CodeRabbit: clean.

## Follow-up
Scope-aware delivery (`ListSystemTtyActionsForDevice` hand-written + `ListTerminalAdminActionsForDevice` in `resolution.go`) and the `EnforceDeviceScope` gate on `StartTerminal`.

Refs manchtools/power-manage-server#7.
