### PR TITLE
feat: #7 — StartTerminal device-group scope gate (Model Y, PR3/4)

### DIFF
--- a/internal/api/scope_resolver.go
+++ b/internal/api/scope_resolver.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"context"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// storeScopeResolver implements auth.ScopeResolver over the device-group
+// and user-group membership projections. The auth package stays
+// store-independent (it only knows the interface); the concrete resolver
+// lives here and is handed to the Enforce* helpers by the handlers (#7).
+type storeScopeResolver struct {
+	store *store.Store
+}
+
+// newScopeResolver builds the projection-backed scope resolver.
+func newScopeResolver(st *store.Store) auth.ScopeResolver {
+	return storeScopeResolver{store: st}
+}
+
+// DeviceGroupsForDevice returns the ids of every device group the device
+// belongs to (static + dynamic-materialized).
+func (r storeScopeResolver) DeviceGroupsForDevice(ctx context.Context, deviceID string) ([]string, error) {
+	groups, err := r.store.Repos().DeviceGroup.ListForDevice(ctx, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(groups))
+	for i, g := range groups {
+		ids[i] = g.ID
+	}
+	return ids, nil
+}
+
+// UserGroupsForUser returns the ids of every user group the user belongs to.
+func (r storeScopeResolver) UserGroupsForUser(ctx context.Context, userID string) ([]string, error) {
+	groups, err := r.store.Repos().UserGroup.ListForUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	ids := make([]string, len(groups))
+	for i, g := range groups {
+		ids[i] = g.ID
+	}
+	return ids, nil
+}

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -129,6 +129,17 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 	// `StartTerminal:self` scope that checks the device's
 	// linux_username matches userCtx.LinuxUsername.
 	filterUserID := userFilterID(ctx, "StartTerminal")
+	// #7 device-group scope: a StartTerminal:scope=dgX holder may open a
+	// session only on devices in dgX. Applies to the unrestricted tier
+	// (filterUserID == nil means the caller holds the base StartTerminal
+	// permission — scoped or global); the :assigned tier is governed by
+	// the owner filter below. Checked before the lookup so an out-of-scope
+	// device is denied, not leaked via NotFound-vs-PermissionDenied.
+	if filterUserID == nil {
+		if err := auth.EnforceDeviceScope(ctx, newScopeResolver(h.store), "StartTerminal", req.Msg.DeviceId); err != nil {
+			return nil, err
+		}
+	}
 	if _, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{ID: req.Msg.DeviceId, OwnerScope: filterUserID}); err != nil {
 		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrDeviceNotFound, connect.CodeNotFound, "device not found")

--- a/internal/api/terminal_handler_scope_test.go
+++ b/internal/api/terminal_handler_scope_test.go
@@ -1,0 +1,48 @@
+package api_test
+
+import (
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestStartTerminal_ScopeGate covers the #7 device-group scope gate on
+// the web session-start RPC: a StartTerminal:scope=dgX holder may open a
+// session only on devices in dgX; a global StartTerminal holder reaches
+// any device.
+func TestStartTerminal_ScopeGate(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _ := newTerminalHandler(t, st)
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, userID, "alice")
+	dgX := testutil.CreateTestDeviceGroup(t, st, userID, "Plant X")
+	devIn := testutil.CreateTestDevice(t, st, "host-in")
+	devOut := testutil.CreateTestDevice(t, st, "host-out")
+	testutil.AddDeviceToTestGroup(t, st, userID, dgX, devIn)
+
+	scopedCtx := testutil.AuthContextScoped(userID, "u@test.com", []string{"StartTerminal"},
+		[]auth.ScopedGrant{{Permission: "StartTerminal", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgX}})
+
+	t.Run("in-scope device allowed", func(t *testing.T) {
+		_, err := h.StartTerminal(scopedCtx, connect.NewRequest(&pm.StartTerminalRequest{DeviceId: devIn}))
+		require.NoError(t, err)
+	})
+	t.Run("out-of-scope device denied", func(t *testing.T) {
+		_, err := h.StartTerminal(scopedCtx, connect.NewRequest(&pm.StartTerminalRequest{DeviceId: devOut}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+	t.Run("global StartTerminal reaches any device", func(t *testing.T) {
+		globalCtx := testutil.AuthContextScoped(userID, "u@test.com", []string{"StartTerminal"},
+			[]auth.ScopedGrant{{Permission: "StartTerminal"}})
+		_, err := h.StartTerminal(globalCtx, connect.NewRequest(&pm.StartTerminalRequest{DeviceId: devOut}))
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Third of the #7 TTY/TerminalAdmin scope PRs (after #340 decoupled the cohort and #341 added the per-scope reconciler). This adds the **`StartTerminal` device-group scope gate** — the user-visible security boundary.

## What this adds
- A `StartTerminal:scope=dgX` holder may open a web terminal session **only** on devices in dgX. The gate calls `auth.EnforceDeviceScope` (from S2b) on the caller's `StartTerminal` scope, before the device lookup (so an out-of-scope id is denied, not leaked via `NotFound` vs `PermissionDenied`).
- Applied to the **unrestricted tier only** (`userFilterID(...) == nil` — the caller holds the base `StartTerminal` permission, scoped or global). The `:assigned` self-service tier is untouched (governed by the existing owner filter). A **global** `StartTerminal` holder reaches any device.
- `storeScopeResolver` (the projection-backed `auth.ScopeResolver`) is re-added for the helper.

## Tests
In-scope allowed, out-of-scope denied (`PermissionDenied`), global reaches any device; all existing `:assigned` StartTerminal tests unaffected. `go vet`, `gofmt`, build, full StartTerminal suite green.

## Follow-up (final PR)
Scope-aware **delivery** of the `pm-tty` account + sudo policy in `resolution.go` (`ListSystemTtyActionsForDevice` + `ListTerminalAdminActionsForDevice`) so those land only on in-scope devices. Until then they deliver globally — but this gate already confines *who can open a session*, so an out-of-scope account/sudo is unusable by the scoped operator.

Refs manchtools/power-manage-server#7.
