### PR TITLE
feat: #7 — scope-aware delivery of pm-tty account + sudo policy (Model Y, PR4/4)

### DIFF
--- a/internal/resolution/resolve.go
+++ b/internal/resolution/resolve.go
@@ -11,8 +11,8 @@ type Querier interface {
 	ListResolvedActionsForDevice(ctx context.Context, targetID string) ([]db.ListResolvedActionsForDeviceRow, error)
 	ListDeviceLayerExcludedActionIDs(ctx context.Context, targetID string) ([]string, error)
 	ListUserLayerResolvedActionsForDevice(ctx context.Context, id string) ([]db.ListUserLayerResolvedActionsForDeviceRow, error)
-	ListSystemTtyActionsForPermissionHolders(ctx context.Context) ([]db.ListSystemTtyActionsForPermissionHoldersRow, error)
-	ListGlobalTerminalAdminActions(ctx context.Context) ([]db.ListGlobalTerminalAdminActionsRow, error)
+	ListSystemTtyActionsForDevice(ctx context.Context, deviceID string) ([]db.ListSystemTtyActionsForDeviceRow, error)
+	ListTerminalAdminActionsForDevice(ctx context.Context, deviceID string) ([]db.ListTerminalAdminActionsForDeviceRow, error)
 }
 
 // ResolveActionsForDevice queries device-layer assignments, user-layer
@@ -75,7 +75,7 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 	// error here makes ProxySyncActions fail fast; the agent retries
 	// on its sync interval and nothing on disk changes in the
 	// meantime.
-	ttyActions, err := q.ListSystemTtyActionsForPermissionHolders(ctx)
+	ttyActions, err := q.ListSystemTtyActionsForDevice(ctx, deviceID)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func ResolveActionsForDevice(ctx context.Context, q Querier, deviceID string) ([
 	//    EXCLUDED must not be able to lock the admin sudoers fragment
 	//    out either. Fail-fast on query error for the same reason as
 	//    the TTY layer (see step 3's failure-mode note).
-	terminalAdminActions, err := q.ListGlobalTerminalAdminActions(ctx)
+	terminalAdminActions, err := q.ListTerminalAdminActionsForDevice(ctx, deviceID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/resolution/resolve_scope_test.go
+++ b/internal/resolution/resolve_scope_test.go
@@ -1,0 +1,109 @@
+package resolution_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/resolution"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+func containsAction(actions []db.ListResolvedActionsForDeviceRow, id string) bool {
+	for _, a := range actions {
+		if a.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// assignScopedStartTerminal grants a StartTerminal role to userID scoped
+// to device group dgID (a device_group-scoped grant).
+func assignScopedStartTerminal(t *testing.T, st *store.Store, adminID, userID, dgID string) {
+	t.Helper()
+	roleID := testutil.CreateTestRole(t, st, adminID, "tty-scoped-"+dgID, []string{"StartTerminal"})
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user_role",
+		StreamID:   userID + ":" + roleID + ":" + dgID,
+		EventType:  "UserRoleAssigned",
+		Data: map[string]any{
+			"user_id": userID, "role_id": roleID,
+			"scope_kind": "device_group", "scope_id": dgID,
+		},
+		ActorType: "user", ActorID: adminID,
+	}))
+}
+
+// A StartTerminal:scope=dgX holder's pm-tty account is delivered ONLY to
+// devices in dgX; a device outside the scope does not receive it.
+func TestResolveActions_TTYScopeAware(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	operatorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+
+	dgX := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant X")
+	assignScopedStartTerminal(t, st, adminID, operatorID, dgX)
+
+	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+operatorID, int(pm.ActionType_ACTION_TYPE_USER))
+	linkSystemTtyAction(t, st, operatorID, ttyActionID)
+
+	devIn := testutil.CreateTestDevice(t, st, "in-scope")
+	devOut := testutil.CreateTestDevice(t, st, "out-scope")
+	testutil.AddDeviceToTestGroup(t, st, adminID, dgX, devIn)
+
+	inActions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), devIn)
+	require.NoError(t, err)
+	assert.True(t, containsAction(inActions, ttyActionID), "in-scope device must receive the pm-tty account")
+
+	outActions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), devOut)
+	require.NoError(t, err)
+	assert.False(t, containsAction(outActions, ttyActionID), "out-of-scope device must NOT receive the pm-tty account")
+}
+
+// A global StartTerminal holder's account still reaches every device.
+func TestResolveActions_TTYGlobalUnaffected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	operatorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	roleID := testutil.CreateTestRole(t, st, adminID, "tty-global", []string{"StartTerminal"})
+	testutil.AssignRoleToTestUser(t, st, adminID, operatorID, roleID)
+
+	ttyActionID := testutil.CreateTestAction(t, st, adminID, "system:tty-user:"+operatorID, int(pm.ActionType_ACTION_TYPE_USER))
+	linkSystemTtyAction(t, st, operatorID, ttyActionID)
+
+	devAnywhere := testutil.CreateTestDevice(t, st, "anywhere")
+	actions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), devAnywhere)
+	require.NoError(t, err)
+	assert.True(t, containsAction(actions, ttyActionID), "a global StartTerminal holder's account reaches any device")
+}
+
+// A per-scope TerminalAdmin sudo action is delivered ONLY to devices in
+// its scope group; the global ones reach every device.
+func TestResolveActions_TerminalAdminScopeAware(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	dgX := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant X")
+	scopedActionID := testutil.CreateTestAction(t, st, adminID, "system:terminal-admin-limited:"+dgX, int(pm.ActionType_ACTION_TYPE_ADMIN_POLICY))
+	globalActionID := testutil.CreateTestAction(t, st, adminID, "system:terminal-admin-limited:global", int(pm.ActionType_ACTION_TYPE_ADMIN_POLICY))
+
+	devIn := testutil.CreateTestDevice(t, st, "in-scope")
+	devOut := testutil.CreateTestDevice(t, st, "out-scope")
+	testutil.AddDeviceToTestGroup(t, st, adminID, dgX, devIn)
+
+	inActions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), devIn)
+	require.NoError(t, err)
+	assert.True(t, containsAction(inActions, scopedActionID), "in-scope device gets the per-scope sudo action")
+	assert.True(t, containsAction(inActions, globalActionID), "global sudo action reaches every device")
+
+	outActions, err := resolution.ResolveActionsForDevice(testutil.AdminContext(adminID), st.Queries(), devOut)
+	require.NoError(t, err)
+	assert.False(t, containsAction(outActions, scopedActionID), "out-of-scope device must NOT get the per-scope sudo action")
+	assert.True(t, containsAction(outActions, globalActionID), "global sudo action still reaches the out-of-scope device")
+}

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -513,12 +513,12 @@ type ttyFailingQuerier struct {
 	err error
 }
 
-func (q ttyFailingQuerier) ListSystemTtyActionsForPermissionHolders(ctx context.Context) ([]db.ListSystemTtyActionsForPermissionHoldersRow, error) {
+func (q ttyFailingQuerier) ListSystemTtyActionsForDevice(ctx context.Context, deviceID string) ([]db.ListSystemTtyActionsForDeviceRow, error) {
 	return nil, q.err
 }
 
 // TestResolveActions_TTYPermissionSource_FailsFastOnTtyError locks in
-// the rc13 safety contract: when ListSystemTtyActionsForPermissionHolders
+// the rc13 safety contract: when ListSystemTtyActionsForDevice
 // fails, ResolveActionsForDevice MUST surface the error rather than
 // quietly continuing without TTY rows. ProxySyncActions then fails
 // the sync, the agent retries on its interval, and nothing on disk
@@ -661,7 +661,7 @@ type globalTerminalAdminFailingQuerier struct {
 	err error
 }
 
-func (q globalTerminalAdminFailingQuerier) ListGlobalTerminalAdminActions(ctx context.Context) ([]db.ListGlobalTerminalAdminActionsRow, error) {
+func (q globalTerminalAdminFailingQuerier) ListTerminalAdminActionsForDevice(ctx context.Context, deviceID string) ([]db.ListTerminalAdminActionsForDeviceRow, error) {
 	return nil, q.err
 }
 

--- a/internal/store/generated/assignments.sql.go
+++ b/internal/store/generated/assignments.sql.go
@@ -1144,7 +1144,7 @@ func (q *Queries) ListResolvedActionsForDevice(ctx context.Context, targetID str
 	return items, nil
 }
 
-const listSystemTtyActionsForPermissionHolders = `-- name: ListSystemTtyActionsForPermissionHolders :many
+const listSystemTtyActionsForDevice = `-- name: ListSystemTtyActionsForDevice :many
 SELECT DISTINCT ON (a.id)
        a.id, a.name, a.description, a.action_type, a.desired_state,
        a.params, a.timeout_seconds, a.created_at, a.created_by,
@@ -1156,25 +1156,35 @@ JOIN actions_projection a
 WHERE u.is_deleted = FALSE
   AND u.system_tty_action_id <> ''
   AND EXISTS (
-    SELECT 1 FROM roles_projection r
-    WHERE r.is_deleted = FALSE
+    SELECT 1
+    FROM roles_projection r
+    JOIN user_roles_projection ur ON ur.role_id = r.id
+    WHERE ur.user_id = u.id AND r.is_deleted = FALSE
       AND 'StartTerminal' = ANY(r.permissions)
       AND (
-        r.id IN (
-          SELECT ur.role_id FROM user_roles_projection ur
-          WHERE ur.user_id = u.id
-        )
-        OR r.id IN (
-          SELECT ugr.role_id FROM user_group_roles_projection ugr
-          JOIN user_group_members_projection ugm ON ugm.group_id = ugr.group_id
-          JOIN user_groups_projection ug ON ug.id = ugm.group_id AND ug.is_deleted = FALSE
-          WHERE ugm.user_id = u.id
-        )
+        ur.scope_kind IS NULL
+        OR (ur.scope_kind = 'device_group'
+            AND EXISTS (SELECT 1 FROM device_group_members_projection m
+                        WHERE m.group_id = ur.scope_id AND m.device_id = $1))
+      )
+    UNION ALL
+    SELECT 1
+    FROM roles_projection r
+    JOIN user_group_roles_projection ugr ON ugr.role_id = r.id
+    JOIN user_group_members_projection ugm ON ugm.group_id = ugr.group_id
+    JOIN user_groups_projection ug ON ug.id = ugm.group_id AND ug.is_deleted = FALSE
+    WHERE ugm.user_id = u.id AND r.is_deleted = FALSE
+      AND 'StartTerminal' = ANY(r.permissions)
+      AND (
+        ugr.scope_kind IS NULL
+        OR (ugr.scope_kind = 'device_group'
+            AND EXISTS (SELECT 1 FROM device_group_members_projection m
+                        WHERE m.group_id = ugr.scope_id AND m.device_id = $1))
       )
   )
 `
 
-type ListSystemTtyActionsForPermissionHoldersRow struct {
+type ListSystemTtyActionsForDeviceRow struct {
 	ID                string     `json:"id"`
 	Name              string     `json:"name"`
 	Description       *string    `json:"description"`
@@ -1208,15 +1218,15 @@ type ListSystemTtyActionsForPermissionHoldersRow struct {
 // Filtering rules: skip soft-deleted users, actions, roles, and
 // groups so stale projection rows can't leak through and surface a
 // TTY account that should have been cleaned up.
-func (q *Queries) ListSystemTtyActionsForPermissionHolders(ctx context.Context) ([]ListSystemTtyActionsForPermissionHoldersRow, error) {
-	rows, err := q.db.Query(ctx, listSystemTtyActionsForPermissionHolders)
+func (q *Queries) ListSystemTtyActionsForDevice(ctx context.Context, deviceID string) ([]ListSystemTtyActionsForDeviceRow, error) {
+	rows, err := q.db.Query(ctx, listSystemTtyActionsForDevice, deviceID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListSystemTtyActionsForPermissionHoldersRow{}
+	items := []ListSystemTtyActionsForDeviceRow{}
 	for rows.Next() {
-		var i ListSystemTtyActionsForPermissionHoldersRow
+		var i ListSystemTtyActionsForDeviceRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.Name,
@@ -1243,18 +1253,28 @@ func (q *Queries) ListSystemTtyActionsForPermissionHolders(ctx context.Context) 
 	return items, nil
 }
 
-const listGlobalTerminalAdminActions = `-- name: ListGlobalTerminalAdminActions :many
+const listTerminalAdminActionsForDevice = `-- name: ListTerminalAdminActionsForDevice :many
 SELECT id, name, description, action_type, desired_state,
        params, timeout_seconds, created_at, created_by,
        is_deleted, projection_version,
        signature, params_canonical, schedule
 FROM actions_projection
 WHERE is_deleted = FALSE
-  AND name IN ('system:terminal-admin-limited:global',
-               'system:terminal-admin-full:global')
+  AND (
+    name IN ('system:terminal-admin-limited:global',
+             'system:terminal-admin-full:global')
+    OR (
+      (name LIKE 'system:terminal-admin-limited:%'
+        OR name LIKE 'system:terminal-admin-full:%')
+      AND split_part(name, ':', 3) IN (
+        SELECT m.group_id FROM device_group_members_projection m
+        WHERE m.device_id = $1
+      )
+    )
+  )
 `
 
-type ListGlobalTerminalAdminActionsRow struct {
+type ListTerminalAdminActionsForDeviceRow struct {
 	ID                string     `json:"id"`
 	Name              string     `json:"name"`
 	Description       *string    `json:"description"`
@@ -1284,15 +1304,15 @@ type ListGlobalTerminalAdminActionsRow struct {
 // per-scope variants; that PR will replace the IN-list filter with a
 // scope-aware join. The shape of this query is intentionally simple
 // so the #7 diff is isolated to the WHERE clause.
-func (q *Queries) ListGlobalTerminalAdminActions(ctx context.Context) ([]ListGlobalTerminalAdminActionsRow, error) {
-	rows, err := q.db.Query(ctx, listGlobalTerminalAdminActions)
+func (q *Queries) ListTerminalAdminActionsForDevice(ctx context.Context, deviceID string) ([]ListTerminalAdminActionsForDeviceRow, error) {
+	rows, err := q.db.Query(ctx, listTerminalAdminActionsForDevice, deviceID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []ListGlobalTerminalAdminActionsRow{}
+	items := []ListTerminalAdminActionsForDeviceRow{}
 	for rows.Next() {
-		var i ListGlobalTerminalAdminActionsRow
+		var i ListTerminalAdminActionsForDeviceRow
 		if err := rows.Scan(
 			&i.ID,
 			&i.Name,

--- a/internal/store/queries/assignments.sql
+++ b/internal/store/queries/assignments.sql
@@ -879,7 +879,14 @@ ORDER BY created_at DESC;
 -- Filtering rules: skip soft-deleted users, actions, roles, and
 -- groups so stale projection rows can't leak through and surface a
 -- TTY account that should have been cleaned up.
--- name: ListSystemTtyActionsForPermissionHolders :many
+-- name: ListSystemTtyActionsForDevice :many
+-- #7: scope-aware. Returns the tty action of every user who holds
+-- StartTerminal GLOBAL or scoped to a device_group containing $1.
+-- scope_kind/scope_id live on user_roles_projection /
+-- user_group_roles_projection (the S2 columns inside migration 010's
+-- DO-block) — sqlc can't resolve them, so the generated method is
+-- HAND-MAINTAINED; keep it in sync. A user_group-scoped StartTerminal
+-- grant has no device meaning and is excluded.
 SELECT DISTINCT ON (a.id)
        a.id, a.name, a.description, a.action_type, a.desired_state,
        a.params, a.timeout_seconds, a.created_at, a.created_by,
@@ -891,20 +898,30 @@ JOIN actions_projection a
 WHERE u.is_deleted = FALSE
   AND u.system_tty_action_id <> ''
   AND EXISTS (
-    SELECT 1 FROM roles_projection r
-    WHERE r.is_deleted = FALSE
+    SELECT 1
+    FROM roles_projection r
+    JOIN user_roles_projection ur ON ur.role_id = r.id
+    WHERE ur.user_id = u.id AND r.is_deleted = FALSE
       AND 'StartTerminal' = ANY(r.permissions)
       AND (
-        r.id IN (
-          SELECT ur.role_id FROM user_roles_projection ur
-          WHERE ur.user_id = u.id
-        )
-        OR r.id IN (
-          SELECT ugr.role_id FROM user_group_roles_projection ugr
-          JOIN user_group_members_projection ugm ON ugm.group_id = ugr.group_id
-          JOIN user_groups_projection ug ON ug.id = ugm.group_id AND ug.is_deleted = FALSE
-          WHERE ugm.user_id = u.id
-        )
+        ur.scope_kind IS NULL
+        OR (ur.scope_kind = 'device_group'
+            AND EXISTS (SELECT 1 FROM device_group_members_projection m
+                        WHERE m.group_id = ur.scope_id AND m.device_id = $1))
+      )
+    UNION ALL
+    SELECT 1
+    FROM roles_projection r
+    JOIN user_group_roles_projection ugr ON ugr.role_id = r.id
+    JOIN user_group_members_projection ugm ON ugm.group_id = ugr.group_id
+    JOIN user_groups_projection ug ON ug.id = ugm.group_id AND ug.is_deleted = FALSE
+    WHERE ugm.user_id = u.id AND r.is_deleted = FALSE
+      AND 'StartTerminal' = ANY(r.permissions)
+      AND (
+        ugr.scope_kind IS NULL
+        OR (ugr.scope_kind = 'device_group'
+            AND EXISTS (SELECT 1 FROM device_group_members_projection m
+                        WHERE m.group_id = ugr.scope_id AND m.device_id = $1))
       )
   );
 
@@ -917,19 +934,30 @@ WHERE u.is_deleted = FALSE
 -- pm-tty-* operators get their sudoers fragment regardless of
 -- assignment.
 --
--- #70 ships with the two GLOBAL rows. #7 extends this design by adding
--- per-scope variants; that PR will replace the IN-list filter with a
--- scope-aware join. The shape of this query is intentionally simple
--- so the #7 diff is isolated to the WHERE clause.
--- name: ListGlobalTerminalAdminActions :many
+-- #70 ships with the two GLOBAL rows. #7 extends this to per-scope
+-- actions: the two :global rows reach every device, PLUS any
+-- system:terminal-admin-{limited,full}:<deviceGroupID> whose group
+-- contains $1. split_part(name,':',3) extracts the device-group id
+-- (ULIDs are colon-free).
+-- name: ListTerminalAdminActionsForDevice :many
 SELECT id, name, description, action_type, desired_state,
        params, timeout_seconds, created_at, created_by,
        is_deleted, projection_version,
        signature, params_canonical, schedule
 FROM actions_projection
 WHERE is_deleted = FALSE
-  AND name IN ('system:terminal-admin-limited:global',
-               'system:terminal-admin-full:global');
+  AND (
+    name IN ('system:terminal-admin-limited:global',
+             'system:terminal-admin-full:global')
+    OR (
+      (name LIKE 'system:terminal-admin-limited:%'
+        OR name LIKE 'system:terminal-admin-full:%')
+      AND split_part(name, ':', 3) IN (
+        SELECT m.group_id FROM device_group_members_projection m
+        WHERE m.device_id = $1
+      )
+    )
+  );
 
 -- name: ListScopedTerminalAdminActionNames :many
 -- Names of every PER-SCOPE terminal-admin action (excluding the two


### PR DESCRIPTION
**Final** PR of #7's TTY/TerminalAdmin scope work (after #340 cohort-decouple, #341 per-scope reconciler, #342 StartTerminal gate). This makes the `pm-tty` account and the LIMITED/FULL sudo policy land on a device **only when the driving permission's scope covers it** — completing the feature end-to-end.

## What this adds
- `ListSystemTtyActionsForPermissionHolders` → **`ListSystemTtyActionsForDevice(deviceID)`**: a user's `pm-tty` account is delivered only when they hold `StartTerminal` **global** (`scope_kind NULL`) or scoped to a device_group containing the device. Hand-maintained (references migration-010's `DO`-block scope columns sqlc can't see, per #336); `user_group`-scoped StartTerminal is excluded (no device meaning).
- `ListGlobalTerminalAdminActions` → **`ListTerminalAdminActionsForDevice(deviceID)`**: the two `:global` actions on every device PLUS any `system:terminal-admin-{limited,full}:<dgID>` whose group contains the device (`split_part(name,':',3)`; ULIDs are colon-free).
- `resolve.go` threads `deviceID` into both (it already has it); fail-fast-on-error + exclusion-exempt merge semantics unchanged.

## Backward compatible
A deployment with only global grants behaves exactly as before — `NULL` scope matches every device and the `:global` actions deliver everywhere.

## Tests
Scoped StartTerminal account delivered to in-scope devices only (global still reaches every device); per-scope sudo action delivered to in-scope devices only while the global sudo still reaches all. Full resolution suite green; `go vet ./...`, `gofmt`, build clean.

> Note on the local CodeRabbit "Critical": it flags `linkSystemTtyAction` as undefined — a false positive from reviewing the diff in isolation; the helper is defined in `resolve_test.go` (same `resolution_test` package). The build and tests pass, proving it's defined.

Closes the #7 TTY/TerminalAdmin scope feature (server side). Refs manchtools/power-manage-server#7.
