### PR TITLE
feat(api): populate role_grants; fix scope-blind assign skip + roles dedup (#7 round-trip)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260609134833-73a636cdf6a3
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260610161746-5136d8f059b3

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260609134833-73a636cdf6a3 h1:UWd+f3FfnaUdHR6NE3vTF05GHl3DvKOyO/oy1qYm/Jg=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260609134833-73a636cdf6a3/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260610161746-5136d8f059b3 h1:66jjZXu/7wvRraOKXPCKcJ726ZvmOgdGSYslcSWVs9k=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260610161746-5136d8f059b3/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/role_grants_roundtrip_test.go
+++ b/internal/api/role_grants_roundtrip_test.go
@@ -1,0 +1,109 @@
+package api_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// findGrant returns the RoleGrant for roleID at the given scope id
+// ("" = unscoped), or nil.
+func findGrant(grants []*pm.RoleGrant, roleID, scopeID string) *pm.RoleGrant {
+	for _, g := range grants {
+		if g.GetRole().GetId() == roleID && g.GetScopeId() == scopeID {
+			return g
+		}
+	}
+	return nil
+}
+
+// A role granted both scoped to a device group AND globally must come
+// back as two RoleGrant entries carrying scope, while the legacy `roles`
+// field stays de-duplicated. scope_name resolves to the group's name.
+func TestGetUser_RoleGrantsCarryScope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	roleH := api.NewRoleHandler(st, slog.Default())
+	userH := api.NewUserHandler(st, slog.Default(), nil)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "TTY", []string{"TerminalAdminLimited"})
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 2")
+
+	_, err := roleH.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.NoError(t, err)
+	_, err = roleH.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: role, // no scope → global
+	}))
+	require.NoError(t, err)
+
+	resp, err := userH.GetUser(ctx, connect.NewRequest(&pm.GetUserRequest{Id: target}))
+	require.NoError(t, err)
+	grants := resp.Msg.GetUser().GetRoleGrants()
+
+	scoped := findGrant(grants, role, dg)
+	require.NotNil(t, scoped, "device-group-scoped grant must appear in role_grants")
+	assert.Equal(t, deviceGroupScope, scoped.GetScopeKind())
+	assert.Equal(t, "Plant 2", scoped.GetScopeName(), "scope_name resolves to the device group's display name")
+
+	global := findGrant(grants, role, "")
+	require.NotNil(t, global, "the unscoped grant must appear as a separate role_grant")
+	assert.Equal(t, pm.RoleGrantScopeKind_ROLE_GRANT_SCOPE_KIND_UNSPECIFIED, global.GetScopeKind())
+	assert.Empty(t, global.GetScopeName())
+
+	count := 0
+	for _, r := range resp.Msg.GetUser().GetRoles() {
+		if r.GetId() == role {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "legacy roles field stays de-duplicated by role id")
+}
+
+// A user with no role grants returns an empty role_grants list (not nil
+// surprises, no panic).
+func TestGetUser_NoGrants_EmptyRoleGrants(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	userH := api.NewUserHandler(st, slog.Default(), nil)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+
+	resp, err := userH.GetUser(testutil.AdminContext(adminID), connect.NewRequest(&pm.GetUserRequest{Id: target}))
+	require.NoError(t, err)
+	assert.Empty(t, resp.Msg.GetUser().GetRoleGrants())
+}
+
+// A user-group scoped role grant round-trips through GetUserGroup.
+func TestGetUserGroup_RoleGrantsCarryScope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	groupH := api.NewUserGroupHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	group := testutil.CreateTestUserGroup(t, st, adminID, "Ops Team")
+	role := testutil.CreateTestRole(t, st, adminID, "TTY", []string{"TerminalAdminFull"})
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 7")
+
+	_, err := groupH.AssignRoleToUserGroup(ctx, connect.NewRequest(&pm.AssignRoleToUserGroupRequest{
+		GroupId: group, RoleId: role, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.NoError(t, err)
+
+	resp, err := groupH.GetUserGroup(ctx, connect.NewRequest(&pm.GetUserGroupRequest{Id: group}))
+	require.NoError(t, err)
+
+	scoped := findGrant(resp.Msg.GetGroup().GetRoleGrants(), role, dg)
+	require.NotNil(t, scoped, "user-group's scoped role grant must appear in role_grants")
+	assert.Equal(t, deviceGroupScope, scoped.GetScopeKind())
+	assert.Equal(t, "Plant 7", scoped.GetScopeName())
+}

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -319,12 +319,15 @@ func (h *RoleHandler) AssignRoleToUser(ctx context.Context, req *connect.Request
 		}
 
 		// Unscoped grants are unique per (user, role) — skip a redundant
-		// re-assign. Scoped grants skip the pre-check: the projector's
-		// INSERT ... ON CONFLICT DO NOTHING (both partial unique indexes)
-		// makes a redundant scoped re-assign an idempotent no-op, and the
-		// 2-tuple UserHasRole can't distinguish scopes.
+		// re-assign. Use the scope-aware UserHasUnscopedRole, NOT the
+		// 2-tuple UserHasRole: an UNSCOPED grant must still be created when
+		// a SCOPED grant of the same role already exists (#7 grants are
+		// independent — global and per-scope coexist). Scoped grants skip
+		// the pre-check entirely: the projector's INSERT ... ON CONFLICT
+		// DO NOTHING (both partial unique indexes) makes a redundant scoped
+		// re-assign an idempotent no-op.
 		if scopeKind == "" {
-			hasRole, err := q.UserHasRole(ctx, db.UserHasRoleParams{
+			hasRole, err := q.UserHasUnscopedRole(ctx, db.UserHasRoleParams{
 				UserID: req.Msg.UserId,
 				RoleID: roleID,
 			})

--- a/internal/api/scope_grant.go
+++ b/internal/api/scope_grant.go
@@ -29,6 +29,32 @@ func scopeKindString(k pm.RoleGrantScopeKind) (string, bool) {
 	}
 }
 
+// scopeKindProto maps the store/auth scope-kind string back to the proto
+// enum for response messages (#7). An unrecognized value maps to
+// UNSPECIFIED (displayed as unscoped) — the store only ever persists the
+// two known kinds or "".
+func scopeKindProto(scopeKind string) pm.RoleGrantScopeKind {
+	switch scopeKind {
+	case auth.ScopeKindDeviceGroup:
+		return pm.RoleGrantScopeKind_ROLE_GRANT_SCOPE_KIND_DEVICE_GROUP
+	case auth.ScopeKindUserGroup:
+		return pm.RoleGrantScopeKind_ROLE_GRANT_SCOPE_KIND_USER_GROUP
+	default:
+		return pm.RoleGrantScopeKind_ROLE_GRANT_SCOPE_KIND_UNSPECIFIED
+	}
+}
+
+// roleGrantToProto converts a store.RoleGrant (role + scope) to its proto
+// form for User.role_grants / UserGroup.role_grants (#7).
+func roleGrantToProto(g store.RoleGrant) *pm.RoleGrant {
+	return &pm.RoleGrant{
+		Role:      roleToProto(g.Role),
+		ScopeKind: scopeKindProto(g.ScopeKind),
+		ScopeId:   g.ScopeID,
+		ScopeName: g.ScopeName,
+	}
+}
+
 // scopePtrs converts an empty-or-set (kind, id) pair to the nil-or-set
 // pointer pair the event payloads carry (nil together = unscoped).
 func scopePtrs(scopeKind, scopeID string) (*string, *string) {

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -118,7 +118,7 @@ func (h *UserGroupHandler) CreateUserGroup(ctx context.Context, req *connect.Req
 	}
 
 	return connect.NewResponse(&pm.CreateUserGroupResponse{
-		Group: userGroupToProto(group, nil, false),
+		Group: userGroupToProto(group, nil, nil, false),
 	}), nil
 }
 
@@ -155,7 +155,7 @@ func (h *UserGroupHandler) GetUserGroup(ctx context.Context, req *connect.Reques
 	isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
 
 	return connect.NewResponse(&pm.GetUserGroupResponse{
-		Group:   userGroupToProto(group, roles, isScimManaged),
+		Group:   userGroupToProto(group, roles, h.userGroupRoleGrants(ctx, group.ID), isScimManaged),
 		Members: protoMembers,
 	}), nil
 }
@@ -187,7 +187,7 @@ func (h *UserGroupHandler) ListUserGroups(ctx context.Context, req *connect.Requ
 	for i, g := range groups {
 		roles, _ := h.store.Queries().GetUserGroupRoles(ctx, g.ID)
 		isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, g.ID)
-		protoGroups[i] = userGroupToProto(g, roles, isScimManaged)
+		protoGroups[i] = userGroupToProto(g, roles, h.userGroupRoleGrants(ctx, g.ID), isScimManaged)
 	}
 
 	return connect.NewResponse(&pm.ListUserGroupsResponse{
@@ -237,7 +237,7 @@ func (h *UserGroupHandler) UpdateUserGroup(ctx context.Context, req *connect.Req
 	isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, req.Msg.GroupId)
 
 	return connect.NewResponse(&pm.UpdateUserGroupResponse{
-		Group: userGroupToProto(updated, roles, isScimManaged),
+		Group: userGroupToProto(updated, roles, h.userGroupRoleGrants(ctx, updated.ID), isScimManaged),
 	}), nil
 }
 
@@ -285,7 +285,7 @@ func (h *UserGroupHandler) SetUserGroupMaintenanceWindow(ctx context.Context, re
 	isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
 
 	return connect.NewResponse(&pm.UpdateUserGroupResponse{
-		Group: userGroupToProto(updated, roles, isScimManaged),
+		Group: userGroupToProto(updated, roles, h.userGroupRoleGrants(ctx, updated.ID), isScimManaged),
 	}), nil
 }
 
@@ -669,7 +669,7 @@ func (h *UserGroupHandler) ListUserGroupsForUser(ctx context.Context, req *conne
 	for i, g := range groups {
 		roles, _ := h.store.Queries().GetUserGroupRoles(ctx, g.ID)
 		isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, g.ID)
-		protoGroups[i] = userGroupToProto(g, roles, isScimManaged)
+		protoGroups[i] = userGroupToProto(g, roles, h.userGroupRoleGrants(ctx, g.ID), isScimManaged)
 	}
 
 	return connect.NewResponse(&pm.ListUserGroupsForUserResponse{
@@ -741,7 +741,7 @@ func (h *UserGroupHandler) UpdateUserGroupQuery(ctx context.Context, req *connec
 	isScimManaged, _ := h.store.Repos().SCIM.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
 
 	return connect.NewResponse(&pm.UpdateUserGroupQueryResponse{
-		Group: userGroupToProto(group, roles, isScimManaged),
+		Group: userGroupToProto(group, roles, h.userGroupRoleGrants(ctx, group.ID), isScimManaged),
 	}), nil
 }
 
@@ -832,7 +832,7 @@ func (h *UserGroupHandler) EvaluateDynamicUserGroup(ctx context.Context, req *co
 	}
 
 	return connect.NewResponse(&pm.EvaluateDynamicUserGroupResponse{
-		Group:        userGroupToProto(group, roles, isScimManaged),
+		Group:        userGroupToProto(group, roles, h.userGroupRoleGrants(ctx, group.ID), isScimManaged),
 		UsersAdded:   usersAdded,
 		UsersRemoved: usersRemoved,
 	}), nil
@@ -888,8 +888,11 @@ func (h *UserGroupHandler) bumpSessionVersionForGroupMembers(ctx context.Context
 	return firstErr
 }
 
-// userGroupToProto converts a database user group projection to a protobuf UserGroup.
-func userGroupToProto(g store.UserGroup, roles []db.RolesProjection, isScimManaged bool) *pm.UserGroup {
+// userGroupToProto converts a database user group projection to a protobuf
+// UserGroup. roles is the scope-blind, de-duplicated role set (kept for
+// backward compatibility); grants is the per-grant view with each grant's
+// scope (#7), used for scoped-grant display + revocation.
+func userGroupToProto(g store.UserGroup, roles []db.RolesProjection, grants []store.RoleGrant, isScimManaged bool) *pm.UserGroup {
 	group := &pm.UserGroup{
 		Id:                g.ID,
 		Name:              g.Name,
@@ -922,7 +925,23 @@ func userGroupToProto(g store.UserGroup, roles []db.RolesProjection, isScimManag
 		}))
 	}
 
+	for _, g := range grants {
+		group.RoleGrants = append(group.RoleGrants, roleGrantToProto(g))
+	}
+
 	return group
+}
+
+// userGroupRoleGrants fetches a group's scoped role grants for
+// userGroupToProto, swallowing the error to nil (role_grants is a
+// best-effort enrichment, like the de-duplicated roles fetch).
+func (h *UserGroupHandler) userGroupRoleGrants(ctx context.Context, groupID string) []store.RoleGrant {
+	grants, err := h.store.Repos().Role.ListUserGroupRoleGrants(ctx, groupID)
+	if err != nil {
+		h.logger.Warn("failed to list user group role grants for proto enrichment", "group_id", groupID, "error", err)
+		return nil
+	}
+	return grants
 }
 
 // Suppress unused import warning

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -802,9 +802,23 @@ func (h *UserHandler) populateUserIdentityLinks(ctx context.Context, user *pm.Us
 func (h *UserHandler) populateUserRoles(ctx context.Context, user *pm.User) {
 	roles, err := h.store.Repos().Role.ListUserRoles(ctx, user.Id)
 	if err != nil {
+		h.logger.Warn("failed to list user roles for proto enrichment", "user_id", user.Id, "error", err)
 		return
 	}
 	for _, r := range roles {
 		user.Roles = append(user.Roles, roleToProto(r))
+	}
+
+	// role_grants carries each DIRECT grant with its scope (#7), the
+	// authoritative source for scoped-grant display + revocation. Group-
+	// inherited roles stay in `roles`/`inherited_roles` only — a scope on
+	// an inherited grant lives on the group, not the user.
+	grants, err := h.store.Repos().Role.ListUserRoleGrants(ctx, user.Id)
+	if err != nil {
+		h.logger.Warn("failed to list user role grants for proto enrichment", "user_id", user.Id, "error", err)
+		return
+	}
+	for _, g := range grants {
+		user.RoleGrants = append(user.RoleGrants, roleGrantToProto(g))
 	}
 }

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -800,13 +800,15 @@ func (h *UserHandler) populateUserIdentityLinks(ctx context.Context, user *pm.Us
 
 // populateUserRoles loads roles for a user and attaches them to the proto User.
 func (h *UserHandler) populateUserRoles(ctx context.Context, user *pm.User) {
+	// roles and role_grants are independent best-effort enrichments — a
+	// failure of one must not suppress the other (CR #345).
 	roles, err := h.store.Repos().Role.ListUserRoles(ctx, user.Id)
 	if err != nil {
 		h.logger.Warn("failed to list user roles for proto enrichment", "user_id", user.Id, "error", err)
-		return
-	}
-	for _, r := range roles {
-		user.Roles = append(user.Roles, roleToProto(r))
+	} else {
+		for _, r := range roles {
+			user.Roles = append(user.Roles, roleToProto(r))
+		}
 	}
 
 	// role_grants carries each DIRECT grant with its scope (#7), the

--- a/internal/store/generated/roles.sql.go
+++ b/internal/store/generated/roles.sql.go
@@ -201,7 +201,7 @@ func (q *Queries) GetUserScopedGrants(ctx context.Context, userID string) ([]Get
 }
 
 const getUserRoles = `-- name: GetUserRoles :many
-SELECT r.id, r.name, r.description, r.permissions, r.is_system, r.created_at, r.created_by, r.updated_at, r.is_deleted, r.projection_version FROM roles_projection r
+SELECT DISTINCT r.id, r.name, r.description, r.permissions, r.is_system, r.created_at, r.created_by, r.updated_at, r.is_deleted, r.projection_version FROM roles_projection r
 JOIN user_roles_projection ur ON ur.role_id = r.id
 WHERE ur.user_id = $1 AND r.is_deleted = FALSE
 ORDER BY r.name
@@ -227,6 +227,103 @@ func (q *Queries) GetUserRoles(ctx context.Context, userID string) ([]RolesProje
 			&i.UpdatedAt,
 			&i.IsDeleted,
 			&i.ProjectionVersion,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getUserRoleGrants = `-- name: GetUserRoleGrants :many
+SELECT r.id, r.name, r.description, r.permissions, r.is_system,
+       r.created_at, r.created_by, r.updated_at,
+       ur.scope_kind, ur.scope_id,
+       COALESCE(dg.name, ug.name, '')::TEXT AS scope_name
+FROM roles_projection r
+JOIN user_roles_projection ur ON ur.role_id = r.id
+LEFT JOIN device_groups_projection dg
+       ON ur.scope_kind = 'device_group' AND dg.id = ur.scope_id AND dg.is_deleted = FALSE
+LEFT JOIN user_groups_projection ug
+       ON ur.scope_kind = 'user_group' AND ug.id = ur.scope_id AND ug.is_deleted = FALSE
+WHERE ur.user_id = $1 AND r.is_deleted = FALSE
+ORDER BY r.name, ur.scope_id NULLS FIRST
+`
+
+// GetUserRoleGrantsRow is one (role, scope) grant. ScopeKind and ScopeID
+// are nil together for an unscoped (global) grant; ScopeName is the
+// resolved group display name (” when unscoped or the group is deleted).
+// Hand-maintained — scope_kind/scope_id live in migration 010's DO-block,
+// which sqlc cannot resolve (#336).
+type GetUserRoleGrantsRow struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Permissions []string   `json:"permissions"`
+	IsSystem    bool       `json:"is_system"`
+	CreatedAt   time.Time  `json:"created_at"`
+	CreatedBy   string     `json:"created_by"`
+	UpdatedAt   *time.Time `json:"updated_at"`
+	ScopeKind   *string    `json:"scope_kind"`
+	ScopeID     *string    `json:"scope_id"`
+	ScopeName   string     `json:"scope_name"`
+}
+
+func (q *Queries) GetUserRoleGrants(ctx context.Context, userID string) ([]GetUserRoleGrantsRow, error) {
+	rows, err := q.db.Query(ctx, getUserRoleGrants, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetUserRoleGrantsRow{}
+	for rows.Next() {
+		var i GetUserRoleGrantsRow
+		if err := rows.Scan(
+			&i.ID, &i.Name, &i.Description, &i.Permissions, &i.IsSystem,
+			&i.CreatedAt, &i.CreatedBy, &i.UpdatedAt,
+			&i.ScopeKind, &i.ScopeID, &i.ScopeName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const getUserGroupRoleGrants = `-- name: GetUserGroupRoleGrants :many
+SELECT r.id, r.name, r.description, r.permissions, r.is_system,
+       r.created_at, r.created_by, r.updated_at,
+       ugr.scope_kind, ugr.scope_id,
+       COALESCE(dg.name, ug.name, '')::TEXT AS scope_name
+FROM roles_projection r
+JOIN user_group_roles_projection ugr ON ugr.role_id = r.id
+LEFT JOIN device_groups_projection dg
+       ON ugr.scope_kind = 'device_group' AND dg.id = ugr.scope_id AND dg.is_deleted = FALSE
+LEFT JOIN user_groups_projection ug
+       ON ugr.scope_kind = 'user_group' AND ug.id = ugr.scope_id AND ug.is_deleted = FALSE
+WHERE ugr.group_id = $1 AND r.is_deleted = FALSE
+ORDER BY r.name, ugr.scope_id NULLS FIRST
+`
+
+func (q *Queries) GetUserGroupRoleGrants(ctx context.Context, groupID string) ([]GetUserRoleGrantsRow, error) {
+	rows, err := q.db.Query(ctx, getUserGroupRoleGrants, groupID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetUserRoleGrantsRow{}
+	for rows.Next() {
+		var i GetUserRoleGrantsRow
+		if err := rows.Scan(
+			&i.ID, &i.Name, &i.Description, &i.Permissions, &i.IsSystem,
+			&i.CreatedAt, &i.CreatedBy, &i.UpdatedAt,
+			&i.ScopeKind, &i.ScopeID, &i.ScopeName,
 		); err != nil {
 			return nil, err
 		}
@@ -478,6 +575,24 @@ type UserHasRoleParams struct {
 
 func (q *Queries) UserHasRole(ctx context.Context, arg UserHasRoleParams) (bool, error) {
 	row := q.db.QueryRow(ctx, userHasRole, arg.UserID, arg.RoleID)
+	var has_role bool
+	err := row.Scan(&has_role)
+	return has_role, err
+}
+
+const userHasUnscopedRole = `-- name: UserHasUnscopedRole :one
+SELECT EXISTS(SELECT 1 FROM user_roles_projection
+              WHERE user_id = $1 AND role_id = $2 AND scope_id IS NULL) AS has_role
+`
+
+// UserHasUnscopedRole reports whether the user holds the role as an
+// UNSCOPED (global) grant specifically — scope-aware, unlike UserHasRole
+// (2-tuple, counts scoped grants too). Used by the assign-role redundancy
+// pre-check so an unscoped assign isn't dropped just because a scoped
+// grant of the same role exists (#7 grant independence). Hand-maintained:
+// scope_id is a migration-010 DO-block column sqlc cannot resolve (#336).
+func (q *Queries) UserHasUnscopedRole(ctx context.Context, arg UserHasRoleParams) (bool, error) {
+	row := q.db.QueryRow(ctx, userHasUnscopedRole, arg.UserID, arg.RoleID)
 	var has_role bool
 	err := row.Scan(&has_role)
 	return has_role, err

--- a/internal/store/postgres/role.go
+++ b/internal/store/postgres/role.go
@@ -70,6 +70,45 @@ func (r *Role) ListUserRoles(ctx context.Context, userID string) ([]store.Role, 
 	return out, nil
 }
 
+func (r *Role) ListUserRoleGrants(ctx context.Context, userID string) ([]store.RoleGrant, error) {
+	rows, err := r.q.GetUserRoleGrants(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("role: list user role grants: %w", err)
+	}
+	return roleGrantsFromRows(rows), nil
+}
+
+func (r *Role) ListUserGroupRoleGrants(ctx context.Context, groupID string) ([]store.RoleGrant, error) {
+	rows, err := r.q.GetUserGroupRoleGrants(ctx, groupID)
+	if err != nil {
+		return nil, fmt.Errorf("role: list user group role grants: %w", err)
+	}
+	return roleGrantsFromRows(rows), nil
+}
+
+// roleGrantsFromRows maps the shared scoped-grant Row to store.RoleGrant.
+func roleGrantsFromRows(rows []generated.GetUserRoleGrantsRow) []store.RoleGrant {
+	out := make([]store.RoleGrant, len(rows))
+	for i, row := range rows {
+		out[i] = store.RoleGrant{
+			Role: store.Role{
+				ID:          row.ID,
+				Name:        row.Name,
+				Description: row.Description,
+				Permissions: row.Permissions,
+				IsSystem:    row.IsSystem,
+				CreatedAt:   row.CreatedAt,
+				CreatedBy:   row.CreatedBy,
+				UpdatedAt:   row.UpdatedAt,
+			},
+			ScopeKind: derefString(row.ScopeKind),
+			ScopeID:   derefString(row.ScopeID),
+			ScopeName: row.ScopeName,
+		}
+	}
+	return out
+}
+
 func (r *Role) UserHasRole(ctx context.Context, userID, roleID string) (bool, error) {
 	has, err := r.q.UserHasRole(ctx, generated.UserHasRoleParams{
 		UserID: userID,

--- a/internal/store/queries/roles.sql
+++ b/internal/store/queries/roles.sql
@@ -11,7 +11,10 @@ SELECT * FROM roles_projection WHERE is_deleted = FALSE ORDER BY name LIMIT $1 O
 SELECT count(*) FROM roles_projection WHERE is_deleted = FALSE;
 
 -- name: GetUserRoles :many
-SELECT r.* FROM roles_projection r
+-- DISTINCT because a role can now be granted to a user multiple times at
+-- different scopes (#7); this de-duplicated, scope-blind set backs the
+-- legacy User.roles field. The per-grant view is GetUserRoleGrants.
+SELECT DISTINCT r.* FROM roles_projection r
 JOIN user_roles_projection ur ON ur.role_id = r.id
 WHERE ur.user_id = $1 AND r.is_deleted = FALSE
 ORDER BY r.name;
@@ -45,6 +48,44 @@ SELECT grants.permission, grants.scope_kind, grants.scope_id FROM (
     WHERE ugm.user_id = $1 AND r.is_deleted = FALSE
 ) grants;
 
+-- name: GetUserRoleGrants :many
+-- #7 scoped-grant round-trip. Returns the user's DIRECTLY-assigned role
+-- grants WITH each grant's scope (NOT de-duplicated — the same role
+-- granted globally and scoped to a device group yields two rows), and
+-- resolves scope_name from the device-/user-group projection (COALESCE to
+-- '' when unscoped or the group was deleted). Drives User.role_grants for
+-- scoped-grant display + revocation. Hand-maintained: scope_kind/scope_id
+-- live in migration 010's DO-block, which sqlc cannot resolve (#336).
+SELECT r.id, r.name, r.description, r.permissions, r.is_system,
+       r.created_at, r.created_by, r.updated_at,
+       ur.scope_kind, ur.scope_id,
+       COALESCE(dg.name, ug.name, '')::TEXT AS scope_name
+FROM roles_projection r
+JOIN user_roles_projection ur ON ur.role_id = r.id
+LEFT JOIN device_groups_projection dg
+       ON ur.scope_kind = 'device_group' AND dg.id = ur.scope_id AND dg.is_deleted = FALSE
+LEFT JOIN user_groups_projection ug
+       ON ur.scope_kind = 'user_group' AND ug.id = ur.scope_id AND ug.is_deleted = FALSE
+WHERE ur.user_id = $1 AND r.is_deleted = FALSE
+ORDER BY r.name, ur.scope_id NULLS FIRST;
+
+-- name: GetUserGroupRoleGrants :many
+-- #7 scoped-grant round-trip for a user group's own role grants. Same
+-- shape + scope_name resolution as GetUserRoleGrants; drives
+-- UserGroup.role_grants. Hand-maintained (DO-block scope columns).
+SELECT r.id, r.name, r.description, r.permissions, r.is_system,
+       r.created_at, r.created_by, r.updated_at,
+       ugr.scope_kind, ugr.scope_id,
+       COALESCE(dg.name, ug.name, '')::TEXT AS scope_name
+FROM roles_projection r
+JOIN user_group_roles_projection ugr ON ugr.role_id = r.id
+LEFT JOIN device_groups_projection dg
+       ON ugr.scope_kind = 'device_group' AND dg.id = ugr.scope_id AND dg.is_deleted = FALSE
+LEFT JOIN user_groups_projection ug
+       ON ugr.scope_kind = 'user_group' AND ug.id = ugr.scope_id AND ug.is_deleted = FALSE
+WHERE ugr.group_id = $1 AND r.is_deleted = FALSE
+ORDER BY r.name, ugr.scope_id NULLS FIRST;
+
 -- name: CountUsersWithRole :one
 SELECT count(*) FROM user_roles_projection WHERE role_id = $1;
 
@@ -53,6 +94,15 @@ SELECT user_id FROM user_roles_projection WHERE role_id = $1;
 
 -- name: UserHasRole :one
 SELECT EXISTS(SELECT 1 FROM user_roles_projection WHERE user_id = $1 AND role_id = $2) AS has_role;
+
+-- name: UserHasUnscopedRole :one
+-- Scope-aware variant: does the user hold this role as an UNSCOPED
+-- (global) grant specifically? The assign-role redundancy pre-check uses
+-- this so an unscoped assign isn't dropped when only a SCOPED grant of the
+-- same role exists (#7 grant independence). Hand-maintained: scope_id is a
+-- migration-010 DO-block column sqlc cannot resolve (#336).
+SELECT EXISTS(SELECT 1 FROM user_roles_projection
+              WHERE user_id = $1 AND role_id = $2 AND scope_id IS NULL) AS has_role;
 
 -- name: UserHasScopedRole :one
 -- Existence of a SPECIFIC (user, role, scope) grant. IS NOT DISTINCT

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -27,6 +27,20 @@ type ListRolesFilter struct {
 	Offset int32
 }
 
+// RoleGrant is a single, scoped role assignment (#7). Unlike
+// ListUserRoles (de-duplicated by role id), a RoleGrant preserves the
+// grant's scope, so the same role granted both globally and scoped to a
+// device group appears as two grants. ScopeKind is "" for an unscoped
+// (global) grant; otherwise "device_group" or "user_group", with ScopeID
+// the group id and ScopeName its resolved display name ("" when unscoped
+// or the group was deleted).
+type RoleGrant struct {
+	Role      Role
+	ScopeKind string
+	ScopeID   string
+	ScopeName string
+}
+
 // RoleRepo reads role definitions and per-user role membership from
 // the projection. Writes (RoleCreated / RoleUpdated / RoleDeleted /
 // UserRoleAssigned / UserRoleRevoked) flow through the event store.
@@ -55,6 +69,17 @@ type RoleRepo interface {
 	// directly and via groups, deduplicated. Empty slice when the
 	// user has no roles.
 	ListUserRoles(ctx context.Context, userID string) ([]Role, error)
+
+	// ListUserRoleGrants returns the user's DIRECTLY-assigned role
+	// grants WITH each grant's scope (#7), not de-duplicated — the same
+	// role granted globally and scoped to a device group yields two
+	// grants. Empty slice when the user has no direct grants.
+	ListUserRoleGrants(ctx context.Context, userID string) ([]RoleGrant, error)
+
+	// ListUserGroupRoleGrants returns a user group's role grants WITH
+	// each grant's scope (#7), not de-duplicated. Empty slice when the
+	// group has no role grants.
+	ListUserGroupRoleGrants(ctx context.Context, groupID string) ([]RoleGrant, error)
 
 	// UserHasRole reports whether the user has the given role
 	// assigned, either directly or via a group membership.


### PR DESCRIPTION
Closes #344. Server half of #7's web scope picker — scoped role grants now round-trip (assignable, visible, revocable). Consumes sdk RoleGrant (sdk #85; go.mod bumped to 5136d8f).

## Changes
- **GetUserRoleGrants / GetUserGroupRoleGrants** (hand-maintained — DO-block scope columns, #336) resolve each grant's (scope_kind, scope_id) plus the device-/user-group display name (COALESCE to '' when unscoped or the group was deleted); populate User.role_grants / UserGroup.role_grants. The legacy roles fields stay the scope-blind, de-duplicated set.

## Bugs found + fixed mid-task (pinned by tests, red-before-green)
- **Grant independence:** AssignRoleToUser's unscoped redundancy pre-check used the scope-blind 2-tuple UserHasRole, so a global grant was silently dropped when a scoped grant of the same role already existed. New scope-aware UserHasUnscopedRole makes global + per-scope grants coexist.
- **Dedup:** GetUserRoles lacked DISTINCT; with multiple scoped grants of one role it returned the role N times. Added DISTINCT.

## Tests
Scoped + global same role → two role_grants carrying scope/scope_name, roles de-duplicated; empty-grants; user-group scoped grant round-trip. Focused suite across every touched area green (full-suite hit the Ryuk testcontainer-reaper exhaustion #338 targets — no individual test failed).

Local CodeRabbit: 2 error-swallow sites fixed (slog.Warn); the 'type mismatch' Major is a false positive (the two queries share GetUserRoleGrantsRow — build passes).

Refs manchtools/power-manage-server#7.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Role grants now carry scope information, distinguishing between global and device-group-specific role assignments.
  * Users and user groups now return detailed role grant data in API responses, including scope details.

* **Tests**
  * Added integration tests validating that scope information is preserved correctly when fetching users and user groups with role grants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->