### PR TITLE
build(sqlc): pinned Makefile + pg_catalog override + scope overlay (#336)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+# Power Manage — Control / Gateway server.
+#
+# Build/test recipes live in CLAUDE.md / README.md; this Makefile exists
+# for the code-generation steps that must be reproducible and version-
+# pinned (#336).
+.PHONY: sqlc-generate sqlc-check help
+
+# Pinned OFFICIAL sqlc image. This is load-bearing: a locally
+# `go install`-ed sqlc resolves type overrides differently from the
+# release build — it silently ignored the (unqualified) `timestamptz`
+# override and emitted `pgtype.Timestamptz` instead of `time.Time`
+# (#336). Generation MUST go through this image for output that matches
+# the committed config.
+SQLC_IMAGE ?= sqlc/sqlc:1.30.0
+
+help:
+	@echo "Targets:"
+	@echo "  sqlc-generate  regenerate internal/store/generated/ via the pinned sqlc image"
+	@echo "  sqlc-check     fail if generated code is stale (run sqlc-generate first)"
+
+# Regenerate the sqlc query layer. Runs from internal/store so the image
+# sees sqlc.yaml, queries/, migrations/, and the parse-only
+# sqlc_schema_overlay.sql (which re-declares the scope columns that
+# migration 010 hides from sqlc's parser inside a DO-block, #336).
+#
+# Two prerequisites are baked into internal/store/sqlc.yaml:
+#   * overrides use `db_type: "pg_catalog.timestamptz"` — the qualified
+#     name modern sqlc matches (the bare `timestamptz` is ignored).
+#   * timestamptz PARAMETERS must NOT carry a redundant `::TIMESTAMPTZ`
+#     cast in queries/: sqlc applies go_type overrides to catalog-resolved
+#     columns but not to cast-typed params, so a cast forces
+#     pgtype.Timestamptz. Drop the no-op cast and sqlc infers the param
+#     type from the bound column.
+#
+# NOTE (#336): the committed generated/ has accumulated hand-maintenance
+# that diverges from a clean regen — most notably Event.SequenceNum is
+# *int64 (the column is `bigint NOT NULL`, so sqlc emits int64) with ~131
+# deref() call sites built around it, plus the hand-written #7 scope-grant
+# queries. A first full regen therefore surfaces a real reconciliation,
+# not a no-op — review the diff before committing.
+sqlc-generate:
+	cd internal/store && docker run --rm \
+		-v "$$(pwd)":/src:Z -w /src $(SQLC_IMAGE) generate
+
+# Fail if generated code is out of date. NOT wired into CI yet — the
+# historical divergence above must be reconciled first (#336 follow-up).
+sqlc-check: sqlc-generate
+	git diff --exit-code internal/store/generated

--- a/internal/store/sqlc.yaml
+++ b/internal/store/sqlc.yaml
@@ -2,7 +2,7 @@ version: "2"
 sql:
   - engine: "postgresql"
     queries: "queries/"
-    schema: "migrations/"
+    schema: ["migrations/", "sqlc_schema_overlay.sql"]
     gen:
       go:
         package: "generated"
@@ -12,9 +12,9 @@ sql:
         emit_pointers_for_null_types: true
         sql_package: "pgx/v5"
         overrides:
-          - db_type: "timestamptz"
+          - db_type: "pg_catalog.timestamptz"
             go_type: "time.Time"
-          - db_type: "timestamptz"
+          - db_type: "pg_catalog.timestamptz"
             nullable: true
             go_type:
               import: "time"

--- a/internal/store/sqlc_schema_overlay.sql
+++ b/internal/store/sqlc_schema_overlay.sql
@@ -1,0 +1,17 @@
+-- sqlc PARSE-ONLY schema overlay (#336). NOT a goose migration; never
+-- applied to a database.
+--
+-- migration 010_role_grant_scope_7.sql adds scope_kind / scope_id to
+-- user_roles_projection and user_group_roles_projection INSIDE a
+-- `DO $$ … END $$;` PL/pgSQL block (for atomic multi-statement
+-- application). sqlc's schema parser does not read DO-blocks, so it never
+-- learns those columns exist and any SELECT that *outputs* them fails
+-- `sqlc generate` with "column scope_kind does not exist".
+--
+-- This file re-declares exactly those columns as plain DDL so sqlc can
+-- resolve them as query outputs. It is listed AFTER migrations/ in
+-- sqlc.yaml's `schema:`, so the tables already exist when these run.
+--
+-- KEEP IN SYNC with migration 010: same tables, columns, and TEXT type.
+ALTER TABLE user_roles_projection       ADD COLUMN scope_kind TEXT, ADD COLUMN scope_id TEXT;
+ALTER TABLE user_group_roles_projection ADD COLUMN scope_kind TEXT, ADD COLUMN scope_id TEXT;


### PR DESCRIPTION
Makes sqlc generation reproducible and fixes the silently-broken type override — the tooling/config half of #336, without the large historical regen.

## Root cause (why generated code drifted)
`sqlc.yaml` used `db_type: "timestamptz"` (unqualified). Modern sqlc only matches the **pg_catalog-qualified** name, so the override was silently ignored and every timestamptz fell back to `pgtype.Timestamptz`. Verified across the official `sqlc/sqlc` images 1.20→1.30 — all drift identically with the bare form; it has been broken since well before 1.27. It went unnoticed because nobody runs a full `sqlc generate` (generated/ is hand-maintained).

## This PR
- **Makefile** — `make sqlc-generate` via the pinned official image (`sqlc/sqlc:1.30.0`). A locally `go install`-ed sqlc resolves overrides differently from the release build.
- **sqlc.yaml** — `pg_catalog.timestamptz` override (252 → ~5 residual pgtype, all params).
- **sqlc_schema_overlay.sql** — parse-only re-declaration of the migration-010 DO-block scope columns so scope-read SELECTs can generate.

`generated/` is unchanged, so the build is unaffected.

## Why the residual 5 (the `nullable:true` drill-down)
They're not a nullability issue — they're query **parameters** written `sqlc.arg(x)::TIMESTAMPTZ`. sqlc applies `go_type` overrides to catalog-resolved result columns but **not to cast-typed params** (and `column:` overrides don't reach them either, while corrupting result columns). Dropping the redundant `::TIMESTAMPTZ` casts lets sqlc infer the param from the bound column → `time.Time` (drift → 0, confirmed).

## Deliberately deferred (the regen reconciliation)
A full clean regen surfaces accumulated hand-maintenance: `Event.SequenceNum` is `*int64` though `sequence_num` is `bigint NOT NULL` (sqlc emits `int64`) with **~131 `deref()` call sites**, plus the hand-written #7 scope queries (Row-type ripple into `postgres/role.go`). That's a dedicated refactor, tracked under #336.

Refs manchtools/power-manage-server#336.