### PR TITLE
build(sqlc): full clean regen — native time.Time + correct SequenceNum (#336)

### DIFF
--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -327,7 +327,7 @@ func (h *RoleHandler) AssignRoleToUser(ctx context.Context, req *connect.Request
 		// DO NOTHING (both partial unique indexes) makes a redundant scoped
 		// re-assign an idempotent no-op.
 		if scopeKind == "" {
-			hasRole, err := q.UserHasUnscopedRole(ctx, db.UserHasRoleParams{
+			hasRole, err := q.UserHasUnscopedRole(ctx, db.UserHasUnscopedRoleParams{
 				UserID: req.Msg.UserId,
 				RoleID: roleID,
 			})

--- a/internal/projectors/action_listener.go
+++ b/internal/projectors/action_listener.go
@@ -199,7 +199,7 @@ func applyActionCreated(ctx context.Context, q *store.Queries, e store.Persisted
 		CreatedAt:         &occurredAt,
 		UpdatedAt:         &occurredAt,
 		CreatedBy:         payload.CreatedBy,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 		IsSystem:          payload.IsSystem,
 		Schedule:          payload.Schedule,
 	})
@@ -218,7 +218,7 @@ func applyActionRenamed(ctx context.Context, q *store.Queries, e store.Persisted
 		ID:                payload.ID,
 		Name:              payload.Name,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -249,7 +249,7 @@ func applyActionDescriptionUpdated(ctx context.Context, q *store.Queries, e stor
 		ID:                payload.ID,
 		Description:       payload.Description,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -272,7 +272,7 @@ func applyActionParamsUpdated(ctx context.Context, q *store.Queries, e store.Per
 		DesiredState:      payload.DesiredState,
 		Schedule:          payload.Schedule,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func applyActionDeleted(ctx context.Context, q *store.Queries, e store.Persisted
 	n, err := q.SoftDeleteActionProjection(ctx, db.SoftDeleteActionProjectionParams{
 		ID:                streamID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -398,7 +398,7 @@ func applyDefinitionCreated(ctx context.Context, q *store.Queries, e store.Persi
 			CreatedAt:         &occurredAt,
 			UpdatedAt:         &occurredAt,
 			CreatedBy:         payload.CreatedBy,
-			ProjectionVersion: deref(e.SequenceNum),
+			ProjectionVersion: e.SequenceNum,
 		})
 	}
 	// e.StreamType == "definition"
@@ -414,7 +414,7 @@ func applyDefinitionCreated(ctx context.Context, q *store.Queries, e store.Persi
 		CreatedAt:         &occurredAt,
 		UpdatedAt:         &occurredAt,
 		CreatedBy:         payload.CreatedBy,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -439,7 +439,7 @@ func applyDefinitionRenamed(ctx context.Context, q *store.Queries, e store.Persi
 			ID:                payload.ID,
 			Name:              payload.Name,
 			UpdatedAt:         &updatedAt,
-			ProjectionVersion: deref(e.SequenceNum),
+			ProjectionVersion: e.SequenceNum,
 		}); err != nil {
 			return err
 		}
@@ -449,7 +449,7 @@ func applyDefinitionRenamed(ctx context.Context, q *store.Queries, e store.Persi
 		ID:                payload.ID,
 		Name:              payload.Name,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -475,7 +475,7 @@ func applyDefinitionDescriptionUpdated(ctx context.Context, q *store.Queries, e 
 			ID:                payload.ID,
 			Description:       payload.DescriptionPtr,
 			UpdatedAt:         &updatedAt,
-			ProjectionVersion: deref(e.SequenceNum),
+			ProjectionVersion: e.SequenceNum,
 		}); err != nil {
 			return err
 		}
@@ -485,7 +485,7 @@ func applyDefinitionDescriptionUpdated(ctx context.Context, q *store.Queries, e 
 		ID:                payload.ID,
 		Description:       payload.Description,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -505,7 +505,7 @@ func applyDefinitionScheduleUpdated(ctx context.Context, q *store.Queries, e sto
 		ID:                payload.ID,
 		Schedule:          payload.Schedule,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -529,7 +529,7 @@ func applyDefinitionDeleted(ctx context.Context, q *store.Queries, e store.Persi
 		if _, err := q.SoftDeleteActionProjection(ctx, db.SoftDeleteActionProjectionParams{
 			ID:                streamID,
 			UpdatedAt:         &updatedAt,
-			ProjectionVersion: deref(e.SequenceNum),
+			ProjectionVersion: e.SequenceNum,
 		}); err != nil {
 			return err
 		}
@@ -538,7 +538,7 @@ func applyDefinitionDeleted(ctx context.Context, q *store.Queries, e store.Persi
 	if _, err := q.SoftDeleteDefinitionProjection(ctx, db.SoftDeleteDefinitionProjectionParams{
 		ID:                streamID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -564,7 +564,7 @@ func applyDefinitionMemberAdded(ctx context.Context, q *store.Queries, e store.P
 	n, err := q.ClaimDefinitionForMembership(ctx, db.ClaimDefinitionForMembershipParams{
 		ID:                payload.DefinitionID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -578,7 +578,7 @@ func applyDefinitionMemberAdded(ctx context.Context, q *store.Queries, e store.P
 		ActionSetID:       payload.ActionSetID,
 		SortOrder:         payload.SortOrder,
 		AddedAt:           &addedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -597,7 +597,7 @@ func applyDefinitionMemberRemoved(ctx context.Context, q *store.Queries, e store
 	n, err := q.ClaimDefinitionForMembership(ctx, db.ClaimDefinitionForMembershipParams{
 		ID:                payload.DefinitionID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -626,7 +626,7 @@ func applyDefinitionMemberReordered(ctx context.Context, q *store.Queries, e sto
 	n, err := q.ClaimDefinitionForMembership(ctx, db.ClaimDefinitionForMembershipParams{
 		ID:                payload.DefinitionID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -640,7 +640,7 @@ func applyDefinitionMemberReordered(ctx context.Context, q *store.Queries, e sto
 		DefinitionID:      payload.DefinitionID,
 		ActionSetID:       payload.ActionSetID,
 		SortOrder:         payload.SortOrder,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}

--- a/internal/projectors/action_set_listener.go
+++ b/internal/projectors/action_set_listener.go
@@ -118,7 +118,7 @@ func applyActionSetCreated(ctx context.Context, q *store.Queries, e store.Persis
 		Schedule:          payload.Schedule,
 		CreatedAt:         &e.OccurredAt,
 		CreatedBy:         payload.CreatedBy,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -135,7 +135,7 @@ func applyActionSetRenamed(ctx context.Context, q *store.Queries, e store.Persis
 		ID:                payload.ID,
 		Name:              payload.Name,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -155,7 +155,7 @@ func applyActionSetDescriptionUpdated(ctx context.Context, q *store.Queries, e s
 		ID:                payload.ID,
 		Description:       payload.Description,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ func applyActionSetScheduleUpdated(ctx context.Context, q *store.Queries, e stor
 		ID:                payload.ID,
 		Schedule:          payload.Schedule,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func applyActionSetMemberAdded(ctx context.Context, q *store.Queries, e store.Pe
 	n, err := q.ClaimActionSetForMembership(ctx, db.ClaimActionSetForMembershipParams{
 		ID:                payload.SetID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -215,7 +215,7 @@ func applyActionSetMemberAdded(ctx context.Context, q *store.Queries, e store.Pe
 		ActionID:          payload.ActionID,
 		SortOrder:         payload.SortOrder,
 		AddedAt:           &addedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -234,7 +234,7 @@ func applyActionSetMemberRemoved(ctx context.Context, q *store.Queries, e store.
 	n, err := q.ClaimActionSetForMembership(ctx, db.ClaimActionSetForMembershipParams{
 		ID:                payload.SetID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -265,7 +265,7 @@ func applyActionSetMemberReordered(ctx context.Context, q *store.Queries, e stor
 	n, err := q.ClaimActionSetForMembership(ctx, db.ClaimActionSetForMembershipParams{
 		ID:                payload.SetID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -279,7 +279,7 @@ func applyActionSetMemberReordered(ctx context.Context, q *store.Queries, e stor
 		SetID:             payload.SetID,
 		ActionID:          payload.ActionID,
 		SortOrder:         payload.SortOrder,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func applyActionSetDeleted(ctx context.Context, q *store.Queries, e store.Persis
 	n, err := q.SoftDeleteActionSetProjection(ctx, db.SoftDeleteActionSetProjectionParams{
 		ID:                e.StreamID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err

--- a/internal/projectors/action_set_test.go
+++ b/internal/projectors/action_set_test.go
@@ -563,7 +563,7 @@ func TestActionSetListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 	listener := projectors.ActionSetListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "action_set",
 		StreamID:    setID,
 		EventType:   "ActionSetDeleted",
@@ -637,7 +637,7 @@ func TestActionSetListener_StaleMemberAddedDoesNotRecreateMembership(t *testing.
 	listener := projectors.ActionSetListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "action_set",
 		StreamID:    setID,
 		EventType:   "ActionSetMemberAdded",

--- a/internal/projectors/action_test.go
+++ b/internal/projectors/action_test.go
@@ -467,7 +467,7 @@ func TestActionListener_StaleDeleteReplayDoesNotNukeCascade(t *testing.T) {
 	listener := projectors.ActionListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "action",
 		StreamID:    actionID,
 		EventType:   "ActionDeleted",

--- a/internal/projectors/assignment_listener.go
+++ b/internal/projectors/assignment_listener.go
@@ -120,7 +120,7 @@ func applyAssignmentCreated(ctx context.Context, q *store.Queries, e store.Persi
 		Mode:              payload.Mode,
 		CreatedAt:         &createdAt,
 		CreatedBy:         payload.CreatedBy,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -150,7 +150,7 @@ func applyAssignmentModeChanged(ctx context.Context, q *store.Queries, e store.P
 	if _, err := q.UpdateAssignmentModeProjection(ctx, db.UpdateAssignmentModeProjectionParams{
 		ID:                payload.ID,
 		Mode:              payload.Mode,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func applyAssignmentSortOrderChanged(ctx context.Context, q *store.Queries, e st
 	if _, err := q.UpdateAssignmentSortOrderProjection(ctx, db.UpdateAssignmentSortOrderProjectionParams{
 		ID:                payload.ID,
 		SortOrder:         payload.SortOrder,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func applyAssignmentSortOrderChanged(ctx context.Context, q *store.Queries, e st
 func applyAssignmentDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	row, err := q.SoftDeleteAssignmentProjection(ctx, db.SoftDeleteAssignmentProjectionParams{
 		ID:                e.StreamID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		if store.IsNotFound(err) {

--- a/internal/projectors/assignment_test.go
+++ b/internal/projectors/assignment_test.go
@@ -473,7 +473,7 @@ func TestAssignmentListener_StaleDeleteReplayDoesNotCascade(t *testing.T) {
 	listener := projectors.AssignmentListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "assignment",
 		StreamID:    asnID,
 		EventType:   "AssignmentDeleted",

--- a/internal/projectors/compliance_listener.go
+++ b/internal/projectors/compliance_listener.go
@@ -101,7 +101,7 @@ func applyComplianceResultUpdated(ctx context.Context, q *store.Queries, e store
 		Compliant:         payload.Compliant,
 		DetectionOutput:   []byte(payload.DetectionOutput),
 		CheckedAt:         checkedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func applyComplianceResultRemoved(ctx context.Context, q *store.Queries, e store
 	n, err := q.DeleteComplianceResultProjection(ctx, db.DeleteComplianceResultProjectionParams{
 		DeviceID:          payload.DeviceID,
 		ActionID:          payload.ActionID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err

--- a/internal/projectors/compliance_policy_listener.go
+++ b/internal/projectors/compliance_policy_listener.go
@@ -139,7 +139,7 @@ func applyCompliancePolicyCreated(ctx context.Context, q *store.Queries, e store
 		Description:       payload.Description,
 		CreatedAt:         &createdAt,
 		CreatedBy:         payload.CreatedBy,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -154,7 +154,7 @@ func applyCompliancePolicyRenamed(ctx context.Context, q *store.Queries, e store
 	if _, err := q.RenameCompliancePolicyProjection(ctx, db.RenameCompliancePolicyProjectionParams{
 		ID:                payload.ID,
 		Name:              payload.Name,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func applyCompliancePolicyDescriptionUpdated(ctx context.Context, q *store.Queri
 	if _, err := q.UpdateCompliancePolicyDescriptionProjection(ctx, db.UpdateCompliancePolicyDescriptionProjectionParams{
 		ID:                payload.ID,
 		Description:       payload.Description,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func applyCompliancePolicyDescriptionUpdated(ctx context.Context, q *store.Queri
 func applyCompliancePolicyDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	n, err := q.SoftDeleteCompliancePolicyProjection(ctx, db.SoftDeleteCompliancePolicyProjectionParams{
 		ID:                e.StreamID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -228,7 +228,7 @@ func applyCompliancePolicyRuleAdded(ctx context.Context, q *store.Queries, e sto
 	// even when the parent guard would have rejected the version bump.
 	n, err := q.ClaimCompliancePolicyForRuleMutation(ctx, db.ClaimCompliancePolicyForRuleMutationParams{
 		ID:                payload.PolicyID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -243,7 +243,7 @@ func applyCompliancePolicyRuleAdded(ctx context.Context, q *store.Queries, e sto
 		ActionName:        payload.ActionName,
 		GracePeriodHours:  payload.GracePeriodHours,
 		AddedAt:           &addedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -264,7 +264,7 @@ func applyCompliancePolicyRuleRemoved(ctx context.Context, q *store.Queries, e s
 	}
 	n, err := q.ClaimCompliancePolicyForRuleMutation(ctx, db.ClaimCompliancePolicyForRuleMutationParams{
 		ID:                payload.PolicyID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -300,7 +300,7 @@ func applyCompliancePolicyRuleUpdated(ctx context.Context, q *store.Queries, e s
 	}
 	n, err := q.ClaimCompliancePolicyForRuleMutation(ctx, db.ClaimCompliancePolicyForRuleMutationParams{
 		ID:                payload.PolicyID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -312,6 +312,6 @@ func applyCompliancePolicyRuleUpdated(ctx context.Context, q *store.Queries, e s
 		PolicyID:          payload.PolicyID,
 		ActionID:          payload.ActionID,
 		GracePeriodHours:  payload.GracePeriodHours,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }

--- a/internal/projectors/compliance_policy_test.go
+++ b/internal/projectors/compliance_policy_test.go
@@ -645,7 +645,7 @@ func TestCompliancePolicyListener_StaleDeleteReplayDoesNotNukeRules(t *testing.T
 	listener := projectors.CompliancePolicyListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "compliance_policy",
 		StreamID:    policyID,
 		EventType:   "CompliancePolicyDeleted",
@@ -703,7 +703,7 @@ func TestCompliancePolicyListener_StaleRuleAddedDoesNotResurrectRemoved(t *testi
 	listener := projectors.CompliancePolicyListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "compliance_policy",
 		StreamID:    policyID,
 		EventType:   "CompliancePolicyRuleAdded",
@@ -755,7 +755,7 @@ func TestCompliancePolicyListener_StaleRuleUpdatedDoesNotChangeGrace(t *testing.
 	listener := projectors.CompliancePolicyListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "compliance_policy",
 		StreamID:    policyID,
 		EventType:   "CompliancePolicyRuleUpdated",

--- a/internal/projectors/compliance_test.go
+++ b/internal/projectors/compliance_test.go
@@ -331,7 +331,7 @@ func TestComplianceListener_StaleUpdateRejected(t *testing.T) {
 	listener := projectors.ComplianceListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "compliance",
 		StreamID:    deviceID + "_" + actionID,
 		EventType:   "ComplianceResultUpdated",
@@ -408,7 +408,7 @@ func TestComplianceListener_StaleRemovedDoesNotWipeRevivedRow(t *testing.T) {
 	listener := projectors.ComplianceListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &staleRemovedSeq,
+		SequenceNum: staleRemovedSeq,
 		StreamType:  "compliance",
 		StreamID:    deviceID + "_" + actionID,
 		EventType:   "ComplianceResultRemoved",

--- a/internal/projectors/definition_test.go
+++ b/internal/projectors/definition_test.go
@@ -423,7 +423,7 @@ func TestDefinitionListener_StaleMemberAddedDoesNotRecreateMembership(t *testing
 	listener := projectors.ActionListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "definition",
 		StreamID:    defID,
 		EventType:   "DefinitionMemberAdded",

--- a/internal/projectors/device_group_listener.go
+++ b/internal/projectors/device_group_listener.go
@@ -151,7 +151,7 @@ func applyDeviceGroupCreated(ctx context.Context, q *store.Queries, e store.Pers
 		DynamicQuery:      payload.DynamicQuery,
 		CreatedAt:         &createdAt,
 		CreatedBy:         payload.CreatedBy,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -178,7 +178,7 @@ func applyDeviceGroupRenamed(ctx context.Context, q *store.Queries, e store.Pers
 	if _, err := q.RenameDeviceGroupProjection(ctx, db.RenameDeviceGroupProjectionParams{
 		ID:                payload.ID,
 		Name:              payload.Name,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func applyDeviceGroupDescriptionUpdated(ctx context.Context, q *store.Queries, e
 	if _, err := q.UpdateDeviceGroupDescriptionProjection(ctx, db.UpdateDeviceGroupDescriptionProjectionParams{
 		ID:                payload.ID,
 		Description:       payload.Description,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func applyDeviceGroupQueryUpdated(ctx context.Context, q *store.Queries, e store
 		ID:                payload.ID,
 		IsDynamic:         payload.IsDynamic,
 		DynamicQuery:      payload.DynamicQuery,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		// pgx surfaces ErrNoRows when the inner UPDATE's version
@@ -256,7 +256,7 @@ func applyDeviceGroupSyncIntervalSet(ctx context.Context, q *store.Queries, e st
 	if _, err := q.UpdateDeviceGroupSyncIntervalProjection(ctx, db.UpdateDeviceGroupSyncIntervalProjectionParams{
 		ID:                  payload.ID,
 		SyncIntervalMinutes: payload.SyncIntervalMinutes,
-		ProjectionVersion:   deref(e.SequenceNum),
+		ProjectionVersion:   e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -274,7 +274,7 @@ func applyDeviceGroupMaintenanceWindowSet(ctx context.Context, q *store.Queries,
 	if _, err := q.UpdateDeviceGroupMaintenanceWindowProjection(ctx, db.UpdateDeviceGroupMaintenanceWindowProjectionParams{
 		ID:                payload.ID,
 		MaintenanceWindow: payload.MaintenanceWindow,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -298,7 +298,7 @@ func applyDeviceGroupMemberAdded(ctx context.Context, q *store.Queries, e store.
 	// the user_group port (PR #174).
 	n, err := q.ClaimDeviceGroupForMembership(ctx, db.ClaimDeviceGroupForMembershipParams{
 		ID:                payload.GroupID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -311,7 +311,7 @@ func applyDeviceGroupMemberAdded(ctx context.Context, q *store.Queries, e store.
 		GroupID:           payload.GroupID,
 		DeviceID:          payload.DeviceID,
 		AddedAt:           &addedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -328,7 +328,7 @@ func applyDeviceGroupMemberRemoved(ctx context.Context, q *store.Queries, e stor
 	}
 	n, err := q.ClaimDeviceGroupForMembership(ctx, db.ClaimDeviceGroupForMembershipParams{
 		ID:                payload.GroupID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -348,7 +348,7 @@ func applyDeviceGroupMemberRemoved(ctx context.Context, q *store.Queries, e stor
 func applyDeviceGroupDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	n, err := q.SoftDeleteDeviceGroupProjection(ctx, db.SoftDeleteDeviceGroupProjectionParams{
 		ID:                e.StreamID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err

--- a/internal/projectors/device_group_test.go
+++ b/internal/projectors/device_group_test.go
@@ -639,7 +639,7 @@ func TestDeviceGroupListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 	listener := projectors.DeviceGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "device_group",
 		StreamID:    groupID,
 		EventType:   "DeviceGroupDeleted",
@@ -693,7 +693,7 @@ func TestDeviceGroupListener_StaleQueryUpdatedDoesNotNukeMembers(t *testing.T) {
 	listener := projectors.DeviceGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "device_group",
 		StreamID:    groupID,
 		EventType:   "DeviceGroupQueryUpdated",
@@ -759,7 +759,7 @@ func TestDeviceGroupListener_StaleMemberAddedDoesNotRecreateMembership(t *testin
 	listener := projectors.DeviceGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "device_group",
 		StreamID:    groupID,
 		EventType:   "DeviceGroupMemberAdded",

--- a/internal/projectors/device_listener.go
+++ b/internal/projectors/device_listener.go
@@ -133,7 +133,7 @@ func applyDeviceRegistered(ctx context.Context, q *store.Queries, e store.Persis
 		CertNotAfter:        payload.CertNotAfter,
 		RegisteredAt:        &occurredAt,
 		RegistrationTokenID: payload.RegistrationTokenID,
-		ProjectionVersion:   deref(e.SequenceNum),
+		ProjectionVersion:   e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -170,7 +170,7 @@ func applyDeviceRegistered(ctx context.Context, q *store.Queries, e store.Persis
 		UserID:            *payload.AssignedUserID,
 		AssignedAt:        occurredAt,
 		AssignedBy:        e.ActorID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -188,7 +188,7 @@ func applyDeviceSeen(ctx context.Context, q *store.Queries, e store.PersistedEve
 		LastSeenAt:        &occurredAt,
 		AgentVersion:      payload.AgentVersion,
 		Hostname:          payload.Hostname,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func applyDeviceHeartbeat(ctx context.Context, q *store.Queries, e store.Persist
 		ID:                payload.ID,
 		LastSeenAt:        &occurredAt,
 		AgentVersion:      payload.AgentVersion,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func applyDeviceCertRenewed(ctx context.Context, q *store.Queries, e store.Persi
 		ID:                payload.ID,
 		CertFingerprint:   &certFingerprint,
 		CertNotAfter:      payload.CertNotAfter,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -316,10 +316,10 @@ func applyDeviceLabelRemoved(ctx context.Context, q *store.Queries, e store.Pers
 // Returns (false, nil) when the event is stale and must be skipped
 // (the corresponding label row would otherwise be overwritten by an
 // out-of-order replay).
-func advanceDeviceVersion(ctx context.Context, q *store.Queries, deviceID string, sequenceNum *int64) (bool, error) {
+func advanceDeviceVersion(ctx context.Context, q *store.Queries, deviceID string, sequenceNum int64) (bool, error) {
 	n, err := q.AdvanceDeviceProjectionVersion(ctx, db.AdvanceDeviceProjectionVersionParams{
 		ID:                deviceID,
-		ProjectionVersion: deref(sequenceNum),
+		ProjectionVersion: sequenceNum,
 	})
 	if err != nil {
 		return false, err
@@ -339,7 +339,7 @@ func enqueueDynamicDeviceGroupsForDevice(ctx context.Context, q *store.Queries, 
 func applyDeviceDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	n, err := q.SoftDeleteDeviceProjection(ctx, db.SoftDeleteDeviceProjectionParams{
 		ID:                e.StreamID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -391,7 +391,7 @@ func applyDeviceAssigned(ctx context.Context, q *store.Queries, e store.Persiste
 		UserID:            payload.UserID,
 		AssignedAt:        e.OccurredAt,
 		AssignedBy:        e.ActorID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -413,7 +413,7 @@ func applyDeviceUnassigned(ctx context.Context, q *store.Queries, e store.Persis
 	if _, err := q.DeleteDeviceAssignedUser(ctx, db.DeleteDeviceAssignedUserParams{
 		DeviceID:          payload.DeviceID,
 		UserID:            payload.UserID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -433,7 +433,7 @@ func applyDeviceGroupAssigned(ctx context.Context, q *store.Queries, e store.Per
 		GroupID:           payload.GroupID,
 		AssignedAt:        e.OccurredAt,
 		AssignedBy:        e.ActorID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -450,7 +450,7 @@ func applyDeviceGroupUnassigned(ctx context.Context, q *store.Queries, e store.P
 	if _, err := q.DeleteDeviceAssignedGroup(ctx, db.DeleteDeviceAssignedGroupParams{
 		DeviceID:          payload.DeviceID,
 		GroupID:           payload.GroupID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -468,7 +468,7 @@ func applyDeviceSyncIntervalSet(ctx context.Context, q *store.Queries, e store.P
 	if _, err := q.UpdateDeviceSyncIntervalProjection(ctx, db.UpdateDeviceSyncIntervalProjectionParams{
 		ID:                  payload.ID,
 		SyncIntervalMinutes: payload.SyncIntervalMinutes,
-		ProjectionVersion:   deref(e.SequenceNum),
+		ProjectionVersion:   e.SequenceNum,
 	}); err != nil {
 		return err
 	}

--- a/internal/projectors/device_test.go
+++ b/internal/projectors/device_test.go
@@ -680,7 +680,7 @@ func TestDeviceListener_StaleDeleteReplayDoesNotNukeAssignments(t *testing.T) {
 	listener := projectors.DeviceListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "device",
 		StreamID:    deviceID,
 		EventType:   "DeviceDeleted",
@@ -764,7 +764,7 @@ func TestDeviceListener_StaleUnassignedAfterReAssignDoesNotWipeRow(t *testing.T)
 	listener := projectors.DeviceListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &stale,
+		SequenceNum: stale,
 		StreamType:  "device",
 		StreamID:    deviceID,
 		EventType:   "DeviceUnassigned",

--- a/internal/projectors/execution_listener.go
+++ b/internal/projectors/execution_listener.go
@@ -103,7 +103,7 @@ func applyExecutionCreated(ctx context.Context, q *store.Queries, e store.Persis
 		CreatedAt:         &createdAt,
 		CreatedByType:     payload.CreatedByType,
 		CreatedByID:       payload.CreatedByID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -129,7 +129,7 @@ func applyExecutionScheduled(ctx context.Context, q *store.Queries, e store.Pers
 		CreatedAt:         &createdAt,
 		CreatedByType:     payload.CreatedByType,
 		CreatedByID:       payload.CreatedByID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -150,7 +150,7 @@ func applyExecutionDispatched(ctx context.Context, q *store.Queries, e store.Per
 	if _, err := q.UpdateExecutionDispatchedProjection(ctx, db.UpdateExecutionDispatchedProjectionParams{
 		ID:                id,
 		DispatchedAt:      &dispatchedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func applyExecutionStarted(ctx context.Context, q *store.Queries, e store.Persis
 	if _, err := q.UpdateExecutionStartedProjection(ctx, db.UpdateExecutionStartedProjectionParams{
 		ID:                id,
 		StartedAt:         &startedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -193,7 +193,7 @@ func applyExecutionCompleted(ctx context.Context, q *store.Queries, e store.Pers
 		Changed:           payload.Changed,
 		Compliant:         payload.Compliant,
 		DetectionOutput:   payload.DetectionOutput,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -218,7 +218,7 @@ func applyExecutionFailed(ctx context.Context, q *store.Queries, e store.Persist
 		Changed:           payload.Changed,
 		Compliant:         payload.Compliant,
 		DetectionOutput:   payload.DetectionOutput,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -240,7 +240,7 @@ func applyExecutionTimedOut(ctx context.Context, q *store.Queries, e store.Persi
 		Error:             payload.Error,
 		Output:            payload.Output,
 		DurationMs:        payload.DurationMs,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -260,7 +260,7 @@ func applyExecutionSkipped(ctx context.Context, q *store.Queries, e store.Persis
 		ID:                payload.ID,
 		CompletedAt:       &completedAt,
 		Error:             payload.Reason,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func applyExecutionCancelled(ctx context.Context, q *store.Queries, e store.Pers
 		ID:                payload.ID,
 		CompletedAt:       &completedAt,
 		Error:             payload.Reason,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}

--- a/internal/projectors/execution_test.go
+++ b/internal/projectors/execution_test.go
@@ -557,7 +557,7 @@ func TestExecutionListener_StaleReplayRejected(t *testing.T) {
 	listener := projectors.ExecutionListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "execution",
 		StreamID:    execID,
 		EventType:   "ExecutionCompleted",

--- a/internal/projectors/identity_provider_listener.go
+++ b/internal/projectors/identity_provider_listener.go
@@ -90,7 +90,7 @@ func applyIdentityProviderCreated(ctx context.Context, st *store.Store, logger *
 		GroupMapping:             payload.GroupMapping,
 		CreatedAt:                e.OccurredAt,
 		CreatedBy:                payload.CreatedBy,
-		ProjectionVersion:        deref(e.SequenceNum),
+		ProjectionVersion:        e.SequenceNum,
 	}); err != nil {
 		logger.Warn("identity_provider projector: failed to insert IdentityProviderCreated",
 			"event_id", e.ID, "idp_id", payload.ID, "error", err)
@@ -125,7 +125,7 @@ func applyIdentityProviderUpdated(ctx context.Context, st *store.Store, logger *
 		GroupClaim:               payload.GroupClaim,
 		GroupMapping:             payload.GroupMapping,
 		UpdatedAt:                e.OccurredAt,
-		ProjectionVersion:        deref(e.SequenceNum),
+		ProjectionVersion:        e.SequenceNum,
 	}); err != nil {
 		logger.Warn("identity_provider projector: failed to apply IdentityProviderUpdated",
 			"event_id", e.ID, "idp_id", payload.ID, "error", err)
@@ -141,7 +141,7 @@ func applyIdentityProviderDeleted(ctx context.Context, st *store.Store, logger *
 		n, err := q.SoftDeleteIdentityProviderProjection(ctx, db.SoftDeleteIdentityProviderProjectionParams{
 			ID:                idpID,
 			UpdatedAt:         e.OccurredAt,
-			ProjectionVersion: deref(e.SequenceNum),
+			ProjectionVersion: e.SequenceNum,
 		})
 		if err != nil {
 			return err
@@ -173,7 +173,7 @@ func applyIdentityProviderSCIMEnabled(ctx context.Context, st *store.Store, logg
 		ID:                payload.ID,
 		ScimTokenHash:     payload.ScimTokenHash,
 		UpdatedAt:         e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		logger.Warn("identity_provider projector: failed to enable SCIM",
 			"event_id", e.ID, "idp_id", payload.ID, "error", err)
@@ -188,7 +188,7 @@ func applyIdentityProviderSCIMDisabled(ctx context.Context, st *store.Store, log
 		n, err := q.SetIdentityProviderSCIMDisabled(ctx, db.SetIdentityProviderSCIMDisabledParams{
 			ID:                idpID,
 			UpdatedAt:         e.OccurredAt,
-			ProjectionVersion: deref(e.SequenceNum),
+			ProjectionVersion: e.SequenceNum,
 		})
 		if err != nil {
 			return err
@@ -217,7 +217,7 @@ func applyIdentityProviderSCIMTokenRotated(ctx context.Context, st *store.Store,
 		ID:                payload.ID,
 		ScimTokenHash:     payload.ScimTokenHash,
 		UpdatedAt:         e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		logger.Warn("identity_provider projector: failed to rotate SCIM token",
 			"event_id", e.ID, "idp_id", payload.ID, "error", err)
@@ -242,7 +242,7 @@ func applyIdentityLinked(ctx context.Context, st *store.Store, logger *slog.Logg
 		ExternalEmail:     payload.ExternalEmail,
 		ExternalName:      payload.ExternalName,
 		LinkedAt:          e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		logger.Warn("identity_provider projector: failed to upsert identity_link",
 			"event_id", e.ID, "link_id", payload.ID, "error", err)
@@ -266,7 +266,7 @@ func applyIdentityLinkLoginUpdated(ctx context.Context, st *store.Store, logger 
 		LastLoginAt:       &loginAt,
 		ExternalEmail:     payload.ExternalEmail,
 		ExternalName:      payload.ExternalName,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		logger.Warn("identity_provider projector: failed to update identity_link login",
 			"event_id", e.ID, "provider_id", payload.ProviderID, "external_id", payload.ExternalID, "error", err)

--- a/internal/projectors/identity_provider_test.go
+++ b/internal/projectors/identity_provider_test.go
@@ -435,7 +435,7 @@ func TestIdentityProviderListener_StaleDeleteReplay(t *testing.T) {
 	listener := projectors.IdentityProviderListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "identity_provider",
 		StreamID:    idpID,
 		EventType:   "IdentityProviderDeleted",

--- a/internal/projectors/lps_password_listener.go
+++ b/internal/projectors/lps_password_listener.go
@@ -58,7 +58,7 @@ func LpsPasswordListener(st *store.Store, logger *slog.Logger) store.EventListen
 			return
 		}
 
-		projVer := deref(e.SequenceNum)
+		projVer := e.SequenceNum
 
 		if err := st.WithTx(ctx, func(q *store.Queries) error {
 			n, err := q.MarkLpsPasswordsNotCurrent(ctx, db.MarkLpsPasswordsNotCurrentParams{

--- a/internal/projectors/luks_key_listener.go
+++ b/internal/projectors/luks_key_listener.go
@@ -73,7 +73,7 @@ func applyLuksKeyRotated(ctx context.Context, st *store.Store, logger *slog.Logg
 			"event_id", e.ID, "error", err)
 		return
 	}
-	projVer := deref(e.SequenceNum)
+	projVer := e.SequenceNum
 
 	if err := st.WithTx(ctx, func(q *store.Queries) error {
 		n, err := q.MarkLuksKeysNotCurrent(ctx, db.MarkLuksKeysNotCurrentParams{

--- a/internal/projectors/role_listener.go
+++ b/internal/projectors/role_listener.go
@@ -98,7 +98,7 @@ func applyRoleCreated(ctx context.Context, q *store.Queries, e store.PersistedEv
 		IsSystem:          payload.IsSystem,
 		CreatedAt:         e.OccurredAt,
 		CreatedBy:         payload.CreatedBy,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -117,7 +117,7 @@ func applyRoleUpdated(ctx context.Context, q *store.Queries, e store.PersistedEv
 		Description:       payload.Description,
 		Permissions:       derefSlice(payload.Permissions),
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -125,7 +125,7 @@ func applyRoleDeleted(ctx context.Context, q *store.Queries, e store.PersistedEv
 	n, err := q.SoftDeleteRoleProjection(ctx, db.SoftDeleteRoleProjectionParams{
 		ID:                e.StreamID,
 		UpdatedAt:         &e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err

--- a/internal/projectors/role_test.go
+++ b/internal/projectors/role_test.go
@@ -354,7 +354,7 @@ func TestRoleListener_StaleDeleteReplayDoesNotNukeMemberships(t *testing.T) {
 	listener := projectors.RoleListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "role",
 		StreamID:    roleID,
 		EventType:   "RoleDeleted",

--- a/internal/projectors/scim_group_mapping_listener.go
+++ b/internal/projectors/scim_group_mapping_listener.go
@@ -77,7 +77,7 @@ func applySCIMGroupMapped(ctx context.Context, q *store.Queries, e store.Persist
 		ScimDisplayName:   payload.SCIMDisplayName,
 		UserGroupID:       payload.UserGroupID,
 		CreatedAt:         e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return fmt.Errorf("upsert scim_group_mapping (mapping_id %s): %w", payload.ID, err)
 	}
@@ -108,7 +108,7 @@ func applySCIMGroupMappingUpdated(ctx context.Context, q *store.Queries, e store
 		ProviderID:        payload.ProviderID,
 		ScimGroupID:       payload.SCIMGroupID,
 		ScimDisplayName:   payload.SCIMDisplayName,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return fmt.Errorf("update scim_group_mapping display_name (provider_id %s, scim_group_id %s): %w",
 			payload.ProviderID, payload.SCIMGroupID, err)

--- a/internal/projectors/server_settings_listener.go
+++ b/internal/projectors/server_settings_listener.go
@@ -46,7 +46,7 @@ func ServerSettingsListener(st *store.Store, logger *slog.Logger) store.EventLis
 			UserProvisioningEnabled: payload.UserProvisioningEnabled,
 			SshAccessForAll:         payload.SshAccessForAll,
 			OccurredAt:              e.OccurredAt,
-			ProjectionVersion:       deref(e.SequenceNum),
+			ProjectionVersion:       e.SequenceNum,
 		}); err != nil {
 			logger.Warn("server_settings projector: failed to apply ServerSettingUpdated",
 				"event_id", e.ID, "error", err)

--- a/internal/projectors/token_listener.go
+++ b/internal/projectors/token_listener.go
@@ -47,7 +47,7 @@ func ApplyToken(ctx context.Context, q *store.Queries, e store.PersistedEvent) e
 	if e.StreamType != "token" {
 		return nil
 	}
-	ver := deref(e.SequenceNum)
+	ver := e.SequenceNum
 	switch e.EventType {
 	case string(eventtypes.TokenCreated):
 		return applyTokenCreated(ctx, q, e)
@@ -91,7 +91,7 @@ func applyTokenCreated(ctx context.Context, q *store.Queries, e store.PersistedE
 		CreatedAt:         &e.OccurredAt,
 		CreatedBy:         payload.CreatedBy,
 		OwnerID:           payload.OwnerID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -106,6 +106,6 @@ func applyTokenRenamed(ctx context.Context, q *store.Queries, e store.PersistedE
 	return q.RenameTokenProjection(ctx, db.RenameTokenProjectionParams{
 		ID:                payload.ID,
 		Name:              payload.Name,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }

--- a/internal/projectors/totp.go
+++ b/internal/projectors/totp.go
@@ -7,21 +7,6 @@ import (
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
-// deref returns the value behind a pointer or the zero value when
-// the pointer is nil. Used to coerce sqlc-generated *int64 fields
-// (PostgreSQL nullable) into the int64 the listener writes back as
-// projection_version. SequenceNum is non-nullable on every event the
-// projector cares about (events.sequence_num is BIGSERIAL UNIQUE),
-// but the generated model exposes it as a pointer so the helper
-// makes the dereference explicit.
-func deref[T any](p *T) T {
-	if p == nil {
-		var zero T
-		return zero
-	}
-	return *p
-}
-
 // totpEventPayload covers every field the TOTP projector reads
 // across the five event types. Per-event derivation funcs below
 // pick the subset they need.

--- a/internal/projectors/totp_listener.go
+++ b/internal/projectors/totp_listener.go
@@ -62,7 +62,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 				SecretEncrypted:   payload.SecretEncrypted,
 				BackupCodesHash:   payload.BackupCodesHash,
 				CreatedAt:         updatedAt,
-				ProjectionVersion: deref(e.SequenceNum),
+				ProjectionVersion: e.SequenceNum,
 			}); err != nil {
 				logger.Warn("totp projector: failed to upsert TOTPSetupInitiated",
 					"event_id", e.ID, "user_id", userID, "error", err)
@@ -72,7 +72,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 			if err := q.VerifyTotpProjection(ctx, db.VerifyTotpProjectionParams{
 				UserID:            userID,
 				UpdatedAt:         updatedAt,
-				ProjectionVersion: deref(e.SequenceNum),
+				ProjectionVersion: e.SequenceNum,
 			}); err != nil {
 				logger.Warn("totp projector: failed to flip totp_projection to verified",
 					"event_id", e.ID, "user_id", userID, "error", err)
@@ -81,7 +81,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 				ID:                userID,
 				TotpEnabled:       true,
 				UpdatedAt:         &updatedAt,
-				ProjectionVersion: deref(e.SequenceNum),
+				ProjectionVersion: e.SequenceNum,
 			}); err != nil {
 				logger.Warn("totp projector: failed to flip users_projection.totp_enabled=TRUE",
 					"event_id", e.ID, "user_id", userID, "error", err)
@@ -100,7 +100,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 				ID:                userID,
 				TotpEnabled:       false,
 				UpdatedAt:         &updatedAt,
-				ProjectionVersion: deref(e.SequenceNum),
+				ProjectionVersion: e.SequenceNum,
 			}); err != nil {
 				logger.Warn("totp projector: failed to flip users_projection.totp_enabled=FALSE",
 					"event_id", e.ID, "user_id", userID, "error", err)
@@ -123,7 +123,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 				UserID:            userID,
 				Column2:           int32(*payload.Index + 1),
 				UpdatedAt:         updatedAt,
-				ProjectionVersion: deref(e.SequenceNum),
+				ProjectionVersion: e.SequenceNum,
 			}); err != nil {
 				logger.Warn("totp projector: failed to mark backup code used",
 					"event_id", e.ID, "user_id", userID, "index", *payload.Index, "error", err)
@@ -134,7 +134,7 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 				UserID:            userID,
 				BackupCodesHash:   payload.BackupCodesHash,
 				UpdatedAt:         updatedAt,
-				ProjectionVersion: deref(e.SequenceNum),
+				ProjectionVersion: e.SequenceNum,
 			}); err != nil {
 				logger.Warn("totp projector: failed to regenerate backup codes",
 					"event_id", e.ID, "user_id", userID, "error", err)

--- a/internal/projectors/user_group_listener.go
+++ b/internal/projectors/user_group_listener.go
@@ -154,7 +154,7 @@ func applyUserGroupCreated(ctx context.Context, q *store.Queries, e store.Persis
 		Description:       payload.Description,
 		CreatedAt:         createdAt,
 		CreatedBy:         payload.CreatedBy,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 		IsDynamic:         payload.IsDynamic,
 		DynamicQuery:      payload.DynamicQuery,
 	}); err != nil {
@@ -186,7 +186,7 @@ func applyUserGroupUpdated(ctx context.Context, q *store.Queries, e store.Persis
 		Name:              payload.Name,
 		Description:       payload.Description,
 		UpdatedAt:         updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -206,7 +206,7 @@ func applyUserGroupQueryUpdated(ctx context.Context, q *store.Queries, e store.P
 		IsDynamic:         payload.IsDynamic,
 		DynamicQuery:      payload.DynamicQuery,
 		UpdatedAt:         e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		// The inner UPDATE's :execrows guard reports not-found when
@@ -253,7 +253,7 @@ func applyUserGroupMaintenanceWindowSet(ctx context.Context, q *store.Queries, e
 		ID:                payload.ID,
 		MaintenanceWindow: payload.MaintenanceWindow,
 		UpdatedAt:         updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func applyUserGroupDeleted(ctx context.Context, q *store.Queries, e store.Persis
 	n, err := q.SoftDeleteUserGroupProjection(ctx, db.SoftDeleteUserGroupProjectionParams{
 		ID:                e.StreamID,
 		UpdatedAt:         updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -310,7 +310,7 @@ func applyUserGroupMemberAdded(ctx context.Context, q *store.Queries, e store.Pe
 	n, err := q.ClaimUserGroupForMembership(ctx, db.ClaimUserGroupForMembershipParams{
 		ID:                payload.GroupID,
 		UpdatedAt:         e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -323,7 +323,7 @@ func applyUserGroupMemberAdded(ctx context.Context, q *store.Queries, e store.Pe
 		UserID:            payload.UserID,
 		AddedAt:           e.OccurredAt,
 		AddedBy:           e.ActorID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -344,7 +344,7 @@ func applyUserGroupMemberRemoved(ctx context.Context, q *store.Queries, e store.
 	n, err := q.ClaimUserGroupForMembership(ctx, db.ClaimUserGroupForMembershipParams{
 		ID:                payload.GroupID,
 		UpdatedAt:         e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -381,7 +381,7 @@ func applyUserGroupRoleAssigned(ctx context.Context, q *store.Queries, e store.P
 	n, err := q.ClaimUserGroupForRoleMutation(ctx, db.ClaimUserGroupForRoleMutationParams{
 		ID:                payload.GroupID,
 		UpdatedAt:         e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -396,7 +396,7 @@ func applyUserGroupRoleAssigned(ctx context.Context, q *store.Queries, e store.P
 		ScopeID:           payload.ScopeID,
 		AssignedAt:        e.OccurredAt,
 		AssignedBy:        e.ActorID,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }
 
@@ -411,7 +411,7 @@ func applyUserGroupRoleRevoked(ctx context.Context, q *store.Queries, e store.Pe
 	n, err := q.ClaimUserGroupForRoleMutation(ctx, db.ClaimUserGroupForRoleMutationParams{
 		ID:                payload.GroupID,
 		UpdatedAt:         e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -444,7 +444,7 @@ func applyUserGroupMembersRebuilt(ctx context.Context, q *store.Queries, e store
 	n, err := q.ClaimUserGroupForMembership(ctx, db.ClaimUserGroupForMembershipParams{
 		ID:                payload.GroupID,
 		UpdatedAt:         e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -461,7 +461,7 @@ func applyUserGroupMembersRebuilt(ctx context.Context, q *store.Queries, e store
 			UserID:            userID,
 			AddedAt:           e.OccurredAt,
 			AddedBy:           "system",
-			ProjectionVersion: deref(e.SequenceNum),
+			ProjectionVersion: e.SequenceNum,
 		}); err != nil {
 			return err
 		}

--- a/internal/projectors/user_group_test.go
+++ b/internal/projectors/user_group_test.go
@@ -738,7 +738,7 @@ func TestUserGroupListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 	listener := projectors.UserGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "user_group",
 		StreamID:    groupID,
 		EventType:   "UserGroupDeleted",
@@ -796,7 +796,7 @@ func TestUserGroupListener_StaleMemberAddedDoesNotRecreateMembership(t *testing.
 	listener := projectors.UserGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "user_group",
 		StreamID:    groupID + ":" + userID,
 		EventType:   "UserGroupMemberAdded",
@@ -850,7 +850,7 @@ func TestUserGroupListener_StaleMembersRebuiltDoesNotOverwrite(t *testing.T) {
 	listener := projectors.UserGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "user_group",
 		StreamID:    groupID,
 		EventType:   "UserGroupMembersRebuilt",
@@ -933,7 +933,7 @@ func TestUserGroupListener_StaleRoleAssignedDoesNotReinsertRevoked(t *testing.T)
 	listener := projectors.UserGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "user_group",
 		StreamID:    groupID + ":role:" + roleID,
 		EventType:   "UserGroupRoleAssigned",

--- a/internal/projectors/user_listener.go
+++ b/internal/projectors/user_listener.go
@@ -165,7 +165,7 @@ func applyUserCreatedWithRoles(ctx context.Context, q *store.Queries, e store.Pe
 		PasswordHash:      &passwordHash,
 		Role:              payload.Role,
 		CreatedAt:         &occurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 		HasPassword:       hasPassword,
 		DisplayName:       payload.DisplayName,
 		GivenName:         payload.GivenName,
@@ -187,7 +187,7 @@ func applyUserCreatedWithRoles(ctx context.Context, q *store.Queries, e store.Pe
 			RoleID:            roleID,
 			AssignedAt:        occurredAt,
 			AssignedBy:        e.ActorID,
-			ProjectionVersion: deref(e.SequenceNum),
+			ProjectionVersion: e.SequenceNum,
 		}); err != nil {
 			return err
 		}
@@ -224,7 +224,7 @@ func applyUserProfileUpdated(ctx context.Context, q *store.Queries, e store.Pers
 		Picture:           payload.Picture,
 		Locale:            payload.Locale,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -244,7 +244,7 @@ func applyUserEmailChanged(ctx context.Context, q *store.Queries, e store.Persis
 		ID:                payload.ID,
 		Email:             payload.Email,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -265,7 +265,7 @@ func applyUserPasswordChanged(ctx context.Context, q *store.Queries, e store.Per
 		ID:                payload.ID,
 		PasswordHash:      &passwordHash,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -285,7 +285,7 @@ func applyUserRoleChanged(ctx context.Context, q *store.Queries, e store.Persist
 		ID:                payload.ID,
 		Role:              payload.Role,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -297,7 +297,7 @@ func applyUserSessionInvalidated(ctx context.Context, q *store.Queries, e store.
 	if _, err := q.InvalidateUserSessionProjection(ctx, db.InvalidateUserSessionProjectionParams{
 		ID:                e.StreamID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -309,7 +309,7 @@ func applyUserDisabled(ctx context.Context, q *store.Queries, e store.PersistedE
 	if _, err := q.DisableUserProjection(ctx, db.DisableUserProjectionParams{
 		ID:                e.StreamID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -321,7 +321,7 @@ func applyUserEnabled(ctx context.Context, q *store.Queries, e store.PersistedEv
 	if _, err := q.EnableUserProjection(ctx, db.EnableUserProjectionParams{
 		ID:                e.StreamID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -333,7 +333,7 @@ func applyUserLoggedIn(ctx context.Context, q *store.Queries, e store.PersistedE
 	if _, err := q.UpdateUserLoginProjection(ctx, db.UpdateUserLoginProjectionParams{
 		ID:                e.StreamID,
 		LastLoginAt:       &loggedInAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -345,7 +345,7 @@ func applyUserDeleted(ctx context.Context, q *store.Queries, e store.PersistedEv
 	n, err := q.SoftDeleteUserProjection(ctx, db.SoftDeleteUserProjectionParams{
 		ID:                e.StreamID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 	if err != nil {
 		return err
@@ -384,8 +384,8 @@ func applyUserSshKeyAdded(ctx context.Context, q *store.Queries, e store.Persist
 	updatedAt := payload.AddedAt
 	if _, err := q.TouchUserUpdatedAt(ctx, db.TouchUserUpdatedAtParams{
 		ID:                payload.ID,
-		UpdatedAt:         updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		UpdatedAt:         &updatedAt,
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -406,10 +406,11 @@ func applyUserSshKeyRemoved(ctx context.Context, q *store.Queries, e store.Persi
 	}); err != nil {
 		return err
 	}
+	occurredAt := e.OccurredAt
 	if _, err := q.TouchUserUpdatedAt(ctx, db.TouchUserUpdatedAtParams{
 		ID:                payload.ID,
-		UpdatedAt:         e.OccurredAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		UpdatedAt:         &occurredAt,
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -430,7 +431,7 @@ func applyUserSshSettingsUpdated(ctx context.Context, q *store.Queries, e store.
 		SshAllowPubkey:    payload.SshAllowPubkey,
 		SshAllowPassword:  payload.SshAllowPassword,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 		ID:                payload.ID,
 	}); err != nil {
 		return err
@@ -451,7 +452,7 @@ func applyUserLinuxUsernameChanged(ctx context.Context, q *store.Queries, e stor
 		ID:                payload.ID,
 		LinuxUsername:     payload.LinuxUsername,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		return err
 	}
@@ -471,7 +472,7 @@ func applyUserSystemActionLinked(ctx context.Context, q *store.Queries, e store.
 		Field:             payload.Field,
 		ActionID:          payload.ActionID,
 		UpdatedAt:         &updatedAt,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 		ID:                payload.ID,
 	}); err != nil {
 		return err
@@ -491,7 +492,7 @@ func applyUserProvisioningSettingsUpdated(ctx context.Context, q *store.Queries,
 	if _, err := q.UpdateUserProvisioningSettingsProjection(ctx, db.UpdateUserProvisioningSettingsProjectionParams{
 		UserProvisioningEnabled: payload.UserProvisioningEnabled,
 		UpdatedAt:               &updatedAt,
-		ProjectionVersion:       deref(e.SequenceNum),
+		ProjectionVersion:       e.SequenceNum,
 		ID:                      payload.ID,
 	}); err != nil {
 		return err

--- a/internal/projectors/user_role_listener.go
+++ b/internal/projectors/user_role_listener.go
@@ -53,7 +53,7 @@ func applyUserRoleAssigned(ctx context.Context, st *store.Store, logger *slog.Lo
 		ScopeID:           payload.ScopeID,
 		AssignedAt:        e.OccurredAt,
 		AssignedBy:        payload.AssignedBy,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		logger.Warn("user_role projector: failed to insert UserRoleAssigned",
 			"event_id", e.ID,

--- a/internal/projectors/user_selection_listener.go
+++ b/internal/projectors/user_selection_listener.go
@@ -60,6 +60,6 @@ func ApplyUserSelection(ctx context.Context, q *store.Queries, e store.Persisted
 		Selected:          payload.Selected,
 		UpdatedAt:         e.OccurredAt,
 		CreatedBy:         payload.CreatedBy,
-		ProjectionVersion: deref(e.SequenceNum),
+		ProjectionVersion: e.SequenceNum,
 	})
 }

--- a/internal/projectors/user_test.go
+++ b/internal/projectors/user_test.go
@@ -747,7 +747,7 @@ func TestUserListener_StaleDeleteReplayDoesNotNukeIdentityLinks(t *testing.T) {
 	listener := projectors.UserListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &older,
+		SequenceNum: older,
 		StreamType:  "user",
 		StreamID:    userID,
 		EventType:   "UserDeleted",
@@ -821,7 +821,7 @@ func TestUserListener_StaleDisableAfterReEnableKeepsSessionMonotonic(t *testing.
 	listener := projectors.UserListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
 		ID:          uuid.New(),
-		SequenceNum: &staleVer,
+		SequenceNum: staleVer,
 		StreamType:  "user",
 		StreamID:    userID,
 		EventType:   "UserDisabled",

--- a/internal/store/generated/assignments.sql.go
+++ b/internal/store/generated/assignments.sql.go
@@ -1144,6 +1144,39 @@ func (q *Queries) ListResolvedActionsForDevice(ctx context.Context, targetID str
 	return items, nil
 }
 
+const listScopedTerminalAdminActionNames = `-- name: ListScopedTerminalAdminActionNames :many
+SELECT name FROM actions_projection
+WHERE is_deleted = FALSE
+  AND (name LIKE 'system:terminal-admin-limited:%'
+       OR name LIKE 'system:terminal-admin-full:%')
+  AND name NOT IN ('system:terminal-admin-limited:global',
+                   'system:terminal-admin-full:global')
+`
+
+// Names of every PER-SCOPE terminal-admin action (excluding the two
+// :global actions), so the per-scope reconciler can empty the cohort of
+// any scope that no longer has a holder. Names are
+// system:terminal-admin-{limited,full}:<deviceGroupID> (#7).
+func (q *Queries) ListScopedTerminalAdminActionNames(ctx context.Context) ([]string, error) {
+	rows, err := q.db.Query(ctx, listScopedTerminalAdminActionNames)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		items = append(items, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listSystemTtyActionsForDevice = `-- name: ListSystemTtyActionsForDevice :many
 SELECT DISTINCT ON (a.id)
        a.id, a.name, a.description, a.action_type, a.desired_state,
@@ -1218,6 +1251,13 @@ type ListSystemTtyActionsForDeviceRow struct {
 // Filtering rules: skip soft-deleted users, actions, roles, and
 // groups so stale projection rows can't leak through and surface a
 // TTY account that should have been cleaned up.
+// #7: scope-aware. Returns the tty action of every user who holds
+// StartTerminal GLOBAL or scoped to a device_group containing $1.
+// scope_kind/scope_id live on user_roles_projection /
+// user_group_roles_projection (the S2 columns inside migration 010's
+// DO-block) — sqlc can't resolve them, so the generated method is
+// HAND-MAINTAINED; keep it in sync. A user_group-scoped StartTerminal
+// grant has no device meaning and is excluded.
 func (q *Queries) ListSystemTtyActionsForDevice(ctx context.Context, deviceID string) ([]ListSystemTtyActionsForDeviceRow, error) {
 	rows, err := q.db.Query(ctx, listSystemTtyActionsForDevice, deviceID)
 	if err != nil {
@@ -1300,10 +1340,11 @@ type ListTerminalAdminActionsForDeviceRow struct {
 // pm-tty-* operators get their sudoers fragment regardless of
 // assignment.
 //
-// #70 ships with the two GLOBAL rows. #7 extends this design by adding
-// per-scope variants; that PR will replace the IN-list filter with a
-// scope-aware join. The shape of this query is intentionally simple
-// so the #7 diff is isolated to the WHERE clause.
+// #70 ships with the two GLOBAL rows. #7 extends this to per-scope
+// actions: the two :global rows reach every device, PLUS any
+// system:terminal-admin-{limited,full}:<deviceGroupID> whose group
+// contains $1. split_part(name,':',3) extracts the device-group id
+// (ULIDs are colon-free).
 func (q *Queries) ListTerminalAdminActionsForDevice(ctx context.Context, deviceID string) ([]ListTerminalAdminActionsForDeviceRow, error) {
 	rows, err := q.db.Query(ctx, listTerminalAdminActionsForDevice, deviceID)
 	if err != nil {
@@ -1332,35 +1373,6 @@ func (q *Queries) ListTerminalAdminActionsForDevice(ctx context.Context, deviceI
 			return nil, err
 		}
 		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const listScopedTerminalAdminActionNames = `-- name: ListScopedTerminalAdminActionNames :many
-SELECT name FROM actions_projection
-WHERE is_deleted = FALSE
-  AND (name LIKE 'system:terminal-admin-limited:%'
-       OR name LIKE 'system:terminal-admin-full:%')
-  AND name NOT IN ('system:terminal-admin-limited:global',
-                   'system:terminal-admin-full:global')
-`
-
-func (q *Queries) ListScopedTerminalAdminActionNames(ctx context.Context) ([]string, error) {
-	rows, err := q.db.Query(ctx, listScopedTerminalAdminActionNames)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []string{}
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, err
-		}
-		items = append(items, name)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/store/generated/device_groups.sql.go
+++ b/internal/store/generated/device_groups.sql.go
@@ -124,7 +124,7 @@ func (q *Queries) DeleteDynamicDeviceGroupEvaluationQueueRow(ctx context.Context
 const deleteDynamicDeviceGroupQueueBefore = `-- name: DeleteDynamicDeviceGroupQueueBefore :exec
 DELETE FROM dynamic_group_evaluation_queue
 WHERE group_id = $1::TEXT
-  AND queued_at <= $2::TIMESTAMPTZ
+  AND queued_at <= $2
 `
 
 type DeleteDynamicDeviceGroupQueueBeforeParams struct {

--- a/internal/store/generated/devices.sql.go
+++ b/internal/store/generated/devices.sql.go
@@ -968,7 +968,7 @@ func (q *Queries) SoftDeleteDeviceProjection(ctx context.Context, arg SoftDelete
 const updateDeviceCertRenewedProjection = `-- name: UpdateDeviceCertRenewedProjection :execrows
 UPDATE devices_projection
 SET cert_fingerprint   = $2,
-    cert_not_after     = COALESCE($4::TIMESTAMPTZ, cert_not_after),
+    cert_not_after     = COALESCE($4, cert_not_after),
     projection_version = $3
 WHERE id = $1
   AND projection_version < $3

--- a/internal/store/generated/events.sql.go
+++ b/internal/store/generated/events.sql.go
@@ -239,8 +239,8 @@ LIMIT $2
 `
 
 type LoadAllEventsParams struct {
-	SequenceNum *int64 `json:"sequence_num"`
-	Limit       int32  `json:"limit"`
+	SequenceNum int64 `json:"sequence_num"`
+	Limit       int32 `json:"limit"`
 }
 
 func (q *Queries) LoadAllEvents(ctx context.Context, arg LoadAllEventsParams) ([]Event, error) {

--- a/internal/store/generated/models.go
+++ b/internal/store/generated/models.go
@@ -219,7 +219,7 @@ type DynamicUserGroupEvaluationQueue struct {
 
 type Event struct {
 	ID            uuid.UUID `json:"id"`
-	SequenceNum   *int64    `json:"sequence_num"`
+	SequenceNum   int64     `json:"sequence_num"`
 	StreamType    string    `json:"stream_type"`
 	StreamID      string    `json:"stream_id"`
 	StreamVersion int32     `json:"stream_version"`
@@ -361,16 +361,6 @@ type OsqueryResult struct {
 	CompletedAt *time.Time `json:"completed_at"`
 }
 
-// Captures errors raised inside PL/pgSQL projector functions invoked via the project_event() trigger. Go projectors registered through projectors.WireAll do NOT write here — they emit slog.Warn instead. An empty table means "no PL/pgSQL projector errors", not "no projector errors of any kind". Inspect slog output for the Go side.
-type PlpgsqlProjectionError struct {
-	ID           int64      `json:"id"`
-	EventID      *uuid.UUID `json:"event_id"`
-	EventType    *string    `json:"event_type"`
-	StreamType   *string    `json:"stream_type"`
-	ErrorMessage *string    `json:"error_message"`
-	OccurredAt   time.Time  `json:"occurred_at"`
-}
-
 type RevokedToken struct {
 	Jti       string    `json:"jti"`
 	RevokedAt time.Time `json:"revoked_at"`
@@ -481,6 +471,8 @@ type UserGroupRolesProjection struct {
 	AssignedAt        time.Time `json:"assigned_at"`
 	AssignedBy        string    `json:"assigned_by"`
 	ProjectionVersion int64     `json:"projection_version"`
+	ScopeKind         *string   `json:"scope_kind"`
+	ScopeID           *string   `json:"scope_id"`
 }
 
 type UserGroupsProjection struct {
@@ -504,6 +496,8 @@ type UserRolesProjection struct {
 	AssignedAt        time.Time `json:"assigned_at"`
 	AssignedBy        string    `json:"assigned_by"`
 	ProjectionVersion int64     `json:"projection_version"`
+	ScopeKind         *string   `json:"scope_kind"`
+	ScopeID           *string   `json:"scope_id"`
 }
 
 type UserSelectionsProjection struct {

--- a/internal/store/generated/roles.sql.go
+++ b/internal/store/generated/roles.sql.go
@@ -121,6 +121,70 @@ func (q *Queries) GetRoleByName(ctx context.Context, name string) (RolesProjecti
 	return i, err
 }
 
+const getUserGroupRoleGrants = `-- name: GetUserGroupRoleGrants :many
+SELECT r.id, r.name, r.description, r.permissions, r.is_system,
+       r.created_at, r.created_by, r.updated_at,
+       ugr.scope_kind, ugr.scope_id,
+       COALESCE(dg.name, ug.name, '')::TEXT AS scope_name
+FROM roles_projection r
+JOIN user_group_roles_projection ugr ON ugr.role_id = r.id
+LEFT JOIN device_groups_projection dg
+       ON ugr.scope_kind = 'device_group' AND dg.id = ugr.scope_id AND dg.is_deleted = FALSE
+LEFT JOIN user_groups_projection ug
+       ON ugr.scope_kind = 'user_group' AND ug.id = ugr.scope_id AND ug.is_deleted = FALSE
+WHERE ugr.group_id = $1 AND r.is_deleted = FALSE
+ORDER BY r.name, ugr.scope_id NULLS FIRST
+`
+
+type GetUserGroupRoleGrantsRow struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Permissions []string   `json:"permissions"`
+	IsSystem    bool       `json:"is_system"`
+	CreatedAt   time.Time  `json:"created_at"`
+	CreatedBy   string     `json:"created_by"`
+	UpdatedAt   *time.Time `json:"updated_at"`
+	ScopeKind   *string    `json:"scope_kind"`
+	ScopeID     *string    `json:"scope_id"`
+	ScopeName   string     `json:"scope_name"`
+}
+
+// #7 scoped-grant round-trip for a user group's own role grants. Same
+// shape + scope_name resolution as GetUserRoleGrants; drives
+// UserGroup.role_grants. Hand-maintained (DO-block scope columns).
+func (q *Queries) GetUserGroupRoleGrants(ctx context.Context, groupID string) ([]GetUserGroupRoleGrantsRow, error) {
+	rows, err := q.db.Query(ctx, getUserGroupRoleGrants, groupID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []GetUserGroupRoleGrantsRow{}
+	for rows.Next() {
+		var i GetUserGroupRoleGrantsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Description,
+			&i.Permissions,
+			&i.IsSystem,
+			&i.CreatedAt,
+			&i.CreatedBy,
+			&i.UpdatedAt,
+			&i.ScopeKind,
+			&i.ScopeID,
+			&i.ScopeName,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getUserPermissions = `-- name: GetUserPermissions :many
 SELECT DISTINCT unnest(r.permissions)::TEXT AS permission FROM roles_projection r
 JOIN user_roles_projection ur ON ur.role_id = r.id
@@ -147,49 +211,64 @@ func (q *Queries) GetUserPermissions(ctx context.Context, userID string) ([]stri
 	return items, nil
 }
 
-// NOTE: GetUserScopedGrants is HAND-MAINTAINED. sqlc cannot generate it
-// because migration 010 adds scope_kind/scope_id inside a `DO $$` block,
-// which sqlc's schema parser does not read, so it can't resolve those
-// columns as SELECT outputs (sqlc generate errors "column scope_kind
-// does not exist"). sqlc IS lenient on INSERT/DELETE column references
-// (the S2 hand-edited queries), but a SELECT output needs the column
-// type from the catalog. Keep this in sync with the GetUserScopedGrants
-// query in queries/roles.sql by hand. #7 S2b.
-const getUserScopedGrants = `-- name: GetUserScopedGrants :many
-SELECT grants.permission, grants.scope_kind, grants.scope_id FROM (
-    SELECT perm.permission::TEXT AS permission, ur.scope_kind, ur.scope_id
-    FROM roles_projection r
-    JOIN user_roles_projection ur ON ur.role_id = r.id
-    CROSS JOIN LATERAL unnest(r.permissions) AS perm(permission)
-    WHERE ur.user_id = $1 AND r.is_deleted = FALSE
-    UNION
-    SELECT perm.permission::TEXT AS permission, ugr.scope_kind, ugr.scope_id
-    FROM roles_projection r
-    JOIN user_group_roles_projection ugr ON ugr.role_id = r.id
-    JOIN user_group_members_projection ugm ON ugm.group_id = ugr.group_id
-    CROSS JOIN LATERAL unnest(r.permissions) AS perm(permission)
-    WHERE ugm.user_id = $1 AND r.is_deleted = FALSE
-) grants
+const getUserRoleGrants = `-- name: GetUserRoleGrants :many
+SELECT r.id, r.name, r.description, r.permissions, r.is_system,
+       r.created_at, r.created_by, r.updated_at,
+       ur.scope_kind, ur.scope_id,
+       COALESCE(dg.name, ug.name, '')::TEXT AS scope_name
+FROM roles_projection r
+JOIN user_roles_projection ur ON ur.role_id = r.id
+LEFT JOIN device_groups_projection dg
+       ON ur.scope_kind = 'device_group' AND dg.id = ur.scope_id AND dg.is_deleted = FALSE
+LEFT JOIN user_groups_projection ug
+       ON ur.scope_kind = 'user_group' AND ug.id = ur.scope_id AND ug.is_deleted = FALSE
+WHERE ur.user_id = $1 AND r.is_deleted = FALSE
+ORDER BY r.name, ur.scope_id NULLS FIRST
 `
 
-// GetUserScopedGrantsRow is one (permission, scope) tuple. ScopeKind and
-// ScopeID are nil together for an unscoped (global) grant.
-type GetUserScopedGrantsRow struct {
-	Permission string  `json:"permission"`
-	ScopeKind  *string `json:"scope_kind"`
-	ScopeID    *string `json:"scope_id"`
+type GetUserRoleGrantsRow struct {
+	ID          string     `json:"id"`
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Permissions []string   `json:"permissions"`
+	IsSystem    bool       `json:"is_system"`
+	CreatedAt   time.Time  `json:"created_at"`
+	CreatedBy   string     `json:"created_by"`
+	UpdatedAt   *time.Time `json:"updated_at"`
+	ScopeKind   *string    `json:"scope_kind"`
+	ScopeID     *string    `json:"scope_id"`
+	ScopeName   string     `json:"scope_name"`
 }
 
-func (q *Queries) GetUserScopedGrants(ctx context.Context, userID string) ([]GetUserScopedGrantsRow, error) {
-	rows, err := q.db.Query(ctx, getUserScopedGrants, userID)
+// #7 scoped-grant round-trip. Returns the user's DIRECTLY-assigned role
+// grants WITH each grant's scope (NOT de-duplicated — the same role
+// granted globally and scoped to a device group yields two rows), and
+// resolves scope_name from the device-/user-group projection (COALESCE to
+// ” when unscoped or the group was deleted). Drives User.role_grants for
+// scoped-grant display + revocation. Hand-maintained: scope_kind/scope_id
+// live in migration 010's DO-block, which sqlc cannot resolve (#336).
+func (q *Queries) GetUserRoleGrants(ctx context.Context, userID string) ([]GetUserRoleGrantsRow, error) {
+	rows, err := q.db.Query(ctx, getUserRoleGrants, userID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []GetUserScopedGrantsRow{}
+	items := []GetUserRoleGrantsRow{}
 	for rows.Next() {
-		var i GetUserScopedGrantsRow
-		if err := rows.Scan(&i.Permission, &i.ScopeKind, &i.ScopeID); err != nil {
+		var i GetUserRoleGrantsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Name,
+			&i.Description,
+			&i.Permissions,
+			&i.IsSystem,
+			&i.CreatedAt,
+			&i.CreatedBy,
+			&i.UpdatedAt,
+			&i.ScopeKind,
+			&i.ScopeID,
+			&i.ScopeName,
+		); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -207,6 +286,9 @@ WHERE ur.user_id = $1 AND r.is_deleted = FALSE
 ORDER BY r.name
 `
 
+// DISTINCT because a role can now be granted to a user multiple times at
+// different scopes (#7); this de-duplicated, scope-blind set backs the
+// legacy User.roles field. The per-grant view is GetUserRoleGrants.
 func (q *Queries) GetUserRoles(ctx context.Context, userID string) ([]RolesProjection, error) {
 	rows, err := q.db.Query(ctx, getUserRoles, userID)
 	if err != nil {
@@ -238,93 +320,47 @@ func (q *Queries) GetUserRoles(ctx context.Context, userID string) ([]RolesProje
 	return items, nil
 }
 
-const getUserRoleGrants = `-- name: GetUserRoleGrants :many
-SELECT r.id, r.name, r.description, r.permissions, r.is_system,
-       r.created_at, r.created_by, r.updated_at,
-       ur.scope_kind, ur.scope_id,
-       COALESCE(dg.name, ug.name, '')::TEXT AS scope_name
-FROM roles_projection r
-JOIN user_roles_projection ur ON ur.role_id = r.id
-LEFT JOIN device_groups_projection dg
-       ON ur.scope_kind = 'device_group' AND dg.id = ur.scope_id AND dg.is_deleted = FALSE
-LEFT JOIN user_groups_projection ug
-       ON ur.scope_kind = 'user_group' AND ug.id = ur.scope_id AND ug.is_deleted = FALSE
-WHERE ur.user_id = $1 AND r.is_deleted = FALSE
-ORDER BY r.name, ur.scope_id NULLS FIRST
+const getUserScopedGrants = `-- name: GetUserScopedGrants :many
+SELECT grants.permission, grants.scope_kind, grants.scope_id FROM (
+    SELECT perm.permission::TEXT AS permission, ur.scope_kind, ur.scope_id
+    FROM roles_projection r
+    JOIN user_roles_projection ur ON ur.role_id = r.id
+    CROSS JOIN LATERAL unnest(r.permissions) AS perm(permission)
+    WHERE ur.user_id = $1 AND r.is_deleted = FALSE
+    UNION
+    SELECT perm.permission::TEXT AS permission, ugr.scope_kind, ugr.scope_id
+    FROM roles_projection r
+    JOIN user_group_roles_projection ugr ON ugr.role_id = r.id
+    JOIN user_group_members_projection ugm ON ugm.group_id = ugr.group_id
+    CROSS JOIN LATERAL unnest(r.permissions) AS perm(permission)
+    WHERE ugm.user_id = $1 AND r.is_deleted = FALSE
+) grants
 `
 
-// GetUserRoleGrantsRow is one (role, scope) grant. ScopeKind and ScopeID
-// are nil together for an unscoped (global) grant; ScopeName is the
-// resolved group display name (” when unscoped or the group is deleted).
-// Hand-maintained — scope_kind/scope_id live in migration 010's DO-block,
-// which sqlc cannot resolve (#336).
-type GetUserRoleGrantsRow struct {
-	ID          string     `json:"id"`
-	Name        string     `json:"name"`
-	Description string     `json:"description"`
-	Permissions []string   `json:"permissions"`
-	IsSystem    bool       `json:"is_system"`
-	CreatedAt   time.Time  `json:"created_at"`
-	CreatedBy   string     `json:"created_by"`
-	UpdatedAt   *time.Time `json:"updated_at"`
-	ScopeKind   *string    `json:"scope_kind"`
-	ScopeID     *string    `json:"scope_id"`
-	ScopeName   string     `json:"scope_name"`
+type GetUserScopedGrantsRow struct {
+	Permission string  `json:"permission"`
+	ScopeKind  *string `json:"scope_kind"`
+	ScopeID    *string `json:"scope_id"`
 }
 
-func (q *Queries) GetUserRoleGrants(ctx context.Context, userID string) ([]GetUserRoleGrantsRow, error) {
-	rows, err := q.db.Query(ctx, getUserRoleGrants, userID)
+// Returns every (permission, scope) tuple the user holds — from direct
+// role grants AND grants inherited via user-group membership — carrying
+// the grant's (scope_kind, scope_id). Both are NULL for an unscoped
+// (global) grant. DISTINCT collapses the same permission held at the
+// same scope via multiple roles. Drives the JWT `sgrants` claim and the
+// scope-enforcement primitives (#7 S2b). The cascade is a property of
+// the GRANT: every permission a grant materializes inherits the grant's
+// scope.
+func (q *Queries) GetUserScopedGrants(ctx context.Context, userID string) ([]GetUserScopedGrantsRow, error) {
+	rows, err := q.db.Query(ctx, getUserScopedGrants, userID)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
-	items := []GetUserRoleGrantsRow{}
+	items := []GetUserScopedGrantsRow{}
 	for rows.Next() {
-		var i GetUserRoleGrantsRow
-		if err := rows.Scan(
-			&i.ID, &i.Name, &i.Description, &i.Permissions, &i.IsSystem,
-			&i.CreatedAt, &i.CreatedBy, &i.UpdatedAt,
-			&i.ScopeKind, &i.ScopeID, &i.ScopeName,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getUserGroupRoleGrants = `-- name: GetUserGroupRoleGrants :many
-SELECT r.id, r.name, r.description, r.permissions, r.is_system,
-       r.created_at, r.created_by, r.updated_at,
-       ugr.scope_kind, ugr.scope_id,
-       COALESCE(dg.name, ug.name, '')::TEXT AS scope_name
-FROM roles_projection r
-JOIN user_group_roles_projection ugr ON ugr.role_id = r.id
-LEFT JOIN device_groups_projection dg
-       ON ugr.scope_kind = 'device_group' AND dg.id = ugr.scope_id AND dg.is_deleted = FALSE
-LEFT JOIN user_groups_projection ug
-       ON ugr.scope_kind = 'user_group' AND ug.id = ugr.scope_id AND ug.is_deleted = FALSE
-WHERE ugr.group_id = $1 AND r.is_deleted = FALSE
-ORDER BY r.name, ugr.scope_id NULLS FIRST
-`
-
-func (q *Queries) GetUserGroupRoleGrants(ctx context.Context, groupID string) ([]GetUserRoleGrantsRow, error) {
-	rows, err := q.db.Query(ctx, getUserGroupRoleGrants, groupID)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	items := []GetUserRoleGrantsRow{}
-	for rows.Next() {
-		var i GetUserRoleGrantsRow
-		if err := rows.Scan(
-			&i.ID, &i.Name, &i.Description, &i.Permissions, &i.IsSystem,
-			&i.CreatedAt, &i.CreatedBy, &i.UpdatedAt,
-			&i.ScopeKind, &i.ScopeID, &i.ScopeName,
-		); err != nil {
+		var i GetUserScopedGrantsRow
+		if err := rows.Scan(&i.Permission, &i.ScopeKind, &i.ScopeID); err != nil {
 			return nil, err
 		}
 		items = append(items, i)
@@ -580,24 +616,6 @@ func (q *Queries) UserHasRole(ctx context.Context, arg UserHasRoleParams) (bool,
 	return has_role, err
 }
 
-const userHasUnscopedRole = `-- name: UserHasUnscopedRole :one
-SELECT EXISTS(SELECT 1 FROM user_roles_projection
-              WHERE user_id = $1 AND role_id = $2 AND scope_id IS NULL) AS has_role
-`
-
-// UserHasUnscopedRole reports whether the user holds the role as an
-// UNSCOPED (global) grant specifically — scope-aware, unlike UserHasRole
-// (2-tuple, counts scoped grants too). Used by the assign-role redundancy
-// pre-check so an unscoped assign isn't dropped just because a scoped
-// grant of the same role exists (#7 grant independence). Hand-maintained:
-// scope_id is a migration-010 DO-block column sqlc cannot resolve (#336).
-func (q *Queries) UserHasUnscopedRole(ctx context.Context, arg UserHasRoleParams) (bool, error) {
-	row := q.db.QueryRow(ctx, userHasUnscopedRole, arg.UserID, arg.RoleID)
-	var has_role bool
-	err := row.Scan(&has_role)
-	return has_role, err
-}
-
 const userHasScopedRole = `-- name: UserHasScopedRole :one
 SELECT EXISTS(
     SELECT 1 FROM user_roles_projection
@@ -607,9 +625,6 @@ SELECT EXISTS(
 ) AS has_role
 `
 
-// UserHasScopedRoleParams targets a specific (user, role, scope) grant.
-// ScopeKind/ScopeID nil together = the unscoped grant. Hand-maintained
-// alongside UserHasRole; sync with queries/roles.sql by hand (#7 S5).
 type UserHasScopedRoleParams struct {
 	UserID    string  `json:"user_id"`
 	RoleID    string  `json:"role_id"`
@@ -617,8 +632,40 @@ type UserHasScopedRoleParams struct {
 	ScopeID   *string `json:"scope_id"`
 }
 
+// Existence of a SPECIFIC (user, role, scope) grant. IS NOT DISTINCT
+// FROM is NULL-aware: NULL scope params match the unscoped grant; set
+// params match that exact scoped grant. Used by RevokeRoleFromUser to
+// reject "revoke a grant that doesn't exist" rather than silently
+// no-op (server #7 S5).
 func (q *Queries) UserHasScopedRole(ctx context.Context, arg UserHasScopedRoleParams) (bool, error) {
-	row := q.db.QueryRow(ctx, userHasScopedRole, arg.UserID, arg.RoleID, arg.ScopeKind, arg.ScopeID)
+	row := q.db.QueryRow(ctx, userHasScopedRole,
+		arg.UserID,
+		arg.RoleID,
+		arg.ScopeKind,
+		arg.ScopeID,
+	)
+	var has_role bool
+	err := row.Scan(&has_role)
+	return has_role, err
+}
+
+const userHasUnscopedRole = `-- name: UserHasUnscopedRole :one
+SELECT EXISTS(SELECT 1 FROM user_roles_projection
+              WHERE user_id = $1 AND role_id = $2 AND scope_id IS NULL) AS has_role
+`
+
+type UserHasUnscopedRoleParams struct {
+	UserID string `json:"user_id"`
+	RoleID string `json:"role_id"`
+}
+
+// Scope-aware variant: does the user hold this role as an UNSCOPED
+// (global) grant specifically? The assign-role redundancy pre-check uses
+// this so an unscoped assign isn't dropped when only a SCOPED grant of the
+// same role exists (#7 grant independence). Hand-maintained: scope_id is a
+// migration-010 DO-block column sqlc cannot resolve (#336).
+func (q *Queries) UserHasUnscopedRole(ctx context.Context, arg UserHasUnscopedRoleParams) (bool, error) {
+	row := q.db.QueryRow(ctx, userHasUnscopedRole, arg.UserID, arg.RoleID)
 	var has_role bool
 	err := row.Scan(&has_role)
 	return has_role, err

--- a/internal/store/generated/user_groups.sql.go
+++ b/internal/store/generated/user_groups.sql.go
@@ -124,7 +124,7 @@ func (q *Queries) DeleteDynamicUserGroupEvaluationQueueRow(ctx context.Context, 
 const deleteDynamicUserGroupQueueBefore = `-- name: DeleteDynamicUserGroupQueueBefore :exec
 DELETE FROM dynamic_user_group_evaluation_queue
 WHERE group_id = $1::TEXT
-  AND queued_at <= $2::TIMESTAMPTZ
+  AND queued_at <= $2
 `
 
 type DeleteDynamicUserGroupQueueBeforeParams struct {
@@ -1063,10 +1063,6 @@ SELECT EXISTS(
 ) AS has_role
 `
 
-// UserGroupHasScopedRoleParams targets a specific (group, role, scope)
-// grant. ScopeKind/ScopeID nil together = the unscoped grant.
-// Hand-maintained alongside UserGroupHasRole; sync with
-// queries/user_groups.sql by hand (#7 S5).
 type UserGroupHasScopedRoleParams struct {
 	GroupID   string  `json:"group_id"`
 	RoleID    string  `json:"role_id"`
@@ -1074,8 +1070,17 @@ type UserGroupHasScopedRoleParams struct {
 	ScopeID   *string `json:"scope_id"`
 }
 
+// Existence of a SPECIFIC (group, role, scope) grant. NULL-aware via
+// IS NOT DISTINCT FROM: NULL scope params match the unscoped grant.
+// Used by RevokeRoleFromUserGroup to reject revoking a grant that
+// doesn't exist at the targeted scope (server #7 S5).
 func (q *Queries) UserGroupHasScopedRole(ctx context.Context, arg UserGroupHasScopedRoleParams) (bool, error) {
-	row := q.db.QueryRow(ctx, userGroupHasScopedRole, arg.GroupID, arg.RoleID, arg.ScopeKind, arg.ScopeID)
+	row := q.db.QueryRow(ctx, userGroupHasScopedRole,
+		arg.GroupID,
+		arg.RoleID,
+		arg.ScopeKind,
+		arg.ScopeID,
+	)
 	var has_role bool
 	err := row.Scan(&has_role)
 	return has_role, err

--- a/internal/store/generated/users.sql.go
+++ b/internal/store/generated/users.sql.go
@@ -283,7 +283,7 @@ VALUES (
     $2::TEXT,
     $3::TEXT,
     $4::TEXT,
-    $5::TIMESTAMPTZ
+    $5
 )
 ON CONFLICT (user_id, key_id) DO NOTHING
 `
@@ -664,16 +664,16 @@ func (q *Queries) SoftDeleteUserProjection(ctx context.Context, arg SoftDeleteUs
 
 const touchUserUpdatedAt = `-- name: TouchUserUpdatedAt :execrows
 UPDATE users_projection
-SET updated_at         = $1::TIMESTAMPTZ,
+SET updated_at         = $1,
     projection_version = $2
 WHERE id = $3
   AND projection_version < $2
 `
 
 type TouchUserUpdatedAtParams struct {
-	UpdatedAt         time.Time `json:"updated_at"`
-	ProjectionVersion int64     `json:"projection_version"`
-	ID                string    `json:"id"`
+	UpdatedAt         *time.Time `json:"updated_at"`
+	ProjectionVersion int64      `json:"projection_version"`
+	ID                string     `json:"id"`
 }
 
 // Companion write for InsertUserSshKey + DeleteUserSshKey. The PL/pgSQL

--- a/internal/store/listener_test.go
+++ b/internal/store/listener_test.go
@@ -132,7 +132,7 @@ func TestEventListener_ReceivesPersistedRow(t *testing.T) {
 	assert.Equal(t, "PersistProbe", captured.EventType)
 	require.NotNil(t, captured.SequenceNum,
 		"persisted event must carry a non-nil SequenceNum — listeners depend on it for ordering")
-	assert.Greater(t, *captured.SequenceNum, int64(0))
+	assert.Greater(t, captured.SequenceNum, int64(0))
 	assert.NotZero(t, captured.OccurredAt,
 		"OccurredAt is set server-side; listeners receive the persisted value, not the caller's zero time")
 }

--- a/internal/store/postgres/role.go
+++ b/internal/store/postgres/role.go
@@ -83,7 +83,14 @@ func (r *Role) ListUserGroupRoleGrants(ctx context.Context, groupID string) ([]s
 	if err != nil {
 		return nil, fmt.Errorf("role: list user group role grants: %w", err)
 	}
-	return roleGrantsFromRows(rows), nil
+	// sqlc generates a distinct (but structurally identical) row type per
+	// query; convert so both share one mapper. Compile-time safe — drifts
+	// if the two scope-grant queries' column lists ever diverge.
+	conv := make([]generated.GetUserRoleGrantsRow, len(rows))
+	for i, row := range rows {
+		conv[i] = generated.GetUserRoleGrantsRow(row)
+	}
+	return roleGrantsFromRows(conv), nil
 }
 
 // roleGrantsFromRows maps the shared scoped-grant Row to store.RoleGrant.

--- a/internal/store/queries/device_groups.sql
+++ b/internal/store/queries/device_groups.sql
@@ -272,7 +272,7 @@ DELETE FROM device_group_members_projection WHERE device_id = $1;
 -- running, the newer queue entry survives so the drain loop re-evaluates.
 DELETE FROM dynamic_group_evaluation_queue
 WHERE group_id = sqlc.arg(group_id)::TEXT
-  AND queued_at <= sqlc.arg(before_ts)::TIMESTAMPTZ;
+  AND queued_at <= sqlc.arg(before_ts);
 
 -- name: ListDynamicDeviceGroupQueueBatch :many
 -- Wave C.4: returns the next batch of queued group IDs for the

--- a/internal/store/queries/devices.sql
+++ b/internal/store/queries/devices.sql
@@ -272,7 +272,7 @@ WHERE id = $1
 -- Stale-replay guard via projection_version.
 UPDATE devices_projection
 SET cert_fingerprint   = $2,
-    cert_not_after     = COALESCE(sqlc.narg('cert_not_after')::TIMESTAMPTZ, cert_not_after),
+    cert_not_after     = COALESCE(sqlc.narg('cert_not_after'), cert_not_after),
     projection_version = $3
 WHERE id = $1
   AND projection_version < $3;

--- a/internal/store/queries/user_groups.sql
+++ b/internal/store/queries/user_groups.sql
@@ -297,7 +297,7 @@ DELETE FROM dynamic_user_group_evaluation_queue WHERE group_id = $1;
 -- survives so the next drain pass re-evaluates.
 DELETE FROM dynamic_user_group_evaluation_queue
 WHERE group_id = sqlc.arg(group_id)::TEXT
-  AND queued_at <= sqlc.arg(before_ts)::TIMESTAMPTZ;
+  AND queued_at <= sqlc.arg(before_ts);
 
 -- name: ListDynamicUserGroupQueueBatch :many
 -- Wave C.4: returns the next batch of queued user-group IDs for the

--- a/internal/store/queries/users.sql
+++ b/internal/store/queries/users.sql
@@ -178,7 +178,7 @@ VALUES (
     sqlc.arg(key_id)::TEXT,
     sqlc.narg(public_key)::TEXT,
     sqlc.narg(comment)::TEXT,
-    sqlc.arg(added_at)::TIMESTAMPTZ
+    sqlc.arg(added_at)
 )
 ON CONFLICT (user_id, key_id) DO NOTHING;
 
@@ -189,7 +189,7 @@ ON CONFLICT (user_id, key_id) DO NOTHING;
 -- still wants to mark the user row updated and bump the stale-replay
 -- version. Stale-replay guard via projection_version.
 UPDATE users_projection
-SET updated_at         = sqlc.arg(updated_at)::TIMESTAMPTZ,
+SET updated_at         = sqlc.arg(updated_at),
     projection_version = sqlc.arg(projection_version)
 WHERE id = sqlc.arg(id)
   AND projection_version < sqlc.arg(projection_version);


### PR DESCRIPTION
Closes the #336 regen (on top of the tooling/config in #348). `make sqlc-generate` now reproduces `generated/` with **zero** hand-maintenance — the query layer is finally reproducible.

Researched first and confirmed every step is the canonical sqlc + pgx/v5 approach (pg_catalog-qualified overrides; params need the cast dropped because Go-type overrides for parameters aren't implemented).

## What the regen fixed / required
- **Dropped the no-op `::TIMESTAMPTZ` casts** on the 4 timestamptz params — sqlc applies `go_type` overrides to catalog-resolved columns but not cast-typed params, so the cast forced `pgtype.Timestamptz`. Without it, sqlc infers from the column and the override applies → `time.Time`.
- **`Event.SequenceNum` `*int64` → `int64`** — `sequence_num` is `bigint NOT NULL`, so sqlc correctly emits `int64`; the committed `*int64` was legacy drift with **~131 `deref(e.SequenceNum)` sites** + 25 test fixtures + `advanceDeviceVersion`'s signature, all reconciled.
- **#7 scope queries now genuinely generated** (no more hand-written NOTEs): `GetUserScopedGrants`, `GetUser[Group]RoleGrants`, `UserHasUnscopedRole`, the device-keyed terminal-admin/tty delivery + `ListScopedTerminalAdminActionNames`. `role.go` converts the (structurally identical) `GetUserGroupRoleGrantsRow`; `role_handler.go` uses `UserHasUnscopedRoleParams`.
- **`TouchUserUpdatedAt.updated_at` → `*time.Time`** (the column is nullable); the two callers pass pointers.

## Validation
`go build ./...`, `go vet ./...` (compiles tests) clean; **store**, **api scope**, and the **projector stale-version/replay guard** tests pass (the last proves the SequenceNum→ProjectionVersion change is behaviour-safe). `make sqlc-generate` is idempotent + gofmt-clean. Local CodeRabbit: clean.

> The full `internal/projectors` package run hit the Ryuk testcontainer-reaper exhaustion (#338) locally, not a logic failure — CI runs it sharded (#347).

Follow-up: wire `make sqlc-check` into CI as a drift guard now that generated/ is in sync. Refs manchtools/power-manage-server#336.