### PR TITLE
ci(sqlc): wire make sqlc-check into CI as a drift guard (#336)

### DIFF
--- a/.github/workflows/sqlc.yml
+++ b/.github/workflows/sqlc.yml
@@ -1,0 +1,49 @@
+name: sqlc drift
+
+# Guards against the failure mode that caused #336: internal/store/generated/
+# silently diverging from `sqlc generate`. The check regenerates via the
+# pinned official image (make sqlc-check -> sqlc-generate) and fails if the
+# committed output differs.
+#
+# This needs its own path filter because the drift case is a `.sql`/.yaml
+# change WITHOUT a matching `.go` regen — lint.yml / test.yml only fire on
+# `**.go`, so they would miss exactly the divergence we're guarding against.
+on:
+  push:
+    branches: [main, 'v*']
+    paths:
+      - 'internal/store/queries/**'
+      - 'internal/store/migrations/**'
+      - 'internal/store/sqlc.yaml'
+      - 'internal/store/sqlc_schema_overlay.sql'
+      - 'internal/store/generated/**'
+      - 'Makefile'
+      - '.github/workflows/sqlc.yml'
+  pull_request:
+    paths:
+      - 'internal/store/queries/**'
+      - 'internal/store/migrations/**'
+      - 'internal/store/sqlc.yaml'
+      - 'internal/store/sqlc_schema_overlay.sql'
+      - 'internal/store/generated/**'
+      - 'Makefile'
+      - '.github/workflows/sqlc.yml'
+
+jobs:
+  drift:
+    name: generated/ matches sqlc generate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # No setup-go: sqlc runs inside the pinned sqlc/sqlc image (Docker is
+      # preinstalled on ubuntu-latest), so the result does not depend on this
+      # runner's toolchain — same image the Makefile documents as the
+      # reproducible reference (#336).
+      - name: sqlc drift check
+        run: |
+          make sqlc-check || {
+            echo "::error::internal/store/generated/ is out of date. Run 'make sqlc-generate' and commit the result. See Makefile / #336."
+            git --no-pager diff internal/store/generated
+            exit 1
+          }

--- a/Makefile
+++ b/Makefile
@@ -32,17 +32,20 @@ help:
 #     pgtype.Timestamptz. Drop the no-op cast and sqlc infers the param
 #     type from the bound column.
 #
-# NOTE (#336): the committed generated/ has accumulated hand-maintenance
-# that diverges from a clean regen — most notably Event.SequenceNum is
+# HISTORY (#336): the committed generated/ had years of hand-maintenance
+# that diverged from a clean regen — most notably Event.SequenceNum was
 # *int64 (the column is `bigint NOT NULL`, so sqlc emits int64) with ~131
-# deref() call sites built around it, plus the hand-written #7 scope-grant
-# queries. A first full regen therefore surfaces a real reconciliation,
-# not a no-op — review the diff before committing.
+# deref() call sites built around it, plus hand-written #7 scope-grant
+# queries. That divergence was fully reconciled in #349, so a regen is now
+# a no-op against committed main — and the sqlc-drift CI job keeps it that
+# way. If sqlc-generate produces a diff, the queries/config changed: commit
+# the regenerated output, never hand-edit generated/.
 sqlc-generate:
 	cd internal/store && docker run --rm \
 		-v "$$(pwd)":/src:Z -w /src $(SQLC_IMAGE) generate
 
-# Fail if generated code is out of date. NOT wired into CI yet — the
-# historical divergence above must be reconciled first (#336 follow-up).
+# Fail if generated code is out of date. Wired into CI as the "sqlc drift"
+# workflow (.github/workflows/sqlc.yml), which runs on any change to
+# queries/, migrations/, sqlc.yaml, the overlay, generated/, or this file.
 sqlc-check: sqlc-generate
 	git diff --exit-code internal/store/generated


### PR DESCRIPTION
## What

Adds a dedicated **`sqlc drift`** workflow (`.github/workflows/sqlc.yml`) that regenerates `internal/store/generated/` via the pinned official sqlc image (`make sqlc-check` → `make sqlc-generate`) and fails if the committed output differs.

## Why

This closes the open #336 follow-up. After the #349 reconciliation, `generated/` finally matches a clean regen (`make sqlc-check` is a no-op on `main`). This gate keeps it that way — the years-long silent divergence that #336 documented becomes structurally impossible to reintroduce.

The workflow needs its **own path filter** (`queries/`, `migrations/`, `sqlc.yaml`, the overlay, `generated/`, `Makefile`): the drift case is a `.sql`/`.yaml` change *without* a matching `.go` regen, and both `lint.yml` and `test.yml` are `**.go`-gated — so they'd miss exactly the divergence we're guarding against.

No `setup-go`: sqlc runs inside the pinned `sqlc/sqlc:1.30.0` image (Docker preinstalled on `ubuntu-latest`), so the result is independent of the runner toolchain — the same reproducible reference the Makefile documents.

## Validation

- `make sqlc-check` → **EXIT 0** (no-op) on current `main`.
- Red proof: injecting a query change without regenerating committed output → `make sqlc-check` **EXIT 2** (regen produced a method the committed output lacked); revert restored a clean tree.
- Workflow YAML parses; local CodeRabbit clean (one minor error-message wording fix applied).

Closes #336.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added automated continuous integration check to ensure generated SQL code remains synchronized with source definitions.
  * Updated build process documentation to reflect new code generation validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->