### PR TITLE
fix(api): make audit-log secret redaction actually fire (#352)

### DIFF
--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -308,6 +308,11 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 	}
 
 	eventData := map[string]any{
+		// action_type lets the audit redactor classify the updated params
+		// (and keeps the event self-describing for replay). The action's
+		// type is immutable, so the existing projection value is authoritative
+		// (#352).
+		"action_type":   existing.ActionType,
 		"params":        params,
 		"desired_state": int32(req.Msg.DesiredState),
 	}

--- a/internal/api/audit_handler.go
+++ b/internal/api/audit_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"sort"
 
 	"connectrpc.com/connect"
 	"github.com/oklog/ulid/v2"
@@ -111,9 +112,12 @@ var eventRedactionSchemas = map[string]map[string]redactionSchema{
 		string(eventtypes.UserCreatedWithRoles): {paths: []string{"password_hash"}},
 	},
 	"lps_password": {
-		// LPS rotations carry an array of {username, password}
-		// records under "rotations[].password".
-		"LpsPasswordRotated": {paths: []string{"rotations[].password"}},
+		// One LpsPasswordRotated event is emitted PER rotation
+		// (internal_handler.go), each a flat payloads.LpsPasswordRotated
+		// with the credential at top-level "password" — NOT an array under
+		// "rotations[].password" (the prior path matched nothing, so the
+		// encrypted credential was exposed). #352.
+		"LpsPasswordRotated": {paths: []string{"password"}},
 	},
 	"luks_key": {
 		// LUKS rotations are emitted via the internal handler with
@@ -135,28 +139,41 @@ var eventRedactionSchemas = map[string]map[string]redactionSchema{
 //
 // One schema per action type that carries secret-bearing parameters:
 //
-//   - SHELL        -> params.script + params.detectionScript
-//     (both can hold full shell bodies)
+//   - SHELL / SCRIPT_RUN -> params.script + params.detectionScript
+//     (both can hold full shell bodies; SCRIPT_RUN reuses ShellParams)
 //   - FILE         -> params.content (file body, may contain secrets)
+//   - SERVICE      -> params.unitContent (systemd/openrc unit body; can
+//     embed Environment= credentials)
 //   - ADMIN_POLICY -> params.customConfig (sudoers / doas.conf fragment;
 //     proto field renamed from unit_content)
 //   - REPOSITORY   -> params.gpgKey (GPG signing key material; URL form
 //     params.gpgKeyUrl is intentionally NOT scrubbed)
 //   - ENCRYPTION   -> params.presharedKey (LUKS bootstrap entropy)
+//   - WIFI         -> params.psk (WPA pre-shared key) + params.clientKey
+//     (EAP-TLS client private key PEM; caCert/clientCert are public, not
+//     scrubbed)
 //
-// Action types not in this map have no params secrets to scrub
-// (PACKAGE, UPDATE, REBOOT, SYNC, USER, GROUP, SSH, SSHD,
-// SYSTEMD/SERVICE, DIRECTORY, APP_IMAGE, DEB, RPM, FLATPAK, LPS).
-// LpsParams in particular looks like a hit but is not — the actual
-// rotated password is generated agent-side and surfaces via the
-// LpsPasswordRotated event (covered by eventRedactionSchemas), not
-// via the dispatch action_params.
+// SCRIPT_RUN, SERVICE and WIFI were absent from the original schema and
+// leaked (#352); the self-discovering TestActionParamsSecretFieldsCovered
+// walks the proto and fails if any sensitive params field lacks a path.
+//
+// Action types not in this map have no params secrets to scrub (PACKAGE,
+// UPDATE, REBOOT, SYNC, USER, GROUP, SSH, SSHD, DIRECTORY, APP_IMAGE, DEB,
+// RPM, FLATPAK, LPS, AGENT_UPDATE) — and even so, actionSchemaFor applies
+// the union of all the paths below as a fail-safe to any action/execution
+// event whose action_type is missing or unrecognised. LpsParams in
+// particular looks like a hit but is not — the rotated password is
+// generated agent-side and surfaces via the LpsPasswordRotated event
+// (covered by eventRedactionSchemas), not via the dispatch action_params.
 var actionRedactionSchemas = map[string]redactionSchema{
 	"ACTION_TYPE_SHELL":        {paths: []string{"params.script", "params.detectionScript"}},
+	"ACTION_TYPE_SCRIPT_RUN":   {paths: []string{"params.script", "params.detectionScript"}},
 	"ACTION_TYPE_FILE":         {paths: []string{"params.content"}},
+	"ACTION_TYPE_SERVICE":      {paths: []string{"params.unitContent"}},
 	"ACTION_TYPE_ADMIN_POLICY": {paths: []string{"params.customConfig"}},
 	"ACTION_TYPE_REPOSITORY":   {paths: []string{"params.gpgKey"}},
 	"ACTION_TYPE_ENCRYPTION":   {paths: []string{"params.presharedKey"}},
+	"ACTION_TYPE_WIFI":         {paths: []string{"params.psk", "params.clientKey"}},
 }
 
 // redactEventData removes sensitive fields from a serialized event
@@ -207,15 +224,15 @@ func redactEventData(streamType, eventType string, data []byte) string {
 	return string(out)
 }
 
-// schemaFor selects the redactionSchema for an event. For action
-// streams it dispatches on the action-type code embedded at
-// `payload.type`; for every other stream it looks up
-// (streamType, eventType) directly.
+// schemaFor selects the redactionSchema for an event. Action AND
+// execution streams both embed action params under `params.` and carry the
+// action type as the integer `action_type` field (NOT a top-level `type`
+// string — that key never existed in the emit, which is why the redactor
+// was dead before #352). Every other stream looks up (streamType, eventType)
+// directly.
 func schemaFor(streamType, eventType string, payload map[string]any) (redactionSchema, bool) {
-	if streamType == "action" {
-		typeCode, _ := payload["type"].(string)
-		s, ok := actionRedactionSchemas[typeCode]
-		return s, ok
+	if streamType == "action" || streamType == "execution" {
+		return actionSchemaFor(payload)
 	}
 	if streamSchemas, ok := eventRedactionSchemas[streamType]; ok {
 		s, ok := streamSchemas[eventType]
@@ -223,6 +240,80 @@ func schemaFor(streamType, eventType string, payload map[string]any) (redactionS
 	}
 	return redactionSchema{}, false
 }
+
+// actionSchemaFor resolves the redaction schema for an action/execution
+// event from its integer `action_type`. When that names a known
+// secret-bearing type, the precise per-type schema is returned (the design's
+// intent — scrub only that type's secret paths, never over-scrub). For a
+// known non-secret type (PACKAGE, …) there is nothing to scrub. In every
+// remaining case — `action_type` absent (a legacy ActionParamsUpdated, or an
+// execution result event), ACTION_TYPE_UNSPECIFIED (e.g. a COALESCE'd
+// replay), or an unrecognised enum from a newer server — it falls back to the
+// UNION of all known action-secret paths. Each union entry is an exact
+// `params.<key>` leaf, so the fallback is a no-op on any payload that does
+// not carry that secret, but it guarantees an event holding secret params can
+// never slip through unclassified.
+func actionSchemaFor(payload map[string]any) (redactionSchema, bool) {
+	if code, ok := actionTypeName(payload); ok && code != pm.ActionType_ACTION_TYPE_UNSPECIFIED.String() {
+		if s, known := actionRedactionSchemas[code]; known {
+			return s, true
+		}
+		if _, valid := pm.ActionType_value[code]; valid {
+			return redactionSchema{}, false // recognised type with no secret params
+		}
+	}
+	return allActionSecretPaths, true
+}
+
+// actionTypeName reads the integer `action_type` field from a decoded event
+// payload and maps it to its proto enum name (e.g. 200 ->
+// "ACTION_TYPE_SHELL"). encoding/json decodes numbers as float64; json.Number
+// and the native integer types are accepted defensively. Returns ("", false)
+// when the field is absent or not a number.
+func actionTypeName(payload map[string]any) (string, bool) {
+	v, present := payload["action_type"]
+	if !present {
+		return "", false
+	}
+	var n int32
+	switch t := v.(type) {
+	case float64:
+		n = int32(t)
+	case json.Number:
+		i, err := t.Int64()
+		if err != nil {
+			return "", false
+		}
+		n = int32(i)
+	case int32:
+		n = t
+	case int:
+		n = int32(t)
+	default:
+		return "", false
+	}
+	return pm.ActionType(n).String(), true
+}
+
+// allActionSecretPaths is the union of every action-redaction path, used as
+// the fail-safe in actionSchemaFor when an action/execution event lacks a
+// usable action_type. Built from actionRedactionSchemas so a newly-added
+// secret type's paths are included automatically; sorted for deterministic
+// redaction ordering.
+var allActionSecretPaths = func() redactionSchema {
+	seen := map[string]bool{}
+	var paths []string
+	for _, s := range actionRedactionSchemas {
+		for _, p := range s.paths {
+			if p != "" && !seen[p] {
+				seen[p] = true
+				paths = append(paths, p)
+			}
+		}
+	}
+	sort.Strings(paths)
+	return redactionSchema{paths: paths}
+}()
 
 // redactPath descends the dot-separated path inside a decoded JSON
 // payload and replaces the leaf with "[REDACTED]". The "[]" segment

--- a/internal/api/audit_redaction_integration_test.go
+++ b/internal/api/audit_redaction_integration_test.go
@@ -1,0 +1,100 @@
+package api_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestListAuditEvents_RedactsActionSecrets is the real-emit-path proof for
+// audit finding #1. It drives the ACTUAL CreateAction handler — which emits
+// ActionCreated with `action_type` as an int and `params` nested, the true
+// wire shape — then reads the audit log back through ListAuditEvents and
+// asserts the secret never appears.
+//
+// The prior unit tests hand-built a `{"type": "ACTION_TYPE_SHELL", ...}` map
+// that matched the redactor's (broken) dispatch key, so they stayed green
+// while the redactor was dead against the real `action_type` int the
+// handlers actually write. Sourcing the payload from the production emit
+// means this test can only pass if the redactor fires on what handlers
+// genuinely persist.
+func TestListAuditEvents_RedactsActionSecrets(t *testing.T) {
+	cases := []struct {
+		name   string
+		secret string
+		req    *pm.CreateActionRequest
+	}{
+		{
+			name:   "SHELL script",
+			secret: "SENTINEL_SHELL_8a1f",
+			req: &pm.CreateActionRequest{
+				Name: "shell-leak",
+				Type: pm.ActionType_ACTION_TYPE_SHELL,
+				Params: &pm.CreateActionRequest_Shell{
+					Shell: &pm.ShellParams{Script: "SENTINEL_SHELL_8a1f"},
+				},
+			},
+		},
+		{
+			name:   "FILE content",
+			secret: "SENTINEL_FILE_8a1f",
+			req: &pm.CreateActionRequest{
+				Name: "file-leak",
+				Type: pm.ActionType_ACTION_TYPE_FILE,
+				Params: &pm.CreateActionRequest_File{
+					File: &pm.FileParams{Path: "/etc/x", Content: "SENTINEL_FILE_8a1f"},
+				},
+			},
+		},
+		{
+			name:   "ENCRYPTION presharedKey (plaintext LUKS bootstrap entropy)",
+			secret: "SENTINEL_LUKS_8a1f",
+			req: &pm.CreateActionRequest{
+				Name: "luks-leak",
+				Type: pm.ActionType_ACTION_TYPE_ENCRYPTION,
+				Params: &pm.CreateActionRequest_Encryption{
+					Encryption: &pm.EncryptionParams{
+						PresharedKey:         "SENTINEL_LUKS_8a1f",
+						RotationIntervalDays: 30,
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := testutil.SetupPostgres(t)
+			actionH := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+			auditH := api.NewAuditHandler(st, slog.Default())
+			adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+			ctx := testutil.AdminContext(adminID)
+
+			_, err := actionH.CreateAction(ctx, connect.NewRequest(tc.req))
+			require.NoError(t, err)
+
+			resp, err := auditH.ListAuditEvents(ctx, connect.NewRequest(&pm.ListAuditEventsRequest{
+				StreamType: "action",
+			}))
+			require.NoError(t, err)
+			require.NotEmpty(t, resp.Msg.Events)
+
+			var sawActionCreated bool
+			for _, e := range resp.Msg.Events {
+				if e.EventType == "ActionCreated" {
+					sawActionCreated = true
+				}
+				assert.NotContainsf(t, e.Data, tc.secret,
+					"secret %q leaked unredacted in audit event %s: %s", tc.secret, e.EventType, e.Data)
+			}
+			require.True(t, sawActionCreated, "expected an ActionCreated event in the audit log")
+		})
+	}
+}

--- a/internal/api/audit_redactor_internal_test.go
+++ b/internal/api/audit_redactor_internal_test.go
@@ -7,96 +7,143 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 )
 
-// TestRedactEventData_ActionParams locks the schema-aware contract:
-// each action type has its own redaction schema rooted at `params.`.
-// A SHELL action's `script`, a FILE action's `content`, an
-// ADMIN_POLICY action's `customConfig`, etc. must NOT appear verbatim
-// in the redacted output.
-//
-// The fixtures here use the **camelCase** keys the production wire
-// format actually produces — see audit F-34. Earlier versions of this
-// test used snake_case keys that matched a (broken) snake_case
-// schema, masking the production leak. The fixtures match what
-// `serializeProtoParams` in internal/api/action_params.go emits via
-// protojson (`UseProtoNames=false`).
+// actionEnvelope builds an event payload in the SHAPE THE HANDLERS ACTUALLY
+// EMIT: an integer `action_type` (NOT a top-level `type` string — that key
+// never existed, which is exactly why the redactor was dead) and the params
+// nested under `params`. Sourcing the fixture from the real wire shape is the
+// point — the prior tests fed `{"type": "..."}` that matched the broken
+// dispatch key, so they passed while the control was off.
+func actionEnvelope(at pm.ActionType, params map[string]any) []byte {
+	raw, _ := json.Marshal(map[string]any{
+		"name":        "test-action",
+		"action_type": int32(at),
+		"params":      params,
+	})
+	return raw
+}
+
+// TestRedactEventData_ActionParams locks the schema-aware contract against
+// the real `action_type` wire shape: each secret-bearing action type's
+// params secret must not survive into the redacted output, with exactly one
+// [REDACTED] marker per scrubbed secret.
 func TestRedactEventData_ActionParams(t *testing.T) {
 	cases := []struct {
 		name       string
-		actionType string
+		actionType pm.ActionType
 		params     map[string]any
 		secrets    []string
 	}{
 		{
 			name:       "SHELL params.script + params.detectionScript",
-			actionType: "ACTION_TYPE_SHELL",
-			params: map[string]any{
-				"script":          "echo SENTINEL_SHELL",
-				"detectionScript": "echo SENTINEL_DETECT",
-			},
-			secrets: []string{"SENTINEL_SHELL", "SENTINEL_DETECT"},
+			actionType: pm.ActionType_ACTION_TYPE_SHELL,
+			params:     map[string]any{"script": "SENTINEL_SHELL", "detectionScript": "SENTINEL_DETECT"},
+			secrets:    []string{"SENTINEL_SHELL", "SENTINEL_DETECT"},
+		},
+		{
+			name:       "SCRIPT_RUN reuses ShellParams script paths",
+			actionType: pm.ActionType_ACTION_TYPE_SCRIPT_RUN,
+			params:     map[string]any{"script": "SENTINEL_SCRIPTRUN"},
+			secrets:    []string{"SENTINEL_SCRIPTRUN"},
 		},
 		{
 			name:       "FILE params.content",
-			actionType: "ACTION_TYPE_FILE",
-			params: map[string]any{
-				"path":    "/etc/foo",
-				"content": "SENTINEL_FILE",
-			},
-			secrets: []string{"SENTINEL_FILE"},
+			actionType: pm.ActionType_ACTION_TYPE_FILE,
+			params:     map[string]any{"path": "/etc/foo", "content": "SENTINEL_FILE"},
+			secrets:    []string{"SENTINEL_FILE"},
+		},
+		{
+			name:       "SERVICE params.unitContent",
+			actionType: pm.ActionType_ACTION_TYPE_SERVICE,
+			params:     map[string]any{"name": "foo.service", "unitContent": "SENTINEL_UNIT"},
+			secrets:    []string{"SENTINEL_UNIT"},
 		},
 		{
 			name:       "ADMIN_POLICY params.customConfig",
-			actionType: "ACTION_TYPE_ADMIN_POLICY",
-			params: map[string]any{
-				"customConfig": "SENTINEL_SUDO",
-			},
-			secrets: []string{"SENTINEL_SUDO"},
+			actionType: pm.ActionType_ACTION_TYPE_ADMIN_POLICY,
+			params:     map[string]any{"customConfig": "SENTINEL_SUDO"},
+			secrets:    []string{"SENTINEL_SUDO"},
 		},
 		{
 			name:       "REPOSITORY params.gpgKey",
-			actionType: "ACTION_TYPE_REPOSITORY",
-			params: map[string]any{
-				"url":    "https://example.com/repo",
-				"gpgKey": "SENTINEL_GPG",
-			},
-			secrets: []string{"SENTINEL_GPG"},
+			actionType: pm.ActionType_ACTION_TYPE_REPOSITORY,
+			params:     map[string]any{"url": "https://example.com/repo", "gpgKey": "SENTINEL_GPG"},
+			secrets:    []string{"SENTINEL_GPG"},
 		},
 		{
-			name:       "ENCRYPTION (LUKS) params.presharedKey",
-			actionType: "ACTION_TYPE_ENCRYPTION",
-			params: map[string]any{
-				"devicePath":   "/dev/sda1",
-				"presharedKey": "SENTINEL_LUKS_PSK",
-			},
-			secrets: []string{"SENTINEL_LUKS_PSK"},
+			name:       "ENCRYPTION params.presharedKey",
+			actionType: pm.ActionType_ACTION_TYPE_ENCRYPTION,
+			params:     map[string]any{"devicePath": "/dev/sda1", "presharedKey": "SENTINEL_LUKS_PSK"},
+			secrets:    []string{"SENTINEL_LUKS_PSK"},
+		},
+		{
+			name:       "WIFI params.psk + params.clientKey",
+			actionType: pm.ActionType_ACTION_TYPE_WIFI,
+			params:     map[string]any{"ssid": "corp", "psk": "SENTINEL_WIFI_PSK", "clientKey": "SENTINEL_WIFI_CLIENTKEY", "caCert": "public-ca"},
+			secrets:    []string{"SENTINEL_WIFI_PSK", "SENTINEL_WIFI_CLIENTKEY"},
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			payload := map[string]any{
-				"name":   "test-action",
-				"type":   tc.actionType,
-				"params": tc.params,
-			}
-			raw, err := json.Marshal(payload)
-			require.NoError(t, err)
-			out := redactEventData("action", "ActionCreated", raw)
+			out := redactEventData("action", "ActionCreated", actionEnvelope(tc.actionType, tc.params))
 			for _, s := range tc.secrets {
-				assert.NotContains(t, out, s, "secret %q must not appear in redacted output: %s", s, out)
+				assert.NotContainsf(t, out, s, "secret %q must not appear in redacted output: %s", s, out)
 			}
-			assert.Equal(t, strings.Count(out, "[REDACTED]"), len(tc.secrets),
+			assert.Equal(t, len(tc.secrets), strings.Count(out, "[REDACTED]"),
 				"expected one [REDACTED] marker per scrubbed secret")
 		})
 	}
 }
 
-// TestRedactEventData_NonActionStreams locks the per-(stream,event)
-// schema. The IdentityProvider client_secret_encrypted, the
-// User password_hash, and the LPS rotations[].password / LUKS
-// passphrase paths must scrub.
+// TestRedactEventData_ExecutionStream locks that execution-stream events —
+// which embed the SAME params + action_type as the action stream
+// (action_dispatch.go) — are redacted identically. Before #352 the
+// execution stream had no schema at all, so dispatched action params leaked
+// through the audit log.
+func TestRedactEventData_ExecutionStream(t *testing.T) {
+	raw, err := json.Marshal(map[string]any{
+		"execution_id": "exec-1",
+		"action_type":  int32(pm.ActionType_ACTION_TYPE_SHELL),
+		"params":       map[string]any{"script": "SENTINEL_EXEC_SHELL"},
+	})
+	require.NoError(t, err)
+	out := redactEventData("execution", "ExecutionCreated", raw)
+	assert.NotContains(t, out, "SENTINEL_EXEC_SHELL")
+	assert.Contains(t, out, "[REDACTED]")
+}
+
+// TestRedactEventData_ActionParamsUpdated locks that an ActionParamsUpdated
+// event (which now carries action_type, #352) has its updated secret params
+// scrubbed.
+func TestRedactEventData_ActionParamsUpdated(t *testing.T) {
+	raw := actionEnvelope(pm.ActionType_ACTION_TYPE_FILE, map[string]any{"content": "SENTINEL_UPDATED_FILE"})
+	out := redactEventData("action", "ActionParamsUpdated", raw)
+	assert.NotContains(t, out, "SENTINEL_UPDATED_FILE")
+	assert.Contains(t, out, "[REDACTED]")
+}
+
+// TestRedactEventData_ActionStreamMissingActionTypeFallback locks the
+// fail-safe: an action/execution event with NO usable action_type (a legacy
+// ActionParamsUpdated emitted before #352, say) still has any known secret
+// param scrubbed via the union fallback, rather than leaking it.
+func TestRedactEventData_ActionStreamMissingActionTypeFallback(t *testing.T) {
+	raw, err := json.Marshal(map[string]any{
+		"params": map[string]any{"content": "SENTINEL_LEGACY_FILE"},
+	})
+	require.NoError(t, err)
+	out := redactEventData("action", "ActionParamsUpdated", raw)
+	assert.NotContains(t, out, "SENTINEL_LEGACY_FILE", "legacy event without action_type must still be scrubbed via the union fallback")
+	assert.Contains(t, out, "[REDACTED]")
+}
+
+// TestRedactEventData_NonActionStreams locks the per-(stream,event) schema:
+// IdentityProvider client_secret_encrypted, User password_hash, the flat LPS
+// password, and the LUKS passphrase must scrub.
 func TestRedactEventData_NonActionStreams(t *testing.T) {
 	cases := []struct {
 		name       string
@@ -109,42 +156,32 @@ func TestRedactEventData_NonActionStreams(t *testing.T) {
 			name:       "IdentityProviderCreated client_secret_encrypted",
 			streamType: "identity_provider",
 			eventType:  "IdentityProviderCreated",
-			payload: map[string]any{
-				"name":                    "okta",
-				"client_secret_encrypted": "SENTINEL_IDP",
-			},
-			secret: "SENTINEL_IDP",
+			payload:    map[string]any{"name": "okta", "client_secret_encrypted": "SENTINEL_IDP"},
+			secret:     "SENTINEL_IDP",
 		},
 		{
 			name:       "UserCreatedWithRoles password_hash",
 			streamType: "user",
 			eventType:  "UserCreatedWithRoles",
-			payload: map[string]any{
-				"email":         "alice@example.com",
-				"password_hash": "SENTINEL_PWD_HASH",
-			},
-			secret: "SENTINEL_PWD_HASH",
+			payload:    map[string]any{"email": "alice@example.com", "password_hash": "SENTINEL_PWD_HASH"},
+			secret:     "SENTINEL_PWD_HASH",
 		},
 		{
-			name:       "LpsPasswordRotated rotations[].password",
+			// Real emit is one flat payloads.LpsPasswordRotated per rotation
+			// with the credential at top-level "password" (#352 fixed the
+			// phantom "rotations[].password" path).
+			name:       "LpsPasswordRotated flat password",
 			streamType: "lps_password",
 			eventType:  "LpsPasswordRotated",
-			payload: map[string]any{
-				"rotations": []any{
-					map[string]any{"username": "alice", "password": "SENTINEL_LPS_ROT"},
-				},
-			},
-			secret: "SENTINEL_LPS_ROT",
+			payload:    map[string]any{"username": "alice", "password": "SENTINEL_LPS_ROT"},
+			secret:     "SENTINEL_LPS_ROT",
 		},
 		{
 			name:       "LuksKeyRotated passphrase",
 			streamType: "luks_key",
 			eventType:  "LuksKeyRotated",
-			payload: map[string]any{
-				"device_path": "/dev/sda1",
-				"passphrase":  "SENTINEL_LUKS_ROT",
-			},
-			secret: "SENTINEL_LUKS_ROT",
+			payload:    map[string]any{"device_path": "/dev/sda1", "passphrase": "SENTINEL_LUKS_ROT"},
+			secret:     "SENTINEL_LUKS_ROT",
 		},
 	}
 
@@ -159,37 +196,22 @@ func TestRedactEventData_NonActionStreams(t *testing.T) {
 	}
 }
 
-// TestRedactEventData_UnknownShapesPassThrough locks the design
-// contract that the redactor is fail-closed but conservative: an
-// unknown stream/event combination passes through unchanged (the
-// audit log is for operators, not consumers, and the schema-aware
-// approach explicitly does not over-scrub unrecognized shapes).
+// TestRedactEventData_UnknownShapesPassThrough locks the design contract that
+// the redactor is conservative for NON action/execution streams: an unknown
+// (stream,event) combination passes through unchanged.
 func TestRedactEventData_UnknownShapesPassThrough(t *testing.T) {
-	in := map[string]any{
-		// Not an action emit shape, not in eventRedactionSchemas.
-		"name":     "do-thing",
-		"password": "this-is-not-actually-redacted-because-we-dont-know-the-schema",
-	}
+	in := map[string]any{"name": "do-thing", "password": "not-redacted-unknown-schema"}
 	raw, err := json.Marshal(in)
 	require.NoError(t, err)
 	out := redactEventData("unknown_stream", "UnknownEvent", raw)
 	assert.Equal(t, string(raw), out)
 }
 
-// TestRedactEventData_ActionWithoutSecretsPassesThrough locks that
-// action types without sensitive params (PACKAGE, USER, GROUP, …)
-// never get rewritten — bytes-equal output saves a re-marshal on the
-// hot path.
+// TestRedactEventData_ActionWithoutSecretsPassesThrough locks that a
+// recognised action type with no secret params (PACKAGE) is not rewritten —
+// bytes-equal output saves a re-marshal on the hot path.
 func TestRedactEventData_ActionWithoutSecretsPassesThrough(t *testing.T) {
-	in := map[string]any{
-		"name": "install-pkg",
-		"type": "ACTION_TYPE_PACKAGE",
-		"params": map[string]any{
-			"package": "vim",
-		},
-	}
-	raw, err := json.Marshal(in)
-	require.NoError(t, err)
+	raw := actionEnvelope(pm.ActionType_ACTION_TYPE_PACKAGE, map[string]any{"package": "vim"})
 	out := redactEventData("action", "ActionCreated", raw)
 	assert.Equal(t, string(raw), out)
 }
@@ -200,8 +222,110 @@ func TestRedactEventData_EmptyAndInvalid(t *testing.T) {
 	assert.Equal(t, "{not json", redactEventData("action", "ActionCreated", []byte("{not json")))
 }
 
-// TestSplitPath_ArraySegments locks the path parser against the four
-// shapes that appear in eventRedactionSchemas / actionRedactionSchemas.
+// TestEveryActionTypeClassified is self-discovering against the proto enum:
+// every ActionType must be consciously classified — either it has a redaction
+// schema (secret params) or it is listed as having none. A new action type
+// added without classification fails here, forcing a redaction decision and
+// preventing a repeat of the SCRIPT_RUN/SERVICE/WIFI omissions (#352).
+func TestEveryActionTypeClassified(t *testing.T) {
+	// Action types whose params carry NO secret. Curated from the proto, but
+	// the test below fails if the enum grows and a value lands in neither set.
+	noSecretParams := map[string]bool{
+		"ACTION_TYPE_PACKAGE":      true,
+		"ACTION_TYPE_UPDATE":       true,
+		"ACTION_TYPE_APP_IMAGE":    true,
+		"ACTION_TYPE_DEB":          true,
+		"ACTION_TYPE_RPM":          true,
+		"ACTION_TYPE_FLATPAK":      true,
+		"ACTION_TYPE_DIRECTORY":    true,
+		"ACTION_TYPE_REBOOT":       true,
+		"ACTION_TYPE_SYNC":         true,
+		"ACTION_TYPE_USER":         true,
+		"ACTION_TYPE_GROUP":        true,
+		"ACTION_TYPE_SSH":          true,
+		"ACTION_TYPE_SSHD":         true,
+		"ACTION_TYPE_LPS":          true, // rotated password surfaces via LpsPasswordRotated event, not params
+		"ACTION_TYPE_AGENT_UPDATE": true,
+	}
+	require.NotEmpty(t, pm.ActionType_name)
+	for v, name := range pm.ActionType_name {
+		if name == "ACTION_TYPE_UNSPECIFIED" {
+			continue
+		}
+		_, hasSchema := actionRedactionSchemas[name]
+		noSec := noSecretParams[name]
+		require.Falsef(t, hasSchema && noSec,
+			"action type %s (%d) is in BOTH the redaction schema and the no-secret list — pick one", name, v)
+		require.Truef(t, hasSchema || noSec,
+			"action type %s (%d) is unclassified for audit redaction — add a schema to actionRedactionSchemas or list it in noSecretParams", name, v)
+	}
+}
+
+// TestActionParamsSecretFieldsCovered is self-discovering against the proto
+// MESSAGES: it walks every params message reachable from the
+// CreateActionRequest params oneof and asserts that any string field whose
+// name looks sensitive has a redaction path in the union. A secret field
+// added to any action's params with no matching redaction path fails here.
+func TestActionParamsSecretFieldsCovered(t *testing.T) {
+	union := map[string]bool{}
+	for _, p := range allActionSecretPaths.paths {
+		union[p] = true
+	}
+
+	desc := (&pm.CreateActionRequest{}).ProtoReflect().Descriptor()
+	scanned := 0
+	for oi := 0; oi < desc.Oneofs().Len(); oi++ {
+		fields := desc.Oneofs().Get(oi).Fields()
+		for fi := 0; fi < fields.Len(); fi++ {
+			f := fields.Get(fi)
+			if f.Kind() != protoreflect.MessageKind {
+				continue
+			}
+			msg := f.Message()
+			for mi := 0; mi < msg.Fields().Len(); mi++ {
+				pf := msg.Fields().Get(mi)
+				if pf.Kind() != protoreflect.StringKind || pf.IsList() {
+					continue
+				}
+				if !isSensitiveParamField(string(pf.Name())) {
+					continue
+				}
+				path := "params." + pf.JSONName()
+				require.Truef(t, union[path],
+					"params message %s field %q looks secret but has no redaction path %q — add it to actionRedactionSchemas (#352)",
+					msg.Name(), pf.Name(), path)
+				scanned++
+			}
+		}
+	}
+	require.Positivef(t, scanned, "self-discovering scan matched zero sensitive fields — isSensitiveParamField is broken")
+}
+
+// isSensitiveParamField classifies a proto params field name (snake_case) as
+// secret-bearing. The explicit allowlist covers public material and
+// non-secret config that would otherwise match a fragment.
+func isSensitiveParamField(name string) bool {
+	switch name {
+	case "ca_cert", "client_cert", // public PEM certificates
+		"ssh_authorized_keys",   // public keys
+		"gpg_key_url", "gpgkey", // repository key URLs, not key material
+		"checksum_sha256":
+		return false
+	}
+	for _, frag := range []string{
+		"script", "content", "custom_config",
+		"psk", "preshared_key", "client_key", "private_key", "gpg_key",
+		"passphrase", "password", "secret",
+	} {
+		if strings.Contains(name, frag) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSplitPath_ArraySegments locks the path parser against the shapes that
+// appear in the schemas (including the array form retained for defensiveness).
 func TestSplitPath_ArraySegments(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/internal/api/audit_redactor_paths_test.go
+++ b/internal/api/audit_redactor_paths_test.go
@@ -40,7 +40,7 @@ import (
 func fullyPopulatedParamsFor(t *testing.T, actionType string) proto.Message {
 	t.Helper()
 	switch actionType {
-	case "ACTION_TYPE_SHELL":
+	case "ACTION_TYPE_SHELL", "ACTION_TYPE_SCRIPT_RUN":
 		return &pm.ShellParams{
 			Script:           "S",
 			DetectionScript:  "D",
@@ -48,6 +48,20 @@ func fullyPopulatedParamsFor(t *testing.T, actionType string) proto.Message {
 			RunAsRoot:        true,
 			Environment:      map[string]string{"K": "V"},
 			WorkingDirectory: "/tmp",
+		}
+	case "ACTION_TYPE_SERVICE":
+		return &pm.ServiceParams{
+			UnitName:    "foo.service",
+			UnitContent: "U",
+		}
+	case "ACTION_TYPE_WIFI":
+		return &pm.WifiParams{
+			Ssid:       "corp",
+			AuthType:   pm.WifiAuthType(1),
+			Psk:        "P",
+			ClientKey:  "K",
+			ClientCert: "C",
+			CaCert:     "CA",
 		}
 	case "ACTION_TYPE_FILE":
 		return &pm.FileParams{


### PR DESCRIPTION
Security audit `SECURITY_AUDIT_2026-06-10.md` finding **#1 (Critical)**.

## The bug
`schemaFor` dispatched action redaction on a top-level `payload["type"]` **string**, but every emitter writes `"action_type"` as an **int32** (`action_crud.go`, `action_dispatch.go`). So `actionRedactionSchemas` never matched and `ListAuditEvents` returned **raw** payloads. Any "View audit log" holder saw, unredacted: shell/detection scripts, file contents, sudoers fragments, repo GPG keys, and **plaintext LUKS preshared keys**. The unit tests hand-built `{"type": ...}` maps, so the suite stayed green while the control was dead (test-derived-from-artifact).

## Fix
- Dispatch **action AND execution** streams on the real integer `action_type` via `pm.ActionType(...).String()`. The execution stream had **no** schema before, so dispatched action params leaked too.
- **Fail-safe:** when `action_type` is absent/unspecified/unknown, scrub the union of all known action-secret paths (no-op when a path is absent) — covers legacy `ActionParamsUpdated` and forward-compat.
- Add `action_type` to the `ActionParamsUpdated` emit so updated params are classifiable (projector ignores the extra field — no `DisallowUnknownFields`).
- Fix the `LpsPasswordRotated` path: real emit is a flat `password`, not `rotations[].password` (the phantom path scrubbed nothing).
- **Found and closed three leaks the audit missed:** `SCRIPT_RUN` (script/detectionScript), `SERVICE` (unitContent), `WIFI` (psk/clientKey).

## Tests
- **Real-emit-path** test drives `CreateAction` → `ListAuditEvents` and asserts the secret never appears (SHELL/FILE/ENCRYPTION); this is **red** against the old code.
- Unit fixtures rebuilt on the true `action_type` wire shape (no more `{"type": ...}`).
- Self-discovering: `TestEveryActionTypeClassified` (every `ActionType` is in a schema or the no-secret set) + `TestActionParamsSecretFieldsCovered` (walks the proto; fails if any sensitive params field lacks a redaction path).

Local: full `internal/api` (162s) + `internal/projectors` (24.7s) green; gofmt/vet/staticcheck clean; local CodeRabbit clean.

Closes #352.