### PR TITLE
fix(auth): make UpdateUserLinuxUsername admin-only (#354)

### DIFF
--- a/internal/api/self_scope_enforcement_test.go
+++ b/internal/api/self_scope_enforcement_test.go
@@ -1,0 +1,108 @@
+package api_test
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// selfScopeForcedOwnership lists :self permissions whose RPC enforces self-scope
+// NOT by rejecting a cross-user target, but by ignoring any caller-supplied
+// owner and forcing self-ownership. CreateToken:self does this
+// (token_handler.go): it discards req.OwnerId and mints a self-owned, one-time,
+// 7-day token, so a cross-user call cannot affect another user. Such RPCs are
+// exempt from the cross-user-rejection check below, but must still be listed
+// here so the self-discovering coverage assertion accounts for them.
+var selfScopeForcedOwnership = map[string]bool{
+	"CreateToken": true,
+}
+
+// TestSelfScopedRPCsRejectCrossUser is self-discovering against the permission
+// registry: for every `:self` permission, the corresponding RPC must refuse a
+// caller (holding only the :self grant) who targets a DIFFERENT user — i.e. it
+// must call auth.EnforceSelfScope. This is the guard that would have caught the
+// UpdateUserLinuxUsername IDOR (#354), where the handler skipped the check
+// entirely (the interceptor admits any :self holder because it passes an empty
+// ResourceID to Authorize).
+//
+// A new :self permission added without either a cross-user invocation here or a
+// documented forced-ownership exemption fails the coverage assertion at the end.
+func TestSelfScopedRPCsRejectCrossUser(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	userH := api.NewUserHandler(st, slog.Default(), nil)
+
+	caller := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "password123", "user")
+	victim := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "password123", "user")
+	// UserContext holds DefaultUserPermissions, i.e. the :self grants — so a
+	// rejection here proves EnforceSelfScope refused a cross-user target, not
+	// merely that the permission was absent.
+	ctx := testutil.UserContext(caller)
+
+	// Each invocation targets `victim` while the caller holds only :self grants.
+	invocations := map[string]func() error{
+		"GetUser": func() error {
+			_, err := userH.GetUser(ctx, connect.NewRequest(&pm.GetUserRequest{Id: victim}))
+			return err
+		},
+		"UpdateUserEmail": func() error {
+			_, err := userH.UpdateUserEmail(ctx, connect.NewRequest(&pm.UpdateUserEmailRequest{Id: victim, Email: "attacker@example.com"}))
+			return err
+		},
+		"UpdateUserPassword": func() error {
+			_, err := userH.UpdateUserPassword(ctx, connect.NewRequest(&pm.UpdateUserPasswordRequest{Id: victim, NewPassword: "newpassword123"}))
+			return err
+		},
+		"UpdateUserProfile": func() error {
+			_, err := userH.UpdateUserProfile(ctx, connect.NewRequest(&pm.UpdateUserProfileRequest{Id: victim, DisplayName: "attacker"}))
+			return err
+		},
+		"UpdateUserSshSettings": func() error {
+			_, err := userH.UpdateUserSshSettings(ctx, connect.NewRequest(&pm.UpdateUserSshSettingsRequest{UserId: victim, SshAccessEnabled: true}))
+			return err
+		},
+		"AddUserSshKey": func() error {
+			_, err := userH.AddUserSshKey(ctx, connect.NewRequest(&pm.AddUserSshKeyRequest{UserId: victim, PublicKey: "ssh-ed25519 AAAACROSSUSER"}))
+			return err
+		},
+		"RemoveUserSshKey": func() error {
+			_, err := userH.RemoveUserSshKey(ctx, connect.NewRequest(&pm.RemoveUserSshKeyRequest{UserId: victim, KeyId: testutil.NewID()}))
+			return err
+		},
+		// NOTE: UpdateUserLinuxUsername is intentionally absent — #354 made it
+		// admin-only (no :self variant), so a stock User can't reach it at all.
+	}
+
+	for name, call := range invocations {
+		t.Run(name, func(t *testing.T) {
+			err := call()
+			require.Errorf(t, err, "%s must reject a cross-user :self call", name)
+			assert.Equalf(t, connect.CodePermissionDenied, connect.CodeOf(err),
+				"%s must return PermissionDenied for a cross-user :self call (missing EnforceSelfScope?), got: %v", name, err)
+		})
+	}
+
+	// Self-discovering coverage: every :self permission must be exercised above
+	// or explicitly exempted, so a future :self RPC can't silently skip
+	// self-scope enforcement.
+	selfPerms := map[string]bool{}
+	for _, p := range auth.AllPermissions() {
+		if base, ok := strings.CutSuffix(p.Key, ":self"); ok {
+			selfPerms[base] = true
+		}
+	}
+	require.NotEmpty(t, selfPerms, "expected some :self permissions in the registry")
+	for base := range selfPerms {
+		covered := invocations[base] != nil || selfScopeForcedOwnership[base]
+		assert.Truef(t, covered,
+			"permission %q:self has no cross-user-rejection test and no forced-ownership exemption — add one (#354 self-scope guard)", base)
+	}
+}

--- a/internal/auth/authorizer_test.go
+++ b/internal/auth/authorizer_test.go
@@ -10,6 +10,36 @@ import (
 // Permission-based user access
 // ============================================================================
 
+// TestAuthorize_UpdateUserLinuxUsername_AdminOnly pins the #354 fix at the
+// authorization layer: a stock User must NOT be authorized for
+// UpdateUserLinuxUsername, while an admin must be. The interceptor invokes
+// Authorize with an EMPTY ResourceID (it never extracts the target id), so a
+// :self grant would short-circuit to allowed here — which is exactly how the
+// bug let any user rewrite any user's linux_username. The fix removes the
+// :self variant, so the stock User role no longer authorizes the action.
+func TestAuthorize_UpdateUserLinuxUsername_AdminOnly(t *testing.T) {
+	// Stock User: denied (no linux_username permission of any kind).
+	deniedUser := Authorize(AuthzInput{
+		Permissions: DefaultUserPermissions(),
+		SubjectID:   "user-1",
+		Action:      "UpdateUserLinuxUsername",
+		ResourceID:  "", // interceptor shape: target id not threaded in
+	})
+	assert.False(t, deniedUser, "stock User must not be authorized for UpdateUserLinuxUsername")
+
+	// The :self variant being removed from the registry is asserted in
+	// reconcile_test (TestUpdateUserLinuxUsername_IsAdminOnly); here we pin the
+	// authorization outcome for the stock role and the admin.
+
+	// Admin: allowed via the base TargetUser permission.
+	allowedAdmin := Authorize(AuthzInput{
+		Permissions: []string{"UpdateUserLinuxUsername"},
+		SubjectID:   "admin-1",
+		Action:      "UpdateUserLinuxUsername",
+	})
+	assert.True(t, allowedAdmin, "an admin holding UpdateUserLinuxUsername must be authorized")
+}
+
 func TestAuthorize_UnrestrictedPermission(t *testing.T) {
 	allowed := Authorize(AuthzInput{
 		Permissions: []string{"CreateUser", "ListUsers", "DeleteUser"},

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -63,8 +63,13 @@ func AllPermissions() []PermissionInfo {
 		{"DeleteUser", "Users", "Delete users", TargetUser},
 		{"UpdateUserSshSettings", "Users", "Update any user's SSH settings", TargetUser},
 		{"UpdateUserSshSettings:self", "Users", "Update own SSH settings", TargetUnspecified},
+		// linux_username keys pm-tty/sudo account naming on managed devices, so
+		// it is ADMIN-ONLY: there is intentionally NO :self variant (#354). The
+		// interceptor admits any :self holder (Authorize short-circuits :self
+		// when the interceptor passes an empty ResourceID), and the handler did
+		// not enforce self-scope — so a self grant let any user rewrite any
+		// user's linux_username. Only the base TargetUser permission gates it.
 		{"UpdateUserLinuxUsername", "Users", "Change any user's linux username", TargetUser},
-		{"UpdateUserLinuxUsername:self", "Users", "Change own linux username", TargetUnspecified},
 		{"AddUserSshKey", "Users", "Add SSH key to any user", TargetUser},
 		{"AddUserSshKey:self", "Users", "Add own SSH key", TargetUnspecified},
 		{"RemoveUserSshKey", "Users", "Remove SSH key from any user", TargetUser},
@@ -310,7 +315,7 @@ func DefaultUserPermissions() []string {
 		"UnlinkIdentity",
 		"GetDeviceCompliance:assigned",
 		"UpdateUserSshSettings:self",
-		"UpdateUserLinuxUsername:self",
+		// UpdateUserLinuxUsername is admin-only — no :self for the User role (#354).
 		"AddUserSshKey:self",
 		"RemoveUserSshKey:self",
 		"StopTerminal",

--- a/internal/auth/reconcile_test.go
+++ b/internal/auth/reconcile_test.go
@@ -44,15 +44,22 @@ func TestReconcileSystemRoles_UpdatesDB(t *testing.T) {
 	assert.ElementsMatch(t, auth.DefaultUserPermissions(), userRole.Permissions)
 }
 
-func TestUpdateUserLinuxUsername_PermissionExists(t *testing.T) {
+// TestUpdateUserLinuxUsername_IsAdminOnly pins the intent that changing a
+// user's linux_username is an ADMIN action, not self-service: linux_username
+// keys pm-tty/sudo account naming on managed devices, so a user must not be
+// able to rewrite it (theirs or anyone's). The audit (#354) found the handler
+// never enforced :self, so the :self grant in the default User role let any
+// user rewrite ANY user's linux_username. The fix removes the :self variant
+// entirely — only the base TargetUser permission gates the RPC.
+func TestUpdateUserLinuxUsername_IsAdminOnly(t *testing.T) {
 	allPerms := auth.AllPermissions()
 	allKeys := make(map[string]bool, len(allPerms))
 	for _, p := range allPerms {
 		allKeys[p.Key] = true
 	}
 
-	assert.True(t, allKeys["UpdateUserLinuxUsername"], "AllPermissions() should include UpdateUserLinuxUsername")
-	assert.True(t, allKeys["UpdateUserLinuxUsername:self"], "AllPermissions() should include UpdateUserLinuxUsername:self")
+	assert.True(t, allKeys["UpdateUserLinuxUsername"], "AllPermissions() should include the admin UpdateUserLinuxUsername")
+	assert.False(t, allKeys["UpdateUserLinuxUsername:self"], "the :self variant must be removed — linux_username is admin-only (#354)")
 
 	defaultPerms := auth.DefaultUserPermissions()
 	defaultSet := make(map[string]bool, len(defaultPerms))
@@ -60,5 +67,6 @@ func TestUpdateUserLinuxUsername_PermissionExists(t *testing.T) {
 		defaultSet[p] = true
 	}
 
-	assert.True(t, defaultSet["UpdateUserLinuxUsername:self"], "DefaultUserPermissions() should include UpdateUserLinuxUsername:self")
+	assert.False(t, defaultSet["UpdateUserLinuxUsername:self"], "the default User role must not self-service linux_username (#354)")
+	assert.False(t, defaultSet["UpdateUserLinuxUsername"], "the default User role must not hold the admin linux_username permission either (#354)")
 }


### PR DESCRIPTION
Security audit finding **#2 (High)**.

## The bug
`UpdateUserLinuxUsername` called only `requireAuth` and emitted `UserLinuxUsernameChanged` for `req.Msg.UserId` — it never called `EnforceSelfScope`, unlike its seven `:self` siblings. `UpdateUserLinuxUsername:self` was in the default User role, and the interceptor admits any `:self` holder (it passes an **empty** ResourceID to `Authorize`, which short-circuits `:self` to true). So every authenticated user could rewrite **any** user's `linux_username` — the identity that keys pm-tty/sudo account naming on managed devices.

## Fix (admin-only)
`linux_username` keys device-side account naming, so it is admin-only: the `:self` variant is removed from the permission registry **and** `DefaultUserPermissions`. Only the base `UpdateUserLinuxUsername` (TargetUser) permission gates the RPC now. (The web UI already gated the edit on the base permission.)

## Tests
- `reconcile_test`/`authorizer_test`: red→green pins that the `:self` variant is gone and a stock User is **not** authorized for the RPC, while an admin is.
- **Self-discovering** `TestSelfScopedRPCsRejectCrossUser`: drives every `:self` RPC cross-user and asserts `PermissionDenied`, with a coverage assertion that every `:self` permission is exercised or explicitly exempted (`CreateToken:self` enforces self-scope by forced ownership, not rejection). All seven sibling `:self` handlers verified to enforce — `UpdateUserLinuxUsername` was the only gap. This guard would have caught the original bug.

Closes #354.