### PR TITLE
test(api): cover SERVICE + WIFI in redaction real-emit-path test (#352)

### DIFF
--- a/internal/api/audit_redaction_integration_test.go
+++ b/internal/api/audit_redaction_integration_test.go
@@ -67,6 +67,37 @@ func TestListAuditEvents_RedactsActionSecrets(t *testing.T) {
 				},
 			},
 		},
+		{
+			// SERVICE/WIFI were among the leaks #352 found beyond the audit's
+			// list; cover them end-to-end through the real emit path too.
+			name:   "SERVICE unitContent (systemd unit body)",
+			secret: "SENTINEL_SERVICE_8a1f",
+			req: &pm.CreateActionRequest{
+				Name: "service-leak",
+				Type: pm.ActionType_ACTION_TYPE_SERVICE,
+				Params: &pm.CreateActionRequest_Service{
+					Service: &pm.ServiceParams{
+						UnitName:    "test.service",
+						UnitContent: "SENTINEL_SERVICE_8a1f",
+					},
+				},
+			},
+		},
+		{
+			name:   "WIFI psk (WPA pre-shared key)",
+			secret: "SENTINEL_WIFI_8a1f",
+			req: &pm.CreateActionRequest{
+				Name: "wifi-leak",
+				Type: pm.ActionType_ACTION_TYPE_WIFI,
+				Params: &pm.CreateActionRequest_Wifi{
+					Wifi: &pm.WifiParams{
+						Ssid:     "corp",
+						AuthType: pm.WifiAuthType(1),
+						Psk:      "SENTINEL_WIFI_8a1f",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Follow-up to #353 (finding #1). CodeRabbit suggested adding SERVICE (`unitContent`) and WIFI (`psk`) cases to the end-to-end redaction test `TestListAuditEvents_RedactsActionSecrets` — two of the leaks #352 found beyond the audit's list. Already covered by the redactor unit + self-discovering proto-walk tests; this extends the real-emit-path proof to them too. Test-only.