### PR TITLE
fix(api): scope-check GetDeviceCompliance + PolicyStatus (IDOR) (#357)

### DIFF
--- a/internal/api/compliance_handler.go
+++ b/internal/api/compliance_handler.go
@@ -34,6 +34,18 @@ func (h *ComplianceHandler) GetDeviceCompliance(ctx context.Context, req *connec
 
 	deviceID := req.Msg.DeviceId
 
+	// Enforce the same assignment/owner scope as GetDevice. Without this any
+	// user could read any device's compliance — including detection-script
+	// stdout/stderr — by supplying an arbitrary device_id (#357). An admin
+	// (unrestricted GetDeviceCompliance) gets a nil filter and sees all; a
+	// scoped user only sees devices assigned to them.
+	if _, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{
+		ID:         deviceID,
+		OwnerScope: userFilterID(ctx, "GetDeviceCompliance"),
+	}); err != nil {
+		return nil, handleGetError(ctx, err, ErrDeviceNotFound, "device not found")
+	}
+
 	results, err := h.store.Repos().Compliance.DeviceResults(ctx, deviceID)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to query compliance results")

--- a/internal/api/compliance_handler_test.go
+++ b/internal/api/compliance_handler_test.go
@@ -27,6 +27,27 @@ func newComplianceHandler(t *testing.T) (*api.ComplianceHandler, *store.Store) {
 	return api.NewComplianceHandler(st, slog.Default()), st
 }
 
+// TestGetDeviceCompliance_RejectsDeviceNotAssignedToCaller pins the #357 fix:
+// GetDeviceCompliance returned a device's compliance (including detection
+// script stdout/stderr) for ANY device_id, with no ownership/scope check —
+// unlike its sibling GetDevice. A stock User holds GetDeviceCompliance:assigned
+// (default role), so this was a cross-user disclosure IDOR. The handler must
+// resolve the assignment filter (mirroring GetDevice) and refuse a device not
+// assigned to the caller.
+func TestGetDeviceCompliance_RejectsDeviceNotAssignedToCaller(t *testing.T) {
+	h, st := newComplianceHandler(t)
+	deviceID := testutil.CreateTestDevice(t, st, "compliance-idor")
+	attacker := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	// UserContext holds GetDeviceCompliance:assigned but not the unrestricted
+	// permission, so the assignment filter resolves to the caller's id.
+	ctx := testutil.UserContext(attacker)
+
+	_, err := h.GetDeviceCompliance(ctx,
+		connect.NewRequest(&pm.GetDeviceComplianceRequest{DeviceId: deviceID}))
+	require.Error(t, err, "a user must not read compliance for a device not assigned to them")
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
 func TestGetDeviceCompliance_NoResults_EmptyChecks(t *testing.T) {
 	h, st := newComplianceHandler(t)
 	deviceID := testutil.CreateTestDevice(t, st, "compliance-empty")

--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -406,6 +406,16 @@ func (h *CompliancePolicyHandler) GetDeviceCompliancePolicyStatus(ctx context.Co
 		return nil, err
 	}
 
+	// Mirror GetDevice's assignment/owner scope so a scoped user can't read
+	// another device's per-policy compliance (incl. detection output) by
+	// supplying an arbitrary device_id (#357).
+	if _, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{
+		ID:         req.Msg.DeviceId,
+		OwnerScope: userFilterID(ctx, "GetDeviceCompliancePolicyStatus"),
+	}); err != nil {
+		return nil, handleGetError(ctx, err, ErrDeviceNotFound, "device not found")
+	}
+
 	evals, err := h.store.Repos().Compliance.ListDeviceEvaluations(ctx, req.Msg.DeviceId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get compliance evaluations")

--- a/internal/api/compliance_policy_handler_test.go
+++ b/internal/api/compliance_policy_handler_test.go
@@ -15,6 +15,23 @@ import (
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
+// TestGetDeviceCompliancePolicyStatus_RejectsDeviceNotAssignedToCaller pins the
+// #357 fix for the second IDOR site: per-policy compliance status (incl.
+// detection output) was returned for any device_id with no ownership/scope
+// check. A scoped user must be refused a device not assigned to them.
+func TestGetDeviceCompliancePolicyStatus_RejectsDeviceNotAssignedToCaller(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewCompliancePolicyHandler(st, slog.Default())
+	deviceID := testutil.CreateTestDevice(t, st, "policy-status-idor")
+	attacker := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "user")
+	ctx := testutil.UserContext(attacker)
+
+	_, err := h.GetDeviceCompliancePolicyStatus(ctx,
+		connect.NewRequest(&pm.GetDeviceCompliancePolicyStatusRequest{DeviceId: deviceID}))
+	require.Error(t, err, "a user must not read per-policy compliance for a device not assigned to them")
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
 // createComplianceShellAction creates a shell action with is_compliance=true
 // and returns its ID. This is needed because AddCompliancePolicyRule validates
 // the action type and params.


### PR DESCRIPTION
Security audit finding **#3 (High / Med-High)**.

`GetDeviceCompliance` and `GetDeviceCompliancePolicyStatus` read `req.Msg.DeviceId` and queried compliance — **including detection-script stdout/stderr/exit_code** — with **no** ownership/scope filter, unlike the sibling `GetDevice` (`OwnerScope: userFilterID(ctx, "GetDevice")`). `GetDeviceCompliance:assigned` is in the default User role, so any authenticated user could read any device's compliance by supplying an arbitrary `device_id` — a cross-user disclosure IDOR.

## Fix
Both handlers now resolve the device through `Device.Get` with `OwnerScope: userFilterID(ctx, "<perm>")` (mirroring `GetDevice`) and return device-not-found when it isn't in the caller's scope. Admins (unrestricted permission) get a nil filter and see all; scoped users see only assigned devices.

Red→green rejection tests on both sites; existing `context.Background()` tests (nil filter) unaffected.

Closes #357.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced access control for device compliance data: users can now only view compliance information for devices they own or are assigned to, preventing unauthorized access to compliance details and detection output.
  * Device compliance policy status is now restricted to authorized users only, ensuring proper scoping of compliance evaluations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->