### PR TITLE
fix(idp): require email_verified before using the OIDC email claim (#359)

### DIFF
--- a/internal/idp/oidc.go
+++ b/internal/idp/oidc.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -140,8 +141,20 @@ func (p *OIDCProvider) VerifyAndExtractClaims(ctx context.Context, oauth2Token *
 		Subject: idToken.Subject,
 	}
 
-	if email, ok := claims["email"].(string); ok {
-		userClaims.Email = email
+	// Only trust the email for linking / auto-create when the IdP asserts it
+	// is verified (#359). Without this gate, an attacker who can set an
+	// arbitrary, unverified email at the IdP (common with multi-tenant Azure
+	// AD or self-service IdPs) could set it to a local admin's address and,
+	// with AutoLinkByEmail on, receive that admin's session. The external
+	// identity is keyed on the subject regardless; only the email field —
+	// which the linker uses for auto-link/auto-create — is gated.
+	if email, ok := claims["email"].(string); ok && email != "" {
+		if claimIsTrue(claims["email_verified"]) {
+			userClaims.Email = email
+		} else {
+			slog.Warn("SSO: ignoring email claim because email_verified is not true; it will not be used for auto-link or auto-create",
+				"subject", idToken.Subject)
+		}
 	}
 	if name, ok := claims["name"].(string); ok {
 		userClaims.Name = name
@@ -168,6 +181,20 @@ func (p *OIDCProvider) VerifyAndExtractClaims(ctx context.Context, oauth2Token *
 	}
 
 	return userClaims, nil
+}
+
+// claimIsTrue interprets an OIDC boolean claim. The spec defines
+// email_verified as a JSON boolean, but some IdPs (and some proxies) emit it
+// as the string "true"/"false"; accept both. Anything else — including an
+// absent claim — is treated as not-true, which is the fail-closed default.
+func claimIsTrue(v any) bool {
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		return t == "true"
+	}
+	return false
 }
 
 // extractGroups extracts group names from claims.

--- a/internal/idp/oidc_verify_test.go
+++ b/internal/idp/oidc_verify_test.go
@@ -123,9 +123,12 @@ func TestVerifyAndExtractClaims_HappyPath(t *testing.T) {
 	require.NoError(t, err)
 
 	idToken := f.signIDToken(t, "test-client", "the-expected-nonce", map[string]any{
-		"email":      "alice@example.com",
-		"name":       "Alice Test",
-		"given_name": "Alice",
+		"email": "alice@example.com",
+		// email_verified gates whether the email is usable for linking /
+		// auto-create (#359). The happy path is a verified email.
+		"email_verified": true,
+		"name":           "Alice Test",
+		"given_name":     "Alice",
 	})
 	tok := (&oauth2.Token{}).WithExtra(map[string]any{"id_token": idToken})
 
@@ -135,6 +138,58 @@ func TestVerifyAndExtractClaims_HappyPath(t *testing.T) {
 	assert.Equal(t, "alice@example.com", claims.Email)
 	assert.Equal(t, "Alice Test", claims.Name)
 	assert.Equal(t, "Alice", claims.GivenName)
+}
+
+// TestVerifyAndExtractClaims_EmailVerifiedGate pins the #359 fix: an email
+// claim is only populated (and thus usable for auto-link / auto-create) when
+// email_verified is true. An attacker who can set an arbitrary, UNVERIFIED
+// email at the IdP (common with multi-tenant Azure AD / self-service IdPs)
+// must not be able to drive account linking by claiming a victim's address.
+// The subject is always populated — identity is keyed on sub, not email.
+func TestVerifyAndExtractClaims_EmailVerifiedGate(t *testing.T) {
+	cases := []struct {
+		name            string
+		email           string
+		emailPresent    bool
+		emailVerified   any
+		verifiedPresent bool
+		wantEmail       string
+	}{
+		{name: "verified (bool true)", email: "alice@example.com", emailPresent: true, emailVerified: true, verifiedPresent: true, wantEmail: "alice@example.com"},
+		{name: "verified (string \"true\")", email: "alice@example.com", emailPresent: true, emailVerified: "true", verifiedPresent: true, wantEmail: "alice@example.com"},
+		{name: "unverified (bool false)", email: "alice@example.com", emailPresent: true, emailVerified: false, verifiedPresent: true, wantEmail: ""},
+		{name: "unverified (string \"false\")", email: "alice@example.com", emailPresent: true, emailVerified: "false", verifiedPresent: true, wantEmail: ""},
+		{name: "email_verified claim absent", email: "alice@example.com", emailPresent: true, verifiedPresent: false, wantEmail: ""},
+		{name: "email claim absent (verified true)", emailPresent: false, emailVerified: true, verifiedPresent: true, wantEmail: ""},
+		{name: "email empty string (verified true)", email: "", emailPresent: true, emailVerified: true, verifiedPresent: true, wantEmail: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newSignedOIDCFixture(t)
+			p, err := idp.NewOIDCProvider(context.Background(), idp.ProviderConfig{
+				IssuerURL:   f.srv.URL,
+				ClientID:    "test-client",
+				RedirectURL: "https://app.example.com/cb",
+			})
+			require.NoError(t, err)
+
+			extra := map[string]any{}
+			if tc.emailPresent {
+				extra["email"] = tc.email
+			}
+			if tc.verifiedPresent {
+				extra["email_verified"] = tc.emailVerified
+			}
+			idToken := f.signIDToken(t, "test-client", "n", extra)
+			tok := (&oauth2.Token{}).WithExtra(map[string]any{"id_token": idToken})
+
+			claims, err := p.VerifyAndExtractClaims(context.Background(), tok, "n")
+			require.NoError(t, err)
+			assert.Equal(t, "test-subject-123", claims.Subject, "subject is always populated")
+			assert.Equalf(t, tc.wantEmail, claims.Email,
+				"email must be populated only when email_verified is true")
+		})
+	}
 }
 
 func TestVerifyAndExtractClaims_NonceMismatch(t *testing.T) {


### PR DESCRIPTION
Security audit finding **#5 (High)**.

`VerifyAndExtractClaims` extracted the `email` claim but never read `email_verified`, and the linker auto-links / auto-creates by email when the provider has `AutoLinkByEmail`/`AutoCreateUsers` on. An attacker able to set an arbitrary, **unverified** email at the IdP (multi-tenant Azure AD, self-service IdPs) could set it to a local admin's address and, after the OIDC dance, receive that admin's session — remote root across the fleet.

## Fix
Populate `UserClaims.Email` only when `email_verified` is true — accept the JSON bool and the string `"true"`; absent/false fail closed. The external identity stays keyed on `subject`; gating the email field closes both the auto-link and auto-create paths (both guard on `claims.Email != ""`).

## Tests
Table-driven gate test (verified bool/string, unverified bool/string, claim absent, email absent, email empty); happy-path test updated to send a verified email.

> Note (not built): the audit also suggests an optional per-provider trusted-domain allowlist. A stricter consequence of this fix: an IdP that omits `email_verified` will no longer auto-provision by email (mainstream IdPs send it). That is the fail-closed-correct behavior for an account-takeover fix.

Closes #359.