### PR TITLE
fix(api): require renewal CSR to match the current cert key (PoP) (#361)

### DIFF
--- a/internal/api/certificate_handler.go
+++ b/internal/api/certificate_handler.go
@@ -78,6 +78,17 @@ func (h *CertificateHandler) RenewCertificate(ctx context.Context, req *connect.
 		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "certificate not recognized")
 	}
 
+	// Proof-of-possession: the CSR must carry the SAME public key as the
+	// current certificate. The current cert is an untrusted request field on a
+	// public (non-mTLS) listener and certs are public material, so without this
+	// anyone holding a device's cert PEM could renew it onto a key they control
+	// and impersonate the device (#361). Agents reuse their keypair on renewal,
+	// so this is behavior-compatible.
+	if err := ca.AssertCSRMatchesCertKey(req.Msg.CurrentCertificate, req.Msg.Csr); err != nil {
+		h.logger.Warn("certificate renewal proof-of-possession failed", "device_id", deviceID, "error", err)
+		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "CSR key does not match current certificate")
+	}
+
 	// Sign the new CSR
 	newCert, err := h.ca.IssueCertificateFromCSR(deviceID, req.Msg.Csr)
 	if err != nil {

--- a/internal/api/certificate_handler_test.go
+++ b/internal/api/certificate_handler_test.go
@@ -41,14 +41,28 @@ func issueTestDeviceCert(t *testing.T, certAuth *ca.CA, deviceID string) (certPE
 	cert, err := certAuth.IssueCertificateFromCSR(deviceID, initialCSR)
 	require.NoError(t, err)
 
-	// Generate a new key + CSR for renewal
-	renewKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	require.NoError(t, err)
-	renewCSRDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, renewKey)
+	// Renewal CSR reuses the SAME key — this matches real agent behavior
+	// (cert_rotation.go calls GenerateCSRFromKey on the existing private key)
+	// and is required by the renewal proof-of-possession check (#361): the
+	// renewer must prove possession of the key bound to the current cert.
+	renewCSRDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, deviceKey)
 	require.NoError(t, err)
 	renewCSR := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: renewCSRDER})
 
 	return cert.CertPEM, cert.Fingerprint, renewCSR
+}
+
+// genDeviceCSR builds a renewal CSR for deviceID with a FRESH, independent key
+// — i.e. a request that does NOT possess the current certificate's key. Used to
+// simulate the impersonation attempt the proof-of-possession check rejects.
+func genDeviceCSR(t *testing.T, deviceID string) []byte {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.CreateCertificateRequest(rand.Reader,
+		&x509.CertificateRequest{Subject: pkix.Name{CommonName: deviceID}}, k)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
 }
 
 // setDeviceCertFingerprint stores a cert fingerprint on a device via event.
@@ -85,6 +99,31 @@ func TestRenewCertificate_Success(t *testing.T) {
 	assert.NotEmpty(t, resp.Msg.Certificate)
 	assert.NotNil(t, resp.Msg.NotAfter)
 	assert.NotEmpty(t, resp.Msg.CaCertificate)
+}
+
+// TestRenewCertificate_RejectsKeyMismatch pins the #361 proof-of-possession
+// fix: a renewal whose CSR public key differs from the current certificate's
+// must be refused. Certificates are public (returned at registration + stored
+// in the event log), so without this an attacker who reads a device's cert PEM
+// could submit a CSR for a key they control and mint an impersonation cert
+// bound to that device id.
+func TestRenewCertificate_RejectsKeyMismatch(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	certAuth := newTestCA(t)
+	h := api.NewCertificateHandler(st, certAuth, slog.Default())
+
+	deviceID := testutil.CreateTestDevice(t, st, "renew-mismatch-host")
+	certPEM, fingerprint, _ := issueTestDeviceCert(t, certAuth, deviceID)
+	setDeviceCertFingerprint(t, st, deviceID, fingerprint)
+
+	// Valid current cert + correct fingerprint, but a CSR for a DIFFERENT key.
+	foreignCSR := genDeviceCSR(t, deviceID)
+	_, err := h.RenewCertificate(t.Context(), connect.NewRequest(&pm.RenewCertificateRequest{
+		CurrentCertificate: certPEM,
+		Csr:                foreignCSR,
+	}))
+	require.Error(t, err, "renewal must reject a CSR whose key differs from the current certificate")
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 }
 
 func TestRenewCertificate_DeviceNotFound(t *testing.T) {

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -275,3 +275,45 @@ func DeviceIDFromPEM(certPEM []byte) (string, error) {
 
 	return cert.Subject.CommonName, nil
 }
+
+// AssertCSRMatchesCertKey verifies that the CSR's public key equals the
+// certificate's public key. On certificate renewal this is the
+// proof-of-possession: the renewer must hold the private key bound to the cert
+// it presented, which agents do because they reuse their keypair
+// (GenerateCSRFromKey). Without it, certificates are public material — returned
+// at registration and stored in the event log — so anyone who reads a device's
+// cert PEM could submit a CSR for a key they control and mint an impersonation
+// cert bound to that device id (#361).
+func AssertCSRMatchesCertKey(certPEM, csrPEM []byte) error {
+	certBlock, _ := pem.Decode(certPEM)
+	if certBlock == nil {
+		return fmt.Errorf("failed to decode certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(certBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse certificate: %w", err)
+	}
+
+	csrBlock, _ := pem.Decode(csrPEM)
+	if csrBlock == nil {
+		return fmt.Errorf("failed to decode CSR PEM")
+	}
+	csr, err := x509.ParseCertificateRequest(csrBlock.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse CSR: %w", err)
+	}
+
+	// crypto.PublicKey for ecdsa/rsa/ed25519 implements Equal; compare via it
+	// rather than re-encoding so a curve/parameter mismatch can't slip through.
+	type equalKey interface {
+		Equal(crypto.PublicKey) bool
+	}
+	certKey, ok := cert.PublicKey.(equalKey)
+	if !ok {
+		return fmt.Errorf("unsupported certificate public key type %T", cert.PublicKey)
+	}
+	if !certKey.Equal(csr.PublicKey) {
+		return fmt.Errorf("CSR public key does not match the current certificate")
+	}
+	return nil
+}

--- a/internal/ca/ca_test.go
+++ b/internal/ca/ca_test.go
@@ -69,6 +69,47 @@ func generateCSR(t *testing.T, deviceID string) (csrPEM []byte, key *ecdsa.Priva
 	return csrPEM, key
 }
 
+// csrForKey builds a CSR PEM for deviceID signed by the given key. Unlike
+// generateCSR it lets the caller reuse a key, which is what renewal does.
+func csrForKey(t *testing.T, deviceID string, key *ecdsa.PrivateKey) []byte {
+	t.Helper()
+	der, err := x509.CreateCertificateRequest(rand.Reader,
+		&x509.CertificateRequest{Subject: pkix.Name{CommonName: deviceID}}, key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
+}
+
+// TestAssertCSRMatchesCertKey covers the renewal proof-of-possession helper
+// (#361): a renewal CSR is accepted only when its public key equals the current
+// certificate's.
+func TestAssertCSRMatchesCertKey(t *testing.T) {
+	certPEM, keyPEM := generateTestCA(t)
+	c, err := ca.NewFromPEM(certPEM, keyPEM, 24*time.Hour)
+	require.NoError(t, err)
+
+	deviceKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	issued, err := c.IssueCertificateFromCSR("device-001", csrForKey(t, "device-001", deviceKey))
+	require.NoError(t, err)
+
+	t.Run("matching key passes", func(t *testing.T) {
+		require.NoError(t, ca.AssertCSRMatchesCertKey(issued.CertPEM, csrForKey(t, "device-001", deviceKey)))
+	})
+	t.Run("mismatched key rejected", func(t *testing.T) {
+		other, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
+		err = ca.AssertCSRMatchesCertKey(issued.CertPEM, csrForKey(t, "device-001", other))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "does not match")
+	})
+	t.Run("malformed cert PEM rejected", func(t *testing.T) {
+		assert.Error(t, ca.AssertCSRMatchesCertKey([]byte("not a cert"), csrForKey(t, "device-001", deviceKey)))
+	})
+	t.Run("malformed CSR PEM rejected", func(t *testing.T) {
+		assert.Error(t, ca.AssertCSRMatchesCertKey(issued.CertPEM, []byte("not a csr")))
+	})
+}
+
 func TestNewFromPEM(t *testing.T) {
 	certPEM, keyPEM := generateTestCA(t)
 


### PR DESCRIPTION
Security audit finding **#6 (High)**.

`RenewCertificate` authenticated by the bytes of the *current certificate* (verified issued-by-CA + fingerprint matches DB) then signed the caller's CSR using `csr.PublicKey` verbatim — it **never** checked the CSR key equalled the current cert's. The RPC is public (non-mTLS listener) and certs are public material (returned at registration, stored in the event log), so anyone who read a device's cert PEM could submit a CSR for a key they control and mint an **impersonation cert** bound to that device id (chains to the internal CA, carries the agent SPIFFE SAN, receives the device's dispatched actions + proxied LUKS keys).

## Fix
Add `ca.AssertCSRMatchesCertKey` (compares public keys via `crypto` `Equal`) and call it in `RenewCertificate` after the fingerprint check, rejecting with `PermissionDenied` on mismatch. Agents reuse their keypair on renewal (`GenerateCSRFromKey`), so this is **behavior-compatible**.

## Tests
The test helper previously generated a **fresh** renewal key — blessing the insecure key-change the bug allowed; corrected to reuse the key (production-faithful). Adds a mismatch-rejection handler test (red→green) + a direct unit test for the helper (match / mismatch / malformed PEM).

> The compounding revocation gaps the audit notes (per-connection fingerprint check at the gateway, 1-year validity / no real revocation, concurrent-renewal version guard) are a larger cross-component change tracked into the Medium-findings wave.

Closes #361.

_Note: local CodeRabbit hit its rate limit on this push; relying on the PR review here._