### PR TITLE
fix(deploy): stop mounting the CA signing key into the gateway (#363)

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -218,7 +218,17 @@ services:
       control:
         condition: service_healthy
     volumes:
-      - ./certs:/certs:ro,z
+      # Mount ONLY the files the gateway actually uses (its own mTLS keypair +
+      # the CA cert for verifying peers). The gateway is the public,
+      # agent-facing mTLS endpoint — the most exposed component — and must NOT
+      # have the CA SIGNING key (ca.key) on disk. Mounting the whole ./certs
+      # dir put ca.key in the gateway, so a gateway compromise yielded the CA
+      # private key, which mints arbitrary device certs AND forges action
+      # signatures (the same key signs both). ca.key now lives only in the
+      # control service, which is the CA. (#363)
+      - ./certs/gateway.crt:/certs/gateway.crt:ro,z
+      - ./certs/gateway.key:/certs/gateway.key:ro,z
+      - ./certs/ca.crt:/certs/ca.crt:ro,z
     environment:
       - GATEWAY_VALKEY_ADDR=valkey:6379
       - GATEWAY_VALKEY_PASSWORD=${VALKEY_PASSWORD}


### PR DESCRIPTION
Security audit finding **#7 (High)**.

`deploy/compose.yml` mounted the whole `./certs` dir (ro) into the gateway, which only reads `gateway.crt`/`gateway.key`/`ca.crt` — but the dir also contains **`ca.key`**, the CA signing key. The gateway is the public, agent-facing mTLS endpoint (most exposed component), so a gateway compromise yielded the CA private key, which **mints arbitrary device certs AND forges action signatures** (the same key signs both, via `ca.Signer()`).

## Fix
Mount only the three files the gateway actually uses; `ca.key` now lives only in the `control` service (the CA).

## Validation
- `docker compose config` exits 0.
- The gateway service references only `/certs/{gateway.crt,gateway.key,ca.crt}` (verified by parsing the service block); `ca.key` is no longer mounted.
- `setup.sh` generates all three files, so the individual bind mounts have valid sources.

**Deploy note:** requires recreating the gateway container (`docker compose up -d`). The deeper action-signing-key / CA-key separation (so even a control compromise is compartmentalized) is tracked as a follow-up.

Closes #363.