### PR TITLE
fix(api): enforce a privilege ceiling on role/group grants (#365)

### DIFF
--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -218,7 +218,17 @@ services:
       control:
         condition: service_healthy
     volumes:
-      - ./certs:/certs:ro,z
+      # Mount ONLY the files the gateway actually uses (its own mTLS keypair +
+      # the CA cert for verifying peers). The gateway is the public,
+      # agent-facing mTLS endpoint — the most exposed component — and must NOT
+      # have the CA SIGNING key (ca.key) on disk. Mounting the whole ./certs
+      # dir put ca.key in the gateway, so a gateway compromise yielded the CA
+      # private key, which mints arbitrary device certs AND forges action
+      # signatures (the same key signs both). ca.key now lives only in the
+      # control service, which is the CA. (#363)
+      - ./certs/gateway.crt:/certs/gateway.crt:ro,z
+      - ./certs/gateway.key:/certs/gateway.key:ro,z
+      - ./certs/ca.crt:/certs/ca.crt:ro,z
     environment:
       - GATEWAY_VALKEY_ADDR=valkey:6379
       - GATEWAY_VALKEY_PASSWORD=${VALKEY_PASSWORD}

--- a/internal/api/grant_ceiling.go
+++ b/internal/api/grant_ceiling.go
@@ -1,0 +1,28 @@
+package api
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+)
+
+// assertCanGrant enforces the "grant only what you hold" privilege ceiling: the
+// authenticated caller must hold every permission in `granted` (holding an
+// unrestricted permission covers its :self/:assigned scoped forms). The
+// role/group management handlers call this so a delegated manager cannot
+// escalate by creating/updating a role or assigning a role/group that confers
+// permissions they lack (#365). Admins hold every permission, so they are never
+// blocked.
+func assertCanGrant(ctx context.Context, granted []string) error {
+	userCtx, ok := auth.UserFromContext(ctx)
+	if !ok {
+		return apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, "not authenticated")
+	}
+	if missing := auth.UncoveredPermissions(userCtx.Permissions, granted); len(missing) > 0 {
+		return apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied,
+			"cannot grant permissions you do not hold")
+	}
+	return nil
+}

--- a/internal/api/grant_ceiling_handler_test.go
+++ b/internal/api/grant_ceiling_handler_test.go
@@ -1,0 +1,122 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// delegatedManagerCtx is a non-admin who holds role/group MANAGEMENT
+// permissions plus ListDevices — but NOT DispatchAction. Granting
+// DispatchAction is therefore an escalation the "grant only what you hold"
+// ceiling must block (#365).
+func delegatedManagerCtx(id string) context.Context {
+	return testutil.AuthContext(id, "mgr@test.com", []string{
+		"CreateRole", "UpdateRole", "AssignRoleToUser",
+		"AssignRoleToUserGroup", "AddUserToGroup", "ListDevices",
+	})
+}
+
+func TestCreateRole_PrivilegeCeiling(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	mgr := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	ctx := delegatedManagerCtx(mgr)
+
+	// Granting a permission the caller does NOT hold is rejected.
+	_, err := h.CreateRole(ctx, connect.NewRequest(&pm.CreateRoleRequest{
+		Name: "escalation", Permissions: []string{"DispatchAction"},
+	}))
+	require.Error(t, err, "must not be able to mint a role with a permission you don't hold")
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	// Granting only permissions the caller holds succeeds.
+	_, err = h.CreateRole(ctx, connect.NewRequest(&pm.CreateRoleRequest{
+		Name: "ok-role", Permissions: []string{"ListDevices"},
+	}))
+	require.NoError(t, err)
+}
+
+func TestUpdateRole_PrivilegeCeiling(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	mgr := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	role := testutil.CreateTestRole(t, st, adminID, "Editable", []string{"ListDevices"})
+
+	ctx := delegatedManagerCtx(mgr)
+	_, err := h.UpdateRole(ctx, connect.NewRequest(&pm.UpdateRoleRequest{
+		RoleId: role, Name: "Editable", Permissions: []string{"ListDevices", "DispatchAction"},
+	}))
+	require.Error(t, err, "must not be able to rewrite a role to add a permission you don't hold")
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+func TestAssignRoleToUser_PrivilegeCeiling(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	mgr := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	privRole := testutil.CreateTestRole(t, st, adminID, "Privileged", []string{"DispatchAction"})
+	okRole := testutil.CreateTestRole(t, st, adminID, "OkRole", []string{"ListDevices"})
+
+	ctx := delegatedManagerCtx(mgr)
+	// Unscoped (global) assignment of a role with permissions the caller lacks → rejected.
+	_, err := h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: privRole,
+	}))
+	require.Error(t, err, "must not globally assign a role conferring a permission you don't hold")
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	// Unscoped assignment within the caller's permissions → allowed.
+	_, err = h.AssignRoleToUser(ctx, connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: okRole,
+	}))
+	require.NoError(t, err)
+
+	// An admin (holds every permission) is never blocked by the ceiling.
+	_, err = h.AssignRoleToUser(testutil.AdminContext(adminID), connect.NewRequest(&pm.AssignRoleToUserRequest{
+		UserId: target, RoleId: privRole,
+	}))
+	require.NoError(t, err)
+}
+
+func TestAddUserToGroup_PrivilegeCeiling(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	groupH := api.NewUserGroupHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+	adminCtx := testutil.AdminContext(adminID)
+	mgr := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+	target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "user")
+
+	// Admin builds a group that confers a privileged role (DispatchAction).
+	group := testutil.CreateTestUserGroup(t, st, adminID, "Privileged Group")
+	privRole := testutil.CreateTestRole(t, st, adminID, "Privileged", []string{"DispatchAction"})
+	_, err := groupH.AssignRoleToUserGroup(adminCtx, connect.NewRequest(&pm.AssignRoleToUserGroupRequest{
+		GroupId: group, RoleId: privRole,
+	}))
+	require.NoError(t, err)
+
+	// A delegated manager who lacks DispatchAction cannot add a member to that
+	// group (doing so would confer DispatchAction to the member).
+	_, err = groupH.AddUserToGroup(delegatedManagerCtx(mgr), connect.NewRequest(&pm.AddUserToGroupRequest{
+		GroupId: group, UserId: target,
+	}))
+	require.Error(t, err, "must not add a member to a group conferring a permission you don't hold")
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	// The admin can.
+	_, err = groupH.AddUserToGroup(adminCtx, connect.NewRequest(&pm.AddUserToGroupRequest{
+		GroupId: group, UserId: target,
+	}))
+	require.NoError(t, err)
+}

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -61,6 +61,13 @@ func (h *RoleHandler) CreateRole(ctx context.Context, req *connect.Request[pm.Cr
 		return nil, err
 	}
 
+	// Privilege ceiling: a caller can only create a role with permissions they
+	// themselves hold, else any role-management holder could mint an Admin-level
+	// role and escalate (#365).
+	if err := assertCanGrant(ctx, req.Msg.Permissions); err != nil {
+		return nil, err
+	}
+
 	id := ulid.Make().String()
 
 	perms := req.Msg.Permissions
@@ -180,6 +187,13 @@ func (h *RoleHandler) UpdateRole(ctx context.Context, req *connect.Request[pm.Up
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	// Privilege ceiling: a caller can only set a role's permissions to ones
+	// they themselves hold, else a role-management holder could rewrite a role
+	// to confer Admin-level permissions and escalate (#365).
+	if err := assertCanGrant(ctx, req.Msg.Permissions); err != nil {
 		return nil, err
 	}
 
@@ -310,6 +324,19 @@ func (h *RoleHandler) AssignRoleToUser(ctx context.Context, req *connect.Request
 				return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeNotFound, "role not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get role")
+		}
+
+		// Privilege ceiling (UNSCOPED/global grants only): a caller can only
+		// globally assign a role whose permissions they hold, else any
+		// AssignRoleToUser holder could grant themselves an Admin-level role and
+		// escalate (#365). SCOPED grants are governed by the #7 device-group
+		// scope model (AssignRoleScope + escalation bound); their full
+		// enforcement lands in 2026.08, so the ceiling does not further restrict
+		// them here.
+		if scopeKind == "" {
+			if err := assertCanGrant(ctx, role.Permissions); err != nil {
+				return nil, err
+			}
 		}
 
 		// Every permission in a scoped grant's role must accept this

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -366,6 +366,28 @@ func (h *UserGroupHandler) AddUserToGroup(ctx context.Context, req *connect.Requ
 		return nil, apiErrorCtx(ctx, ErrDynamicGroupManualModify, connect.CodeFailedPrecondition, "cannot manually modify members of a dynamic group")
 	}
 
+	// Privilege ceiling: adding a user to a group confers ALL of the group's
+	// roles' permissions to that member, so a caller may only add members to a
+	// group whose conferred permissions they themselves hold — otherwise a
+	// role-management holder could add themselves (or anyone) to an
+	// Admin-bearing group and escalate (#365).
+	grants, err := h.store.Repos().Role.ListUserGroupRoleGrants(ctx, req.Msg.GroupId)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve group permissions")
+	}
+	var groupPerms []string
+	for _, g := range grants {
+		// Only globally-effective (unscoped) grants gate the ceiling; scoped
+		// grants follow the #7 device-group scope model (full enforcement
+		// 2026.08).
+		if g.ScopeKind == "" {
+			groupPerms = append(groupPerms, g.Role.Permissions...)
+		}
+	}
+	if err := assertCanGrant(ctx, groupPerms); err != nil {
+		return nil, err
+	}
+
 	for _, userID := range userIDs {
 		// Verify user exists
 		_, err = q.GetUserByID(ctx, userID)
@@ -520,6 +542,18 @@ func (h *UserGroupHandler) AssignRoleToUserGroup(ctx context.Context, req *conne
 				return nil, apiErrorCtx(ctx, ErrRoleNotFound, connect.CodeNotFound, "role not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get role")
+		}
+
+		// Privilege ceiling (UNSCOPED/global grants only): a caller can only
+		// grant a group a role whose permissions they hold — a group's roles are
+		// additive to every member, so this prevents escalating members past the
+		// caller's own grant (#365). SCOPED grants follow the #7 device-group
+		// scope model (full enforcement 2026.08), so the ceiling does not further
+		// restrict them here.
+		if scopeKind == "" {
+			if err := assertCanGrant(ctx, role.Permissions); err != nil {
+				return nil, err
+			}
 		}
 
 		if err := rejectUnscopableRole(ctx, scopeKind, role.Permissions); err != nil {

--- a/internal/auth/grant_ceiling.go
+++ b/internal/auth/grant_ceiling.go
@@ -1,0 +1,46 @@
+package auth
+
+import "strings"
+
+// scopeSuffixes are the permission scope qualifiers. Holding the unrestricted
+// base permission entitles the holder to grant any scoped form of it.
+var scopeSuffixes = []string{":self", ":assigned"}
+
+// UncoveredPermissions returns the subset of granted that a caller holding
+// `held` may NOT grant — the basis of the "grant only what you hold" privilege
+// ceiling. A held permission covers a granted one when they are equal, or when
+// the held permission is the unrestricted base of a scoped granted permission
+// (holding `X` covers granting `X:self` / `X:assigned`). You may grant a
+// NARROWER scope than you hold, never a broader one.
+//
+// An empty result means the caller is entitled to grant everything in granted.
+// Admins hold every unrestricted permission (AdminPermissions), so they cover
+// any grant.
+func UncoveredPermissions(held, granted []string) []string {
+	heldSet := make(map[string]bool, len(held))
+	for _, h := range held {
+		heldSet[h] = true
+	}
+	var missing []string
+	for _, g := range granted {
+		if heldSet[g] {
+			continue
+		}
+		if base, scoped := baseOfScoped(g); scoped && heldSet[base] {
+			continue
+		}
+		missing = append(missing, g)
+	}
+	return missing
+}
+
+// baseOfScoped strips a :self / :assigned suffix, reporting whether one was
+// present.
+func baseOfScoped(p string) (string, bool) {
+	for _, s := range scopeSuffixes {
+		if b, ok := strings.CutSuffix(p, s); ok {
+			return b, true
+		}
+	}
+	return p, false
+}

--- a/internal/auth/grant_ceiling_test.go
+++ b/internal/auth/grant_ceiling_test.go
@@ -1,0 +1,73 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUncoveredPermissions encodes the "grant only what you hold" contract,
+// including the broader-implies-narrower scope rule and the admin-covers-all
+// invariant (#365).
+func TestUncoveredPermissions(t *testing.T) {
+	cases := []struct {
+		name    string
+		held    []string
+		granted []string
+		want    []string
+	}{
+		{
+			name:    "exact subset is fully covered",
+			held:    []string{"CreateUser", "ListUsers", "DeleteUser"},
+			granted: []string{"CreateUser", "ListUsers"},
+			want:    nil,
+		},
+		{
+			name:    "granting a permission not held is uncovered",
+			held:    []string{"CreateUser"},
+			granted: []string{"CreateUser", "DispatchAction"},
+			want:    []string{"DispatchAction"},
+		},
+		{
+			name:    "holding unrestricted covers granting the :self scope",
+			held:    []string{"GetUser"},
+			granted: []string{"GetUser:self"},
+			want:    nil,
+		},
+		{
+			name:    "holding unrestricted covers granting the :assigned scope",
+			held:    []string{"GetDevice"},
+			granted: []string{"GetDevice:assigned"},
+			want:    nil,
+		},
+		{
+			name:    "holding only :self does NOT cover granting the unrestricted form",
+			held:    []string{"GetUser:self"},
+			granted: []string{"GetUser"},
+			want:    []string{"GetUser"},
+		},
+		{
+			name:    "holding :self covers granting the same :self",
+			held:    []string{"GetUser:self"},
+			granted: []string{"GetUser:self"},
+			want:    nil,
+		},
+		{
+			name:    "admin holding all permissions covers any grant",
+			held:    AdminPermissions(),
+			granted: []string{"DispatchAction", "DeleteDevice", "GetUser:self", "GetDevice:assigned"},
+			want:    nil,
+		},
+		{
+			name:    "empty grant is always covered",
+			held:    []string{"CreateUser"},
+			granted: nil,
+			want:    nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, UncoveredPermissions(tc.held, tc.granted))
+		})
+	}
+}


### PR DESCRIPTION
Security audit finding **#8 (High)** — part 1 of 2 (the privilege ceiling; centralized last-admin protection follows).

## The bug
`CreateRole`/`UpdateRole` validated only that permission keys were *valid*, not that the caller *held* them; `AssignRoleToUser`/`AssignRoleToUserGroup` did no subset check; `AddUserToGroup` added members with no check on the group's privilege. So any delegated role/group-management holder could grant permissions they lack — **escalating to Admin**.

## Fix — "grant only what you hold"
`auth.UncoveredPermissions` (a caller covers a grant iff they hold it, or hold its unrestricted base for a `:self`/`:assigned` scoped form) + an `assertCanGrant` helper, enforced at:
- **CreateRole / UpdateRole** — caller must hold every permission in the role.
- **AssignRoleToUser / AssignRoleToUserGroup** — for **unscoped (global)** grants, the caller must hold the role's permissions. **Scoped** grants stay governed by the #7 device-group scope model (full enforcement 2026.08), so the ceiling does not further restrict them — this is the only interpretation consistent with both the strict-ceiling decision and the #4/scoped deferral.
- **AddUserToGroup** — caller must hold the group's unscoped conferred permissions.

Admins hold every permission, so they are never blocked. Reuses the existing `permission_denied` code (no cross-repo error-code churn).

## Tests
`auth.UncoveredPermissions` spec (broader-implies-narrower + admin-covers-all); red→green handler tests for each site; the existing #7 scoped-delegation test still passes (ceiling is unscoped-only). Full `internal/api` suite green locally.

Part of #365. The centralized last-admin protection (DeleteUser/SetUserDisabled/RevokeRole + Admin-role immutability) is the follow-up PR.