### PR TITLE
fix(api): centralized last-admin lockout protection (#365)

### DIFF
--- a/internal/api/admin_guard.go
+++ b/internal/api/admin_guard.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// assertOtherEnabledAdminExists rejects an operation that would remove the LAST
+// enabled administrator. It verifies at least one ENABLED admin OTHER than
+// affectedUserID remains — an admin being a user who holds the Admin system
+// role directly OR via a group. Used by DeleteUser, SetUserDisabled and
+// RevokeRoleFromUser so the sole administrator cannot be locked out (#365).
+//
+// Conservative by design: it requires a *different* enabled admin to remain
+// rather than recomputing the affected user's post-operation admin paths. For a
+// lockout guard, refusing to remove the only OTHER admin is the safe bound, and
+// it counts group-inherited admins (which the prior RevokeRoleFromUser check
+// ignored) and excludes disabled/deleted ones (which it also ignored).
+//
+// LIMITATION (pre-existing): this is a read-side preflight, NOT atomic with the
+// delete/disable/revoke event it guards. Two concurrent admin-removing requests
+// for *different* admins can both observe "another enabled admin exists" and
+// both proceed, racing to zero enabled admins. The prior CountUsersWithRole
+// check had the identical race. The outcome is recoverable — the bootstrap
+// admin (CONTROL_ADMIN_EMAIL/PASSWORD) is re-created on server start — so this
+// strict-improvement guard does not close the race; atomic enforcement in the
+// projection/transaction is a tracked follow-up.
+func assertOtherEnabledAdminExists(ctx context.Context, st *store.Store, affectedUserID string) error {
+	adminRole, err := st.Repos().Role.GetByName(ctx, "Admin")
+	if err != nil {
+		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve Admin role")
+	}
+	direct, err := st.Repos().Role.ListUserIDsWithRole(ctx, adminRole.ID)
+	if err != nil {
+		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list admins")
+	}
+	viaGroup, err := st.Repos().Role.ListUserIDsWithGroupRole(ctx, adminRole.ID)
+	if err != nil {
+		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list group admins")
+	}
+
+	candidates := make([]string, 0, len(direct)+len(viaGroup))
+	candidates = append(candidates, direct...)
+	candidates = append(candidates, viaGroup...)
+
+	seen := make(map[string]bool, len(candidates))
+	for _, id := range candidates {
+		if id == affectedUserID || seen[id] {
+			continue
+		}
+		seen[id] = true
+		u, err := st.Repos().User.Get(ctx, id)
+		if err != nil {
+			if store.IsNotFound(err) {
+				continue
+			}
+			return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to load admin user")
+		}
+		if !u.Disabled && !u.IsDeleted {
+			return nil // at least one other enabled admin remains
+		}
+	}
+	return apiErrorCtx(ctx, ErrCannotRemoveLastAdmin, connect.CodeFailedPrecondition,
+		"cannot remove the last enabled administrator")
+}
+
+// permissionSetsEqual reports whether two permission lists contain the same set
+// of keys, ignoring order and duplicates.
+func permissionSetsEqual(a, b []string) bool {
+	set := make(map[string]struct{}, len(a))
+	for _, p := range a {
+		set[p] = struct{}{}
+	}
+	bset := make(map[string]struct{}, len(b))
+	for _, p := range b {
+		bset[p] = struct{}{}
+	}
+	if len(set) != len(bset) {
+		return false
+	}
+	for p := range set {
+		if _, ok := bset[p]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/api/admin_guard_test.go
+++ b/internal/api/admin_guard_test.go
@@ -1,0 +1,113 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// The last-admin guard (#365) refuses any operation that would leave zero
+// ENABLED administrators (counting group-inherited admins). These tests rely on
+// CreateTestUser(...,"admin") being a real RBAC admin (a user_roles_projection
+// assignment), which the factory now ensures.
+
+func TestDeleteUser_LastAdminRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserHandler(st, slog.Default(), nil)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	// Deleting the only admin is refused.
+	_, err := h.DeleteUser(ctx, connect.NewRequest(&pm.DeleteUserRequest{Id: adminID}))
+	require.Error(t, err, "deleting the sole admin must be refused")
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	// With a second admin, deleting one is allowed.
+	admin2 := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	_, err = h.DeleteUser(ctx, connect.NewRequest(&pm.DeleteUserRequest{Id: admin2}))
+	require.NoError(t, err)
+}
+
+func TestSetUserDisabled_LastAdminRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserHandler(st, slog.Default(), nil)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.SetUserDisabled(ctx, connect.NewRequest(&pm.SetUserDisabledRequest{Id: adminID, Disabled: true}))
+	require.Error(t, err, "disabling the sole admin must be refused")
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+func TestRevokeRoleFromUser_LastAdminRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	adminRole, err := st.Repos().Role.GetByName(context.Background(), "Admin")
+	require.NoError(t, err)
+
+	// Revoking Admin from the sole admin is refused.
+	_, err = h.RevokeRoleFromUser(ctx, connect.NewRequest(&pm.RevokeRoleFromUserRequest{
+		UserId: adminID, RoleId: adminRole.ID,
+	}))
+	require.Error(t, err, "revoking Admin from the sole admin must be refused")
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	// With a second admin, revoking from one is allowed.
+	admin2 := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	_, err = h.RevokeRoleFromUser(ctx, connect.NewRequest(&pm.RevokeRoleFromUserRequest{
+		UserId: admin2, RoleId: adminRole.ID,
+	}))
+	require.NoError(t, err)
+}
+
+// TestRevokeRoleFromUser_ScopedAdminRevokeNotBlocked pins that the last-admin
+// guard is UNSCOPED-only: revoking a SCOPED Admin grant doesn't remove global
+// admin, so it must reach scope resolution rather than be rejected as a
+// lockout. The sole admin holds only an unscoped Admin grant here, so targeting
+// a scoped grant surfaces the wrong-scope precondition — proving the guard was
+// skipped (else it would be the last-admin error).
+func TestRevokeRoleFromUser_ScopedAdminRevokeNotBlocked(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	adminRole, err := st.Repos().Role.GetByName(context.Background(), "Admin")
+	require.NoError(t, err)
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Plant 1")
+
+	_, err = h.RevokeRoleFromUser(ctx, connect.NewRequest(&pm.RevokeRoleFromUserRequest{
+		UserId: adminID, RoleId: adminRole.ID, ScopeKind: deviceGroupScope, ScopeId: dg,
+	}))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not assigned at the specified scope",
+		"a scoped Admin revoke must reach scope resolution, not be blocked by the unscoped last-admin guard")
+}
+
+func TestUpdateRole_AdminPermissionsImmutable(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewRoleHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	adminRole, err := st.Repos().Role.GetByName(context.Background(), "Admin")
+	require.NoError(t, err)
+
+	// Stripping the Admin role's permissions is refused (it would disable every
+	// administrator at once).
+	_, err = h.UpdateRole(ctx, connect.NewRequest(&pm.UpdateRoleRequest{
+		RoleId: adminRole.ID, Name: adminRole.Name, Permissions: []string{"ListDevices"},
+	}))
+	require.Error(t, err, "the Admin role's permissions must be immutable")
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -177,6 +177,13 @@ func (h *RoleHandler) UpdateRole(ctx context.Context, req *connect.Request[pm.Up
 		return nil, apiErrorCtx(ctx, ErrCannotRenameSystemRole, connect.CodeFailedPrecondition, "cannot rename system role")
 	}
 
+	// The Admin system role's permissions are immutable: it must remain the
+	// all-permissions role. Allowing them to be stripped would disable every
+	// administrator at once and lock the operator out (#365).
+	if role.IsSystem && role.Name == "Admin" && !permissionSetsEqual(req.Msg.Permissions, role.Permissions) {
+		return nil, apiErrorCtx(ctx, ErrCannotRemoveLastAdmin, connect.CodeFailedPrecondition, "the Admin role's permissions cannot be changed")
+	}
+
 	// Validate permissions
 	validPerms := auth.ValidPermissionKeys()
 	for _, p := range req.Msg.Permissions {
@@ -413,17 +420,6 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 		return nil, handleGetError(ctx, err, ErrRoleNotFound, "role not found")
 	}
 
-	// Prevent removing the last user from the Admin system role
-	if role.IsSystem && role.Name == "Admin" {
-		userCount, err := h.store.Repos().Role.CountUsersWithRole(ctx, req.Msg.RoleId)
-		if err != nil {
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count users")
-		}
-		if userCount <= 1 {
-			return nil, apiErrorCtx(ctx, ErrCannotRemoveLastAdmin, connect.CodeFailedPrecondition, "cannot remove last user from Admin role")
-		}
-	}
-
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
@@ -450,6 +446,21 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 	}
 
 	if hasScoped {
+		// Prevent removing the last enabled administrator. Checked only when an
+		// UNSCOPED Admin grant will actually be removed: a scoped Admin grant
+		// doesn't confer global admin, and a non-existent grant is a no-op, so
+		// neither threatens lockout. Counts group-inherited admins and ignores
+		// disabled/deleted ones — which the old CountUsersWithRole check did not
+		// (#365). NOTE: this is a read-side preflight, not atomic with the
+		// revoke event; two concurrent admin removals can still race to zero
+		// admins (recoverable via the bootstrap admin on restart). Atomic
+		// enforcement in the projector is a follow-up.
+		if role.IsSystem && role.Name == "Admin" && scopeKind == "" {
+			if err := assertOtherEnabledAdminExists(ctx, h.store, req.Msg.UserId); err != nil {
+				return nil, err
+			}
+		}
+
 		streamID := req.Msg.UserId + ":" + req.Msg.RoleId
 		if scopeKind != "" {
 			streamID += ":" + scopeID

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -403,6 +403,13 @@ func (h *UserHandler) SetUserDisabled(ctx context.Context, req *connect.Request[
 		return nil, err
 	}
 
+	// Disabling the last enabled administrator would lock everyone out (#365).
+	if req.Msg.Disabled {
+		if err := assertOtherEnabledAdminExists(ctx, h.store, req.Msg.Id); err != nil {
+			return nil, err
+		}
+	}
+
 	// Emit appropriate event
 	eventType := string(eventtypes.UserEnabled)
 	if req.Msg.Disabled {
@@ -449,6 +456,12 @@ func (h *UserHandler) DeleteUser(ctx context.Context, req *connect.Request[pm.De
 	user, err := h.store.Repos().User.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
+	}
+
+	// Refuse to delete the last enabled administrator (#365). A no-op for
+	// non-admins (other admins still exist).
+	if err := assertOtherEnabledAdminExists(ctx, h.store, req.Msg.Id); err != nil {
+		return nil, err
 	}
 
 	// Emit UserDeleted event

--- a/internal/testutil/factories_user.go
+++ b/internal/testutil/factories_user.go
@@ -31,6 +31,22 @@ func CreateTestUser(t *testing.T, st *store.Store, email, password, role string)
 		}
 	}
 
+	// Resolve the named role to a real user_roles_projection assignment so an
+	// "admin" test user is a genuine RBAC principal. The last-admin guard (and
+	// anything reading user_roles) depends on the role assignment, NOT the
+	// legacy `role` column — without this the guard sees zero admins. Only the
+	// seeded "Admin" role is mapped; "user"/"viewer" keep the prior
+	// legacy-field-only behaviour (empty role_ids) so non-admin call sites are
+	// unaffected.
+	roleIDs := []string{}
+	if role == "admin" {
+		adminRole, err := st.Repos().Role.GetByName(ctx, "Admin")
+		if err != nil {
+			t.Fatalf("look up Admin role: %v", err)
+		}
+		roleIDs = []string{adminRole.ID}
+	}
+
 	if err := st.AppendEvent(ctx, store.Event{
 		StreamType: "user",
 		StreamID:   id,
@@ -39,7 +55,7 @@ func CreateTestUser(t *testing.T, st *store.Store, email, password, role string)
 			"email":         email,
 			"password_hash": hash,
 			"role":          role,
-			"role_ids":      []string{},
+			"role_ids":      roleIDs,
 		},
 		ActorType: "system",
 		ActorID:   "test",


### PR DESCRIPTION
Security audit finding **#8 (High)** — part 2 of 2 (the ceiling was #366; this is the last-admin protection).

## The bug
Last-admin protection existed only on `RevokeRoleFromUser`, and it naively counted users with the Admin role (`CountUsersWithRole`) — ignoring whether they're **enabled** and ignoring **group-inherited** admins. `DeleteUser`, `SetUserDisabled`, and stripping the Admin role's permissions via `UpdateRole` all bypassed it, so the sole administrator could be locked out.

## Fix
- `assertOtherEnabledAdminExists`: refuses an op that would leave **zero enabled admins**, where an admin holds the Admin role **directly OR via a group**, filtered to `!Disabled && !IsDeleted`. Wired into `DeleteUser`, `SetUserDisabled` (when disabling), and `RevokeRoleFromUser` (replacing the naive check).
- **Admin system role permission immutability** in `UpdateRole` — closes the strip-Admin-perms lockout (reuses `cannot_remove_last_admin`, no new error code).

## Test harness fix (the reason #8b was split out)
`testutil.CreateTestUser(…,"admin")` previously wrote only the legacy `role` column with **empty `role_ids`**, so it was not a real RBAC admin — with the guard in place it'd see zero admins and (correctly) block every delete/disable. It now creates a genuine `user_roles_projection` assignment via `role_ids`. **Validated the factory change alone passes the full `internal/api` suite (zero blast radius)**, then api + auth pass with the guard.

Red→green tests for each guarded path + Admin-role immutability.

> Remaining narrower vector (noted, follow-up): revoking the Admin role from a **group** that confers it (`RevokeRoleFromUserGroup`). The bootstrap admin is always a *direct* admin, so it can't lock out that way; a correct multi-user guard there needs its own design.

Closes #365.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards to ensure at least one enabled administrator remains in the system.
  * Enhanced validation across admin-related operations including user deletion, account disabling, and role revocation.

* **Tests**
  * Added comprehensive test coverage verifying admin protection mechanisms across multiple operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->