### PR TITLE
fix(actionparams): fail closed on bad/unknown action params (#368)

### DIFF
--- a/internal/actionparams/actionparams.go
+++ b/internal/actionparams/actionparams.go
@@ -59,196 +59,267 @@ func MarshalActionParams(msg proto.Message) ([]byte, error) {
 	return marshalOptions.Marshal(msg)
 }
 
-// PopulateAction deserializes params JSON into a wire-format Action proto.
-// Used by the gateway (action dispatch) and internal service (agent sync).
-func PopulateAction(action *pm.Action, actionType int32, paramsJSON []byte) {
-	switch pm.ActionType(actionType) {
-	case pm.ActionType_ACTION_TYPE_PACKAGE:
-		var p pm.PackageParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Package{Package: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_APP_IMAGE, pm.ActionType_ACTION_TYPE_DEB, pm.ActionType_ACTION_TYPE_RPM:
-		var p pm.AppInstallParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_App{App: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_FLATPAK:
-		var p pm.FlatpakParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Flatpak{Flatpak: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_SHELL, pm.ActionType_ACTION_TYPE_SCRIPT_RUN:
-		var p pm.ShellParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Shell{Shell: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_SERVICE:
-		var p pm.ServiceParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Service{Service: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_FILE:
-		var p pm.FileParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_File{File: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_UPDATE:
-		var p pm.UpdateParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Update{Update: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_REPOSITORY:
-		var p pm.RepositoryParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Repository{Repository: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_DIRECTORY:
-		var p pm.DirectoryParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Directory{Directory: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_USER:
-		var p pm.UserParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_User{User: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_GROUP:
-		var p pm.GroupParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Group{Group: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_SSH:
-		var p pm.SshParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Ssh{Ssh: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_SSHD:
-		var p pm.SshdParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Sshd{Sshd: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_ADMIN_POLICY:
-		var p pm.AdminPolicyParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_AdminPolicy{AdminPolicy: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_LPS:
-		var p pm.LpsParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Lps{Lps: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_ENCRYPTION:
-		var p pm.EncryptionParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Encryption{Encryption: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_WIFI:
-		var p pm.WifiParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_Wifi{Wifi: &p}
-		}
-	case pm.ActionType_ACTION_TYPE_AGENT_UPDATE:
-		var p pm.AgentUpdateParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.Action_AgentUpdate{AgentUpdate: &p}
-		}
+// isNoParamsActionType reports whether an action type legitimately carries no
+// params oneof (so reaching the switch default is expected, not an error).
+// REBOOT and SYNC are instant actions with no parameters; UNSPECIFIED is the
+// zero value. Any OTHER unhandled type is a new ActionType that PopulateAction
+// forgot to wire up.
+func isNoParamsActionType(t pm.ActionType) bool {
+	switch t {
+	case pm.ActionType_ACTION_TYPE_UNSPECIFIED,
+		pm.ActionType_ACTION_TYPE_REBOOT,
+		pm.ActionType_ACTION_TYPE_SYNC:
+		return true
+	default:
+		return false
 	}
 }
 
-// PopulateManagedAction deserializes params JSON into an API-format ManagedAction proto.
-// Used by the control server API (action list/get responses).
-func PopulateManagedAction(action *pm.ManagedAction, actionType pm.ActionType, paramsJSON []byte) {
+// PopulateAction deserializes params JSON into a wire-format Action proto.
+// Used by the gateway (action dispatch) and internal service (agent sync).
+//
+// Returns an error on a protojson parse failure OR an unhandled action type,
+// so callers can fail closed (retry/dead-letter, log) instead of dispatching an
+// action with empty/nil params (#368). Previously it swallowed both, and the
+// gateway dispatched the action anyway.
+func PopulateAction(action *pm.Action, actionType int32, paramsJSON []byte) error {
+	switch pm.ActionType(actionType) {
+	case pm.ActionType_ACTION_TYPE_PACKAGE:
+		var p pm.PackageParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal PACKAGE params: %w", err)
+		}
+		action.Params = &pm.Action_Package{Package: &p}
+	case pm.ActionType_ACTION_TYPE_APP_IMAGE, pm.ActionType_ACTION_TYPE_DEB, pm.ActionType_ACTION_TYPE_RPM:
+		var p pm.AppInstallParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal APP_INSTALL params: %w", err)
+		}
+		action.Params = &pm.Action_App{App: &p}
+	case pm.ActionType_ACTION_TYPE_FLATPAK:
+		var p pm.FlatpakParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal FLATPAK params: %w", err)
+		}
+		action.Params = &pm.Action_Flatpak{Flatpak: &p}
+	case pm.ActionType_ACTION_TYPE_SHELL, pm.ActionType_ACTION_TYPE_SCRIPT_RUN:
+		var p pm.ShellParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SHELL params: %w", err)
+		}
+		action.Params = &pm.Action_Shell{Shell: &p}
+	case pm.ActionType_ACTION_TYPE_SERVICE:
+		var p pm.ServiceParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SERVICE params: %w", err)
+		}
+		action.Params = &pm.Action_Service{Service: &p}
+	case pm.ActionType_ACTION_TYPE_FILE:
+		var p pm.FileParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal FILE params: %w", err)
+		}
+		action.Params = &pm.Action_File{File: &p}
+	case pm.ActionType_ACTION_TYPE_UPDATE:
+		var p pm.UpdateParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal UPDATE params: %w", err)
+		}
+		action.Params = &pm.Action_Update{Update: &p}
+	case pm.ActionType_ACTION_TYPE_REPOSITORY:
+		var p pm.RepositoryParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal REPOSITORY params: %w", err)
+		}
+		action.Params = &pm.Action_Repository{Repository: &p}
+	case pm.ActionType_ACTION_TYPE_DIRECTORY:
+		var p pm.DirectoryParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal DIRECTORY params: %w", err)
+		}
+		action.Params = &pm.Action_Directory{Directory: &p}
+	case pm.ActionType_ACTION_TYPE_USER:
+		var p pm.UserParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal USER params: %w", err)
+		}
+		action.Params = &pm.Action_User{User: &p}
+	case pm.ActionType_ACTION_TYPE_GROUP:
+		var p pm.GroupParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal GROUP params: %w", err)
+		}
+		action.Params = &pm.Action_Group{Group: &p}
+	case pm.ActionType_ACTION_TYPE_SSH:
+		var p pm.SshParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SSH params: %w", err)
+		}
+		action.Params = &pm.Action_Ssh{Ssh: &p}
+	case pm.ActionType_ACTION_TYPE_SSHD:
+		var p pm.SshdParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SSHD params: %w", err)
+		}
+		action.Params = &pm.Action_Sshd{Sshd: &p}
+	case pm.ActionType_ACTION_TYPE_ADMIN_POLICY:
+		var p pm.AdminPolicyParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal ADMIN_POLICY params: %w", err)
+		}
+		action.Params = &pm.Action_AdminPolicy{AdminPolicy: &p}
+	case pm.ActionType_ACTION_TYPE_LPS:
+		var p pm.LpsParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal LPS params: %w", err)
+		}
+		action.Params = &pm.Action_Lps{Lps: &p}
+	case pm.ActionType_ACTION_TYPE_ENCRYPTION:
+		var p pm.EncryptionParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal ENCRYPTION params: %w", err)
+		}
+		action.Params = &pm.Action_Encryption{Encryption: &p}
+	case pm.ActionType_ACTION_TYPE_WIFI:
+		var p pm.WifiParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal WIFI params: %w", err)
+		}
+		action.Params = &pm.Action_Wifi{Wifi: &p}
+	case pm.ActionType_ACTION_TYPE_AGENT_UPDATE:
+		var p pm.AgentUpdateParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal AGENT_UPDATE params: %w", err)
+		}
+		action.Params = &pm.Action_AgentUpdate{AgentUpdate: &p}
+	default:
+		if isNoParamsActionType(pm.ActionType(actionType)) {
+			return nil
+		}
+		return fmt.Errorf("actionparams: unhandled action type %d (%s)", actionType, pm.ActionType(actionType))
+	}
+	return nil
+}
+
+// PopulateManagedAction deserializes params JSON into an API-format
+// ManagedAction proto. Used by the control server API (action list/get
+// responses). Returns an error on a protojson parse failure OR an unhandled
+// action type (#368).
+func PopulateManagedAction(action *pm.ManagedAction, actionType pm.ActionType, paramsJSON []byte) error {
 	switch actionType {
 	case pm.ActionType_ACTION_TYPE_PACKAGE:
 		var p pm.PackageParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Package{Package: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal PACKAGE params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Package{Package: &p}
 	case pm.ActionType_ACTION_TYPE_APP_IMAGE, pm.ActionType_ACTION_TYPE_DEB, pm.ActionType_ACTION_TYPE_RPM:
 		var p pm.AppInstallParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_App{App: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal APP_INSTALL params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_App{App: &p}
 	case pm.ActionType_ACTION_TYPE_FLATPAK:
 		var p pm.FlatpakParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Flatpak{Flatpak: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal FLATPAK params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Flatpak{Flatpak: &p}
 	case pm.ActionType_ACTION_TYPE_SHELL, pm.ActionType_ACTION_TYPE_SCRIPT_RUN:
 		var p pm.ShellParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Shell{Shell: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SHELL params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Shell{Shell: &p}
 	case pm.ActionType_ACTION_TYPE_SERVICE:
 		var p pm.ServiceParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Service{Service: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SERVICE params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Service{Service: &p}
 	case pm.ActionType_ACTION_TYPE_FILE:
 		var p pm.FileParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_File{File: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal FILE params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_File{File: &p}
 	case pm.ActionType_ACTION_TYPE_UPDATE:
 		var p pm.UpdateParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Update{Update: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal UPDATE params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Update{Update: &p}
 	case pm.ActionType_ACTION_TYPE_REPOSITORY:
 		var p pm.RepositoryParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Repository{Repository: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal REPOSITORY params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Repository{Repository: &p}
 	case pm.ActionType_ACTION_TYPE_DIRECTORY:
 		var p pm.DirectoryParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Directory{Directory: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal DIRECTORY params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Directory{Directory: &p}
 	case pm.ActionType_ACTION_TYPE_USER:
 		var p pm.UserParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_User{User: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal USER params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_User{User: &p}
 	case pm.ActionType_ACTION_TYPE_GROUP:
 		var p pm.GroupParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Group{Group: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal GROUP params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Group{Group: &p}
 	case pm.ActionType_ACTION_TYPE_SSH:
 		var p pm.SshParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Ssh{Ssh: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SSH params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Ssh{Ssh: &p}
 	case pm.ActionType_ACTION_TYPE_SSHD:
 		var p pm.SshdParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Sshd{Sshd: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SSHD params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Sshd{Sshd: &p}
 	case pm.ActionType_ACTION_TYPE_ADMIN_POLICY:
 		var p pm.AdminPolicyParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_AdminPolicy{AdminPolicy: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal ADMIN_POLICY params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_AdminPolicy{AdminPolicy: &p}
 	case pm.ActionType_ACTION_TYPE_LPS:
 		var p pm.LpsParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Lps{Lps: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal LPS params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Lps{Lps: &p}
 	case pm.ActionType_ACTION_TYPE_ENCRYPTION:
 		var p pm.EncryptionParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Encryption{Encryption: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal ENCRYPTION params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Encryption{Encryption: &p}
 	case pm.ActionType_ACTION_TYPE_WIFI:
 		var p pm.WifiParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_Wifi{Wifi: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal WIFI params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_Wifi{Wifi: &p}
 	case pm.ActionType_ACTION_TYPE_AGENT_UPDATE:
 		var p pm.AgentUpdateParams
-		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err == nil {
-			action.Params = &pm.ManagedAction_AgentUpdate{AgentUpdate: &p}
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal AGENT_UPDATE params: %w", err)
 		}
+		action.Params = &pm.ManagedAction_AgentUpdate{AgentUpdate: &p}
+	default:
+		if isNoParamsActionType(actionType) {
+			return nil
+		}
+		return fmt.Errorf("actionparams: unhandled action type %d (%s)", int32(actionType), actionType)
 	}
+	return nil
 }

--- a/internal/actionparams/actionparams_test.go
+++ b/internal/actionparams/actionparams_test.go
@@ -1,0 +1,75 @@
+package actionparams_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
+)
+
+// TestPopulateAction_MalformedParamsReturnsError pins the #368 fix: a protojson
+// parse failure surfaces as an error and leaves the oneof unset, rather than
+// being swallowed (which let the gateway dispatch an action with empty params).
+func TestPopulateAction_MalformedParamsReturnsError(t *testing.T) {
+	action := &pm.Action{}
+	err := actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SHELL), []byte("{not valid json"))
+	require.Error(t, err)
+	assert.Nil(t, action.Params, "params must not be set on a parse error")
+}
+
+// TestPopulateAction_UnknownTypeWithParamsReturnsError pins that an action type
+// the switch doesn't handle (a new enum value, here a synthetic one) errors
+// instead of silently falling through with nil params.
+func TestPopulateAction_UnknownTypeWithParamsReturnsError(t *testing.T) {
+	action := &pm.Action{}
+	err := actionparams.PopulateAction(action, 999999, []byte(`{"x":1}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unhandled action type")
+	assert.Nil(t, action.Params)
+}
+
+// TestPopulateAction_NoParamsTypesReturnNil pins that the param-less action
+// types (REBOOT/SYNC) and the zero value are NOT treated as errors.
+func TestPopulateAction_NoParamsTypesReturnNil(t *testing.T) {
+	for _, at := range []pm.ActionType{
+		pm.ActionType_ACTION_TYPE_UNSPECIFIED,
+		pm.ActionType_ACTION_TYPE_REBOOT,
+		pm.ActionType_ACTION_TYPE_SYNC,
+	} {
+		action := &pm.Action{}
+		require.NoErrorf(t, actionparams.PopulateAction(action, int32(at), []byte("{}")), "type %s", at)
+		assert.Nil(t, action.Params)
+	}
+}
+
+// TestPopulateAction_EveryActionTypeHandled is self-discovering against the
+// generated ActionType enum: every value must either be wired into the switch
+// (an empty `{}` parses cleanly for any params message) or classified as
+// param-less. A new action type added without a case fails here rather than
+// silently dispatching with nil params (#368).
+func TestPopulateAction_EveryActionTypeHandled(t *testing.T) {
+	require.NotEmpty(t, pm.ActionType_name)
+	for v, name := range pm.ActionType_name {
+		t.Run(name, func(t *testing.T) {
+			action := &pm.Action{}
+			require.NoErrorf(t, actionparams.PopulateAction(action, v, []byte("{}")),
+				"PopulateAction does not handle %s (%d) — add a case or classify it param-less (#368)", name, v)
+
+			managed := &pm.ManagedAction{}
+			require.NoErrorf(t, actionparams.PopulateManagedAction(managed, pm.ActionType(v), []byte("{}")),
+				"PopulateManagedAction does not handle %s (%d) — add a case or classify it param-less (#368)", name, v)
+		})
+	}
+}
+
+// TestPopulateManagedAction_MalformedParamsReturnsError mirrors the wire-format
+// guard for the API-format path.
+func TestPopulateManagedAction_MalformedParamsReturnsError(t *testing.T) {
+	action := &pm.ManagedAction{}
+	err := actionparams.PopulateManagedAction(action, pm.ActionType_ACTION_TYPE_FILE, []byte("{bad"))
+	require.Error(t, err)
+	assert.Nil(t, action.Params)
+}

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -89,7 +89,11 @@ func (h *ActionHandler) actionToProto(a store.Action) *pm.ManagedAction {
 	}
 
 	if len(a.Params) > 0 {
-		actionparams.PopulateManagedAction(action, pm.ActionType(a.ActionType), a.Params)
+		if err := actionparams.PopulateManagedAction(action, pm.ActionType(a.ActionType), a.Params); err != nil {
+			// Read path: log and return the action without params rather than
+			// failing the whole list/get response (#368).
+			h.logger.Warn("action params failed to parse for API response", "action_id", a.ID, "error", err)
+		}
 	}
 
 	if len(a.Schedule) > 0 {

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -139,8 +139,11 @@ func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Req
 		if !ok {
 			continue
 		}
-		wire := dbActionToWireAction(raw)
-		if wire == nil {
+		wire, err := dbActionToWireAction(raw)
+		if err != nil {
+			// Fail closed: skip an action whose params don't parse rather than
+			// sync it to the agent with empty params (#368).
+			h.logger.Warn("skipping standalone action with unparseable params", "action_id", raw.ID, "error", err)
 			continue
 		}
 		if sa.Mode == resolution.ModeUninstall {
@@ -156,10 +159,13 @@ func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Req
 		if covered[dbAction.ID] {
 			continue
 		}
-		action := dbResolvedActionToWireAction(dbAction)
-		if action != nil {
-			standalone = append(standalone, action)
+		action, err := dbResolvedActionToWireAction(dbAction)
+		if err != nil {
+			// Fail closed: skip rather than sync empty params (#368).
+			h.logger.Warn("skipping resolved action with unparseable params", "action_id", dbAction.ID, "error", err)
+			continue
 		}
+		standalone = append(standalone, action)
 	}
 
 	// Group emission: walk the tree's group list, hydrate proto Actions,
@@ -173,8 +179,10 @@ func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Req
 			if !ok {
 				continue
 			}
-			wire := dbActionToWireAction(raw)
-			if wire == nil {
+			wire, err := dbActionToWireAction(raw)
+			if err != nil {
+				// Fail closed: skip rather than sync empty params (#368).
+				h.logger.Warn("skipping group action with unparseable params", "action_id", raw.ID, "error", err)
 				continue
 			}
 			if g.Mode == resolution.ModeUninstall {
@@ -229,7 +237,7 @@ func windowEntryCount(w *pm.MaintenanceWindow) int {
 // format. Mirrors dbResolvedActionToWireAction but operates on the
 // projection row directly so the tree resolver doesn't have to detour
 // through the per-action mode-collapse query for every member action.
-func dbActionToWireAction(a db.ActionsProjection) *pm.Action {
+func dbActionToWireAction(a db.ActionsProjection) (*pm.Action, error) {
 	action := &pm.Action{
 		Id:              &pm.ActionId{Value: a.ID},
 		Type:            pm.ActionType(a.ActionType),
@@ -239,12 +247,14 @@ func dbActionToWireAction(a db.ActionsProjection) *pm.Action {
 		ParamsCanonical: a.ParamsCanonical,
 	}
 	if len(a.Params) > 0 {
-		actionparams.PopulateAction(action, a.ActionType, a.Params)
+		if err := actionparams.PopulateAction(action, a.ActionType, a.Params); err != nil {
+			return nil, err
+		}
 	}
 	if len(a.Schedule) > 0 {
 		action.Schedule = actionparams.ScheduleFromJSON(a.Schedule)
 	}
-	return action
+	return action, nil
 }
 
 // ProxyValidateLuksToken validates and consumes a one-time LUKS token.
@@ -539,7 +549,7 @@ func (h *InternalHandler) ProxyValidateTerminalToken(ctx context.Context, req *c
 // dbResolvedActionToWireAction converts a resolved action row to wire format.
 // Note: This is also defined in handler/agent.go — when the gateway migration
 // is complete, only this version will remain.
-func dbResolvedActionToWireAction(a db.ListResolvedActionsForDeviceRow) *pm.Action {
+func dbResolvedActionToWireAction(a db.ListResolvedActionsForDeviceRow) (*pm.Action, error) {
 	action := &pm.Action{
 		Id:              &pm.ActionId{Value: a.ID},
 		Type:            pm.ActionType(a.ActionType),
@@ -550,14 +560,16 @@ func dbResolvedActionToWireAction(a db.ListResolvedActionsForDeviceRow) *pm.Acti
 	}
 
 	if len(a.Params) > 0 {
-		actionparams.PopulateAction(action, a.ActionType, a.Params)
+		if err := actionparams.PopulateAction(action, a.ActionType, a.Params); err != nil {
+			return nil, err
+		}
 	}
 
 	if len(a.Schedule) > 0 {
 		action.Schedule = actionparams.ScheduleFromJSON(a.Schedule)
 	}
 
-	return action
+	return action, nil
 }
 
 // rotationReasonToString converts the wire enum into the lowercase

--- a/internal/gateway/task_handlers.go
+++ b/internal/gateway/task_handlers.go
@@ -90,9 +90,13 @@ func (h *deviceTaskHandler) handleActionDispatch(_ context.Context, t *asynq.Tas
 		ParamsCanonical: payload.ParamsCanonical,
 	}
 
-	// Parse params
+	// Parse params. Fail closed on a parse error or an unhandled action type:
+	// return the error so Asynq retries / dead-letters instead of dispatching an
+	// action to the agent with empty/nil params (#368).
 	if len(payload.Params) > 0 && string(payload.Params) != "null" && string(payload.Params) != "{}" {
-		actionparams.PopulateAction(action, payload.ActionType, payload.Params)
+		if err := actionparams.PopulateAction(action, payload.ActionType, payload.Params); err != nil {
+			return fmt.Errorf("populate action params (type %d): %w", payload.ActionType, err)
+		}
 	}
 
 	// Wrap in ServerMessage

--- a/internal/gateway/task_handlers_test.go
+++ b/internal/gateway/task_handlers_test.go
@@ -20,7 +20,7 @@ import (
 func TestParseActionParams_Package(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"name":"vim"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_PACKAGE), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_PACKAGE), []byte(params)))
 
 	require.NotNil(t, action.GetPackage())
 	assert.Equal(t, "vim", action.GetPackage().Name)
@@ -29,7 +29,7 @@ func TestParseActionParams_Package(t *testing.T) {
 func TestParseActionParams_Shell(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"script":"echo hello","runAsRoot":true}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SHELL), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SHELL), []byte(params)))
 
 	require.NotNil(t, action.GetShell())
 	assert.Equal(t, "echo hello", action.GetShell().Script)
@@ -39,7 +39,7 @@ func TestParseActionParams_Shell(t *testing.T) {
 func TestParseActionParams_ScriptRun(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"script":"#!/bin/bash\nexit 0"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SCRIPT_RUN), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SCRIPT_RUN), []byte(params)))
 
 	require.NotNil(t, action.GetShell())
 	assert.Contains(t, action.GetShell().Script, "exit 0")
@@ -48,7 +48,7 @@ func TestParseActionParams_ScriptRun(t *testing.T) {
 func TestParseActionParams_Systemd(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"unitName":"nginx.service","enable":true}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SERVICE), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SERVICE), []byte(params)))
 
 	require.NotNil(t, action.GetService())
 	assert.Equal(t, "nginx.service", action.GetService().UnitName)
@@ -58,7 +58,7 @@ func TestParseActionParams_Systemd(t *testing.T) {
 func TestParseActionParams_File(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"path":"/etc/test.conf","content":"key=value"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_FILE), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_FILE), []byte(params)))
 
 	require.NotNil(t, action.GetFile())
 	assert.Equal(t, "/etc/test.conf", action.GetFile().Path)
@@ -67,7 +67,7 @@ func TestParseActionParams_File(t *testing.T) {
 func TestParseActionParams_Directory(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"path":"/opt/myapp"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_DIRECTORY), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_DIRECTORY), []byte(params)))
 
 	require.NotNil(t, action.GetDirectory())
 	assert.Equal(t, "/opt/myapp", action.GetDirectory().Path)
@@ -76,7 +76,7 @@ func TestParseActionParams_Directory(t *testing.T) {
 func TestParseActionParams_Update(t *testing.T) {
 	action := &pm.Action{}
 	params := `{}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_UPDATE), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_UPDATE), []byte(params)))
 
 	require.NotNil(t, action.GetUpdate())
 }
@@ -84,7 +84,7 @@ func TestParseActionParams_Update(t *testing.T) {
 func TestParseActionParams_Repository(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"name":"myrepo"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_REPOSITORY), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_REPOSITORY), []byte(params)))
 
 	require.NotNil(t, action.GetRepository())
 	assert.Equal(t, "myrepo", action.GetRepository().Name)
@@ -93,7 +93,7 @@ func TestParseActionParams_Repository(t *testing.T) {
 func TestParseActionParams_Flatpak(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"appId":"org.gnome.Calculator"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_FLATPAK), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_FLATPAK), []byte(params)))
 
 	require.NotNil(t, action.GetFlatpak())
 	assert.Equal(t, "org.gnome.Calculator", action.GetFlatpak().AppId)
@@ -102,7 +102,7 @@ func TestParseActionParams_Flatpak(t *testing.T) {
 func TestParseActionParams_User(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"username":"testuser"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_USER), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_USER), []byte(params)))
 
 	require.NotNil(t, action.GetUser())
 	assert.Equal(t, "testuser", action.GetUser().Username)
@@ -111,7 +111,7 @@ func TestParseActionParams_User(t *testing.T) {
 func TestParseActionParams_Group(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"name":"developers"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_GROUP), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_GROUP), []byte(params)))
 
 	require.NotNil(t, action.GetGroup())
 	assert.Equal(t, "developers", action.GetGroup().Name)
@@ -119,23 +119,22 @@ func TestParseActionParams_Group(t *testing.T) {
 
 func TestParseActionParams_InvalidJSON(t *testing.T) {
 	action := &pm.Action{}
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_PACKAGE), []byte("not json"))
-
-	// Should not panic and params should remain nil
+	// Malformed params now FAIL CLOSED (#368): an error so the dispatch
+	// handler retries/dead-letters instead of sending empty params.
+	require.Error(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_PACKAGE), []byte("not json")))
 	assert.Nil(t, action.Params)
 }
 
 func TestParseActionParams_UnknownType(t *testing.T) {
 	action := &pm.Action{}
-	actionparams.PopulateAction(action, 9999, []byte(`{"name":"test"}`))
-
-	// Should not panic and params should remain nil for unknown types
+	// An unhandled action type now errors rather than silently no-op'ing (#368).
+	require.Error(t, actionparams.PopulateAction(action, 9999, []byte(`{"name":"test"}`)))
 	assert.Nil(t, action.Params)
 }
 
 func TestParseActionParams_EmptyParams(t *testing.T) {
 	action := &pm.Action{}
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SHELL), []byte("{}"))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_SHELL), []byte("{}")))
 
 	// Should parse without error, Shell should be set (with empty fields)
 	require.NotNil(t, action.GetShell())
@@ -144,7 +143,7 @@ func TestParseActionParams_EmptyParams(t *testing.T) {
 func TestParseActionParams_AppImage(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"url":"https://example.com/app.AppImage"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_APP_IMAGE), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_APP_IMAGE), []byte(params)))
 
 	require.NotNil(t, action.GetApp())
 }
@@ -152,7 +151,7 @@ func TestParseActionParams_AppImage(t *testing.T) {
 func TestParseActionParams_Deb(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"url":"https://example.com/app.deb"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_DEB), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_DEB), []byte(params)))
 
 	require.NotNil(t, action.GetApp())
 }
@@ -160,7 +159,7 @@ func TestParseActionParams_Deb(t *testing.T) {
 func TestParseActionParams_Rpm(t *testing.T) {
 	action := &pm.Action{}
 	params := `{"url":"https://example.com/app.rpm"}`
-	actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_RPM), []byte(params))
+	require.NoError(t, actionparams.PopulateAction(action, int32(pm.ActionType_ACTION_TYPE_RPM), []byte(params)))
 
 	require.NotNil(t, action.GetApp())
 }


### PR DESCRIPTION
Security audit serialization finding — **PopulateAction fails open (High, functional correctness)**.

## The bug
`PopulateAction`/`PopulateManagedAction` unmarshalled each action type with `if err == nil { set }` and returned nothing, so a protojson parse error left the params oneof **nil** and the gateway dispatched the action to the agent with empty params anyway (`task_handlers.go`). A new `ActionType` fell through the 18-case switch with **no default**, producing the same silent nil-params result.

## Fix — fail closed
Both functions now return an error on a parse failure **or** an unhandled action type (param-less REBOOT/SYNC/UNSPECIFIED are classified and return nil). Callers fail closed:
- **gateway dispatch** — returns the error so Asynq retries/dead-letters instead of sending empty params to the agent.
- **internal sync converters** (`dbActionToWireAction`/`dbResolvedActionToWireAction`) — log and **skip** the action rather than syncing empty params.
- **API list/get converter** — logs and returns the action without params (read path).

## Tests
Malformed-params and unknown-type return errors with params unset; param-less types return nil; **self-discovering** `TestPopulateAction_EveryActionTypeHandled` walks the generated `ActionType` enum so a new type without a case fails CI. Existing gateway tests that blessed the old fail-open behaviour updated to assert the fail-closed contract.

Closes #368.