### PR TITLE
fix(control): reject cross-device result spoofing on the inbox (#371)

### DIFF
--- a/internal/api/osquery_handler_test.go
+++ b/internal/api/osquery_handler_test.go
@@ -128,11 +128,12 @@ func TestGetOSQueryResult_Completed(t *testing.T) {
 	rowsJSON, err := json.Marshal(rows)
 	require.NoError(t, err)
 
-	err = st.Queries().CompleteOSQueryResult(ctx, generated.CompleteOSQueryResultParams{
-		QueryID: queryID,
-		Success: true,
-		Error:   "",
-		Rows:    rowsJSON,
+	_, err = st.Queries().CompleteOSQueryResult(ctx, generated.CompleteOSQueryResultParams{
+		QueryID:  queryID,
+		Success:  true,
+		Error:    "",
+		Rows:     rowsJSON,
+		DeviceID: deviceID,
 	})
 	require.NoError(t, err)
 
@@ -165,11 +166,12 @@ func TestGetOSQueryResult_CompletedWithError(t *testing.T) {
 	require.NoError(t, err)
 
 	// Simulate agent error
-	err = st.Queries().CompleteOSQueryResult(ctx, generated.CompleteOSQueryResultParams{
-		QueryID: dispatchResp.Msg.QueryId,
-		Success: false,
-		Error:   "table not found: nonexistent_table",
-		Rows:    []byte("[]"),
+	_, err = st.Queries().CompleteOSQueryResult(ctx, generated.CompleteOSQueryResultParams{
+		QueryID:  dispatchResp.Msg.QueryId,
+		Success:  false,
+		Error:    "table not found: nonexistent_table",
+		Rows:     []byte("[]"),
+		DeviceID: deviceID,
 	})
 	require.NoError(t, err)
 

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -208,6 +208,16 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 
 	existingExec, err := w.store.Repos().Execution.Get(ctx, resultID)
 	if err == nil {
+		// The reporting device must OWN this execution. resultID (an execution
+		// ID) is non-secret, so without this a compromised agent could write
+		// forged results onto another device's execution by supplying its ID
+		// (cross-device result spoofing). The agent-scheduled path below is
+		// already device-safe — its execution ID is derived from deviceID.
+		if existingExec.DeviceID != deviceID {
+			logger.Warn("rejecting execution result: execution belongs to a different device",
+				"execution_device_id", existingExec.DeviceID)
+			return fmt.Errorf("execution %s does not belong to reporting device %s", resultID, deviceID)
+		}
 		executionID = existingExec.ID
 		if existingExec.ActionID != nil {
 			actionID = *existingExec.ActionID
@@ -466,12 +476,24 @@ func (w *InboxWorker) handleOSQueryResult(ctx context.Context, t *asynq.Task) er
 		"success", payload.Success,
 	)
 
-	return w.store.Queries().CompleteOSQueryResult(ctx, db.CompleteOSQueryResultParams{
-		QueryID: payload.QueryID,
-		Success: payload.Success,
-		Error:   payload.Error,
-		Rows:    payload.RowsJSON,
+	n, err := w.store.Queries().CompleteOSQueryResult(ctx, db.CompleteOSQueryResultParams{
+		QueryID:  payload.QueryID,
+		Success:  payload.Success,
+		Error:    payload.Error,
+		Rows:     payload.RowsJSON,
+		DeviceID: payload.DeviceID,
 	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		// No matching pending query for THIS device — either an unknown/expired
+		// query, or a result reported for a query owned by a different device
+		// (cross-device spoofing). Drop it; a retry won't change the match.
+		w.logger.Warn("dropping osquery result: no matching pending query for this device",
+			"query_id", payload.QueryID, "device_id", payload.DeviceID)
+	}
+	return nil
 }
 
 func (w *InboxWorker) handleLogQueryResult(ctx context.Context, t *asynq.Task) error {
@@ -486,12 +508,21 @@ func (w *InboxWorker) handleLogQueryResult(ctx context.Context, t *asynq.Task) e
 		"success", payload.Success,
 	)
 
-	return w.store.Queries().CompleteLogQueryResult(ctx, db.CompleteLogQueryResultParams{
-		QueryID: payload.QueryID,
-		Success: payload.Success,
-		Error:   payload.Error,
-		Logs:    payload.Logs,
+	n, err := w.store.Queries().CompleteLogQueryResult(ctx, db.CompleteLogQueryResultParams{
+		QueryID:  payload.QueryID,
+		Success:  payload.Success,
+		Error:    payload.Error,
+		Logs:     payload.Logs,
+		DeviceID: payload.DeviceID,
 	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		w.logger.Warn("dropping log query result: no matching pending query for this device",
+			"query_id", payload.QueryID, "device_id", payload.DeviceID)
+	}
+	return nil
 }
 
 func (w *InboxWorker) handleInventoryUpdate(ctx context.Context, t *asynq.Task) error {

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -202,6 +202,95 @@ func TestHandleExecutionResult_Success(t *testing.T) {
 	assert.Equal(t, "success", exec.Status)
 }
 
+// TestHandleExecutionResult_RejectsCrossDeviceSpoof pins the fix for
+// cross-device result spoofing: an execution ID is non-secret, so a compromised
+// agent must not be able to write a forged result onto ANOTHER device's
+// execution by supplying its ID. The reporting device must own the execution.
+func TestHandleExecutionResult_RejectsCrossDeviceSpoof(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	mux := worker.NewMux()
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	victimDevice := testutil.CreateTestDevice(t, st, "victim-host")
+	attackerDevice := testutil.CreateTestDevice(t, st, "attacker-host")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Test Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+
+	// Execution owned by the VICTIM device.
+	executionID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "execution",
+		StreamID:   executionID,
+		EventType:  "ExecutionCreated",
+		Data: map[string]any{
+			"device_id":       victimDevice,
+			"action_id":       actionID,
+			"action_type":     int(pm.ActionType_ACTION_TYPE_SHELL),
+			"desired_state":   0,
+			"params":          map[string]any{},
+			"timeout_seconds": 300,
+			"executed_at":     time.Now().Format(time.RFC3339Nano),
+		},
+		ActorType: "user",
+		ActorID:   adminID,
+	}))
+
+	// The ATTACKER device reports a forged result for the victim's execution.
+	result := &pm.ActionResult{
+		ActionId:    &pm.ActionId{Value: executionID},
+		Status:      pm.ExecutionStatus_EXECUTION_STATUS_SUCCESS,
+		CompletedAt: timestamppb.Now(),
+		Output:      &pm.CommandOutput{Stdout: "FORGED", ExitCode: 0},
+	}
+	resultJSON, err := protojson.Marshal(result)
+	require.NoError(t, err)
+	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
+		DeviceID:         attackerDevice,
+		ActionResultJSON: resultJSON,
+	})
+
+	err = mux.ProcessTask(context.Background(), task)
+	require.Error(t, err, "a device must not complete another device's execution")
+
+	// The victim's execution must NOT have been completed by the forged result.
+	exec, err := st.Queries().GetExecutionByID(context.Background(), executionID)
+	require.NoError(t, err)
+	assert.NotEqual(t, "success", exec.Status, "forged result must not update the victim's execution")
+}
+
+// TestHandleOSQueryResult_RejectsCrossDeviceSpoof pins that the device_id WHERE
+// clause prevents a compromised agent from completing another device's pending
+// osquery result by supplying its (non-secret) query_id.
+func TestHandleOSQueryResult_RejectsCrossDeviceSpoof(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	mux := worker.NewMux()
+
+	victimDevice := testutil.CreateTestDevice(t, st, "victim-osq")
+	attackerDevice := testutil.CreateTestDevice(t, st, "attacker-osq")
+	queryID := testutil.NewID()
+	require.NoError(t, st.Queries().CreateOSQueryResult(context.Background(), db.CreateOSQueryResultParams{
+		QueryID:   queryID,
+		DeviceID:  victimDevice,
+		TableName: "processes",
+	}))
+
+	// The attacker device reports a forged result for the victim's query.
+	task := newTask(t, taskqueue.TypeOSQueryResult, taskqueue.OSQueryResultPayload{
+		DeviceID: attackerDevice,
+		QueryID:  queryID,
+		Success:  true,
+		RowsJSON: []byte(`[{"forged":"1"}]`),
+	})
+	// Dropped (0 rows), not a retryable error.
+	require.NoError(t, mux.ProcessTask(context.Background(), task))
+
+	// The victim's query result must remain NOT completed.
+	res, err := st.Queries().GetOSQueryResult(context.Background(), queryID)
+	require.NoError(t, err)
+	assert.False(t, res.Completed, "forged osquery result for another device must be dropped")
+}
+
 func TestHandleExecutionResult_Failed(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())

--- a/internal/store/generated/logs.sql.go
+++ b/internal/store/generated/logs.sql.go
@@ -9,27 +9,35 @@ import (
 	"context"
 )
 
-const completeLogQueryResult = `-- name: CompleteLogQueryResult :exec
+const completeLogQueryResult = `-- name: CompleteLogQueryResult :execrows
 UPDATE log_query_results
 SET completed = TRUE, success = $2, error = $3, logs = $4, completed_at = NOW()
-WHERE query_id = $1
+WHERE query_id = $1 AND device_id = $5
 `
 
 type CompleteLogQueryResultParams struct {
-	QueryID string `json:"query_id"`
-	Success bool   `json:"success"`
-	Error   string `json:"error"`
-	Logs    string `json:"logs"`
+	QueryID  string `json:"query_id"`
+	Success  bool   `json:"success"`
+	Error    string `json:"error"`
+	Logs     string `json:"logs"`
+	DeviceID string `json:"device_id"`
 }
 
-func (q *Queries) CompleteLogQueryResult(ctx context.Context, arg CompleteLogQueryResultParams) error {
-	_, err := q.db.Exec(ctx, completeLogQueryResult,
+// device_id is matched so a compromised agent can't complete another device's
+// query result by supplying its (non-secret) query_id. :execrows lets the
+// caller detect a 0-row update (unknown query or wrong device) and drop it.
+func (q *Queries) CompleteLogQueryResult(ctx context.Context, arg CompleteLogQueryResultParams) (int64, error) {
+	result, err := q.db.Exec(ctx, completeLogQueryResult,
 		arg.QueryID,
 		arg.Success,
 		arg.Error,
 		arg.Logs,
+		arg.DeviceID,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const createLogQueryResult = `-- name: CreateLogQueryResult :exec

--- a/internal/store/generated/osquery.sql.go
+++ b/internal/store/generated/osquery.sql.go
@@ -9,27 +9,35 @@ import (
 	"context"
 )
 
-const completeOSQueryResult = `-- name: CompleteOSQueryResult :exec
+const completeOSQueryResult = `-- name: CompleteOSQueryResult :execrows
 UPDATE osquery_results
 SET completed = TRUE, success = $2, error = $3, rows = $4, completed_at = NOW()
-WHERE query_id = $1
+WHERE query_id = $1 AND device_id = $5
 `
 
 type CompleteOSQueryResultParams struct {
-	QueryID string `json:"query_id"`
-	Success bool   `json:"success"`
-	Error   string `json:"error"`
-	Rows    []byte `json:"rows"`
+	QueryID  string `json:"query_id"`
+	Success  bool   `json:"success"`
+	Error    string `json:"error"`
+	Rows     []byte `json:"rows"`
+	DeviceID string `json:"device_id"`
 }
 
-func (q *Queries) CompleteOSQueryResult(ctx context.Context, arg CompleteOSQueryResultParams) error {
-	_, err := q.db.Exec(ctx, completeOSQueryResult,
+// device_id is matched so a compromised agent can't complete another device's
+// query result by supplying its (non-secret) query_id. :execrows lets the
+// caller detect a 0-row update (unknown query or wrong device) and drop it.
+func (q *Queries) CompleteOSQueryResult(ctx context.Context, arg CompleteOSQueryResultParams) (int64, error) {
+	result, err := q.db.Exec(ctx, completeOSQueryResult,
 		arg.QueryID,
 		arg.Success,
 		arg.Error,
 		arg.Rows,
+		arg.DeviceID,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
 }
 
 const createOSQueryResult = `-- name: CreateOSQueryResult :exec

--- a/internal/store/queries/logs.sql
+++ b/internal/store/queries/logs.sql
@@ -4,10 +4,13 @@
 INSERT INTO log_query_results (query_id, device_id)
 VALUES ($1, $2);
 
--- name: CompleteLogQueryResult :exec
+-- name: CompleteLogQueryResult :execrows
+-- device_id is matched so a compromised agent can't complete another device's
+-- query result by supplying its (non-secret) query_id. :execrows lets the
+-- caller detect a 0-row update (unknown query or wrong device) and drop it.
 UPDATE log_query_results
 SET completed = TRUE, success = $2, error = $3, logs = $4, completed_at = NOW()
-WHERE query_id = $1;
+WHERE query_id = $1 AND device_id = $5;
 
 -- name: GetLogQueryResult :one
 SELECT * FROM log_query_results

--- a/internal/store/queries/osquery.sql
+++ b/internal/store/queries/osquery.sql
@@ -4,10 +4,13 @@
 INSERT INTO osquery_results (query_id, device_id, table_name)
 VALUES ($1, $2, $3);
 
--- name: CompleteOSQueryResult :exec
+-- name: CompleteOSQueryResult :execrows
+-- device_id is matched so a compromised agent can't complete another device's
+-- query result by supplying its (non-secret) query_id. :execrows lets the
+-- caller detect a 0-row update (unknown query or wrong device) and drop it.
 UPDATE osquery_results
 SET completed = TRUE, success = $2, error = $3, rows = $4, completed_at = NOW()
-WHERE query_id = $1;
+WHERE query_id = $1 AND device_id = $5;
 
 -- name: GetOSQueryResult :one
 SELECT * FROM osquery_results


### PR DESCRIPTION
Security audit Medium item — **cross-device result spoofing**.

The inbox worker resolved the target execution/query purely from a message-supplied ID without checking it belongs to the reporting device. Execution/query IDs are 80-bit random but **non-secret** (they flow back to the agent), so a compromised agent that learns device B's outstanding ID could write forged results onto B's streams.

## Fix
- **Execution result:** reject when `existingExec.DeviceID != reportingDevice`. The agent-scheduled path is already device-safe — its execution ID is derived from the device ID.
- **`CompleteOSQueryResult` / `CompleteLogQueryResult`:** add `AND device_id = $5` to the WHERE and switch to `:execrows`; the handler drops + logs a 0-row update (unknown query or wrong device). sqlc regenerated via the pinned Makefile (only the two generated files change).

## Tests
Red→green: a device cannot complete another device's execution (forged result doesn't update the victim's status); the osquery `device_id` filter drops a cross-device completion (LogQuery uses the identical pattern).

Closes #371.