### PR TITLE
fix(api): harden RediSearch query escaping (#373)

### DIFF
--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -444,27 +444,35 @@ func parseFTSearchResult(raw any, scope string) ([]*pm.SearchResult, int32) {
 	return results, int32(total)
 }
 
-// escapeRediSearchQuery escapes special characters that have meaning in RediSearch query syntax.
-func escapeRediSearchQuery(query string) string {
-	special := []string{
-		"@", "!", "{", "}", "(", ")", "|", "-", "=", ">", "[", "]", ":", ";", "~",
-	}
-	result := query
-	for _, ch := range special {
-		result = strings.ReplaceAll(result, ch, "\\"+ch)
-	}
-	return result
+// rediSearchSpecialChars is the full set of characters RediSearch treats
+// specially in query / TAG syntax. Backslash is NOT in this list — it is
+// escaped separately and FIRST in escapeRediSearch.
+var rediSearchSpecialChars = []string{
+	",", ".", "<", ">", "{", "}", "[", "]", "\"", "'", ":", ";", "!", "@",
+	"#", "$", "%", "^", "&", "*", "(", ")", "-", "+", "=", "~", "|", "/",
 }
 
-// escapeRediSearchTagValue escapes special characters in a RediSearch TAG value.
-func escapeRediSearchTagValue(val string) string {
-	special := []string{
-		",", ".", "<", ">", "{", "}", "[", "]", "\"", "'", ":", ";", "!", "@", "#",
-		"$", "%", "^", "&", "*", "(", ")", "-", "+", "=", "~",
+// escapeRediSearch escapes every character RediSearch treats specially so a
+// user-supplied string is matched literally rather than parsed as query syntax.
+//
+// Backslash is escaped FIRST. Otherwise escaping another metacharacter (which
+// inserts a backslash) is re-interpreted and leaves a LIVE operator: the prior
+// code turned `\|` into `\\|` — a literal backslash followed by a live OR — and
+// omitted `% * "` entirely, so a Search-permission holder could manipulate the
+// query scope / build an error oracle. Whitespace is intentionally left alone:
+// in the query path the result is a prefix term (`escaped*`) where spaces are
+// the token separators a multi-word search relies on.
+func escapeRediSearch(s string) string {
+	s = strings.ReplaceAll(s, "\\", "\\\\")
+	for _, ch := range rediSearchSpecialChars {
+		s = strings.ReplaceAll(s, ch, "\\"+ch)
 	}
-	result := val
-	for _, ch := range special {
-		result = strings.ReplaceAll(result, ch, "\\"+ch)
-	}
-	return result
+	return s
 }
+
+// escapeRediSearchQuery escapes a free-text query before it is embedded in a
+// RediSearch query string.
+func escapeRediSearchQuery(query string) string { return escapeRediSearch(query) }
+
+// escapeRediSearchTagValue escapes a RediSearch TAG field value.
+func escapeRediSearchTagValue(val string) string { return escapeRediSearch(val) }

--- a/internal/api/search_handler_test.go
+++ b/internal/api/search_handler_test.go
@@ -23,8 +23,9 @@ func TestBuildFTQuery_EmptyReturnsWildcard(t *testing.T) {
 
 func TestBuildFTQuery_TextWithSpecialChars(t *testing.T) {
 	q := buildFTQuery("user@example.com", nil, nil)
-	// The query escaper escapes @ but NOT dots (dots are only in the tag value escaper)
-	assert.Contains(t, q, "user\\@example.com")
+	// The escaper now neutralises every RediSearch metacharacter (incl. @ and .)
+	// so user input is matched literally rather than parsed as query syntax.
+	assert.Contains(t, q, "user\\@example\\.com")
 }
 
 func TestBuildFTQuery_DateFilterOnly(t *testing.T) {
@@ -130,6 +131,14 @@ func TestEscapeRediSearchQuery(t *testing.T) {
 		{"a:b", "a\\:b"},
 		{"a;b", "a\\;b"},
 		{"a~b", "a\\~b"},
+		// Injection vectors the prior escaper left live (audit). Backslash is
+		// escaped first, so an attacker can't smuggle an operator through.
+		{"a\\b", "a\\\\b"},         // bare backslash -> doubled
+		{"\\|", "\\\\\\|"},         // \| -> escaped backslash + escaped pipe (no live OR)
+		{"\\(", "\\\\\\("},         // \( -> no live group
+		{"%%x%%", "\\%\\%x\\%\\%"}, // fuzzy-match operators neutralised
+		{"a*", "a\\*"},             // user wildcard neutralised
+		{"\"hi\"", "\\\"hi\\\""},   // exact-phrase quotes neutralised
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Security audit Medium item — **RediSearch query escaping leaves live operators**.

`escapeRediSearchQuery` escaped a denylist of metacharacters but **not backslash**, and **not first** — so a user-supplied `\|` became `\\|` (a literal backslash followed by a **live OR** operator), and the query escaper omitted `% * "` and the rest of the reserved set. A Search-permission holder could manipulate the query scope or build an error oracle.

## Fix
- Escape backslash **first**, then the full RediSearch reserved set.
- Unify the query + tag-value escapers on one complete set. Whitespace is intentionally left alone so the prefix-search path (`escaped*`) keeps multi-word tokenisation.

## Tests
The escape test feeds the audit's vectors: `\|`, `\(`, `%%x%%`, `a*`, exact-phrase quotes, and a bare backslash — all neutralised. Existing cases unchanged; the `buildFTQuery` special-char test updated for the now-escaped dot.

Closes #373.