### PR TITLE
fix(api): don't leak raw internal errors to clients (#375)

### DIFF
--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -138,7 +138,8 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		inputs.desiredState = action.DesiredState
 		serialized, err := serializeProtoParams(extractActionParamsMsg(action))
 		if err != nil {
-			return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, fmt.Sprintf("failed to serialize inline action params: %v", err))
+			h.logger.Warn("failed to serialize inline action params", "error", err)
+			return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "failed to serialize inline action params")
 		}
 		inputs.params = serialized
 		inputs.timeoutSeconds = action.TimeoutSeconds

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -198,7 +198,8 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 			if strings.Contains(errMsg, "Unknown index") || strings.Contains(errMsg, "Unknown Index") || strings.Contains(errMsg, "not found") {
 				continue
 			}
-			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, fmt.Sprintf("search index query failed for scope %s: %v", scope, err))
+			h.logger.Error("search index query failed", "scope", scope, "error", err)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "search index query failed")
 		}
 
 		parsed, count := parseFTSearchResult(raw, scope)
@@ -229,7 +230,8 @@ func (h *SearchHandler) RebuildSearchIndex(ctx context.Context, req *connect.Req
 	}
 
 	if err := h.searchIdx.Rebuild(ctx); err != nil {
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, fmt.Sprintf("search index rebuild failed: %v", err))
+		h.logger.Error("search index rebuild failed", "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "search index rebuild failed")
 	}
 
 	return connect.NewResponse(&pm.RebuildSearchIndexResponse{}), nil


### PR DESCRIPTION
Security audit Low item — **raw internal errors leak to clients**.

Three handler spots embedded the raw error in the client-facing `apiError` message via `fmt.Sprintf("...: %v", err)`:
- `search_handler.go` — FT.SEARCH query failure (leaked the raw RediSearch error)
- `search_handler.go` — `RebuildSearchIndex` failure
- `action_dispatch.go` — inline-params serialize failure

All three now **log the error server-side** (structured slog) and return a **static** client message.

Left as-is (correctly, per the audit's 3-site scope): the two `ExecutionFailed.Error` fields at `action_dispatch.go:300/815` are intentional operator-facing execution-failure diagnostics, not client `apiError` messages.

**On tests:** all three branches require dependency-failure injection that isn't cheaply mockable — real redis-stack returns `Unknown index` (which the code already `continue`s past), and `protojson.Marshal` of a valid proto doesn't fail. The change is message-only; success paths are unchanged and covered by existing tests. Flagging explicitly rather than mocking a Redis failure for a Low-severity message-hygiene change — happy to add an integration-level test if you'd prefer.

Closes #375.