### PR TITLE
fix(gateway): cap agent bidi stream read size at 64 MiB (#377)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/oklog/ulid/v2"
 	"github.com/redis/go-redis/v9"
 	"golang.org/x/net/http2"
@@ -35,6 +36,15 @@ import (
 
 // version is set at build time via -ldflags.
 var version = "dev"
+
+// maxAgentMessageBytes caps how many bytes the gateway will read from a single
+// agent message on the mTLS bidi stream. Without a ceiling, a compromised or
+// malicious agent could stream an arbitrarily large message and OOM the
+// gateway. 64 MiB is comfortably above any legitimate single message — agent
+// command output is truncated to 1 MiB control-side, terminal input is capped
+// at 8 MiB, and inventory/osquery payloads are at most a few MiB — while
+// bounding the blast radius of a hostile peer.
+const maxAgentMessageBytes = 64 << 20
 
 func main() {
 	// Parse flags — TLS is always required for mTLS agent connections
@@ -529,7 +539,7 @@ func main() {
 	agentHandler := handler.NewAgentHandlerWithTLS(manager, aqClient, controlProxy, workerMgr, version, cfg.HeartbeatInterval, logger)
 	agentHandler.SetGatewayRouting(gatewayReg, gatewayID)
 	agentHandler.SetTerminalSessions(terminalSessions)
-	path, h := pmv1connect.NewAgentServiceHandler(agentHandler)
+	path, h := pmv1connect.NewAgentServiceHandler(agentHandler, connect.WithReadMaxBytes(maxAgentMessageBytes))
 
 	// Compose middlewares (innermost first):
 	//   pmv1connect handler


### PR DESCRIPTION
Security audit DoS-hardening item — **unbounded agent bidi read**.

The gateway mounted `pmv1connect.NewAgentServiceHandler(agentHandler)` with **no read-size ceiling**, so a compromised/malicious agent could stream an arbitrarily large message on the mTLS bidi stream and OOM the gateway.

## Fix
`connect.WithReadMaxBytes(64 << 20)` — 64 MiB is comfortably above any legitimate single agent message (command output is truncated to 1 MiB control-side, terminal input is capped at 8 MiB, inventory/osquery payloads are a few MiB) while bounding the blast radius of a hostile peer. Value chosen with you.

**Scope:** the agent bidi handler only. The control↔gateway `GatewayService` / `InternalService` are trusted-peer (admitted by the control cert) and weren't flagged — capping them risks breaking legitimate large internal requests; noted as optional defense-in-depth.

**On tests:** enforcing `WithReadMaxBytes` meaningfully needs a full connect server + an oversized message, and the value lives in package `main` (awkward to test); a small-cap wiring test wouldn't pin the production value and a real-size test allocates 64+ MiB. The const + wiring are inspection-verifiable and connect's enforcement is library-tested. Flagging explicitly per the agreed approach.

Closes #377.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added read-size limit safeguard (64 MiB) to the agent service handler on mTLS bidirectional streams to prevent oversized messages from being processed, improving system stability and resource protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->