### PR TITLE
fix(auth): make the TOTP login challenge single-use (#379)

### DIFF
--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -17,6 +18,12 @@ import (
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
+// totpChallengeConsumeWindow is how long a consumed TOTP-login-challenge JTI is
+// remembered. It MUST exceed the challenge JWT's 5-minute TTL (jwt.go) so a
+// still-valid challenge can never outlive its "already consumed" marker —
+// otherwise the single-use guard would silently lapse near the token's expiry.
+const totpChallengeConsumeWindow = 6 * time.Minute
+
 // TOTPHandler handles TOTP two-factor authentication RPCs.
 type TOTPHandler struct {
 	store      *store.Store
@@ -24,6 +31,12 @@ type TOTPHandler struct {
 	jwtManager *auth.JWTManager
 	encryptor  *crypto.Encryptor
 	issuer     string
+	// challengeConsumer enforces single-use of the TOTP login challenge: a
+	// limit-1 sliding window keyed by challenge JTI, so the first VerifyLoginTOTP
+	// for a given challenge is admitted and every later one (even with a valid
+	// code) is rejected. Without it the challenge JWT is replayable for its full
+	// 5-min life — unlimited TOTP guesses per single password step.
+	challengeConsumer *auth.RateLimiter
 }
 
 // NewTOTPHandler creates a new TOTP handler.
@@ -32,11 +45,12 @@ func NewTOTPHandler(st *store.Store, logger *slog.Logger, jwtManager *auth.JWTMa
 		issuer = totp.DefaultIssuer
 	}
 	return &TOTPHandler{
-		store:      st,
-		logger:     logger,
-		jwtManager: jwtManager,
-		encryptor:  enc,
-		issuer:     issuer,
+		store:             st,
+		logger:            logger,
+		jwtManager:        jwtManager,
+		encryptor:         enc,
+		issuer:            issuer,
+		challengeConsumer: auth.NewRateLimiter(1, totpChallengeConsumeWindow),
 	}
 }
 
@@ -321,6 +335,16 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 	claims, err := h.jwtManager.ValidateToken(req.Msg.Challenge, auth.TokenTypeTOTPChallenge)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrTOTPChallengeExpired, connect.CodeFailedPrecondition, "invalid or expired TOTP challenge")
+	}
+
+	// Single-use: consume the challenge by its JTI as soon as it validates, so a
+	// challenge is worth exactly ONE VerifyLoginTOTP attempt. Without this the
+	// challenge JWT is replayable for its full 5-minute life — unlimited TOTP
+	// guesses per single password step. Fail closed: any later presentation
+	// (even with a valid code) is rejected and the user must re-authenticate
+	// with their password (which is IP-rate-limited).
+	if !h.challengeConsumer.Allow(claims.ID) {
+		return nil, apiErrorCtx(ctx, ErrTOTPChallengeExpired, connect.CodeFailedPrecondition, "TOTP challenge already used")
 	}
 
 	// Get TOTP record

--- a/internal/api/totp_handler_test.go
+++ b/internal/api/totp_handler_test.go
@@ -249,6 +249,84 @@ func TestVerifyLoginTOTP_Success(t *testing.T) {
 	assert.Equal(t, email, resp.Msg.User.Email)
 }
 
+// TestVerifyLoginTOTP_ChallengeIsSingleUse pins that a TOTP login challenge is
+// usable exactly once: after a successful verification the same challenge JWT
+// (still well within its 5-min TTL) is rejected, even with a fresh valid code.
+// Without this the challenge is replayable for its whole life.
+func TestVerifyLoginTOTP_ChallengeIsSingleUse(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	enc := testutil.NewEncryptor(t)
+	h := api.NewTOTPHandler(st, slog.Default(), jwtMgr, enc, "TestApp")
+
+	email := testutil.NewID() + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "password", "user")
+	secret := testutil.SetupTOTP(t, st, enc, userID, email)
+
+	challenge, err := jwtMgr.GenerateTOTPChallenge(userID, email, 0)
+	require.NoError(t, err)
+
+	code, err := totp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+
+	// First use succeeds.
+	_, err = h.VerifyLoginTOTP(context.Background(), connect.NewRequest(&pm.VerifyLoginTOTPRequest{
+		Challenge: challenge,
+		Code:      code,
+	}))
+	require.NoError(t, err)
+
+	// Reusing the SAME challenge is rejected, even with a fresh valid code.
+	freshCode, err := totp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+	_, err = h.VerifyLoginTOTP(context.Background(), connect.NewRequest(&pm.VerifyLoginTOTPRequest{
+		Challenge: challenge,
+		Code:      freshCode,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "already used")
+}
+
+// TestVerifyLoginTOTP_WrongCodeStillConsumesChallenge pins consume-on-
+// presentation: even a FAILED first attempt burns the challenge, so an attacker
+// cannot brute-force multiple codes against one challenge. The wrong guess
+// burns it; a subsequent correct code on the same challenge is rejected, NOT
+// accepted.
+func TestVerifyLoginTOTP_WrongCodeStillConsumesChallenge(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	enc := testutil.NewEncryptor(t)
+	h := api.NewTOTPHandler(st, slog.Default(), jwtMgr, enc, "TestApp")
+
+	email := testutil.NewID() + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "password", "user")
+	secret := testutil.SetupTOTP(t, st, enc, userID, email)
+
+	challenge, err := jwtMgr.GenerateTOTPChallenge(userID, email, 0)
+	require.NoError(t, err)
+
+	// First attempt with a wrong code fails (and consumes the challenge).
+	_, err = h.VerifyLoginTOTP(context.Background(), connect.NewRequest(&pm.VerifyLoginTOTPRequest{
+		Challenge: challenge,
+		Code:      "000000",
+	}))
+	require.Error(t, err)
+
+	// A correct code on the SAME challenge must now be rejected as already used,
+	// not accepted — proving the wrong guess burned the one allowed attempt.
+	code, err := totp.GenerateCode(secret, time.Now())
+	require.NoError(t, err)
+	resp, err := h.VerifyLoginTOTP(context.Background(), connect.NewRequest(&pm.VerifyLoginTOTPRequest{
+		Challenge: challenge,
+		Code:      code,
+	}))
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "already used")
+}
+
 func TestVerifyLoginTOTP_InvalidCode(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	jwtMgr := testutil.NewJWTManager()


### PR DESCRIPTION
Security audit (line 172, **part 1 of 2**) — **TOTP login challenge is replayable**.

The TOTP challenge JWT issued after the password step was validated by `VerifyLoginTOTP` but **never consumed**, so it stayed valid for its full 5-minute TTL: an attacker who cleared the password step could replay one challenge for unlimited TOTP guesses.

## Fix
Consume the challenge by its JTI the instant it validates (a limit-1 sliding window keyed by JTI, window 6m > the 5m challenge TTL), **before** the code check. A challenge is now worth exactly one `VerifyLoginTOTP` attempt and even a wrong guess burns it. Fail closed — any later presentation (even with a valid code) is rejected and the user must re-authenticate with their password (which is IP-rate-limited). Reuses `ErrTOTPChallengeExpired` → no cross-repo error-code change.

## Tests
- A reused challenge is rejected even with a **fresh valid code**.
- A **wrong** first guess burns the challenge, so a later **correct** code on the same challenge is rejected — proving consume-on-presentation, not consume-on-success.

## Scope
Part 1 of 2 for the audit's per-account login/TOTP hardening. Decision confirmed with maintainer: **consume-on-first-use**. The per-account failed-attempt rate-limit dimension follows in a separate PR.

Closes #379.