### PR TITLE
fix(auth): per-account failed-login/TOTP rate limit (#381)

### DIFF
--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -4,6 +4,8 @@ package api
 import (
 	"context"
 	"log/slog"
+	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -15,12 +17,26 @@ import (
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
+// Per-account login throttle: at most loginAccountFailLimit FAILED password
+// attempts per account within loginAccountFailWindow, independent of source IP.
+// The interceptor's IP limiter is bypassable by rotating IPs, so a targeted
+// admin needs an account-keyed ceiling too. Only FAILURES are counted, so a
+// legitimate user's normal/successful logins never accrue toward it.
+const (
+	loginAccountFailLimit  = 10
+	loginAccountFailWindow = 15 * time.Minute
+)
+
 // AuthHandler handles authentication RPCs.
 type AuthHandler struct {
 	store               *store.Store
 	logger              *slog.Logger
 	jwtManager          *auth.JWTManager
 	passwordAuthEnabled bool
+	// loginAccountLimiter throttles FAILED password attempts per account
+	// (keyed by normalised email), closing the IP-rotation bypass on the
+	// interceptor's per-IP login limiter.
+	loginAccountLimiter *auth.RateLimiter
 }
 
 // NewAuthHandler creates a new auth handler. The passwordAuthEnabled flag
@@ -35,6 +51,7 @@ func NewAuthHandler(st *store.Store, logger *slog.Logger, jwtManager *auth.JWTMa
 		logger:              logger,
 		jwtManager:          jwtManager,
 		passwordAuthEnabled: passwordAuthEnabled,
+		loginAccountLimiter: auth.NewRateLimiter(loginAccountFailLimit, loginAccountFailWindow),
 	}
 }
 
@@ -52,11 +69,27 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 		return nil, apiErrorCtx(ctx, ErrPasswordLoginDisabled, connect.CodeUnauthenticated, "password login is disabled on this server")
 	}
 
+	// Per-account brute-force ceiling. Checked BEFORE the user lookup so the
+	// response is identical whether or not the account exists (no enumeration
+	// signal) and so a blocked account spends no bcrypt cycles. Keyed by
+	// normalised email; only failed attempts are counted (below), so it never
+	// throttles a legitimate user's successful logins. This closes the
+	// IP-rotation bypass on the interceptor's per-IP login limiter (#381).
+	acctKey := "login:" + strings.ToLower(strings.TrimSpace(req.Msg.Email))
+	if h.loginAccountLimiter.Blocked(acctKey) {
+		return nil, apiErrorCtx(ctx, ErrRateLimited, connect.CodeResourceExhausted, "too many failed login attempts for this account, try again later")
+	}
+
 	user, err := h.store.Repos().User.GetByEmail(ctx, req.Msg.Email)
 	if err != nil {
 		if store.IsNotFound(err) {
 			// Perform a dummy bcrypt comparison to prevent timing-based user enumeration
 			auth.VerifyPassword(req.Msg.Password, auth.DummyHash)
+			// Count the failure for the per-account ceiling. Recording for a
+			// non-existent email too keeps the behaviour identical to a real
+			// account (no enumeration), and an attacker spraying one address is
+			// still throttled.
+			h.loginAccountLimiter.Allow(acctKey)
 			return nil, apiErrorCtx(ctx, ErrInvalidCredentials, connect.CodeUnauthenticated, "invalid credentials")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up user")
@@ -74,6 +107,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 	}
 
 	if !auth.VerifyPassword(req.Msg.Password, derefPasswordHash(user.PasswordHash)) {
+		h.loginAccountLimiter.Allow(acctKey) // count the failed attempt
 		return nil, apiErrorCtx(ctx, ErrInvalidCredentials, connect.CodeUnauthenticated, "invalid credentials")
 	}
 

--- a/internal/api/auth_handler_test.go
+++ b/internal/api/auth_handler_test.go
@@ -53,6 +53,67 @@ func TestLogin_WrongPassword(t *testing.T) {
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
 }
 
+// TestLogin_PerAccountFailedAttemptLimit pins the per-account brute-force
+// ceiling (#381): after loginAccountFailLimit (10) failed password attempts the
+// account is throttled regardless of source IP — and the throttle is by
+// ACCOUNT, not credentials, so even a subsequent CORRECT password is rejected.
+func TestLogin_PerAccountFailedAttemptLimit(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	h := api.NewAuthHandler(st, slog.Default(), jwtMgr, true)
+
+	email := testutil.NewID() + "@test.com"
+	testutil.CreateTestUser(t, st, email, "correct-password", "user")
+
+	for i := 0; i < 10; i++ {
+		_, err := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+			Email:    email,
+			Password: "wrong-password",
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err), "failed attempt %d should be invalid-credentials, not yet throttled", i+1)
+	}
+
+	// 11th: blocked even with the CORRECT password (throttle is account-level).
+	_, err := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email:    email,
+		Password: "correct-password",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err), "account should be throttled after 10 failures")
+
+	// A different account has an independent budget.
+	other := testutil.NewID() + "@test.com"
+	testutil.CreateTestUser(t, st, other, "correct-password", "user")
+	resp, err := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email:    other,
+		Password: "correct-password",
+	}))
+	require.NoError(t, err, "a different account must not be affected by another account's failures")
+	assert.NotEmpty(t, resp.Msg.AccessToken)
+}
+
+// TestLogin_SuccessfulLoginsNotThrottled pins that ONLY failures accrue toward
+// the per-account ceiling: repeated SUCCESSFUL logins (more than the failure
+// limit) are never throttled, so a legitimate user is unaffected (#381).
+func TestLogin_SuccessfulLoginsNotThrottled(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	h := api.NewAuthHandler(st, slog.Default(), jwtMgr, true)
+
+	email := testutil.NewID() + "@test.com"
+	testutil.CreateTestUser(t, st, email, "correct-password", "user")
+
+	for i := 0; i < 12; i++ {
+		resp, err := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+			Email:    email,
+			Password: "correct-password",
+		}))
+		require.NoError(t, err, "successful login %d must not be throttled", i+1)
+		assert.NotEmpty(t, resp.Msg.AccessToken)
+	}
+}
+
 func TestLogin_NonexistentUser(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	jwtMgr := testutil.NewJWTManager()

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -24,6 +24,15 @@ import (
 // otherwise the single-use guard would silently lapse near the token's expiry.
 const totpChallengeConsumeWindow = 6 * time.Minute
 
+// Per-account TOTP throttle: at most totpAccountFailLimit FAILED VerifyLoginTOTP
+// attempts per account within totpAccountFailWindow, independent of source IP.
+// Defence-in-depth alongside the single-use challenge — bounds 2FA-bypass
+// guessing against a targeted account even across rotating IPs/challenges.
+const (
+	totpAccountFailLimit  = 10
+	totpAccountFailWindow = 15 * time.Minute
+)
+
 // TOTPHandler handles TOTP two-factor authentication RPCs.
 type TOTPHandler struct {
 	store      *store.Store
@@ -37,6 +46,9 @@ type TOTPHandler struct {
 	// code) is rejected. Without it the challenge JWT is replayable for its full
 	// 5-min life — unlimited TOTP guesses per single password step.
 	challengeConsumer *auth.RateLimiter
+	// totpAccountLimiter throttles FAILED TOTP login attempts per account
+	// (keyed by user ID), independent of source IP.
+	totpAccountLimiter *auth.RateLimiter
 }
 
 // NewTOTPHandler creates a new TOTP handler.
@@ -45,12 +57,13 @@ func NewTOTPHandler(st *store.Store, logger *slog.Logger, jwtManager *auth.JWTMa
 		issuer = totp.DefaultIssuer
 	}
 	return &TOTPHandler{
-		store:             st,
-		logger:            logger,
-		jwtManager:        jwtManager,
-		encryptor:         enc,
-		issuer:            issuer,
-		challengeConsumer: auth.NewRateLimiter(1, totpChallengeConsumeWindow),
+		store:              st,
+		logger:             logger,
+		jwtManager:         jwtManager,
+		encryptor:          enc,
+		issuer:             issuer,
+		challengeConsumer:  auth.NewRateLimiter(1, totpChallengeConsumeWindow),
+		totpAccountLimiter: auth.NewRateLimiter(totpAccountFailLimit, totpAccountFailWindow),
 	}
 }
 
@@ -337,6 +350,14 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 		return nil, apiErrorCtx(ctx, ErrTOTPChallengeExpired, connect.CodeFailedPrecondition, "invalid or expired TOTP challenge")
 	}
 
+	// Per-account brute-force ceiling. Checked before the challenge is consumed
+	// so a blocked account neither burns its challenge nor does TOTP work. Only
+	// failed attempts are counted (below), independent of source IP.
+	totpAcctKey := "totp:" + claims.UserID
+	if h.totpAccountLimiter.Blocked(totpAcctKey) {
+		return nil, apiErrorCtx(ctx, ErrRateLimited, connect.CodeResourceExhausted, "too many failed TOTP attempts for this account, try again later")
+	}
+
 	// Single-use: consume the challenge by its JTI as soon as it validates, so a
 	// challenge is worth exactly ONE VerifyLoginTOTP attempt. Without this the
 	// challenge JWT is replayable for its full 5-minute life — unlimited TOTP
@@ -475,6 +496,7 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 	}
 
 	if !codeValid {
+		h.totpAccountLimiter.Allow(totpAcctKey) // count the failed 2FA attempt
 		return nil, apiErrorCtx(ctx, ErrTOTPInvalid, connect.CodeInvalidArgument, "invalid TOTP code")
 	}
 

--- a/internal/api/totp_handler_test.go
+++ b/internal/api/totp_handler_test.go
@@ -327,6 +327,43 @@ func TestVerifyLoginTOTP_WrongCodeStillConsumesChallenge(t *testing.T) {
 	assert.Contains(t, err.Error(), "already used")
 }
 
+// TestVerifyLoginTOTP_PerAccountFailedAttemptLimit pins the per-account 2FA
+// brute-force ceiling (#381): after totpAccountFailLimit (10) failed
+// VerifyLoginTOTP attempts the account is throttled, independent of source IP
+// and even with a fresh valid challenge. Uses a no-backup-code TOTP user so the
+// 11 failed attempts don't each run the bcrypt backup-code loop.
+func TestVerifyLoginTOTP_PerAccountFailedAttemptLimit(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	enc := testutil.NewEncryptor(t)
+	h := api.NewTOTPHandler(st, slog.Default(), jwtMgr, enc, "TestApp")
+
+	email := testutil.NewID() + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "password", "user")
+	testutil.SetupTOTPCheapBackup(t, st, enc, userID, email)
+
+	for i := 0; i < 10; i++ {
+		challenge, err := jwtMgr.GenerateTOTPChallenge(userID, email, 0)
+		require.NoError(t, err)
+		_, err = h.VerifyLoginTOTP(context.Background(), connect.NewRequest(&pm.VerifyLoginTOTPRequest{
+			Challenge: challenge,
+			Code:      "000000",
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err), "attempt %d should be invalid TOTP, not yet throttled", i+1)
+	}
+
+	// 11th: a fresh, valid challenge — but the account is now throttled.
+	challenge, err := jwtMgr.GenerateTOTPChallenge(userID, email, 0)
+	require.NoError(t, err)
+	_, err = h.VerifyLoginTOTP(context.Background(), connect.NewRequest(&pm.VerifyLoginTOTPRequest{
+		Challenge: challenge,
+		Code:      "000000",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err), "account should be throttled after 10 failed TOTP attempts")
+}
+
 func TestVerifyLoginTOTP_InvalidCode(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	jwtMgr := testutil.NewJWTManager()

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -82,6 +82,25 @@ func (rl *RateLimiter) Allow(key string) bool {
 	return true
 }
 
+// Blocked reports whether key is already at or over the limit within the
+// current window, WITHOUT recording an attempt. Use it to gate an action up
+// front, then call Allow only on the outcomes you want to count (e.g. record
+// only failed logins, so successful logins never accrue toward a per-account
+// brute-force ceiling).
+func (rl *RateLimiter) Blocked(key string) bool {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	cutoff := time.Now().Add(-rl.window)
+	valid := 0
+	for _, t := range rl.attempts[key] {
+		if t.After(cutoff) {
+			valid++
+		}
+	}
+	return valid >= rl.limit
+}
+
 // evictEldestLocked removes the single key with the oldest lastSeen
 // timestamp. Caller must hold rl.mu. O(n) scan — only called on the
 // rare path where the map is at the key ceiling, so the cost lives in

--- a/internal/auth/ratelimit_test.go
+++ b/internal/auth/ratelimit_test.go
@@ -79,3 +79,26 @@ func TestRateLimiter_ConcurrentAccess(t *testing.T) {
 
 	assert.Equal(t, 100, trueCount, "exactly 100 attempts should be allowed")
 }
+
+// TestRateLimiter_Blocked pins the read-only check used by the per-account
+// login/TOTP ceiling: Blocked reports whether the key is at/over the limit
+// WITHOUT recording an attempt, so callers can gate up front and count only the
+// outcomes they choose (e.g. only failed logins).
+func TestRateLimiter_Blocked(t *testing.T) {
+	rl := NewRateLimiter(3, time.Minute)
+
+	// Read-only: many Blocked calls must never record an attempt.
+	for i := 0; i < 50; i++ {
+		assert.False(t, rl.Blocked("k"), "Blocked must not record attempts")
+	}
+
+	rl.Allow("k") // 1
+	assert.False(t, rl.Blocked("k"))
+	rl.Allow("k") // 2
+	assert.False(t, rl.Blocked("k"))
+	rl.Allow("k") // 3 == limit
+	assert.True(t, rl.Blocked("k"), "at the limit the key is blocked")
+
+	// Keys are independent.
+	assert.False(t, rl.Blocked("other"))
+}

--- a/internal/testutil/factories_idp.go
+++ b/internal/testutil/factories_idp.go
@@ -78,6 +78,58 @@ func SetupTOTP(t *testing.T, st *store.Store, enc *crypto.Encryptor, userID, ema
 	return key.Secret()
 }
 
+// SetupTOTPCheapBackup enables TOTP for a user with a SINGLE backup code whose
+// hash uses bcrypt.MinCost, and returns the plaintext secret. Use it in tests
+// that drive many FAILED VerifyLoginTOTP attempts: SetupTOTP provisions
+// BackupCodeCount codes at the production bcrypt cost, so every failed attempt
+// runs that many slow bcrypt compares (~seconds each). One MinCost code keeps
+// the backup-code path valid — an empty array fails the TOTP projection's
+// NOT NULL array column — while making each failed attempt cheap.
+func SetupTOTPCheapBackup(t *testing.T, st *store.Store, enc *crypto.Encryptor, userID, email string) string {
+	t.Helper()
+	ctx := context.Background()
+
+	key, err := totp.GenerateKey("Test", email)
+	if err != nil {
+		t.Fatalf("generate TOTP key: %v", err)
+	}
+	encryptedSecret, err := enc.Encrypt(key.Secret())
+	if err != nil {
+		t.Fatalf("encrypt TOTP secret: %v", err)
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte("unused-test-backup-code"), bcrypt.MinCost)
+	if err != nil {
+		t.Fatalf("hash backup code: %v", err)
+	}
+
+	if err := st.AppendEvent(ctx, store.Event{
+		StreamType: "totp",
+		StreamID:   userID,
+		EventType:  string(eventtypes.TOTPSetupInitiated),
+		Data: map[string]any{
+			"secret_encrypted":  encryptedSecret,
+			"backup_codes_hash": []string{string(hash)},
+		},
+		ActorType: "user",
+		ActorID:   userID,
+	}); err != nil {
+		t.Fatalf("setup TOTP (cheap backup): %v", err)
+	}
+	if err := st.AppendEvent(ctx, store.Event{
+		StreamType: "totp",
+		StreamID:   userID,
+		EventType:  string(eventtypes.TOTPVerified),
+		Data:       map[string]any{},
+		ActorType:  "user",
+		ActorID:    userID,
+	}); err != nil {
+		t.Fatalf("verify TOTP (cheap backup): %v", err)
+	}
+
+	return key.Secret()
+}
+
 // CreateTestIdentityProvider creates an identity provider via events and returns the provider ID.
 func CreateTestIdentityProvider(t *testing.T, st *store.Store, enc *crypto.Encryptor, actorID, name, slug string) string {
 	t.Helper()


### PR DESCRIPTION
Security audit (line 172, **part 2 of 2**) — **login/TOTP rate limiting is IP-only**, so rotating IPs bypasses the ceiling on a targeted admin.

## Fix
A per-account FAILED-attempt limiter on both credential steps, independent of source IP:
- **`RateLimiter.Blocked(key)`** — read-only check (counts non-expired attempts without recording), so callers gate up front and `Allow()` only on the outcomes they choose to count.
- **Login** — keyed by normalised email; blocked **before the user lookup** so the response is identical for existent/non-existent accounts (no enumeration) and a blocked account spends no bcrypt cycles. Records on the not-found and wrong-password paths.
- **VerifyLoginTOTP** — keyed by user ID; blocked before the challenge is consumed; records on the invalid-code path. Defence-in-depth alongside the single-use challenge (#379).

Only **failures** are counted, so legitimate successful logins never accrue — this is a per-account throttle, **not** a hard `locked_until` lockout (which would let an attacker DoS a target admin). Decision confirmed with maintainer. Limit: 10 failures / 15 min per account.

## Tests
- `Blocked()` transitions at the limit and never records.
- 10 failed logins throttle the 11th **even with the correct password**; a different account is unaffected.
- More than the limit in **successful** logins are never throttled.
- The TOTP path throttles after 10 failed `VerifyLoginTOTP`.
- New `testutil.SetupTOTPCheapBackup` provisions one MinCost backup code so the many-failed-attempt TOTP test avoids the production-cost backup-code bcrypt loop (an empty array fails the projection's NOT NULL array column).

Closes #381.