### PR TITLE
fix(auth): close user-enumeration oracles on Login + ListAuthMethods (#383)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -261,11 +261,12 @@ func main() {
 	// share one limiter — they're all auth-attempt vectors that a
 	// defender treats as one logical "attempt" per IP.
 	rateLimiters := auth.RateLimiters{
-		Login:     auth.NewRateLimiter(10, 1*time.Minute), // credential-spray defense
-		Refresh:   auth.NewRateLimiter(60, 1*time.Minute), // legitimate refreshes are frequent
-		Register:  auth.NewRateLimiter(5, 1*time.Minute),  // registration spam protection
-		Logout:    auth.NewRateLimiter(30, 1*time.Minute), // legitimate multi-session logout ceiling
-		RenewCert: auth.NewRateLimiter(5, 1*time.Minute),  // cert rotation = once/lifetime, not in tight loop
+		Login:       auth.NewRateLimiter(10, 1*time.Minute), // credential-spray defense
+		Refresh:     auth.NewRateLimiter(60, 1*time.Minute), // legitimate refreshes are frequent
+		Register:    auth.NewRateLimiter(5, 1*time.Minute),  // registration spam protection
+		Logout:      auth.NewRateLimiter(30, 1*time.Minute), // legitimate multi-session logout ceiling
+		RenewCert:   auth.NewRateLimiter(5, 1*time.Minute),  // cert rotation = once/lifetime, not in tight loop
+		AuthMethods: auth.NewRateLimiter(30, 1*time.Minute), // unauth email-lookup oracle — bound bulk enumeration
 	}
 
 	interceptors := connect.WithInterceptors(

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -95,15 +95,33 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up user")
 	}
 
-	// Check password eligibility
+	// Check password eligibility. An SSO-only account (no password) must be
+	// INDISTINGUISHABLE from a non-existent account or a wrong password to an
+	// unauthenticated caller — same timing (dummy bcrypt), same per-account
+	// throttle accounting, same generic error. The prior fast-path + distinct
+	// "password login is not available" error was a user-enumeration oracle
+	// (audit). The login UI learns the right method from the (now rate-limited)
+	// ListAuthMethods, not from this error.
 	if !user.HasPassword {
-		return nil, apiErrorCtx(ctx, ErrPasswordLoginDisabled, connect.CodeUnauthenticated, "password login is not available for this account")
+		auth.VerifyPassword(req.Msg.Password, auth.DummyHash)
+		h.loginAccountLimiter.Allow(acctKey)
+		return nil, apiErrorCtx(ctx, ErrInvalidCredentials, connect.CodeUnauthenticated, "invalid credentials")
 	}
 
-	// Check if any linked provider disables password login
+	// A linked provider that disables password login gets the SAME enumeration-
+	// safe response — no provider-name disclosure to an unauthenticated caller.
+	// Fail CLOSED on a query error: the prior `if err == nil` swallowed a
+	// transient DB failure and fell through to password verification, letting a
+	// provider-disabled account authenticate. A lookup error denies login.
 	disablingProviders, err := h.store.Queries().GetLinkedProvidersDisablingPassword(ctx, user.ID)
-	if err == nil && len(disablingProviders) > 0 {
-		return nil, apiErrorCtx(ctx, ErrPasswordLoginDisabled, connect.CodeUnauthenticated, "password login is disabled; use "+disablingProviders[0].Name+" to sign in")
+	if err != nil {
+		h.logger.Error("failed to check provider password restrictions", "user_id", user.ID, "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to verify login eligibility")
+	}
+	if len(disablingProviders) > 0 {
+		auth.VerifyPassword(req.Msg.Password, auth.DummyHash)
+		h.loginAccountLimiter.Allow(acctKey)
+		return nil, apiErrorCtx(ctx, ErrInvalidCredentials, connect.CodeUnauthenticated, "invalid credentials")
 	}
 
 	if !auth.VerifyPassword(req.Msg.Password, derefPasswordHash(user.PasswordHash)) {

--- a/internal/api/auth_handler_test.go
+++ b/internal/api/auth_handler_test.go
@@ -394,14 +394,18 @@ func TestLogin_PasswordDisabledByProvider(t *testing.T) {
 	// Link the user to this provider
 	testutil.CreateTestIdentityLink(t, st, userID, providerID, "corp-ext-123", email)
 
-	// Login with correct password should still be rejected
+	// Login with the correct password is still rejected — but enumeration-safely:
+	// the SAME generic error as a wrong password / non-existent account, with NO
+	// disclosure that the account exists or which provider disables it.
 	_, err = h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
 		Email:    email,
 		Password: "password",
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
-	assert.Contains(t, err.Error(), "password login is disabled")
+	assert.Contains(t, err.Error(), "invalid credentials")
+	assert.NotContains(t, err.Error(), "Corporate SSO", "must not disclose the provider name")
+	assert.NotContains(t, err.Error(), "disabled", "must not disclose that the account exists / is provider-disabled")
 }
 
 func TestLogin_SSOOnlyUserNoPassword(t *testing.T) {
@@ -414,14 +418,54 @@ func TestLogin_SSOOnlyUserNoPassword(t *testing.T) {
 	err := st.AppendEvent(context.Background(), testutil.SSOOnlyUserEvent(userID, email))
 	require.NoError(t, err)
 
-	// Login attempt should fail because user has no password
+	// Login fails because the user has no password — but enumeration-safely: the
+	// SAME generic error as a wrong password / non-existent account, so an
+	// SSO-only account can't be distinguished from one that doesn't exist.
 	_, err = h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
 		Email:    email,
 		Password: "anything",
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
-	assert.Contains(t, err.Error(), "password login is not available")
+	assert.Contains(t, err.Error(), "invalid credentials")
+	assert.NotContains(t, err.Error(), "not available", "must not disclose that the account is SSO-only")
+}
+
+// TestLogin_EnumerationSafe_IdenticalErrors pins that an unauthenticated caller
+// cannot tell a non-existent account, an SSO-only account, and a real account
+// with a wrong password apart: all three return the IDENTICAL Unauthenticated
+// "invalid credentials" error (audit user-enumeration fix). Timing parity comes
+// from the dummy bcrypt each path runs.
+func TestLogin_EnumerationSafe_IdenticalErrors(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	h := api.NewAuthHandler(st, slog.Default(), jwtMgr, true)
+
+	// Real account with a password (we'll send a wrong one).
+	pwEmail := testutil.NewID() + "@test.com"
+	testutil.CreateTestUser(t, st, pwEmail, "correct-password", "user")
+
+	// SSO-only account (no password).
+	ssoEmail := testutil.NewID() + "@test.com"
+	require.NoError(t, st.AppendEvent(context.Background(), testutil.SSOOnlyUserEvent(testutil.NewID(), ssoEmail)))
+
+	// Non-existent account.
+	missingEmail := testutil.NewID() + "@test.com"
+
+	errFor := func(email string) error {
+		_, err := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{Email: email, Password: "wrong-password"}))
+		return err
+	}
+	wrongPw := errFor(pwEmail)
+	ssoOnly := errFor(ssoEmail)
+	missing := errFor(missingEmail)
+
+	for _, e := range []error{wrongPw, ssoOnly, missing} {
+		require.Error(t, e)
+		assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(e))
+	}
+	assert.Equal(t, wrongPw.Error(), ssoOnly.Error(), "SSO-only must be indistinguishable from a wrong password")
+	assert.Equal(t, wrongPw.Error(), missing.Error(), "non-existent must be indistinguishable from a wrong password")
 }
 
 func TestLogin_UserHasPassword(t *testing.T) {

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -246,12 +246,17 @@ func clientIP(req connect.AnyRequest) string {
 //   - Register                              → Register
 //   - Logout                                → Logout
 //   - RenewCertificate                      → RenewCert
+//   - ListAuthMethods                       → AuthMethods
 type RateLimiters struct {
 	Login     *RateLimiter
 	Refresh   *RateLimiter
 	Register  *RateLimiter
 	Logout    *RateLimiter
 	RenewCert *RateLimiter
+	// AuthMethods throttles the unauthenticated ListAuthMethods lookup, which
+	// reflects whether an email exists and its auth config — an enumeration
+	// oracle if left unthrottled (audit). Keyed by client IP.
+	AuthMethods *RateLimiter
 }
 
 // AuthInterceptor provides Connect-RPC authentication interceptor.
@@ -322,6 +327,19 @@ func (i *AuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			if !i.limiters.RenewCert.Allow(ip) {
 				i.logger.Warn("rate limit exceeded", "limiter", "renew_cert", "ip", ip, "procedure", procedure)
 				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many certificate renewal attempts, try again later")
+			}
+		}
+
+		// Rate limit ListAuthMethods — public, unauthenticated procedure. It
+		// reflects whether an email exists and its auth config (password / TOTP /
+		// linked providers) to drive the login UI, which makes it an enumeration
+		// oracle. Throttling by IP bounds bulk enumeration without removing the
+		// legitimate single-email lookup the login page needs (audit).
+		if procedure == "/pm.v1.ControlService/ListAuthMethods" && i.limiters.AuthMethods != nil {
+			ip := clientIP(req)
+			if !i.limiters.AuthMethods.Allow(ip) {
+				i.logger.Warn("rate limit exceeded", "limiter", "auth_methods", "ip", ip, "procedure", procedure)
+				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many requests, try again later")
 			}
 		}
 

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -566,3 +566,39 @@ func TestPermissionIsAlternative_UnknownAlt(t *testing.T) {
 	assert.False(t, PermissionIsAlternative("CreateDeviceGroup"),
 		"the legacy single-key permission MUST NOT register as an alternative — it was removed by #7")
 }
+
+// TestAuthInterceptor_ListAuthMethodsThrottled pins that the unauthenticated
+// ListAuthMethods lookup is rate-limited by IP (audit user-enumeration fix):
+// it reflects whether an email exists + its auth config, so an unthrottled
+// caller could bulk-enumerate accounts. Drives the real interceptor over an
+// httptest server so the per-IP throttle (clientIP from the peer) is exercised.
+func TestAuthInterceptor_ListAuthMethodsThrottled(t *testing.T) {
+	jwtMgr := NewJWTManager(JWTConfig{Secret: []byte("test-secret"), AccessTokenExpiry: 15 * time.Minute})
+	interceptor := NewAuthInterceptor(testLogger, jwtMgr, RateLimiters{
+		AuthMethods: NewRateLimiter(3, time.Minute),
+	})
+
+	procedure := "/pm.v1.ControlService/ListAuthMethods"
+	mux := http.NewServeMux()
+	mux.Handle(procedure, connect.NewUnaryHandler(
+		procedure,
+		func(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+			return connect.NewResponse(&emptypb.Empty{}), nil
+		},
+		connect.WithInterceptors(interceptor),
+	))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, srv.URL+procedure)
+
+	// The first 3 (the configured limit) succeed; the 4th from the same IP is throttled.
+	for i := 0; i < 3; i++ {
+		_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err, "request %d within the limit should succeed", i+1)
+	}
+	_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "too many", "must trip the AuthMethods limiter, not some other gate")
+}


### PR DESCRIPTION
Security audit (line 173) — two unauthenticated **user-enumeration** oracles.

## 1. Login SSO fast-path
An **SSO-only** account (no password) and a **linked-provider-disabled** account skipped the dummy bcrypt and returned a *distinct* error — even naming the provider (`"password login is disabled; use Corporate SSO to sign in"`). That diverged from the non-existent / wrong-password paths in **both timing and content**, letting an attacker enumerate accounts and their SSO provider.

**Fix:** both paths now mirror the wrong-password path exactly — dummy bcrypt (timing), per-account throttle accounting (#382), and a generic `ErrInvalidCredentials`. The login UI learns the right method from `ListAuthMethods`, not from this error. The **global** password-disabled switch (pre-lookup, account-independent) is unchanged.

## 2. Unthrottled `ListAuthMethods`
The unauthenticated lookup reflecting `TotpEnabled` / linked providers per email had **no rate limit** — a bulk enumeration oracle. **Fix:** a per-IP `AuthMethods` limiter (30/min) in the auth interceptor.

## Tests
- `TestLogin_EnumerationSafe_IdenticalErrors` — non-existent, SSO-only, and wrong-password Login responses are **byte-identical**.
- Updated the provider/SSO tests: assertions inverted to `NotContains` (no provider name, no "not available" disclosure).
- `TestAuthInterceptor_ListAuthMethodsThrottled` — exercises the throttle end-to-end through the real interceptor over an httptest server.

There is **no user self-registration or password-reset flow** (my earlier framing of "Register + reset" was off; this is the actual finding).

Closes #383.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added rate limiting for authentication method retrieval to prevent abuse.
  * Implemented rate limiting for certificate renewal operations.

* **Bug Fixes**
  * Enhanced security by standardizing authentication error messages to prevent user account enumeration attacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->