### PR TITLE
fix(store): expire stale pending executions; cap dispatch backlog age (#385)

### DIFF
--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -579,3 +579,74 @@ func TestDispatchPendingActions_ReSignsWithExecutionID(t *testing.T) {
 	assert.JSONEq(t, `{"username":"test"}`, string(calls[0].ParamsJSON),
 		"signer must receive the canonical params from the action")
 }
+
+// createPendingExecutionAt emits an ExecutionCreated event whose created_at is
+// backdated to `at` (the projection takes created_at from executed_at), so
+// time-based expiry can be tested deterministically. Returns the execution ID.
+func createPendingExecutionAt(t *testing.T, st *store.Store, deviceID, actionID string, at time.Time) string {
+	t.Helper()
+	id := testutil.NewID()
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "execution",
+		StreamID:   id,
+		EventType:  "ExecutionCreated",
+		Data: map[string]any{
+			"device_id":       deviceID,
+			"action_id":       actionID,
+			"action_type":     int(pm.ActionType_ACTION_TYPE_SHELL),
+			"desired_state":   0,
+			"params":          map[string]any{},
+			"timeout_seconds": 300,
+			"executed_at":     at.Format(time.RFC3339Nano),
+		},
+		ActorType: "user",
+		ActorID:   "test",
+	}))
+	return id
+}
+
+// TestListStaleExecutions_ExpiresStalePending pins the audit fix: a 'pending'
+// execution older than the 24h max-age is now surfaced by ListStale (so the
+// expiry sweep times it out), while a fresh pending one is left alone. Without
+// this a months-offline device runs its whole stale backlog on reconnect.
+func TestListStaleExecutions_ExpiresStalePending(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "stale-host")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Stale Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+
+	stale := createPendingExecutionAt(t, st, deviceID, actionID, time.Now().Add(-25*time.Hour))
+	fresh := createPendingExecutionAt(t, st, deviceID, actionID, time.Now())
+
+	staleRows, err := st.Repos().Execution.ListStale(context.Background())
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, r := range staleRows {
+		ids[r.ID] = true
+	}
+	assert.True(t, ids[stale], "a pending execution older than 24h must be timed out")
+	assert.False(t, ids[fresh], "a fresh pending execution must NOT be timed out")
+}
+
+// TestListPendingForDevice_SkipsStalePending pins that dispatchPendingActions
+// (via ListPendingForDevice) does NOT re-dispatch a stale pending execution on
+// reconnect — only fresh ones — so a long-offline device can't run stale,
+// possibly destructive actions when it comes back.
+func TestListPendingForDevice_SkipsStalePending(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "reconnect-host")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Backlog Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+
+	stale := createPendingExecutionAt(t, st, deviceID, actionID, time.Now().Add(-25*time.Hour))
+	fresh := createPendingExecutionAt(t, st, deviceID, actionID, time.Now())
+
+	pending, err := st.Repos().Execution.ListPendingForDevice(context.Background(), deviceID)
+	require.NoError(t, err)
+	ids := map[string]bool{}
+	for _, e := range pending {
+		ids[e.ID] = true
+	}
+	assert.False(t, ids[stale], "a stale (>24h) pending execution must not be re-dispatched on reconnect")
+	assert.True(t, ids[fresh], "a fresh pending execution must still be dispatched")
+}

--- a/internal/store/generated/actions.sql.go
+++ b/internal/store/generated/actions.sql.go
@@ -663,11 +663,16 @@ func (q *Queries) ListExecutionsForWarm(ctx context.Context, arg ListExecutionsF
 const listPendingExecutionsForDevice = `-- name: ListPendingExecutionsForDevice :many
 SELECT id, device_id, action_id, action_type, desired_state, params, timeout_seconds, status, error, output, created_at, dispatched_at, started_at, completed_at, duration_ms, created_by_type, created_by_id, projection_version, changed, compliant, detection_output, scheduled_for FROM executions_projection
 WHERE device_id = $1 AND status IN ('pending', 'dispatched')
+  AND created_at > NOW() - INTERVAL '24 hours'
 ORDER BY created_at ASC
 `
 
 // Include both 'pending' and 'dispatched' statuses, since dispatched executions
-// may need to be re-sent if the agent disconnected before receiving them
+// may need to be re-sent if the agent disconnected before receiving them.
+// Skip executions older than the 24h max-age: a long-offline device must NOT
+// run its entire stale backlog (possibly destructive) on reconnect. Stale ones
+// are timed out by ListStaleExecutions instead — keep the 24h here in sync with
+// the pending branch there (audit).
 func (q *Queries) ListPendingExecutionsForDevice(ctx context.Context, deviceID string) ([]ExecutionsProjection, error) {
 	rows, err := q.db.Query(ctx, listPendingExecutionsForDevice, deviceID)
 	if err != nil {
@@ -769,8 +774,10 @@ func (q *Queries) ListRecentExecutionsForDevice(ctx context.Context, arg ListRec
 const listStaleExecutions = `-- name: ListStaleExecutions :many
 SELECT id, device_id, timeout_seconds, status, created_at, dispatched_at
 FROM executions_projection
-WHERE status = 'dispatched'
-  AND dispatched_at < NOW() - make_interval(secs => GREATEST(timeout_seconds, 300) + 300)
+WHERE (status = 'dispatched'
+       AND dispatched_at < NOW() - make_interval(secs => GREATEST(timeout_seconds, 300) + 300))
+   OR (status = 'pending'
+       AND created_at <= NOW() - INTERVAL '24 hours')
 LIMIT 100
 `
 
@@ -783,10 +790,13 @@ type ListStaleExecutionsRow struct {
 	DispatchedAt   *time.Time `json:"dispatched_at"`
 }
 
-// Find dispatched executions that exceeded their timeout + grace period.
-// Only expires 'dispatched' status — 'pending' executions are left alone
-// because they represent assigned actions waiting for an offline device
-// to reconnect. dispatchPendingActions will dispatch them on reconnect.
+// Find executions that must be timed out:
+//   - 'dispatched' rows past their per-action timeout + grace (agent didn't
+//     respond), and
+//   - 'pending' rows older than the 24h max-age — assigned to a device that
+//     never came online in time. Without this they wait forever and run as a
+//     stale, possibly destructive action when the device finally reconnects
+//     (audit). Keep the 24h in sync with ListPendingExecutionsForDevice.
 func (q *Queries) ListStaleExecutions(ctx context.Context) ([]ListStaleExecutionsRow, error) {
 	rows, err := q.db.Query(ctx, listStaleExecutions)
 	if err != nil {

--- a/internal/store/queries/actions.sql
+++ b/internal/store/queries/actions.sql
@@ -263,20 +263,30 @@ WHERE ($1::TEXT = '' OR device_id = $1)
 
 -- name: ListPendingExecutionsForDevice :many
 -- Include both 'pending' and 'dispatched' statuses, since dispatched executions
--- may need to be re-sent if the agent disconnected before receiving them
+-- may need to be re-sent if the agent disconnected before receiving them.
+-- Skip executions older than the 24h max-age: a long-offline device must NOT
+-- run its entire stale backlog (possibly destructive) on reconnect. Stale ones
+-- are timed out by ListStaleExecutions instead — keep the 24h here in sync with
+-- the pending branch there (audit).
 SELECT * FROM executions_projection
 WHERE device_id = $1 AND status IN ('pending', 'dispatched')
+  AND created_at > NOW() - INTERVAL '24 hours'
 ORDER BY created_at ASC;
 
 -- name: ListStaleExecutions :many
--- Find dispatched executions that exceeded their timeout + grace period.
--- Only expires 'dispatched' status — 'pending' executions are left alone
--- because they represent assigned actions waiting for an offline device
--- to reconnect. dispatchPendingActions will dispatch them on reconnect.
+-- Find executions that must be timed out:
+--   - 'dispatched' rows past their per-action timeout + grace (agent didn't
+--     respond), and
+--   - 'pending' rows older than the 24h max-age — assigned to a device that
+--     never came online in time. Without this they wait forever and run as a
+--     stale, possibly destructive action when the device finally reconnects
+--     (audit). Keep the 24h in sync with ListPendingExecutionsForDevice.
 SELECT id, device_id, timeout_seconds, status, created_at, dispatched_at
 FROM executions_projection
-WHERE status = 'dispatched'
-  AND dispatched_at < NOW() - make_interval(secs => GREATEST(timeout_seconds, 300) + 300)
+WHERE (status = 'dispatched'
+       AND dispatched_at < NOW() - make_interval(secs => GREATEST(timeout_seconds, 300) + 300))
+   OR (status = 'pending'
+       AND created_at <= NOW() - INTERVAL '24 hours')
 LIMIT 100;
 
 -- name: ListRecentExecutionsForDevice :many


### PR DESCRIPTION
Security audit (line 175) — **pending executions never expire; stale backlog re-dispatched on reconnect**.

`ListStaleExecutions` only timed out `dispatched` rows; `pending` executions waited forever, and `dispatchPendingActions` re-enqueued the **entire backlog** on reconnect with **no max-age** — so a months-offline device runs stale, possibly destructive actions on return.

## Fix (SQL only)
The 1-minute expiry sweep already *intends* to handle pending (its comment says "pending/dispatched"); only the query limited it to dispatched.
- **`ListStaleExecutions`** now also matches `pending` rows older than a **24h** max-age → the sweep emits `ExecutionTimedOut` for them.
- **`ListPendingExecutionsForDevice`** (drives `dispatchPendingActions`) skips rows older than 24h → a long-offline device's stale backlog is not re-dispatched on reconnect.

The 24h max-age is cross-referenced between the two queries to stay in sync. No signature changes (sqlc regen touched only the SQL strings).

## Tests
Backdate via `executed_at` (the projection takes `created_at` from it): a 25h-old pending execution is surfaced by `ListStale` and skipped by `ListPendingForDevice`; a fresh one stays dispatchable.

**Note on the TTL:** 24h (your call) is firm but on the aggressive side for devices offline over a weekend — it's a single literal cross-referenced in both queries, trivially raised (e.g. to 72h/7d) if your fleet's offline patterns need it.

Closes #385.