### PR TITLE
feat(security): agent cert revocation via Valkey CRL (#388)

### DIFF
--- a/cmd/control/valkey.go
+++ b/cmd/control/valkey.go
@@ -34,6 +34,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/asynqutil"
 	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/control"
+	"github.com/manchtools/power-manage/server/internal/crl"
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -64,6 +65,11 @@ type valkeySubsystem struct {
 	// one instance so ProxyValidateTerminalToken can validate tokens
 	// minted by the same control replica.
 	TerminalTokenStore *terminal.TokenStore
+
+	// CRLStore is the Valkey-backed certificate revocation list. main() hands
+	// it to the ControlService so renewal/device-deletion revoke the old cert;
+	// gateways read the same Valkey key to enforce it on mTLS connections.
+	CRLStore *crl.Store
 }
 
 // Close stops the Asynq servers and closes the Valkey clients.
@@ -136,6 +142,8 @@ func newValkeySubsystem(ctx context.Context, cfg *Config, st *store.Store, svc *
 	st.RegisterEventListener(api.SearchListener(st, searchIdx, logger.With("component", "search_listener")))
 
 	v.TerminalTokenStore = terminal.NewTokenStore(terminal.NewValkeyBackend(v.rdb))
+	v.CRLStore = crl.NewStore(v.rdb)
+	svc.SetCRLStore(v.CRLStore)
 	gatewayReg := registry.New(registry.NewValkeyBackend(v.rdb), logger.With("component", "gateway_registry"))
 	termHandler := api.NewTerminalHandler(
 		st,

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/manchtools/power-manage/sdk/go/logging"
 	"github.com/manchtools/power-manage/server/internal/config"
 	"github.com/manchtools/power-manage/server/internal/connection"
+	"github.com/manchtools/power-manage/server/internal/crl"
 	"github.com/manchtools/power-manage/server/internal/gateway"
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/handler"
@@ -45,6 +46,12 @@ var version = "dev"
 // at 8 MiB, and inventory/osquery payloads are at most a few MiB — while
 // bounding the blast radius of a hostile peer.
 const maxAgentMessageBytes = 64 << 20
+
+// crlRefreshInterval is how often the gateway reloads the cert-revocation list
+// from Valkey into its in-memory cache. A revocation takes at most this long to
+// propagate to a gateway — acceptable for cert revocation, and far better than
+// the cert's 1-year natural expiry.
+const crlRefreshInterval = 30 * time.Second
 
 func main() {
 	// Parse flags — TLS is always required for mTLS agent connections
@@ -541,12 +548,30 @@ func main() {
 	agentHandler.SetTerminalSessions(terminalSessions)
 	path, h := pmv1connect.NewAgentServiceHandler(agentHandler, connect.WithReadMaxBytes(maxAgentMessageBytes))
 
+	// Certificate revocation: the control server publishes superseded/deleted
+	// agent-cert fingerprints to a shared Valkey CRL. Cache it in memory (loaded
+	// now, refreshed on a ticker) so the per-connection check below is a local
+	// map lookup that survives a Valkey blip. The gateway always has Valkey
+	// (required above), so this is always on.
+	crlRDB := redis.NewClient(&redis.Options{
+		Addr:     cfg.ValkeyAddr,
+		Password: cfg.ValkeyPassword,
+		DB:       cfg.ValkeyDB,
+		Protocol: 2,
+	})
+	defer crlRDB.Close()
+	crlCache := crl.NewCache(crl.NewStore(crlRDB), logger.With("component", "crl"))
+	if err := crlCache.Refresh(shutdownCtx); err != nil {
+		logger.Warn("initial CRL load failed; starting with empty revocation list (will retry)", "error", err)
+	}
+	go crlCache.Run(shutdownCtx, crlRefreshInterval)
+
 	// Compose middlewares (innermost first):
 	//   pmv1connect handler
-	//     ↑ MTLSMiddleware (extracts device ID from client cert)
+	//     ↑ MTLSMiddleware (extracts device ID, rejects revoked certs)
 	//     ↑ BootstrapRedirectMiddleware (returns 307 to assignedHost
 	//       when the request landed on the wildcard root via LB)
-	mtlsHandler := handler.MTLSMiddleware(h, logger)
+	mtlsHandler := handler.MTLSMiddleware(h, crlCache, logger)
 	bootstrappedHandler := handler.BootstrapRedirectMiddleware(mtlsHandler, bootstrapHost, assignedHost, logger)
 	mux.Handle(path, bootstrappedHandler)
 

--- a/internal/api/cert_revocation_test.go
+++ b/internal/api/cert_revocation_test.go
@@ -1,0 +1,78 @@
+package api_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/crl"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+func testCRLStore(t *testing.T) *crl.Store {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return crl.NewStore(rdb)
+}
+
+// TestRenewCertificate_RevokesSupersededCert pins that a successful renewal puts
+// the OLD cert's fingerprint on the CRL, so the superseded cert stops working at
+// the gateway instead of staying valid for its full year (audit #6).
+func TestRenewCertificate_RevokesSupersededCert(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	certAuth := newTestCA(t)
+	h := api.NewCertificateHandler(st, certAuth, slog.Default())
+
+	crlStore := testCRLStore(t)
+	h.SetCRLStore(crlStore)
+
+	deviceID := testutil.CreateTestDevice(t, st, "renew-revoke-host")
+	certPEM, oldFingerprint, csrPEM := issueTestDeviceCert(t, certAuth, deviceID)
+	setDeviceCertFingerprint(t, st, deviceID, oldFingerprint)
+
+	_, err := h.RenewCertificate(t.Context(), connect.NewRequest(&pm.RenewCertificateRequest{
+		CurrentCertificate: certPEM,
+		Csr:                csrPEM,
+	}))
+	require.NoError(t, err)
+
+	active, err := crlStore.LoadActive(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, active, oldFingerprint, "the superseded cert must be revoked after renewal")
+}
+
+// TestDeleteDevice_RevokesCert pins that deleting a device revokes its current
+// cert — otherwise the deleted device's still-valid cert keeps connecting at the
+// gateway until its 1-year expiry (audit #6).
+func TestDeleteDevice_RevokesCert(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	certAuth := newTestCA(t)
+	enc := testutil.NewEncryptor(t)
+	h := api.NewDeviceHandler(st, enc, slog.Default())
+
+	crlStore := testCRLStore(t)
+	h.SetCRLStore(crlStore)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "delete-revoke-host")
+	_, fingerprint, _ := issueTestDeviceCert(t, certAuth, deviceID)
+	setDeviceCertFingerprint(t, st, deviceID, fingerprint)
+
+	_, err := h.DeleteDevice(testutil.AdminContext(adminID), connect.NewRequest(&pm.DeleteDeviceRequest{
+		Id: deviceID,
+	}))
+	require.NoError(t, err)
+
+	active, err := crlStore.LoadActive(t.Context())
+	require.NoError(t, err)
+	assert.Contains(t, active, fingerprint, "a deleted device's cert must be revoked")
+}

--- a/internal/api/certificate_handler.go
+++ b/internal/api/certificate_handler.go
@@ -11,6 +11,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/crl"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -21,6 +22,10 @@ type CertificateHandler struct {
 	store  *store.Store
 	ca     *ca.CA
 	logger *slog.Logger
+	// crl, when set, receives the superseded fingerprint on renewal so the
+	// old cert stops working at the gateway (revocation). nil disables it
+	// (no Valkey configured / tests).
+	crl *crl.Store
 }
 
 // NewCertificateHandler creates a new certificate handler.
@@ -31,6 +36,10 @@ func NewCertificateHandler(st *store.Store, certAuth *ca.CA, logger *slog.Logger
 		logger: logger,
 	}
 }
+
+// SetCRLStore wires the certificate revocation list (post-construction, after
+// the Valkey subsystem comes up).
+func (h *CertificateHandler) SetCRLStore(s *crl.Store) { h.crl = s }
 
 // RenewCertificate renews a device certificate.
 // The agent authenticates by presenting its current (still valid) certificate.
@@ -112,6 +121,20 @@ func (h *CertificateHandler) RenewCertificate(ctx context.Context, req *connect.
 	}); err != nil {
 		h.logger.Error("failed to append cert renewed event", "error", err, "device_id", deviceID)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to record certificate renewal")
+	}
+
+	// Revoke the superseded cert: add its fingerprint to the CRL until its own
+	// expiry, so a gateway stops admitting the old cert immediately (it would
+	// otherwise stay valid for its full year). Best-effort — a CRL failure must
+	// not fail the renewal the agent already committed to; it's logged and the
+	// next renewal/the periodic refresh re-converge. The DB fingerprint was
+	// already advanced by the DeviceCertRenewed event above.
+	if h.crl != nil {
+		if oldNotAfter, err := ca.NotAfterFromPEM(req.Msg.CurrentCertificate); err != nil {
+			h.logger.Warn("could not parse old cert expiry for CRL; superseded cert not revoked", "device_id", deviceID, "error", err)
+		} else if err := h.crl.Revoke(ctx, currentFP, oldNotAfter); err != nil {
+			h.logger.Error("failed to revoke superseded cert in CRL", "device_id", deviceID, "error", err)
+		}
 	}
 
 	h.logger.Info("certificate renewed", "device_id", deviceID, "not_after", newCert.NotAfter)

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -17,6 +17,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/crl"
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
@@ -31,12 +32,18 @@ type DeviceHandler struct {
 	store     *store.Store
 	logger    *slog.Logger
 	encryptor *crypto.Encryptor
+	// crl, when set, receives a deleted device's cert fingerprint so the cert
+	// stops working at the gateway. nil disables it (no Valkey / tests).
+	crl *crl.Store
 }
 
 // NewDeviceHandler creates a new device handler.
 func NewDeviceHandler(st *store.Store, enc *crypto.Encryptor, logger *slog.Logger) *DeviceHandler {
 	return &DeviceHandler{store: st, encryptor: enc, logger: logger}
 }
+
+// SetCRLStore wires the certificate revocation list (post-construction).
+func (h *DeviceHandler) SetCRLStore(s *crl.Store) { h.crl = s }
 
 // ListDevices returns a paginated list of devices.
 // Admins see all devices; regular users see only their assigned devices.
@@ -246,6 +253,23 @@ func (h *DeviceHandler) DeleteDevice(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
+	// Capture the device's cert fingerprint BEFORE deletion so we can revoke it
+	// — otherwise a deleted device's still-valid cert keeps connecting at the
+	// gateway until its 1-year expiry. Only loaded when a CRL is configured.
+	var revokeFP string
+	var revokeUntil time.Time
+	if h.crl != nil {
+		dev, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{ID: req.Msg.Id})
+		if err != nil {
+			// Best-effort: don't fail the delete, but log — a swallowed lookup
+			// error would leave the deleted device's cert unrevoked silently.
+			h.logger.Warn("failed to load device for CRL revocation; its cert may stay valid until expiry", "device_id", req.Msg.Id, "error", err)
+		} else if dev.CertFingerprint != nil && dev.CertNotAfter != nil {
+			revokeFP = *dev.CertFingerprint
+			revokeUntil = *dev.CertNotAfter
+		}
+	}
+
 	// Emit DeviceDeleted event
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device",
@@ -256,6 +280,14 @@ func (h *DeviceHandler) DeleteDevice(ctx context.Context, req *connect.Request[p
 		ActorID:    userCtx.ID,
 	}, "failed to delete device"); err != nil {
 		return nil, err
+	}
+
+	// Revoke the deleted device's cert (best-effort — a CRL failure must not
+	// undo the deletion that already committed).
+	if revokeFP != "" {
+		if err := h.crl.Revoke(ctx, revokeFP, revokeUntil); err != nil {
+			h.logger.Error("failed to revoke deleted device cert in CRL", "device_id", req.Msg.Id, "error", err)
+		}
 	}
 
 	// Search-index removal is handled by api.SearchListener (post-commit

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/crl"
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/search"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -101,6 +102,15 @@ func (s *ControlService) SetTaskQueueClient(c *taskqueue.Client) {
 	s.osquery.SetTaskQueueClient(c)
 	s.logs.SetTaskQueueClient(c)
 	s.device.SetTaskQueueClient(c)
+}
+
+// SetCRLStore wires the Valkey-backed certificate revocation list into the
+// handlers that supersede or remove agent certs (renewal, device deletion).
+// Called from main.go after the Valkey subsystem comes up; nil-safe (the
+// handlers skip revocation when unset).
+func (s *ControlService) SetCRLStore(store *crl.Store) {
+	s.certificate.SetCRLStore(store)
+	s.device.SetCRLStore(store)
 }
 
 // SetTerminalHandler wires the terminal session RPC handler. Called

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -261,6 +261,38 @@ func FingerprintFromPEM(certPEM []byte) (string, error) {
 	return hex.EncodeToString(fingerprint[:]), nil
 }
 
+// NotAfterFromPEM returns the expiry of a PEM-encoded certificate. Used to set
+// the CRL entry's TTL to the revoked cert's own lifetime — a revoked cert never
+// needs to outlive its expiry on the list (mTLS rejects an expired cert anyway).
+func NotAfterFromPEM(certPEM []byte) (time.Time, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return time.Time{}, fmt.Errorf("failed to decode certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse certificate: %w", err)
+	}
+	return cert.NotAfter, nil
+}
+
+// FingerprintFromCert computes the fingerprint of an already-parsed
+// certificate. It is byte-for-byte identical to FingerprintFromPEM /
+// IssueCertificateFromCSR (hex of SHA-256 over the DER), so a fingerprint the
+// control server stored or revoked matches one the gateway derives from the
+// cert presented on an mTLS connection. cert.Raw is the DER encoding.
+func FingerprintFromCert(cert *x509.Certificate) string {
+	// Defensive: callers reach this from the gateway mTLS path where the leaf is
+	// already verified non-nil, but never panic on a hot request path. An empty
+	// fingerprint matches no revoked entry — a nil cert is already rejected by
+	// the peer-class / TLS checks upstream, so this fails safe, not open.
+	if cert == nil {
+		return ""
+	}
+	fingerprint := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(fingerprint[:])
+}
+
 // DeviceIDFromPEM extracts the device ID from a PEM-encoded certificate.
 func DeviceIDFromPEM(certPEM []byte) (string, error) {
 	block, _ := pem.Decode(certPEM)

--- a/internal/ca/ca_test.go
+++ b/internal/ca/ca_test.go
@@ -310,3 +310,9 @@ func TestTrustPool(t *testing.T) {
 	pool := c.TrustPool()
 	assert.NotNil(t, pool)
 }
+
+// TestFingerprintFromCert_NilSafe pins the defensive nil guard — the gateway
+// mTLS path must never panic computing a revocation fingerprint.
+func TestFingerprintFromCert_NilSafe(t *testing.T) {
+	assert.Empty(t, ca.FingerprintFromCert(nil))
+}

--- a/internal/crl/crl.go
+++ b/internal/crl/crl.go
@@ -1,0 +1,140 @@
+// Package crl is a Valkey-backed certificate revocation list shared by the
+// control server (the writer) and the gateways (cached readers). Agent certs
+// keep their 1-year validity, so revocation — not expiry — is what makes a
+// leaked or superseded cert stop working; this list is that mechanism.
+//
+// Revoked fingerprints live in a single sorted set scored by the revoked cert's
+// expiry (Unix seconds). That gives three things for free:
+//   - the active list is one ZRANGEBYSCORE (no keyspace SCAN),
+//   - entries age out on their own (a cert past its own NotAfter is rejected by
+//     mTLS expiry anyway, so it never needs to stay revoked), and
+//   - the gateway caches the set in memory, so the per-connection check is a
+//     local map lookup — no per-connection RPC — and survives a Valkey blip.
+package crl
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// DefaultKey is the Valkey sorted-set key holding revoked fingerprints.
+const DefaultKey = "pm:crl:revoked"
+
+// Store is the Valkey-backed CRL. The control server holds one to Revoke;
+// gateways wrap one in a Cache to read.
+type Store struct {
+	rdb *redis.Client
+	key string
+	now func() time.Time
+}
+
+// Option configures a Store.
+type Option func(*Store)
+
+// WithKey overrides the sorted-set key (tests).
+func WithKey(k string) Option { return func(s *Store) { s.key = k } }
+
+// WithClock overrides the time source (tests).
+func WithClock(now func() time.Time) Option { return func(s *Store) { s.now = now } }
+
+// NewStore creates a CRL store over the given Valkey client.
+func NewStore(rdb *redis.Client, opts ...Option) *Store {
+	s := &Store{rdb: rdb, key: DefaultKey, now: time.Now}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
+}
+
+// Revoke records fingerprint as revoked until expiresAt (the revoked cert's
+// NotAfter). An empty fingerprint or one whose cert has already expired is a
+// no-op: mTLS already rejects an expired cert, so it never needs listing.
+func (s *Store) Revoke(ctx context.Context, fingerprint string, expiresAt time.Time) error {
+	if fingerprint == "" || !expiresAt.After(s.now()) {
+		return nil
+	}
+	return s.rdb.ZAdd(ctx, s.key, redis.Z{
+		Score:  float64(expiresAt.Unix()),
+		Member: fingerprint,
+	}).Err()
+}
+
+// LoadActive returns the set of fingerprints that are revoked and not yet
+// expired. It also best-effort prunes already-expired members (a prune error is
+// non-fatal — the score filter already excludes them from the result).
+func (s *Store) LoadActive(ctx context.Context) (map[string]struct{}, error) {
+	nowUnix := strconv.FormatInt(s.now().Unix(), 10)
+	fps, err := s.rdb.ZRangeByScore(ctx, s.key, &redis.ZRangeBy{
+		Min: nowUnix,
+		Max: "+inf",
+	}).Result()
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]struct{}, len(fps))
+	for _, fp := range fps {
+		out[fp] = struct{}{}
+	}
+	// Opportunistic prune of strictly-expired members. Best-effort.
+	_ = s.rdb.ZRemRangeByScore(ctx, s.key, "-inf", "("+nowUnix).Err()
+	return out, nil
+}
+
+// Cache is an in-memory snapshot of the CRL for the gateway's per-connection
+// fingerprint check. It refreshes from the Store on a ticker; on a refresh
+// error it KEEPS the previous snapshot (fail-static, never fail-open-to-empty),
+// so a transient Valkey outage cannot silently drop revocation enforcement.
+type Cache struct {
+	store   *Store
+	logger  *slog.Logger
+	mu      sync.RWMutex
+	revoked map[string]struct{}
+}
+
+// NewCache creates an empty cache over the given store.
+func NewCache(store *Store, logger *slog.Logger) *Cache {
+	return &Cache{store: store, logger: logger, revoked: map[string]struct{}{}}
+}
+
+// IsRevoked reports whether fingerprint is in the last loaded snapshot.
+func (c *Cache) IsRevoked(fingerprint string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.revoked[fingerprint]
+	return ok
+}
+
+// Refresh reloads the snapshot from the Store. Exported so the gateway can do
+// one synchronous load at startup before it starts admitting connections.
+func (c *Cache) Refresh(ctx context.Context) error {
+	next, err := c.store.LoadActive(ctx)
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	c.revoked = next
+	c.mu.Unlock()
+	return nil
+}
+
+// Run refreshes the snapshot every interval until ctx is cancelled. A refresh
+// error logs and keeps the previous snapshot.
+func (c *Cache) Run(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			if err := c.Refresh(ctx); err != nil {
+				c.logger.Warn("CRL refresh failed; keeping previous snapshot", "error", err)
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/internal/crl/crl_test.go
+++ b/internal/crl/crl_test.go
@@ -1,0 +1,96 @@
+package crl
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testStore(t *testing.T, now func() time.Time) (*Store, *miniredis.Miniredis, *redis.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	return NewStore(rdb, WithKey("test:crl"), WithClock(now)), mr, rdb
+}
+
+func TestStore_RevokeAndLoadActive(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	s, _, _ := testStore(t, func() time.Time { return now })
+
+	require.NoError(t, s.Revoke(context.Background(), "fp-a", now.Add(time.Hour)))
+	require.NoError(t, s.Revoke(context.Background(), "fp-b", now.Add(24*time.Hour)))
+
+	active, err := s.LoadActive(context.Background())
+	require.NoError(t, err)
+	assert.Contains(t, active, "fp-a")
+	assert.Contains(t, active, "fp-b")
+}
+
+func TestStore_RevokeAlreadyExpiredIsNoop(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	s, _, _ := testStore(t, func() time.Time { return now })
+
+	// A cert that already expired never needs revoking — mTLS rejects it anyway.
+	require.NoError(t, s.Revoke(context.Background(), "fp-old", now.Add(-time.Minute)))
+	require.NoError(t, s.Revoke(context.Background(), "", now.Add(time.Hour))) // empty fp no-op
+
+	active, err := s.LoadActive(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, active)
+}
+
+func TestStore_LoadActiveExcludesAndPrunesExpired(t *testing.T) {
+	cur := time.Unix(1_000_000, 0)
+	s, _, rdb := testStore(t, func() time.Time { return cur })
+
+	require.NoError(t, s.Revoke(context.Background(), "fp-short", cur.Add(time.Minute)))
+	require.NoError(t, s.Revoke(context.Background(), "fp-long", cur.Add(time.Hour)))
+
+	// Advance the clock past fp-short's expiry.
+	cur = cur.Add(2 * time.Minute)
+
+	active, err := s.LoadActive(context.Background())
+	require.NoError(t, err)
+	assert.NotContains(t, active, "fp-short", "expired revocation must not be returned")
+	assert.Contains(t, active, "fp-long")
+
+	// The expired member was pruned from the sorted set.
+	card, err := rdb.ZCard(context.Background(), "test:crl").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), card, "expired member should have been pruned")
+}
+
+func TestCache_IsRevokedAfterRefresh(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	s, _, _ := testStore(t, func() time.Time { return now })
+	require.NoError(t, s.Revoke(context.Background(), "fp-x", now.Add(time.Hour)))
+
+	c := NewCache(s, slog.Default())
+	assert.False(t, c.IsRevoked("fp-x"), "empty cache before refresh")
+	require.NoError(t, c.Refresh(context.Background()))
+	assert.True(t, c.IsRevoked("fp-x"))
+	assert.False(t, c.IsRevoked("fp-unknown"))
+}
+
+func TestCache_FailStaticOnRefreshError(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	s, mr, _ := testStore(t, func() time.Time { return now })
+	require.NoError(t, s.Revoke(context.Background(), "fp-x", now.Add(time.Hour)))
+
+	c := NewCache(s, slog.Default())
+	require.NoError(t, c.Refresh(context.Background()))
+	require.True(t, c.IsRevoked("fp-x"))
+
+	// Valkey goes away — a refresh now errors, but the cache must KEEP the last
+	// good snapshot rather than fail open to an empty (no-revocations) set.
+	mr.Close()
+	require.Error(t, c.Refresh(context.Background()))
+	assert.True(t, c.IsRevoked("fp-x"), "must retain the previous snapshot on a refresh error")
+}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -17,6 +17,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/connection"
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/mtls"
@@ -138,7 +139,14 @@ func (h *AgentHandler) SetTerminalSessions(reg *connection.TerminalSessionRegist
 // does not carry the "agent" peer-class URI SAN — the AgentService
 // listener is for managed devices only, and a leaked gateway or
 // control cert must not be usable here.
-func MTLSMiddleware(next http.Handler, logger *slog.Logger) http.Handler {
+// RevocationChecker reports whether an agent cert (by SHA-256 fingerprint) has
+// been revoked. The gateway's crl.Cache satisfies it; a nil checker disables the
+// revocation gate (e.g. when no Valkey is configured).
+type RevocationChecker interface {
+	IsRevoked(fingerprint string) bool
+}
+
+func MTLSMiddleware(next http.Handler, revocation RevocationChecker, logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip TLS check for health endpoints
 		if r.URL.Path == "/health" || r.URL.Path == "/ready" {
@@ -187,6 +195,22 @@ func MTLSMiddleware(next http.Handler, logger *slog.Logger) http.Handler {
 			)
 			http.Error(w, "peer class not allowed", http.StatusForbidden)
 			return
+		}
+
+		// Reject revoked certs. The chain already verified against the CA above;
+		// this is the revocation gate that makes a leaked or superseded cert stop
+		// working before its (1-year) natural expiry. r.TLS.PeerCertificates[0]
+		// is the same leaf the peer-class check used, so it's non-nil here.
+		if revocation != nil {
+			fp := ca.FingerprintFromCert(r.TLS.PeerCertificates[0])
+			if revocation.IsRevoked(fp) {
+				logger.Warn("mTLS rejected: certificate revoked",
+					"device_id", deviceID,
+					"remote_addr", r.RemoteAddr,
+				)
+				http.Error(w, "client certificate revoked", http.StatusForbidden)
+				return
+			}
 		}
 
 		// Add device ID to context

--- a/internal/handler/agent_middleware_test.go
+++ b/internal/handler/agent_middleware_test.go
@@ -176,7 +176,7 @@ func TestMTLSMiddleware_HealthBypassesAllChecks(t *testing.T) {
 	// don't present client certs and a 401 here would mark the
 	// gateway pod unhealthy and trigger a flap-restart loop.
 	called := false
-	mw := MTLSMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }), newTestLogger())
+	mw := MTLSMiddleware(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true }), nil, newTestLogger())
 
 	for _, path := range []string{"/health", "/ready"} {
 		t.Run(path, func(t *testing.T) {
@@ -191,7 +191,7 @@ func TestMTLSMiddleware_HealthBypassesAllChecks(t *testing.T) {
 }
 
 func TestMTLSMiddleware_NoTLSState_Returns401(t *testing.T) {
-	mw := MTLSMiddleware(newOKHandler(), newTestLogger())
+	mw := MTLSMiddleware(newOKHandler(), nil, newTestLogger())
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	req.TLS = nil
 	rec := httptest.NewRecorder()
@@ -201,7 +201,7 @@ func TestMTLSMiddleware_NoTLSState_Returns401(t *testing.T) {
 }
 
 func TestMTLSMiddleware_PeerClassMissing_Returns403(t *testing.T) {
-	mw := MTLSMiddleware(newOKHandler(), newTestLogger())
+	mw := MTLSMiddleware(newOKHandler(), nil, newTestLogger())
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	req.TLS = fakeTLSStateWithPeerClass(t, "device-1", nil)
 	rec := httptest.NewRecorder()
@@ -215,7 +215,7 @@ func TestMTLSMiddleware_GatewayClassRejectedOnAgentService(t *testing.T) {
 	// The agent listener is for managed devices only; admitting a
 	// gateway cert would let one gateway impersonate every connected
 	// agent simultaneously.
-	mw := MTLSMiddleware(newOKHandler(), newTestLogger())
+	mw := MTLSMiddleware(newOKHandler(), nil, newTestLogger())
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	gw := mtls.PeerClassGateway
 	req.TLS = fakeTLSStateWithPeerClass(t, "gateway-1", &gw)
@@ -234,7 +234,7 @@ func TestMTLSMiddleware_AgentClassReachesInnerWithDeviceIDInContext(t *testing.T
 	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		gotDeviceID, gotOK = DeviceIDFromContext(r.Context())
 	})
-	mw := MTLSMiddleware(inner, newTestLogger())
+	mw := MTLSMiddleware(inner, nil, newTestLogger())
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	agent := mtls.PeerClassAgent
@@ -264,4 +264,39 @@ func TestBootstrapRedirectMiddleware_IPv6HostHeaderHandledCorrectly(t *testing.T
 	mw.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusTemporaryRedirect, rec.Code,
 		"IPv6 bracketed authority MUST match — the strings.IndexByte(':') bug truncated host at the first internal colon, leaving reqHost = '['")
+}
+
+// fakeRevocation is a RevocationChecker whose verdict is fixed, so a CRL test
+// doesn't have to predict the synthetic cert's fingerprint.
+type fakeRevocation struct{ revoked bool }
+
+func (f fakeRevocation) IsRevoked(string) bool { return f.revoked }
+
+// TestMTLSMiddleware_RevokedCertRejected pins the CRL gate (audit #6): an
+// agent cert whose fingerprint is on the revocation list is rejected at the
+// mTLS layer (403, never reaches AgentService), while a non-revoked one passes.
+func TestMTLSMiddleware_RevokedCertRejected(t *testing.T) {
+	agent := mtls.PeerClassAgent
+
+	called := false
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true })
+
+	// Revoked → 403, inner not reached.
+	mw := MTLSMiddleware(inner, fakeRevocation{revoked: true}, newTestLogger())
+	req := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req.TLS = fakeTLSStateWithPeerClass(t, "device-1", &agent)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "a revoked agent cert MUST be rejected at the mTLS layer")
+	assert.False(t, called, "a revoked cert must not reach AgentService")
+
+	// Not revoked → reaches inner.
+	called = false
+	mw2 := MTLSMiddleware(inner, fakeRevocation{revoked: false}, newTestLogger())
+	req2 := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req2.TLS = fakeTLSStateWithPeerClass(t, "device-1", &agent)
+	rec2 := httptest.NewRecorder()
+	mw2.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	assert.True(t, called, "a non-revoked agent cert must reach AgentService")
 }


### PR DESCRIPTION
Security audit **#6** — agent certs keep their 1-year validity, but the gateway never re-checked a presented cert against any revocation state, so a **leaked, superseded (post-renewal), or deleted-device** cert kept connecting until its natural expiry.

Design (maintainer-directed): broadcast a CRL over the existing **Valkey** infra — **no per-connection RPC**, gateways cache it.

## How it works
- **`internal/crl`** — a Valkey **sorted set** scored by each revoked cert's expiry. That gives a single `ZRANGEBYSCORE` load, automatic age-out (a cert past its own `NotAfter` is rejected by mTLS expiry anyway), and one key. `Store` (control writes) + `Cache` (gateway reads): the cache refreshes on a 30s ticker and **fail-static** on a Valkey blip — it keeps the last good snapshot rather than fail-open to an empty list.
- **Control writes** the superseded fingerprint on `RenewCertificate` (old fp + old `NotAfter` for the TTL) and the device's fingerprint on `DeleteDevice`. Wired via `SetCRLStore` from the Valkey subsystem; nil-safe when no Valkey is configured.
- **Gateway** loads the CRL at startup + refreshes, and rejects a revoked cert in `MTLSMiddleware` (403). New `ca.FingerprintFromCert` is byte-for-byte identical to `FingerprintFromPEM` (hex SHA-256 of DER) so the control-write and gateway-read fingerprints can't drift.

Keeps 1-year validity (your call — offline-agent tolerance); revocation is now the enforcement mechanism. The concurrent-renewal version-guard (the heartbeat-stream-CAS half of #6) is a separate, lower-priority item.

## Tests
- `crl` Store/Cache over miniredis — revoke/load, expiry exclusion + prune, and **fail-static on a refresh error**.
- `RenewCertificate` and `DeleteDevice` put the fingerprint on the CRL.
- `MTLSMiddleware` rejects a revoked agent cert (403, never reaches AgentService) and admits a non-revoked one.

`go vet ./...` caught the changed `MTLSMiddleware` signature's test callers before push.

Closes #388.