### PR TITLE
feat(security): close terminal sessions on user revocation (#390)

### DIFF
--- a/cmd/control/valkey.go
+++ b/cmd/control/valkey.go
@@ -159,6 +159,13 @@ func newValkeySubsystem(ctx context.Context, cfg *Config, st *store.Store, svc *
 		_ = err
 	}
 	svc.SetTerminalHandler(termHandler)
+
+	// Close a user's live terminal sessions when their access is revoked
+	// (UserDisabled / UserDeleted) — otherwise a disabled/deleted user keeps a
+	// root-capable shell until they disconnect (audit l.174). Runs the gateway
+	// fan-out in the background so it never blocks the disable/delete.
+	st.RegisterEventListener(api.TerminalRevocationListener(termHandler, logger.With("component", "terminal_revocation")))
+
 	if cfg.TerminalGatewayURL != "" {
 		logger.Info("remote terminal sessions enabled",
 			"fallback_gateway_url", cfg.TerminalGatewayURL,

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -678,6 +678,45 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 	return connect.NewResponse(&pm.TerminateTerminalSessionResponse{}), nil
 }
 
+// TerminateUserSessions force-closes every LIVE terminal session belonging to
+// userID across all gateways. It's the revocation path (audit l.174): a disabled
+// or deleted user's already-open, root-capable shell must be killed, not left
+// running until they happen to disconnect. The single-use token already blocks
+// NEW sessions and pending tokens expire within the token TTL, so this closes
+// the gap of an ALREADY-ACCEPTED session.
+//
+// Best-effort and non-fatal: per-session failures are logged so one stuck
+// gateway can't strand the others. Reuses the admin RPCs — ListActiveTerminal
+// Sessions has no in-method auth gate, and Terminate is invoked under a
+// synthetic system actor so the audit event is correctly attributed to the
+// system, not an admin. Intended to run on a background goroutine (see
+// TerminalRevocationListener) so it never blocks the disable/delete that
+// triggered it.
+func (h *TerminalHandler) TerminateUserSessions(ctx context.Context, userID string) {
+	listResp, err := h.ListActiveTerminalSessions(ctx, connect.NewRequest(&pm.ListActiveTerminalSessionsRequest{}))
+	if err != nil {
+		h.logger.Error("revocation: failed to list terminal sessions", "user_id", userID, "error", err)
+		return
+	}
+
+	sysCtx := auth.WithUser(ctx, &auth.UserContext{ID: "system", Email: "system@power-manage"})
+	for _, s := range listResp.Msg.Sessions {
+		if s.UserId != userID {
+			continue
+		}
+		if _, err := h.TerminateTerminalSession(sysCtx, connect.NewRequest(&pm.TerminateTerminalSessionRequest{
+			SessionId: s.SessionId,
+			Reason:    "user access revoked",
+		})); err != nil {
+			h.logger.Error("revocation: failed to terminate terminal session",
+				"user_id", userID, "session_id", s.SessionId, "error", err)
+		} else {
+			h.logger.Info("revocation: terminated terminal session",
+				"user_id", userID, "session_id", s.SessionId)
+		}
+	}
+}
+
 // GatewayBaseURL normalises the configured gateway URL into the
 // token-free form returned by StartTerminalResponse.gateway_url:
 // any query string, fragment, or trailing slash is stripped so the

--- a/internal/api/terminal_revocation_listener.go
+++ b/internal/api/terminal_revocation_listener.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// userSessionTerminator closes a user's live terminal sessions. *TerminalHandler
+// implements it; the interface keeps TerminalRevocationListener unit-testable
+// without the gateway fan-out.
+type userSessionTerminator interface {
+	TerminateUserSessions(ctx context.Context, userID string)
+}
+
+// terminalRevocationCloseTimeout bounds the background close fan-out.
+const terminalRevocationCloseTimeout = 30 * time.Second
+
+// TerminalRevocationListener returns a post-commit event listener that closes a
+// user's LIVE terminal sessions when their access is revoked — on UserDisabled
+// or UserDeleted. The close (a gateway fan-out) runs on a background goroutine
+// with its own timeout context, so it NEVER blocks the disable/delete RPC that
+// triggered it and survives that request's context being cancelled when the RPC
+// returns. Best-effort by design (audit l.174: a revoked user's already-open
+// root shell must be killed, not left running until they disconnect).
+//
+// Scope: disable + delete only. Role-revoke is intentionally excluded — a user
+// may retain terminal access via another role, so closing on every role-revoke
+// could be wrong; that needs a "does the user still have terminal access?"
+// recompute and is tracked separately.
+func TerminalRevocationListener(term userSessionTerminator, logger *slog.Logger) store.EventListener {
+	return func(_ context.Context, ev store.PersistedEvent) {
+		if ev.StreamType != "user" {
+			return
+		}
+		if ev.EventType != string(eventtypes.UserDisabled) && ev.EventType != string(eventtypes.UserDeleted) {
+			return
+		}
+		userID := ev.StreamID
+		logger.Info("revoking terminal access: closing user's live sessions", "user_id", userID, "event", ev.EventType)
+		go func() {
+			// Recover: an unrecovered panic in a spawned goroutine crashes the
+			// whole control process — a best-effort session close must never do
+			// that. Also log completion (with any context error) for observability.
+			defer func() {
+				if r := recover(); r != nil {
+					logger.Error("panic while closing terminal sessions for a revoked user", "user_id", userID, "panic", r)
+				}
+			}()
+			bgCtx, cancel := context.WithTimeout(context.Background(), terminalRevocationCloseTimeout)
+			defer cancel()
+			term.TerminateUserSessions(bgCtx, userID)
+			logger.Info("closed terminal sessions for a revoked user", "user_id", userID, "context_error", bgCtx.Err())
+		}()
+	}
+}

--- a/internal/api/terminal_revocation_listener_test.go
+++ b/internal/api/terminal_revocation_listener_test.go
@@ -1,0 +1,91 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// fakeSessionTerminator records which user IDs the listener asked to close.
+// (Structurally satisfies the unexported userSessionTerminator interface.)
+type fakeSessionTerminator struct{ ch chan string }
+
+func (f *fakeSessionTerminator) TerminateUserSessions(_ context.Context, userID string) {
+	f.ch <- userID
+}
+
+// TestTerminalRevocationListener pins the trigger: a user's live terminal
+// sessions are closed on UserDisabled and UserDeleted, and NOT on re-enable or
+// any non-user event. (The gateway fan-out itself is exercised by the terminal
+// admin RPCs; here we pin only that the right events fire it.)
+func TestTerminalRevocationListener(t *testing.T) {
+	ft := &fakeSessionTerminator{ch: make(chan string, 1)}
+	l := api.TerminalRevocationListener(ft, slog.Default())
+
+	fire := func(streamType, eventType, streamID string) {
+		l(context.Background(), store.PersistedEvent{
+			StreamType: streamType,
+			EventType:  eventType,
+			StreamID:   streamID,
+		})
+	}
+	expectClose := func(wantUserID string) {
+		t.Helper()
+		select {
+		case got := <-ft.ch:
+			assert.Equal(t, wantUserID, got)
+		case <-time.After(2 * time.Second):
+			t.Fatalf("expected the listener to close sessions for %q, got none", wantUserID)
+		}
+	}
+	expectNoClose := func() {
+		t.Helper()
+		select {
+		case got := <-ft.ch:
+			t.Fatalf("expected NO session close, but it fired for %q", got)
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+
+	fire("user", "UserDisabled", "u1")
+	expectClose("u1")
+
+	fire("user", "UserDeleted", "u2")
+	expectClose("u2")
+
+	fire("user", "UserEnabled", "u3") // re-enabling must NOT close sessions
+	expectNoClose()
+
+	fire("device", "DeviceDeleted", "d1") // non-user stream is irrelevant
+	expectNoClose()
+}
+
+// panicTerminator panics, but signals (via defer) that it ran.
+type panicTerminator struct{ done chan struct{} }
+
+func (p panicTerminator) TerminateUserSessions(context.Context, string) {
+	defer close(p.done)
+	panic("boom")
+}
+
+// TestTerminalRevocationListener_RecoversPanic pins that a panic in the
+// background close does NOT crash the control process — an unrecovered panic in
+// a spawned goroutine takes the whole program down. If the recover regressed,
+// this test run would abort rather than merely fail.
+func TestTerminalRevocationListener_RecoversPanic(t *testing.T) {
+	done := make(chan struct{})
+	l := api.TerminalRevocationListener(panicTerminator{done: done}, slog.Default())
+	l(context.Background(), store.PersistedEvent{StreamType: "user", EventType: "UserDisabled", StreamID: "u1"})
+	select {
+	case <-done:
+		// goroutine ran and the listener's recover swallowed the panic.
+	case <-time.After(2 * time.Second):
+		t.Fatal("background close goroutine did not run")
+	}
+}


### PR DESCRIPTION
Security audit **l.174** — terminal sessions survive revocation. `ValidateTerminalToken` runs once at WS accept, so a live session then runs with **no re-auth**: a user who is **disabled or deleted keeps a root-capable shell** until they disconnect or an admin manually kills it.

Design (your direction, refined): the token is opaque + **single-use** (`GETDEL` at accept) so it can't start new sessions, and pending tokens expire within the TTL — the real gap is the **already-open** session. Close it on revocation.

## How it works
- **`TerminalHandler.TerminateUserSessions(userID)`** — lists active sessions across gateways (`ListActiveTerminalSessions`, which has no in-method auth gate) and terminates each via the existing fan-out under a synthetic **system** actor, so the audit event attributes correctly.
- **`TerminalRevocationListener`** — a post-commit listener on `UserDisabled` / `UserDeleted` that runs the fan-out on a **background goroutine** (async, best-effort, your call) so it never blocks the disable/delete RPC and survives that request's context being cancelled when the RPC returns. Wired into the Valkey subsystem.
- **Scope:** disable + delete only (your call). Role-revoke is excluded — a user may keep terminal access via another role, so it needs a "still has access?" recompute → follow-up **#391**.

## Tests
The listener closes sessions on `UserDisabled` and `UserDeleted`, and **not** on re-enable or non-user events (via a terminator interface — the gateway fan-out itself is covered by the existing terminal admin RPC tests). `go vet ./...` clean.

Closes #390.