### PR TITLE
test(search): pin scopeFilterFields ↔ index schema parity (#393)

### DIFF
--- a/internal/api/search_scope_parity_test.go
+++ b/internal/api/search_scope_parity_test.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/search"
+)
+
+// TestScopeFilterFields_MirrorIndexSchemas is a self-discovering guard that the
+// per-scope filter allow-list (scopeFilterFields) stays in lockstep with the
+// RediSearch FT.CREATE schemas (search.IndexSchemas). The two MUST agree: a
+// tag/range filter on a field an index never declared makes RediSearch reject
+// the whole query with a SYNTAX error (server#158), and a declared TAG/NUMERIC
+// field that's missing here is silently unfilterable. Both sides are derived
+// from their sources — no hardcoded field list to fall stale — and the test
+// fails if either gains a field the other lacks, or an index gains no entry.
+func TestScopeFilterFields_MirrorIndexSchemas(t *testing.T) {
+	require.NotEmpty(t, search.IndexSchemas, "no index schemas discovered — the parity check would vacuously pass")
+
+	indexedScopes := map[string]bool{}
+	for _, ix := range search.IndexSchemas {
+		scope := ix.Scope()
+		indexedScopes[scope] = true
+
+		got, ok := scopeFilterFields[scope]
+		assert.Truef(t, ok,
+			"index %q (scope %q) has no scopeFilterFields entry — add one (an empty map if it declares no TAG/NUMERIC fields)", ix.Name, scope)
+
+		want := ix.FilterableFields() // TAG/NUMERIC fields the index actually declares
+
+		// Every declared filterable field must be advertised, else operators
+		// can't filter on it.
+		for field := range want {
+			assert.Truef(t, got[field],
+				"scope %q: index %q declares filterable field %q (TAG/NUMERIC) but scopeFilterFields omits it", scope, ix.Name, field)
+		}
+		// Every advertised field must have a backing TAG/NUMERIC attribute, else
+		// the filter the api accepts makes RediSearch reject the query.
+		for field := range got {
+			assert.Truef(t, want[field],
+				"scope %q: scopeFilterFields lists %q but index %q has no TAG/NUMERIC attribute for it", scope, field, ix.Name)
+		}
+	}
+
+	// Every scope the api advertises must map to a real index.
+	for scope := range scopeFilterFields {
+		assert.Truef(t, indexedScopes[scope],
+			"scopeFilterFields advertises scope %q with no matching index schema", scope)
+	}
+}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -132,136 +132,168 @@ func (idx *Index) FlushSearchData(ctx context.Context) error {
 	return nil
 }
 
-// EnsureIndexes creates the FT search indexes if they don't already exist.
-func (idx *Index) EnsureIndexes(ctx context.Context) error {
-	indexes := []struct {
-		name   string
-		prefix string
-		schema []any
-	}{
-		{
-			name:   idxActions,
-			prefix: prefixAction,
-			schema: []any{
-				"name", "TEXT",
-				"description", "TEXT",
-				"type", "TAG",
-				"is_compliance", "TAG",
-				"created_at", "NUMERIC", "SORTABLE",
-				"updated_at", "NUMERIC", "SORTABLE",
-			},
-		},
-		{
-			name:   idxActionSets,
-			prefix: prefixActionSet,
-			schema: []any{
-				"name", "TEXT",
-				"description", "TEXT",
-				"member_count", "NUMERIC",
-				"action_names", "TEXT",
-				"created_at", "NUMERIC", "SORTABLE",
-				"updated_at", "NUMERIC", "SORTABLE",
-			},
-		},
-		{
-			name:   idxDefinitions,
-			prefix: prefixDefinition,
-			schema: []any{
-				"name", "TEXT",
-				"description", "TEXT",
-				"member_count", "NUMERIC",
-				"set_names", "TEXT",
-				"action_names", "TEXT",
-				"created_at", "NUMERIC", "SORTABLE",
-				"updated_at", "NUMERIC", "SORTABLE",
-			},
-		},
-		{
-			name:   idxCompliancePolicies,
-			prefix: prefixCompliancePolicy,
-			schema: []any{
-				"name", "TEXT",
-				"description", "TEXT",
-				"action_names", "TEXT",
-			},
-		},
-		{
-			name:   idxDevices,
-			prefix: prefixDevice,
-			schema: []any{
-				"hostname", "TEXT",
-				"agent_version", "TAG",
-				"labels", "TEXT",
-				"os_name", "TEXT",
-				"os_version", "TEXT",
-				"os_arch", "TAG",
-				"kernel", "TEXT",
-				"compliance_status", "TAG",
-				"registered_at", "NUMERIC", "SORTABLE",
-				"last_seen_at", "NUMERIC", "SORTABLE",
-			},
-		},
-		{
-			name:   idxUsers,
-			prefix: prefixUser,
-			schema: []any{
-				"email", "TEXT",
-				"display_name", "TEXT",
-				"linux_username", "TEXT",
-				"disabled", "TAG",
-				"created_at", "NUMERIC", "SORTABLE",
-			},
-		},
-		{
-			name:   idxDeviceGroups,
-			prefix: prefixDeviceGroup,
-			schema: []any{
-				"name", "TEXT",
-				"description", "TEXT",
-				"is_dynamic", "TAG",
-				"member_count", "NUMERIC",
-				"created_at", "NUMERIC", "SORTABLE",
-			},
-		},
-		{
-			name:   idxUserGroups,
-			prefix: prefixUserGroup,
-			schema: []any{
-				"name", "TEXT",
-				"description", "TEXT",
-				"is_dynamic", "TAG",
-				"member_count", "NUMERIC",
-				"created_at", "NUMERIC", "SORTABLE",
-			},
-		},
-		{
-			name:   idxExecutions,
-			prefix: prefixExecution,
-			schema: []any{
-				"action_name", "TEXT",
-				"device_hostname", "TEXT",
-				"status", "TAG",
-				"action_type", "TAG",
-				"device_id", "TAG",
-				"created_at", "NUMERIC", "SORTABLE",
-			},
-		},
-		{
-			name:   idxAuditEvents,
-			prefix: prefixAuditEvent,
-			schema: []any{
-				"event_type", "TEXT",
-				"stream_type", "TAG",
-				"actor_type", "TAG",
-				"actor_id", "TAG",
-				"occurred_at", "NUMERIC", "SORTABLE",
-			},
-		},
-	}
+// IndexSchema is one RediSearch (FT.CREATE) index definition. Exported so a
+// test can assert that the api-layer scopeFilterFields mirror the TAG/NUMERIC
+// fields actually declared here — the two must stay in lockstep, since a tag
+// filter on a field the index never declared makes RediSearch reject the whole
+// query (server#158).
+type IndexSchema struct {
+	Name   string // e.g. "idx:devices"
+	Prefix string
+	Schema []any // field, type, [modifier...] exactly as passed to FT.CREATE SCHEMA
+}
 
-	for _, ix := range indexes {
-		args := []any{"FT.CREATE", ix.name, "ON", "HASH", "PREFIX", "1", ix.prefix, "SCHEMA"}
-		args = append(args, ix.schema...)
+// Scope returns the search scope string this index backs — the index name with
+// the "idx:" prefix stripped (e.g. "idx:devices" → "devices"). This is the key
+// used in the api-layer scopeFilterFields map.
+func (s IndexSchema) Scope() string { return strings.TrimPrefix(s.Name, "idx:") }
+
+// FilterableFields returns the field names declared TAG or NUMERIC — the only
+// kinds a structured (@field:{...} / range) filter can target. TEXT fields are
+// full-text only and are intentionally excluded. Derived by pairing each type
+// token with its preceding field name, so SORTABLE and other modifiers are
+// ignored.
+func (s IndexSchema) FilterableFields() map[string]bool {
+	out := map[string]bool{}
+	for i := 1; i < len(s.Schema); i++ {
+		t, _ := s.Schema[i].(string)
+		if t != "TAG" && t != "NUMERIC" {
+			continue
+		}
+		if field, ok := s.Schema[i-1].(string); ok {
+			out[field] = true
+		}
+	}
+	return out
+}
+
+// IndexSchemas is the canonical set of RediSearch indexes EnsureIndexes creates.
+var IndexSchemas = []IndexSchema{
+	{
+		Name:   idxActions,
+		Prefix: prefixAction,
+		Schema: []any{
+			"name", "TEXT",
+			"description", "TEXT",
+			"type", "TAG",
+			"is_compliance", "TAG",
+			"created_at", "NUMERIC", "SORTABLE",
+			"updated_at", "NUMERIC", "SORTABLE",
+		},
+	},
+	{
+		Name:   idxActionSets,
+		Prefix: prefixActionSet,
+		Schema: []any{
+			"name", "TEXT",
+			"description", "TEXT",
+			"member_count", "NUMERIC",
+			"action_names", "TEXT",
+			"created_at", "NUMERIC", "SORTABLE",
+			"updated_at", "NUMERIC", "SORTABLE",
+		},
+	},
+	{
+		Name:   idxDefinitions,
+		Prefix: prefixDefinition,
+		Schema: []any{
+			"name", "TEXT",
+			"description", "TEXT",
+			"member_count", "NUMERIC",
+			"set_names", "TEXT",
+			"action_names", "TEXT",
+			"created_at", "NUMERIC", "SORTABLE",
+			"updated_at", "NUMERIC", "SORTABLE",
+		},
+	},
+	{
+		Name:   idxCompliancePolicies,
+		Prefix: prefixCompliancePolicy,
+		Schema: []any{
+			"name", "TEXT",
+			"description", "TEXT",
+			"action_names", "TEXT",
+		},
+	},
+	{
+		Name:   idxDevices,
+		Prefix: prefixDevice,
+		Schema: []any{
+			"hostname", "TEXT",
+			"agent_version", "TAG",
+			"labels", "TEXT",
+			"os_name", "TEXT",
+			"os_version", "TEXT",
+			"os_arch", "TAG",
+			"kernel", "TEXT",
+			"compliance_status", "TAG",
+			"registered_at", "NUMERIC", "SORTABLE",
+			"last_seen_at", "NUMERIC", "SORTABLE",
+		},
+	},
+	{
+		Name:   idxUsers,
+		Prefix: prefixUser,
+		Schema: []any{
+			"email", "TEXT",
+			"display_name", "TEXT",
+			"linux_username", "TEXT",
+			"disabled", "TAG",
+			"created_at", "NUMERIC", "SORTABLE",
+		},
+	},
+	{
+		Name:   idxDeviceGroups,
+		Prefix: prefixDeviceGroup,
+		Schema: []any{
+			"name", "TEXT",
+			"description", "TEXT",
+			"is_dynamic", "TAG",
+			"member_count", "NUMERIC",
+			"created_at", "NUMERIC", "SORTABLE",
+		},
+	},
+	{
+		Name:   idxUserGroups,
+		Prefix: prefixUserGroup,
+		Schema: []any{
+			"name", "TEXT",
+			"description", "TEXT",
+			"is_dynamic", "TAG",
+			"member_count", "NUMERIC",
+			"created_at", "NUMERIC", "SORTABLE",
+		},
+	},
+	{
+		Name:   idxExecutions,
+		Prefix: prefixExecution,
+		Schema: []any{
+			"action_name", "TEXT",
+			"device_hostname", "TEXT",
+			"status", "TAG",
+			"action_type", "TAG",
+			"device_id", "TAG",
+			"created_at", "NUMERIC", "SORTABLE",
+		},
+	},
+	{
+		Name:   idxAuditEvents,
+		Prefix: prefixAuditEvent,
+		Schema: []any{
+			"event_type", "TEXT",
+			"stream_type", "TAG",
+			"actor_type", "TAG",
+			"actor_id", "TAG",
+			"occurred_at", "NUMERIC", "SORTABLE",
+		},
+	},
+}
+
+// EnsureIndexes creates the FT search indexes if they do not already exist.
+func (idx *Index) EnsureIndexes(ctx context.Context) error {
+	for _, ix := range IndexSchemas {
+		args := []any{"FT.CREATE", ix.Name, "ON", "HASH", "PREFIX", "1", ix.Prefix, "SCHEMA"}
+		args = append(args, ix.Schema...)
 		err := idx.rdb.Do(ctx, args...).Err()
 		if err != nil {
 			// "already exists" substring covers both backends used during
@@ -273,7 +305,7 @@ func (idx *Index) EnsureIndexes(ctx context.Context) error {
 			if strings.Contains(err.Error(), "already exists") {
 				continue
 			}
-			return fmt.Errorf("create index %s: %w", ix.name, err)
+			return fmt.Errorf("create index %s: %w", ix.Name, err)
 		}
 	}
 


### PR DESCRIPTION
Security audit (Low). `scopeFilterFields` (api) must mirror the **TAG/NUMERIC** fields the RediSearch `FT.CREATE` schemas (search) declare. They agree today, but nothing pinned it — drift breaks filtered search: a tag/range filter on a field an index never declared makes RediSearch reject the **whole** query (server#158), and a declared field missing from the allow-list is silently unfilterable.

- Export the index definitions from `search` as `IndexSchemas`, with `IndexSchema.Scope()` (name minus the `idx:` prefix) and `.FilterableFields()` (the TAG/NUMERIC attributes). `EnsureIndexes` now iterates the exported slice — single source of truth, no behavior change.
- Add a self-discovering `package api` test asserting parity **both ways**: every declared filterable field is advertised, every advertised field has a backing TAG/NUMERIC attribute, and every scope maps to a real index. Derived from the sources (no hardcoded list), and guards against an empty discovery set.

Verified it goes red when a field is dropped from either side (e.g. removing `os_arch` from `scopeFilterFields` fails with a precise message), green when restored.

Closes #393.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added parity verification test for search filter fields and index schemas.

* **Refactor**
  * Refactored index creation logic to streamline schema management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->