### PR TITLE
fix(security): make last-admin guard atomic with the mutation (#369)

### DIFF
--- a/internal/api/admin_guard.go
+++ b/internal/api/admin_guard.go
@@ -2,11 +2,43 @@ package api
 
 import (
 	"context"
+	"errors"
 
 	"connectrpc.com/connect"
 
 	"github.com/manchtools/power-manage/server/internal/store"
 )
+
+// advisoryKeyAdminMutation serializes every last-admin-guarded mutation
+// (disable / delete / admin-role-revoke) so the read-side guard and its
+// mutating event append are atomic against a concurrent admin-removing request
+// — closing the TOCTOU where two requests for different admins both observe
+// "another admin exists" and race to zero (#369). The value is "admin" in hex;
+// it only needs to be a stable constant distinct from any other advisory lock.
+const advisoryKeyAdminMutation int64 = 0x61646d696e
+
+// guardedAdminMutation runs the last-admin guard and the mutating append under
+// one advisory lock, so two concurrent admin-removing requests cannot both pass
+// the guard and lock everyone out (#369). affectedUserID is the admin being
+// removed; appendFn performs the mutation and MUST return a connect-coded error
+// (or nil). Guard/append errors pass through unchanged; only a lock-
+// infrastructure failure is re-coded Internal.
+func guardedAdminMutation(ctx context.Context, st *store.Store, affectedUserID string, appendFn func() error) error {
+	err := st.WithAdvisoryLock(ctx, advisoryKeyAdminMutation, func() error {
+		if gerr := assertOtherEnabledAdminExists(ctx, st, affectedUserID); gerr != nil {
+			return gerr
+		}
+		return appendFn()
+	})
+	if err == nil {
+		return nil
+	}
+	var ce *connect.Error
+	if errors.As(err, &ce) {
+		return err
+	}
+	return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to serialize admin mutation")
+}
 
 // assertOtherEnabledAdminExists rejects an operation that would remove the LAST
 // enabled administrator. It verifies at least one ENABLED admin OTHER than
@@ -20,14 +52,12 @@ import (
 // it counts group-inherited admins (which the prior RevokeRoleFromUser check
 // ignored) and excludes disabled/deleted ones (which it also ignored).
 //
-// LIMITATION (pre-existing): this is a read-side preflight, NOT atomic with the
-// delete/disable/revoke event it guards. Two concurrent admin-removing requests
-// for *different* admins can both observe "another enabled admin exists" and
-// both proceed, racing to zero enabled admins. The prior CountUsersWithRole
-// check had the identical race. The outcome is recoverable — the bootstrap
-// admin (CONTROL_ADMIN_EMAIL/PASSWORD) is re-created on server start — so this
-// strict-improvement guard does not close the race; atomic enforcement in the
-// projection/transaction is a tracked follow-up.
+// This is a read-side preflight and is NOT atomic with the mutating event on
+// its own. Callers MUST run it together with that append via guardedAdminMutation
+// (below), which holds an advisory lock across both so two concurrent admin-
+// removing requests for *different* admins can't both observe "another enabled
+// admin exists" and race to zero (#369). Calling it standalone reintroduces that
+// TOCTOU.
 func assertOtherEnabledAdminExists(ctx context.Context, st *store.Store, affectedUserID string) error {
 	adminRole, err := st.Repos().Role.GetByName(ctx, "Admin")
 	if err != nil {

--- a/internal/api/admin_guard_test.go
+++ b/internal/api/admin_guard_test.go
@@ -3,6 +3,7 @@ package api_test
 import (
 	"context"
 	"log/slog"
+	"sync"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -11,6 +12,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
@@ -110,4 +112,56 @@ func TestUpdateRole_AdminPermissionsImmutable(t *testing.T) {
 	}))
 	require.Error(t, err, "the Admin role's permissions must be immutable")
 	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+// countEnabledAdmins returns the number of enabled, non-deleted holders of the
+// Admin role (direct grants — the test factory assigns it directly).
+func countEnabledAdmins(t *testing.T, st *store.Store) int {
+	t.Helper()
+	ctx := context.Background()
+	role, err := st.Repos().Role.GetByName(ctx, "Admin")
+	require.NoError(t, err)
+	ids, err := st.Repos().Role.ListUserIDsWithRole(ctx, role.ID)
+	require.NoError(t, err)
+	n := 0
+	for _, id := range ids {
+		u, err := st.Repos().User.Get(ctx, id)
+		require.NoError(t, err)
+		if !u.Disabled && !u.IsDeleted {
+			n++
+		}
+	}
+	return n
+}
+
+// TestSetUserDisabled_ConcurrentLastAdminInvariant pins the #369 fix's
+// invariant: no amount of concurrent admin-disabling may drive the enabled-admin
+// count to zero. Four admins are disabled simultaneously; the advisory lock
+// serializes each guard+append so each guard sees the running count and refuses
+// the one that would hit zero — at least one enabled admin must remain. Without
+// the lock the guards read a stale count concurrently and can all pass, zeroing
+// out admins — which this asserts against.
+func TestSetUserDisabled_ConcurrentLastAdminInvariant(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserHandler(st, slog.Default(), nil)
+
+	const n = 4
+	admins := make([]string, n)
+	for i := range admins {
+		admins[i] = testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	}
+	ctx := testutil.AdminContext(admins[0])
+
+	var wg sync.WaitGroup
+	for _, id := range admins {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			_, _ = h.SetUserDisabled(ctx, connect.NewRequest(&pm.SetUserDisabledRequest{Id: id, Disabled: true}))
+		}(id)
+	}
+	wg.Wait()
+
+	assert.GreaterOrEqual(t, countEnabledAdmins(t, st), 1,
+		"at least one enabled admin must always remain — concurrent disables must not race to zero (#369)")
 }

--- a/internal/api/role_handler.go
+++ b/internal/api/role_handler.go
@@ -451,33 +451,33 @@ func (h *RoleHandler) RevokeRoleFromUser(ctx context.Context, req *connect.Reque
 		// doesn't confer global admin, and a non-existent grant is a no-op, so
 		// neither threatens lockout. Counts group-inherited admins and ignores
 		// disabled/deleted ones — which the old CountUsersWithRole check did not
-		// (#365). NOTE: this is a read-side preflight, not atomic with the
-		// revoke event; two concurrent admin removals can still race to zero
-		// admins (recoverable via the bootstrap admin on restart). Atomic
-		// enforcement in the projector is a follow-up.
-		if role.IsSystem && role.Name == "Admin" && scopeKind == "" {
-			if err := assertOtherEnabledAdminExists(ctx, h.store, req.Msg.UserId); err != nil {
-				return nil, err
-			}
-		}
-
+		// (#365). The guard + revoke append run under one advisory lock so two
+		// concurrent admin removals can't both pass and race to zero (#369).
 		streamID := req.Msg.UserId + ":" + req.Msg.RoleId
 		if scopeKind != "" {
 			streamID += ":" + scopeID
 		}
-		if err := appendEvent(ctx, h.store, h.logger, store.Event{
-			StreamType: "user_role",
-			StreamID:   streamID,
-			EventType:  string(eventtypes.UserRoleRevoked),
-			Data: payloads.UserRoleRevoked{
-				UserID:    req.Msg.UserId,
-				RoleID:    req.Msg.RoleId,
-				ScopeKind: sk,
-				ScopeID:   si,
-			},
-			ActorType: "user",
-			ActorID:   userCtx.ID,
-		}, "failed to revoke role"); err != nil {
+		appendRevoke := func() error {
+			return appendEvent(ctx, h.store, h.logger, store.Event{
+				StreamType: "user_role",
+				StreamID:   streamID,
+				EventType:  string(eventtypes.UserRoleRevoked),
+				Data: payloads.UserRoleRevoked{
+					UserID:    req.Msg.UserId,
+					RoleID:    req.Msg.RoleId,
+					ScopeKind: sk,
+					ScopeID:   si,
+				},
+				ActorType: "user",
+				ActorID:   userCtx.ID,
+			}, "failed to revoke role")
+		}
+
+		if role.IsSystem && role.Name == "Admin" && scopeKind == "" {
+			if err := guardedAdminMutation(ctx, h.store, req.Msg.UserId, appendRevoke); err != nil {
+				return nil, err
+			}
+		} else if err := appendRevoke(); err != nil {
 			return nil, err
 		}
 	} else {

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -403,29 +403,36 @@ func (h *UserHandler) SetUserDisabled(ctx context.Context, req *connect.Request[
 		return nil, err
 	}
 
-	// Disabling the last enabled administrator would lock everyone out (#365).
-	if req.Msg.Disabled {
-		if err := assertOtherEnabledAdminExists(ctx, h.store, req.Msg.Id); err != nil {
-			return nil, err
-		}
-	}
-
 	// Emit appropriate event
 	eventType := string(eventtypes.UserEnabled)
 	if req.Msg.Disabled {
 		eventType = string(eventtypes.UserDisabled)
 	}
 
-	err = h.store.AppendEvent(ctx, store.Event{
-		StreamType: "user",
-		StreamID:   req.Msg.Id,
-		EventType:  eventType,
-		Data:       map[string]any{},
-		ActorType:  "user",
-		ActorID:    userCtx.ID,
-	})
+	appendDisable := func() error {
+		if err := h.store.AppendEvent(ctx, store.Event{
+			StreamType: "user",
+			StreamID:   req.Msg.Id,
+			EventType:  eventType,
+			Data:       map[string]any{},
+			ActorType:  "user",
+			ActorID:    userCtx.ID,
+		}); err != nil {
+			return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to update disabled status")
+		}
+		return nil
+	}
+
+	// Disabling the last enabled administrator would lock everyone out (#365);
+	// run the guard + append under one advisory lock so two concurrent disables
+	// can't both pass and race to zero admins (#369). Enabling needs no guard.
+	if req.Msg.Disabled {
+		err = guardedAdminMutation(ctx, h.store, req.Msg.Id, appendDisable)
+	} else {
+		err = appendDisable()
+	}
 	if err != nil {
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to update disabled status")
+		return nil, err
 	}
 
 	// Read back from projection
@@ -458,23 +465,24 @@ func (h *UserHandler) DeleteUser(ctx context.Context, req *connect.Request[pm.De
 		return nil, handleGetError(ctx, err, ErrUserNotFound, "user not found")
 	}
 
-	// Refuse to delete the last enabled administrator (#365). A no-op for
-	// non-admins (other admins still exist).
-	if err := assertOtherEnabledAdminExists(ctx, h.store, req.Msg.Id); err != nil {
-		return nil, err
-	}
-
-	// Emit UserDeleted event
-	err = h.store.AppendEvent(ctx, store.Event{
-		StreamType: "user",
-		StreamID:   req.Msg.Id,
-		EventType:  string(eventtypes.UserDeleted),
-		Data:       map[string]any{},
-		ActorType:  "user",
-		ActorID:    userCtx.ID,
+	// Refuse to delete the last enabled administrator (#365); run the guard +
+	// UserDeleted append under one advisory lock so concurrent deletes can't
+	// both pass and race to zero admins (#369). A no-op for non-admins.
+	err = guardedAdminMutation(ctx, h.store, req.Msg.Id, func() error {
+		if err := h.store.AppendEvent(ctx, store.Event{
+			StreamType: "user",
+			StreamID:   req.Msg.Id,
+			EventType:  string(eventtypes.UserDeleted),
+			Data:       map[string]any{},
+			ActorType:  "user",
+			ActorID:    userCtx.ID,
+		}); err != nil {
+			return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to delete user")
+		}
+		return nil
 	})
 	if err != nil {
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to delete user")
+		return nil, err
 	}
 
 	// Search-index removal is handled by api.SearchListener (post-commit

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -403,6 +403,38 @@ func (s *Store) LoadStreamByType(ctx context.Context, streamType string, limit, 
 	})
 }
 
+// WithAdvisoryLock runs fn while holding a session-level PostgreSQL advisory
+// lock on key, serializing every caller that uses the same key on this
+// database. The lock is held across the ENTIRE fn — including any synchronous
+// post-commit projector writes triggered by an AppendEvent inside fn — so a
+// read-side guard that checks a projection and then appends an event is atomic
+// against a concurrent caller: the next caller blocks until this one's
+// projection write has landed, rather than racing on a stale read.
+//
+// The lock is taken on a dedicated pooled connection and explicitly released
+// (a pooled connection is not closed on Release, so a session lock would
+// otherwise leak). The release is detached from ctx so a cancelled request
+// still frees the lock, and surfaces as the returned error only when fn itself
+// succeeded.
+func (s *Store) WithAdvisoryLock(ctx context.Context, key int64, fn func() error) (err error) {
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire connection for advisory lock: %w", err)
+	}
+	defer conn.Release()
+
+	if _, err := conn.Exec(ctx, "SELECT pg_advisory_lock($1)", key); err != nil {
+		return fmt.Errorf("acquire advisory lock %d: %w", key, err)
+	}
+	defer func() {
+		if _, uerr := conn.Exec(context.WithoutCancel(ctx), "SELECT pg_advisory_unlock($1)", key); uerr != nil && err == nil {
+			err = fmt.Errorf("release advisory lock %d: %w", key, uerr)
+		}
+	}()
+
+	return fn()
+}
+
 // WithTx runs a function within a transaction.
 func (s *Store) WithTx(ctx context.Context, fn func(*Queries) error) error {
 	tx, err := s.pool.Begin(ctx)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -523,4 +524,39 @@ func TestProjection_AssignmentCreated(t *testing.T) {
 	assert.Equal(t, actionID, sourceID)
 	assert.Equal(t, "device", targetType)
 	assert.Equal(t, deviceID, targetID)
+}
+
+// TestWithAdvisoryLock_SerializesSameKey verifies the lock actually serializes
+// same-key critical sections — the property the last-admin TOCTOU fix (#369)
+// relies on. Five goroutines run an overlapping-by-design critical section
+// (each sleeps while "inside"); with the lock, at most one is ever inside.
+func TestWithAdvisoryLock_SerializesSameKey(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	const key int64 = 0x5151
+
+	var mu sync.Mutex
+	concurrent, maxConcurrent := 0, 0
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := st.WithAdvisoryLock(context.Background(), key, func() error {
+				mu.Lock()
+				concurrent++
+				if concurrent > maxConcurrent {
+					maxConcurrent = concurrent
+				}
+				mu.Unlock()
+				time.Sleep(25 * time.Millisecond)
+				mu.Lock()
+				concurrent--
+				mu.Unlock()
+				return nil
+			})
+			assert.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+	assert.Equal(t, 1, maxConcurrent, "same-key advisory lock must serialize critical sections (no overlap)")
 }


### PR DESCRIPTION
Follow-up from #367/#365. `assertOtherEnabledAdminExists` was a **read-side preflight, not atomic** with the delete/disable/revoke event it guards — two concurrent admin-removing requests for *different* admins could both observe "another enabled admin exists" and **race to zero**, locking the org out of all admin access (recoverable only via the bootstrap admin on restart).

## Fix
- **`Store.WithAdvisoryLock(ctx, key, fn)`** — a session-level `pg_advisory_lock` taken on a dedicated pooled connection and held across the **entire** callback, including the synchronous post-commit projector write an `AppendEvent` triggers (so the next caller blocks until the prior projection write lands, not just until commit). Explicitly released (a pooled conn isn't closed on Release), detached from ctx so a cancelled request still frees it.
- **`guardedAdminMutation`** runs the guard + the mutating append under that lock. `SetUserDisabled`, `DeleteUser`, and `RevokeRoleFromUser` (unscoped-Admin branch) now go through it. The serialized next caller sees the true count, so the guard refuses the one that would hit zero.

## Tests
- `WithAdvisoryLock` deterministically serializes same-key critical sections.
- Four concurrent admin-disables leave **≥1 enabled admin**. Verified this invariant test goes **red** (races to zero) with the lock bypassed, green with it.

Closes #369.