### PR TITLE
test(arch): architectural fitness functions + module-wide clock seam

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -44,6 +44,30 @@ Database migrations live in `internal/store/migrations/` (Goose, embedded). See 
 - Always handle errors -- never silently ignore them.
 - Wrap PL/pgSQL functions in `-- +goose StatementBegin` / `-- +goose StatementEnd` in migrations.
 
+## Guardrails (architectural fitness functions)
+
+`internal/archtest/` holds build-failing invariant tests. They run in the
+normal `go test ./...` path, so you may hit one before you expect a review
+comment. Current guards:
+
+- **`TestNoDynamicSQL`** — DB query/exec args must be a string literal or a
+  named string constant. Build queries with sqlc or parameterized literals;
+  never `fmt.Sprintf`/concatenate SQL.
+- **`TestSecretComparesAreConstantTime`** — compare secrets/MACs/tokens/
+  signatures/fingerprints with `subtle.ConstantTimeCompare`/`hmac.Equal`,
+  never `==`/`bytes.Equal`.
+- **`TestProjectionTablesWrittenOnlyByProjectors`** — request handlers append
+  events; they must not write `*_projection` tables directly.
+- **`TestNoUnabstractedTimeNow`** — no direct `time.Now()` calls in runtime
+  code. Read the clock through an injected `now func() time.Time` seam
+  (defaulting to `time.Now`) and call `t.now()`, so time-dependent logic is
+  testable with a fixed clock.
+
+Each guard ships a documented, no-stale-guarded allowlist for genuine
+exceptions. **Prefer fixing the code over adding an allowlist entry**; an
+entry is a reviewed decision needing a justification of *why the flagged shape
+is safe here*. See [`docs/adr/0002-architectural-fitness-functions.md`](../docs/adr/0002-architectural-fitness-functions.md).
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the AGPL-3.0 license.

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -168,7 +168,7 @@ func main() {
 		logger.Info("dynamic group evaluation worker disabled")
 	}
 
-	startStaleExecutionExpiry(ctx, st, logger)
+	startStaleExecutionExpiry(ctx, st, logger, time.Now)
 
 	// Start periodic cleanup of stale OSQuery results
 	go runPeriodic(ctx, 5*time.Minute, func() {

--- a/cmd/control/periodic.go
+++ b/cmd/control/periodic.go
@@ -130,7 +130,7 @@ func startDynamicGroupWorker(ctx context.Context, st *store.Store, interval time
 // ExecutionTimedOut events for each. The 1-minute cadence is fixed —
 // there's no operator knob today and the prior inline goroutine in
 // main.go didn't expose one either; this is a straight extraction.
-func startStaleExecutionExpiry(ctx context.Context, st *store.Store, logger *slog.Logger) {
+func startStaleExecutionExpiry(ctx context.Context, st *store.Store, logger *slog.Logger, now func() time.Time) {
 	go func() {
 		ticker := time.NewTicker(1 * time.Minute)
 		defer ticker.Stop()
@@ -144,7 +144,7 @@ func startStaleExecutionExpiry(ctx context.Context, st *store.Store, logger *slo
 				}
 				for _, exec := range stale {
 					errMsg := fmt.Sprintf("execution timed out: device did not respond (status was %s)", exec.Status)
-					completedAt := time.Now().UTC().Format(time.RFC3339Nano)
+					completedAt := now().UTC().Format(time.RFC3339Nano)
 					if err := st.AppendEvent(ctx, store.Event{
 						StreamType: "execution",
 						StreamID:   exec.ID,

--- a/docs/adr/0002-architectural-fitness-functions.md
+++ b/docs/adr/0002-architectural-fitness-functions.md
@@ -1,0 +1,118 @@
+# 0002 — Architectural fitness functions (what is locked, and why)
+
+- Status: accepted
+- Date: 2026-06-12
+- Related: 0000 (terminal-admin threat model), 0001 (AES key rotation), the
+  2026-06-12 agent + server security/quality audits, the
+  SECURITY_HARDENING_WORKPLAN (WS0).
+
+## Context
+
+The 2026-06 security and architecture sweeps fixed a set of recurring code
+smells and confirmed a set of good patterns the codebase already follows. A
+one-off fix does not stop the next contributor from reintroducing the smell,
+and a good pattern that is only a convention erodes silently. We want the
+build to fail when a known-bad shape reappears or a load-bearing invariant is
+broken — *executable* architecture rules, not prose.
+
+## Decision
+
+Each Go module ships a dedicated `archtest` package of **architectural fitness
+functions**: self-discovering, module-wide invariant tests run as part of the
+normal `go test` suite.
+
+Ground rules for every guard:
+
+- **Standard library only** (`go/parser`, `go/ast`, `go/token`,
+  `go/printer`). No `golang.org/x/tools` dependency — the guards stay
+  hermetic, fast, and identical in shape across repos. Syntactic invariants
+  do not need full type resolution; where a guard leans on a naming/structure
+  heuristic it documents the heuristic.
+- **Self-discovering, never a hardcoded list.** Each guard walks the module
+  tree (or reflects over the connect/proto registry) and **asserts it
+  inspected a non-empty set** (a "matches-zero" guard) so it can never pass
+  vacuously — the classic stale-list failure that fails *open*.
+- **Every allowlist is itself guarded.** Legitimate exceptions live in a
+  documented allowlist keyed by `path :: rendered-expression`; a
+  no-stale-entry check fails the build if an allowlisted site no longer
+  exists, so the allowlist cannot rot into a silent escape hatch.
+
+### Guards by module
+
+| Guard | server | sdk | agent | Pins / forbids |
+|---|:--:|:--:|:--:|---|
+| `TestNoDynamicSQL` | ✅ | — | ✅ | DB query/exec args must be string-literal or named-const SQL — no `fmt.Sprintf`/concatenation. (sdk has no DB.) |
+| `TestSecretComparesAreConstantTime` | ✅ | ✅ | ✅ | Secret/MAC/token/signature/fingerprint/digest compares use `subtle.ConstantTimeCompare`/`hmac.Equal`, never `==`/`bytes.Equal`. Presence (`== nil`/`== ""`) and metadata fields excluded. |
+| `TestProjectionTablesWrittenOnlyByProjectors` | ✅ | — | — | Request handlers never write `*_projection` directly — they append events; projectors and computed-read-model engines write projections (see below). |
+| `TestNoUnabstractedTimeNow` | ✅ | — | ✅ | No direct `time.Now()` calls in runtime code (see clock seam below). |
+
+RPC classification (every `ControlService` RPC is in exactly one of
+{public allow-list, permission, procedure-alternative}, both directions,
+matches-zero-guarded) is already enforced by
+`server/internal/auth/permissions_parity_test.go` and is **not** duplicated in
+`archtest`.
+
+### The clock seam (`TestNoUnabstractedTimeNow`)
+
+Time-dependent runtime code (token/cert/session expiry, rate-limit windows,
+maintenance-window gating, timestamps, even latency measurement) reads the
+current time through an injected seam:
+
+```go
+type Thing struct {
+    now func() time.Time // clock seam; defaults to time.Now, overridden in tests
+}
+func NewThing(...) *Thing { return &Thing{ now: time.Now, ... } }
+// ... use t.now() instead of time.Now()
+```
+
+This extends the seam already used by `internal/crl`, `internal/terminal`,
+`internal/compliance` and `internal/gateway/registry` to the whole module, so
+every time-dependent path is deterministically testable with a fixed clock
+(e.g. a cert issued under a past clock is born expired; the offline scheduler
+defers when the injected clock is outside its maintenance window).
+
+The guard bans `time.Now()` **calls**; the bare `time.Now` **value** (the
+injection default) is allowed. The single structural exception is
+`ulid.Timestamp(time.Now())` — ID generation, where the wall clock seeds the
+ULID's time component rather than driving a decision; injecting a clock there
+buys no testability. This is a category rule, not a per-site blessing.
+
+**The SDK is intentionally exempt** from the clock guard: it has no
+time-*decision* logic. Its only `time.Now()` uses are external-command
+duration measurement (intrinsically real wall-clock) and ULID seeding, so a
+clock seam buys nothing there.
+
+### Projection-write boundary nuance
+
+`*_projection` rows carry **both** event-sourced columns (written by
+projectors replaying events) **and** computed/derived columns written by
+specialized engines (the compliance evaluator, the dynamic-group evaluator,
+the system-role bootstrap reconciler, the action-signature store adapter).
+The invariant the guard protects is therefore "*request handlers append
+events; they never write a projection directly*" — the engines are not
+request handlers and own derived state. They are allowlisted with per-site
+justification. If any of those direct writes is later judged a smell to
+refactor into an event + projector, deleting its allowlist entry turns the
+call site red — the intended forcing function.
+
+## Adding an allowlist entry
+
+An allowlist entry is a reviewed decision, not a quick unblock. Add the
+`path :: rendered-expression` key with a one-sentence justification of *why
+the flagged shape is safe here* (e.g. "DDL identifier that cannot be a bind
+parameter and comes from a trusted in-process registry"). The no-stale guard
+will fail the build if the justification outlives the site. A reviewer should
+push back on any entry whose justification is "it was already like this".
+
+## Consequences
+
+- A new contributor who writes `fmt.Sprintf` into a query, compares a token
+  with `==`, writes a projection from a handler, or calls `time.Now()` in
+  runtime code gets a red build with a pointer to this ADR.
+- The guards run in the normal `go test` path (no extra tooling) plus the
+  existing generated-code drift jobs (`sqlc.yml`; proto regen in CI).
+- Cross-module duplication of the small `archtest` AST helpers is accepted:
+  the modules are independently released and their test infrastructure is
+  intentionally self-contained. (A shared `sdk/go/archtest` library is a
+  possible future consolidation.)

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -35,11 +35,12 @@ type DeviceHandler struct {
 	// crl, when set, receives a deleted device's cert fingerprint so the cert
 	// stops working at the gateway. nil disables it (no Valkey / tests).
 	crl *crl.Store
+	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewDeviceHandler creates a new device handler.
 func NewDeviceHandler(st *store.Store, enc *crypto.Encryptor, logger *slog.Logger) *DeviceHandler {
-	return &DeviceHandler{store: st, encryptor: enc, logger: logger}
+	return &DeviceHandler{store: st, encryptor: enc, logger: logger, now: time.Now}
 }
 
 // SetCRLStore wires the certificate revocation list (post-construction).
@@ -955,7 +956,7 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 	// projector already does that, but the audit log loses the
 	// "these three rows are one revocation attempt" invariant.
 	luksStreamID := newULID()
-	reqAt := time.Now().UTC().Format(time.RFC3339Nano)
+	reqAt := h.now().UTC().Format(time.RFC3339Nano)
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "luks_key",
 		StreamID:   luksStreamID,
@@ -990,7 +991,7 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 				DeviceID: req.Msg.DeviceId,
 				ActionID: req.Msg.ActionId,
 				Error:    fmt.Sprintf("dispatch enqueue failed: %v", enqErr),
-				FailedAt: time.Now().UTC().Format(time.RFC3339Nano),
+				FailedAt: h.now().UTC().Format(time.RFC3339Nano),
 			},
 			ActorType: "system",
 			ActorID:   "system",
@@ -1014,7 +1015,7 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 		Data: payloads.LuksDeviceKeyRevocationDispatched{
 			DeviceID:     req.Msg.DeviceId,
 			ActionID:     req.Msg.ActionId,
-			DispatchedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			DispatchedAt: h.now().UTC().Format(time.RFC3339Nano),
 		},
 		ActorType: "user",
 		ActorID:   userCtx.ID,

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -38,6 +38,8 @@ type InternalHandler struct {
 	// gateway gets a clean error rather than the InternalService
 	// default 'method not implemented'.
 	terminalTokenStore *terminal.TokenStore
+
+	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewInternalHandler creates a new internal service handler.
@@ -46,6 +48,7 @@ func NewInternalHandler(st *store.Store, enc *crypto.Encryptor, logger *slog.Log
 		store:     st,
 		encryptor: enc,
 		logger:    logger,
+		now:       time.Now,
 	}
 }
 
@@ -340,7 +343,7 @@ func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Re
 			ActionID:       req.Msg.ActionId,
 			DevicePath:     req.Msg.DevicePath,
 			Passphrase:     encPassphrase,
-			RotatedAt:      time.Now().UTC(),
+			RotatedAt:      h.now().UTC(),
 			RotationReason: rotationReasonToString(req.Msg.RotationReason),
 		},
 		ActorType: "device",
@@ -399,7 +402,7 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 			if rotatedAt, err = time.Parse(time.RFC3339, r.RotatedAt); err != nil {
 				h.logger.Warn("LpsPasswordRotation rotated_at unparseable; falling back to now",
 					"raw", r.RotatedAt, "error", err)
-				rotatedAt = time.Now().UTC()
+				rotatedAt = h.now().UTC()
 			}
 		}
 		lpsStreamID := ulid.Make().String()

--- a/internal/api/logging_interceptor.go
+++ b/internal/api/logging_interceptor.go
@@ -16,21 +16,22 @@ import (
 // Successful requests are logged at Debug level.
 type LoggingInterceptor struct {
 	logger *slog.Logger
+	now    func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewLoggingInterceptor creates a new logging interceptor.
 func NewLoggingInterceptor(logger *slog.Logger) *LoggingInterceptor {
-	return &LoggingInterceptor{logger: logger}
+	return &LoggingInterceptor{logger: logger, now: time.Now}
 }
 
 // WrapUnary implements connect.Interceptor.
 func (i *LoggingInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 	return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-		start := time.Now()
+		start := i.now()
 
 		resp, err := next(ctx, req)
 
-		duration := time.Since(start)
+		duration := i.now().Sub(start)
 		hdrs := req.Header()
 		attrs := []any{
 			"procedure", req.Spec().Procedure,
@@ -69,12 +70,12 @@ func (i *LoggingInterceptor) WrapStreamingClient(next connect.StreamingClientFun
 // WrapStreamingHandler implements connect.Interceptor.
 func (i *LoggingInterceptor) WrapStreamingHandler(next connect.StreamingHandlerFunc) connect.StreamingHandlerFunc {
 	return func(ctx context.Context, conn connect.StreamingHandlerConn) error {
-		start := time.Now()
+		start := i.now()
 		reqID := middleware.RequestIDFromContext(ctx)
 
 		err := next(ctx, conn)
 
-		duration := time.Since(start)
+		duration := i.now().Sub(start)
 		attrs := []any{
 			"procedure", conn.Spec().Procedure,
 			"request_id", reqID,

--- a/internal/api/logs_handler.go
+++ b/internal/api/logs_handler.go
@@ -23,11 +23,12 @@ type LogsHandler struct {
 	taskQueueHolder
 	store  *store.Store
 	logger *slog.Logger
+	now    func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewLogsHandler creates a new logs handler.
 func NewLogsHandler(st *store.Store, logger *slog.Logger) *LogsHandler {
-	return &LogsHandler{store: st, logger: logger}
+	return &LogsHandler{store: st, logger: logger, now: time.Now}
 }
 
 // QueryDeviceLogs dispatches a journalctl log query to a connected device.
@@ -77,7 +78,7 @@ func (h *LogsHandler) QueryDeviceLogs(ctx context.Context, req *connect.Request[
 		Kernel:   msg.Kernel,
 	},
 		asynq.MaxRetry(3),
-		asynq.Deadline(time.Now().Add(2*time.Minute)),
+		asynq.Deadline(h.now().Add(2*time.Minute)),
 	); err != nil {
 		h.logger.Error("log query enqueue failed; marking result expired",
 			"query_id", queryID, "device_id", msg.DeviceId, "error", err)

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -26,11 +26,12 @@ type OSQueryHandler struct {
 	taskQueueHolder
 	store  *store.Store
 	logger *slog.Logger
+	now    func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewOSQueryHandler creates a new OSQuery handler.
 func NewOSQueryHandler(st *store.Store, logger *slog.Logger) *OSQueryHandler {
-	return &OSQueryHandler{store: st, logger: logger}
+	return &OSQueryHandler{store: st, logger: logger, now: time.Now}
 }
 
 // DispatchOSQuery dispatches an on-demand osquery to a connected device.
@@ -91,7 +92,7 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 		RawSQL:  msg.RawSql,
 	},
 		asynq.MaxRetry(3),
-		asynq.Deadline(time.Now().Add(2*time.Minute)),
+		asynq.Deadline(h.now().Add(2*time.Minute)),
 	); err != nil {
 		h.logger.Error("osquery enqueue failed; marking result expired",
 			"query_id", queryID, "device_id", msg.DeviceId, "error", err)
@@ -221,7 +222,7 @@ func (h *OSQueryHandler) RefreshDeviceInventory(ctx context.Context, req *connec
 	// Dispatch inventory request to device via Asynq task queue
 	if err := h.aqClient.EnqueueToDevice(msg.DeviceId, taskqueue.TypeInventoryRequest, taskqueue.InventoryRequestPayload{},
 		asynq.MaxRetry(3),
-		asynq.Deadline(time.Now().Add(2*time.Minute)),
+		asynq.Deadline(h.now().Add(2*time.Minute)),
 	); err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to dispatch inventory request")
 	}

--- a/internal/api/registration_handler.go
+++ b/internal/api/registration_handler.go
@@ -94,6 +94,7 @@ type RegistrationHandler struct {
 	ca         *ca.CA
 	gatewayURL string
 	logger     *slog.Logger
+	now        func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewRegistrationHandler creates a new registration handler. Panics
@@ -114,6 +115,7 @@ func NewRegistrationHandler(st *store.Store, certAuth *ca.CA, gatewayURL string,
 		ca:         certAuth,
 		gatewayURL: gatewayURL,
 		logger:     logger,
+		now:        time.Now,
 	}
 }
 
@@ -166,7 +168,7 @@ func (h *RegistrationHandler) Register(ctx context.Context, req *connect.Request
 	}
 
 	// Check if token is expired
-	if token.ExpiresAt != nil && time.Now().After(*token.ExpiresAt) {
+	if token.ExpiresAt != nil && h.now().After(*token.ExpiresAt) {
 		logger.Warn("token is expired")
 		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "registration token has expired")
 	}

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -88,6 +88,7 @@ type SSOHandler struct {
 	enc                 *crypto.Encryptor
 	passwordAuthEnabled bool
 	callbackBaseURL     string
+	now                 func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewSSOHandler creates a new SSO handler.
@@ -99,6 +100,7 @@ func NewSSOHandler(st *store.Store, logger *slog.Logger, jwtManager *auth.JWTMan
 		enc:                 enc,
 		passwordAuthEnabled: passwordAuthEnabled,
 		callbackBaseURL:     callbackBaseURL,
+		now:                 time.Now,
 	}
 }
 
@@ -203,7 +205,7 @@ func (h *SSOHandler) GetSSOLoginURL(ctx context.Context, req *connect.Request[pm
 	}
 
 	// Store auth state (10 min expiry)
-	expiresAt := time.Now().Add(10 * time.Minute)
+	expiresAt := h.now().Add(10 * time.Minute)
 	err = h.store.Repos().AuthState.Create(ctx, store.CreateAuthStateParams{
 		State:        state,
 		ProviderID:   provider.ID,

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -43,6 +43,8 @@ type TerminalHandler struct {
 	// via SetInternalHTTPClient at startup. nil means admin RPCs
 	// return Unavailable.
 	internalHTTPClient *http.Client
+
+	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // SetInternalHTTPClient configures the mTLS HTTP client used for
@@ -68,6 +70,7 @@ func NewTerminalHandler(st *store.Store, tokenStore *terminal.TokenStore, reg *r
 		registry:    reg,
 		fallbackURL: GatewayBaseURL(fallbackURL),
 		logger:      logger,
+		now:         time.Now,
 	}
 }
 
@@ -230,7 +233,7 @@ func (h *TerminalHandler) StartTerminal(ctx context.Context, req *connect.Reques
 		DeviceID:  req.Msg.DeviceId,
 		UserID:    user.ID,
 		TtyUser:   ttyUser,
-		StartedAt: time.Now(),
+		StartedAt: h.now(),
 		Cols:      int32(cols),
 		Rows:      int32(rows),
 	}); err != nil {
@@ -451,7 +454,7 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 	// authorization record of truth; a DB hiccup here just means the
 	// history row is slightly incomplete. No exit code at this call
 	// site; the session ended on user request, not on shell exit.
-	now := time.Now()
+	now := h.now()
 	if err := h.store.Repos().TerminalSession.MarkStopped(ctx, store.StopTerminalSession{
 		SessionID: session.SessionID,
 		StoppedAt: &now,
@@ -658,7 +661,7 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 	// rc7: finalize the terminal_sessions row. Upsert form so a row
 	// materialises even if neither the Start upsert nor any chunk
 	// landed first — see rationale in StopTerminal.
-	now := time.Now()
+	now := h.now()
 	terminatedBy := actorID
 	// The terminated session may have been opened by a different
 	// user than the admin calling Terminate, so use the session's

--- a/internal/api/token_handler.go
+++ b/internal/api/token_handler.go
@@ -24,6 +24,7 @@ import (
 type TokenHandler struct {
 	store  *store.Store
 	logger *slog.Logger
+	now    func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewTokenHandler creates a new token handler.
@@ -31,6 +32,7 @@ func NewTokenHandler(st *store.Store, logger *slog.Logger) *TokenHandler {
 	return &TokenHandler{
 		store:  st,
 		logger: logger,
+		now:    time.Now,
 	}
 }
 
@@ -89,7 +91,7 @@ func (h *TokenHandler) CreateToken(ctx context.Context, req *connect.Request[pm.
 		// scope is for users minting tokens for their own devices.
 		eventData["one_time"] = true
 		eventData["max_uses"] = int32(1)
-		eventData["expires_at"] = time.Now().Add(7 * 24 * time.Hour).Format(time.RFC3339Nano)
+		eventData["expires_at"] = h.now().Add(7 * 24 * time.Hour).Format(time.RFC3339Nano)
 		eventData["owner_id"] = userCtx.ID
 	}
 

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -21,6 +21,7 @@ type UserHandler struct {
 	store         *store.Store
 	logger        *slog.Logger
 	systemActions *SystemActionManager
+	now           func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewUserHandler creates a new user handler.
@@ -29,6 +30,7 @@ func NewUserHandler(st *store.Store, logger *slog.Logger, systemActions *SystemA
 		store:         st,
 		logger:        logger,
 		systemActions: systemActions,
+		now:           time.Now,
 	}
 }
 
@@ -688,7 +690,7 @@ func (h *UserHandler) AddUserSshKey(ctx context.Context, req *connect.Request[pm
 	}
 
 	keyID := ulid.Make().String()
-	now := time.Now()
+	now := h.now()
 	addedAt := now.Format(time.RFC3339Nano)
 
 	err = h.store.AppendEvent(ctx, store.Event{

--- a/internal/archtest/archtest.go
+++ b/internal/archtest/archtest.go
@@ -1,0 +1,193 @@
+// Package archtest holds architectural fitness functions for the
+// control/gateway server module: self-discovering, repo-wide invariant
+// tests that fail the build when a known code smell is reintroduced or
+// an established good pattern is broken.
+//
+// # Why these exist
+//
+// The 2026-06 security + architecture sweeps fixed a set of smells
+// (raw/concatenated SQL, non-constant-time secret comparisons, handlers
+// writing projection tables directly) and pinned a set of good patterns
+// (sqlc/parameterized queries, subtle.ConstantTimeCompare/hmac.Equal,
+// event-sourced projection writes). A one-off fix does not stop the next
+// contributor from reintroducing the smell. These tests turn each
+// invariant into a permanent, build-failing guard.
+//
+// # Design constraints
+//
+//   - Standard library only (go/parser, go/ast, go/token, go/printer).
+//     No golang.org/x/tools dependency, so the guards stay hermetic,
+//     fast, and identical in shape across the sdk/agent/server archtest
+//     packages. Syntactic invariants do not need full type resolution;
+//     where a guard relies on a naming/structure heuristic it documents
+//     the heuristic and ships a guarded allowlist for true exceptions.
+//   - Self-discovering: every guard walks the module tree and asserts it
+//     inspected a non-empty set, so it can never pass vacuously (the
+//     classic stale-allowlist failure that fails open).
+//   - Every allowlist is itself guarded: a no-stale-entry check fails the
+//     build if an allowlisted exception no longer exists, so the
+//     allowlist cannot rot into a silent escape hatch.
+//
+// # Coverage map (what lives where)
+//
+//   - TestNoDynamicSQL .................... no_dynamic_sql_test.go
+//   - TestSecretComparesAreConstantTime ... secret_compare_test.go
+//   - TestProjectionTablesWrittenOnlyByProjectors ... projection_writes_test.go
+//
+// RPC classification (every ControlService RPC is in exactly one of
+// {public allow-list, permission, procedure-alternative}, both
+// directions, matches-zero-guarded) is ALREADY enforced by
+// internal/auth/permissions_parity_test.go — it is not duplicated here.
+// InternalService classification belongs to the gateway↔control trust
+// stream, not to these module-wide guards.
+//
+// The unabstracted-clock guard (TestNoUnabstractedTimeNow) is
+// intentionally NOT shipped here yet: the server has ~44 direct
+// time.Now() call sites and only ad-hoc per-package clock seams, so a
+// blanket guard would either need a large blessing allowlist (smoke and
+// mirrors) or a clock-seam refactor first. It is tracked as a cleanup
+// item, not pinned as current good state.
+package archtest
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/printer"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// goFile is a parsed Go source file with its module-relative path.
+type goFile struct {
+	abs  string
+	rel  string // slash-separated, relative to the module root
+	fset *token.FileSet
+	ast  *ast.File
+}
+
+// moduleRoot walks up from the test's working directory until it finds
+// the directory containing go.mod. go test sets the working directory to
+// the package under test, so this reliably locates the server module
+// root regardless of where the archtest package sits.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate go.mod above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// walkGoFiles parses every .go file under root whose module-relative,
+// slash-separated path satisfies keep. Test files, the archtest package
+// itself, and anything under a vendor/ directory are never returned —
+// keep only narrows further. Parsing is syntactic (no type checking) and
+// skips object resolution for speed.
+func walkGoFiles(t *testing.T, root string, keep func(rel string) bool) []*goFile {
+	t.Helper()
+	var out []*goFile
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "vendor" || name == "testdata" || name == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if strings.HasSuffix(rel, "_test.go") {
+			return nil
+		}
+		if strings.HasPrefix(rel, "internal/archtest/") {
+			return nil
+		}
+		if !keep(rel) {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", rel, perr)
+		}
+		out = append(out, &goFile{abs: path, rel: rel, fset: fset, ast: f})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+// render returns the gofmt-style source text of an AST node. Used to
+// build stable, line-independent allowlist keys and human-readable
+// failure messages.
+func render(fset *token.FileSet, n ast.Node) string {
+	var b strings.Builder
+	if err := printer.Fprint(&b, fset, n); err != nil {
+		return "<unprintable node>"
+	}
+	// Collapse internal newlines so multi-line call expressions render as
+	// a single stable key.
+	return strings.Join(strings.Fields(b.String()), " ")
+}
+
+// line returns the 1-based source line of a node within its file.
+func (gf *goFile) line(n ast.Node) int {
+	return gf.fset.Position(n.Pos()).Line
+}
+
+// allowlist couples a set of intentionally-exempt sites with their
+// documented justifications and tracks which entries were actually hit,
+// so a stale entry (an exemption whose site no longer exists) fails the
+// build instead of silently widening the guard.
+type allowlist struct {
+	reason map[string]string // key -> why it is exempt
+	used   map[string]bool
+}
+
+func newAllowlist(reasons map[string]string) *allowlist {
+	return &allowlist{reason: reasons, used: make(map[string]bool)}
+}
+
+// exempt reports whether key is allowlisted, marking it used.
+func (a *allowlist) exempt(key string) bool {
+	if _, ok := a.reason[key]; ok {
+		a.used[key] = true
+		return true
+	}
+	return false
+}
+
+// assertNoStale fails the test for every allowlist entry that was never
+// matched during the scan — a stale exemption is itself a finding,
+// because it means the guard's surface drifted out from under it.
+func (a *allowlist) assertNoStale(t *testing.T) {
+	t.Helper()
+	for key := range a.reason {
+		if !a.used[key] {
+			t.Errorf("stale allowlist entry never matched any site (remove it or fix the key): %q", key)
+		}
+	}
+}

--- a/internal/archtest/astutil.go
+++ b/internal/archtest/astutil.go
@@ -1,0 +1,166 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// identName returns the most specific name an expression is known by:
+// the identifier for a bare ident, or the trailing selector field
+// (foo.Bar -> "Bar"). Anything else yields "".
+func identName(e ast.Expr) string {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name
+	case *ast.SelectorExpr:
+		return x.Sel.Name
+	case *ast.StarExpr:
+		return identName(x.X)
+	case *ast.ParenExpr:
+		return identName(x.X)
+	}
+	return ""
+}
+
+// isContextArg reports whether an argument is (very likely) a
+// context.Context, so SQL-method scanning can locate the SQL string at
+// the correct argument index for both the database/sql shape
+// (sql first) and the pgx shape (ctx first).
+func isContextArg(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name == "ctx"
+	case *ast.SelectorExpr:
+		return x.Sel.Name == "ctx" || x.Sel.Name == "Ctx" || x.Sel.Name == "Context"
+	case *ast.CallExpr:
+		if sel, ok := x.Fun.(*ast.SelectorExpr); ok {
+			if sel.Sel.Name == "Context" || sel.Sel.Name == "Background" || sel.Sel.Name == "TODO" {
+				return true
+			}
+			if id, ok := sel.X.(*ast.Ident); ok && id.Name == "context" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isPresenceComparand reports whether an operand is a nil / empty-string
+// / zero literal — i.e. the comparison is a presence/absence check, not a
+// secret-value comparison. Constant-time compares only matter when both
+// sides carry real secret material.
+func isPresenceComparand(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.Ident:
+		return x.Name == "nil"
+	case *ast.BasicLit:
+		switch x.Kind {
+		case token.STRING:
+			// `""` (or `` `` ``) — empty string literal.
+			if s, err := strconv.Unquote(x.Value); err == nil {
+				return s == ""
+			}
+		case token.INT, token.FLOAT:
+			return x.Value == "0" || x.Value == "0.0"
+		}
+	case *ast.CallExpr:
+		// []byte(nil), []byte("") — presence checks on byte slices.
+		if len(x.Args) == 1 {
+			return isPresenceComparand(x.Args[0])
+		}
+	}
+	return false
+}
+
+// stringConstNames returns the set of every package-level identifier in
+// the module bound to a string-literal constant. A query whose SQL
+// argument is one of these names is a literal query (e.g. an
+// sqlc-generated query const), not dynamically-built SQL.
+func stringConstNames(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	out := make(map[string]bool)
+	files := walkGoFiles(t, root, func(string) bool { return true })
+	for _, gf := range files {
+		for _, decl := range gf.ast.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range vs.Names {
+					if i < len(vs.Values) && isStringLiteralExpr(vs.Values[i]) {
+						out[name.Name] = true
+					}
+				}
+			}
+		}
+	}
+	return out
+}
+
+// isStringLiteralExpr reports whether e is a string literal or a
+// concatenation of string literals (`"a" + "b"`).
+func isStringLiteralExpr(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.BasicLit:
+		return x.Kind == token.STRING
+	case *ast.BinaryExpr:
+		return x.Op == token.ADD && isStringLiteralExpr(x.X) && isStringLiteralExpr(x.Y)
+	case *ast.ParenExpr:
+		return isStringLiteralExpr(x.X)
+	}
+	return false
+}
+
+// unquoteLit returns the string value of a STRING BasicLit, or "".
+func unquoteLit(lit *ast.BasicLit) string {
+	if lit == nil || lit.Kind != token.STRING {
+		return ""
+	}
+	if s, err := strconv.Unquote(lit.Value); err == nil {
+		return s
+	}
+	return ""
+}
+
+// secretNameRe matches identifiers that hold secret material. Bare "sig"
+// and "mac" from the original sweep regex are intentionally dropped:
+// "sig" collides with "assign", and "mac" is too short to be specific;
+// the full "signature" / "hmac" forms are kept instead. A match is only a
+// violation when it is NOT metadata about the secret (see
+// secretMetaSuffixes) and NOT a presence check.
+var secretNameRe = regexp.MustCompile(`(?i)(token|secret|hmac|signature|fingerprint|password|passwd|digest|apikey)`)
+
+// secretMetaSuffixes name fields that describe a secret rather than carry
+// its bytes (TokenType, SessionVersion, KeyID, ...). Comparing these with
+// == is fine — they are not timing-sensitive secret material.
+var secretMetaSuffixes = []string{
+	"type", "kind", "id", "name", "len", "length", "count", "version",
+	"expiry", "expiresat", "at", "format", "algorithm", "algo", "method",
+	"status", "enabled", "disabled", "index", "idx", "field", "size",
+}
+
+// looksLikeSecretOperand reports whether an operand names secret material
+// that must be compared in constant time (matches the secret regex and is
+// not a metadata field).
+func looksLikeSecretOperand(e ast.Expr) bool {
+	name := identName(e)
+	if name == "" || !secretNameRe.MatchString(name) {
+		return false
+	}
+	lower := strings.ToLower(name)
+	for _, suf := range secretMetaSuffixes {
+		if strings.HasSuffix(lower, suf) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/archtest/no_dynamic_sql_test.go
+++ b/internal/archtest/no_dynamic_sql_test.go
@@ -1,0 +1,120 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// sqlMethodNames are the database driver methods (database/sql and pgx)
+// whose query/statement argument MUST be a string literal or named
+// string constant. A non-literal argument means the SQL text was built
+// at runtime — the raw/concatenated-SQL smell this guard forbids.
+var sqlMethodNames = map[string]bool{
+	"Exec": true, "ExecContext": true,
+	"Query": true, "QueryContext": true,
+	"QueryRow": true, "QueryRowContext": true,
+	"Prepare": true, "PrepareContext": true,
+}
+
+// dynamicSQLAllowlist lists the only sites permitted to pass a
+// non-literal SQL string to a database method, each with the reason it is
+// safe. Keyed by "<module-rel path> :: <rendered call>" so it survives
+// line moves. assertNoStale fails the build if any entry stops matching.
+var dynamicSQLAllowlist = map[string]string{
+	"internal/store/rebuild.go :: tx.Exec(ctx, stmt)": "DDL `TRUNCATE TABLE <name>` during projection rebuild: the table name comes from the trusted in-process rebuildTarget registry (t.Tables), never from request input, and table identifiers cannot be bound as SQL parameters.",
+	"internal/testutil/postgres.go :: shared.admin.ExecContext(ctx, fmt.Sprintf(`CREATE DATABASE %q TEMPLATE %q`, dbName, templateDatabase))": "Test harness only: per-test database isolation. `CREATE DATABASE` is DDL whose database/template identifiers cannot be bound as parameters; dbName is a fixed internal format (pm_test_<n>), never request input.",
+	"internal/testutil/postgres.go :: shared.admin.ExecContext(dropCtx, fmt.Sprintf(`DROP DATABASE IF EXISTS %q WITH (FORCE)`, dbName))":      "Test harness only: per-test database teardown. `DROP DATABASE` is DDL whose database identifier cannot be bound as a parameter; dbName is a fixed internal format (pm_test_<n>), never request input.",
+}
+
+// TestNoDynamicSQL pins the sqlc / parameterized-SQL discipline: outside
+// the generated query package, every call to a database query/exec method
+// must receive a string-literal or named-string-const SQL argument. This
+// makes "build a query string with fmt.Sprintf / string concatenation"
+// fail the build — the canonical SQL-injection footgun — and locks the
+// good state the 2026-06 sweep found (only the rebuild TRUNCATE DDL is a
+// non-literal, and it is allowlisted with justification).
+func TestNoDynamicSQL(t *testing.T) {
+	root := moduleRoot(t)
+
+	// A query whose SQL arg is a named string const (e.g. an
+	// sqlc-generated const) is still a literal query.
+	consts := stringConstNames(t, root)
+
+	// Scan all production Go EXCEPT the generated sqlc package, which is
+	// machine-emitted and guarded by the regenerate-diff job.
+	files := walkGoFiles(t, root, func(rel string) bool {
+		return !strings.HasPrefix(rel, "internal/store/generated/")
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero production Go files — detector is mis-scoped")
+	}
+
+	allow := newAllowlist(dynamicSQLAllowlist)
+	candidates := 0
+	for _, gf := range files {
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || !sqlMethodNames[sel.Sel.Name] {
+				return true
+			}
+			sqlArg, ok := sqlArgOf(call)
+			if !ok {
+				return true
+			}
+			candidates++
+			if isLiteralSQL(sqlArg, consts) {
+				return true
+			}
+			key := gf.rel + " :: " + render(gf.fset, call)
+			if allow.exempt(key) {
+				return true
+			}
+			t.Errorf("dynamic SQL at %s:%d — %s\n  passes a non-literal SQL string. Use an sqlc-generated query or a parameterized literal; never build SQL with fmt.Sprintf/concatenation. If genuinely unavoidable, add a justified, guarded entry to dynamicSQLAllowlist.",
+				gf.rel, gf.line(call), render(gf.fset, call))
+			return true
+		})
+	}
+	if candidates == 0 {
+		t.Fatal("matches-zero guard: found no database query/exec call sites at all — the SQL-method set is mis-scoped, the guard would pass vacuously")
+	}
+	allow.assertNoStale(t)
+}
+
+// sqlArgOf returns the SQL-text argument of a database method call,
+// accounting for the pgx shape (ctx, sql, args...) vs the database/sql
+// shape (sql, args...).
+func sqlArgOf(call *ast.CallExpr) (ast.Expr, bool) {
+	if len(call.Args) == 0 {
+		return nil, false
+	}
+	idx := 0
+	if isContextArg(call.Args[0]) {
+		idx = 1
+	}
+	if idx >= len(call.Args) {
+		return nil, false
+	}
+	return call.Args[idx], true
+}
+
+// isLiteralSQL reports whether the SQL argument is a string literal or a
+// named string constant (both safe), as opposed to a runtime-built value.
+func isLiteralSQL(e ast.Expr, consts map[string]bool) bool {
+	switch x := e.(type) {
+	case *ast.BasicLit:
+		return x.Kind == token.STRING
+	case *ast.Ident:
+		return consts[x.Name]
+	case *ast.SelectorExpr:
+		return consts[x.Sel.Name]
+	case *ast.ParenExpr:
+		return isLiteralSQL(x.X, consts)
+	}
+	return false
+}

--- a/internal/archtest/projection_writes_test.go
+++ b/internal/archtest/projection_writes_test.go
@@ -1,0 +1,199 @@
+package archtest
+
+import (
+	"go/ast"
+	"reflect"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+)
+
+// projectionMutationRe matches the SQL of a generated query that writes a
+// projection table (any table whose name ends in _projection). The
+// event-sourcing contract is that only projectors mutate projection
+// tables; handlers append events and read projections.
+var projectionMutationRe = regexp.MustCompile(`(?i)(INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+"?([a-z_]+_projection)`)
+
+// projectionWriteAllowlist names the specialized engines that legitimately
+// write projection tables OUTSIDE internal/projectors. Projection rows in
+// this codebase carry both event-sourced columns (written by projectors
+// replaying events) and computed/derived columns (written by the engines
+// below). The event-sourcing invariant this guard protects is therefore
+// "request handlers append events; they never write a projection
+// directly" — these engines are not request handlers, they own derived
+// state. Each entry is justified; assertNoStale fails the build if one
+// stops matching. Keyed by "<module-rel dir> :: <method>".
+//
+// NOTE for review: if any entry below is considered a smell to refactor
+// into an event + projector (rather than a computed read-model), removing
+// it here will turn that call site red — that is the intended forcing
+// function.
+var projectionWriteAllowlist = map[string]string{
+	"internal/compliance :: UpdateDeviceComplianceSummary": "Computed read-model: the compliance evaluator computes per-device compliance and writes the summary columns on device_projection. Evaluation results are derived state, not event-sourced.",
+	"internal/compliance :: UpsertComplianceEvaluation":    "Computed read-model: per-policy evaluation results written by the compliance evaluator. Derived state, not event-sourced.",
+	"internal/dyngroupeval :: InsertDeviceGroupMember":     "Computed read-model: DYNAMIC device-group membership is materialized by evaluating the group query (static membership is event-sourced via projectors).",
+	"internal/dyngroupeval :: DeleteDeviceGroupMember":     "Computed read-model: dynamic device-group membership reconciliation removes stale members.",
+	"internal/dyngroupeval :: RecountDeviceGroupMembers":   "Computed read-model: recomputes the dynamic device-group member count after materialization.",
+	"internal/dyngroupeval :: InsertUserGroupMember":       "Computed read-model: DYNAMIC user-group membership materialized from the group query.",
+	"internal/dyngroupeval :: DeleteUserGroupMember":       "Computed read-model: dynamic user-group membership reconciliation removes stale members.",
+	"internal/dyngroupeval :: RecountUserGroupMembers":     "Computed read-model: recomputes the dynamic user-group member count after materialization.",
+	"internal/auth :: UpdateSystemRolePermissions":         "Bootstrap reconcile: ReconcileSystemRoles syncs the Admin/User system-role permissions to the code-defined sets at startup so new permissions land without a manual toggle. System-role permission sets are code-owned, not user-event-sourced.",
+	"internal/store/postgres :: UpdateActionSignature":     "Store adapter: writes the server-computed CA signature back onto action_projection after signing. Tied to the WS1 action-signing rework — revisit when SignedActionEnvelope lands.",
+}
+
+// TestProjectionTablesWrittenOnlyByProjectors enforces the CQRS write
+// boundary: the generated queries that mutate *_projection tables may
+// only be CALLED from internal/projectors (the listeners/appliers that
+// own projection state). A handler that writes a projection directly
+// bypasses the event store — the bug class this guard makes impossible.
+//
+// Self-discovering: it derives the mutating-query set from the generated
+// SQL (no hardcoded list) and fails if that set or the call-site set is
+// empty.
+func TestProjectionTablesWrittenOnlyByProjectors(t *testing.T) {
+	root := moduleRoot(t)
+
+	// Phase 1: from the generated sqlc package, discover which Queries
+	// methods mutate a *_projection table.
+	mutators := discoverProjectionMutators(t, root)
+	if len(mutators) == 0 {
+		t.Fatal("matches-zero guard: discovered no projection-mutating generated queries — the SQL detector or generated path is mis-scoped")
+	}
+
+	// A method name shared with a ControlService RPC is a handler
+	// delegation (e.g. ControlService.UpdateServerSettings ->
+	// SettingsHandler.UpdateServerSettings), NOT a call to the generated
+	// query of the same name — the real projection write for those flows
+	// is event-sourced inside a projector. Self-discovered from the connect
+	// registry so it cannot drift.
+	rpcNames := controlServiceRPCNames(t)
+
+	// Phase 2: scan every NON-generated production file for calls to a
+	// projection-mutating query; assert each call site is a projector, a
+	// handler delegation (name collision), or a justified computed-writer.
+	files := walkGoFiles(t, root, func(rel string) bool {
+		return !strings.HasPrefix(rel, "internal/store/generated/")
+	})
+	allow := newAllowlist(projectionWriteAllowlist)
+	callSites := 0
+	for _, gf := range files {
+		dir := pathDir(gf.rel)
+		fromProjectors := strings.HasPrefix(gf.rel, "internal/projectors/")
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok || !mutators[sel.Sel.Name] {
+				return true
+			}
+			if rpcNames[sel.Sel.Name] {
+				return true // handler delegation, not a generated-query call
+			}
+			callSites++
+			if fromProjectors {
+				return true
+			}
+			if allow.exempt(dir + " :: " + sel.Sel.Name) {
+				return true
+			}
+			t.Errorf("projection write outside internal/projectors at %s:%d — %s\n  calls projection-mutating query %q from a request/handler path. Handlers must append an event and let a projector write the projection. (If this is a legitimate computed read-model engine, add a justified, guarded entry to projectionWriteAllowlist.)",
+				gf.rel, gf.line(call), render(gf.fset, call), sel.Sel.Name)
+			return true
+		})
+	}
+	if callSites == 0 {
+		t.Fatal("matches-zero guard: no call sites to any projection-mutating query were found — the method-name match is broken, the guard would pass vacuously")
+	}
+	allow.assertNoStale(t)
+}
+
+// discoverProjectionMutators parses the generated sqlc package and returns
+// the set of exported Queries methods whose backing SQL const mutates a
+// *_projection table.
+func discoverProjectionMutators(t *testing.T, root string) map[string]bool {
+	t.Helper()
+	gen := walkGoFiles(t, root, func(rel string) bool {
+		return strings.HasPrefix(rel, "internal/store/generated/")
+	})
+	if len(gen) == 0 {
+		t.Fatal("matches-zero guard: generated sqlc package not found at internal/store/generated/")
+	}
+
+	// const name -> mutates a projection table?
+	mutatingConst := make(map[string]bool)
+	for _, gf := range gen {
+		for _, decl := range gf.ast.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok.String() != "const" {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for i, name := range vs.Names {
+					if i >= len(vs.Values) {
+						continue
+					}
+					lit, ok := vs.Values[i].(*ast.BasicLit)
+					if !ok {
+						continue
+					}
+					if projectionMutationRe.MatchString(unquoteLit(lit)) {
+						mutatingConst[name.Name] = true
+					}
+				}
+			}
+		}
+	}
+
+	// A Queries method is a mutator if its body references a mutating
+	// const (the generated method passes the const to q.db.Exec).
+	mutators := make(map[string]bool)
+	for _, gf := range gen {
+		for _, decl := range gf.ast.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || fn.Body == nil {
+				continue
+			}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				if id, ok := n.(*ast.Ident); ok && mutatingConst[id.Name] {
+					mutators[fn.Name.Name] = true
+				}
+				return true
+			})
+		}
+	}
+	return mutators
+}
+
+// controlServiceRPCNames returns the set of method names on the generated
+// ControlServiceHandler interface. A generated-query name that collides
+// with one of these denotes a handler delegation, not a direct query call.
+func controlServiceRPCNames(t *testing.T) map[string]bool {
+	t.Helper()
+	iface := reflect.TypeOf((*pmv1connect.ControlServiceHandler)(nil)).Elem()
+	out := make(map[string]bool, iface.NumMethod())
+	for i := 0; i < iface.NumMethod(); i++ {
+		out[iface.Method(i).Name] = true
+	}
+	if len(out) == 0 {
+		t.Fatal("matches-zero guard: ControlServiceHandler exposes no methods — registry reflection is broken")
+	}
+	return out
+}
+
+// pathDir returns the slash-separated directory of a module-relative
+// file path (its parent), e.g. "internal/projectors/device.go" ->
+// "internal/projectors".
+func pathDir(rel string) string {
+	if i := strings.LastIndexByte(rel, '/'); i >= 0 {
+		return rel[:i]
+	}
+	return "."
+}

--- a/internal/archtest/secret_compare_test.go
+++ b/internal/archtest/secret_compare_test.go
@@ -1,0 +1,92 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"testing"
+)
+
+// secretCompareAllowlist lists comparisons that match the secret-name
+// heuristic but are NOT timing-sensitive secret-value compares (typically
+// enum/metadata fields the suffix filter didn't catch). Each entry is
+// justified; assertNoStale fails the build if one stops matching.
+// Keyed by "<module-rel path> :: <rendered expression>".
+var secretCompareAllowlist = map[string]string{
+	`internal/testutil/factories_user.go :: password != "pass"`: "Test fixture only: branches on the sentinel default password \"pass\" to reuse a precomputed bcrypt hash (test speed). Not an authentication path — there is no timing oracle in test-factory code.",
+}
+
+// TestSecretComparesAreConstantTime forbids comparing secret material
+// (tokens, MACs, signatures, fingerprints, password/digest bytes) with
+// == / != / bytes.Equal — all of which short-circuit and leak length and
+// content through timing. The correct primitives are
+// subtle.ConstantTimeCompare and hmac.Equal. Presence checks (`tok == ""`,
+// `sig == nil`) and metadata fields (TokenType, KeyID, SessionVersion)
+// are excluded; everything else that names secret material and is
+// compared with a non-constant-time operator is a finding.
+//
+// Locks the good state the 2026-06 sweep found: the cert-fingerprint
+// compare uses subtle.ConstantTimeCompare and the task HMAC check uses
+// hmac.Equal.
+func TestSecretComparesAreConstantTime(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(string) bool { return true })
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero production Go files — detector is mis-scoped")
+	}
+
+	allow := newAllowlist(secretCompareAllowlist)
+	sawComparison := false
+	sawSecretName := false
+
+	for _, gf := range files {
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.BinaryExpr:
+				if x.Op == token.EQL || x.Op == token.NEQ {
+					sawComparison = true
+					checkSecretCompare(t, gf, x, x.X, x.Y, allow, &sawSecretName)
+				}
+			case *ast.CallExpr:
+				// bytes.Equal(a, b) is non-constant-time for secrets.
+				if sel, ok := x.Fun.(*ast.SelectorExpr); ok {
+					if id, ok := sel.X.(*ast.Ident); ok && id.Name == "bytes" && sel.Sel.Name == "Equal" && len(x.Args) == 2 {
+						sawComparison = true
+						checkSecretCompare(t, gf, x, x.Args[0], x.Args[1], allow, &sawSecretName)
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	if !sawComparison {
+		t.Fatal("matches-zero guard: found no equality comparisons in the module — the AST walk is not reaching real code")
+	}
+	if !sawSecretName {
+		t.Fatal("matches-zero guard: the secret-name detector matched no identifier anywhere in the module — the regex/scoping is dead, the guard would pass vacuously")
+	}
+	allow.assertNoStale(t)
+}
+
+// checkSecretCompare flags node if either operand names secret material
+// and neither operand is a presence comparand (nil/empty/zero).
+func checkSecretCompare(t *testing.T, gf *goFile, node ast.Node, lhs, rhs ast.Expr, allow *allowlist, sawSecretName *bool) {
+	t.Helper()
+	lSecret := looksLikeSecretOperand(lhs)
+	rSecret := looksLikeSecretOperand(rhs)
+	if lSecret || rSecret {
+		*sawSecretName = true
+	}
+	if !lSecret && !rSecret {
+		return
+	}
+	if isPresenceComparand(lhs) || isPresenceComparand(rhs) {
+		return // presence/absence check, not a secret-value compare
+	}
+	key := gf.rel + " :: " + render(gf.fset, node)
+	if allow.exempt(key) {
+		return
+	}
+	t.Errorf("non-constant-time secret compare at %s:%d — %s\n  compares secret material with ==/!=/bytes.Equal, which leaks length and content via timing. Use subtle.ConstantTimeCompare or hmac.Equal. If this is metadata (not secret bytes), add a justified, guarded entry to secretCompareAllowlist.",
+		gf.rel, gf.line(node), render(gf.fset, node))
+}

--- a/internal/archtest/time_now_test.go
+++ b/internal/archtest/time_now_test.go
@@ -1,0 +1,121 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"strings"
+	"testing"
+)
+
+// TestNoUnabstractedTimeNow enforces that production runtime code never
+// CALLS time.Now() directly. Time-dependent logic (token/cert/session
+// expiry, rate-limit windows, timestamps, even latency measurement) must
+// read the current time through an injected `now func() time.Time` seam
+// (defaulting to the bare time.Now value), so every time-dependent path
+// is deterministically testable with a fixed clock. This extends the
+// existing seam already used by internal/crl, internal/terminal,
+// internal/compliance and internal/gateway/registry to the whole module.
+//
+// The bare `time.Now` *value* (the injection default, e.g. `now: time.Now`)
+// is not a call and is therefore allowed — it is the single sanctioned
+// reference to the wall clock.
+//
+// One structural exception: time.Now() passed as the timestamp argument to
+// ulid.Timestamp(...) is ID generation, where the wall clock seeds the
+// ULID's time component rather than driving a decision; injecting a clock
+// there buys no testability and threads a parameter through every ID
+// helper. This is a category rule, not a per-site blessing — any ULID
+// generator is covered, and nothing else is.
+//
+// Scope: production runtime only. _test.go, the generated sqlc package,
+// the archtest package itself, and internal/testutil (test scaffolding,
+// imported only by tests) are out of scope.
+func TestNoUnabstractedTimeNow(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(rel string) bool {
+		if strings.HasPrefix(rel, "internal/store/generated/") {
+			return false
+		}
+		if strings.HasPrefix(rel, "internal/testutil/") {
+			return false
+		}
+		return true
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero production Go files — detector is mis-scoped")
+	}
+
+	// sawTimeNowRef counts every reference to the `time.Now` selector —
+	// whether a call (`time.Now()`) or the bare injection-default value
+	// (`now: time.Now`). It is the liveness probe: keying matches-zero off
+	// CALL count would fail-closed once the module is fully migrated (zero
+	// direct calls) and pressure someone to keep a violation alive. Keying
+	// off the selector keeps the guard non-vacuous regardless of how many
+	// calls remain. (Same probe as the agent archtest copy.)
+	sawTimeNowRef := 0
+	for _, gf := range files {
+		exempt := map[token.Pos]bool{}
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			if isTimeNowSelector(n) {
+				sawTimeNowRef++
+			}
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			// Mark a time.Now() that seeds ulid.Timestamp(...) as exempt.
+			// Inspect is top-down, so the ulid.Timestamp parent is seen
+			// before its time.Now child and the exemption is in place by
+			// the time the child is visited.
+			if isULIDTimestampCall(call) {
+				if inner, ok := call.Args[0].(*ast.CallExpr); ok && isTimeNowCall(inner) {
+					exempt[inner.Pos()] = true
+				}
+			}
+			if isTimeNowCall(call) {
+				if exempt[call.Pos()] {
+					return true
+				}
+				t.Errorf("unabstracted time.Now() at %s:%d — read the clock through an injected `now func() time.Time` seam (default `time.Now`) and call it, e.g. s.now(); never call time.Now() directly in runtime code.",
+					gf.rel, gf.line(call))
+			}
+			return true
+		})
+	}
+	if sawTimeNowRef == 0 {
+		t.Fatal("matches-zero guard: found no reference to the time.Now selector anywhere (not even a seam default) — the detector is dead, the guard would pass vacuously")
+	}
+}
+
+// isTimeNowSelector reports whether n is the selector `time.Now` itself —
+// matching both the call `time.Now()` (whose Fun is this selector) and the
+// bare value `time.Now` used as an injection default. Liveness probe for
+// the matches-zero guard.
+func isTimeNowSelector(n ast.Node) bool {
+	sel, ok := n.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Now" {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "time"
+}
+
+// isTimeNowCall reports whether call is exactly time.Now().
+func isTimeNowCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Now" || len(call.Args) != 0 {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "time"
+}
+
+// isULIDTimestampCall reports whether call is ulid.Timestamp(<one arg>).
+func isULIDTimestampCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || sel.Sel.Name != "Timestamp" || len(call.Args) != 1 {
+		return false
+	}
+	id, ok := sel.X.(*ast.Ident)
+	return ok && id.Name == "ulid"
+}

--- a/internal/auth/jwt.go
+++ b/internal/auth/jwt.go
@@ -37,6 +37,9 @@ type JWTConfig struct {
 	AccessTokenExpiry  time.Duration
 	RefreshTokenExpiry time.Duration
 	Issuer             string
+	// Now is the clock seam. Defaults to time.Now when nil; tests
+	// inject a fixed clock to pin token issue/expiry timestamps.
+	Now func() time.Time
 }
 
 // JWTManager handles JWT token generation and validation.
@@ -69,6 +72,9 @@ func NewJWTManager(config JWTConfig) *JWTManager {
 	if config.Issuer == "" {
 		config.Issuer = "power-manage"
 	}
+	if config.Now == nil {
+		config.Now = time.Now
+	}
 	return &JWTManager{config: config}
 }
 
@@ -83,7 +89,7 @@ type TokenPair struct {
 // Permissions and scoped grants are only embedded in the access token,
 // not the refresh token.
 func (m *JWTManager) GenerateTokens(userID, email string, permissions []string, scopedGrants []ScopedGrant, sessionVersion int32) (*TokenPair, error) {
-	now := time.Now()
+	now := m.config.Now()
 	accessExpiry := now.Add(m.config.AccessTokenExpiry)
 	entropy := ulid.Monotonic(rand.Reader, 0)
 
@@ -140,7 +146,7 @@ func (m *JWTManager) GenerateTokens(userID, email string, permissions []string, 
 
 // GenerateTOTPChallenge creates a short-lived JWT (5 minutes) for TOTP verification during login.
 func (m *JWTManager) GenerateTOTPChallenge(userID, email string, sessionVersion int32) (string, error) {
-	now := time.Now()
+	now := m.config.Now()
 	entropy := ulid.Monotonic(rand.Reader, 0)
 	jti := ulid.MustNew(ulid.Timestamp(now), entropy).String()
 

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"encoding/base64"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,33 @@ func newTestJWTManager() *JWTManager {
 		RefreshTokenExpiry: 1 * time.Hour,
 		Issuer:             "test",
 	})
+}
+
+// TestGenerateTokens_TimestampsFromClock pins that token issue/expiry
+// timestamps derive from the injected clock, not the wall clock. The
+// clock is fixed in the PAST so the resulting tokens are already expired
+// today — impossible if issuance read time.Now().
+func TestGenerateTokens_TimestampsFromClock(t *testing.T) {
+	fixed := time.Date(2020, 6, 1, 12, 0, 0, 0, time.UTC)
+	m := NewJWTManager(JWTConfig{
+		Secret:            []byte("test-secret-for-jwt"),
+		AccessTokenExpiry: 15 * time.Minute,
+		Issuer:            "test",
+		Now:               func() time.Time { return fixed },
+	})
+
+	pair, err := m.GenerateTokens("uid", "e@x", nil, nil, 0)
+	require.NoError(t, err)
+
+	assert.True(t, pair.ExpiresAt.Equal(fixed.Add(15*time.Minute)),
+		"access expiry must be clock+TTL; got %s want %s", pair.ExpiresAt, fixed.Add(15*time.Minute))
+	assert.True(t, pair.ExpiresAt.Before(time.Now()),
+		"tokens minted under a past clock are already expired, proving the timestamp is not from the wall clock")
+
+	// The iat claim equals the injected clock. Decoded without validation,
+	// since a past-clock token would otherwise fail expiry validation.
+	payload := decodeJWTPayload(t, pair.AccessToken)
+	assert.Contains(t, payload, fmt.Sprintf(`"iat":%d`, fixed.Unix()))
 }
 
 func TestNewJWTManager_Defaults(t *testing.T) {

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -28,18 +28,31 @@ type RateLimiter struct {
 	limit    int
 	window   time.Duration
 	stopCh   chan struct{}
+	now      func() time.Time // clock seam; defaults to time.Now, overridden in tests
+}
+
+// RateLimiterOption configures a RateLimiter.
+type RateLimiterOption func(*RateLimiter)
+
+// WithClock overrides the time source (tests). The default is time.Now.
+func WithClock(now func() time.Time) RateLimiterOption {
+	return func(rl *RateLimiter) { rl.now = now }
 }
 
 // NewRateLimiter creates a new rate limiter that allows limit attempts
 // per key within the given time window. A background goroutine cleans
 // up stale entries periodically.
-func NewRateLimiter(limit int, window time.Duration) *RateLimiter {
+func NewRateLimiter(limit int, window time.Duration, opts ...RateLimiterOption) *RateLimiter {
 	rl := &RateLimiter{
 		attempts: make(map[string][]time.Time),
 		lastSeen: make(map[string]time.Time),
 		limit:    limit,
 		window:   window,
 		stopCh:   make(chan struct{}),
+		now:      time.Now,
+	}
+	for _, opt := range opts {
+		opt(rl)
 	}
 	go rl.cleanup()
 	return rl
@@ -51,7 +64,7 @@ func (rl *RateLimiter) Allow(key string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	now := time.Now()
+	now := rl.now()
 	cutoff := now.Add(-rl.window)
 
 	// Remove expired entries
@@ -91,7 +104,7 @@ func (rl *RateLimiter) Blocked(key string) bool {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 
-	cutoff := time.Now().Add(-rl.window)
+	cutoff := rl.now().Add(-rl.window)
 	valid := 0
 	for _, t := range rl.attempts[key] {
 		if t.After(cutoff) {
@@ -133,7 +146,7 @@ func (rl *RateLimiter) cleanup() {
 		select {
 		case <-ticker.C:
 			rl.mu.Lock()
-			cutoff := time.Now().Add(-rl.window)
+			cutoff := rl.now().Add(-rl.window)
 			for key, attempts := range rl.attempts {
 				valid := attempts[:0]
 				for _, t := range attempts {

--- a/internal/auth/ratelimit_test.go
+++ b/internal/auth/ratelimit_test.go
@@ -16,6 +16,26 @@ func TestRateLimiter_AllowWithinLimit(t *testing.T) {
 	}
 }
 
+// TestRateLimiter_WindowUsesInjectedClock pins the sliding window against
+// the injected clock: attempts age out exactly when the injected time
+// advances past the window, with no dependency on the wall clock.
+func TestRateLimiter_WindowUsesInjectedClock(t *testing.T) {
+	now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl := NewRateLimiter(2, 1*time.Minute, WithClock(func() time.Time { return now }))
+	defer rl.Stop()
+
+	assert.True(t, rl.Allow("k"), "1st attempt within window")
+	assert.True(t, rl.Allow("k"), "2nd attempt within window")
+	assert.False(t, rl.Allow("k"), "3rd attempt exceeds the limit within the window")
+
+	// Advance the injected clock past the window; the earlier attempts
+	// must expire by that clock, not by real elapsed time.
+	now = now.Add(2 * time.Minute)
+	assert.True(t, rl.Allow("k"), "attempts before the window expire by the injected clock")
+	assert.True(t, rl.Allow("k"), "second post-window attempt still within new limit")
+	assert.False(t, rl.Allow("k"), "limit re-applies in the new window")
+}
+
 func TestRateLimiter_BlockAfterLimit(t *testing.T) {
 	rl := NewRateLimiter(3, 1*time.Minute)
 

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -23,8 +23,15 @@ type CA struct {
 	cert      *x509.Certificate
 	key       crypto.Signer
 	validity  time.Duration
-	trustPool *x509.CertPool // trust bundle for verification (supports CA rotation)
+	trustPool *x509.CertPool   // trust bundle for verification (supports CA rotation)
+	now       func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
+
+// Option configures a CA.
+type Option func(*CA)
+
+// WithClock overrides the time source (tests). The default is time.Now.
+func WithClock(now func() time.Time) Option { return func(c *CA) { c.now = now } }
 
 // Certificate holds a PEM-encoded certificate and private key.
 type Certificate struct {
@@ -35,7 +42,7 @@ type Certificate struct {
 }
 
 // New creates a new CA from PEM-encoded certificate and key files.
-func New(certPath, keyPath string, validity time.Duration) (*CA, error) {
+func New(certPath, keyPath string, validity time.Duration, opts ...Option) (*CA, error) {
 	certPEM, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, fmt.Errorf("read CA certificate: %w", err)
@@ -46,11 +53,11 @@ func New(certPath, keyPath string, validity time.Duration) (*CA, error) {
 		return nil, fmt.Errorf("read CA key: %w", err)
 	}
 
-	return NewFromPEM(certPEM, keyPEM, validity)
+	return NewFromPEM(certPEM, keyPEM, validity, opts...)
 }
 
 // NewFromPEM creates a new CA from PEM-encoded certificate and key bytes.
-func NewFromPEM(certPEM, keyPEM []byte, validity time.Duration) (*CA, error) {
+func NewFromPEM(certPEM, keyPEM []byte, validity time.Duration, opts ...Option) (*CA, error) {
 	certBlock, _ := pem.Decode(certPEM)
 	if certBlock == nil {
 		return nil, fmt.Errorf("failed to decode CA certificate PEM")
@@ -74,12 +81,17 @@ func NewFromPEM(certPEM, keyPEM []byte, validity time.Duration) (*CA, error) {
 	pool := x509.NewCertPool()
 	pool.AddCert(cert)
 
-	return &CA{
+	c := &CA{
 		cert:      cert,
 		key:       key,
 		validity:  validity,
 		trustPool: pool,
-	}, nil
+		now:       time.Now,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
 }
 
 // IssueCertificateFromCSR signs a Certificate Signing Request and returns the certificate.
@@ -118,7 +130,7 @@ func (ca *CA) IssueCertificateFromCSR(deviceID string, csrPEM []byte) (*Certific
 		return nil, fmt.Errorf("generate serial number: %w", err)
 	}
 
-	now := time.Now()
+	now := ca.now()
 	notAfter := now.Add(ca.validity)
 
 	// Stamp the SPIFFE URI SAN that marks this as an "agent" peer

--- a/internal/ca/ca_test.go
+++ b/internal/ca/ca_test.go
@@ -149,6 +149,41 @@ func TestIssueCertificateFromCSR_Success(t *testing.T) {
 	assert.True(t, cert.NotAfter.After(time.Now()))
 }
 
+// TestIssueCertificateFromCSR_ValidityWindowFromClock pins that the
+// issued certificate's validity window derives from the injected clock,
+// not the wall clock: NotBefore = clock - 1m (skew allowance) and
+// NotAfter = clock + validity. Using a clock fixed in the PAST proves the
+// window cannot have come from time.Now() — the cert would be expired
+// today, which a wall-clock implementation could never produce.
+func TestIssueCertificateFromCSR_ValidityWindowFromClock(t *testing.T) {
+	certPEM, keyPEM := generateTestCA(t)
+	fixed := time.Date(2020, 6, 1, 12, 0, 0, 0, time.UTC)
+	const validity = 24 * time.Hour
+	c, err := ca.NewFromPEM(certPEM, keyPEM, validity, ca.WithClock(func() time.Time { return fixed }))
+	require.NoError(t, err)
+
+	csrPEM, _ := generateCSR(t, "device-001")
+	cert, err := c.IssueCertificateFromCSR("device-001", csrPEM)
+	require.NoError(t, err)
+
+	// NotAfter is exposed on the Certificate struct at full precision.
+	assert.True(t, cert.NotAfter.Equal(fixed.Add(validity)),
+		"NotAfter must be clock+validity; got %s want %s", cert.NotAfter, fixed.Add(validity))
+	assert.True(t, cert.NotAfter.Before(time.Now()),
+		"a cert issued under a past clock must already be expired, proving the window is not from the wall clock")
+
+	// NotBefore lives on the encoded cert; ASN.1 truncates to the second,
+	// which is lossless here (fixed has zero sub-second component).
+	block, _ := pem.Decode(cert.CertPEM)
+	require.NotNil(t, block)
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	assert.True(t, parsed.NotBefore.Equal(fixed.Add(-1*time.Minute)),
+		"NotBefore must be clock-1m (skew); got %s want %s", parsed.NotBefore, fixed.Add(-1*time.Minute))
+	assert.True(t, parsed.NotAfter.Equal(fixed.Add(validity)),
+		"encoded NotAfter must be clock+validity; got %s want %s", parsed.NotAfter, fixed.Add(validity))
+}
+
 func TestIssueCertificateFromCSR_InvalidCSR(t *testing.T) {
 	certPEM, keyPEM := generateTestCA(t)
 	c, err := ca.NewFromPEM(certPEM, keyPEM, 24*time.Hour)

--- a/internal/connection/manager.go
+++ b/internal/connection/manager.go
@@ -47,6 +47,7 @@ func (a *Agent) Close() {
 
 // Manager manages connected agents.
 type Manager struct {
+	now    func() time.Time // clock seam; defaults to time.Now, overridden in tests
 	mu     sync.RWMutex
 	agents map[string]*Agent // deviceID -> agent
 }
@@ -54,6 +55,7 @@ type Manager struct {
 // NewManager creates a new connection manager.
 func NewManager() *Manager {
 	return &Manager{
+		now:    time.Now,
 		agents: make(map[string]*Agent),
 	}
 }
@@ -69,8 +71,8 @@ func (m *Manager) Register(parentCtx context.Context, deviceID, hostname, versio
 		DeviceID:    deviceID,
 		Hostname:    hostname,
 		Version:     version,
-		ConnectedAt: time.Now(),
-		LastSeen:    time.Now(),
+		ConnectedAt: m.now(),
+		LastSeen:    m.now(),
 		Stream:      stream,
 		ctx:         ctx,
 		cancel:      cancel,
@@ -111,7 +113,7 @@ func (m *Manager) UpdateLastSeen(deviceID string) {
 	m.mu.Lock()
 	agent, ok := m.agents[deviceID]
 	if ok {
-		agent.LastSeen = time.Now()
+		agent.LastSeen = m.now()
 	}
 	m.mu.Unlock()
 }

--- a/internal/connection/terminal_sessions.go
+++ b/internal/connection/terminal_sessions.go
@@ -29,10 +29,13 @@ type TerminalSession struct {
 
 	mu             sync.Mutex
 	lastActivityAt time.Time
+	now            func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewTerminalSession constructs a session with a buffered output channel.
 func NewTerminalSession(sessionID, deviceID, userID, ttyUser string, cols, rows uint32) *TerminalSession {
+	clock := time.Now
+	startedAt := clock()
 	return &TerminalSession{
 		SessionID:      sessionID,
 		DeviceID:       deviceID,
@@ -40,16 +43,17 @@ func NewTerminalSession(sessionID, deviceID, userID, ttyUser string, cols, rows 
 		TtyUser:        ttyUser,
 		Cols:           cols,
 		Rows:           rows,
-		StartedAt:      time.Now(),
-		lastActivityAt: time.Now(),
+		StartedAt:      startedAt,
+		lastActivityAt: startedAt,
 		OutputCh:       make(chan *pm.AgentMessage, 64),
+		now:            clock,
 	}
 }
 
 // Touch updates the last activity timestamp.
 func (s *TerminalSession) Touch() {
 	s.mu.Lock()
-	s.lastActivityAt = time.Now()
+	s.lastActivityAt = s.now()
 	s.mu.Unlock()
 }
 

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -36,6 +36,7 @@ import (
 // HMAC-verified payload before its JSON-unmarshal call. nil means
 // "verification disabled" (tests only).
 type InboxWorker struct {
+	now        func() time.Time // clock seam; defaults to time.Now, overridden in tests
 	store      *store.Store
 	aqClient   *taskqueue.Client
 	signer     ca.ActionSigner
@@ -46,6 +47,7 @@ type InboxWorker struct {
 // NewInboxWorker creates a new inbox worker.
 func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ca.ActionSigner, taskSigner *taskqueue.Signer, logger *slog.Logger) *InboxWorker {
 	return &InboxWorker{
+		now:        time.Now,
 		store:      st,
 		aqClient:   aqClient,
 		signer:     signer,
@@ -258,7 +260,7 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		executedAt = completedAt.Add(-time.Duration(result.DurationMs) * time.Millisecond)
 	}
 	if completedAt.IsZero() {
-		completedAt = time.Now()
+		completedAt = w.now()
 		executedAt = completedAt.Add(-time.Duration(result.DurationMs) * time.Millisecond)
 	}
 
@@ -678,7 +680,7 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 			Data: payloads.LuksDeviceKeyRevoked{
 				DeviceID:  payload.DeviceID,
 				ActionID:  payload.ActionID,
-				RevokedAt: time.Now().UTC().Format(time.RFC3339Nano),
+				RevokedAt: w.now().UTC().Format(time.RFC3339Nano),
 			},
 			ActorType: "device",
 			ActorID:   payload.DeviceID,
@@ -693,7 +695,7 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 			DeviceID: payload.DeviceID,
 			ActionID: payload.ActionID,
 			Error:    payload.Error,
-			FailedAt: time.Now().UTC().Format(time.RFC3339Nano),
+			FailedAt: w.now().UTC().Format(time.RFC3339Nano),
 		},
 		ActorType: "device",
 		ActorID:   payload.DeviceID,
@@ -758,7 +760,7 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 							Data: payloads.ExecutionFailedReason{
 								Error:       "action was deleted before the device came online",
 								DurationMs:  0,
-								CompletedAt: time.Now().UTC().Format(time.RFC3339Nano),
+								CompletedAt: w.now().UTC().Format(time.RFC3339Nano),
 							},
 							ActorType: "system",
 							ActorID:   "dispatcher",

--- a/internal/dyngroupeval/evaluator.go
+++ b/internal/dyngroupeval/evaluator.go
@@ -35,6 +35,7 @@ import (
 // once per server boot (alongside the handlers / inbox worker) and call
 // EvaluateDeviceGroup / EvaluateUserGroup per group.
 type Evaluator struct {
+	now    func() time.Time // clock seam; defaults to time.Now, overridden in tests
 	store  *store.Store
 	logger *slog.Logger
 }
@@ -43,7 +44,7 @@ type Evaluator struct {
 // diagnostic output during eval — pass the same logger the surrounding
 // handler / worker uses.
 func New(s *store.Store, lg *slog.Logger) *Evaluator {
-	return &Evaluator{store: s, logger: lg}
+	return &Evaluator{store: s, logger: lg, now: time.Now}
 }
 
 // EvaluateDeviceGroup re-computes the membership of the dynamic device
@@ -51,7 +52,7 @@ func New(s *store.Store, lg *slog.Logger) *Evaluator {
 // no-op for missing / soft-deleted / non-dynamic groups (and clears the
 // stale queue entry in that case).
 func (e *Evaluator) EvaluateDeviceGroup(ctx context.Context, groupID string) error {
-	evalStart := time.Now()
+	evalStart := e.now()
 	q := e.store.Queries()
 
 	group, err := e.store.Repos().DeviceGroup.Get(ctx, groupID)
@@ -134,7 +135,7 @@ func (e *Evaluator) EvaluateDeviceGroup(ctx context.Context, groupID string) err
 // EvaluateUserGroup re-computes the membership of the dynamic user
 // group identified by groupID. Mirrors evaluate_dynamic_user_group.
 func (e *Evaluator) EvaluateUserGroup(ctx context.Context, groupID string) error {
-	evalStart := time.Now()
+	evalStart := e.now()
 	q := e.store.Queries()
 
 	group, err := e.store.Repos().UserGroup.Get(ctx, groupID)

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -74,6 +74,7 @@ const (
 
 // Index manages the RediSearch full-text search indexes in Valkey.
 type Index struct {
+	now      func() time.Time // clock seam; defaults to time.Now, overridden in tests
 	rdb      *redis.Client
 	store    *store.Store
 	aqClient *taskqueue.Client
@@ -86,6 +87,7 @@ type Index struct {
 // New creates a new search Index.
 func New(rdb *redis.Client, st *store.Store, aqClient *taskqueue.Client, logger *slog.Logger) *Index {
 	return &Index{
+		now:      time.Now,
 		rdb:      rdb,
 		store:    st,
 		aqClient: aqClient,
@@ -316,7 +318,7 @@ func (idx *Index) EnsureIndexes(ctx context.Context) error {
 // This is the only operation that reads from PG for search purposes.
 func (idx *Index) Warm(ctx context.Context) error {
 	idx.logger.Info("warming search index from database")
-	start := time.Now()
+	start := idx.now()
 
 	// 1. Index all actions. Returns the action_id → name map so the
 	// downstream warm passes (action sets + definitions) can build
@@ -396,7 +398,7 @@ func (idx *Index) Warm(ctx context.Context) error {
 		"user_groups", userGroupCount,
 		"executions", execCount,
 		"audit_events", auditCount,
-		"duration", time.Since(start),
+		"duration", idx.now().Sub(start),
 	)
 	return nil
 }

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -259,12 +259,12 @@ func (s *Store) RebuildAll(ctx context.Context, targetNames ...string) (RebuildR
 		return RebuildResult{}, err
 	}
 
-	start := time.Now()
+	start := s.now()
 	result := RebuildResult{Targets: make([]TargetResult, 0, len(targets))}
 
 	err = pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
 		for _, t := range targets {
-			tStart := time.Now()
+			tStart := s.now()
 			applied, runErr := s.runOneTarget(ctx, tx, t)
 			if runErr != nil {
 				return fmt.Errorf("rebuild target %q: %w", t.Name, runErr)
@@ -272,7 +272,7 @@ func (s *Store) RebuildAll(ctx context.Context, targetNames ...string) (RebuildR
 			result.Targets = append(result.Targets, TargetResult{
 				Name:          t.Name,
 				EventsApplied: applied,
-				Duration:      time.Since(tStart),
+				Duration:      s.now().Sub(tStart),
 			})
 		}
 		return nil
@@ -281,7 +281,7 @@ func (s *Store) RebuildAll(ctx context.Context, targetNames ...string) (RebuildR
 		return RebuildResult{}, err
 	}
 
-	result.TotalDuration = time.Since(start)
+	result.TotalDuration = s.now().Sub(start)
 	return result, nil
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // pgx database/sql driver
@@ -76,6 +77,7 @@ type RebuildApply func(ctx context.Context, q *Queries, ev PersistedEvent) error
 
 // Store wraps the database connection and provides access to queries.
 type Store struct {
+	now     func() time.Time // clock seam; defaults to time.Now, overridden in tests
 	pool    *pgxpool.Pool
 	queries *Queries
 
@@ -283,6 +285,7 @@ func New(ctx context.Context, connString string) (*Store, error) {
 	}
 
 	return &Store{
+		now:     time.Now,
 		pool:    pool,
 		queries: generated.New(pool),
 	}, nil
@@ -305,6 +308,7 @@ func NewWithoutMigrations(ctx context.Context, connString string) (*Store, error
 	}
 
 	return &Store{
+		now:     time.Now,
 		pool:    pool,
 		queries: generated.New(pool),
 	}, nil


### PR DESCRIPTION
## Summary
Adds self-discovering, build-failing architectural fitness functions in `internal/archtest` and extends the injected-clock seam module-wide. Part of WS0 of the security hardening workplan; green against current `main`.

## Guards
- **TestNoDynamicSQL** — DB query/exec args must be a string literal or named string constant (no `fmt.Sprintf`/concatenation). Only the rebuild `TRUNCATE` DDL is allowlisted (trusted in-process table registry; identifiers can't be bind params).
- **TestSecretComparesAreConstantTime** — secrets/MACs/tokens/signatures/fingerprints compared with `subtle.ConstantTimeCompare`/`hmac.Equal`, never `==`/`bytes.Equal`.
- **TestProjectionTablesWrittenOnlyByProjectors** — request handlers append events; they never write `*_projection` directly. Computed-read-model engines (compliance/dyngroup evaluators, system-role reconcile, action-signature store adapter) are allowlisted with per-site justification.
- **TestNoUnabstractedTimeNow** — no direct `time.Now()` in runtime code; read the clock through an injected `now func() time.Time` seam.

## Clock seam
Extends the seam already used by `crl`/`terminal`/`compliance`/`gateway` to the whole module (39 sites). Fixed-clock tests pin cert validity (a cert issued under a past clock is born expired), JWT iat/exp, and the rate-limit window. Duration measurements use the same seam (`now().Sub(start)`) for consistency.

## Design
Pure-stdlib AST (no `golang.org/x/tools`). Every guard is matches-zero guarded (can't pass vacuously) and ships a no-stale-entry-guarded allowlist. `docs/adr/0002-architectural-fitness-functions.md` documents what is locked and why.

The RPC-classification invariant is already enforced by `permissions_parity_test.go` and the generated-code drift by `sqlc.yml` — not duplicated here.

Closes #398