### PR TITLE
feat(api,control,gateway)!: sign the full action envelope at dispatch

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -309,7 +309,7 @@ func main() {
 
 	// Mount InternalService on a separate mTLS-protected listener.
 	// The gateway presents its CA-signed certificate as a client cert.
-	internalHandler := api.NewInternalHandler(st, encryptor, logger.With("component", "internal_service"))
+	internalHandler := api.NewInternalHandler(st, encryptor, logger.With("component", "internal_service"), actionSigner)
 	if valkey != nil && valkey.TerminalTokenStore != nil {
 		// Shared with the ControlService.StartTerminal handler so the
 		// gateway can validate tokens minted on this instance via

--- a/docs/adr/0003-action-signing-full-envelope.md
+++ b/docs/adr/0003-action-signing-full-envelope.md
@@ -1,0 +1,92 @@
+# 0003 — Action signing binds the full executed envelope
+
+- Status: accepted
+- Date: 2026-06-12
+- Related: sdk#82; the 2026-06-12 audits (agent F-C2 = server SA-C1); WS1 of
+  the SECURITY_HARDENING_WORKPLAN; ADR 0002 (fitness functions).
+
+## Context
+
+Actions dispatched to agents are signed by the control server's CA key so an
+agent can prove an action originated from control and was not forged by a
+compromised gateway or Valkey relay (trust model: actor #4 — untrusted *for
+origination*).
+
+The old signature covered only `SHA-256(domain | actionID : actionType :
+base64(paramsJSON))`, and the wire carried two separate representations: a
+`params_canonical` JSON blob (verified) and the typed `params` oneof
+(executed). The agent verified `params_canonical` but **executed the typed
+oneof**, and the signature bound neither `desired_state`, `timeout_seconds`,
+`schedule`, nor the target device. A compromised relay could therefore:
+
+- flip `desired_state` PRESENT→ABSENT (turn a signed install into an
+  unsigned root deletion),
+- swap the executed params while leaving `params_canonical` intact,
+- change the timeout or schedule,
+- lift a signature onto a different action type (e.g. SYNC), or
+- replay a captured action onto a different device.
+
+## Decision
+
+Sign the **full executed envelope** as **deterministic binary protobuf**, and
+make the agent execute exactly the bytes it verified.
+
+- A new proto message `pm.SignedActionEnvelope` carries everything that
+  executes: `action_id`, `action_type`, `desired_state`, `timeout_seconds`,
+  `schedule`, `target_device_id`, and the params oneof.
+- The CA signs `proto.MarshalOptions{Deterministic:true}.Marshal(envelope)`
+  (helper `verify.MarshalEnvelope`). The signature pre-image is
+  `SHA-256( len32(domain) || "power-manage-action" || envelopeBytes )`; the
+  length-prefixed domain tag keeps this surface disjoint from any other that
+  might share the CA key.
+- Those **exact bytes are transported** — push path:
+  `ActionDispatch{ bytes envelope, bytes signature }`; pull/offline-sync path:
+  `Action.signed_envelope` + `Action.signature` (each synced action is signed
+  device-bound at delivery). The agent verifies the signature over the
+  received bytes and `proto.Unmarshal`s **those same bytes** to execute.
+- Clean break: `Action.params_canonical` and the `params_canonical`/typed-
+  `params` split are removed. There is one representation — the executed
+  message *is* the verified message. The wire `Action`'s typed fields remain
+  only as advisory display/scheduling metadata; execution and every
+  security-relevant decision read the verified envelope.
+
+### Re-sign at dispatch / sign-at-delivery; device-bound
+
+There is no stable persisted dispatch-grade signature. The push path signs at
+dispatch with the execution id + target device. The offline-sync pull path
+signs each delivered action device-bound at delivery (the agent has no
+execution id yet — the envelope binds the action's own id; the agent mints the
+execution offline). Both bind `target_device_id`, so a captured envelope
+cannot be replayed onto another device. The server still stores the canonical
+params blob (in the `params_canonical` column) as the source the dispatcher
+re-marshals the envelope from — that column is now a params store, not a
+signature input. No migration; SDK bump with lock-step deploy.
+
+### Why transporting the bytes (not re-marshalling to compare)
+
+Correctness comes from signing-and-transporting the exact bytes and
+unmarshalling those same bytes — never re-marshalling a reconstructed message
+to compare. Determinism is belt-and-braces. This is safe because the server
+(Go) always signs and the agent (Go) always verifies; the web client never
+verifies an action signature, so cross-language/version marshalling drift
+cannot bite.
+
+### Two signing layers stay separate
+
+This CA action signature is independent of the taskqueue HMAC envelope
+(`taskqueue.Wrap`/`VerifyMiddleware`), which wraps the whole Asynq payload to
+keep a compromised Valkey from injecting tasks. Both are required; neither
+substitutes for the other.
+
+## Consequences
+
+- A compromised gateway/Valkey cannot swap params, flip desired_state, change
+  the timeout/schedule, lift the type onto SYNC, or retarget a device under a
+  valid signature. `verify`'s charter pins each of these as a rejected swap.
+- The agent's offline scheduler verifies the stored signed envelope before
+  every execution; an unsigned/tampered synced action is refused, never run.
+- `revertAction` (revert-on-unassign) is the one path that runs a locally
+  flipped `desired_state=ABSENT`: it executes the params from the *verified*
+  stored envelope with only desired_state overridden, so the executed params
+  stay authenticated (a relay cannot inject an install via revert).
+- Breaking proto/SDK change, shipped sdk→server→agent in lock-step.

--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260610161746-5136d8f059b3
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260612214757-f929ee828ab5

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260610161746-5136d8f059b3 h1:66jjZXu/7wvRraOKXPCKcJ726ZvmOgdGSYslcSWVs9k=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260610161746-5136d8f059b3/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260612214757-f929ee828ab5 h1:LnY88/pho6AkhKwDWJJBMruAJpP/BzYH8c9UEKXdoYw=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260612214757-f929ee828ab5/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/actionparams/actionparams.go
+++ b/internal/actionparams/actionparams.go
@@ -201,6 +201,140 @@ func PopulateAction(action *pm.Action, actionType int32, paramsJSON []byte) erro
 	return nil
 }
 
+// PopulateEnvelope deserializes params JSON into a SignedActionEnvelope's
+// params oneof — the signed/transported representation the agent verifies
+// and unmarshals to execute. Used by the dispatch signing path
+// (api.buildAndSignEnvelope) so the bytes the CA signs carry exactly the
+// typed params that run.
+//
+// Fail-closed identically to PopulateAction: a protojson parse failure OR
+// an unhandled action type returns an error so the caller never signs (and
+// transports) an envelope with empty/nil params. Param-less instant types
+// (REBOOT/SYNC) and the zero value leave the oneof unset and return nil.
+//
+// TODO(WS1b #1): collapse via proto reflection — this duplicates the
+// PopulateAction switch one-for-one. The two MUST stay in lockstep until
+// the reflection-based collapse lands; a new ACTION_TYPE_* added to one
+// switch but not the other is a fail-closed dispatch bug.
+func PopulateEnvelope(env *pm.SignedActionEnvelope, actionType int32, paramsJSON []byte) error {
+	switch pm.ActionType(actionType) {
+	case pm.ActionType_ACTION_TYPE_PACKAGE:
+		var p pm.PackageParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal PACKAGE params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Package{Package: &p}
+	case pm.ActionType_ACTION_TYPE_APP_IMAGE, pm.ActionType_ACTION_TYPE_DEB, pm.ActionType_ACTION_TYPE_RPM:
+		var p pm.AppInstallParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal APP_INSTALL params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_App{App: &p}
+	case pm.ActionType_ACTION_TYPE_FLATPAK:
+		var p pm.FlatpakParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal FLATPAK params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Flatpak{Flatpak: &p}
+	case pm.ActionType_ACTION_TYPE_SHELL, pm.ActionType_ACTION_TYPE_SCRIPT_RUN:
+		var p pm.ShellParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SHELL params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Shell{Shell: &p}
+	case pm.ActionType_ACTION_TYPE_SERVICE:
+		var p pm.ServiceParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SERVICE params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Service{Service: &p}
+	case pm.ActionType_ACTION_TYPE_FILE:
+		var p pm.FileParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal FILE params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_File{File: &p}
+	case pm.ActionType_ACTION_TYPE_UPDATE:
+		var p pm.UpdateParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal UPDATE params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Update{Update: &p}
+	case pm.ActionType_ACTION_TYPE_REPOSITORY:
+		var p pm.RepositoryParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal REPOSITORY params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Repository{Repository: &p}
+	case pm.ActionType_ACTION_TYPE_DIRECTORY:
+		var p pm.DirectoryParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal DIRECTORY params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Directory{Directory: &p}
+	case pm.ActionType_ACTION_TYPE_USER:
+		var p pm.UserParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal USER params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_User{User: &p}
+	case pm.ActionType_ACTION_TYPE_GROUP:
+		var p pm.GroupParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal GROUP params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Group{Group: &p}
+	case pm.ActionType_ACTION_TYPE_SSH:
+		var p pm.SshParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SSH params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Ssh{Ssh: &p}
+	case pm.ActionType_ACTION_TYPE_SSHD:
+		var p pm.SshdParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal SSHD params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Sshd{Sshd: &p}
+	case pm.ActionType_ACTION_TYPE_ADMIN_POLICY:
+		var p pm.AdminPolicyParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal ADMIN_POLICY params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_AdminPolicy{AdminPolicy: &p}
+	case pm.ActionType_ACTION_TYPE_LPS:
+		var p pm.LpsParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal LPS params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Lps{Lps: &p}
+	case pm.ActionType_ACTION_TYPE_ENCRYPTION:
+		var p pm.EncryptionParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal ENCRYPTION params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Encryption{Encryption: &p}
+	case pm.ActionType_ACTION_TYPE_WIFI:
+		var p pm.WifiParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal WIFI params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_Wifi{Wifi: &p}
+	case pm.ActionType_ACTION_TYPE_AGENT_UPDATE:
+		var p pm.AgentUpdateParams
+		if err := unmarshalOpts.Unmarshal(paramsJSON, &p); err != nil {
+			return fmt.Errorf("actionparams: unmarshal AGENT_UPDATE params: %w", err)
+		}
+		env.Params = &pm.SignedActionEnvelope_AgentUpdate{AgentUpdate: &p}
+	default:
+		if isNoParamsActionType(pm.ActionType(actionType)) {
+			return nil
+		}
+		return fmt.Errorf("actionparams: unhandled action type %d (%s)", actionType, pm.ActionType(actionType))
+	}
+	return nil
+}
+
 // PopulateManagedAction deserializes params JSON into an API-format
 // ManagedAction proto. Used by the control server API (action list/get
 // responses). Returns an error on a protojson parse failure OR an unhandled

--- a/internal/actionparams/actionparams_test.go
+++ b/internal/actionparams/actionparams_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
@@ -72,4 +73,161 @@ func TestPopulateManagedAction_MalformedParamsReturnsError(t *testing.T) {
 	err := actionparams.PopulateManagedAction(action, pm.ActionType_ACTION_TYPE_FILE, []byte("{bad"))
 	require.Error(t, err)
 	assert.Nil(t, action.Params)
+}
+
+// =============================================================================
+// PopulateEnvelope — the signed/transported representation
+// =============================================================================
+//
+// Contract restated: PopulateEnvelope unmarshals params JSON into a
+// SignedActionEnvelope's oneof, mirroring PopulateAction exactly. It MUST:
+//   - set the typed oneof for every params-carrying ACTION_TYPE_* (correct),
+//   - leave the oneof unset and return nil for the param-less types
+//     (REBOOT/SYNC/UNSPECIFIED) — present-but-empty is fine,
+//   - reject malformed JSON (present-but-wrong),
+//   - reject an unhandled type (absent case) rather than silently no-op.
+// The rejection paths are the point: a swallowed error would let the dispatch
+// signer sign (and transport) an envelope with empty params (#368).
+
+// TestPopulateEnvelope_MalformedParamsReturnsError pins that a protojson parse
+// failure surfaces as an error and leaves the oneof unset.
+func TestPopulateEnvelope_MalformedParamsReturnsError(t *testing.T) {
+	env := &pm.SignedActionEnvelope{}
+	err := actionparams.PopulateEnvelope(env, int32(pm.ActionType_ACTION_TYPE_SHELL), []byte("{not valid json"))
+	require.Error(t, err)
+	assert.Nil(t, env.Params, "params oneof must not be set on a parse error")
+}
+
+// TestPopulateEnvelope_UnknownTypeWithParamsReturnsError pins that an action
+// type the switch doesn't handle errors rather than falling through with nil
+// params. "Wrong" type (999999) is sourced from the design rule "every
+// dispatched type must be wired", NOT from the switch itself.
+func TestPopulateEnvelope_UnknownTypeWithParamsReturnsError(t *testing.T) {
+	env := &pm.SignedActionEnvelope{}
+	err := actionparams.PopulateEnvelope(env, 999999, []byte(`{"x":1}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unhandled action type")
+	assert.Nil(t, env.Params)
+}
+
+// TestPopulateEnvelope_NoParamsTypesReturnNil pins that the param-less action
+// types (REBOOT/SYNC) and the zero value leave the oneof unset without error —
+// instant actions legitimately carry no params.
+func TestPopulateEnvelope_NoParamsTypesReturnNil(t *testing.T) {
+	for _, at := range []pm.ActionType{
+		pm.ActionType_ACTION_TYPE_UNSPECIFIED,
+		pm.ActionType_ACTION_TYPE_REBOOT,
+		pm.ActionType_ACTION_TYPE_SYNC,
+	} {
+		env := &pm.SignedActionEnvelope{}
+		require.NoErrorf(t, actionparams.PopulateEnvelope(env, int32(at), []byte("{}")), "type %s", at)
+		assert.Nil(t, env.Params, "param-less type %s must leave the oneof unset", at)
+	}
+}
+
+// TestPopulateEnvelope_EveryActionTypeHandled is self-discovering against the
+// generated ActionType enum: every value must either be wired into the
+// envelope switch or classified as param-less. A new action type added to
+// PopulateAction but forgotten in PopulateEnvelope fails HERE — closing the
+// "the two switches drifted" gap until the reflection collapse lands. Guards
+// against matching zero by requiring a non-empty enum map.
+func TestPopulateEnvelope_EveryActionTypeHandled(t *testing.T) {
+	require.NotEmpty(t, pm.ActionType_name)
+	for v, name := range pm.ActionType_name {
+		t.Run(name, func(t *testing.T) {
+			env := &pm.SignedActionEnvelope{}
+			require.NoErrorf(t, actionparams.PopulateEnvelope(env, v, []byte("{}")),
+				"PopulateEnvelope does not handle %s (%d) — add a case or classify it param-less (drift vs PopulateAction)", name, v)
+		})
+	}
+}
+
+// TestPopulateEnvelope_SetsTypedParams pins that a representative params-carrying
+// type lands its fields in the envelope's oneof (not just "no error").
+func TestPopulateEnvelope_SetsTypedParams(t *testing.T) {
+	env := &pm.SignedActionEnvelope{}
+	require.NoError(t, actionparams.PopulateEnvelope(env, int32(pm.ActionType_ACTION_TYPE_SHELL), []byte(`{"script":"echo hi","runAsRoot":true}`)))
+	require.NotNil(t, env.GetShell())
+	assert.Equal(t, "echo hi", env.GetShell().Script)
+	assert.True(t, env.GetShell().RunAsRoot)
+}
+
+// =============================================================================
+// BuildAndSignEnvelope — the single dispatch signing site
+// =============================================================================
+
+// recordingEnvelopeSigner captures the exact bytes it was asked to sign so a
+// test can prove the signer signs the SAME bytes BuildAndSignEnvelope returns
+// (the load-bearing "sign == transport" invariant). It returns a deterministic
+// fixed signature.
+type recordingEnvelopeSigner struct {
+	signed [][]byte
+}
+
+func (r *recordingEnvelopeSigner) Sign(envelopeBytes []byte) ([]byte, error) {
+	r.signed = append(r.signed, append([]byte(nil), envelopeBytes...))
+	return []byte("recorded-sig"), nil
+}
+
+// TestBuildAndSignEnvelope_SignsExactTransportedBytes pins the core invariant:
+// the bytes handed to the signer are byte-for-byte the envelopeBytes returned
+// for transport, AND they deterministically decode to the envelope built from
+// the inputs (id/type/desired_state/timeout/device/params all bound).
+func TestBuildAndSignEnvelope_SignsExactTransportedBytes(t *testing.T) {
+	signer := &recordingEnvelopeSigner{}
+	envBytes, sig, err := actionparams.BuildAndSignEnvelope(
+		signer,
+		"exec-123",
+		int32(pm.ActionType_ACTION_TYPE_SHELL),
+		[]byte(`{"script":"echo hi"}`),
+		int32(pm.DesiredState_DESIRED_STATE_ABSENT),
+		420,
+		nil,
+		"device-xyz",
+	)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("recorded-sig"), sig)
+
+	require.Len(t, signer.signed, 1, "signer must be called exactly once")
+	assert.Equal(t, envBytes, signer.signed[0],
+		"the bytes signed MUST equal the bytes transported — never re-marshal a second envelope")
+
+	// The transported bytes decode to the bound envelope.
+	var env pm.SignedActionEnvelope
+	require.NoError(t, proto.Unmarshal(envBytes, &env))
+	assert.Equal(t, "exec-123", env.GetActionId().GetValue())
+	assert.Equal(t, pm.ActionType_ACTION_TYPE_SHELL, env.GetActionType())
+	assert.Equal(t, pm.DesiredState_DESIRED_STATE_ABSENT, env.GetDesiredState())
+	assert.Equal(t, int32(420), env.GetTimeoutSeconds())
+	assert.Equal(t, "device-xyz", env.GetTargetDeviceId())
+	require.NotNil(t, env.GetShell())
+	assert.Equal(t, "echo hi", env.GetShell().Script)
+}
+
+// TestBuildAndSignEnvelope_NilSignerRejected pins fail-closed on a nil signer —
+// a wiring bug must not produce an unsigned envelope.
+func TestBuildAndSignEnvelope_NilSignerRejected(t *testing.T) {
+	_, _, err := actionparams.BuildAndSignEnvelope(
+		nil, "e", int32(pm.ActionType_ACTION_TYPE_SHELL), []byte("{}"), 0, 1, nil, "d")
+	require.Error(t, err)
+}
+
+// TestBuildAndSignEnvelope_MalformedParamsRejected pins that a params parse
+// failure aborts BEFORE signing — we must never sign/transport empty params.
+func TestBuildAndSignEnvelope_MalformedParamsRejected(t *testing.T) {
+	signer := &recordingEnvelopeSigner{}
+	_, _, err := actionparams.BuildAndSignEnvelope(
+		signer, "e", int32(pm.ActionType_ACTION_TYPE_SHELL), []byte("{bad"), 0, 1, nil, "d")
+	require.Error(t, err)
+	assert.Empty(t, signer.signed, "signer must NOT be called when params fail to parse")
+}
+
+// TestBuildAndSignEnvelope_UnhandledTypeRejected pins that an unhandled type
+// aborts before signing (absent-case rejection).
+func TestBuildAndSignEnvelope_UnhandledTypeRejected(t *testing.T) {
+	signer := &recordingEnvelopeSigner{}
+	_, _, err := actionparams.BuildAndSignEnvelope(
+		signer, "e", 999999, []byte(`{"x":1}`), 0, 1, nil, "d")
+	require.Error(t, err)
+	assert.Empty(t, signer.signed, "signer must NOT be called for an unhandled type")
 }

--- a/internal/actionparams/sign_envelope.go
+++ b/internal/actionparams/sign_envelope.go
@@ -1,0 +1,78 @@
+package actionparams
+
+import (
+	"fmt"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/verify"
+)
+
+// EnvelopeSigner is the minimal contract BuildAndSignEnvelope needs: sign
+// the deterministic wire bytes of a SignedActionEnvelope and return the CA
+// signature. Both ca.ActionSigner and the SDK's *verify.ActionSigner
+// satisfy it structurally — declaring it here (rather than importing ca)
+// keeps actionparams a leaf package with no server-internal dependencies
+// and avoids any import cycle.
+type EnvelopeSigner interface {
+	Sign(envelopeBytes []byte) ([]byte, error)
+}
+
+// BuildAndSignEnvelope is the single signing site shared by every dispatch
+// path (api.DispatchAction, api.DispatchInstantAction, the control inbox
+// reconnect re-dispatch). It builds a pm.SignedActionEnvelope bound to the
+// executing device + execution id, deterministically marshals it
+// (verify.MarshalEnvelope), and signs THOSE bytes.
+//
+// The load-bearing contract: the returned envelopeBytes are the exact bytes
+// the signature covers AND the exact bytes the caller must transport
+// (ActionDispatchPayload.EnvelopeBytes -> ActionDispatch.envelope). The
+// agent verifies the signature over the received bytes and unmarshals THOSE
+// SAME bytes to execute — so the executed message is byte-for-byte the
+// signed message. Never re-marshal a second envelope to verify or transport:
+// a re-marshal can diverge and silently break the full-envelope binding.
+//
+// Fail-closed: a nil signer, an unhandled/malformed params type, a marshal
+// failure, or a sign failure all return an error so no caller ever enqueues
+// an unsigned or empty-params task the agent would drop.
+func BuildAndSignEnvelope(
+	signer EnvelopeSigner,
+	executionID string,
+	actionType int32,
+	paramsJSON []byte,
+	desiredState int32,
+	timeoutSeconds int32,
+	schedule *pm.ActionSchedule,
+	deviceID string,
+) (envelopeBytes []byte, signature []byte, err error) {
+	if signer == nil {
+		return nil, nil, fmt.Errorf("actionparams.BuildAndSignEnvelope: nil signer")
+	}
+
+	env := &pm.SignedActionEnvelope{
+		ActionId:       &pm.ActionId{Value: executionID},
+		ActionType:     pm.ActionType(actionType),
+		DesiredState:   pm.DesiredState(desiredState),
+		TimeoutSeconds: timeoutSeconds,
+		Schedule:       schedule,
+		TargetDeviceId: deviceID,
+	}
+
+	// Bind the typed params into the envelope's oneof. Fail-closed on a
+	// parse error or an unhandled type — exactly like PopulateAction, so we
+	// never sign an envelope with empty params (#368).
+	if err := PopulateEnvelope(env, actionType, paramsJSON); err != nil {
+		return nil, nil, fmt.Errorf("actionparams.BuildAndSignEnvelope: populate params (type %d): %w", actionType, err)
+	}
+
+	envelopeBytes, err = verify.MarshalEnvelope(env)
+	if err != nil {
+		return nil, nil, fmt.Errorf("actionparams.BuildAndSignEnvelope: marshal envelope: %w", err)
+	}
+
+	signature, err = signer.Sign(envelopeBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("actionparams.BuildAndSignEnvelope: sign envelope: %w", err)
+	}
+
+	return envelopeBytes, signature, nil
+}

--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -359,26 +359,36 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 	}), nil
 }
 
-// computeActionSignature produces a signature over (id, actionType,
-// paramsJSON). Pure compute — no DB access. Fail-closed on nil
-// signer. Split out of the legacy signAction() so Create/Update
-// can compute the signature BEFORE writing the ActionCreated /
-// ActionParamsUpdated event, so a sign failure never produces an
-// unsigned row in the projection.
+// computeActionSignature NO LONGER signs at create/update time.
+//
+// Action-signing rewrite: a dispatch-grade signature is now produced at
+// EVERY dispatch (api.DispatchAction / DispatchInstantAction and the inbox
+// reconnect re-dispatch) over the full SignedActionEnvelope, bound to the
+// execution id and target device. Persisting a signature at create time is
+// pointless and actively misleading: it was computed over a different
+// pre-image (the old (id, type, params) tuple, keyed on the ACTION id not
+// the EXECUTION id), would not verify against a dispatch envelope, and goes
+// stale on key rotation. We therefore stop writing a dispatch-grade
+// signature here and persist nil.
+//
+// We DO still persist the params blob (paramsJSON) in the ParamsCanonical
+// column: it is the immutable record of exactly what JSON the action
+// carries, kept for audit/history. The projection signature column stays in
+// place (no migration); it simply holds nil for newly created/updated rows.
+//
+// Pure compute, no DB access, no signer dependency — kept as a thin shim so
+// the Create / UpdateActionParams call sites need no structural change. The
+// _ = ctx, _ = actionType params are retained for signature stability.
 func (h *ActionHandler) computeActionSignature(ctx context.Context, id string, actionType int32, paramsJSON []byte) ([]byte, []byte, error) {
-	if h.signer == nil {
-		h.logger.Error("computeActionSignature called with nil signer — wiring bug", "action_id", id)
-		return nil, nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
-	}
+	_ = ctx
+	_ = id
+	_ = actionType
 	if paramsJSON == nil {
 		paramsJSON = []byte("{}")
 	}
-	sig, err := h.signer.Sign(id, actionType, paramsJSON)
-	if err != nil {
-		h.logger.Error("failed to sign action", "action_id", id, "error", err)
-		return nil, nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign action")
-	}
-	return sig, paramsJSON, nil
+	// Signature is intentionally nil: signing happens at dispatch, never
+	// at create/update time.
+	return nil, paramsJSON, nil
 }
 
 // persistActionSignature writes a precomputed signature to the

--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -20,6 +20,7 @@ import (
 	"github.com/oklog/ulid/v2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -83,8 +84,6 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 	}
 
 	var inputs dispatchInputs
-	var signature []byte
-	var paramsCanonical []byte
 
 	switch source := req.Msg.ActionSource.(type) {
 	case *pm.DispatchActionRequest_ActionId:
@@ -233,13 +232,26 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 			"execution_id", id, "error", marshalErr)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to marshal dispatch params")
 	}
-	sig, signErr := h.signer.Sign(id, int32(inputs.actionType), paramsJSON)
+	// Build and sign the full SignedActionEnvelope. The bytes we sign are
+	// the bytes we transport (envelopeBytes -> ActionDispatchPayload.
+	// EnvelopeBytes) — the agent verifies and unmarshals the same bytes.
+	// Ad-hoc dispatch carries no schedule (nil): the schedule field is
+	// authoritative only on the autonomous sync path, not on a one-shot
+	// dispatch.
+	envelopeBytes, signature, signErr := actionparams.BuildAndSignEnvelope(
+		h.signer,
+		id,
+		int32(inputs.actionType),
+		paramsJSON,
+		int32(inputs.desiredState),
+		inputs.timeoutSeconds,
+		nil, // schedule: not part of an ad-hoc dispatch
+		req.Msg.DeviceId,
+	)
 	if signErr != nil {
-		h.logger.Error("dispatch: failed to sign action", "execution_id", id, "error", signErr)
+		h.logger.Error("dispatch: failed to build/sign action envelope", "execution_id", id, "error", signErr)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign dispatched action")
 	}
-	signature = sig
-	paramsCanonical = paramsJSON
 
 	// Choose ExecutionScheduled vs ExecutionCreated based on whether
 	// the caller asked for a deferred dispatch. The two events are
@@ -277,13 +289,9 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 		enqueueOpts = append(enqueueOpts, asynq.TaskID(id), asynq.ProcessIn(dispatchDelay))
 	}
 	if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
-		ExecutionID:     id,
-		ActionType:      int32(inputs.actionType),
-		DesiredState:    int32(inputs.desiredState),
-		Params:          paramsJSON,
-		TimeoutSeconds:  inputs.timeoutSeconds,
-		Signature:       signature,
-		ParamsCanonical: paramsCanonical,
+		ExecutionID:   id,
+		EnvelopeBytes: envelopeBytes,
+		Signature:     signature,
 	}, enqueueOpts...); err != nil {
 		h.logger.Error("failed to enqueue action dispatch; emitting ExecutionFailed",
 			"error", err, "execution_id", id)
@@ -789,21 +797,31 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 		h.logger.Error("instant dispatch: nil signer — wiring bug", "execution_id", id)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
 	}
-	canonicalParams := []byte("{}")
-	instantSig, sigErr := h.signer.Sign(id, int32(req.Msg.InstantAction), canonicalParams)
+	// Build and sign the full envelope for the instant action. REBOOT /
+	// SYNC carry no params, so the empty-object JSON `{}` is the params
+	// source — PopulateEnvelope classifies these as param-less and leaves
+	// the oneof unset. The action_type is bound inside the signed bytes so
+	// a compromised relay can't lift a REBOOT signature onto SYNC (or vice
+	// versa) or retarget the device.
+	envelopeBytes, instantSig, sigErr := actionparams.BuildAndSignEnvelope(
+		h.signer,
+		id,
+		int32(req.Msg.InstantAction),
+		[]byte("{}"),
+		int32(pm.DesiredState_DESIRED_STATE_PRESENT),
+		timeoutSeconds,
+		nil, // instant actions are one-shot, no schedule
+		req.Msg.DeviceId,
+	)
 	if sigErr != nil {
-		h.logger.Error("failed to sign instant action; refusing dispatch",
+		h.logger.Error("failed to build/sign instant action envelope; refusing dispatch",
 			"execution_id", id, "action_type", req.Msg.InstantAction.String(), "error", sigErr)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to sign instant action")
 	}
 	if err := h.aqClient.EnqueueToDevice(req.Msg.DeviceId, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
-		ExecutionID:     id,
-		ActionType:      int32(req.Msg.InstantAction),
-		DesiredState:    int32(pm.DesiredState_DESIRED_STATE_PRESENT),
-		Params:          json.RawMessage("{}"),
-		ParamsCanonical: canonicalParams,
-		Signature:       instantSig,
-		TimeoutSeconds:  timeoutSeconds,
+		ExecutionID:   id,
+		EnvelopeBytes: envelopeBytes,
+		Signature:     instantSig,
 	}, enqueueOpts...); err != nil {
 		h.logger.Error("failed to enqueue instant action dispatch; emitting ExecutionFailed",
 			"error", err, "execution_id", id)

--- a/internal/api/action_dispatch_signing_test.go
+++ b/internal/api/action_dispatch_signing_test.go
@@ -1,0 +1,228 @@
+package api_test
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log/slog"
+	"math/big"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/verify"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/taskqueue"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// newDispatchTestCA mints a fresh self-signed CA and returns a real
+// ca.ActionSigner over its private key plus a verify.ActionVerifier over the
+// matching certificate. The dispatch charter tests use the REAL signer +
+// verifier so they prove the enqueued envelope is what an agent would accept,
+// and that the full-envelope binding rejects field swaps.
+func newDispatchTestCA(t *testing.T) (ca.ActionSigner, *verify.ActionVerifier) {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Dispatch Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(caKey)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+
+	c, err := ca.NewFromPEM(certPEM, keyPEM, 24*time.Hour)
+	require.NoError(t, err)
+	verifier, err := verify.NewActionVerifier(certPEM)
+	require.NoError(t, err)
+	return ca.NewActionSigner(c), verifier
+}
+
+// lastDispatchPayload extracts the most recent ActionDispatch payload the
+// recording enqueuer captured. Fails if none / wrong type.
+func lastDispatchPayload(t *testing.T, q *api.NoOpEnqueuer) taskqueue.ActionDispatchPayload {
+	t.Helper()
+	require.NotEmpty(t, q.DeviceCalls, "expected at least one EnqueueToDevice call")
+	last := q.DeviceCalls[len(q.DeviceCalls)-1]
+	assert.Equal(t, taskqueue.TypeActionDispatch, last.TaskType)
+	payload, ok := last.Payload.(taskqueue.ActionDispatchPayload)
+	require.True(t, ok, "enqueued payload must be an ActionDispatchPayload, got %T", last.Payload)
+	return payload
+}
+
+// TestDispatchAction_SignsExecutedEnvelope drives the REAL DispatchAction with
+// a REAL CA signer + recording enqueuer and asserts:
+//   - the enqueued EnvelopeBytes verify under the matching verifier+signature;
+//   - the envelope decodes to the request's executed semantics (desired_state,
+//     timeout, params, target device, execution id);
+//   - mutating ANY bound field and re-marshalling breaks verification — the
+//     full-envelope binding is real (a compromised relay can't rewrite the
+//     action under a still-valid signature).
+func TestDispatchAction_SignsExecutedEnvelope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	signer, verifier := newDispatchTestCA(t)
+	h := api.NewActionHandler(st, slog.Default(), signer)
+	queue := &api.NoOpEnqueuer{}
+	h.SetTaskQueueClient(queue)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "dispatch-host")
+
+	resp, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_InlineAction{
+			InlineAction: &pm.Action{
+				// Inline Id satisfies request validation (Action.id is
+				// validate:"required,ulid"); the handler IGNORES it and mints
+				// its own execution id, which is what binds the envelope.
+				Id:             &pm.ActionId{Value: testutil.NewID()},
+				Type:           pm.ActionType_ACTION_TYPE_SHELL,
+				DesiredState:   pm.DesiredState_DESIRED_STATE_ABSENT,
+				TimeoutSeconds: 222,
+				Params: &pm.Action_Shell{
+					Shell: &pm.ShellParams{Script: "echo dispatched", RunAsRoot: true},
+				},
+			},
+		},
+	}))
+	require.NoError(t, err)
+	executionID := resp.Msg.Execution.Id
+
+	payload := lastDispatchPayload(t, queue)
+	require.Equal(t, executionID, payload.ExecutionID)
+	require.NotEmpty(t, payload.EnvelopeBytes)
+	require.NotEmpty(t, payload.Signature)
+
+	// The enqueued envelope verifies under the agent-side verifier over the
+	// EXACT transported bytes.
+	require.NoError(t, verifier.Verify(payload.EnvelopeBytes, payload.Signature),
+		"enqueued envelope must verify under the matching CA verifier")
+
+	// The transported bytes decode to the request's executed semantics.
+	var env pm.SignedActionEnvelope
+	require.NoError(t, proto.Unmarshal(payload.EnvelopeBytes, &env))
+	assert.Equal(t, executionID, env.GetActionId().GetValue())
+	assert.Equal(t, deviceID, env.GetTargetDeviceId())
+	assert.Equal(t, pm.ActionType_ACTION_TYPE_SHELL, env.GetActionType())
+	assert.Equal(t, pm.DesiredState_DESIRED_STATE_ABSENT, env.GetDesiredState())
+	assert.Equal(t, int32(222), env.GetTimeoutSeconds())
+	require.NotNil(t, env.GetShell())
+	assert.Equal(t, "echo dispatched", env.GetShell().Script)
+	assert.True(t, env.GetShell().RunAsRoot)
+
+	// Binding proof: flip desired_state and re-marshal — the original
+	// signature must reject the tampered bytes.
+	env.DesiredState = pm.DesiredState_DESIRED_STATE_PRESENT
+	tampered, err := verify.MarshalEnvelope(&env)
+	require.NoError(t, err)
+	require.Error(t, verifier.Verify(tampered, payload.Signature),
+		"mutating desired_state must break verification")
+}
+
+// TestDispatchAction_BindsTargetDevice pins that the target device is bound:
+// taking a signature legitimately issued for one device and presenting the
+// envelope retargeted at another device fails verification — no cross-device
+// replay of a captured envelope.
+func TestDispatchAction_BindsTargetDevice(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	signer, verifier := newDispatchTestCA(t)
+	h := api.NewActionHandler(st, slog.Default(), signer)
+	queue := &api.NoOpEnqueuer{}
+	h.SetTaskQueueClient(queue)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "device-A")
+	_ = testutil.CreateTestDevice(t, st, "device-B")
+
+	_, err := h.DispatchAction(ctx, connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId: deviceID,
+		ActionSource: &pm.DispatchActionRequest_InlineAction{
+			InlineAction: &pm.Action{
+				Id:           &pm.ActionId{Value: testutil.NewID()},
+				Type:         pm.ActionType_ACTION_TYPE_SHELL,
+				DesiredState: pm.DesiredState_DESIRED_STATE_PRESENT,
+				Params:       &pm.Action_Shell{Shell: &pm.ShellParams{Script: "id"}},
+			},
+		},
+	}))
+	require.NoError(t, err)
+
+	payload := lastDispatchPayload(t, queue)
+	require.NoError(t, verifier.Verify(payload.EnvelopeBytes, payload.Signature))
+
+	var env pm.SignedActionEnvelope
+	require.NoError(t, proto.Unmarshal(payload.EnvelopeBytes, &env))
+	require.Equal(t, deviceID, env.GetTargetDeviceId())
+
+	env.TargetDeviceId = "device-B"
+	retargeted, err := verify.MarshalEnvelope(&env)
+	require.NoError(t, err)
+	require.Error(t, verifier.Verify(retargeted, payload.Signature),
+		"retargeting the device must break verification — no cross-device replay")
+}
+
+// TestDispatchInstantAction_SignsEnvelope drives the REAL DispatchInstantAction
+// (REBOOT/SYNC) with a REAL signer and asserts the envelope binds the instant
+// action type + device, and that lifting the signature onto a DIFFERENT type
+// is rejected.
+func TestDispatchInstantAction_SignsEnvelope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	signer, verifier := newDispatchTestCA(t)
+	h := api.NewActionHandler(st, slog.Default(), signer)
+	queue := &api.NoOpEnqueuer{}
+	h.SetTaskQueueClient(queue)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "instant-host")
+
+	resp, err := h.DispatchInstantAction(ctx, connect.NewRequest(&pm.DispatchInstantActionRequest{
+		DeviceId:      deviceID,
+		InstantAction: pm.ActionType_ACTION_TYPE_REBOOT,
+	}))
+	require.NoError(t, err)
+	executionID := resp.Msg.Execution.Id
+
+	payload := lastDispatchPayload(t, queue)
+	require.Equal(t, executionID, payload.ExecutionID)
+	require.NoError(t, verifier.Verify(payload.EnvelopeBytes, payload.Signature),
+		"instant-action envelope must verify under the matching CA verifier")
+
+	var env pm.SignedActionEnvelope
+	require.NoError(t, proto.Unmarshal(payload.EnvelopeBytes, &env))
+	assert.Equal(t, executionID, env.GetActionId().GetValue())
+	assert.Equal(t, deviceID, env.GetTargetDeviceId())
+	assert.Equal(t, pm.ActionType_ACTION_TYPE_REBOOT, env.GetActionType())
+	// REBOOT carries no params — the oneof must be unset.
+	assert.Nil(t, env.GetParams(), "instant actions carry no params")
+
+	// Binding proof: lift the REBOOT signature onto SYNC by mutating the type
+	// and re-marshalling. Verification must fail — a compromised relay cannot
+	// turn a signed REBOOT into a SYNC (or vice versa).
+	env.ActionType = pm.ActionType_ACTION_TYPE_SYNC
+	lifted, err := verify.MarshalEnvelope(&env)
+	require.NoError(t, err)
+	require.Error(t, verifier.Verify(lifted, payload.Signature),
+		"lifting the signature onto a different instant type must break verification")
+}

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -13,6 +13,7 @@ import (
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
@@ -31,6 +32,15 @@ type InternalHandler struct {
 	encryptor *crypto.Encryptor
 	logger    *slog.Logger
 
+	// signer signs the SignedActionEnvelope for each action delivered by
+	// the autonomous SYNC path (ProxySyncActions). The PUSH/dispatch
+	// rewrite stopped create-time signing, so the sync path re-signs at
+	// DELIVERY, device-bound to the syncing device. A nil signer is a
+	// wiring bug: ProxySyncActions fails closed rather than hand the agent
+	// an unsigned action it would reject. main.go passes the real
+	// internal/ca signer; tests pass a CA-backed ca.ActionSigner.
+	signer ca.ActionSigner
+
 	// terminalTokenStore is set via SetTerminalTokenStore after the
 	// Valkey-backed store is constructed in main.go. nil when terminal
 	// sessions are not configured on this control instance, in which
@@ -43,11 +53,17 @@ type InternalHandler struct {
 }
 
 // NewInternalHandler creates a new internal service handler.
-func NewInternalHandler(st *store.Store, enc *crypto.Encryptor, logger *slog.Logger) *InternalHandler {
+//
+// signer is the CA-backed action signer used by ProxySyncActions to sign
+// each delivered SignedActionEnvelope device-bound. It is required for the
+// sync path; a nil signer makes ProxySyncActions fail closed rather than
+// deliver unsigned actions the agent would reject.
+func NewInternalHandler(st *store.Store, enc *crypto.Encryptor, logger *slog.Logger, signer ca.ActionSigner) *InternalHandler {
 	return &InternalHandler{
 		store:     st,
 		encryptor: enc,
 		logger:    logger,
+		signer:    signer,
 		now:       time.Now,
 	}
 }
@@ -90,6 +106,16 @@ func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Req
 	deviceID := req.Msg.DeviceId
 	if deviceID == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id is required")
+	}
+
+	// Fail closed on a missing signer. Synced actions are signed at
+	// DELIVERY device-bound (the dispatch rewrite stopped create-time
+	// signing); without a signer every Action would ship with an empty
+	// signature the offline agent rejects. A nil signer is a wiring bug —
+	// surface it loudly rather than silently sync unverifiable actions.
+	if h.signer == nil {
+		h.logger.Error("sync actions: nil signer — wiring bug", "device_id", deviceID)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "action signer not configured")
 	}
 
 	// Verify the device exists and is not deleted.
@@ -142,15 +168,20 @@ func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Req
 		if !ok {
 			continue
 		}
-		wire, err := dbActionToWireAction(raw)
-		if err != nil {
-			// Fail closed: skip an action whose params don't parse rather than
-			// sync it to the agent with empty params (#368).
-			h.logger.Warn("skipping standalone action with unparseable params", "action_id", raw.ID, "error", err)
-			continue
-		}
+		// Fold UNINSTALL → ABSENT into the desired state we SIGN, not just
+		// the advisory wire field: the agent executes the verified envelope,
+		// so the container's uninstall intent must ride in the signed bytes.
+		desiredState := raw.DesiredState
 		if sa.Mode == resolution.ModeUninstall {
-			wire.DesiredState = pm.DesiredState_DESIRED_STATE_ABSENT
+			desiredState = int32(pm.DesiredState_DESIRED_STATE_ABSENT)
+		}
+		wire, err := dbActionToWireAction(raw, h.signer, deviceID, desiredState)
+		if err != nil {
+			// Fail closed: skip an action whose params don't parse (or
+			// whose envelope can't be signed) rather than sync it to the
+			// agent with empty/invalid params or an empty signature (#368).
+			h.logger.Warn("skipping standalone action with unparseable params or unsignable envelope", "action_id", raw.ID, "error", err)
+			continue
 		}
 		standalone = append(standalone, wire)
 	}
@@ -162,10 +193,11 @@ func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Req
 		if covered[dbAction.ID] {
 			continue
 		}
-		action, err := dbResolvedActionToWireAction(dbAction)
+		action, err := dbResolvedActionToWireAction(dbAction, h.signer, deviceID)
 		if err != nil {
-			// Fail closed: skip rather than sync empty params (#368).
-			h.logger.Warn("skipping resolved action with unparseable params", "action_id", dbAction.ID, "error", err)
+			// Fail closed: skip rather than sync empty params or an
+			// unsignable envelope (#368).
+			h.logger.Warn("skipping resolved action with unparseable params or unsignable envelope", "action_id", dbAction.ID, "error", err)
 			continue
 		}
 		standalone = append(standalone, action)
@@ -182,14 +214,20 @@ func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Req
 			if !ok {
 				continue
 			}
-			wire, err := dbActionToWireAction(raw)
-			if err != nil {
-				// Fail closed: skip rather than sync empty params (#368).
-				h.logger.Warn("skipping group action with unparseable params", "action_id", raw.ID, "error", err)
-				continue
-			}
+			// Fold the group container's UNINSTALL → ABSENT into the signed
+			// desired state (see the standalone path above): the agent
+			// executes the verified envelope, so the override must be inside
+			// the signed bytes, not just the advisory wire field.
+			desiredState := raw.DesiredState
 			if g.Mode == resolution.ModeUninstall {
-				wire.DesiredState = pm.DesiredState_DESIRED_STATE_ABSENT
+				desiredState = int32(pm.DesiredState_DESIRED_STATE_ABSENT)
+			}
+			wire, err := dbActionToWireAction(raw, h.signer, deviceID, desiredState)
+			if err != nil {
+				// Fail closed: skip rather than sync empty params or an
+				// unsignable envelope (#368).
+				h.logger.Warn("skipping group action with unparseable params or unsignable envelope", "action_id", raw.ID, "error", err)
+				continue
 			}
 			groupActions = append(groupActions, wire)
 		}
@@ -240,14 +278,32 @@ func windowEntryCount(w *pm.MaintenanceWindow) int {
 // format. Mirrors dbResolvedActionToWireAction but operates on the
 // projection row directly so the tree resolver doesn't have to detour
 // through the per-action mode-collapse query for every member action.
-func dbActionToWireAction(a db.ActionsProjection) (*pm.Action, error) {
+//
+// SYNC-path device-bound signing (WS1 SERVER): the PUSH/dispatch rewrite
+// stopped create-time signing, so the autonomous SYNC path re-signs each
+// action at DELIVERY, bound to the SYNCING DEVICE. The built Action carries
+// signed_envelope (the deterministic bytes the agent verifies + executes)
+// and signature (the CA signature over those exact bytes). The typed-params
+// oneof + schedule stay populated as advisory metadata for the offline
+// scheduler — the agent executes the VERIFIED envelope, not the advisory
+// fields, so the signed envelope is the source of truth.
+//
+// effectiveDesiredState lets the caller fold the container-mode override
+// (UNINSTALL → ABSENT) INTO the signed envelope rather than only the
+// advisory wire field. The agent honours UNINSTALL only if it rides in the
+// signed bytes it executes — flipping the wire field alone would be a no-op
+// the verifier never sees.
+//
+// executionID = a.ID: synced actions have no execution id yet (the agent
+// mints the execution when it runs the action offline), so the action's own
+// id binds the envelope. This mirrors the dispatch path, where the freshly
+// minted execution id binds the envelope.
+func dbActionToWireAction(a db.ActionsProjection, signer ca.ActionSigner, deviceID string, effectiveDesiredState int32) (*pm.Action, error) {
 	action := &pm.Action{
-		Id:              &pm.ActionId{Value: a.ID},
-		Type:            pm.ActionType(a.ActionType),
-		DesiredState:    pm.DesiredState(a.DesiredState),
-		TimeoutSeconds:  a.TimeoutSeconds,
-		Signature:       a.Signature,
-		ParamsCanonical: a.ParamsCanonical,
+		Id:             &pm.ActionId{Value: a.ID},
+		Type:           pm.ActionType(a.ActionType),
+		DesiredState:   pm.DesiredState(effectiveDesiredState),
+		TimeoutSeconds: a.TimeoutSeconds,
 	}
 	if len(a.Params) > 0 {
 		if err := actionparams.PopulateAction(action, a.ActionType, a.Params); err != nil {
@@ -257,6 +313,22 @@ func dbActionToWireAction(a db.ActionsProjection) (*pm.Action, error) {
 	if len(a.Schedule) > 0 {
 		action.Schedule = actionparams.ScheduleFromJSON(a.Schedule)
 	}
+
+	envelopeBytes, signature, err := actionparams.BuildAndSignEnvelope(
+		signer,
+		a.ID,
+		a.ActionType,
+		a.Params,
+		effectiveDesiredState,
+		a.TimeoutSeconds,
+		action.Schedule,
+		deviceID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	action.SignedEnvelope = envelopeBytes
+	action.Signature = signature
 	return action, nil
 }
 
@@ -552,14 +624,18 @@ func (h *InternalHandler) ProxyValidateTerminalToken(ctx context.Context, req *c
 // dbResolvedActionToWireAction converts a resolved action row to wire format.
 // Note: This is also defined in handler/agent.go — when the gateway migration
 // is complete, only this version will remain.
-func dbResolvedActionToWireAction(a db.ListResolvedActionsForDeviceRow) (*pm.Action, error) {
+//
+// SYNC-path device-bound signing: like dbActionToWireAction, the delivered
+// Action carries a freshly signed, device-bound SignedActionEnvelope so the
+// offline agent can verify it. The flat resolver already collapsed this row
+// to its effective desired_state, so a.DesiredState is what we sign — there
+// is no separate container override to fold here.
+func dbResolvedActionToWireAction(a db.ListResolvedActionsForDeviceRow, signer ca.ActionSigner, deviceID string) (*pm.Action, error) {
 	action := &pm.Action{
-		Id:              &pm.ActionId{Value: a.ID},
-		Type:            pm.ActionType(a.ActionType),
-		DesiredState:    pm.DesiredState(a.DesiredState),
-		TimeoutSeconds:  a.TimeoutSeconds,
-		Signature:       a.Signature,
-		ParamsCanonical: a.ParamsCanonical,
+		Id:             &pm.ActionId{Value: a.ID},
+		Type:           pm.ActionType(a.ActionType),
+		DesiredState:   pm.DesiredState(a.DesiredState),
+		TimeoutSeconds: a.TimeoutSeconds,
 	}
 
 	if len(a.Params) > 0 {
@@ -571,6 +647,22 @@ func dbResolvedActionToWireAction(a db.ListResolvedActionsForDeviceRow) (*pm.Act
 	if len(a.Schedule) > 0 {
 		action.Schedule = actionparams.ScheduleFromJSON(a.Schedule)
 	}
+
+	envelopeBytes, signature, err := actionparams.BuildAndSignEnvelope(
+		signer,
+		a.ID,
+		a.ActionType,
+		a.Params,
+		a.DesiredState,
+		a.TimeoutSeconds,
+		action.Schedule,
+		deviceID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	action.SignedEnvelope = envelopeBytes
+	action.Signature = signature
 
 	return action, nil
 }

--- a/internal/api/internal_handler_sync_signing_test.go
+++ b/internal/api/internal_handler_sync_signing_test.go
@@ -1,0 +1,209 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/verify"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// CHARTER — sync-path device-bound signing (WS1 SERVER).
+//
+// Contract under test (ProxySyncActions, served by the gateway's
+// SyncActions RPC):
+//
+//   - Every pm.Action delivered to a syncing device — standalone AND
+//     grouped members — MUST carry a signed_envelope + signature pair so
+//     the offline agent can verify it before executing. The PUSH/dispatch
+//     rewrite stopped create-time signing, so an unsigned sync delivery is
+//     a regression the agent rejects.
+//   - The envelope is DEVICE-BOUND: its TargetDeviceId is the syncing
+//     device. A signature legitimately issued for device A must NOT verify
+//     against an envelope retargeted at device B — no cross-device replay
+//     of a captured envelope.
+//   - The signature covers the EXACT bytes transported (Action.signed_envelope):
+//     mutating any bound field and re-marshalling must break verification.
+//   - The envelope's executed semantics (desired_state, params, type,
+//     timeout, the action id) match the synced action.
+
+// All three charters build the handler with a REAL ca.ActionSigner over a
+// fresh test CA (newDispatchTestCA, shared with the dispatch charter) and a
+// verify.ActionVerifier over the SAME CA cert — so the test verifies exactly
+// what an agent holding that CA cert would verify, end to end.
+
+// TestSyncActions_SignsDeviceBoundEnvelope drives the REAL ProxySyncActions
+// with a REAL ca.ActionSigner over a test CA and asserts every returned
+// Action (standalone) carries a device-bound, verifiable envelope, that its
+// decoded semantics match the synced action, and that tampering rejects.
+func TestSyncActions_SignsDeviceBoundEnvelope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	signer, verifier := newDispatchTestCA(t)
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), signer)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "sync-sign-host")
+	actionID := testutil.CreateTestActionWithDesiredState(t, st, adminID, "Synced Shell",
+		int(pm.ActionType_ACTION_TYPE_SHELL), int(pm.DesiredState_DESIRED_STATE_ABSENT))
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID,
+		int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
+
+	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.StandaloneActions, 1)
+	a := resp.Msg.StandaloneActions[0]
+
+	// Every delivered action must carry the signed envelope + signature.
+	require.NotEmpty(t, a.SignedEnvelope, "synced action must carry signed_envelope")
+	require.NotEmpty(t, a.Signature, "synced action must carry a signature")
+
+	// The signature verifies under the SAME-CA verifier over the EXACT
+	// transported bytes — this is what the offline agent does.
+	require.NoError(t, verifier.Verify(a.SignedEnvelope, a.Signature),
+		"synced envelope must verify under the matching CA verifier")
+
+	// The transported bytes decode to device-bound, matching semantics.
+	var env pm.SignedActionEnvelope
+	require.NoError(t, proto.Unmarshal(a.SignedEnvelope, &env))
+	assert.Equal(t, deviceID, env.GetTargetDeviceId(),
+		"envelope must be bound to the syncing device")
+	assert.Equal(t, actionID, env.GetActionId().GetValue(),
+		"synced actions carry their own id as the execution id (agent mints the execution offline)")
+	assert.Equal(t, pm.ActionType_ACTION_TYPE_SHELL, env.GetActionType())
+	assert.Equal(t, pm.DesiredState_DESIRED_STATE_ABSENT, env.GetDesiredState())
+
+	// Binding proof: flip desired_state and re-marshal — the original
+	// signature must reject the tampered bytes.
+	env.DesiredState = pm.DesiredState_DESIRED_STATE_PRESENT
+	tampered, err := verify.MarshalEnvelope(&env)
+	require.NoError(t, err)
+	require.Error(t, verifier.Verify(tampered, a.Signature),
+		"mutating desired_state must break verification")
+}
+
+// TestSyncActions_BindsTargetDevice pins that the device binding is real:
+// the envelope synced to device A carries A's id, and retargeting it at a
+// different device breaks verification under A's signature — a captured
+// envelope cannot be replayed against another device.
+func TestSyncActions_BindsTargetDevice(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	signer, verifier := newDispatchTestCA(t)
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), signer)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceA := testutil.CreateTestDevice(t, st, "sync-bind-A")
+	deviceB := testutil.CreateTestDevice(t, st, "sync-bind-B")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Bound Shell", int(pm.ActionType_ACTION_TYPE_SHELL))
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceA,
+		int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
+
+	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+		DeviceId: deviceA,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.StandaloneActions, 1)
+	a := resp.Msg.StandaloneActions[0]
+	require.NoError(t, verifier.Verify(a.SignedEnvelope, a.Signature))
+
+	var env pm.SignedActionEnvelope
+	require.NoError(t, proto.Unmarshal(a.SignedEnvelope, &env))
+	require.Equal(t, deviceA, env.GetTargetDeviceId(),
+		"envelope synced to device A must be bound to device A")
+
+	// Retarget at device B and re-marshal — A's signature must reject it.
+	env.TargetDeviceId = deviceB
+	retargeted, err := verify.MarshalEnvelope(&env)
+	require.NoError(t, err)
+	require.Error(t, verifier.Verify(retargeted, a.Signature),
+		"retargeting the envelope at device B must break verification — no cross-device replay")
+}
+
+// TestSyncActions_UninstallFoldsIntoSignedEnvelope pins that the container's
+// UNINSTALL → ABSENT override rides INSIDE the signed bytes, not just the
+// advisory wire field. The agent executes the verified envelope, so an
+// override applied only to the advisory pm.Action.DesiredState would be a
+// no-op: the agent would re-install something the operator marked for
+// removal. Assert the DECODED envelope (the thing the agent executes) is
+// ABSENT, and that the advisory field agrees.
+func TestSyncActions_UninstallFoldsIntoSignedEnvelope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	signer, verifier := newDispatchTestCA(t)
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), signer)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "sync-uninstall-sign-host")
+	// Create the action with PRESENT as its stored desired_state so the
+	// override is observable: the signed envelope must NOT echo PRESENT.
+	actionID := testutil.CreateTestActionWithDesiredState(t, st, adminID, "Doomed Shell",
+		int(pm.ActionType_ACTION_TYPE_SHELL), int(pm.DesiredState_DESIRED_STATE_PRESENT))
+	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID,
+		int(pm.AssignmentMode_ASSIGNMENT_MODE_UNINSTALL))
+
+	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.StandaloneActions, 1)
+	a := resp.Msg.StandaloneActions[0]
+
+	assert.Equal(t, pm.DesiredState_DESIRED_STATE_ABSENT, a.DesiredState,
+		"advisory wire field must reflect the UNINSTALL override")
+	require.NoError(t, verifier.Verify(a.SignedEnvelope, a.Signature))
+
+	var env pm.SignedActionEnvelope
+	require.NoError(t, proto.Unmarshal(a.SignedEnvelope, &env))
+	assert.Equal(t, pm.DesiredState_DESIRED_STATE_ABSENT, env.GetDesiredState(),
+		"UNINSTALL override must ride in the SIGNED envelope the agent executes, not just the advisory field")
+}
+
+// TestSyncActions_SignsGroupedMembers pins that grouped members (action-set
+// members ride on grouped_actions, not standalone_actions) are signed
+// device-bound too — every Action delivered by the sync path, not just the
+// standalone ones, must verify.
+func TestSyncActions_SignsGroupedMembers(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	signer, verifier := newDispatchTestCA(t)
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), signer)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "sync-group-sign-host")
+	a1 := testutil.CreateTestAction(t, st, adminID, "Group Member 1", int(pm.ActionType_ACTION_TYPE_SHELL))
+	a2 := testutil.CreateTestAction(t, st, adminID, "Group Member 2", int(pm.ActionType_ACTION_TYPE_SHELL))
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Signed Set")
+	testutil.AddActionToTestSet(t, st, adminID, setID, a1, 0)
+	testutil.AddActionToTestSet(t, st, adminID, setID, a2, 1)
+	testutil.CreateTestAssignment(t, st, adminID, "action_set", setID, "device", deviceID,
+		int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
+
+	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.GroupedActions, 1)
+	g := resp.Msg.GroupedActions[0]
+	require.Len(t, g.Actions, 2)
+
+	for _, member := range g.Actions {
+		require.NotEmpty(t, member.SignedEnvelope, "grouped member must carry signed_envelope")
+		require.NotEmpty(t, member.Signature, "grouped member must carry a signature")
+		require.NoError(t, verifier.Verify(member.SignedEnvelope, member.Signature),
+			"grouped member envelope must verify under the matching CA verifier")
+
+		var env pm.SignedActionEnvelope
+		require.NoError(t, proto.Unmarshal(member.SignedEnvelope, &env))
+		assert.Equal(t, deviceID, env.GetTargetDeviceId(),
+			"grouped member envelope must be bound to the syncing device")
+		assert.Equal(t, member.Id.Value, env.GetActionId().GetValue(),
+			"grouped member envelope binds the member's own id")
+	}
+}

--- a/internal/api/internal_handler_test.go
+++ b/internal/api/internal_handler_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestVerifyDevice_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	deviceID := testutil.CreateTestDevice(t, st, "verify-host")
 
@@ -30,7 +30,7 @@ func TestVerifyDevice_Success(t *testing.T) {
 
 func TestVerifyDevice_NotFound(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	_, err := h.VerifyDevice(context.Background(), connect.NewRequest(&pm.VerifyDeviceRequest{
 		DeviceId: testutil.NewID(),
@@ -41,7 +41,7 @@ func TestVerifyDevice_NotFound(t *testing.T) {
 
 func TestVerifyDevice_EmptyID(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	_, err := h.VerifyDevice(context.Background(), connect.NewRequest(&pm.VerifyDeviceRequest{
 		DeviceId: "",
@@ -52,7 +52,7 @@ func TestVerifyDevice_EmptyID(t *testing.T) {
 
 func TestProxySyncActions_EmptyDeviceID(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	_, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: "",
@@ -63,7 +63,7 @@ func TestProxySyncActions_EmptyDeviceID(t *testing.T) {
 
 func TestProxySyncActions_DeviceNotFound(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	_, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: testutil.NewID(),
@@ -74,7 +74,7 @@ func TestProxySyncActions_DeviceNotFound(t *testing.T) {
 
 func TestProxySyncActions_NoAssignments(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	deviceID := testutil.CreateTestDevice(t, st, "sync-host")
 
@@ -87,7 +87,7 @@ func TestProxySyncActions_NoAssignments(t *testing.T) {
 
 func TestProxySyncActions_WithAssignment(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-assigned-host")
@@ -106,7 +106,7 @@ func TestProxySyncActions_WithAssignment(t *testing.T) {
 
 func TestProxySyncActions_UninstallAssignmentForcesAbsent(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-uninstall-host")
@@ -127,7 +127,7 @@ func TestProxySyncActions_UninstallAssignmentForcesAbsent(t *testing.T) {
 // rather than appearing on standalone_actions (#45 grouped sync wire).
 func TestProxySyncActions_ActionSetAssignmentEmitsGroup(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-set-host")
@@ -157,7 +157,7 @@ func TestProxySyncActions_ActionSetAssignmentEmitsGroup(t *testing.T) {
 // to ABSENT regardless of how the action itself was configured.
 func TestProxySyncActions_UninstallActionSetForcesAbsent(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-set-uninstall-host")
@@ -180,7 +180,7 @@ func TestProxySyncActions_UninstallActionSetForcesAbsent(t *testing.T) {
 func TestProxyStoreLuksKey(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	enc := testutil.NewEncryptor(t)
-	h := api.NewInternalHandler(st, enc, slog.Default())
+	h := api.NewInternalHandler(st, enc, slog.Default(), api.NoOpSigner{})
 
 	deviceID := testutil.CreateTestDevice(t, st, "luks-store-host")
 
@@ -197,7 +197,7 @@ func TestProxyStoreLuksKey(t *testing.T) {
 
 func TestProxyStoreLuksKey_MissingFields(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	_, err := h.ProxyStoreLuksKey(context.Background(), connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
 		DeviceId: "",
@@ -209,7 +209,7 @@ func TestProxyStoreLuksKey_MissingFields(t *testing.T) {
 
 func TestProxyValidateLuksToken_MissingFields(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	_, err := h.ProxyValidateLuksToken(context.Background(), connect.NewRequest(&pm.InternalValidateLuksTokenRequest{
 		DeviceId: "",
@@ -221,7 +221,7 @@ func TestProxyValidateLuksToken_MissingFields(t *testing.T) {
 
 func TestProxyGetLuksKey_NotFound(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	_, err := h.ProxyGetLuksKey(context.Background(), connect.NewRequest(&pm.InternalGetLuksKeyRequest{
 		DeviceId: testutil.NewID(),
@@ -234,7 +234,7 @@ func TestProxyGetLuksKey_NotFound(t *testing.T) {
 func TestProxyStoreLpsPasswords(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	enc := testutil.NewEncryptor(t)
-	h := api.NewInternalHandler(st, enc, slog.Default())
+	h := api.NewInternalHandler(st, enc, slog.Default(), api.NoOpSigner{})
 
 	deviceID := testutil.CreateTestDevice(t, st, "lps-host")
 
@@ -256,7 +256,7 @@ func TestProxyStoreLpsPasswords(t *testing.T) {
 
 func TestProxyStoreLpsPasswords_MissingFields(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	_, err := h.ProxyStoreLpsPasswords(context.Background(), connect.NewRequest(&pm.InternalStoreLpsPasswordsRequest{
 		DeviceId: "",
@@ -273,7 +273,7 @@ func TestProxyStoreLpsPasswords_MissingFields(t *testing.T) {
 func newInternalHandlerWithTokenStore(t *testing.T) (*api.InternalHandler, *terminal.TokenStore) {
 	t.Helper()
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 	tokenStore := terminal.NewTokenStore(terminal.NewFakeBackend(nil))
 	h.SetTerminalTokenStore(tokenStore)
 	return h, tokenStore
@@ -434,7 +434,7 @@ func TestProxyValidateTerminalToken_StoreNotConfigured(t *testing.T) {
 	// which would hide the behavior we want to pin. Use a freshly
 	// minted ULID here.
 	st := testutil.SetupPostgres(t)
-	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default())
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
 	_, err := h.ProxyValidateTerminalToken(context.Background(), connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
 		SessionId: testutil.NewID(),

--- a/internal/api/noop_signer_test.go
+++ b/internal/api/noop_signer_test.go
@@ -23,12 +23,12 @@ package api
 // produce unsigned actions in the DB.
 type NoOpSigner struct{}
 
-// Sign returns a deterministic dummy signature. The bytes are
-// distinguishable from real signatures so an accidental escape into
-// production logs is greppable.
-func (NoOpSigner) Sign(actionID string, actionType int32, paramsJSON []byte) ([]byte, error) {
-	_ = actionID
-	_ = actionType
-	_ = paramsJSON
+// Sign returns a deterministic, fixed, non-empty dummy signature over
+// whatever envelope bytes it is handed. The bytes are distinguishable
+// from real signatures so an accidental escape into production logs is
+// greppable. The envelope is ignored — NoOpSigner exists only so test
+// fixtures can satisfy the non-nil signer contract without a real CA.
+func (NoOpSigner) Sign(envelopeBytes []byte) ([]byte, error) {
+	_ = envelopeBytes
 	return []byte("noop-test-signature"), nil
 }

--- a/internal/api/system_action_store.go
+++ b/internal/api/system_action_store.go
@@ -144,26 +144,27 @@ func (s *systemActionStore) LinkAction(ctx context.Context, userID, field, actio
 	})
 }
 
-// SignActionByID loads an action from the DB and signs it.
+// SignActionByID NO LONGER persists a dispatch-grade signature.
 //
-// Fail-closed: every outcome other than "signed and stored" returns
-// an error so the caller (syncUserProvisionAction, syncSshAccessAction,
-// syncTtyUserAction) surfaces it as a sync failure. A missing signer
-// is a wiring mistake, not a soft condition — letting an unsigned
-// system-managed action land in the DB means the agent silently
-// drops it on dispatch and the operator has no projection state to
-// debug from. Turning nil-signer into a hard error here forces main.go
-// to construct SystemActionManager with a real signer (or a
-// deterministic NoOpSigner in tests) instead of accidentally
-// producing silent no-ops.
+// Action-signing rewrite: a system action is signed at DISPATCH, over the
+// full SignedActionEnvelope bound to the execution id and target device —
+// not at sync time. Persisting a create/sign-time signature here was
+// misleading: it covered a different pre-image (the action id, not the
+// execution id) and could never verify against a dispatch envelope.
+//
+// What this method still does — and why it is NOT a pure no-op — is pin
+// the action's params blob into the params_canonical column so there is an
+// immutable record of exactly what JSON the system action carries. It keeps
+// its fail-closed contract on a missing/unloadable action so the callers
+// (syncUserProvisionAction, syncSshAccessAction, syncTtyUserAction) still
+// surface a sync failure rather than leaving a half-provisioned row.
+//
+// The signature column is written nil (the projection column stays; no
+// migration). No signer is required any more.
 func (s *systemActionStore) SignActionByID(ctx context.Context, actionID string) error {
-	if s.signer == nil {
-		return fmt.Errorf("sign system action %s: signer not configured", actionID)
-	}
-
 	action, err := s.store.Repos().Action.Get(ctx, actionID)
 	if err != nil {
-		return fmt.Errorf("load system action %s for signing: %w", actionID, err)
+		return fmt.Errorf("load system action %s for params pinning: %w", actionID, err)
 	}
 
 	paramsJSON := action.Params
@@ -171,13 +172,9 @@ func (s *systemActionStore) SignActionByID(ctx context.Context, actionID string)
 		paramsJSON = []byte("{}")
 	}
 
-	sig, err := s.signer.Sign(action.ID, action.ActionType, paramsJSON)
-	if err != nil {
-		return fmt.Errorf("sign system action %s: %w", actionID, err)
-	}
-
-	if err := s.store.Repos().Action.UpdateSignature(ctx, store.UpdateActionSignatureParams{ID: action.ID, Signature: sig, ParamsCanonical: paramsJSON}); err != nil {
-		return fmt.Errorf("store system action %s signature: %w", actionID, err)
+	// Signature intentionally nil: signing happens at dispatch, never here.
+	if err := s.store.Repos().Action.UpdateSignature(ctx, store.UpdateActionSignatureParams{ID: action.ID, Signature: nil, ParamsCanonical: paramsJSON}); err != nil {
+		return fmt.Errorf("store system action %s params blob: %w", actionID, err)
 	}
 
 	return nil

--- a/internal/api/system_action_store_test.go
+++ b/internal/api/system_action_store_test.go
@@ -169,22 +169,26 @@ func TestSystemActionStore_LinkAction_EmitsUserSystemActionLinked(t *testing.T) 
 }
 
 // =============================================================================
-// SignActionByID — fail-closed on nil signer
+// SignActionByID — pins the params blob, never a dispatch-grade signature
 // =============================================================================
+//
+// Contract after the action-signing rewrite: SignActionByID no longer
+// persists a dispatch-grade signature (signing happens at dispatch over the
+// full SignedActionEnvelope). It still pins the action's params blob into the
+// params_canonical column and stays fail-closed on a missing/unloadable
+// action, so a sync caller surfaces a failure rather than half-provisioning.
 
-func TestSystemActionStore_SignActionByID_NilSignerHardFails(t *testing.T) {
-	// nil signer is a wiring bug; the store must reject the call
-	// rather than silently land an unsigned action that the agent
-	// would drop on dispatch (audit F033's #137 reference).
+func TestSystemActionStore_SignActionByID_FailsOnMissingAction(t *testing.T) {
+	// A nonexistent action must error so the caller (syncUserProvisionAction
+	// et al.) surfaces it as a sync failure rather than silently succeeding.
 	st := testutil.SetupPostgres(t)
-	s := newSystemActionStore(st, nil)
+	s := newSystemActionStore(st, NoOpSigner{})
 
 	err := s.SignActionByID(context.Background(), "nonexistent-action")
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "signer not configured")
 }
 
-func TestSystemActionStore_SignActionByID_HappyPath(t *testing.T) {
+func TestSystemActionStore_SignActionByID_PinsParamsBlobNotSignature(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	s := newSystemActionStore(st, NoOpSigner{})
 
@@ -193,9 +197,13 @@ func TestSystemActionStore_SignActionByID_HappyPath(t *testing.T) {
 
 	require.NoError(t, s.SignActionByID(context.Background(), id))
 
-	// Projection must now have a non-empty signature column.
 	row, err := st.Queries().GetActionByID(context.Background(), id)
 	require.NoError(t, err)
-	assert.NotEmpty(t, row.Signature, "SignActionByID must persist the signature on the action row")
-	assert.NotEmpty(t, row.ParamsCanonical, "ParamsCanonical must be set so the agent can verify")
+	// The params blob is pinned so audit/dispatch has an immutable record.
+	assert.NotEmpty(t, row.ParamsCanonical, "params blob must be pinned into params_canonical")
+	assert.JSONEq(t, `{"x":1}`, string(row.ParamsCanonical))
+	// No dispatch-grade signature is persisted at sign-time any more —
+	// signing happens at dispatch over the full envelope.
+	assert.Empty(t, row.Signature,
+		"SignActionByID must NOT persist a dispatch-grade signature; signing happens at dispatch")
 }

--- a/internal/api/system_actions_manager_test.go
+++ b/internal/api/system_actions_manager_test.go
@@ -117,7 +117,12 @@ func TestSyncUserSystemActions_GlobalProvisioning_CreatesUserAction(t *testing.T
 	action, err := st.Queries().GetActionByID(context.Background(), user.SystemUserActionID)
 	require.NoError(t, err)
 	assert.Equal(t, "system:user-provision:"+userID, action.Name)
-	assert.NotEmpty(t, action.Signature, "system actions MUST be signed at create time")
+	// Action-signing rewrite: signing happens at DISPATCH over the full
+	// SignedActionEnvelope, not at create/sign time. The sync path pins the
+	// params blob (so dispatch/audit has an immutable record) but persists
+	// NO dispatch-grade signature on the row.
+	assert.NotEmpty(t, action.ParamsCanonical, "system actions MUST pin their params blob at create time")
+	assert.Empty(t, action.Signature, "no dispatch-grade signature is persisted at create time — signing happens at dispatch")
 }
 
 // =============================================================================

--- a/internal/api/system_actions_ssh_tty_test.go
+++ b/internal/api/system_actions_ssh_tty_test.go
@@ -52,7 +52,10 @@ func TestSyncUserSystemActions_SshAccessEnabled_CreatesSshAction(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "system:ssh-access:"+userID, action.Name,
 		"system SSH action name pattern is 'system:ssh-access:<userID>' — the listener + audit redactor key on this prefix")
-	assert.NotEmpty(t, action.Signature, "system SSH actions MUST be signed at create time")
+	// Action-signing rewrite: signed at DISPATCH, not at create time — pin
+	// the params blob, persist no dispatch-grade signature.
+	assert.NotEmpty(t, action.ParamsCanonical, "system SSH actions MUST pin their params blob at create time")
+	assert.Empty(t, action.Signature, "no dispatch-grade signature is persisted at create time — signing happens at dispatch")
 }
 
 func TestSyncUserSystemActions_SshAccessDisabled_CleansUpPriorSshAction(t *testing.T) {
@@ -109,7 +112,10 @@ func TestSyncUserSystemActions_StartTerminalPerm_CreatesTtyAction(t *testing.T) 
 	require.NoError(t, err)
 	assert.Equal(t, "system:tty-user:"+userID, action.Name,
 		"TTY action name is 'system:tty-user:<userID>' — the resolution engine keys on this prefix")
-	assert.NotEmpty(t, action.Signature, "system TTY actions MUST be signed at create time")
+	// Action-signing rewrite: signed at DISPATCH, not at create time — pin
+	// the params blob, persist no dispatch-grade signature.
+	assert.NotEmpty(t, action.ParamsCanonical, "system TTY actions MUST pin their params blob at create time")
+	assert.Empty(t, action.Signature, "no dispatch-grade signature is persisted at create time — signing happens at dispatch")
 }
 
 func TestSyncUserSystemActions_NoStartTerminalPerm_CleansUpPriorTtyAction(t *testing.T) {

--- a/internal/api/system_actions_terminal_admin_test.go
+++ b/internal/api/system_actions_terminal_admin_test.go
@@ -45,12 +45,17 @@ func TestBootstrapGlobalTerminalAdminActions_CreatesBothActions(t *testing.T) {
 	limited, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminLimitedActionName)
 	require.NoError(t, err, "Limited global action must be created at bootstrap")
 	assert.True(t, limited.IsSystem, "global TerminalAdmin actions MUST set is_system=true")
-	assert.NotEmpty(t, limited.Signature, "global TerminalAdmin actions MUST be signed at create time — agents reject unsigned actions on dispatch")
+	// Action-signing rewrite: signing happens at DISPATCH over the full
+	// SignedActionEnvelope, not at create time. The bootstrap pins the params
+	// blob (so dispatch/audit has it) but persists no dispatch-grade signature.
+	assert.NotEmpty(t, limited.ParamsCanonical, "global TerminalAdmin actions MUST pin their params blob at create time")
+	assert.Empty(t, limited.Signature, "no dispatch-grade signature is persisted at create time — signing happens at dispatch")
 
 	full, err := st.Queries().GetActionByName(context.Background(), globalTerminalAdminFullActionName)
 	require.NoError(t, err, "Full global action must be created at bootstrap")
 	assert.True(t, full.IsSystem)
-	assert.NotEmpty(t, full.Signature)
+	assert.NotEmpty(t, full.ParamsCanonical)
+	assert.Empty(t, full.Signature)
 
 	assert.NotEqual(t, limited.ID, full.ID, "Limited and Full actions must have distinct IDs")
 }

--- a/internal/ca/signer.go
+++ b/internal/ca/signer.go
@@ -16,8 +16,15 @@ import "github.com/manchtools/power-manage/sdk/go/verify"
 // Previously declared independently in internal/api/action_handler.go
 // and internal/control/inbox_worker.go; consolidated here so the two
 // can't drift.
+//
+// Sign takes the DETERMINISTIC wire bytes of a pm.SignedActionEnvelope
+// (built via verify.MarshalEnvelope) and returns the CA signature over
+// those exact bytes. The caller MUST transport the SAME bytes it signed
+// (ActionDispatch.envelope) so the agent verifies and unmarshals one
+// representation — there is no separate (id, type, paramsJSON) tuple
+// any more. See the verify package docs for the full-envelope binding.
 type ActionSigner interface {
-	Sign(actionID string, actionType int32, paramsJSON []byte) ([]byte, error)
+	Sign(envelopeBytes []byte) ([]byte, error)
 }
 
 // NewActionSigner creates a new action signer using the CA's private key.

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/dyngroupeval"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -715,92 +716,97 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 
 	logger.Debug("found pending executions", "count", len(executions))
 
-	// Cache action lookups — multiple executions may reference the same
-	// action (e.g., system actions assigned to many devices).
-	actionCache := make(map[string][]byte) // actionID → paramsCanonical
-
 	var enqueueErrs []error
 	for _, exec := range executions {
-		// Parse params from []byte to avoid base64 encoding
-		var params json.RawMessage
-		if len(exec.Params) > 0 {
-			params = exec.Params
+		// Every dispatch — whether it references a stored action or is an
+		// inline/compliance execution with no action row — now ships a
+		// fully signed SignedActionEnvelope. The gateway forwards those
+		// bytes verbatim and the agent verifies+executes them, so an empty
+		// envelope/signature is never acceptable. A nil signer is therefore
+		// fatal to dispatch regardless of ActionID.
+		if w.signer == nil {
+			logger.Error("cannot dispatch execution without signer",
+				"execution_id", exec.ID)
+			continue
 		}
 
-		// Re-sign the action with the execution ID. The gateway sets
-		// Action.Id = executionID, so the agent verifies the signature
-		// against the execution ID — not the original action ID the
-		// action was signed with. This mirrors the API dispatch handler.
-		//
-		// Signing failures are permanent (missing signer, deleted action,
-		// broken key) — skip silently rather than returning an error that
-		// would cause Asynq to retry the entire hello handler.
-		var signature, paramsCanonical []byte
+		// When the execution references a stored action, detect the
+		// action-deleted-before-reconnect race and fail the orphan so it
+		// leaves the pending state. The action row is NOT a params source
+		// any more — the envelope params come from the execution's own
+		// stored params (exec.Params), which are authoritative for THIS
+		// execution. (Create-time no longer persists a dispatch-grade
+		// signature/canonical blob; the dispatcher rebuilds the envelope
+		// here.)
 		if exec.ActionID != nil {
-			if w.signer == nil {
-				logger.Error("cannot dispatch execution without signer",
-					"execution_id", exec.ID, "action_id", *exec.ActionID)
-				continue
-			}
-			cached, ok := actionCache[*exec.ActionID]
-			if !ok {
-				action, err := w.store.Repos().Action.Get(ctx, *exec.ActionID)
-				if err != nil {
-					if store.IsNotFound(err) {
-						// Action was deleted after the execution was created.
-						// Mark the execution failed so it leaves the "pending"
-						// state — otherwise every reconnect retries dispatch
-						// and re-logs the same error forever.
-						logger.Warn("action for pending execution no longer exists; failing execution",
-							"execution_id", exec.ID, "action_id", *exec.ActionID)
-						if appendErr := w.store.AppendEvent(ctx, store.Event{
-							StreamType: "execution",
-							StreamID:   exec.ID,
-							EventType:  string(eventtypes.ExecutionFailed),
-							Data: payloads.ExecutionFailedReason{
-								Error:       "action was deleted before the device came online",
-								DurationMs:  0,
-								CompletedAt: w.now().UTC().Format(time.RFC3339Nano),
-							},
-							ActorType: "system",
-							ActorID:   "dispatcher",
-						}); appendErr != nil {
-							logger.Error("failed to mark orphaned execution as failed",
-								"execution_id", exec.ID, "error", appendErr)
-						}
-						continue
+			if _, err := w.store.Repos().Action.Get(ctx, *exec.ActionID); err != nil {
+				if store.IsNotFound(err) {
+					// Action was deleted after the execution was created.
+					// Mark the execution failed so it leaves the "pending"
+					// state — otherwise every reconnect retries dispatch
+					// and re-logs the same error forever.
+					logger.Warn("action for pending execution no longer exists; failing execution",
+						"execution_id", exec.ID, "action_id", *exec.ActionID)
+					if appendErr := w.store.AppendEvent(ctx, store.Event{
+						StreamType: "execution",
+						StreamID:   exec.ID,
+						EventType:  string(eventtypes.ExecutionFailed),
+						Data: payloads.ExecutionFailedReason{
+							Error:       "action was deleted before the device came online",
+							DurationMs:  0,
+							CompletedAt: w.now().UTC().Format(time.RFC3339Nano),
+						},
+						ActorType: "system",
+						ActorID:   "dispatcher",
+					}); appendErr != nil {
+						logger.Error("failed to mark orphaned execution as failed",
+							"execution_id", exec.ID, "error", appendErr)
 					}
-					logger.Error("failed to look up action for re-signing, skipping dispatch",
-						"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
 					continue
 				}
-				cached = action.ParamsCanonical
-				actionCache[*exec.ActionID] = cached
-			}
-			paramsCanonical = cached
-			if paramsCanonical == nil {
-				paramsCanonical = exec.Params
-			}
-			sig, err := w.signer.Sign(exec.ID, exec.ActionType, paramsCanonical)
-			if err != nil {
-				logger.Error("failed to re-sign action for dispatch, skipping",
+				logger.Error("failed to look up action for dispatch, skipping",
 					"execution_id", exec.ID, "action_id", *exec.ActionID, "error", err)
 				continue
 			}
-			signature = sig
+		}
+
+		// Build and sign the full envelope, binding it to the execution id
+		// and target device. The gateway sets nothing — the agent verifies
+		// the signature over these exact bytes and unmarshals them, so the
+		// envelope's ActionId == execution id is the identity the agent
+		// trusts. Reconnect re-dispatch signs the SAME executed semantics
+		// (desired_state / timeout / params / device) the API originally
+		// committed, so a compromised relay can't rewrite them.
+		//
+		// Reconnect re-dispatch carries no schedule (nil): a pending one-shot
+		// dispatch is not an autonomous scheduled action.
+		paramsJSON := exec.Params
+		if len(paramsJSON) == 0 {
+			paramsJSON = []byte("{}")
+		}
+		envelopeBytes, signature, err := actionparams.BuildAndSignEnvelope(
+			w.signer,
+			exec.ID,
+			exec.ActionType,
+			paramsJSON,
+			exec.DesiredState,
+			exec.TimeoutSeconds,
+			nil, // reconnect re-dispatch is one-shot, no schedule
+			deviceID,
+		)
+		if err != nil {
+			logger.Error("failed to build/sign action envelope for dispatch, skipping",
+				"execution_id", exec.ID, "error", err)
+			continue
 		}
 
 		// Enqueue to device queue first — only record the event after the
 		// task is durably queued so we never mark "dispatched" without delivery.
 		// Use a stable TaskID so retries don't create duplicate tasks.
 		if err := w.aqClient.EnqueueToDevice(deviceID, taskqueue.TypeActionDispatch, taskqueue.ActionDispatchPayload{
-			ExecutionID:     exec.ID,
-			ActionType:      exec.ActionType,
-			DesiredState:    exec.DesiredState,
-			Params:          params,
-			TimeoutSeconds:  exec.TimeoutSeconds,
-			Signature:       signature,
-			ParamsCanonical: paramsCanonical,
+			ExecutionID:   exec.ID,
+			EnvelopeBytes: envelopeBytes,
+			Signature:     signature,
 		}, asynq.MaxRetry(3), asynq.TaskID("dispatch:"+exec.ID)); err != nil {
 			if errors.Is(err, asynq.ErrTaskIDConflict) {
 				// Task already in queue — still need to record the dispatch event

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -2,9 +2,15 @@ package control_test
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"log/slog"
-	"sync"
+	"math/big"
 	"testing"
 	"time"
 
@@ -13,9 +19,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/verify"
+	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/control"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -23,34 +32,37 @@ import (
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
-// fakeSigner records Sign calls so tests can verify the signer
-// was invoked with the correct arguments (execution ID, not action ID).
-type fakeSigner struct {
-	mu    sync.Mutex
-	calls []fakeSignCall
-}
+// newTestCASignerVerifier mints a fresh self-signed CA and returns a real
+// ca.ActionSigner over its private key plus a verify.ActionVerifier over the
+// matching certificate's public key. Using the REAL signer + verifier (not a
+// fake) is the point of the re-dispatch charter test: we prove the enqueued
+// envelope verifies under the agent-side verifier and that mutating any bound
+// field breaks verification.
+func newTestCASignerVerifier(t *testing.T) (ca.ActionSigner, *verify.ActionVerifier) {
+	t.Helper()
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &caKey.PublicKey, caKey)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	keyDER, err := x509.MarshalECPrivateKey(caKey)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
 
-type fakeSignCall struct {
-	ActionID   string
-	ActionType int32
-	ParamsJSON []byte
-}
-
-func (s *fakeSigner) Sign(actionID string, actionType int32, paramsJSON []byte) ([]byte, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.calls = append(s.calls, fakeSignCall{
-		ActionID:   actionID,
-		ActionType: actionType,
-		ParamsJSON: append([]byte(nil), paramsJSON...),
-	})
-	return []byte("fake-sig-for-" + actionID), nil
-}
-
-func (s *fakeSigner) getCalls() []fakeSignCall {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return append([]fakeSignCall(nil), s.calls...)
+	c, err := ca.NewFromPEM(certPEM, keyPEM, 24*time.Hour)
+	require.NoError(t, err)
+	verifier, err := verify.NewActionVerifier(certPEM)
+	require.NoError(t, err)
+	return ca.NewActionSigner(c), verifier
 }
 
 func newTask(t *testing.T, typeName string, payload any) *asynq.Task {
@@ -505,37 +517,45 @@ func TestHandleDeviceHello_DeletedDevice(t *testing.T) {
 	require.NoError(t, err)
 }
 
-// TestDispatchPendingActions_ReSignsWithExecutionID verifies that when
-// dispatchPendingActions dispatches a pending execution, it re-signs
-// the action payload with the execution ID (not the original action ID).
-// This is critical because the gateway sets Action.Id = executionID,
-// so the agent verifies the signature against the execution ID.
-func TestDispatchPendingActions_ReSignsWithExecutionID(t *testing.T) {
+// TestDispatchPendingActions_ResignsFullEnvelope pins the reconnect
+// re-dispatch path (signing site #3). On device hello, dispatchPendingActions
+// builds and signs the FULL SignedActionEnvelope for each pending execution
+// and enqueues {EnvelopeBytes, Signature}. The contract restated:
+//
+//   - the enqueued EnvelopeBytes verify under the agent-side verifier built
+//     from the same CA cert (real signer, real verifier — no fake);
+//   - the envelope is bound to the EXECUTION id (not the action id), the
+//     target device, and the committed execution semantics
+//     (desired_state / timeout / params);
+//   - mutating ANY bound field of the unmarshalled envelope and re-marshalling
+//     breaks verification — proving the binding is real, not decorative.
+func TestDispatchPendingActions_ResignsFullEnvelope(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	mr := miniredis.RunT(t)
 	aqClient := taskqueue.NewClient(mr.Addr(), "", 0)
 	defer aqClient.Close()
 
-	signer := &fakeSigner{}
+	signer, verifier := newTestCASignerVerifier(t)
 	worker := control.NewInboxWorker(st, aqClient, signer, nil, slog.Default())
 	mux := worker.NewMux()
 
 	ctx := context.Background()
 
-	// Setup: create user, device, action, and a pending execution
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "resign-host")
 	actionID := testutil.CreateTestAction(t, st, adminID, "Resign Test", int(pm.ActionType_ACTION_TYPE_USER))
 
-	// Sign the action with the action ID (as the real system does)
+	// The action row carries only the params blob now (no dispatch-grade
+	// signature persisted at create/sign time).
 	err := st.Queries().UpdateActionSignature(ctx, db.UpdateActionSignatureParams{
 		ID:              actionID,
-		Signature:       []byte("original-sig-for-action"),
+		Signature:       nil,
 		ParamsCanonical: []byte(`{"username":"test"}`),
 	})
 	require.NoError(t, err)
 
-	// Create a pending execution for this device+action
+	// A pending execution with explicit ABSENT desired state and a non-default
+	// timeout, so the binding test below mutates a value that actually differs.
 	executionID := testutil.NewID()
 	err = st.AppendEvent(ctx, store.Event{
 		StreamType: "execution",
@@ -545,9 +565,9 @@ func TestDispatchPendingActions_ReSignsWithExecutionID(t *testing.T) {
 			"device_id":       deviceID,
 			"action_id":       actionID,
 			"action_type":     int(pm.ActionType_ACTION_TYPE_USER),
-			"desired_state":   0,
+			"desired_state":   int(pm.DesiredState_DESIRED_STATE_ABSENT),
 			"params":          map[string]any{"username": "test"},
-			"timeout_seconds": 300,
+			"timeout_seconds": 321,
 			"executed_at":     time.Now().Format(time.RFC3339Nano),
 		},
 		ActorType: "user",
@@ -555,29 +575,70 @@ func TestDispatchPendingActions_ReSignsWithExecutionID(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Verify execution is pending
 	exec, err := st.Queries().GetExecutionByID(ctx, executionID)
 	require.NoError(t, err)
 	assert.Equal(t, "pending", exec.Status)
 
-	// Trigger device hello — this calls dispatchPendingActions internally
+	// Trigger device hello — calls dispatchPendingActions internally.
 	task := newTask(t, taskqueue.TypeDeviceHello, taskqueue.DeviceHelloPayload{
 		DeviceID:     deviceID,
 		Hostname:     "resign-host",
 		AgentVersion: "1.0.0",
 	})
-	err = mux.ProcessTask(ctx, task)
-	require.NoError(t, err)
+	require.NoError(t, mux.ProcessTask(ctx, task))
 
-	// Verify the signer was called with the EXECUTION ID, not the action ID,
-	// and with the correct canonical params and action type.
-	calls := signer.getCalls()
-	require.Len(t, calls, 1, "signer should be called exactly once for the pending execution")
-	assert.Equal(t, executionID, calls[0].ActionID,
-		"signer must be called with the execution ID (not action ID %s)", actionID)
-	assert.Equal(t, int32(pm.ActionType_ACTION_TYPE_USER), calls[0].ActionType)
-	assert.JSONEq(t, `{"username":"test"}`, string(calls[0].ParamsJSON),
-		"signer must receive the canonical params from the action")
+	// Read the enqueued task back out of the device queue (no HMAC wrap: the
+	// worker was constructed with a nil taskSigner).
+	payload := readEnqueuedDispatch(t, mr.Addr(), deviceID)
+	require.Equal(t, executionID, payload.ExecutionID)
+	require.NotEmpty(t, payload.EnvelopeBytes)
+	require.NotEmpty(t, payload.Signature)
+
+	// The transported envelope verifies under the agent-side verifier.
+	require.NoError(t, verifier.Verify(payload.EnvelopeBytes, payload.Signature),
+		"the enqueued envelope must verify under the matching CA verifier")
+
+	// And it is bound to the execution id + device + committed semantics.
+	var env pm.SignedActionEnvelope
+	require.NoError(t, proto.Unmarshal(payload.EnvelopeBytes, &env))
+	assert.Equal(t, executionID, env.GetActionId().GetValue(),
+		"envelope must bind the EXECUTION id, not the action id %s", actionID)
+	assert.Equal(t, deviceID, env.GetTargetDeviceId())
+	assert.Equal(t, pm.ActionType_ACTION_TYPE_USER, env.GetActionType())
+	assert.Equal(t, pm.DesiredState_DESIRED_STATE_ABSENT, env.GetDesiredState())
+	assert.Equal(t, int32(321), env.GetTimeoutSeconds())
+	require.NotNil(t, env.GetUser())
+	assert.Equal(t, "test", env.GetUser().Username)
+
+	// Binding proof: flip desired_state ABSENT -> PRESENT, re-marshal, and the
+	// original signature must NOT verify the tampered bytes. A compromised
+	// relay cannot rewrite the executed state under a still-valid signature.
+	env.DesiredState = pm.DesiredState_DESIRED_STATE_PRESENT
+	tampered, err := verify.MarshalEnvelope(&env)
+	require.NoError(t, err)
+	require.Error(t, verifier.Verify(tampered, payload.Signature),
+		"mutating desired_state must break verification (full-envelope binding)")
+}
+
+// readEnqueuedDispatch pulls the single pending ActionDispatch task off a
+// device's asynq queue and decodes its payload. Fails the test if there isn't
+// exactly one.
+func readEnqueuedDispatch(t *testing.T, addr, deviceID string) taskqueue.ActionDispatchPayload {
+	t.Helper()
+	insp := asynq.NewInspector(asynq.RedisClientOpt{Addr: addr})
+	defer insp.Close()
+	tasks, err := insp.ListPendingTasks(taskqueue.DeviceQueue(deviceID))
+	require.NoError(t, err)
+	var dispatches []*asynq.TaskInfo
+	for _, ti := range tasks {
+		if ti.Type == taskqueue.TypeActionDispatch {
+			dispatches = append(dispatches, ti)
+		}
+	}
+	require.Len(t, dispatches, 1, "expected exactly one ActionDispatch task enqueued")
+	var payload taskqueue.ActionDispatchPayload
+	require.NoError(t, json.Unmarshal(dispatches[0].Payload, &payload))
+	return payload
 }
 
 // createPendingExecutionAt emits an ExecutionCreated event whose created_at is

--- a/internal/gateway/task_handlers.go
+++ b/internal/gateway/task_handlers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/oklog/ulid/v2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
-	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/connection"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
@@ -77,26 +76,24 @@ func (h *deviceTaskHandler) handleActionDispatch(_ context.Context, t *asynq.Tas
 
 	h.logger.Info("dispatching action to agent",
 		"execution_id", payload.ExecutionID,
-		"action_type", payload.ActionType,
 	)
 
-	// Build Action message
-	action := &pm.Action{
-		Id:              &pm.ActionId{Value: payload.ExecutionID},
-		Type:            pm.ActionType(payload.ActionType),
-		DesiredState:    pm.DesiredState(payload.DesiredState),
-		TimeoutSeconds:  payload.TimeoutSeconds,
-		Signature:       payload.Signature,
-		ParamsCanonical: payload.ParamsCanonical,
+	// Clean break (action-signing rewrite): the control server already
+	// built and signed the full SignedActionEnvelope. The gateway no
+	// longer reconstructs a typed Action or re-serialises params — that
+	// re-marshal was the exact gap a compromised gateway could exploit to
+	// rewrite the executed action under a still-valid signature. Forward
+	// the signed bytes + signature verbatim; the agent verifies the
+	// signature over THESE bytes and unmarshals THESE bytes to execute.
+	//
+	// Fail closed if the producer somehow enqueued an empty envelope or
+	// signature (a wiring bug) rather than sending the agent a message it
+	// would reject anyway.
+	if len(payload.EnvelopeBytes) == 0 {
+		return fmt.Errorf("action dispatch %s: empty envelope bytes", payload.ExecutionID)
 	}
-
-	// Parse params. Fail closed on a parse error or an unhandled action type:
-	// return the error so Asynq retries / dead-letters instead of dispatching an
-	// action to the agent with empty/nil params (#368).
-	if len(payload.Params) > 0 && string(payload.Params) != "null" && string(payload.Params) != "{}" {
-		if err := actionparams.PopulateAction(action, payload.ActionType, payload.Params); err != nil {
-			return fmt.Errorf("populate action params (type %d): %w", payload.ActionType, err)
-		}
+	if len(payload.Signature) == 0 {
+		return fmt.Errorf("action dispatch %s: empty signature", payload.ExecutionID)
 	}
 
 	// Wrap in ServerMessage
@@ -104,7 +101,8 @@ func (h *deviceTaskHandler) handleActionDispatch(_ context.Context, t *asynq.Tas
 		Id: ulid.Make().String(),
 		Payload: &pm.ServerMessage_Action{
 			Action: &pm.ActionDispatch{
-				Action: action,
+				Envelope:  payload.EnvelopeBytes,
+				Signature: payload.Signature,
 			},
 		},
 	}
@@ -115,7 +113,6 @@ func (h *deviceTaskHandler) handleActionDispatch(_ context.Context, t *asynq.Tas
 
 	h.logger.Info("action dispatched successfully",
 		"execution_id", payload.ExecutionID,
-		"action_type", pm.ActionType(payload.ActionType).String(),
 	)
 	return nil
 }

--- a/internal/gateway/task_handlers_test.go
+++ b/internal/gateway/task_handlers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/go/verify"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 )
@@ -165,15 +166,15 @@ func TestParseActionParams_Rpm(t *testing.T) {
 }
 
 // TestActionDispatchPayloadRoundtrip verifies that the payload JSON
-// correctly round-trips through marshal/unmarshal.
+// correctly round-trips through marshal/unmarshal. Post-rewrite the payload
+// carries only the signed envelope bytes + signature (and the correlation
+// ExecutionID) — type/desired_state/timeout/params all live INSIDE the
+// signed envelope bytes, so they are not separate payload fields.
 func TestActionDispatchPayloadRoundtrip(t *testing.T) {
 	original := taskqueue.ActionDispatchPayload{
-		ExecutionID:    "exec-123",
-		ActionType:     int32(pm.ActionType_ACTION_TYPE_SHELL),
-		DesiredState:   int32(pm.DesiredState_DESIRED_STATE_PRESENT),
-		Params:         json.RawMessage(`{"script":"echo hi"}`),
-		TimeoutSeconds: 300,
-		Signature:      []byte("sig"),
+		ExecutionID:   "exec-123",
+		EnvelopeBytes: []byte{0x0a, 0x05, 'h', 'e', 'l', 'l', 'o'},
+		Signature:     []byte("sig"),
 	}
 
 	data, err := json.Marshal(original)
@@ -184,9 +185,8 @@ func TestActionDispatchPayloadRoundtrip(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, original.ExecutionID, decoded.ExecutionID)
-	assert.Equal(t, original.ActionType, decoded.ActionType)
-	assert.Equal(t, original.TimeoutSeconds, decoded.TimeoutSeconds)
-	assert.JSONEq(t, `{"script":"echo hi"}`, string(decoded.Params))
+	assert.Equal(t, original.EnvelopeBytes, decoded.EnvelopeBytes)
+	assert.Equal(t, original.Signature, decoded.Signature)
 }
 
 // TestOSQueryDispatchPayloadRoundtrip verifies osquery payload round-trips.
@@ -251,15 +251,32 @@ func (r *recordingMessageSender) Send(deviceID string, msg *pm.ServerMessage) er
 	return nil
 }
 
-func TestDeviceTaskHandler_BuildsActionMessage(t *testing.T) {
+// TestDeviceTaskHandler_ForwardsEnvelopeVerbatim pins the post-rewrite gateway
+// contract: the gateway no longer reconstructs a typed Action or re-serialises
+// params. It forwards the signed envelope bytes + signature into
+// ActionDispatch.{envelope,signature} BYTE-FOR-BYTE. That verbatim forwarding
+// is the whole point — the agent verifies the signature over THESE bytes and
+// unmarshals THESE bytes, so a gateway re-marshal could never diverge from
+// what was signed.
+func TestDeviceTaskHandler_ForwardsEnvelopeVerbatim(t *testing.T) {
+	// A representative signed envelope's bytes (the gateway treats them as
+	// opaque — it does not unmarshal them — so deterministic-marshalling a
+	// real envelope here is sufficient).
+	env := &pm.SignedActionEnvelope{
+		ActionId:       &pm.ActionId{Value: "exec-001"},
+		ActionType:     pm.ActionType_ACTION_TYPE_PACKAGE,
+		DesiredState:   pm.DesiredState_DESIRED_STATE_PRESENT,
+		TimeoutSeconds: 600,
+		TargetDeviceId: "device-1",
+		Params:         &pm.SignedActionEnvelope_Package{Package: &pm.PackageParams{Name: "htop"}},
+	}
+	envBytes, err := verify.MarshalEnvelope(env)
+	require.NoError(t, err)
+
 	payload := taskqueue.ActionDispatchPayload{
-		ExecutionID:     "exec-001",
-		ActionType:      int32(pm.ActionType_ACTION_TYPE_PACKAGE),
-		DesiredState:    int32(pm.DesiredState_DESIRED_STATE_PRESENT),
-		Params:          json.RawMessage(`{"name":"htop"}`),
-		TimeoutSeconds:  600,
-		Signature:       []byte("sig"),
-		ParamsCanonical: []byte(`{"name":"htop"}`),
+		ExecutionID:   "exec-001",
+		EnvelopeBytes: envBytes,
+		Signature:     []byte("ca-sig-bytes"),
 	}
 	data, err := json.Marshal(payload)
 	require.NoError(t, err)
@@ -276,14 +293,138 @@ func TestDeviceTaskHandler_BuildsActionMessage(t *testing.T) {
 
 	require.Len(t, sender.messages, 1)
 	assert.Equal(t, "device-1", sender.deviceID)
-	action := sender.messages[0].GetAction().GetAction()
-	require.NotNil(t, action)
-	assert.Equal(t, "exec-001", action.Id.Value)
-	assert.Equal(t, pm.ActionType_ACTION_TYPE_PACKAGE, action.Type)
-	assert.Equal(t, pm.DesiredState_DESIRED_STATE_PRESENT, action.DesiredState)
-	assert.Equal(t, int32(600), action.TimeoutSeconds)
-	assert.Equal(t, []byte("sig"), action.Signature)
-	assert.Equal(t, []byte(`{"name":"htop"}`), action.ParamsCanonical)
-	require.NotNil(t, action.GetPackage())
-	assert.Equal(t, "htop", action.GetPackage().Name)
+	dispatch := sender.messages[0].GetAction()
+	require.NotNil(t, dispatch)
+	assert.Equal(t, envBytes, dispatch.GetEnvelope(), "envelope bytes must be forwarded verbatim")
+	assert.Equal(t, []byte("ca-sig-bytes"), dispatch.GetSignature(), "signature must be forwarded verbatim")
+}
+
+// TestDeviceTaskHandler_RejectsEmptyEnvelope pins the fail-closed guard: a
+// dispatch task with no envelope (a producer wiring bug) must error rather
+// than hand the agent a message it would reject anyway.
+func TestDeviceTaskHandler_RejectsEmptyEnvelope(t *testing.T) {
+	payload := taskqueue.ActionDispatchPayload{
+		ExecutionID: "exec-002",
+		Signature:   []byte("sig"),
+		// EnvelopeBytes intentionally empty.
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	sender := &recordingMessageSender{}
+	h := &deviceTaskHandler{deviceID: "device-1", manager: sender, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	err = h.handleActionDispatch(context.Background(), asynq.NewTask(taskqueue.TypeActionDispatch, data))
+	require.Error(t, err)
+	assert.Empty(t, sender.messages, "nothing must be sent to the agent for an empty envelope")
+}
+
+// TestDeviceTaskHandler_RejectsEmptySignature pins the symmetric guard for a
+// missing signature.
+func TestDeviceTaskHandler_RejectsEmptySignature(t *testing.T) {
+	payload := taskqueue.ActionDispatchPayload{
+		ExecutionID:   "exec-003",
+		EnvelopeBytes: []byte{0x0a, 0x01, 'x'},
+		// Signature intentionally empty.
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	sender := &recordingMessageSender{}
+	h := &deviceTaskHandler{deviceID: "device-1", manager: sender, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+
+	err = h.handleActionDispatch(context.Background(), asynq.NewTask(taskqueue.TypeActionDispatch, data))
+	require.Error(t, err)
+	assert.Empty(t, sender.messages, "nothing must be sent to the agent for an empty signature")
+}
+
+// TestGatewayMux_RejectsUnsignedTask exercises the taskqueue HMAC envelope
+// layer (UNCHANGED by this rewrite) end-to-end through the real device mux:
+// only a correctly-wrapped task reaches handleActionDispatch; an unsigned, a
+// wrong-key, and a byte-tampered task are all rejected by VerifyMiddleware
+// BEFORE the handler runs. This is the second, independent signing layer (the
+// CA action signature is the other) — the test pins that the mux still gates
+// on it and that the gate fails closed.
+func TestGatewayMux_RejectsUnsignedTask(t *testing.T) {
+	const keyHex = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+	const wrongKeyHex = "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+
+	taskSigner, err := taskqueue.NewSigner(keyHex)
+	require.NoError(t, err)
+	require.NotNil(t, taskSigner)
+	wrongSigner, err := taskqueue.NewSigner(wrongKeyHex)
+	require.NoError(t, err)
+
+	// A valid signed envelope so a correctly-wrapped task reaches and passes
+	// the inner handler.
+	env := &pm.SignedActionEnvelope{
+		ActionId:       &pm.ActionId{Value: "exec-hmac"},
+		ActionType:     pm.ActionType_ACTION_TYPE_SHELL,
+		TargetDeviceId: "device-hmac",
+		Params:         &pm.SignedActionEnvelope_Shell{Shell: &pm.ShellParams{Script: "echo ok"}},
+	}
+	envBytes, err := verify.MarshalEnvelope(env)
+	require.NoError(t, err)
+	innerPayload, err := json.Marshal(taskqueue.ActionDispatchPayload{
+		ExecutionID:   "exec-hmac",
+		EnvelopeBytes: envBytes,
+		Signature:     []byte("ca-sig"),
+	})
+	require.NoError(t, err)
+
+	newMux := func(sender messageSender) *asynq.ServeMux {
+		f := NewTaskHandlerFactory(nil, taskSigner, slog.New(slog.NewTextHandler(io.Discard, nil)))
+		// NewMux wires the same VerifyMiddleware + handler registration as
+		// production; we only swap the message sender so we can observe
+		// whether the inner handler ran.
+		mux := asynq.NewServeMux()
+		mux.Use(taskSigner.VerifyMiddleware())
+		h := &deviceTaskHandler{deviceID: "device-hmac", manager: sender, logger: f.logger}
+		mux.HandleFunc(taskqueue.TypeActionDispatch, h.handleActionDispatch)
+		return mux
+	}
+
+	// queue context so VerifyMiddleware's queueOf has a name.
+	ctxWithQueue := func() context.Context {
+		return context.Background()
+	}
+
+	t.Run("correctly wrapped task reaches the handler", func(t *testing.T) {
+		sender := &recordingMessageSender{}
+		mux := newMux(sender)
+		wrapped := taskSigner.Wrap(innerPayload)
+		err := mux.ProcessTask(ctxWithQueue(), asynq.NewTask(taskqueue.TypeActionDispatch, wrapped))
+		require.NoError(t, err)
+		require.Len(t, sender.messages, 1, "a correctly HMAC-wrapped task must reach handleActionDispatch")
+	})
+
+	t.Run("unsigned task is rejected before the handler", func(t *testing.T) {
+		sender := &recordingMessageSender{}
+		mux := newMux(sender)
+		// Raw inner payload, NOT wrapped — too short / no HMAC prefix.
+		err := mux.ProcessTask(ctxWithQueue(), asynq.NewTask(taskqueue.TypeActionDispatch, innerPayload))
+		require.Error(t, err)
+		assert.Empty(t, sender.messages, "unsigned task must NOT reach the handler")
+	})
+
+	t.Run("wrong-key task is rejected before the handler", func(t *testing.T) {
+		sender := &recordingMessageSender{}
+		mux := newMux(sender)
+		wrapped := wrongSigner.Wrap(innerPayload) // HMAC under the wrong key
+		err := mux.ProcessTask(ctxWithQueue(), asynq.NewTask(taskqueue.TypeActionDispatch, wrapped))
+		require.Error(t, err)
+		assert.Empty(t, sender.messages, "wrong-key task must NOT reach the handler")
+	})
+
+	t.Run("byte-tampered task is rejected before the handler", func(t *testing.T) {
+		sender := &recordingMessageSender{}
+		mux := newMux(sender)
+		wrapped := taskSigner.Wrap(innerPayload)
+		// Flip a byte in the payload region (after the 32-byte HMAC prefix).
+		tampered := append([]byte(nil), wrapped...)
+		tampered[len(tampered)-1] ^= 0xff
+		err := mux.ProcessTask(ctxWithQueue(), asynq.NewTask(taskqueue.TypeActionDispatch, tampered))
+		require.Error(t, err)
+		assert.Empty(t, sender.messages, "byte-tampered task must NOT reach the handler")
+	})
 }

--- a/internal/resolution/resolve_test.go
+++ b/internal/resolution/resolve_test.go
@@ -557,10 +557,8 @@ func TestResolveActions_TTYPermissionSource_FailsFastOnTtyError(t *testing.T) {
 // package boundaries, so we re-declare the minimal stub here.
 type noOpSigner struct{}
 
-func (noOpSigner) Sign(actionID string, actionType int32, paramsJSON []byte) ([]byte, error) {
-	_ = actionID
-	_ = actionType
-	_ = paramsJSON
+func (noOpSigner) Sign(envelopeBytes []byte) ([]byte, error) {
+	_ = envelopeBytes
 	return []byte("noop-test-signature"), nil
 }
 

--- a/internal/taskqueue/payloads.go
+++ b/internal/taskqueue/payloads.go
@@ -1,18 +1,31 @@
 package taskqueue
 
-import "encoding/json"
-
 // === Control → Gateway payloads (device queues) ===
 
 // ActionDispatchPayload is the payload for TypeActionDispatch tasks.
+//
+// Clean break (action-signing rewrite): the payload now carries only the
+// signed SignedActionEnvelope bytes and the CA signature over them. The
+// action type, desired state, timeout, schedule, target device, and typed
+// params all live INSIDE the signed envelope, so the gateway no longer
+// reconstructs a typed Action or re-serialises params — it forwards
+// EnvelopeBytes + Signature verbatim and the agent verifies+unmarshals the
+// same bytes. This closes the gap where a compromised gateway/Valkey could
+// rewrite the executed action (desired_state, params, type, device) under a
+// signature that covered only (id, type, paramsJSON).
+//
+// ExecutionID is kept OUTSIDE the signed bytes purely for gateway logging /
+// task correlation; it is also bound inside the envelope as ActionId, which
+// is the authoritative copy the agent trusts.
 type ActionDispatchPayload struct {
-	ExecutionID     string          `json:"execution_id"`
-	ActionType      int32           `json:"action_type"`
-	DesiredState    int32           `json:"desired_state"`
-	Params          json.RawMessage `json:"params"`
-	TimeoutSeconds  int32           `json:"timeout_seconds"`
-	Signature       []byte          `json:"signature,omitempty"`
-	ParamsCanonical []byte          `json:"params_canonical,omitempty"`
+	ExecutionID string `json:"execution_id"`
+	// EnvelopeBytes is the deterministic wire encoding of the signed
+	// SignedActionEnvelope (verify.MarshalEnvelope). Transported verbatim
+	// to the agent as ActionDispatch.envelope — the exact bytes the
+	// signature covers.
+	EnvelopeBytes []byte `json:"envelope_bytes"`
+	// Signature is the CA signature over EnvelopeBytes.
+	Signature []byte `json:"signature"`
 }
 
 // OSQueryDispatchPayload is the payload for TypeOSQueryDispatch tasks.


### PR DESCRIPTION
## Summary
Server half of the action-signing rewrite (manchtools/power-manage-sdk#82, audit F-C2/SA-C1). Lock-step breaking change with the SDK; bumps the SDK `replace` to the merged envelope SDK.

Every dispatch site builds a `verify.SignedActionEnvelope` (id, type, params, desired_state, timeout, schedule, **target device**) via `actionparams.BuildAndSignEnvelope`, signs the **deterministic proto bytes**, and transports those exact bytes; the gateway forwards `ActionDispatch{envelope, signature}` verbatim. The offline-sync **pull** path (`SyncActions`) signs each delivered action **device-bound**. Create-time signing is dropped — actions are signed at delivery with the target device.

A compromised gateway/Valkey relay can no longer flip desired_state, swap params, change the timeout/schedule, lift the type onto SYNC, or retarget a device under a valid signature.

## Notable
- `ActionDispatchPayload` now carries `{ExecutionID, EnvelopeBytes, Signature}` — params/desired_state/timeout/schedule all live inside the signed envelope.
- The `UNINSTALL→ABSENT` override is folded into the **signed** desired_state (it was previously only on the advisory wire field — the agent executes the verified envelope, so that was a latent re-install bug).
- The two signing layers stay separate: CA action signature vs taskqueue HMAC.

## Tests
Real-CA-signer charters: `TestDispatchAction_SignsExecutedEnvelope` / `BindsTargetDevice`, `TestDispatchInstantAction_SignsEnvelope`, `TestDispatchPendingActions_ResignsFullEnvelope`, `TestSyncActions_SignsDeviceBoundEnvelope` / `BindsTargetDevice` / `UninstallFoldsIntoSignedEnvelope` / `SignsGroupedMembers`, gateway forward + HMAC-gate tests. Each verifies the enqueued/delivered envelope and rejects a mutated field.

Advances #324 (ADR `docs/adr/0003-action-signing-full-envelope.md`). Do not merge before the SDK PR.