### PR TITLE
feat: bind gateway↔control device-origin requests + events to the device→gateway registry (SA-C2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ All state changes are recorded as immutable events in a single `events` table. P
 
 Inter-service communication uses **Asynq** (Valkey-backed task queue) — when the Control Server dispatches an action, it enqueues an Asynq task to the device's queue (`device:<id>`). The Gateway runs per-device Asynq workers that pick up tasks and stream them to connected agents. Agent responses flow back via the `control:inbox` queue. Credential-bearing operations (LUKS keys, LPS passwords) are proxied via Connect-RPC (`InternalService`) to avoid plaintext secrets in the queue.
 
+**Device-origin binding** (ADR 0005): the gateway peer cert is shared and carries no per-gateway identity, so every device-origin request (`InternalService`) and event (`control:inbox`) self-asserts a `gateway_id` that control cross-checks against the device→gateway routing registry the agent's own mTLS heartbeat populated (`registry.CheckDeviceGatewayBinding`, fail-closed). A compromised gateway therefore cannot pull another device's secrets or forge its events; the `events` audit trail is DB-enforced append-only (migration 011). The binding is bypassed only when no resolver is wired (single-gateway / non-HA).
+
 See the [Control Server README](cmd/control/) for details on the event model, API endpoints, and authorization policies.
 
 ## Internal Packages

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -316,6 +316,13 @@ func main() {
 		// ProxyValidateTerminalToken.
 		internalHandler.SetTerminalTokenStore(valkey.TerminalTokenStore)
 	}
+	if valkey != nil && valkey.GatewayRegistry != nil {
+		// Confine every device-origin InternalService request to the gateway the
+		// device is actually live on (server#403). Wired whenever the
+		// Valkey-backed routing registry is available; a nil resolver (no
+		// registry) keeps the documented single-gateway bypass.
+		internalHandler.SetDeviceGatewayResolver(valkey.GatewayRegistry)
+	}
 	internalPath, internalH := pmv1connect.NewInternalServiceHandler(
 		internalHandler,
 		connect.WithInterceptors(api.NewValidationInterceptor()),

--- a/cmd/control/valkey.go
+++ b/cmd/control/valkey.go
@@ -70,6 +70,12 @@ type valkeySubsystem struct {
 	// it to the ControlService so renewal/device-deletion revoke the old cert;
 	// gateways read the same Valkey key to enforce it on mTLS connections.
 	CRLStore *crl.Store
+
+	// GatewayRegistry is the device→gateway routing registry. main() hands it to
+	// the InternalHandler (SetDeviceGatewayResolver) so every device-origin
+	// InternalService request is confined to the gateway the device is live on
+	// (server#403). The same registry backs terminal URL lookup + fan-out.
+	GatewayRegistry *registry.Registry
 }
 
 // Close stops the Asynq servers and closes the Valkey clients.
@@ -145,6 +151,7 @@ func newValkeySubsystem(ctx context.Context, cfg *Config, st *store.Store, svc *
 	v.CRLStore = crl.NewStore(v.rdb)
 	svc.SetCRLStore(v.CRLStore)
 	gatewayReg := registry.New(registry.NewValkeyBackend(v.rdb), logger.With("component", "gateway_registry"))
+	v.GatewayRegistry = gatewayReg
 	termHandler := api.NewTerminalHandler(
 		st,
 		v.TerminalTokenStore,

--- a/cmd/control/valkey.go
+++ b/cmd/control/valkey.go
@@ -190,7 +190,7 @@ func newValkeySubsystem(ctx context.Context, cfg *Config, st *store.Store, svc *
 	}
 
 	// Asynq mux + servers.
-	inboxWorker := control.NewInboxWorker(st, v.aqClient, actionSigner, v.taskSigner, logger.With("component", "inbox_worker"))
+	inboxWorker := control.NewInboxWorker(st, v.aqClient, actionSigner, v.taskSigner, logger.With("component", "inbox_worker"), gatewayReg)
 	aqLogger := logger.With("component", "asynq_server")
 	v.inboxServer = newInboxAsynqServer(cfg, aqLogger)
 	if err := v.inboxServer.Start(inboxWorker.NewMux()); err != nil {

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -147,7 +147,22 @@ func main() {
 	}
 	http2.ConfigureTransport(controlTransport)
 	controlHTTPClient := &http.Client{Transport: controlTransport}
-	controlProxy := handler.NewControlProxy(controlHTTPClient, cfg.ControlURL)
+
+	// Resolve this gateway's stable ID before constructing the control proxy,
+	// which stamps it onto every device-origin request for the device→gateway
+	// binding check on control. If GATEWAY_ID is set, use it (static-config
+	// Traefik setups where the operator pre-declares per-gateway routes);
+	// otherwise generate a ULID at startup (dynamic-config setups where Traefik
+	// picks up new routes from a watcher / file provider / k8s ingress).
+	gatewayID := cfg.GatewayID
+	if gatewayID == "" {
+		gatewayID = ulid.Make().String()
+		logger.Info("generated dynamic gateway ID", "gateway_id", gatewayID)
+	} else {
+		logger.Info("using configured gateway ID", "gateway_id", gatewayID)
+	}
+
+	controlProxy := handler.NewControlProxy(controlHTTPClient, cfg.ControlURL, gatewayID)
 	logger.Info("control proxy initialized", "control_url", cfg.ControlURL)
 
 	// Create connection manager
@@ -165,19 +180,6 @@ func main() {
 		logger.With("component", "device_worker"),
 	)
 	defer workerMgr.StopAll()
-
-	// Resolve this gateway's stable ID. If GATEWAY_ID is set, use it
-	// (static-config Traefik setups where the operator pre-declares
-	// per-gateway routes). Otherwise generate a ULID at startup
-	// (dynamic-config setups where Traefik picks up new routes from
-	// a watcher / file provider / k8s ingress automatically).
-	gatewayID := cfg.GatewayID
-	if gatewayID == "" {
-		gatewayID = ulid.Make().String()
-		logger.Info("generated dynamic gateway ID", "gateway_id", gatewayID)
-	} else {
-		logger.Info("using configured gateway ID", "gateway_id", gatewayID)
-	}
 
 	// Declare the shutdown signal ctx up-front so downstream goroutines
 	// (registry refresh, internal-URL refresh) can derive from it and

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -669,6 +669,7 @@ func main() {
 	if cfg.WebListenAddr != "" {
 		bridgeHandler := handler.NewTerminalBridgeHandler(
 			manager, terminalSessions, controlProxy, aqClient,
+			gatewayID,
 			logger.With("component", "terminal_bridge"),
 		)
 		webMux := buildWebMux(gatewayID, bridgeHandler)

--- a/docs/adr/0005-gateway-control-device-origin-binding.md
+++ b/docs/adr/0005-gateway-control-device-origin-binding.md
@@ -1,0 +1,88 @@
+# 0005 — Gateway↔control device-origin binding
+
+- Status: accepted
+- Date: 2026-06-13
+- Related: server#403; the 2026-06-12 audit (SA-C2); WS2 of the
+  SECURITY_HARDENING_WORKPLAN; sdk#94 (the `gateway_id` wire field);
+  ADR 0003 (action signing), ADR 0004 (proto-native representation).
+
+## Context
+
+Two server-side trust boundaries carry **device-origin** traffic from a gateway
+to control:
+
+- **InternalService** (gateway → control, mTLS): credential-bearing proxy calls
+  — read/store a device's LUKS key, store LPS passwords, sync signed actions,
+  verify a device.
+- **control:inbox** (gateway → control, Valkey/Asynq): device-attributed events
+  — execution results, output chunks, inventory, security alerts, LUKS-revocation
+  results, terminal audit chunks.
+
+Before this change both boundaries trusted a *self-asserted* `device_id` with no
+proof the calling gateway is the one that device is actually live on:
+
+- The gateway peer-class mTLS cert is **shared** across gateway replicas and
+  carries **no per-gateway identity**, so InternalService could not tell which
+  gateway was calling — any gateway could read or overwrite **any** device's
+  LUKS/LPS secrets (critical, SA-C2 #1).
+- control:inbox authenticated only with the **shared `PM_TASK_SIGNING_KEY`
+  HMAC** — necessary (it stops tampering in Valkey) but **not sufficient**: any
+  holder of the shared key could forge device-attributed events for an arbitrary
+  `device_id` (high, SA-C2 #2). The HMAC also can't tell two devices apart, so
+  several inbox handlers trusted attacker-chosen `(device_id, execution_id /
+  session_id / action_id)` tuples.
+
+## Decision
+
+Bind every device-origin operation to the **authenticated device→gateway routing
+binding** — the registry entry the agent's own mTLS-authenticated heartbeat
+writes (`AttachDevice`), which *is* the per-gateway identity the shared cert
+lacks.
+
+1. **Wire field.** Each device-origin request/event self-asserts a `gateway_id`
+   (sdk#94 added it to the 6 `device_id`-carrying InternalService requests;
+   `taskqueue` payloads carry it on the inbox side). The gateway producer stamps
+   its own id (`ControlProxy`, `AgentHandler`, `TerminalBridgeHandler`).
+2. **One binding policy.** `registry.CheckDeviceGatewayBinding(ctx, lookup,
+   deviceID, claimedGatewayID)` is the single source, reused by both boundaries.
+   Fail-closed: empty `gateway_id` → reject; `ErrNoGateway` (device live on no
+   gateway) → reject (never allow-on-unknown); `lookup ≠ claimed` → reject. The
+   InternalService handlers map the sentinels to connect codes (after `Validate`,
+   validate-then-auth); the inbox worker maps them to `asynq.SkipRetry` drops
+   that append no event.
+3. **Single-gateway bypass.** When no resolver is wired (a `nil` lookup), the
+   binding is **not** enforced — the documented exception for single-gateway /
+   non-HA deployments, where there is exactly one gateway and the binding is
+   moot. Control wires the resolver whenever the Valkey-backed routing registry
+   is available (i.e. wherever more than one gateway can connect).
+4. **Cross-device ownership** (defense the binding does not cover — confining
+   *which* resource a device may write, not *which* gateway speaks for it):
+   output chunks must belong to the reporting device's execution; a LUKS
+   revocation result with no outstanding request is dropped (never mints an
+   orphan stream); a terminal audit chunk requires an existing session whose
+   `(device, user)` it matches, and `AppendTerminalSessionChunk` is UPDATE-only
+   so it can never INSERT an attacker-owned placeholder.
+5. **DB-level append-only events** (ADR-adjacent, migration 011): a `BEFORE
+   UPDATE/DELETE/TRUNCATE` trigger on `public.events` enforces the audit trail's
+   append-only invariant in the database, not only in app code — so even a
+   compromised query path or operator with DB access cannot rewrite history.
+   `RebuildAll` only TRUNCATEs `*_projection`, so projection rebuilds are
+   unaffected.
+
+## Consequences
+
+- A compromised single gateway can no longer pull another device's secrets or
+  forge device-attributed events; the audit trail is DB-enforced append-only.
+- Binding rejections are returned to the **gateway** (a server component), never
+  the web client (the browser talks to ControlService, not InternalService), so
+  they reuse existing internal error codes (`validation_failed`,
+  `device_not_connected`, `permission_denied`) rather than dedicated
+  web-localized ones — no new error-code/i18n surface.
+- **Rolling-upgrade note (pre-1.0):** `gateway_id` is optional on the wire
+  (`omitempty`); a control with the resolver wired will reject device-origin
+  calls from an *un-upgraded* gateway that sends no `gateway_id` until that
+  gateway is upgraded. Acceptable while the re-tag-in-place freedom holds, and
+  control + gateway ship from one server module.
+- `TestInternalHandlers_GatewayBindingIsSelfDiscovering` (completeness-checked
+  against the InternalService descriptor) and `TestInbox_RejectsCrossGatewayDeviceOrigin`
+  keep both boundaries from regressing as new RPCs/handlers are added.

--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260612214757-f929ee828ab5
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260612234504-66832378eba9

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260612214757-f929ee828ab5 h1:LnY88/pho6AkhKwDWJJBMruAJpP/BzYH8c9UEKXdoYw=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260612214757-f929ee828ab5/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260612234504-66832378eba9 h1:mhoF8ZXZ2o/S+UnlWMPzv4YsmdEpTIiRYPsDb9ZJL7E=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260612234504-66832378eba9/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -90,6 +90,16 @@ const (
 	// config" message instead of "An unexpected error occurred". See
 	// rc11 #79.
 	ErrGatewayNotRegistered = "gateway_not_registered"
+
+	// Gateway↔control device-origin binding (WS2 / #403).
+	// ErrGatewayDeviceBindingMismatch: the calling gateway is not the one the
+	// device is live on — a compromised/confused gateway reaching for another
+	// device's secrets or forging its events (CodePermissionDenied).
+	// ErrGatewayDeviceBindingUnknown: the device is not live on any gateway, so
+	// the binding cannot be verified — fail-closed rather than allow
+	// (CodeFailedPrecondition).
+	ErrGatewayDeviceBindingMismatch = "gateway_device_binding_mismatch"
+	ErrGatewayDeviceBindingUnknown  = "gateway_device_binding_unknown"
 )
 
 // Compliance policy error codes.

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -90,16 +90,6 @@ const (
 	// config" message instead of "An unexpected error occurred". See
 	// rc11 #79.
 	ErrGatewayNotRegistered = "gateway_not_registered"
-
-	// Gateway↔control device-origin binding (WS2 / #403).
-	// ErrGatewayDeviceBindingMismatch: the calling gateway is not the one the
-	// device is live on — a compromised/confused gateway reaching for another
-	// device's secrets or forging its events (CodePermissionDenied).
-	// ErrGatewayDeviceBindingUnknown: the device is not live on any gateway, so
-	// the binding cannot be verified — fail-closed rather than allow
-	// (CodeFailedPrecondition).
-	ErrGatewayDeviceBindingMismatch = "gateway_device_binding_mismatch"
-	ErrGatewayDeviceBindingUnknown  = "gateway_device_binding_unknown"
 )
 
 // Compliance policy error codes.

--- a/internal/api/gateway_binding.go
+++ b/internal/api/gateway_binding.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"connectrpc.com/connect"
+
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
+)
+
+// DeviceGatewayResolver resolves which gateway a device is currently live on.
+// *registry.Registry satisfies it; tests inject a fake. Kept as a one-method
+// interface so the api package does not depend on the full registry surface.
+type DeviceGatewayResolver interface {
+	LookupDeviceGateway(ctx context.Context, deviceID string) (string, error)
+}
+
+// verifyDeviceGatewayBinding confines a device-origin InternalService request to
+// the gateway the device is actually live on. The gateway peer-class mTLS cert
+// is shared and carries no per-gateway identity, so control cannot trust the
+// transport to tell it which gateway is calling; instead the request
+// self-asserts claimedGatewayID and this check cross-references it against the
+// device→gateway routing binding the agent's own mTLS-authenticated heartbeat
+// wrote into the registry. Without it, ANY gateway could read or overwrite ANY
+// device's LUKS/LPS secrets and forge device-attributed events (server SA-C2).
+//
+// Fail-closed, in the canonical validate-then-auth position (called AFTER
+// Validate, before any secret access or event append):
+//
+//   - resolver nil  → allow. The single-gateway / non-HA exception: the routing
+//     registry is only wired in multi-gateway compose, so a nil resolver means
+//     "there is exactly one gateway, binding is moot." Documented in the ADR;
+//     the resolver MUST be wired wherever more than one gateway can connect.
+//   - claimedGatewayID empty → reject InvalidArgument. A resolver is wired, so a
+//     request that omits its gateway_id cannot be bound and must not proceed.
+//   - ErrNoGateway (device live on no gateway) → reject FailedPrecondition. Never
+//     "allow because we can't tell" — that is the whole bypass an attacker wants.
+//   - lookup ≠ claimed → reject PermissionDenied. The calling gateway is not the
+//     one the device is live on.
+func (h *InternalHandler) verifyDeviceGatewayBinding(ctx context.Context, deviceID, claimedGatewayID string) error {
+	if h.deviceGatewayResolver == nil {
+		return nil // single-gateway / non-HA: binding not enforced (documented)
+	}
+	if claimedGatewayID == "" {
+		return apiErrorCtx(ctx, ErrGatewayDeviceBindingUnknown, connect.CodeInvalidArgument,
+			"gateway_id is required when the device→gateway routing registry is enabled")
+	}
+	actualGatewayID, err := h.deviceGatewayResolver.LookupDeviceGateway(ctx, deviceID)
+	if err != nil {
+		if errors.Is(err, registry.ErrNoGateway) {
+			// Fail-closed: the device is not live on any gateway, so the binding
+			// cannot be confirmed. Rejecting (not allowing) is the point.
+			return apiErrorCtx(ctx, ErrGatewayDeviceBindingUnknown, connect.CodeFailedPrecondition,
+				"device is not live on any gateway")
+		}
+		h.logger.Error("device→gateway binding lookup failed", "device_id", deviceID, "error", err)
+		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve device gateway")
+	}
+	if actualGatewayID != claimedGatewayID {
+		h.logger.Warn("rejecting device-origin request: gateway binding mismatch",
+			"device_id", deviceID, "claimed_gateway_id", claimedGatewayID, "actual_gateway_id", actualGatewayID)
+		return apiErrorCtx(ctx, ErrGatewayDeviceBindingMismatch, connect.CodePermissionDenied,
+			"device is not live on the calling gateway")
+	}
+	return nil
+}

--- a/internal/api/gateway_binding.go
+++ b/internal/api/gateway_binding.go
@@ -9,59 +9,36 @@ import (
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 )
 
-// DeviceGatewayResolver resolves which gateway a device is currently live on.
-// *registry.Registry satisfies it; tests inject a fake. Kept as a one-method
-// interface so the api package does not depend on the full registry surface.
-type DeviceGatewayResolver interface {
-	LookupDeviceGateway(ctx context.Context, deviceID string) (string, error)
-}
-
 // verifyDeviceGatewayBinding confines a device-origin InternalService request to
-// the gateway the device is actually live on. The gateway peer-class mTLS cert
-// is shared and carries no per-gateway identity, so control cannot trust the
-// transport to tell it which gateway is calling; instead the request
-// self-asserts claimedGatewayID and this check cross-references it against the
-// device→gateway routing binding the agent's own mTLS-authenticated heartbeat
-// wrote into the registry. Without it, ANY gateway could read or overwrite ANY
-// device's LUKS/LPS secrets and forge device-attributed events (server SA-C2).
-//
-// Fail-closed, in the canonical validate-then-auth position (called AFTER
-// Validate, before any secret access or event append):
-//
-//   - resolver nil  → allow. The single-gateway / non-HA exception: the routing
-//     registry is only wired in multi-gateway compose, so a nil resolver means
-//     "there is exactly one gateway, binding is moot." Documented in the ADR;
-//     the resolver MUST be wired wherever more than one gateway can connect.
-//   - claimedGatewayID empty → reject InvalidArgument. A resolver is wired, so a
-//     request that omits its gateway_id cannot be bound and must not proceed.
-//   - ErrNoGateway (device live on no gateway) → reject FailedPrecondition. Never
-//     "allow because we can't tell" — that is the whole bypass an attacker wants.
-//   - lookup ≠ claimed → reject PermissionDenied. The calling gateway is not the
-//     one the device is live on.
+// the gateway the device is actually live on, in the canonical validate-then-auth
+// position (called AFTER Validate, before any secret access or event append).
+// The binding policy itself lives in registry.CheckDeviceGatewayBinding (shared
+// with the control:inbox worker); this method maps its sentinel results to the
+// connect codes the gateway client expects. Without it, ANY gateway could read
+// or overwrite ANY device's LUKS/LPS secrets and forge device-attributed events
+// (server SA-C2).
 func (h *InternalHandler) verifyDeviceGatewayBinding(ctx context.Context, deviceID, claimedGatewayID string) error {
-	if h.deviceGatewayResolver == nil {
-		return nil // single-gateway / non-HA: binding not enforced (documented)
-	}
-	if claimedGatewayID == "" {
-		return apiErrorCtx(ctx, ErrGatewayDeviceBindingUnknown, connect.CodeInvalidArgument,
+	// These binding rejections are returned to the calling GATEWAY (a server
+	// component), never to the web client (the browser talks to ControlService,
+	// not InternalService), so they map to existing internal error codes rather
+	// than dedicated web-localized ones.
+	err := registry.CheckDeviceGatewayBinding(ctx, h.deviceGatewayResolver, deviceID, claimedGatewayID)
+	switch {
+	case err == nil:
+		return nil
+	case errors.Is(err, registry.ErrBindingGatewayMissing):
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument,
 			"gateway_id is required when the device→gateway routing registry is enabled")
-	}
-	actualGatewayID, err := h.deviceGatewayResolver.LookupDeviceGateway(ctx, deviceID)
-	if err != nil {
-		if errors.Is(err, registry.ErrNoGateway) {
-			// Fail-closed: the device is not live on any gateway, so the binding
-			// cannot be confirmed. Rejecting (not allowing) is the point.
-			return apiErrorCtx(ctx, ErrGatewayDeviceBindingUnknown, connect.CodeFailedPrecondition,
-				"device is not live on any gateway")
-		}
+	case errors.Is(err, registry.ErrBindingDeviceNotLive):
+		return apiErrorCtx(ctx, ErrDeviceNotConnected, connect.CodeFailedPrecondition,
+			"device is not live on any gateway")
+	case errors.Is(err, registry.ErrBindingMismatch):
+		h.logger.Warn("rejecting device-origin request: gateway binding mismatch",
+			"device_id", deviceID, "claimed_gateway_id", claimedGatewayID)
+		return apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied,
+			"device is not live on the calling gateway")
+	default:
 		h.logger.Error("device→gateway binding lookup failed", "device_id", deviceID, "error", err)
 		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve device gateway")
 	}
-	if actualGatewayID != claimedGatewayID {
-		h.logger.Warn("rejecting device-origin request: gateway binding mismatch",
-			"device_id", deviceID, "claimed_gateway_id", claimedGatewayID, "actual_gateway_id", actualGatewayID)
-		return apiErrorCtx(ctx, ErrGatewayDeviceBindingMismatch, connect.CodePermissionDenied,
-			"device is not live on the calling gateway")
-	}
-	return nil
 }

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/resolution"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -54,16 +55,16 @@ type InternalHandler struct {
 	// registry). Set via SetDeviceGatewayResolver in HA/multi-gateway
 	// deployments. When nil (single-gateway, non-HA), the device-origin binding
 	// check is bypassed — the documented single-gateway exception (see ADR).
-	deviceGatewayResolver DeviceGatewayResolver
+	deviceGatewayResolver registry.DeviceGatewayLookup
 
 	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // SetDeviceGatewayResolver wires the device→gateway routing registry so every
 // InternalService request that carries a device_id is confined to the gateway
-// the device is actually live on (VerifyDeviceGatewayBinding). Called from
+// the device is actually live on (verifyDeviceGatewayBinding). Called from
 // main.go in HA/multi-gateway deployments; left nil for single-gateway.
-func (h *InternalHandler) SetDeviceGatewayResolver(r DeviceGatewayResolver) {
+func (h *InternalHandler) SetDeviceGatewayResolver(r registry.DeviceGatewayLookup) {
 	h.deviceGatewayResolver = r
 }
 

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -49,7 +49,22 @@ type InternalHandler struct {
 	// default 'method not implemented'.
 	terminalTokenStore *terminal.TokenStore
 
+	// deviceGatewayResolver resolves which gateway a device is currently live
+	// on, written under the agent's mTLS identity (the device→gateway routing
+	// registry). Set via SetDeviceGatewayResolver in HA/multi-gateway
+	// deployments. When nil (single-gateway, non-HA), the device-origin binding
+	// check is bypassed — the documented single-gateway exception (see ADR).
+	deviceGatewayResolver DeviceGatewayResolver
+
 	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
+}
+
+// SetDeviceGatewayResolver wires the device→gateway routing registry so every
+// InternalService request that carries a device_id is confined to the gateway
+// the device is actually live on (VerifyDeviceGatewayBinding). Called from
+// main.go in HA/multi-gateway deployments; left nil for single-gateway.
+func (h *InternalHandler) SetDeviceGatewayResolver(r DeviceGatewayResolver) {
+	h.deviceGatewayResolver = r
 }
 
 // NewInternalHandler creates a new internal service handler.
@@ -87,6 +102,9 @@ func (h *InternalHandler) VerifyDevice(ctx context.Context, req *connect.Request
 	if deviceID == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id is required")
 	}
+	if err := h.verifyDeviceGatewayBinding(ctx, req.Msg.DeviceId, req.Msg.GatewayId); err != nil {
+		return nil, err
+	}
 
 	_, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{ID: deviceID})
 	if err != nil {
@@ -106,6 +124,9 @@ func (h *InternalHandler) ProxySyncActions(ctx context.Context, req *connect.Req
 	deviceID := req.Msg.DeviceId
 	if deviceID == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id is required")
+	}
+	if err := h.verifyDeviceGatewayBinding(ctx, req.Msg.DeviceId, req.Msg.GatewayId); err != nil {
+		return nil, err
 	}
 
 	// Fail closed on a missing signer. Synced actions are signed at
@@ -341,6 +362,9 @@ func (h *InternalHandler) ProxyValidateLuksToken(ctx context.Context, req *conne
 	if req.Msg.DeviceId == "" || req.Msg.Token == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id and token are required")
 	}
+	if err := h.verifyDeviceGatewayBinding(ctx, req.Msg.DeviceId, req.Msg.GatewayId); err != nil {
+		return nil, err
+	}
 
 	token, err := h.store.Repos().Luks.ConsumeToken(ctx, store.ConsumeLuksTokenParams{Token: req.Msg.Token, DeviceID: req.Msg.DeviceId})
 	if err != nil {
@@ -373,6 +397,9 @@ func (h *InternalHandler) ProxyGetLuksKey(ctx context.Context, req *connect.Requ
 	if req.Msg.DeviceId == "" || req.Msg.ActionId == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id and action_id are required")
 	}
+	if err := h.verifyDeviceGatewayBinding(ctx, req.Msg.DeviceId, req.Msg.GatewayId); err != nil {
+		return nil, err
+	}
 
 	key, err := h.store.Repos().Luks.GetCurrentForAction(ctx, store.LuksKeyByActionKey{DeviceID: req.Msg.DeviceId, ActionID: req.Msg.ActionId})
 	if err != nil {
@@ -397,6 +424,9 @@ func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Re
 
 	if req.Msg.DeviceId == "" || req.Msg.ActionId == "" || req.Msg.Passphrase == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id, action_id, and passphrase are required")
+	}
+	if err := h.verifyDeviceGatewayBinding(ctx, req.Msg.DeviceId, req.Msg.GatewayId); err != nil {
+		return nil, err
 	}
 
 	encPassphrase, err := h.encryptor.Encrypt(req.Msg.Passphrase)
@@ -438,6 +468,9 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 
 	if req.Msg.DeviceId == "" || req.Msg.ActionId == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id and action_id are required")
+	}
+	if err := h.verifyDeviceGatewayBinding(ctx, req.Msg.DeviceId, req.Msg.GatewayId); err != nil {
+		return nil, err
 	}
 
 	// Persistence MUST fail-closed. LPS rotation is irreversible:

--- a/internal/api/internal_handler_gateway_binding_test.go
+++ b/internal/api/internal_handler_gateway_binding_test.go
@@ -1,0 +1,218 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// newID returns a fresh ULID string for test action ids.
+func newULID() string { return ulid.Make().String() }
+
+// wiredHandler builds a real InternalHandler with a fake device→gateway
+// registry attached as the resolver, and binds deviceID to gatewayID in it.
+func wiredHandler(t *testing.T, st *store.Store, deviceID, gatewayID string) (*api.InternalHandler, *registry.Registry) {
+	t.Helper()
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	reg := registry.New(registry.NewFakeBackend(nil), nil)
+	require.NoError(t, reg.AttachDevice(context.Background(), deviceID, gatewayID, registry.DefaultDeviceTTL))
+	h.SetDeviceGatewayResolver(reg)
+	return h, reg
+}
+
+// countEvents returns how many events of the given type exist.
+func countEvents(t *testing.T, st *store.Store, eventType string) int {
+	t.Helper()
+	evs, err := st.Queries().LoadEventsByType(context.Background(), db.LoadEventsByTypeParams{
+		EventType: eventType,
+		Limit:     1000,
+		Offset:    0,
+	})
+	require.NoError(t, err)
+	return len(evs)
+}
+
+// TestInternalHandlers_GatewayBindingIsSelfDiscovering pins that EVERY
+// InternalService handler whose request carries a device_id rejects a
+// gateway_id that does not match the device→gateway binding (server SA-C2 / #403).
+// The case table is checked for completeness against the live InternalService
+// proto descriptor, so a newly-added credential-bearing RPC that forgets the
+// binding fails here rather than silently shipping an unbindable handler.
+func TestInternalHandlers_GatewayBindingIsSelfDiscovering(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	device := testutil.CreateTestDevice(t, st, "binding-host")
+	const liveGateway = "gw-A"
+	const wrongGateway = "gw-B"
+	h, _ := wiredHandler(t, st, device, liveGateway)
+	ctx := context.Background()
+	actionID := newULID()
+
+	// Each entry drives the REAL handler with a gateway_id that does NOT match
+	// the binding (device is live on gw-A, request claims gw-B).
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{"VerifyDevice", func() error {
+			_, e := h.VerifyDevice(ctx, connect.NewRequest(&pm.VerifyDeviceRequest{DeviceId: device, GatewayId: wrongGateway}))
+			return e
+		}},
+		{"ProxySyncActions", func() error {
+			_, e := h.ProxySyncActions(ctx, connect.NewRequest(&pm.InternalSyncActionsRequest{DeviceId: device, GatewayId: wrongGateway}))
+			return e
+		}},
+		{"ProxyValidateLuksToken", func() error {
+			_, e := h.ProxyValidateLuksToken(ctx, connect.NewRequest(&pm.InternalValidateLuksTokenRequest{DeviceId: device, Token: "some-token", GatewayId: wrongGateway}))
+			return e
+		}},
+		{"ProxyGetLuksKey", func() error {
+			_, e := h.ProxyGetLuksKey(ctx, connect.NewRequest(&pm.InternalGetLuksKeyRequest{DeviceId: device, ActionId: actionID, GatewayId: wrongGateway}))
+			return e
+		}},
+		{"ProxyStoreLuksKey", func() error {
+			_, e := h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+				DeviceId: device, ActionId: actionID, DevicePath: "/dev/sda1", Passphrase: "secret", RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL, GatewayId: wrongGateway,
+			}))
+			return e
+		}},
+		{"ProxyStoreLpsPasswords", func() error {
+			_, e := h.ProxyStoreLpsPasswords(ctx, connect.NewRequest(&pm.InternalStoreLpsPasswordsRequest{
+				DeviceId: device, ActionId: actionID,
+				Rotations: []*pm.LpsPasswordRotation{{Username: "alice", Password: "pw", RotatedAt: "2026-06-13T00:00:00Z", Reason: pm.RotationReason_ROTATION_REASON_INITIAL}},
+				GatewayId: wrongGateway,
+			}))
+			return e
+		}},
+	}
+
+	for _, c := range cases {
+		err := c.call()
+		require.Errorf(t, err, "%s must reject a cross-gateway device_id", c.name)
+		assert.Equalf(t, connect.CodePermissionDenied, connect.CodeOf(err),
+			"%s must reject a gateway binding mismatch with PermissionDenied", c.name)
+	}
+
+	// Completeness: the table must cover EXACTLY the InternalService requests
+	// that carry a device_id (discovered from the proto descriptor), so a new
+	// device-origin RPC can't escape the binding by omission.
+	want := internalRequestsWithDeviceID(t)
+	assert.Equalf(t, want, len(cases),
+		"every InternalService request carrying device_id needs a binding case here (proto descriptor has %d, table has %d)", want, len(cases))
+}
+
+// internalRequestsWithDeviceID counts InternalService methods whose request
+// message carries a device_id field — the self-discovering completeness anchor.
+func internalRequestsWithDeviceID(t *testing.T) int {
+	t.Helper()
+	svc := pm.File_pm_v1_internal_proto.Services().ByName("InternalService")
+	require.NotNil(t, svc, "InternalService descriptor must resolve")
+	n := 0
+	methods := svc.Methods()
+	for i := 0; i < methods.Len(); i++ {
+		if methods.Get(i).Input().Fields().ByName("device_id") != nil {
+			n++
+		}
+	}
+	require.NotZero(t, n, "matches-zero guard: no InternalService request carries device_id")
+	return n
+}
+
+// TestProxyGetLuksKey_GatewayBinding covers the LUKS-secret read path across all
+// four binding states, proving the secret is never returned to the wrong gateway.
+func TestProxyGetLuksKey_GatewayBinding(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	device := testutil.CreateTestDevice(t, st, "luks-host")
+	const liveGateway = "gw-A"
+	h, _ := wiredHandler(t, st, device, liveGateway)
+	ctx := context.Background()
+	actionID := newULID()
+
+	// Seed a key through the correctly-bound store path.
+	_, err := h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+		DeviceId: device, ActionId: actionID, DevicePath: "/dev/sda1", Passphrase: "topsecret",
+		RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL, GatewayId: liveGateway,
+	}))
+	require.NoError(t, err)
+
+	t.Run("correct gateway returns the passphrase", func(t *testing.T) {
+		resp, err := h.ProxyGetLuksKey(ctx, connect.NewRequest(&pm.InternalGetLuksKeyRequest{
+			DeviceId: device, ActionId: actionID, GatewayId: liveGateway,
+		}))
+		require.NoError(t, err)
+		assert.Equal(t, "topsecret", resp.Msg.Passphrase)
+	})
+
+	t.Run("wrong gateway is rejected and leaks no passphrase", func(t *testing.T) {
+		resp, err := h.ProxyGetLuksKey(ctx, connect.NewRequest(&pm.InternalGetLuksKeyRequest{
+			DeviceId: device, ActionId: actionID, GatewayId: "gw-B",
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+		assert.Nil(t, resp, "no response (and no passphrase) on a binding mismatch")
+	})
+
+	t.Run("absent gateway_id is rejected (InvalidArgument)", func(t *testing.T) {
+		_, err := h.ProxyGetLuksKey(ctx, connect.NewRequest(&pm.InternalGetLuksKeyRequest{
+			DeviceId: device, ActionId: actionID, GatewayId: "",
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	})
+
+	t.Run("device live on no gateway fails closed (FailedPrecondition)", func(t *testing.T) {
+		other := testutil.CreateTestDevice(t, st, "unattached-host")
+		_, err := h.ProxyGetLuksKey(ctx, connect.NewRequest(&pm.InternalGetLuksKeyRequest{
+			DeviceId: other, ActionId: actionID, GatewayId: liveGateway,
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err),
+			"a device not live on any gateway must fail closed, never allow")
+	})
+}
+
+// TestProxyStoreLuksKey_NoEventOnGatewayMismatch proves the device-attributed
+// LuksKeyRotated event is NEVER appended on a binding mismatch — the forge path.
+func TestProxyStoreLuksKey_NoEventOnGatewayMismatch(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	device := testutil.CreateTestDevice(t, st, "luks-forge-host")
+	h, _ := wiredHandler(t, st, device, "gw-A")
+	ctx := context.Background()
+
+	before := countEvents(t, st, "LuksKeyRotated")
+	_, err := h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+		DeviceId: device, ActionId: newULID(), DevicePath: "/dev/sda1", Passphrase: "secret",
+		RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL, GatewayId: "gw-B",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	assert.Equal(t, before, countEvents(t, st, "LuksKeyRotated"),
+		"a forged-gateway store must NOT append a device-attributed LuksKeyRotated event")
+}
+
+// TestInternalHandler_NilResolverBypass pins the documented single-gateway
+// exception: with no resolver wired, the binding is not enforced (gateway_id is
+// ignored) so non-HA deployments keep working.
+func TestInternalHandler_NilResolverBypass(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	device := testutil.CreateTestDevice(t, st, "single-gw-host")
+	// No SetDeviceGatewayResolver — resolver stays nil.
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+	resp, err := h.VerifyDevice(context.Background(), connect.NewRequest(&pm.VerifyDeviceRequest{
+		DeviceId: device, GatewayId: "anything-or-empty",
+	}))
+	require.NoError(t, err, "with no resolver wired, the binding check is bypassed (single-gateway)")
+	assert.NotNil(t, resp)
+}

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -22,6 +22,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/dyngroupeval"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
@@ -46,10 +47,19 @@ type InboxWorker struct {
 	signer     ca.ActionSigner
 	taskSigner *taskqueue.Signer
 	logger     *slog.Logger
+	// resolver looks up which gateway a device is currently live on, so
+	// every device-origin handler can confine the task to that gateway
+	// (registry.CheckDeviceGatewayBinding). nil = single-gateway / non-HA
+	// deployment: the binding is documented-disabled there, exactly as on
+	// the InternalService side (api/gateway_binding.go).
+	resolver registry.DeviceGatewayLookup
 }
 
-// NewInboxWorker creates a new inbox worker.
-func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ca.ActionSigner, taskSigner *taskqueue.Signer, logger *slog.Logger) *InboxWorker {
+// NewInboxWorker creates a new inbox worker. resolver is the
+// device→gateway routing lookup used to bind device-origin tasks to the
+// gateway the device is live on; pass nil in single-gateway deployments
+// where the binding is not enforced.
+func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ca.ActionSigner, taskSigner *taskqueue.Signer, logger *slog.Logger, resolver registry.DeviceGatewayLookup) *InboxWorker {
 	return &InboxWorker{
 		now:        time.Now,
 		store:      st,
@@ -57,7 +67,19 @@ func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ca.Actio
 		signer:     signer,
 		taskSigner: taskSigner,
 		logger:     logger,
+		resolver:   resolver,
 	}
+}
+
+// verifyDeviceGatewayBinding maps the shared binding policy to an inbox drop:
+// a forged/mismatched binding is NOT retryable, so wrap with asynq.SkipRetry
+// and append NO event. Returns nil when the binding is OK (or no resolver).
+func (w *InboxWorker) verifyDeviceGatewayBinding(ctx context.Context, deviceID, gatewayID string) error {
+	if err := registry.CheckDeviceGatewayBinding(ctx, w.resolver, deviceID, gatewayID); err != nil {
+		w.logger.Warn("inbox: rejecting device-origin task: gateway binding", "device_id", deviceID, "claimed_gateway_id", gatewayID, "error", err)
+		return fmt.Errorf("%w: device→gateway binding: %v", asynq.SkipRetry, err)
+	}
+	return nil
 }
 
 // NewMux returns an Asynq ServeMux with handlers for the main
@@ -101,6 +123,10 @@ func (w *InboxWorker) handleDeviceHello(ctx context.Context, t *asynq.Task) erro
 	var payload taskqueue.DeviceHelloPayload
 	if err := json.Unmarshal(t.Payload(), &payload); err != nil {
 		return fmt.Errorf("unmarshal device hello: %w", err)
+	}
+
+	if err := w.verifyDeviceGatewayBinding(ctx, payload.DeviceID, payload.GatewayID); err != nil {
+		return err
 	}
 
 	logger := w.logger.With("device_id", payload.DeviceID, "hostname", payload.Hostname)
@@ -150,6 +176,10 @@ func (w *InboxWorker) handleDeviceHeartbeat(ctx context.Context, t *asynq.Task) 
 	var payload taskqueue.DeviceHeartbeatPayload
 	if err := json.Unmarshal(t.Payload(), &payload); err != nil {
 		return fmt.Errorf("unmarshal device heartbeat: %w", err)
+	}
+
+	if err := w.verifyDeviceGatewayBinding(ctx, payload.DeviceID, payload.GatewayID); err != nil {
+		return err
 	}
 
 	// Skip processing for deleted or unknown devices.
@@ -202,6 +232,10 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 	resultID := result.GetActionId().GetValue()
 	if resultID == "" {
 		return fmt.Errorf("action result missing action ID")
+	}
+
+	if err := w.verifyDeviceGatewayBinding(ctx, deviceID, payload.GatewayID); err != nil {
+		return err
 	}
 
 	logger := w.logger.With("device_id", deviceID, "result_id", resultID)
@@ -433,6 +467,10 @@ func (w *InboxWorker) handleExecutionOutputChunk(ctx context.Context, t *asynq.T
 		return fmt.Errorf("unmarshal output chunk: %w", err)
 	}
 
+	if err := w.verifyDeviceGatewayBinding(ctx, payload.DeviceID, payload.GatewayID); err != nil {
+		return err
+	}
+
 	// Second-line size guard (audit F-33). The gateway already caps
 	// at 64 KiB on the agent-facing side (handler/agent.go,
 	// maxOutputChunkBytes), but the inbox worker is also a trust
@@ -454,6 +492,27 @@ func (w *InboxWorker) handleExecutionOutputChunk(ctx context.Context, t *asynq.T
 		return nil
 	}
 
+	// Cross-device ownership guard (mirrors the handleExecutionResult
+	// check). The execution ID is non-secret, so without this a
+	// compromised agent could splice forged output onto ANOTHER device's
+	// execution stream by supplying its ID. The reporting device must own
+	// the execution. When the execution is not found we keep the prior
+	// behaviour (append anyway) — chunks can legitimately race ahead of
+	// the ExecutionCreated projection, and there is no owner to spoof yet.
+	if exec, err := w.store.Repos().Execution.Get(ctx, payload.ExecutionID); err == nil {
+		if exec.DeviceID != payload.DeviceID {
+			w.logger.Warn("dropping output chunk: execution belongs to a different device",
+				"execution_id", payload.ExecutionID,
+				"reporting_device_id", payload.DeviceID,
+				"execution_device_id", exec.DeviceID)
+			return nil
+		}
+	} else if !store.IsNotFound(err) {
+		// Transient DB / context error — let Asynq retry rather than
+		// drop or blindly append.
+		return fmt.Errorf("look up execution %s for output chunk: %w", payload.ExecutionID, err)
+	}
+
 	return w.store.AppendEvent(ctx, store.Event{
 		StreamType: "execution",
 		StreamID:   payload.ExecutionID,
@@ -472,6 +531,10 @@ func (w *InboxWorker) handleOSQueryResult(ctx context.Context, t *asynq.Task) er
 	var payload taskqueue.OSQueryResultPayload
 	if err := json.Unmarshal(t.Payload(), &payload); err != nil {
 		return fmt.Errorf("unmarshal osquery result: %w", err)
+	}
+
+	if err := w.verifyDeviceGatewayBinding(ctx, payload.DeviceID, payload.GatewayID); err != nil {
+		return err
 	}
 
 	w.logger.Info("received query result",
@@ -506,6 +569,10 @@ func (w *InboxWorker) handleLogQueryResult(ctx context.Context, t *asynq.Task) e
 		return fmt.Errorf("unmarshal log query result: %w", err)
 	}
 
+	if err := w.verifyDeviceGatewayBinding(ctx, payload.DeviceID, payload.GatewayID); err != nil {
+		return err
+	}
+
 	w.logger.Info("received log query result",
 		"device_id", payload.DeviceID,
 		"query_id", payload.QueryID,
@@ -533,6 +600,10 @@ func (w *InboxWorker) handleInventoryUpdate(ctx context.Context, t *asynq.Task) 
 	var payload taskqueue.InventoryUpdatePayload
 	if err := json.Unmarshal(t.Payload(), &payload); err != nil {
 		return fmt.Errorf("unmarshal inventory update: %w", err)
+	}
+
+	if err := w.verifyDeviceGatewayBinding(ctx, payload.DeviceID, payload.GatewayID); err != nil {
+		return err
 	}
 
 	w.logger.Info("received device inventory",
@@ -592,6 +663,10 @@ func (w *InboxWorker) handleSecurityAlert(ctx context.Context, t *asynq.Task) er
 		return fmt.Errorf("unmarshal security alert: %w", err)
 	}
 
+	if err := w.verifyDeviceGatewayBinding(ctx, payload.DeviceID, payload.GatewayID); err != nil {
+		return err
+	}
+
 	w.logger.Warn("received security alert from device",
 		"device_id", payload.DeviceID,
 		"alert_type", payload.AlertType,
@@ -616,6 +691,10 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 	var payload taskqueue.RevokeLuksDeviceKeyResultPayload
 	if err := json.Unmarshal(t.Payload(), &payload); err != nil {
 		return fmt.Errorf("unmarshal revoke luks result: %w", err)
+	}
+
+	if err := w.verifyDeviceGatewayBinding(ctx, payload.DeviceID, payload.GatewayID); err != nil {
+		return err
 	}
 
 	w.logger.Info("received LUKS device key revocation result",
@@ -643,11 +722,14 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 	// not a correctness issue for the projection (it keys by
 	// stream_id), but worth flagging for the audit export.
 	//
-	// If the lookup fails (e.g. the Requested event never made it
-	// to disk because the original API call crashed), fall back to
-	// a fresh stream ID so we still record the Failed outcome
-	// durably — an orphan Failed event is better than dropping the
-	// agent-reported failure on the floor.
+	// If the lookup finds no matching Requested/Dispatched stream, the
+	// result is dropped (see the IsNotFound branch). Earlier versions
+	// minted a FRESH ulid here and appended anyway — but the (device,
+	// action) pair is attacker-supplied, so a compromised gateway could
+	// fabricate an orphan luks_key stream out of thin air (audit:
+	// no genuine operator request ever existed). We only ever land the
+	// terminal event on a stream a real RevokeLuksDeviceKey request
+	// minted.
 	luksStreamID, err := w.store.Repos().Luks.GetRevocationStreamID(ctx, store.LuksRevocationStreamKey{
 		DeviceID: payload.DeviceID,
 		ActionID: payload.ActionID,
@@ -656,16 +738,15 @@ func (w *InboxWorker) handleRevokeLuksDeviceKeyResult(ctx context.Context, t *as
 	case err == nil:
 		// Happy path — stream ID recovered.
 	case store.IsNotFound(err):
-		// Genuinely absent: the Requested event never landed
-		// (original RPC crashed before append). Fall back to a
-		// fresh ULID so we still record the terminal outcome —
-		// an orphan Failed event is better than silently dropping
-		// the agent-reported failure on the floor.
-		w.logger.Warn("LUKS revocation stream ID not found — appending to a fresh stream; projection will show only the terminal event",
+		// No outstanding revocation request for this (device, action).
+		// Either the result is stale/duplicate, or it was forged by a
+		// compromised gateway for a request that was never made. Drop
+		// it rather than fabricate an orphan stream from attacker input.
+		w.logger.Warn("dropping LUKS revocation result: no matching outstanding revocation request",
 			"device_id", payload.DeviceID,
 			"action_id", payload.ActionID,
 		)
-		luksStreamID = ulid.Make().String()
+		return nil
 	default:
 		// Transient DB / context error. Return so Asynq retries;
 		// previously we masked these as "not found" and forked
@@ -1011,9 +1092,13 @@ func writeFramed(h hash.Hash, b []byte) {
 // (TerminalSessionStarted / Stopped / Terminated) stay on the
 // audit stream as the user-visible audit markers.
 //
-// The sqlc query uses INSERT ... ON CONFLICT so a chunk arriving
-// before the lifecycle Started event still creates a valid row;
-// the Started handler's upsert then completes the metadata.
+// The sqlc query is UPDATE-only (keyed on session_id): an audit chunk
+// can append stdin onto an EXISTING session but can never INSERT an
+// owner-bearing row. Session bootstrap is the lifecycle
+// TerminalSessionStarted handler's job (UpsertTerminalSessionStart). A
+// chunk that outruns the Started event — or one a compromised gateway
+// forges for an unknown / unowned session — is dropped here rather than
+// allowed to mint a placeholder with attacker-chosen owners.
 func (w *InboxWorker) handleTerminalAuditChunk(ctx context.Context, t *asynq.Task) error {
 	var payload taskqueue.TerminalAuditChunkPayload
 	if err := json.Unmarshal(t.Payload(), &payload); err != nil {
@@ -1026,10 +1111,38 @@ func (w *InboxWorker) handleTerminalAuditChunk(ctx context.Context, t *asynq.Tas
 		return nil
 	}
 
+	if err := w.verifyDeviceGatewayBinding(ctx, payload.DeviceID, payload.GatewayID); err != nil {
+		return err
+	}
+
+	// The session row is the authority on who owns the stdin stream.
+	// The audit chunk is no longer allowed to CREATE a session (an
+	// upsert keyed on payload DeviceID/UserID would let a compromised
+	// gateway mint a placeholder row with attacker-chosen owners, then
+	// have it back-filled — or simply pollute the audit trail). Require
+	// the session to already exist (bootstrapped by the
+	// TerminalSessionStarted lifecycle handler), and require the chunk's
+	// claimed (device, user) to match the row's owners exactly. Append
+	// using the owners DERIVED FROM THE ROW, never the payload.
+	session, err := w.store.Queries().GetTerminalSession(ctx, payload.SessionID)
+	if err != nil {
+		if store.IsNotFound(err) {
+			w.logger.Warn("dropping terminal audit chunk for unknown session: refusing to create a session from an audit chunk",
+				"session_id", payload.SessionID, "device_id", payload.DeviceID, "user_id", payload.UserID)
+			return nil
+		}
+		return fmt.Errorf("look up terminal session %s: %w", payload.SessionID, err)
+	}
+	if session.DeviceID != payload.DeviceID || session.UserID != payload.UserID {
+		w.logger.Warn("dropping terminal audit chunk: device/user does not own the session",
+			"session_id", payload.SessionID,
+			"claimed_device_id", payload.DeviceID, "session_device_id", session.DeviceID,
+			"claimed_user_id", payload.UserID, "session_user_id", session.UserID)
+		return nil
+	}
+
 	return w.store.Queries().AppendTerminalSessionChunk(ctx, db.AppendTerminalSessionChunkParams{
 		SessionID: payload.SessionID,
-		DeviceID:  payload.DeviceID,
-		UserID:    payload.UserID,
 		Input:     payload.Data,
 		// Sequence guards against duplicate / out-of-order retries
 		// from Asynq. The gateway's audit batcher stamps each chunk

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/manchtools/power-manage/sdk/go/verify"
 	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/control"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
@@ -74,7 +75,7 @@ func newTask(t *testing.T, typeName string, payload any) *asynq.Task {
 
 func TestHandleDeviceHeartbeat(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "heartbeat-host")
@@ -95,7 +96,7 @@ func TestHandleDeviceHeartbeat(t *testing.T) {
 
 func TestHandleDeviceHeartbeat_DeletedDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "deleted-heartbeat-host")
@@ -123,7 +124,7 @@ func TestHandleDeviceHeartbeat_DeletedDevice(t *testing.T) {
 
 func TestHandleSecurityAlert(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "alert-host")
@@ -157,7 +158,7 @@ func TestHandleSecurityAlert(t *testing.T) {
 
 func TestHandleExecutionResult_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -220,7 +221,7 @@ func TestHandleExecutionResult_Success(t *testing.T) {
 // execution by supplying its ID. The reporting device must own the execution.
 func TestHandleExecutionResult_RejectsCrossDeviceSpoof(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -275,7 +276,7 @@ func TestHandleExecutionResult_RejectsCrossDeviceSpoof(t *testing.T) {
 // osquery result by supplying its (non-secret) query_id.
 func TestHandleOSQueryResult_RejectsCrossDeviceSpoof(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	victimDevice := testutil.CreateTestDevice(t, st, "victim-osq")
@@ -305,7 +306,7 @@ func TestHandleOSQueryResult_RejectsCrossDeviceSpoof(t *testing.T) {
 
 func TestHandleExecutionResult_Failed(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -360,7 +361,7 @@ func TestHandleExecutionResult_Failed(t *testing.T) {
 
 func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -389,7 +390,7 @@ func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 
 func TestHandleExecutionOutputChunk(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "chunk-host")
@@ -429,7 +430,7 @@ func TestHandleExecutionOutputChunk(t *testing.T) {
 
 func TestHandleRevokeLuksDeviceKeyResult_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "luks-host")
@@ -447,7 +448,7 @@ func TestHandleRevokeLuksDeviceKeyResult_Success(t *testing.T) {
 
 func TestHandleRevokeLuksDeviceKeyResult_Failure(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "luks-fail-host")
@@ -468,7 +469,7 @@ func TestHandleDeviceHello(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	// handleDeviceHello calls dispatchPendingActions which needs aqClient.
 	// Passing nil is safe here because there are no pending executions to dispatch.
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "hello-host")
@@ -490,7 +491,7 @@ func TestHandleDeviceHello(t *testing.T) {
 
 func TestHandleDeviceHello_DeletedDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default())
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "hello-deleted-host")
@@ -536,7 +537,7 @@ func TestDispatchPendingActions_ResignsFullEnvelope(t *testing.T) {
 	defer aqClient.Close()
 
 	signer, verifier := newTestCASignerVerifier(t)
-	worker := control.NewInboxWorker(st, aqClient, signer, nil, slog.Default())
+	worker := control.NewInboxWorker(st, aqClient, signer, nil, slog.Default(), nil)
 	mux := worker.NewMux()
 
 	ctx := context.Background()
@@ -710,4 +711,384 @@ func TestListPendingForDevice_SkipsStalePending(t *testing.T) {
 	}
 	assert.False(t, ids[stale], "a stale (>24h) pending execution must not be re-dispatched on reconnect")
 	assert.True(t, ids[fresh], "a fresh pending execution must still be dispatched")
+}
+
+// ---------------------------------------------------------------------------
+// Device→gateway trust binding (server SA-C2 / #403, control:inbox half).
+//
+// The gateway peer-class mTLS cert is shared and carries no per-gateway
+// identity, so each device-origin task self-asserts its relaying GatewayID and
+// the inbox worker cross-references it against the device→gateway routing
+// registry the agent's own mTLS-authenticated heartbeat wrote. A confused or
+// compromised gateway must not be able to forge a device-attributed event for
+// a device that is live on a DIFFERENT gateway, nor an event with no gateway
+// at all when the registry is enabled.
+// ---------------------------------------------------------------------------
+
+const inboxTestTaskKeyHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// bindingRegistry returns a real registry over a fake backend with the given
+// device bound to the given live gateway — the same construction the
+// production wiring uses (registry.New over a Valkey backend), exercised here
+// over the in-memory fake.
+func bindingRegistry(t *testing.T, deviceID, gatewayID string) *registry.Registry {
+	t.Helper()
+	reg := registry.New(registry.NewFakeBackend(nil), slog.Default())
+	require.NoError(t, reg.AttachDevice(context.Background(), deviceID, gatewayID, registry.DefaultDeviceTTL))
+	return reg
+}
+
+// countExecutionEvents counts events of a given type on one execution stream.
+func countExecutionEvents(t *testing.T, st *store.Store, executionID, eventType string) int {
+	t.Helper()
+	events, err := st.Queries().LoadStream(context.Background(), db.LoadStreamParams{
+		StreamType: "execution",
+		StreamID:   executionID,
+	})
+	require.NoError(t, err)
+	n := 0
+	for _, e := range events {
+		if e.EventType == eventType {
+			n++
+		}
+	}
+	return n
+}
+
+// TestInbox_RejectsCrossGatewayDeviceOrigin drives the REAL worker (real HMAC
+// task signer + real registry) and pins the binding decision for a
+// device-origin ExecutionResult across the three field states the design
+// requires for gateway_id:
+//
+//   - matches the device's live gateway (gw-A) → accepted, event appended;
+//   - absent ("") while the registry is enabled → rejected, no event;
+//   - mismatched (gw-B) → rejected, no event.
+//
+// The forged cases must append NOTHING — proving the binding gate runs before
+// any store write, not merely that the call "errors".
+func TestInbox_RejectsCrossGatewayDeviceOrigin(t *testing.T) {
+	signer, err := taskqueue.NewSigner(inboxTestTaskKeyHex)
+	require.NoError(t, err)
+
+	const liveGateway = "gw-A"
+	const wrongGateway = "gw-B"
+
+	// signedExecResultTask builds a correctly-HMAC-signed ExecutionResult task
+	// for the victim's execution, carrying the supplied claimed gateway id.
+	signedExecResultTask := func(t *testing.T, deviceID, executionID, claimedGateway string) *asynq.Task {
+		t.Helper()
+		result := &pm.ActionResult{
+			ActionId:    &pm.ActionId{Value: executionID},
+			Status:      pm.ExecutionStatus_EXECUTION_STATUS_SUCCESS,
+			CompletedAt: timestamppb.Now(),
+			Output:      &pm.CommandOutput{Stdout: "ok", ExitCode: 0},
+		}
+		resultJSON, err := protojson.Marshal(result)
+		require.NoError(t, err)
+		raw, err := json.Marshal(taskqueue.ExecutionResultPayload{
+			DeviceID:         deviceID,
+			ActionResultJSON: resultJSON,
+			GatewayID:        claimedGateway,
+		})
+		require.NoError(t, err)
+		// Wrap exactly as the producer does so the mux's VerifyMiddleware
+		// admits the payload — the binding is the ONLY thing under test.
+		return asynq.NewTask(taskqueue.TypeExecutionResult, signer.Wrap(raw))
+	}
+
+	seedVictimExecution := func(t *testing.T, st *store.Store, deviceID string) string {
+		t.Helper()
+		adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+		actionID := testutil.CreateTestAction(t, st, adminID, "Binding Action", int(pm.ActionType_ACTION_TYPE_SHELL))
+		executionID := testutil.NewID()
+		require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+			StreamType: "execution",
+			StreamID:   executionID,
+			EventType:  "ExecutionCreated",
+			Data: map[string]any{
+				"device_id":       deviceID,
+				"action_id":       actionID,
+				"action_type":     int(pm.ActionType_ACTION_TYPE_SHELL),
+				"desired_state":   0,
+				"params":          map[string]any{},
+				"timeout_seconds": 300,
+				"executed_at":     time.Now().Format(time.RFC3339Nano),
+			},
+			ActorType: "user",
+			ActorID:   adminID,
+		}))
+		return executionID
+	}
+
+	t.Run("matching gateway is accepted", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		victim := testutil.CreateTestDevice(t, st, "victim-match")
+		execID := seedVictimExecution(t, st, victim)
+		worker := control.NewInboxWorker(st, nil, nil, signer, slog.Default(), bindingRegistry(t, victim, liveGateway))
+		mux := worker.NewMux()
+
+		require.NoError(t, mux.ProcessTask(context.Background(),
+			signedExecResultTask(t, victim, execID, liveGateway)))
+
+		exec, err := st.Queries().GetExecutionByID(context.Background(), execID)
+		require.NoError(t, err)
+		assert.Equal(t, "success", exec.Status, "a correctly-bound result must complete the execution")
+	})
+
+	t.Run("absent gateway is rejected with no event", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		victim := testutil.CreateTestDevice(t, st, "victim-absent")
+		execID := seedVictimExecution(t, st, victim)
+		worker := control.NewInboxWorker(st, nil, nil, signer, slog.Default(), bindingRegistry(t, victim, liveGateway))
+		mux := worker.NewMux()
+
+		require.Error(t, mux.ProcessTask(context.Background(),
+			signedExecResultTask(t, victim, execID, "")),
+			"an empty gateway_id must be rejected while the registry is enabled")
+
+		exec, err := st.Queries().GetExecutionByID(context.Background(), execID)
+		require.NoError(t, err)
+		assert.NotEqual(t, "success", exec.Status, "a result with no gateway binding must not complete the execution")
+	})
+
+	t.Run("mismatched gateway is rejected with no event", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		victim := testutil.CreateTestDevice(t, st, "victim-mismatch")
+		execID := seedVictimExecution(t, st, victim)
+		// Device is live on gw-A; the task claims gw-B (a compromised /
+		// confused gateway forging the victim's result).
+		worker := control.NewInboxWorker(st, nil, nil, signer, slog.Default(), bindingRegistry(t, victim, liveGateway))
+		mux := worker.NewMux()
+
+		require.Error(t, mux.ProcessTask(context.Background(),
+			signedExecResultTask(t, victim, execID, wrongGateway)),
+			"a gateway the device is not live on must not complete its execution")
+
+		exec, err := st.Queries().GetExecutionByID(context.Background(), execID)
+		require.NoError(t, err)
+		assert.NotEqual(t, "success", exec.Status, "a cross-gateway forged result must not complete the execution")
+	})
+}
+
+// TestHandleExecutionOutputChunk_RejectsCrossDeviceSpoof pins the cross-device
+// ownership guard on the output-chunk path: the execution ID is non-secret, so
+// an attacker device must not be able to splice forged output onto the
+// victim's execution stream by supplying its ID. The owning device's chunk is
+// still appended. (No registry wired here — this isolates the ownership guard
+// from the gateway binding.)
+func TestHandleExecutionOutputChunk_RejectsCrossDeviceSpoof(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	mux := worker.NewMux()
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	victimDevice := testutil.CreateTestDevice(t, st, "victim-chunk")
+	attackerDevice := testutil.CreateTestDevice(t, st, "attacker-chunk")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Chunk Owner", int(pm.ActionType_ACTION_TYPE_SHELL))
+
+	executionID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "execution",
+		StreamID:   executionID,
+		EventType:  "ExecutionCreated",
+		Data: map[string]any{
+			"device_id":       victimDevice,
+			"action_id":       actionID,
+			"action_type":     int(pm.ActionType_ACTION_TYPE_SHELL),
+			"desired_state":   0,
+			"params":          map[string]any{},
+			"timeout_seconds": 300,
+			"executed_at":     time.Now().Format(time.RFC3339Nano),
+		},
+		ActorType: "user",
+		ActorID:   adminID,
+	}))
+
+	// Attacker device sends a chunk for the victim's execution.
+	forged := newTask(t, taskqueue.TypeExecutionOutputChunk, taskqueue.ExecutionOutputChunkPayload{
+		DeviceID:    attackerDevice,
+		ExecutionID: executionID,
+		Stream:      "stdout",
+		Data:        "FORGED",
+		Sequence:    1,
+	})
+	// Dropped (no event), not a retryable error — the execution is owned by
+	// another device.
+	require.NoError(t, mux.ProcessTask(context.Background(), forged))
+	assert.Equal(t, 0, countExecutionEvents(t, st, executionID, "OutputChunk"),
+		"a chunk from a non-owning device must not be appended to the victim's stream")
+
+	// The owning (victim) device's chunk IS appended.
+	legit := newTask(t, taskqueue.TypeExecutionOutputChunk, taskqueue.ExecutionOutputChunkPayload{
+		DeviceID:    victimDevice,
+		ExecutionID: executionID,
+		Stream:      "stdout",
+		Data:        "real output\n",
+		Sequence:    2,
+	})
+	require.NoError(t, mux.ProcessTask(context.Background(), legit))
+	assert.Equal(t, 1, countExecutionEvents(t, st, executionID, "OutputChunk"),
+		"the owning device's chunk must be appended")
+}
+
+// TestHandleRevokeLuksDeviceKeyResult_RejectsCrossDeviceSpoof pins that a
+// revocation result only ever lands a terminal event on a stream a REAL
+// RevokeLuksDeviceKey request minted. An attacker reporting a result for a
+// (device, action) with no outstanding request is dropped — the worker must
+// not fabricate an orphan luks_key stream from attacker-supplied input. The
+// device that actually has an outstanding request gets its terminal event.
+func TestHandleRevokeLuksDeviceKeyResult_RejectsCrossDeviceSpoof(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	mux := worker.NewMux()
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	victimDevice := testutil.CreateTestDevice(t, st, "victim-luks")
+	attackerDevice := testutil.CreateTestDevice(t, st, "attacker-luks")
+	victimAction := testutil.NewID()
+
+	// A genuine revocation request exists for (victimDevice, victimAction),
+	// mirroring the API's phase-1 Requested append on a freshly minted stream.
+	luksStreamID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "luks_key",
+		StreamID:   luksStreamID,
+		EventType:  "LuksDeviceKeyRevocationRequested",
+		Data: map[string]any{
+			"device_id":    victimDevice,
+			"action_id":    victimAction,
+			"requested_at": time.Now().UTC().Format(time.RFC3339Nano),
+		},
+		ActorType: "user",
+		ActorID:   adminID,
+	}))
+
+	// Attacker reports a result for the victim's action from its own device —
+	// no outstanding request for (attackerDevice, victimAction).
+	forged := newTask(t, taskqueue.TypeRevokeLuksDeviceKeyResult, taskqueue.RevokeLuksDeviceKeyResultPayload{
+		DeviceID: attackerDevice,
+		ActionID: victimAction,
+		Success:  true,
+	})
+	require.NoError(t, mux.ProcessTask(context.Background(), forged))
+
+	// No terminal event must have landed on the victim's revocation stream
+	// (nor anywhere) for the forged report.
+	events, err := st.Queries().LoadStream(context.Background(), db.LoadStreamParams{
+		StreamType: "luks_key",
+		StreamID:   luksStreamID,
+	})
+	require.NoError(t, err)
+	for _, e := range events {
+		assert.NotEqual(t, "LuksDeviceKeyRevoked", e.EventType,
+			"a forged cross-device report must not mark the victim's revocation")
+		assert.NotEqual(t, "LuksDeviceKeyRevocationFailed", e.EventType,
+			"a forged cross-device report must not fail the victim's revocation")
+	}
+	// And no fresh orphan stream was fabricated from attacker input.
+	allRevoked, err := st.Queries().LoadEventsByType(context.Background(), db.LoadEventsByTypeParams{
+		EventType: "LuksDeviceKeyRevoked", Limit: 1000, Offset: 0,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, allRevoked, "no Revoked event must exist anywhere after the forged report")
+
+	// The victim reporting its OWN outstanding revocation lands the terminal
+	// event on the SAME stream the request minted.
+	legit := newTask(t, taskqueue.TypeRevokeLuksDeviceKeyResult, taskqueue.RevokeLuksDeviceKeyResultPayload{
+		DeviceID: victimDevice,
+		ActionID: victimAction,
+		Success:  true,
+	})
+	require.NoError(t, mux.ProcessTask(context.Background(), legit))
+
+	events, err = st.Queries().LoadStream(context.Background(), db.LoadStreamParams{
+		StreamType: "luks_key",
+		StreamID:   luksStreamID,
+	})
+	require.NoError(t, err)
+	found := false
+	for _, e := range events {
+		if e.EventType == "LuksDeviceKeyRevoked" {
+			found = true
+		}
+	}
+	assert.True(t, found, "the device's own outstanding revocation must be marked on the request's stream")
+}
+
+// TestHandleTerminalAuditChunk_RejectsUnownedSession pins the terminal-audit
+// ownership + UPDATE-only contract:
+//
+//   - a chunk whose claimed (device, user) does not match the session row is
+//     dropped: the stored owners are unchanged and the forged bytes are not
+//     appended;
+//   - a chunk for an unknown session_id creates NO placeholder row (the
+//     append query is UPDATE-only);
+//   - a correctly-owned chunk is appended.
+func TestHandleTerminalAuditChunk_RejectsUnownedSession(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	mux := worker.NewTerminalAuditMux()
+	ctx := context.Background()
+
+	sessionV := testutil.NewID()
+	victimDevice := testutil.CreateTestDevice(t, st, "victim-tty")
+	attackerDevice := testutil.CreateTestDevice(t, st, "attacker-tty")
+	victimUser := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	attackerUser := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	// Seed the session owned by (victimDevice, victimUser) via the ONLY
+	// query allowed to bootstrap a row.
+	require.NoError(t, st.Queries().UpsertTerminalSessionStart(ctx, db.UpsertTerminalSessionStartParams{
+		SessionID: sessionV,
+		DeviceID:  victimDevice,
+		UserID:    victimUser,
+		TtyUser:   "pm-tty-" + victimUser,
+		StartedAt: time.Now().UTC(),
+		Cols:      80,
+		Rows:      24,
+	}))
+
+	// Attacker sends a chunk claiming to own the victim's session.
+	forged := newTask(t, taskqueue.TypeTerminalAuditChunk, taskqueue.TerminalAuditChunkPayload{
+		SessionID: sessionV,
+		DeviceID:  attackerDevice,
+		UserID:    attackerUser,
+		Data:      []byte("FORGED KEYSTROKES"),
+		Sequence:  1,
+	})
+	require.NoError(t, mux.ProcessTask(ctx, forged))
+
+	row, err := st.Queries().GetTerminalSession(ctx, sessionV)
+	require.NoError(t, err)
+	assert.Equal(t, victimDevice, row.DeviceID, "forged chunk must not rewrite the session owner device")
+	assert.Equal(t, victimUser, row.UserID, "forged chunk must not rewrite the session owner user")
+	assert.Empty(t, row.Input, "forged stdin must not be appended to the victim's session")
+	assert.Equal(t, int32(0), row.ChunkCount)
+
+	// A chunk for an UNKNOWN session must create no placeholder row.
+	unknownSession := testutil.NewID()
+	orphan := newTask(t, taskqueue.TypeTerminalAuditChunk, taskqueue.TerminalAuditChunkPayload{
+		SessionID: unknownSession,
+		DeviceID:  attackerDevice,
+		UserID:    attackerUser,
+		Data:      []byte("ORPHAN"),
+		Sequence:  1,
+	})
+	require.NoError(t, mux.ProcessTask(ctx, orphan))
+	_, err = st.Queries().GetTerminalSession(ctx, unknownSession)
+	require.Error(t, err, "an audit chunk for an unknown session must not create a placeholder row")
+
+	// The genuine owner's chunk IS appended, using owners derived from the row.
+	legit := newTask(t, taskqueue.TypeTerminalAuditChunk, taskqueue.TerminalAuditChunkPayload{
+		SessionID: sessionV,
+		DeviceID:  victimDevice,
+		UserID:    victimUser,
+		Data:      []byte("ls -la\n"),
+		Sequence:  1,
+	})
+	require.NoError(t, mux.ProcessTask(ctx, legit))
+	row, err = st.Queries().GetTerminalSession(ctx, sessionV)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("ls -la\n"), row.Input, "the owning user's chunk must be appended")
+	assert.Equal(t, int32(1), row.ChunkCount)
 }

--- a/internal/gateway/registry/binding.go
+++ b/internal/gateway/registry/binding.go
@@ -1,0 +1,68 @@
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// DeviceGatewayLookup is the one-method view of the registry the
+// device→gateway binding check needs. *Registry satisfies it; tests inject a
+// real registry over a fake backend. Kept narrow so consumers (the
+// InternalService handlers and the control:inbox worker) don't depend on the
+// full registry surface.
+type DeviceGatewayLookup interface {
+	LookupDeviceGateway(ctx context.Context, deviceID string) (string, error)
+}
+
+// Sentinel results of CheckDeviceGatewayBinding. Callers map these to their own
+// protocol: the InternalService handlers to connect codes
+// (InvalidArgument / FailedPrecondition / PermissionDenied), the control:inbox
+// worker to a SkipRetry-wrapped drop. Check with errors.Is.
+var (
+	// ErrBindingGatewayMissing: a resolver is wired but the request/event
+	// carried no gateway_id, so it cannot be bound. Reject (InvalidArgument).
+	ErrBindingGatewayMissing = errors.New("registry: gateway_id is required for the device→gateway binding")
+	// ErrBindingDeviceNotLive: the device is not live on any gateway, so the
+	// binding cannot be confirmed. Fail closed (FailedPrecondition), never
+	// allow-on-unknown — that is the bypass an attacker wants.
+	ErrBindingDeviceNotLive = errors.New("registry: device is not live on any gateway")
+	// ErrBindingMismatch: the calling gateway is not the one the device is live
+	// on — a compromised/confused gateway reaching for another device's secrets
+	// or forging its events. Reject (PermissionDenied).
+	ErrBindingMismatch = errors.New("registry: device is not live on the calling gateway")
+)
+
+// CheckDeviceGatewayBinding confines a device-origin operation to the gateway
+// the device is actually live on. The gateway peer-class mTLS cert is shared
+// and carries no per-gateway identity, so the operation self-asserts
+// claimedGatewayID and this cross-references it against the device→gateway
+// routing binding the agent's own mTLS-authenticated heartbeat wrote into the
+// registry. It is the single source of the binding policy, shared by the
+// InternalService handlers and the control:inbox worker.
+//
+// Fail-closed:
+//   - lookup nil → nil (allow). The single-gateway / non-HA exception: the
+//     routing registry is only wired where more than one gateway can connect.
+//   - claimedGatewayID empty → ErrBindingGatewayMissing.
+//   - ErrNoGateway → ErrBindingDeviceNotLive (never allow when we can't tell).
+//   - actual ≠ claimed → ErrBindingMismatch.
+func CheckDeviceGatewayBinding(ctx context.Context, lookup DeviceGatewayLookup, deviceID, claimedGatewayID string) error {
+	if lookup == nil {
+		return nil // single-gateway / non-HA: binding not enforced (documented)
+	}
+	if claimedGatewayID == "" {
+		return ErrBindingGatewayMissing
+	}
+	actualGatewayID, err := lookup.LookupDeviceGateway(ctx, deviceID)
+	if err != nil {
+		if errors.Is(err, ErrNoGateway) {
+			return ErrBindingDeviceNotLive
+		}
+		return fmt.Errorf("registry: device→gateway binding lookup failed: %w", err)
+	}
+	if actualGatewayID != claimedGatewayID {
+		return ErrBindingMismatch
+	}
+	return nil
+}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -404,6 +404,7 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 		DeviceID:     deviceID,
 		Hostname:     hello.Hostname,
 		AgentVersion: hello.AgentVersion,
+		GatewayID:    h.gatewayID,
 	}); err != nil {
 		h.logger.Warn("failed to enqueue device hello", "error", err)
 	}
@@ -513,7 +514,7 @@ func (h *AgentHandler) handleHeartbeat(ctx context.Context, deviceID string, hb 
 	// were dead writes into the event store. Live metrics will need a
 	// dedicated DeviceMetricsPayload + projection if we ever want them.
 	_ = hb
-	payload := taskqueue.DeviceHeartbeatPayload{DeviceID: deviceID}
+	payload := taskqueue.DeviceHeartbeatPayload{DeviceID: deviceID, GatewayID: h.gatewayID}
 	// Refresh the device→gateway TTL on every heartbeat. Best-effort:
 	// a Valkey failure here is logged but does not refuse the
 	// heartbeat — the existing UpdateLastSeen path is the source of
@@ -555,6 +556,7 @@ func (h *AgentHandler) handleActionResult(ctx context.Context, deviceID string, 
 	return h.aqClient.EnqueueToControl(taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
 		DeviceID:         deviceID,
 		ActionResultJSON: resultJSON,
+		GatewayID:        h.gatewayID,
 	})
 }
 
@@ -650,6 +652,7 @@ func (h *AgentHandler) handleOutputChunk(ctx context.Context, deviceID string, c
 		Stream:      streamType,
 		Data:        string(chunk.Data),
 		Sequence:    int64(chunk.Sequence),
+		GatewayID:   h.gatewayID,
 	})
 }
 
@@ -668,11 +671,12 @@ func (h *AgentHandler) handleQueryResult(deviceID string, result *pm.OSQueryResu
 		rowsBytes = []byte("[]")
 	}
 	return h.aqClient.EnqueueToControl(taskqueue.TypeOSQueryResult, taskqueue.OSQueryResultPayload{
-		DeviceID: deviceID,
-		QueryID:  result.QueryId,
-		Success:  result.Success,
-		Error:    result.Error,
-		RowsJSON: rowsBytes,
+		DeviceID:  deviceID,
+		QueryID:   result.QueryId,
+		Success:   result.Success,
+		Error:     result.Error,
+		RowsJSON:  rowsBytes,
+		GatewayID: h.gatewayID,
 	})
 }
 
@@ -697,8 +701,9 @@ func (h *AgentHandler) handleInventory(deviceID string, inventory *pm.DeviceInve
 		})
 	}
 	return h.aqClient.EnqueueToControl(taskqueue.TypeInventoryUpdate, taskqueue.InventoryUpdatePayload{
-		DeviceID: deviceID,
-		Tables:   tables,
+		DeviceID:  deviceID,
+		Tables:    tables,
+		GatewayID: h.gatewayID,
 	})
 }
 
@@ -714,6 +719,7 @@ func (h *AgentHandler) handleSecurityAlert(ctx context.Context, deviceID string,
 		AlertType: alert.Type.String(),
 		Message:   alert.Message,
 		Details:   alert.Details,
+		GatewayID: h.gatewayID,
 	})
 }
 
@@ -767,10 +773,11 @@ func (h *AgentHandler) handleRevokeLuksResult(deviceID string, result *pm.Revoke
 		"error", result.Error,
 	)
 	return h.aqClient.EnqueueToControl(taskqueue.TypeRevokeLuksDeviceKeyResult, taskqueue.RevokeLuksDeviceKeyResultPayload{
-		DeviceID: deviceID,
-		ActionID: result.ActionId,
-		Success:  result.Success,
-		Error:    result.Error,
+		DeviceID:  deviceID,
+		ActionID:  result.ActionId,
+		Success:   result.Success,
+		Error:     result.Error,
+		GatewayID: h.gatewayID,
 	})
 }
 
@@ -781,11 +788,12 @@ func (h *AgentHandler) handleLogQueryResult(deviceID string, result *pm.LogQuery
 		"success", result.Success,
 	)
 	return h.aqClient.EnqueueToControl(taskqueue.TypeLogQueryResult, taskqueue.LogQueryResultPayload{
-		DeviceID: deviceID,
-		QueryID:  result.QueryId,
-		Success:  result.Success,
-		Error:    result.Error,
-		Logs:     result.Logs,
+		DeviceID:  deviceID,
+		QueryID:   result.QueryId,
+		Success:   result.Success,
+		Error:     result.Error,
+		Logs:      result.Logs,
+		GatewayID: h.gatewayID,
 	})
 }
 

--- a/internal/handler/agent_action_result_test.go
+++ b/internal/handler/agent_action_result_test.go
@@ -66,7 +66,7 @@ func setupForActionResult(t *testing.T) (*AgentHandler, *fakeEnqueuer, *recordin
 	fake := &fakeEnqueuer{}
 	hh := &AgentHandler{
 		aqClient:     fake,
-		controlProxy: NewControlProxy(srv.Client(), srv.URL),
+		controlProxy: NewControlProxy(srv.Client(), srv.URL, "test-gateway"),
 		logger:       slog.Default(),
 	}
 	return hh, fake, stub

--- a/internal/handler/agent_luks_test.go
+++ b/internal/handler/agent_luks_test.go
@@ -92,7 +92,7 @@ func setupAgentForLuksTest(t *testing.T) (*AgentHandler, *recordingInternal) {
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
 
-	proxy := NewControlProxy(srv.Client(), srv.URL)
+	proxy := NewControlProxy(srv.Client(), srv.URL, "test-gateway")
 	mgr := connection.NewManager()
 	return &AgentHandler{
 		manager:      mgr,

--- a/internal/handler/agent_rpc_test.go
+++ b/internal/handler/agent_rpc_test.go
@@ -78,7 +78,7 @@ func setupAgentForRPCTest(t *testing.T) (*AgentHandler, *recordingInternalForRPC
 	t.Cleanup(srv.Close)
 
 	hh := &AgentHandler{
-		controlProxy: NewControlProxy(srv.Client(), srv.URL),
+		controlProxy: NewControlProxy(srv.Client(), srv.URL, "test-gateway"),
 		logger:       slog.Default(),
 	}
 	return hh, stub

--- a/internal/handler/agent_stream_test.go
+++ b/internal/handler/agent_stream_test.go
@@ -104,7 +104,7 @@ func newStreamFixture(t *testing.T, requireTLS bool) *streamFixture {
 
 	// 2) Real ControlProxy + connection.Manager + recording fakes for
 	// the queue and per-device worker manager.
-	proxy := NewControlProxy(internalSrv.Client(), internalSrv.URL)
+	proxy := NewControlProxy(internalSrv.Client(), internalSrv.URL, "test-gateway")
 	mgr := connection.NewManager()
 	worker := &fakeStreamWorkerManager{}
 	h := &AgentHandler{

--- a/internal/handler/control_proxy.go
+++ b/internal/handler/control_proxy.go
@@ -26,6 +26,14 @@ type ControlProxy struct {
 // this gateway's identity, stamped onto device-origin requests for the
 // device→gateway binding check on control.
 func NewControlProxy(httpClient *http.Client, controlURL, gatewayID string) *ControlProxy {
+	// Fail fast on an empty gatewayID: a gateway that stamps "" onto every
+	// device-origin request has control reject ALL of them (the binding check
+	// returns "gateway_id is required") — a total, silent outage. cmd/gateway
+	// guarantees a non-empty id (config or a startup ULID), so this only fires
+	// on a future wiring bug, and a loud crash beats a silently-dead gateway.
+	if gatewayID == "" {
+		panic("handler.NewControlProxy: gatewayID must not be empty")
+	}
 	client := pmv1connect.NewInternalServiceClient(httpClient, controlURL)
 	return &ControlProxy{client: client, gatewayID: gatewayID}
 }

--- a/internal/handler/control_proxy.go
+++ b/internal/handler/control_proxy.go
@@ -14,19 +14,27 @@ import (
 // This replaces direct database access for synchronous operations that need credential handling.
 type ControlProxy struct {
 	client pmv1connect.InternalServiceClient
+	// gatewayID is this gateway's own identity, stamped onto every device-origin
+	// request so control can confine the call to the device→gateway routing
+	// binding (the gateway peer mTLS cert is shared and carries no per-gateway
+	// identity, so the request must self-assert it). See server#403.
+	gatewayID string
 }
 
 // NewControlProxy creates a new control proxy pointing at the given control server URL.
-// The httpClient should be configured with mTLS when TLS is enabled.
-func NewControlProxy(httpClient *http.Client, controlURL string) *ControlProxy {
+// The httpClient should be configured with mTLS when TLS is enabled. gatewayID is
+// this gateway's identity, stamped onto device-origin requests for the
+// device→gateway binding check on control.
+func NewControlProxy(httpClient *http.Client, controlURL, gatewayID string) *ControlProxy {
 	client := pmv1connect.NewInternalServiceClient(httpClient, controlURL)
-	return &ControlProxy{client: client}
+	return &ControlProxy{client: client, gatewayID: gatewayID}
 }
 
 // VerifyDevice checks that a device exists and is not deleted on the control server.
 func (p *ControlProxy) VerifyDevice(ctx context.Context, deviceID string) error {
 	_, err := p.client.VerifyDevice(ctx, connect.NewRequest(&pm.VerifyDeviceRequest{
-		DeviceId: deviceID,
+		DeviceId:  deviceID,
+		GatewayId: p.gatewayID,
 	}))
 	return err
 }
@@ -34,7 +42,8 @@ func (p *ControlProxy) VerifyDevice(ctx context.Context, deviceID string) error 
 // SyncActions resolves all assigned actions for a device via the control server.
 func (p *ControlProxy) SyncActions(ctx context.Context, deviceID string) (*pm.SyncActionsResponse, error) {
 	resp, err := p.client.ProxySyncActions(ctx, connect.NewRequest(&pm.InternalSyncActionsRequest{
-		DeviceId: deviceID,
+		DeviceId:  deviceID,
+		GatewayId: p.gatewayID,
 	}))
 	if err != nil {
 		return nil, err
@@ -45,8 +54,9 @@ func (p *ControlProxy) SyncActions(ctx context.Context, deviceID string) (*pm.Sy
 // ValidateLuksToken validates and consumes a one-time LUKS token via the control server.
 func (p *ControlProxy) ValidateLuksToken(ctx context.Context, deviceID, token string) (*pm.ValidateLuksTokenResponse, error) {
 	resp, err := p.client.ProxyValidateLuksToken(ctx, connect.NewRequest(&pm.InternalValidateLuksTokenRequest{
-		DeviceId: deviceID,
-		Token:    token,
+		DeviceId:  deviceID,
+		Token:     token,
+		GatewayId: p.gatewayID,
 	}))
 	if err != nil {
 		return nil, err
@@ -57,8 +67,9 @@ func (p *ControlProxy) ValidateLuksToken(ctx context.Context, deviceID, token st
 // GetLuksKey retrieves and decrypts the current LUKS key via the control server.
 func (p *ControlProxy) GetLuksKey(ctx context.Context, deviceID, actionID string) (*pm.GetLuksKeyResponse, error) {
 	resp, err := p.client.ProxyGetLuksKey(ctx, connect.NewRequest(&pm.InternalGetLuksKeyRequest{
-		DeviceId: deviceID,
-		ActionId: actionID,
+		DeviceId:  deviceID,
+		ActionId:  actionID,
+		GatewayId: p.gatewayID,
 	}))
 	if err != nil {
 		return nil, err
@@ -74,6 +85,7 @@ func (p *ControlProxy) StoreLuksKey(ctx context.Context, deviceID, actionID, dev
 		DevicePath:     devicePath,
 		Passphrase:     passphrase,
 		RotationReason: reason,
+		GatewayId:      p.gatewayID,
 	}))
 	if err != nil {
 		return nil, err
@@ -87,6 +99,7 @@ func (p *ControlProxy) StoreLpsPasswords(ctx context.Context, deviceID, actionID
 		DeviceId:  deviceID,
 		ActionId:  actionID,
 		Rotations: rotations,
+		GatewayId: p.gatewayID,
 	}))
 	return err
 }

--- a/internal/handler/control_proxy_test.go
+++ b/internal/handler/control_proxy_test.go
@@ -173,7 +173,7 @@ func setupProxy(t *testing.T) (*handler.ControlProxy, *fakeInternalService) {
 	mux.Handle(path, h)
 	srv := httptest.NewServer(mux)
 	t.Cleanup(srv.Close)
-	return handler.NewControlProxy(srv.Client(), srv.URL), fake
+	return handler.NewControlProxy(srv.Client(), srv.URL, "test-gateway"), fake
 }
 
 // =============================================================================
@@ -334,7 +334,7 @@ func TestControlProxy_TransportError_Propagates(t *testing.T) {
 	// Point the proxy at a URL no server is listening on. The Connect
 	// client should surface a transport-class error rather than a
 	// silent zero-value response.
-	p := handler.NewControlProxy(http.DefaultClient, "http://127.0.0.1:1") // port 1 — never listening
+	p := handler.NewControlProxy(http.DefaultClient, "http://127.0.0.1:1", "test-gateway") // port 1 — never listening
 	_, err := p.SyncActions(context.Background(), "dev-1")
 	require.Error(t, err, "transport-level failure must propagate; a zero-value response would be silently bad")
 }

--- a/internal/handler/control_proxy_test.go
+++ b/internal/handler/control_proxy_test.go
@@ -339,6 +339,15 @@ func TestControlProxy_TransportError_Propagates(t *testing.T) {
 	require.Error(t, err, "transport-level failure must propagate; a zero-value response would be silently bad")
 }
 
+// TestNewControlProxy_PanicsOnEmptyGatewayID pins the fail-fast: a gateway that
+// stamps an empty gateway_id onto every device-origin request has control reject
+// ALL of them, a total silent outage. The constructor must crash loudly instead.
+func TestNewControlProxy_PanicsOnEmptyGatewayID(t *testing.T) {
+	require.Panics(t, func() {
+		handler.NewControlProxy(http.DefaultClient, "https://control.invalid", "")
+	}, "an empty gatewayID must fail fast at construction")
+}
+
 // =============================================================================
 // GatewayServiceHandler smoke tests — list / terminate via the
 // in-memory TerminalSessionRegistry. The handler is otherwise a thin

--- a/internal/handler/terminal_bridge.go
+++ b/internal/handler/terminal_bridge.go
@@ -35,15 +35,27 @@ type TerminalBridgeHandler struct {
 	sessions     *connection.TerminalSessionRegistry
 	controlProxy *ControlProxy
 	aqClient     *taskqueue.Client
-	logger       *slog.Logger
+	// gatewayID self-asserts which gateway is relaying the terminal-stdin
+	// audit chunks this bridge tees to control:inbox. The inbox worker
+	// binds it against the session's device→gateway routing so a
+	// confused/compromised gateway cannot forge audit bytes for a device
+	// live elsewhere. Empty in single-gateway deployments (binding
+	// disabled there, matching the rest of the device-origin pipeline).
+	gatewayID string
+	logger    *slog.Logger
 }
 
-// NewTerminalBridgeHandler constructs a bridge handler.
+// NewTerminalBridgeHandler constructs a bridge handler. gatewayID is
+// the relaying gateway's self-asserted identity, stamped onto the
+// terminal-audit chunks so the control:inbox worker can bind them to
+// the device→gateway routing registry; pass "" in single-gateway
+// deployments where the binding is not enforced.
 func NewTerminalBridgeHandler(
 	manager *connection.Manager,
 	sessions *connection.TerminalSessionRegistry,
 	controlProxy *ControlProxy,
 	aqClient *taskqueue.Client,
+	gatewayID string,
 	logger *slog.Logger,
 ) *TerminalBridgeHandler {
 	return &TerminalBridgeHandler{
@@ -51,6 +63,7 @@ func NewTerminalBridgeHandler(
 		sessions:     sessions,
 		controlProxy: controlProxy,
 		aqClient:     aqClient,
+		gatewayID:    gatewayID,
 		logger:       logger,
 	}
 }
@@ -524,6 +537,7 @@ func (h *TerminalBridgeHandler) enqueueAuditChunk(
 		UserID:    validated.UserId,
 		Data:      data,
 		Sequence:  seq,
+		GatewayID: h.gatewayID,
 	}
 	if err := h.aqClient.EnqueueToControl(taskqueue.TypeTerminalAuditChunk, payload); err != nil {
 		h.logger.Debug("failed to enqueue terminal audit chunk",

--- a/internal/store/generated/terminal_sessions.sql.go
+++ b/internal/store/generated/terminal_sessions.sql.go
@@ -11,85 +11,67 @@ import (
 )
 
 const appendTerminalSessionChunk = `-- name: AppendTerminalSessionChunk :exec
-INSERT INTO terminal_sessions (
-    session_id, device_id, user_id, tty_user,
-    started_at,
-    input,
-    input_truncated,
-    last_sequence,
-    chunk_count
-) VALUES (
-    $1, $2, $3, '',
-    NOW(),
-    -- Postgres has no LEFT(bytea, int); use substring for bytea
-    -- clamping. ` + "`" + `FROM 1 FOR n` + "`" + ` is 1-indexed inclusive.
-    substring($4::bytea FROM 1 FOR 8388608),
-    octet_length($4::bytea) > 8388608,
-    $5,
-    1
-)
-ON CONFLICT (session_id) DO UPDATE SET
-    input = terminal_sessions.input
-          || substring(EXCLUDED.input FROM 1 FOR
-                       GREATEST(0, 8388608 - octet_length(terminal_sessions.input))),
-    input_truncated = terminal_sessions.input_truncated
-                   OR (octet_length(EXCLUDED.input)
-                       > GREATEST(0, 8388608 - octet_length(terminal_sessions.input))),
-    last_sequence = EXCLUDED.last_sequence,
-    chunk_count   = terminal_sessions.chunk_count + 1
-  WHERE EXCLUDED.last_sequence > terminal_sessions.last_sequence
+UPDATE terminal_sessions SET
+    input = input
+          || substring($1::bytea FROM 1 FOR
+                       GREATEST(0, 8388608 - octet_length(input))),
+    input_truncated = input_truncated
+                   OR (octet_length($1::bytea)
+                       > GREATEST(0, 8388608 - octet_length(input))),
+    last_sequence = $2,
+    chunk_count   = chunk_count + 1
+  WHERE session_id = $3
+    AND $2 > last_sequence
 `
 
 type AppendTerminalSessionChunkParams struct {
-	SessionID string `json:"session_id"`
-	DeviceID  string `json:"device_id"`
-	UserID    string `json:"user_id"`
 	Input     []byte `json:"input"`
 	Sequence  int64  `json:"sequence"`
+	SessionID string `json:"session_id"`
 }
 
 // Called from the TerminalAuditChunk inbox handler.
 //
-// Two safety guards layered into a single statement:
+// UPDATE-only (defense in depth, server SA-C2 / device-origin trust
+// binding): this statement can ONLY append stdin onto an EXISTING
+// session row, keyed by session_id. It deliberately does NOT INSERT
+// and does NOT set device_id/user_id — those owners are written once,
+// by UpsertTerminalSessionStart from the mTLS-authenticated lifecycle
+// event. A compromised gateway relaying a forged chunk for an unknown
+// session therefore updates zero rows (the inbox handler additionally
+// drops unknown sessions before reaching here), so it can never mint a
+// placeholder row with attacker-chosen owners that a later Started
+// event would bless. Ownership of the chunk is checked in the handler
+// against the session row BEFORE this runs.
 //
-//   - Sequence idempotency. The gateway's audit batcher stamps
-//     each chunk with a strictly-monotonic per-session sequence.
-//     We only apply the append when the incoming sequence is
-//     greater than the stored last_sequence, so a duplicate or
-//     reordered retry from Asynq is a no-op rather than a
-//     double-append that would corrupt `input` and inflate
-//     chunk_count.
+// Two safety guards retained from the previous upsert form:
 //
-//   - 8 MiB cap on `input`. The appended payload is clamped to
-//     the remaining capacity (LEFT(bytes, GREATEST(0, cap -
-//     current))) so a single oversized chunk still produces a
+//   - Sequence idempotency. The gateway's audit batcher stamps each
+//     chunk with a strictly-monotonic per-session sequence. We only
+//     apply the append when the incoming sequence is greater than the
+//     stored last_sequence, so a duplicate or reordered retry from
+//     Asynq is a no-op rather than a double-append that would corrupt
+//     `input` and inflate chunk_count.
+//
+//   - 8 MiB cap on `input`. The appended payload is clamped to the
+//     remaining capacity so a single oversized chunk still produces a
 //     well-formed row and flips input_truncated to mark the loss.
-//     Subsequent chunks clamp to zero bytes until retention or
-//     archive runs.
+//     Subsequent chunks clamp to zero bytes until retention or archive
+//     runs.
 //
-// The INSERT branch creates a placeholder when a chunk outruns
-// the lifecycle Started event. device_id and user_id come from
-// the chunk payload, so the placeholder is well-formed.
-//
-// Concurrency note: this query's last_sequence guard defends
-// against Asynq REDELIVERY of a single task (same sequence twice),
-// but a NAIVE deployment with two workers dequeuing different
-// sequences for the same session in parallel could still drop
-// bytes on the loser of the race (whichever commits last fails
-// the guard and no-ops). To close that window, the control server
-// processes TypeTerminalAuditChunk on a dedicated Asynq server
-// with Concurrency=1 (queue ControlTerminalAuditQueue, wired up
-// in cmd/control/main.go). As long as the operator does not flip
-// that concurrency or re-route the task type to the main inbox
-// queue, per-session chunks commit strictly in sequence order.
+// Concurrency note: the last_sequence guard defends against Asynq
+// REDELIVERY of a single task (same sequence twice), but a NAIVE
+// deployment with two workers dequeuing different sequences for the
+// same session in parallel could still drop bytes on the loser of the
+// race (whichever commits last fails the guard and no-ops). To close
+// that window, the control server processes TypeTerminalAuditChunk on
+// a dedicated Asynq server with Concurrency=1 (queue
+// ControlTerminalAuditQueue, wired up in cmd/control/main.go). As long
+// as the operator does not flip that concurrency or re-route the task
+// type to the main inbox queue, per-session chunks commit strictly in
+// sequence order.
 func (q *Queries) AppendTerminalSessionChunk(ctx context.Context, arg AppendTerminalSessionChunkParams) error {
-	_, err := q.db.Exec(ctx, appendTerminalSessionChunk,
-		arg.SessionID,
-		arg.DeviceID,
-		arg.UserID,
-		arg.Input,
-		arg.Sequence,
-	)
+	_, err := q.db.Exec(ctx, appendTerminalSessionChunk, arg.Input, arg.Sequence, arg.SessionID)
 	return err
 }
 
@@ -431,12 +413,15 @@ type UpsertTerminalSessionStartParams struct {
 //     duplicate or out-of-order retries do not corrupt `input`
 //     or stutter chunk_count.
 //
-// Called from the TerminalSessionStarted inbox handler. The INSERT
-// is idempotent per session_id because a TerminalAuditChunk task
-// can race ahead of the lifecycle event on a busy inbox — the chunk
-// handler has its own INSERT ... ON CONFLICT that creates a
-// placeholder row, and this upsert then fills in the real metadata
-// without clobbering any stdin already appended.
+// Called from the TerminalSessionStarted inbox handler. This is the
+// ONLY query that bootstraps a terminal_sessions row — the
+// AppendTerminalSessionChunk path below is UPDATE-only and cannot
+// INSERT, so an audit chunk can never mint an owner-bearing row with
+// attacker-chosen device_id/user_id. If a chunk races ahead of the
+// lifecycle Started event it is dropped by the inbox handler (the
+// session does not exist yet); the agent re-tees on the next batch
+// once Started has created the row. The upsert remains idempotent per
+// session_id so a redelivered Started event is harmless.
 func (q *Queries) UpsertTerminalSessionStart(ctx context.Context, arg UpsertTerminalSessionStartParams) error {
 	_, err := q.db.Exec(ctx, upsertTerminalSessionStart,
 		arg.SessionID,

--- a/internal/store/migrations/011_events_append_only.sql
+++ b/internal/store/migrations/011_events_append_only.sql
@@ -1,0 +1,40 @@
+-- 011_events_append_only.sql
+--
+-- Defense-in-depth: enforce the event store's append-only invariant at the
+-- DATABASE level, not only in application code. The events table is the
+-- system's audit trail and the single source of truth every projection
+-- rebuilds from; a compromised gateway, a buggy query, or an operator with
+-- direct DB access must not be able to rewrite or erase history. A BEFORE
+-- trigger RAISEs on any UPDATE / DELETE / TRUNCATE, so only INSERT (append)
+-- and SELECT (read) succeed.
+--
+-- RebuildAll only TRUNCATEs *_projection tables, never public.events, so this
+-- guard does not interfere with projection rebuilds. The application-layer
+-- invariant (no sqlc query mutates events) is pinned separately by
+-- TestNoSQLCQueryMutatesEvents; this trigger is the belt to that suspenders.
+
+-- +goose Up
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.events_block_mutation() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION 'events is append-only: % is not permitted on public.events', TG_OP;
+END;
+$$;
+-- +goose StatementEnd
+
+-- Row-level guard for UPDATE/DELETE.
+CREATE TRIGGER events_block_row_mutation
+    BEFORE UPDATE OR DELETE ON public.events
+    FOR EACH ROW EXECUTE FUNCTION public.events_block_mutation();
+
+-- Statement-level guard for TRUNCATE (TRUNCATE fires no per-row triggers).
+CREATE TRIGGER events_block_truncate
+    BEFORE TRUNCATE ON public.events
+    FOR EACH STATEMENT EXECUTE FUNCTION public.events_block_mutation();
+
+-- +goose Down
+DROP TRIGGER IF EXISTS events_block_truncate ON public.events;
+DROP TRIGGER IF EXISTS events_block_row_mutation ON public.events;
+DROP FUNCTION IF EXISTS public.events_block_mutation();

--- a/internal/store/queries/terminal_sessions.sql
+++ b/internal/store/queries/terminal_sessions.sql
@@ -14,12 +14,15 @@
 --      or stutter chunk_count.
 
 -- name: UpsertTerminalSessionStart :exec
--- Called from the TerminalSessionStarted inbox handler. The INSERT
--- is idempotent per session_id because a TerminalAuditChunk task
--- can race ahead of the lifecycle event on a busy inbox — the chunk
--- handler has its own INSERT ... ON CONFLICT that creates a
--- placeholder row, and this upsert then fills in the real metadata
--- without clobbering any stdin already appended.
+-- Called from the TerminalSessionStarted inbox handler. This is the
+-- ONLY query that bootstraps a terminal_sessions row — the
+-- AppendTerminalSessionChunk path below is UPDATE-only and cannot
+-- INSERT, so an audit chunk can never mint an owner-bearing row with
+-- attacker-chosen device_id/user_id. If a chunk races ahead of the
+-- lifecycle Started event it is dropped by the inbox handler (the
+-- session does not exist yet); the agent re-tees on the next batch
+-- once Started has created the row. The upsert remains idempotent per
+-- session_id so a redelivered Started event is harmless.
 INSERT INTO terminal_sessions (
     session_id, device_id, user_id, tty_user,
     started_at, cols, rows
@@ -38,65 +41,55 @@ ON CONFLICT (session_id) DO UPDATE SET
 -- name: AppendTerminalSessionChunk :exec
 -- Called from the TerminalAuditChunk inbox handler.
 --
--- Two safety guards layered into a single statement:
+-- UPDATE-only (defense in depth, server SA-C2 / device-origin trust
+-- binding): this statement can ONLY append stdin onto an EXISTING
+-- session row, keyed by session_id. It deliberately does NOT INSERT
+-- and does NOT set device_id/user_id — those owners are written once,
+-- by UpsertTerminalSessionStart from the mTLS-authenticated lifecycle
+-- event. A compromised gateway relaying a forged chunk for an unknown
+-- session therefore updates zero rows (the inbox handler additionally
+-- drops unknown sessions before reaching here), so it can never mint a
+-- placeholder row with attacker-chosen owners that a later Started
+-- event would bless. Ownership of the chunk is checked in the handler
+-- against the session row BEFORE this runs.
 --
---   * Sequence idempotency. The gateway's audit batcher stamps
---     each chunk with a strictly-monotonic per-session sequence.
---     We only apply the append when the incoming sequence is
---     greater than the stored last_sequence, so a duplicate or
---     reordered retry from Asynq is a no-op rather than a
---     double-append that would corrupt `input` and inflate
---     chunk_count.
+-- Two safety guards retained from the previous upsert form:
 --
---   * 8 MiB cap on `input`. The appended payload is clamped to
---     the remaining capacity (LEFT(bytes, GREATEST(0, cap -
---     current))) so a single oversized chunk still produces a
+--   * Sequence idempotency. The gateway's audit batcher stamps each
+--     chunk with a strictly-monotonic per-session sequence. We only
+--     apply the append when the incoming sequence is greater than the
+--     stored last_sequence, so a duplicate or reordered retry from
+--     Asynq is a no-op rather than a double-append that would corrupt
+--     `input` and inflate chunk_count.
+--
+--   * 8 MiB cap on `input`. The appended payload is clamped to the
+--     remaining capacity so a single oversized chunk still produces a
 --     well-formed row and flips input_truncated to mark the loss.
---     Subsequent chunks clamp to zero bytes until retention or
---     archive runs.
+--     Subsequent chunks clamp to zero bytes until retention or archive
+--     runs.
 --
--- The INSERT branch creates a placeholder when a chunk outruns
--- the lifecycle Started event. device_id and user_id come from
--- the chunk payload, so the placeholder is well-formed.
---
--- Concurrency note: this query's last_sequence guard defends
--- against Asynq REDELIVERY of a single task (same sequence twice),
--- but a NAIVE deployment with two workers dequeuing different
--- sequences for the same session in parallel could still drop
--- bytes on the loser of the race (whichever commits last fails
--- the guard and no-ops). To close that window, the control server
--- processes TypeTerminalAuditChunk on a dedicated Asynq server
--- with Concurrency=1 (queue ControlTerminalAuditQueue, wired up
--- in cmd/control/main.go). As long as the operator does not flip
--- that concurrency or re-route the task type to the main inbox
--- queue, per-session chunks commit strictly in sequence order.
-INSERT INTO terminal_sessions (
-    session_id, device_id, user_id, tty_user,
-    started_at,
-    input,
-    input_truncated,
-    last_sequence,
-    chunk_count
-) VALUES (
-    sqlc.arg(session_id), sqlc.arg(device_id), sqlc.arg(user_id), '',
-    NOW(),
-    -- Postgres has no LEFT(bytea, int); use substring for bytea
-    -- clamping. `FROM 1 FOR n` is 1-indexed inclusive.
-    substring(sqlc.arg(input)::bytea FROM 1 FOR 8388608),
-    octet_length(sqlc.arg(input)::bytea) > 8388608,
-    sqlc.arg(sequence),
-    1
-)
-ON CONFLICT (session_id) DO UPDATE SET
-    input = terminal_sessions.input
-          || substring(EXCLUDED.input FROM 1 FOR
-                       GREATEST(0, 8388608 - octet_length(terminal_sessions.input))),
-    input_truncated = terminal_sessions.input_truncated
-                   OR (octet_length(EXCLUDED.input)
-                       > GREATEST(0, 8388608 - octet_length(terminal_sessions.input))),
-    last_sequence = EXCLUDED.last_sequence,
-    chunk_count   = terminal_sessions.chunk_count + 1
-  WHERE EXCLUDED.last_sequence > terminal_sessions.last_sequence;
+-- Concurrency note: the last_sequence guard defends against Asynq
+-- REDELIVERY of a single task (same sequence twice), but a NAIVE
+-- deployment with two workers dequeuing different sequences for the
+-- same session in parallel could still drop bytes on the loser of the
+-- race (whichever commits last fails the guard and no-ops). To close
+-- that window, the control server processes TypeTerminalAuditChunk on
+-- a dedicated Asynq server with Concurrency=1 (queue
+-- ControlTerminalAuditQueue, wired up in cmd/control/main.go). As long
+-- as the operator does not flip that concurrency or re-route the task
+-- type to the main inbox queue, per-session chunks commit strictly in
+-- sequence order.
+UPDATE terminal_sessions SET
+    input = input
+          || substring(sqlc.arg(input)::bytea FROM 1 FOR
+                       GREATEST(0, 8388608 - octet_length(input))),
+    input_truncated = input_truncated
+                   OR (octet_length(sqlc.arg(input)::bytea)
+                       > GREATEST(0, 8388608 - octet_length(input))),
+    last_sequence = sqlc.arg(sequence),
+    chunk_count   = chunk_count + 1
+  WHERE session_id = sqlc.arg(session_id)
+    AND sqlc.arg(sequence) > last_sequence;
 
 -- name: MarkTerminalSessionStopped :exec
 -- TerminalSessionStopped — clean end of session from the bridge.

--- a/internal/store/store_append_only_test.go
+++ b/internal/store/store_append_only_test.go
@@ -1,0 +1,144 @@
+package store_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// WS2 #3 — the events table is the audit trail and the single source of truth
+// every projection rebuilds from. Append-only is enforced at the DB level
+// (migration 011), not only in app code, so a compromised gateway / buggy
+// query / operator with DB access cannot rewrite or erase history. These tests
+// drive the REAL trigger on a live Postgres and prove the rejection path is the
+// point — the invariant survives even a malicious raw query, not just the
+// absence of such a query today.
+
+func appendAuditEvent(t *testing.T, st *store.Store) string {
+	t.Helper()
+	streamID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "device",
+		StreamID:   streamID,
+		EventType:  "DeviceRegistered",
+		Data:       map[string]any{"hostname": "append-only-host"},
+		ActorType:  "system",
+		ActorID:    "system",
+	}))
+	return streamID
+}
+
+func totalEvents(t *testing.T, st *store.Store) int {
+	t.Helper()
+	var n int
+	require.NoError(t, st.TestingPool().QueryRow(context.Background(), "SELECT count(*) FROM public.events").Scan(&n))
+	return n
+}
+
+func TestEvents_RejectsUpdate(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	streamID := appendAuditEvent(t, st)
+
+	var before string
+	require.NoError(t, st.TestingPool().QueryRow(ctx, "SELECT data::text FROM public.events WHERE stream_id=$1", streamID).Scan(&before))
+
+	_, err := st.TestingPool().Exec(ctx, `UPDATE public.events SET data='{"tampered":true}'::jsonb WHERE stream_id=$1`, streamID)
+	require.Error(t, err, "UPDATE on the append-only events table must be rejected by the DB trigger")
+	assert.Contains(t, err.Error(), "append-only")
+
+	var after string
+	require.NoError(t, st.TestingPool().QueryRow(ctx, "SELECT data::text FROM public.events WHERE stream_id=$1", streamID).Scan(&after))
+	assert.Equal(t, before, after, "the row's data must be byte-for-byte unchanged after the rejected UPDATE")
+}
+
+func TestEvents_RejectsDelete(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	streamID := appendAuditEvent(t, st)
+
+	_, err := st.TestingPool().Exec(ctx, "DELETE FROM public.events WHERE stream_id=$1", streamID)
+	require.Error(t, err, "DELETE on the append-only events table must be rejected")
+	assert.Contains(t, err.Error(), "append-only")
+
+	var n int
+	require.NoError(t, st.TestingPool().QueryRow(ctx, "SELECT count(*) FROM public.events WHERE stream_id=$1", streamID).Scan(&n))
+	assert.Equal(t, 1, n, "the event row must still be present after the rejected DELETE")
+}
+
+func TestEvents_RejectsTruncate(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	appendAuditEvent(t, st)
+	before := totalEvents(t, st)
+	require.Positive(t, before)
+
+	// A plain TRUNCATE is already blocked by the FK from child tables; CASCADE
+	// bypasses that barrier and exercises the append-only trigger itself, which
+	// must RAISE before anything is truncated.
+	_, err := st.TestingPool().Exec(ctx, "TRUNCATE public.events CASCADE")
+	require.Error(t, err, "TRUNCATE on the append-only events table must be rejected")
+	assert.Contains(t, err.Error(), "append-only",
+		"TRUNCATE must be rejected by the append-only trigger, not (only) the FK constraint")
+	assert.Equal(t, before, totalEvents(t, st), "TRUNCATE must be rejected and leave every event in place")
+}
+
+// TestEvents_AppendAndRebuildStillWork proves the guard is INSERT/SELECT-only:
+// normal appends succeed and RebuildAll (which TRUNCATEs only *_projection, never
+// events) is unaffected by the trigger.
+func TestEvents_AppendAndRebuildStillWork(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	streamID := appendAuditEvent(t, st) // append must still succeed with the trigger installed
+	require.NotEmpty(t, streamID)
+
+	res, err := st.RebuildAll(ctx, "users")
+	require.NoError(t, err, "RebuildAll must still succeed — it TRUNCATEs only *_projection, never the events table")
+	require.NotNil(t, res)
+}
+
+// TestNoSQLCQueryMutatesEvents is the self-discovering app-layer half of the
+// invariant: scan the SQL sources + generated query code for any statement that
+// UPDATEs/DELETEs/TRUNCATEs the BARE events table (*_projection and events_*
+// identifiers are legitimately mutated). The DB trigger would reject such a query
+// at runtime; this keeps it from being introduced silently in the first place.
+func TestNoSQLCQueryMutatesEvents(t *testing.T) {
+	// `events\b` matches only the bare table: `events_foo` has no word boundary
+	// after `events` (the `_` is a word char), and `*_projection` never ends in
+	// `events`.
+	re := regexp.MustCompile(`(?is)(update\s+(public\.)?events\b|delete\s+from\s+(public\.)?events\b|truncate\s+(table\s+)?(public\.)?events\b)`)
+
+	scanned := 0
+	var violations []string
+	for _, dir := range []string{"queries", "generated"} {
+		entries, err := os.ReadDir(dir)
+		require.NoErrorf(t, err, "read %s", dir)
+		for _, e := range entries {
+			if e.IsDir() {
+				continue
+			}
+			name := e.Name()
+			if !strings.HasSuffix(name, ".sql") && !strings.HasSuffix(name, ".sql.go") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, name))
+			require.NoError(t, err)
+			scanned++
+			for _, m := range re.FindAllString(string(data), -1) {
+				violations = append(violations, name+": "+strings.Join(strings.Fields(m), " "))
+			}
+		}
+	}
+	require.Positive(t, scanned, "matches-zero guard: scanned no SQL files — the events-mutation check is mis-scoped")
+	assert.Empty(t, violations, "no query may UPDATE/DELETE/TRUNCATE the append-only events table: %v", violations)
+}

--- a/internal/store/terminal_sessions_test.go
+++ b/internal/store/terminal_sessions_test.go
@@ -16,12 +16,13 @@ import (
 // Integration tests for the terminal_sessions table + its sqlc
 // queries. Cover the critical invariants of the rc7 reshape:
 //
-//   - Lifecycle Start creates a complete row.
+//   - Lifecycle Start creates a complete row (and is the ONLY query
+//     that may INSERT one — see the UPDATE-only append below).
 //   - Chunks append to `input`, bump chunk_count, and track
 //     last_sequence for idempotency.
-//   - A chunk arriving before the lifecycle Start creates a
-//     placeholder row that the Start-upsert then fills in
-//     without clobbering already-accumulated stdin.
+//   - A chunk arriving before the lifecycle Start is a no-op: the
+//     append query is UPDATE-only and never mints a placeholder, so a
+//     forged chunk cannot create an owner-bearing row.
 //   - Duplicate or out-of-order chunk sequences are rejected
 //     (last_sequence guard).
 //   - Oversized input clamps at the 8 MiB cap and flips
@@ -47,11 +48,15 @@ func upsertStartParams(sessionID, deviceID, userID string) db.UpsertTerminalSess
 	}
 }
 
-func chunkParams(sessionID, deviceID, userID string, data []byte, seq int64) db.AppendTerminalSessionChunkParams {
+// chunkParams builds an append-chunk parameter set. The append query is
+// UPDATE-only and keyed solely by session_id — it no longer carries
+// device_id/user_id (those are write-once, set by
+// UpsertTerminalSessionStart), so ownership cannot be spoofed via a
+// chunk. deviceID/userID are retained as helper arguments only to keep
+// the call sites self-documenting about which session a chunk targets.
+func chunkParams(sessionID, _deviceID, _userID string, data []byte, seq int64) db.AppendTerminalSessionChunkParams {
 	return db.AppendTerminalSessionChunkParams{
 		SessionID: sessionID,
-		DeviceID:  deviceID,
-		UserID:    userID,
 		Input:     data,
 		Sequence:  seq,
 	}
@@ -81,43 +86,50 @@ func TestTerminalSessions_StartCreatesRow(t *testing.T) {
 	assert.Equal(t, int64(0), row.LastSequence)
 }
 
-func TestTerminalSessions_ChunkBeforeStartCreatesPlaceholder(t *testing.T) {
-	// Covers the inbox-worker race: an AuditChunk task landing
-	// before the TerminalSessionStarted event is processed. The
-	// chunk handler must create a row on its own (minimally
-	// populated) so the stdin isn't dropped. The later Start
-	// upsert fills in the missing metadata without losing data.
+func TestTerminalSessions_ChunkBeforeStartIsNoop(t *testing.T) {
+	// Contract change (device-origin trust binding / SA-C2): the
+	// append-chunk query is UPDATE-only and must NEVER create a row.
+	// A chunk that races ahead of the TerminalSessionStarted event
+	// updates zero rows — the session does not exist yet — so no
+	// placeholder is minted. This is the defense-in-depth half of the
+	// inbox fix: a compromised gateway forging a chunk for a session
+	// it does not own can no longer materialise an owner-bearing row
+	// with attacker-chosen device_id/user_id and have it back-filled.
+	// The data loss is bounded to the pre-Start window; the agent
+	// re-tees on the next batch once Start has created the row.
 	st := testutil.SetupPostgres(t)
 	ctx := context.Background()
 	q := st.Queries()
 	sid := testutil.NewID()
 
+	// Chunk before any Start — must be a silent no-op, not an error,
+	// and must NOT create a row.
 	err := q.AppendTerminalSessionChunk(ctx, chunkParams(sid, "dev-2", "user-2", []byte("early\n"), 1))
-	require.NoError(t, err)
+	require.NoError(t, err, "an orphan chunk must no-op, not error")
+
+	_, err = q.GetTerminalSession(ctx, sid)
+	require.Error(t, err, "an audit chunk must never create a session row")
+
+	// Now the Start arrives — it is the ONLY query that bootstraps the
+	// row, with its own (authoritative, mTLS-sourced) owners.
+	require.NoError(t, q.UpsertTerminalSessionStart(ctx, upsertStartParams(sid, "dev-2", "user-2")))
 
 	row, err := q.GetTerminalSession(ctx, sid)
 	require.NoError(t, err)
 	assert.Equal(t, "dev-2", row.DeviceID)
 	assert.Equal(t, "user-2", row.UserID)
-	assert.Empty(t, row.TtyUser, "tty_user stays empty until the Start upsert fills it")
-	assert.Equal(t, int32(1), row.ChunkCount)
-	assert.Equal(t, int64(1), row.LastSequence)
-	assert.Equal(t, []byte("early\n"), row.Input)
+	assert.Equal(t, "pm-tty-user-2", row.TtyUser)
+	assert.Equal(t, int32(0), row.ChunkCount, "the pre-Start chunk was dropped, not retained")
+	assert.Empty(t, row.Input, "no stdin carried over from before Start")
+	assert.Equal(t, int64(0), row.LastSequence)
 
-	// Now the Start arrives — upsert must merge metadata without
-	// overwriting the already-captured stdin.
-	startParams := upsertStartParams(sid, "dev-2", "user-2")
-	err = q.UpsertTerminalSessionStart(ctx, startParams)
-	require.NoError(t, err)
-
+	// A chunk AFTER Start appends normally onto the existing row.
+	require.NoError(t, q.AppendTerminalSessionChunk(ctx, chunkParams(sid, "dev-2", "user-2", []byte("late\n"), 1)))
 	row, err = q.GetTerminalSession(ctx, sid)
 	require.NoError(t, err)
-	assert.Equal(t, "pm-tty-user-2", row.TtyUser, "Start upsert fills in tty_user")
-	assert.Equal(t, int32(80), row.Cols)
-	assert.Equal(t, int32(24), row.Rows)
-	assert.Equal(t, int32(1), row.ChunkCount, "chunk_count preserved across Start upsert")
-	assert.Equal(t, []byte("early\n"), row.Input, "stdin preserved across Start upsert")
-	assert.Equal(t, int64(1), row.LastSequence, "last_sequence preserved across Start upsert")
+	assert.Equal(t, int32(1), row.ChunkCount)
+	assert.Equal(t, int64(1), row.LastSequence)
+	assert.Equal(t, []byte("late\n"), row.Input)
 }
 
 func TestTerminalSessions_ChunksAppendInOrder(t *testing.T) {
@@ -236,14 +248,16 @@ func TestTerminalSessions_InputCapClampsAndFlagsTruncation(t *testing.T) {
 	assert.Equal(t, int64(3), row.LastSequence)
 }
 
-func TestTerminalSessions_OversizedFirstChunkClampsOnInsert(t *testing.T) {
-	// Pathological first chunk: larger than the entire cap,
-	// arriving before any Start. The INSERT branch must clamp
-	// to the cap and set input_truncated from the get-go.
+func TestTerminalSessions_OversizedFirstChunkClampsOnAppend(t *testing.T) {
+	// Pathological first chunk: larger than the entire cap. The
+	// append (against the row bootstrapped by Start) must clamp to the
+	// cap and set input_truncated from the first byte over.
 	st := testutil.SetupPostgres(t)
 	ctx := context.Background()
 	q := st.Queries()
 	sid := testutil.NewID()
+
+	require.NoError(t, q.UpsertTerminalSessionStart(ctx, upsertStartParams(sid, "dev-big", "user-big")))
 
 	payload := bytes.Repeat([]byte{'X'}, inputCapBytes+1024)
 	require.NoError(t, q.AppendTerminalSessionChunk(ctx, chunkParams(sid, "dev-big", "user-big", payload, 1)))

--- a/internal/taskqueue/payloads.go
+++ b/internal/taskqueue/payloads.go
@@ -75,6 +75,13 @@ type DeviceHelloPayload struct {
 	DeviceID     string `json:"device_id"`
 	Hostname     string `json:"hostname"`
 	AgentVersion string `json:"agent_version"`
+	// GatewayID self-asserts which gateway relayed this device-origin
+	// task. The control:inbox worker cross-references it against the
+	// device→gateway routing binding (registry.CheckDeviceGatewayBinding)
+	// to confine a device-origin event to the gateway the device is
+	// actually live on — the peer-class gateway mTLS cert carries no
+	// per-gateway identity, so this is the only binding signal.
+	GatewayID string `json:"gateway_id"`
 }
 
 // DeviceHeartbeatPayload is the payload for TypeDeviceHeartbeat tasks.
@@ -91,6 +98,8 @@ type DeviceHelloPayload struct {
 type DeviceHeartbeatPayload struct {
 	DeviceID     string `json:"device_id"`
 	AgentVersion string `json:"agent_version,omitempty"`
+	// GatewayID — see DeviceHelloPayload.GatewayID.
+	GatewayID string `json:"gateway_id"`
 }
 
 // ExecutionResultPayload is the payload for TypeExecutionResult tasks.
@@ -99,6 +108,8 @@ type ExecutionResultPayload struct {
 	DeviceID string `json:"device_id"`
 	// ActionResultJSON is the protojson-serialized pm.ActionResult.
 	ActionResultJSON []byte `json:"action_result_json"`
+	// GatewayID — see DeviceHelloPayload.GatewayID.
+	GatewayID string `json:"gateway_id"`
 }
 
 // ExecutionOutputChunkPayload is the payload for TypeExecutionOutputChunk tasks.
@@ -108,6 +119,8 @@ type ExecutionOutputChunkPayload struct {
 	Stream      string `json:"stream"` // "stdout" or "stderr"
 	Data        string `json:"data"`
 	Sequence    int64  `json:"sequence"`
+	// GatewayID — see DeviceHelloPayload.GatewayID.
+	GatewayID string `json:"gateway_id"`
 }
 
 // OSQueryResultPayload is the payload for TypeOSQueryResult tasks.
@@ -117,12 +130,16 @@ type OSQueryResultPayload struct {
 	Success  bool   `json:"success"`
 	Error    string `json:"error,omitempty"`
 	RowsJSON []byte `json:"rows_json"` // JSON-encoded []map[string]string
+	// GatewayID — see DeviceHelloPayload.GatewayID.
+	GatewayID string `json:"gateway_id"`
 }
 
 // InventoryUpdatePayload is the payload for TypeInventoryUpdate tasks.
 type InventoryUpdatePayload struct {
 	DeviceID string           `json:"device_id"`
 	Tables   []InventoryTable `json:"tables"`
+	// GatewayID — see DeviceHelloPayload.GatewayID.
+	GatewayID string `json:"gateway_id"`
 }
 
 // InventoryTable is a single inventory table in an update.
@@ -137,6 +154,8 @@ type SecurityAlertPayload struct {
 	AlertType string            `json:"alert_type"`
 	Message   string            `json:"message"`
 	Details   map[string]string `json:"details,omitempty"`
+	// GatewayID — see DeviceHelloPayload.GatewayID.
+	GatewayID string `json:"gateway_id"`
 }
 
 // RevokeLuksDeviceKeyResultPayload is the payload for TypeRevokeLuksDeviceKeyResult tasks.
@@ -145,6 +164,8 @@ type RevokeLuksDeviceKeyResultPayload struct {
 	ActionID string `json:"action_id"`
 	Success  bool   `json:"success"`
 	Error    string `json:"error,omitempty"`
+	// GatewayID — see DeviceHelloPayload.GatewayID.
+	GatewayID string `json:"gateway_id"`
 }
 
 // LogQueryResultPayload is the payload for TypeLogQueryResult tasks.
@@ -154,6 +175,8 @@ type LogQueryResultPayload struct {
 	Success  bool   `json:"success"`
 	Error    string `json:"error,omitempty"`
 	Logs     string `json:"logs"`
+	// GatewayID — see DeviceHelloPayload.GatewayID.
+	GatewayID string `json:"gateway_id"`
 }
 
 // TerminalAuditChunkPayload carries a stdin chunk from a terminal
@@ -166,6 +189,11 @@ type TerminalAuditChunkPayload struct {
 	UserID    string `json:"user_id"`
 	Data      []byte `json:"data"`
 	Sequence  int64  `json:"sequence"`
+	// GatewayID — see DeviceHelloPayload.GatewayID. Bound against the
+	// DeviceID the audit chunk claims, so a confused/compromised gateway
+	// cannot relay terminal-stdin audit bytes for a device that is live
+	// on a different gateway.
+	GatewayID string `json:"gateway_id"`
 }
 
 // === Search index payloads (search queue) ===

--- a/internal/taskqueue/payloads_test.go
+++ b/internal/taskqueue/payloads_test.go
@@ -19,16 +19,23 @@ import (
 // is deliberately NOT on the wire (the N008 choice documented on the struct):
 // adding it would fail this test, forcing a conscious contract update rather
 // than silent twin drift.
+//
+// gateway_id (server SA-C2 / #403) is a deliberate addition: the relaying
+// gateway self-asserts its identity so the control:inbox worker can bind the
+// device-origin task to the device→gateway routing registry. It is always
+// emitted (no omitempty) so the binding signal is explicit on the wire even
+// when empty (single-gateway deployments, where the binding is disabled).
 func TestDeviceHelloPayload_WireContract(t *testing.T) {
 	in := taskqueue.DeviceHelloPayload{
 		DeviceID:     "01HXAMPLE",
 		Hostname:     "host-1",
 		AgentVersion: "2026.6.0",
+		GatewayID:    "gw-A",
 	}
 
 	got, err := json.Marshal(in)
 	require.NoError(t, err)
-	assert.JSONEq(t, `{"device_id":"01HXAMPLE","hostname":"host-1","agent_version":"2026.6.0"}`, string(got),
+	assert.JSONEq(t, `{"device_id":"01HXAMPLE","hostname":"host-1","agent_version":"2026.6.0","gateway_id":"gw-A"}`, string(got),
 		"device-hello wire shape changed — agent↔control contract; update both sides deliberately")
 
 	var back taskqueue.DeviceHelloPayload


### PR DESCRIPTION
Binds every device-origin operation crossing the gateway↔control boundary to the authenticated device→gateway routing registry, closing the SA-C2 cluster: a compromised gateway can no longer pull another device's secrets or forge its events. Depends on the `gateway_id` wire field from `manchtools/power-manage-sdk#94` (merged; go.mod replace bumped here).

## What changed (per finding)

- **#1 (critical) — InternalService cross-gateway secret access.** The gateway peer cert is shared and carries no per-gateway identity, so every `device_id`-carrying InternalService request self-asserts a `gateway_id` that control cross-checks (after `Validate`, validate-then-auth) against the registry the agent's own mTLS heartbeat populated. Fail-closed: empty → InvalidArgument, device-not-live → FailedPrecondition (never allow-on-unknown), mismatch → PermissionDenied. `TestInternalHandlers_GatewayBindingIsSelfDiscovering` drives every handler and is completeness-checked against the InternalService descriptor.
- **#2 (high) — control:inbox forged device events.** The shared-key HMAC is necessary-but-not-sufficient; every device-origin inbox handler now also rejects a binding mismatch (`SkipRetry`, no event appended).
- **#5/#7/#8/#10 — cross-device ownership** (the HMAC can't tell devices apart): output chunks confined to the reporting device's execution; a LUKS-revocation result with no outstanding request is dropped (no orphan stream); a terminal audit chunk requires an existing session it owns and `AppendTerminalSessionChunk` is now **UPDATE-only** (sqlc) so it can never INSERT an attacker-owned placeholder.
- **#3 (medium) — DB-level append-only events.** Migration `011` adds a `BEFORE UPDATE/DELETE/TRUNCATE` trigger on `public.events`; `RebuildAll` only TRUNCATEs `*_projection`, so rebuilds are unaffected.

## Design notes

- One shared binding policy (`registry.CheckDeviceGatewayBinding`) consumed by both boundaries — the api side maps its sentinels to connect codes, the inbox side to `SkipRetry` drops. No duplicated policy.
- **Single-gateway bypass:** a `nil` resolver disables the binding — the documented non-HA exception; control wires it whenever the Valkey routing registry is available.
- Binding rejections reach the **gateway**, never the web client (the browser talks to ControlService, not InternalService), so they reuse existing internal error codes — **no new error-code / web-i18n surface** (keeps `TestErrorCodeParityWithTSSDK` green).
- See **ADR 0005**. Full server suite green; standalone + workspace builds green.

Closes #403. Advances #324.
