### PR TITLE
feat(api): enforce device/user-group scope at single-resource gates (part 1 of #7 scope enforcement)

### DIFF
--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -426,6 +426,10 @@ func (h *ActionHandler) DispatchAssignedActions(ctx context.Context, req *connec
 		return nil, err
 	}
 
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "DispatchAssignedActions", req.Msg.DeviceId); err != nil {
+		return nil, err
+	}
+
 	actions, err := h.store.Queries().ListAssignedActionsForDevice(ctx, req.Msg.DeviceId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get assigned actions")
@@ -609,6 +613,10 @@ func (h *ActionHandler) GetExecution(ctx context.Context, req *connect.Request[p
 		return nil, handleGetError(ctx, err, ErrExecutionNotFound, "execution not found")
 	}
 
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "GetExecution", exec.DeviceID); err != nil {
+		return nil, err
+	}
+
 	protoExec := h.executionToProto(exec)
 
 	// Fetch action name
@@ -719,6 +727,10 @@ func (h *ActionHandler) DispatchInstantAction(ctx context.Context, req *connect.
 
 	if !isInstantActionType(req.Msg.InstantAction) {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "invalid instant action type: "+req.Msg.InstantAction.String())
+	}
+
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "DispatchInstantAction", req.Msg.DeviceId); err != nil {
+		return nil, err
 	}
 
 	_, err = h.store.Repos().Device.Get(ctx, store.GetDeviceKey{ID: req.Msg.DeviceId})
@@ -901,6 +913,10 @@ func (h *ActionHandler) CancelExecution(ctx context.Context, req *connect.Reques
 	exec, err := h.store.Repos().Execution.Get(ctx, req.Msg.ExecutionId)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrExecutionNotFound, "execution not found")
+	}
+
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "CancelExecution", exec.DeviceID); err != nil {
+		return nil, err
 	}
 
 	// Cancel only acts on rows that haven't dispatched yet. Past that

--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -21,6 +21,7 @@ import (
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -35,6 +36,10 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "DispatchAction", req.Msg.DeviceId); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/compliance_handler.go
+++ b/internal/api/compliance_handler.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -32,6 +33,10 @@ func (h *ComplianceHandler) GetDeviceCompliance(ctx context.Context, req *connec
 	}
 
 	deviceID := req.Msg.DeviceId
+
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "GetDeviceCompliance", deviceID); err != nil {
+		return nil, err
+	}
 
 	// Enforce the same assignment/owner scope as GetDevice. Without this any
 	// user could read any device's compliance — including detection-script

--- a/internal/api/compliance_handler_test.go
+++ b/internal/api/compliance_handler_test.go
@@ -7,7 +7,6 @@ package api_test
 // the empty-results path.
 
 import (
-	"context"
 	"log/slog"
 	"testing"
 
@@ -52,7 +51,7 @@ func TestGetDeviceCompliance_NoResults_EmptyChecks(t *testing.T) {
 	h, st := newComplianceHandler(t)
 	deviceID := testutil.CreateTestDevice(t, st, "compliance-empty")
 
-	resp, err := h.GetDeviceCompliance(context.Background(),
+	resp, err := h.GetDeviceCompliance(testutil.AdminContext(testutil.NewID()),
 		connect.NewRequest(&pm.GetDeviceComplianceRequest{DeviceId: deviceID}))
 	require.NoError(t, err)
 	assert.Empty(t, resp.Msg.Checks, "device with no compliance results returns empty Checks")
@@ -60,7 +59,7 @@ func TestGetDeviceCompliance_NoResults_EmptyChecks(t *testing.T) {
 
 func TestGetDeviceCompliance_DeviceWithResults_DecodesDetectionOutput(t *testing.T) {
 	h, st := newComplianceHandler(t)
-	ctx := context.Background()
+	ctx := testutil.AdminContext(testutil.NewID())
 
 	deviceID := testutil.CreateTestDevice(t, st, "compliance-with-results")
 	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -109,7 +108,7 @@ func TestGetDeviceCompliance_MissingDetectionOutput_NilCommandOutput(t *testing.
 	// zero-value struct that would falsely look like "ran with empty
 	// output".
 	h, st := newComplianceHandler(t)
-	ctx := context.Background()
+	ctx := testutil.AdminContext(testutil.NewID())
 
 	deviceID := testutil.CreateTestDevice(t, st, "compliance-no-output")
 	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")

--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -403,6 +404,10 @@ func (h *CompliancePolicyHandler) UpdateCompliancePolicyRule(ctx context.Context
 // GetDeviceCompliancePolicyStatus returns the per-policy compliance status for a device.
 func (h *CompliancePolicyHandler) GetDeviceCompliancePolicyStatus(ctx context.Context, req *connect.Request[pm.GetDeviceCompliancePolicyStatusRequest]) (*connect.Response[pm.GetDeviceCompliancePolicyStatusResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "GetDeviceCompliancePolicyStatus", req.Msg.DeviceId); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -145,6 +145,10 @@ func (h *DeviceHandler) GetDevice(ctx context.Context, req *connect.Request[pm.G
 		return nil, err
 	}
 
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "GetDevice", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	device, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{
 		ID:         req.Msg.Id,
 		OwnerScope: userFilterID(ctx, "GetDevice"),
@@ -251,6 +255,10 @@ func (h *DeviceHandler) DeleteDevice(ctx context.Context, req *connect.Request[p
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "DeleteDevice", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -508,6 +516,10 @@ func (h *DeviceHandler) SetDeviceSyncInterval(ctx context.Context, req *connect.
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "SetDeviceSyncInterval", req.Msg.Id); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/logs_handler.go
+++ b/internal/api/logs_handler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/oklog/ulid/v2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 
@@ -38,6 +39,10 @@ func (h *LogsHandler) QueryDeviceLogs(ctx context.Context, req *connect.Request[
 	}
 
 	msg := req.Msg
+
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "QueryDeviceLogs", msg.DeviceId); err != nil {
+		return nil, err
+	}
 
 	// Verify device exists
 	_, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{ID: msg.DeviceId})

--- a/internal/api/logs_handler.go
+++ b/internal/api/logs_handler.go
@@ -114,6 +114,10 @@ func (h *LogsHandler) GetDeviceLogResult(ctx context.Context, req *connect.Reque
 		return nil, apiErrorCtx(ctx, ErrQueryResultNotFound, connect.CodeNotFound, "log query result not found")
 	}
 
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "GetDeviceLogResult", result.DeviceID); err != nil {
+		return nil, err
+	}
+
 	// Auto-expire pending results that have been waiting too long
 	if !result.Completed && time.Since(result.CreatedAt) > logQueryResultTimeout {
 		timeoutErr := "log query timed out: device did not respond within 5 minutes"

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/oklog/ulid/v2"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 
@@ -45,6 +46,10 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 	hasRawSQL := strings.TrimSpace(msg.RawSql) != ""
 	if hasTable == hasRawSQL {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "exactly one of table or raw_sql is required")
+	}
+
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "DispatchOSQuery", msg.DeviceId); err != nil {
+		return nil, err
 	}
 
 	// Verify device exists
@@ -163,6 +168,10 @@ func (h *OSQueryHandler) GetDeviceInventory(ctx context.Context, req *connect.Re
 
 	msg := req.Msg
 
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "GetDeviceInventory", msg.DeviceId); err != nil {
+		return nil, err
+	}
+
 	var rows []store.InventoryTable
 	var err error
 
@@ -203,6 +212,10 @@ func (h *OSQueryHandler) RefreshDeviceInventory(ctx context.Context, req *connec
 	}
 
 	msg := req.Msg
+
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "RefreshDeviceInventory", msg.DeviceId); err != nil {
+		return nil, err
+	}
 
 	// Verify device exists
 	_, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{ID: msg.DeviceId})

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -129,6 +129,10 @@ func (h *OSQueryHandler) GetOSQueryResult(ctx context.Context, req *connect.Requ
 		return nil, apiErrorCtx(ctx, ErrQueryResultNotFound, connect.CodeNotFound, "query result not found")
 	}
 
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "GetOSQueryResult", result.DeviceID); err != nil {
+		return nil, err
+	}
+
 	// Auto-expire pending results that have been waiting too long
 	if !result.Completed && time.Since(result.CreatedAt) > osqueryResultTimeout {
 		timeoutErr := "query timed out: device did not respond within 5 minutes"

--- a/internal/api/scope_enforcement_user_test.go
+++ b/internal/api/scope_enforcement_user_test.go
@@ -1,0 +1,82 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// Finding #3 (user side): a caller holding a TargetUser permission scoped to a
+// user group may act ONLY on users in that group. Before enforcement these
+// handlers used EnforceSelfScope, which waved a user-group-scoped holder through
+// to ANY user (the base permission is in their flat set). Each gate now confines
+// via EnforceUserScopeOrSelf. Validate runs before the scope check, so every
+// request below is otherwise valid — the only thing under test is scope.
+func TestUserGates_UserGroupScopeEnforced(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	userH := api.NewUserHandler(st, slog.Default(), nil)
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	// One scope group; an IN-scope target (member) and an OUT-of-scope target.
+	ug := testutil.CreateTestUserGroup(t, st, actor, "Team A")
+	inScope := testutil.CreateTestUser(t, st, testutil.NewID()+"@in.com", "pass", "user")
+	outScope := testutil.CreateTestUser(t, st, testutil.NewID()+"@out.com", "pass", "user")
+	testutil.AddUserToTestGroup(t, st, actor, ug, inScope)
+
+	// Caller holds each user permission scoped ONLY to ug.
+	perms := []string{"GetUser", "SetUserDisabled", "DeleteUser", "SetUserProvisioningEnabled"}
+	grants := make([]auth.ScopedGrant, len(perms))
+	for i, p := range perms {
+		grants[i] = auth.ScopedGrant{Permission: p, ScopeKind: auth.ScopeKindUserGroup, ScopeID: ug}
+	}
+	scoped := func() context.Context {
+		return testutil.AuthContextScoped(testutil.NewID(), "scoped@test.com", perms, grants)
+	}
+
+	// Each gate, invoked against a target id. Read + mutate, both .Id and .UserId.
+	gates := []struct {
+		name   string
+		invoke func(ctx context.Context, target string) error
+	}{
+		{"GetUser", func(ctx context.Context, id string) error {
+			_, err := userH.GetUser(ctx, connect.NewRequest(&pm.GetUserRequest{Id: id}))
+			return err
+		}},
+		{"SetUserDisabled", func(ctx context.Context, id string) error {
+			_, err := userH.SetUserDisabled(ctx, connect.NewRequest(&pm.SetUserDisabledRequest{Id: id, Disabled: true}))
+			return err
+		}},
+		{"DeleteUser", func(ctx context.Context, id string) error {
+			_, err := userH.DeleteUser(ctx, connect.NewRequest(&pm.DeleteUserRequest{Id: id}))
+			return err
+		}},
+		{"SetUserProvisioningEnabled", func(ctx context.Context, id string) error {
+			_, err := userH.SetUserProvisioningEnabled(ctx, connect.NewRequest(&pm.SetUserProvisioningEnabledRequest{UserId: id, Enabled: true}))
+			return err
+		}},
+	}
+
+	for _, g := range gates {
+		t.Run(g.name+" denies out-of-scope target", func(t *testing.T) {
+			err := g.invoke(scoped(), outScope)
+			require.Error(t, err, "a user-group-scoped caller must not act on a user outside the scope")
+			assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+		})
+	}
+
+	// Sanity: the same scoped caller IS allowed for an in-scope target (proves the
+	// gate confines rather than blanket-denying). GetUser is read-only / safe.
+	t.Run("GetUser allows in-scope target", func(t *testing.T) {
+		_, err := userH.GetUser(scoped(), connect.NewRequest(&pm.GetUserRequest{Id: inScope}))
+		require.NoError(t, err)
+	})
+}

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -233,6 +233,10 @@ func (h *TOTPHandler) AdminDisableUserTOTP(ctx context.Context, req *connect.Req
 
 	targetUserID := req.Msg.UserId
 
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "AdminDisableUserTOTP", targetUserID); err != nil {
+		return nil, err
+	}
+
 	// Check target user exists and has TOTP enabled
 	user, err := h.store.Repos().User.Get(ctx, targetUserID)
 	if err != nil {

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -209,7 +209,7 @@ func (h *UserHandler) GetUser(ctx context.Context, req *connect.Request[pm.GetUs
 		return nil, err
 	}
 
-	if err := auth.EnforceSelfScope(ctx, "GetUser", req.Msg.Id); err != nil {
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "GetUser", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -296,7 +296,7 @@ func (h *UserHandler) UpdateUserEmail(ctx context.Context, req *connect.Request[
 		return nil, err
 	}
 
-	if err := auth.EnforceSelfScope(ctx, "UpdateUserEmail", req.Msg.Id); err != nil {
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "UpdateUserEmail", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -337,7 +337,7 @@ func (h *UserHandler) UpdateUserPassword(ctx context.Context, req *connect.Reque
 		return nil, err
 	}
 
-	if err := auth.EnforceSelfScope(ctx, "UpdateUserPassword", req.Msg.Id); err != nil {
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "UpdateUserPassword", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -405,6 +405,10 @@ func (h *UserHandler) SetUserDisabled(ctx context.Context, req *connect.Request[
 		return nil, err
 	}
 
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "SetUserDisabled", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	// Emit appropriate event
 	eventType := string(eventtypes.UserEnabled)
 	if req.Msg.Disabled {
@@ -461,6 +465,10 @@ func (h *UserHandler) DeleteUser(ctx context.Context, req *connect.Request[pm.De
 		return nil, err
 	}
 
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "DeleteUser", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	// Load user BEFORE delete to get system action IDs for cleanup
 	user, err := h.store.Repos().User.Get(ctx, req.Msg.Id)
 	if err != nil {
@@ -504,7 +512,7 @@ func (h *UserHandler) UpdateUserProfile(ctx context.Context, req *connect.Reques
 		return nil, err
 	}
 
-	if err := auth.EnforceSelfScope(ctx, "UpdateUserProfile", req.Msg.Id); err != nil {
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "UpdateUserProfile", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -604,6 +612,10 @@ func (h *UserHandler) SetUserProvisioningEnabled(ctx context.Context, req *conne
 		return nil, err
 	}
 
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "SetUserProvisioningEnabled", req.Msg.UserId); err != nil {
+		return nil, err
+	}
+
 	enabled := req.Msg.Enabled
 	err = h.store.AppendEvent(ctx, store.Event{
 		StreamType: "user",
@@ -650,6 +662,10 @@ func (h *UserHandler) UpdateUserLinuxUsername(ctx context.Context, req *connect.
 		return nil, err
 	}
 
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "UpdateUserLinuxUsername", req.Msg.UserId); err != nil {
+		return nil, err
+	}
+
 	// Sanitize the username the same way as during creation
 	username := deriveLinuxUsername(req.Msg.LinuxUsername, "")
 	if username == "" {
@@ -688,7 +704,7 @@ func (h *UserHandler) AddUserSshKey(ctx context.Context, req *connect.Request[pm
 		return nil, err
 	}
 
-	if err := auth.EnforceSelfScope(ctx, "AddUserSshKey", req.Msg.UserId); err != nil {
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "AddUserSshKey", req.Msg.UserId); err != nil {
 		return nil, err
 	}
 
@@ -736,7 +752,7 @@ func (h *UserHandler) RemoveUserSshKey(ctx context.Context, req *connect.Request
 		return nil, err
 	}
 
-	if err := auth.EnforceSelfScope(ctx, "RemoveUserSshKey", req.Msg.UserId); err != nil {
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "RemoveUserSshKey", req.Msg.UserId); err != nil {
 		return nil, err
 	}
 
@@ -770,7 +786,7 @@ func (h *UserHandler) UpdateUserSshSettings(ctx context.Context, req *connect.Re
 		return nil, err
 	}
 
-	if err := auth.EnforceSelfScope(ctx, "UpdateUserSshSettings", req.Msg.UserId); err != nil {
+	if err := auth.EnforceUserScopeOrSelf(ctx, newScopeResolver(h.store), "UpdateUserSshSettings", req.Msg.UserId); err != nil {
 		return nil, err
 	}
 

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -228,6 +228,61 @@ func EnforceUnscopedGrantAuthority(ctx context.Context) error {
 	return nil // no scope authority — ordinary admin, allowed
 }
 
+// EnforceUserScopeOrSelf authorizes a user-target action across every grant
+// tier, for handlers that previously used EnforceSelfScope:
+//   - caller holds `permission` as the base — unrestricted OR user-group-scoped:
+//     defer to EnforceUserScope (global ⇒ any target; scoped ⇒ only targets in a
+//     covered user group). The base appears in the flat permission set for BOTH
+//     unrestricted and scoped grants (the scope lives on the grant, not the
+//     permission string), so HasPermission catches a scoped holder and confines
+//     them here rather than waving them through;
+//   - caller holds only `permission:self`: allow only when targetUserID is the
+//     caller's own id;
+//   - otherwise deny.
+func EnforceUserScopeOrSelf(ctx context.Context, resolver ScopeResolver, permission, targetUserID string) error {
+	user, ok := UserFromContext(ctx)
+	if !ok {
+		return connect.NewError(connect.CodeUnauthenticated, errors.New("not authenticated"))
+	}
+	if HasPermission(ctx, permission) {
+		// Holds the base. The flat permission set IS the authority; the scoped
+		// grants only CONFINE. If there is a user_group-scoped grant for this
+		// permission, restrict to it; an unscoped grant (Global) or no scoping
+		// grant at all means unrestricted.
+		f := UserScopeFilterFor(ctx, permission)
+		if f.Global || len(f.GroupIDs) == 0 {
+			return nil
+		}
+		return EnforceUserScope(ctx, resolver, permission, targetUserID)
+	}
+	if HasPermission(ctx, permission+":self") && targetUserID == user.ID {
+		return nil
+	}
+	return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+}
+
+// EnforceDeviceScopeOnBaseTier applies #7 device-group scope confinement ONLY on
+// the base-permission tier — when the caller holds `permission` unrestricted or
+// device-group-scoped (the base is present in the flat permission set for both).
+// A caller holding only `permission:assigned` is left to the assigned-owner SQL
+// filter (the OwnerScope/userFilterID path) and passes through here unblocked.
+// This is the StartTerminal gate, generalized for reuse across device handlers.
+func EnforceDeviceScopeOnBaseTier(ctx context.Context, resolver ScopeResolver, permission, deviceID string) error {
+	if _, ok := UserFromContext(ctx); !ok {
+		return connect.NewError(connect.CodeUnauthenticated, errors.New("not authenticated"))
+	}
+	if !HasPermission(ctx, permission) {
+		return nil // :assigned-only tier — confined by the owner SQL filter, not here
+	}
+	// Holds the base. Confine only if a device_group-scoped grant is attached;
+	// an unscoped grant (Global) or no scoping grant means unrestricted.
+	f := DeviceScopeFilterFor(ctx, permission)
+	if f.Global || len(f.GroupIDs) == 0 {
+		return nil
+	}
+	return EnforceDeviceScope(ctx, resolver, permission, deviceID)
+}
+
 // intersects reports whether a and b share any element.
 func intersects(a, b []string) bool {
 	if len(a) == 0 || len(b) == 0 {

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -246,14 +246,24 @@ func EnforceUserScopeOrSelf(ctx context.Context, resolver ScopeResolver, permiss
 	}
 	if HasPermission(ctx, permission) {
 		// Holds the base. The flat permission set IS the authority; the scoped
-		// grants only CONFINE. If there is a user_group-scoped grant for this
-		// permission, restrict to it; an unscoped grant (Global) or no scoping
-		// grant at all means unrestricted.
+		// grants only CONFINE. A user_group-scoped grant restricts to it; an
+		// unscoped grant (Global) is unrestricted.
 		f := UserScopeFilterFor(ctx, permission)
-		if f.Global || len(f.GroupIDs) == 0 {
+		if f.Global {
 			return nil
 		}
-		return EnforceUserScope(ctx, resolver, permission, targetUserID)
+		if len(f.GroupIDs) > 0 {
+			return EnforceUserScope(ctx, resolver, permission, targetUserID)
+		}
+		// No user_group-scoped grant. Only a COMPLETE absence of scoping grants
+		// for this permission is unrestricted (the AuthContext fixture / a
+		// not-yet-resolved grant). A grant of a DIFFERENT kind fails CLOSED —
+		// defense-in-depth against a wrong-kind grant that rejectUnscopableRole
+		// should already prevent, so it can never read as fleet-wide access.
+		if hasScopedGrant(ctx, permission) {
+			return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+		}
+		return nil
 	}
 	if HasPermission(ctx, permission+":self") && targetUserID == user.ID {
 		return nil
@@ -274,13 +284,38 @@ func EnforceDeviceScopeOnBaseTier(ctx context.Context, resolver ScopeResolver, p
 	if !HasPermission(ctx, permission) {
 		return nil // :assigned-only tier — confined by the owner SQL filter, not here
 	}
-	// Holds the base. Confine only if a device_group-scoped grant is attached;
-	// an unscoped grant (Global) or no scoping grant means unrestricted.
+	// Holds the base. A device_group-scoped grant confines to it; an unscoped
+	// grant (Global) is unrestricted; a wrong-kind grant fails CLOSED (see
+	// EnforceUserScopeOrSelf); only a complete absence of scoping grants is
+	// unrestricted.
 	f := DeviceScopeFilterFor(ctx, permission)
-	if f.Global || len(f.GroupIDs) == 0 {
+	if f.Global {
 		return nil
 	}
-	return EnforceDeviceScope(ctx, resolver, permission, deviceID)
+	if len(f.GroupIDs) > 0 {
+		return EnforceDeviceScope(ctx, resolver, permission, deviceID)
+	}
+	if hasScopedGrant(ctx, permission) {
+		return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+	}
+	return nil
+}
+
+// hasScopedGrant reports whether the caller holds ANY scoped grant for the
+// permission, regardless of scope kind. The base-tier scope checks use it to
+// fail closed when a base holder has a grant of a non-matching kind, rather than
+// treating an empty same-kind filter as unrestricted access.
+func hasScopedGrant(ctx context.Context, permission string) bool {
+	user, ok := UserFromContext(ctx)
+	if !ok {
+		return false
+	}
+	for _, g := range user.ScopedGrants {
+		if g.Permission == permission {
+			return true
+		}
+	}
+	return false
 }
 
 // intersects reports whether a and b share any element.

--- a/internal/auth/scope_tier_test.go
+++ b/internal/auth/scope_tier_test.go
@@ -51,6 +51,17 @@ func TestEnforceUserScopeOrSelf(t *testing.T) {
 		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
 	})
 
+	// Defense-in-depth: a base holder with a scoped grant of the WRONG kind
+	// (a device_group grant on a user-target perm) must fail CLOSED, not be
+	// treated as unrestricted. rejectUnscopableRole should prevent creating
+	// such a grant, but this layer must never read it as fleet-wide access.
+	t.Run("wrong-kind scoped grant fails closed (not unrestricted)", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetUser"}, ScopedGrant{Permission: "GetUser", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		err := EnforceUserScopeOrSelf(ctx, res, "GetUser", "userX")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
 	t.Run("self tier allows only own id", func(t *testing.T) {
 		ctx := ctxWith([]string{"GetUser:self"})
 		assert.NoError(t, EnforceUserScopeOrSelf(ctx, res, "GetUser", "caller"))
@@ -102,6 +113,15 @@ func TestEnforceDeviceScopeOnBaseTier(t *testing.T) {
 	t.Run("assigned-only tier passes through (owner filter handles it)", func(t *testing.T) {
 		ctx := ctxWith([]string{"GetDevice:assigned"})
 		assert.NoError(t, EnforceDeviceScopeOnBaseTier(ctx, res, "GetDevice", "devY"))
+	})
+
+	// Defense-in-depth: a base holder with a wrong-kind scoped grant (a
+	// user_group grant on a device-target perm) fails CLOSED.
+	t.Run("wrong-kind scoped grant fails closed (not unrestricted)", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetDevice"}, ScopedGrant{Permission: "GetDevice", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		err := EnforceDeviceScopeOnBaseTier(ctx, res, "GetDevice", "devX")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
 	})
 
 	t.Run("unauthenticated is denied", func(t *testing.T) {

--- a/internal/auth/scope_tier_test.go
+++ b/internal/auth/scope_tier_test.go
@@ -1,0 +1,112 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ctxWith builds a caller context carrying both the flat permission set (what
+// HasPermission reads) and the detailed scoped grants (what the scope filters
+// read) — mirroring how the JWT claims are populated: a scoped grant's BASE
+// permission is in the flat set, the scope lives in the grant.
+func ctxWith(perms []string, grants ...ScopedGrant) context.Context {
+	return WithUser(context.Background(), &UserContext{ID: "caller", Permissions: perms, ScopedGrants: grants})
+}
+
+func TestEnforceUserScopeOrSelf(t *testing.T) {
+	res := &fakeResolver{userGroups: map[string][]string{
+		"userX":  {"ug1"},
+		"userY":  {"ug2"},
+		"caller": {"ug1"},
+	}}
+
+	t.Run("unrestricted base allows any target", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetUser"}, ScopedGrant{Permission: "GetUser"})
+		assert.NoError(t, EnforceUserScopeOrSelf(ctx, res, "GetUser", "userY"))
+	})
+
+	// Flat base permission with no scoping grant (the AuthContext fixture shape;
+	// in production an unscoped grant is always present) ⇒ unrestricted.
+	t.Run("base perm with no scoped grant is unrestricted", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetUser"})
+		assert.NoError(t, EnforceUserScopeOrSelf(ctx, res, "GetUser", "userY"))
+	})
+
+	t.Run("user-group-scoped allows a target inside the scope", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetUser"}, ScopedGrant{Permission: "GetUser", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		assert.NoError(t, EnforceUserScopeOrSelf(ctx, res, "GetUser", "userX"))
+	})
+
+	// THE load-bearing case: a scoped holder carries the base permission in the
+	// flat set, so a naive HasPermission(base) check would wave them through to
+	// ANY user. They must instead be CONFINED to their scope.
+	t.Run("user-group-scoped is DENIED for a target outside the scope", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetUser"}, ScopedGrant{Permission: "GetUser", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		err := EnforceUserScopeOrSelf(ctx, res, "GetUser", "userY")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("self tier allows only own id", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetUser:self"})
+		assert.NoError(t, EnforceUserScopeOrSelf(ctx, res, "GetUser", "caller"))
+		err := EnforceUserScopeOrSelf(ctx, res, "GetUser", "userX")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("no relevant grant is denied", func(t *testing.T) {
+		ctx := ctxWith([]string{"SomethingElse"})
+		err := EnforceUserScopeOrSelf(ctx, res, "GetUser", "caller")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("unauthenticated is denied", func(t *testing.T) {
+		err := EnforceUserScopeOrSelf(context.Background(), res, "GetUser", "userX")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnauthenticated, codeOf(err))
+	})
+}
+
+func TestEnforceDeviceScopeOnBaseTier(t *testing.T) {
+	res := &fakeResolver{deviceGroups: map[string][]string{
+		"devX": {"dg1"},
+		"devY": {"dg2"},
+	}}
+
+	t.Run("unrestricted base allows any device", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetDevice"}, ScopedGrant{Permission: "GetDevice"})
+		assert.NoError(t, EnforceDeviceScopeOnBaseTier(ctx, res, "GetDevice", "devY"))
+	})
+
+	t.Run("base perm with no scoped grant is unrestricted", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetDevice"})
+		assert.NoError(t, EnforceDeviceScopeOnBaseTier(ctx, res, "GetDevice", "devY"))
+	})
+
+	t.Run("device-group-scoped confines to the scope", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetDevice"}, ScopedGrant{Permission: "GetDevice", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		assert.NoError(t, EnforceDeviceScopeOnBaseTier(ctx, res, "GetDevice", "devX"))
+		err := EnforceDeviceScopeOnBaseTier(ctx, res, "GetDevice", "devY")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	// :assigned-only callers do NOT hold the base permission, so device-group
+	// scope does not apply here — the assigned-owner SQL filter confines them.
+	t.Run("assigned-only tier passes through (owner filter handles it)", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetDevice:assigned"})
+		assert.NoError(t, EnforceDeviceScopeOnBaseTier(ctx, res, "GetDevice", "devY"))
+	})
+
+	t.Run("unauthenticated is denied", func(t *testing.T) {
+		err := EnforceDeviceScopeOnBaseTier(context.Background(), res, "GetDevice", "devX")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnauthenticated, codeOf(err))
+	})
+}


### PR DESCRIPTION
**Part 1 of full-breadth device/user-group scope enforcement (#7 S6 / audit #3).** This lands the single-resource **gate** layer — the IDOR-closing core. The remaining mechanisms (list result-filtering, dispatch fan-out, group-mutation scope, terminal-session ops, and the self-discovering `scopable == enforced` parity test) follow in a part 2.

## What this does

A caller holding a device/user-group-scoped grant may now act only on resources in their scope at every single-resource handler, instead of being waved through to the whole fleet/org.

### Tier-aware helpers (`internal/auth/scope.go`, unit-tested)
- `EnforceUserScopeOrSelf` — base holders (unrestricted OR user-group-scoped) defer to user-group scope; `:self` holders may act only on their own id. Replaces bare `EnforceSelfScope`, which let a user-group-scoped holder reach ANY user (the base permission is in their flat set).
- `EnforceDeviceScopeOnBaseTier` — device-group scope on the base tier; the `:assigned` tier still flows through the existing `OwnerScope` SQL filter (the `StartTerminal` gate, generalized).

The load-bearing model: the flat permission set is the **authority**, scoped grants only **confine** — a scoped grant's base perm is in the flat set, so `HasPermission(base)` is true for a scoped holder and the scope check confines them. A base holder with no scoping grant is unrestricted (matches production, where an unscoped grant is always present).

### Gates threaded
- **User-target (12):** GetUser, UpdateUserEmail/Password/Profile, SetUserDisabled, DeleteUser, UpdateUserSshSettings/LinuxUsername, AddUserSshKey, RemoveUserSshKey, AdminDisableUserTOTP, SetUserProvisioningEnabled.
- **Device-target (~14):** GetDevice, DeleteDevice, SetDeviceSyncInterval, DispatchAction, DispatchInstantAction, DispatchAssignedActions, DispatchOSQuery, Get/RefreshDeviceInventory, QueryDeviceLogs, GetDeviceCompliance, GetDeviceCompliancePolicyStatus, plus the result/execution-by-id gates (GetExecution, CancelExecution, GetOSQueryResult, GetDeviceLogResult) which fetch the row then confine on its device. (`StartTerminal` already enforced.)

`GetDeviceCompliance` had no `requireAuth` (it leaned on the nil-safe owner filter); the scope check now fail-closes on an unauthenticated call, so three logic tests that used a bare `context.Background()` are given an admin context (production always authenticates via the interceptor).

## Scope of this PR
- Validate still runs before the scope check (validate-then-auth).
- Perms enforced only by the **non-gate** mechanisms (lists, dispatch fan-out, group-mutation, terminal sessions) are **unchanged** here — their scope remains advisory until part 2 threads + the parity test forces completeness. No behavior regression: this strictly adds confinement at the gates.

## Tests
- `internal/auth/scope_tier_test.go` — both helpers, incl. the load-bearing case (a scoped holder is denied a target outside their scope, not waved through).
- `TestUserGates_UserGroupScopeEnforced` — drives the real user handlers: a user-group-scoped caller is denied out-of-scope targets across read + mutate gates, allowed an in-scope target.

Advances #7. Part 2 (lists / fan-out / group-mutation / parity test / docs) tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented device-group scoped access control restricting device operations to authorized scopes
  * Added user-group scoped access control for user management and profile operations

* **Bug Fixes**
  * Enhanced authorization enforcement across logs, compliance monitoring, and inventory queries
  * Enforced scope-based access validation for action dispatch and execution operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->