### PR TITLE
feat(rbac): enforce device/user-group scope across all scopable handlers; scopable == enforced (part 2 of #7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,25 @@ Certificate renewal is handled via the `RenewCertificate` RPC — agents present
 
 ### Self-Scope Enforcement (`internal/auth/context.go`)
 
-RPCs with `:self` scoped permissions (e.g., `GetUser:self`, `UpdateUserEmail:self`) enforce that the resource ID matches the caller's user ID. The `auth.EnforceSelfScope()` helper is called in each affected handler after validation. Users with the unrestricted permission (e.g., `GetUser`) can access any resource.
+RPCs with `:self` scoped permissions (e.g., `GetUser:self`, `UpdateUserEmail:self`) enforce that the resource ID matches the caller's user ID. The `auth.EnforceUserScopeOrSelf()` helper is called in each affected user handler after validation (it generalises the old `EnforceSelfScope` to also apply user-group scope — see below). Users with the unrestricted permission (e.g., `GetUser`) can access any resource, subject to group scope.
+
+### Device/User-Group Scope Enforcement (`internal/auth/scope.go`, server#7)
+
+A role grant may carry a **scope** — `device_group:<id>` or `user_group:<id>` — confining every permission in that role to the devices/users in that group. Scope is enforced **uniformly at the handler layer on every scopable permission** (a permission is scopable iff it carries a `TargetKind` of `TargetDevice` / `TargetUser` in `permissions.go`). "Scopable == enforced" is kept honest: there is no advisory-scope allowlist, and `TestScopablePermissions_AllEnforced` (a self-discovering AST parity test in `internal/api`) fails the build if a scopable permission is ever left unenforced, or a non-scopable one is enforced.
+
+Model: the flat permission set is the AUTHORITY (does the caller hold the base permission?), the scoped grants only CONFINE (which targets?). A base holder with no scoping grant is unrestricted; with a same-kind scoped grant, confined to it; with only a wrong-kind grant, denied (fail closed). Five mechanisms cover the surface:
+
+- **Single-resource gates** — `EnforceDeviceScopeOnBaseTier` / `EnforceUserScopeOrSelf` for handlers acting on one device/user id; the `:assigned` / `:self` tier falls through to the existing owner SQL filter.
+- **Group-id direct-match gates** — `EnforceDeviceGroupScope` / `EnforceUserGroupScope` for group-management handlers (the group id itself must be in the caller's scope).
+- **List-row filters** — `DeviceScopeListFilter` / `UserScopeListFilter` confine list rows (by membership for devices/users/executions, by direct id-match for group lists); the matching COUNT query takes the same restriction so pagination totals don't leak the out-of-scope count.
+- **Dispatch fan-out** — `enforceDeviceScopeAll` checks every target device and fails the whole request closed if any is out of scope.
+- **Reconciler cohort** — `TerminalAdminLimited` / `TerminalAdminFull` drive the per-scope pm-tty sudo cohort in `system_actions.go` rather than a request-time gate.
+
+Two safeguards: group **creation** (`CreateStaticDeviceGroup` / `CreateStaticUserGroup`) is org-tier (not scopable) — a brand-new group has no id/members to confine, so it is enforced on the downstream management/membership ops instead of being advisory. And **member-add** (`AddDeviceToGroup` / `AddUserToGroup`) checks both the target group *and* that each member is already in the caller's scope, so a scope-limited admin cannot pull an out-of-scope device/user into a group they control and thereby expand their own reach. See ADR 0006.
+
+### Grant authority: the role-management permission is the sole gate
+
+Assigning or defining roles is gated **solely** by holding the relevant role-management permission (`AssignRoleToUser`, `AssignRoleToUserGroup`, `AddUserToGroup`, `CreateRole`, `UpdateRole`, `CreateUser`). There is **no** grant-only-what-you-hold privilege ceiling: a holder of `AssignRoleToUser` may assign any role, including Admin, without personally holding every permission that role confers. These permissions are powerful by design and meant to be handed out deliberately. What remains enforced and orthogonal: **scope authority** (a scope-limited admin may only grant *within their own scope* — `EnforceGrantScopeAuthority` / `EnforceUnscopedGrantAuthority`), the **atomic last-admin** lockout invariant (server#369), and **scope enforcement at call time** (above).
 
 ### HTTP Server Hardening
 

--- a/cmd/control/README.md
+++ b/cmd/control/README.md
@@ -622,9 +622,13 @@ curl http://localhost:8081/health
 
 The Control Server uses **dynamic role-based access control** with:
 
-1. **Custom Roles** — Administrators define roles as collections of permissions (e.g., "Help Desk" = `GetUser`, `SetUserDisabled`, `ListDevices`). Permissions support scoped variants like `GetUser:self` (own profile only) and `ListDevices:assigned` (assigned devices only). Scoped permissions are enforced at the handler level via `auth.EnforceSelfScope()`, which verifies the resource ID matches the caller's user ID.
+1. **Custom Roles** — Administrators define roles as collections of permissions (e.g., "Help Desk" = `GetUser`, `SetUserDisabled`, `ListDevices`). Permissions support scoped variants like `GetUser:self` (own profile only) and `ListDevices:assigned` (assigned devices only), enforced at the handler level via `auth.EnforceUserScopeOrSelf()` / the owner SQL filter.
 
 2. **User Groups** — Users can be organized into groups. Roles assigned to a group are inherited by all members. Permissions are additive — a user's effective permissions are the union of all directly assigned roles and group-inherited roles.
+
+   **Scoped grants (server#7).** A role assignment may carry a scope — `device_group:<id>` or `user_group:<id>` — confining every permission in that role to the devices/users in that group. Scope is enforced **uniformly on every scopable permission** at the handler layer (single-resource gates, group-id direct-match gates, list-row filters, dispatch fan-out, and the TerminalAdmin reconciler cohort). "Scopable == enforced" is pinned by a self-discovering parity test — no advisory scope. A scope-limited admin is confined to their groups on every read, list, mutation, dispatch, and terminal op. Group *creation* is org-tier (nothing to confine at create time); member-add additionally requires each added device/user to already be in the caller's scope, preventing a scope escape. See `server/docs/adr/0006-scope-enforcement-handler-level-uniform.md`.
+
+   **Grant authority is the role-management permission alone.** Holding `AssignRoleToUser` / `AssignRoleToUserGroup` / `AddUserToGroup` / `CreateRole` / `CreateUser` authorizes assigning or defining **any** role, including Admin — there is no grant-only-what-you-hold ceiling. What remains enforced: scope authority (a scope-limited admin grants only within their own scope) and the atomic last-admin lockout invariant (server#369).
 
 3. **Built-in Roles** — `Admin` (all permissions) and `User` (self-service permissions) are created automatically but can be customized.
 

--- a/docs/adr/0006-scope-enforcement-handler-level-uniform.md
+++ b/docs/adr/0006-scope-enforcement-handler-level-uniform.md
@@ -1,0 +1,113 @@
+# 0006 — Scope enforcement is handler-level and uniform; scopable == enforced
+
+- Status: accepted
+- Date: 2026-06-13
+- Related: server#7 (scoped device-group RBAC pilot), server#369 (atomic
+  last-admin), server#391; WS3 of the SECURITY_HARDENING_WORKPLAN (findings
+  #3/#19, and the grant-ceiling reversal that voids #1/#2/#12); ADR 0000
+  (TerminalAdmin threat model). Builds on PR #405 (role-mgmt is the sole grant
+  gate) and PR #406 (the single-resource gate layer, part 1).
+
+## Context
+
+server#7 introduced **scoped role grants**: a role assignment may carry a scope
+(`device_group:<id>` or `user_group:<id>`), so an actor can hold a permission
+confined to the devices/users in that group. The grant data model, the JWT
+`sgrants` claim, and the scope-authority checks (who may *attach* a scope) all
+shipped. But **only `StartTerminal` actually enforced the scope at call time.**
+Every other TargetDevice/TargetUser handler read the flat permission set, saw the
+base permission present (the scope lives on the grant, not the permission string),
+and waved the caller through to the whole fleet. Scope was therefore **advisory**
+almost everywhere — a scope-limited admin had org-wide reach in practice.
+
+Two adjacent decisions frame this one:
+
+- **No grant ceiling (PR #405).** Holding a role-management permission
+  (`AssignRoleToUser`, `CreateUser`, …) authorizes assigning *any* role,
+  including Admin, with no secondary "do you personally hold every permission you
+  grant" check. The role-management permission is the sole gate. Scope
+  enforcement is a *separate axis* — it confines *which devices/users* an actor
+  may act on, not *which permissions* they may confer — and is still wanted.
+- **Scopable must equal enforced (no advisory scope).** A permission marked
+  scopable (`TargetKind != TargetUnspecified`) that isn't actually enforced is a
+  lie to the operator who scoped it. The fix is to either enforce it or de-scope
+  it — never to keep an allowlist of "scopable but not really" permissions.
+
+## Decision
+
+Enforce device-group / user-group scope **uniformly at the handler layer**, on
+**every** scopable permission, and pin "scopable == enforced" with a
+self-discovering test.
+
+1. **One tiered model, five mechanisms.** The flat permission set is the
+   AUTHORITY (it decides *whether* the actor holds the base permission); the
+   scoped grants only CONFINE (they decide *which* targets). A base holder with
+   no scoping grant is unrestricted (production always carries an unscoped grant
+   for an unscoped role; the test fixtures carry none — both read as
+   unrestricted). A base holder with a same-kind scoped grant is confined to it.
+   A base holder with only a *wrong-kind* grant fails **closed**. The mechanisms,
+   all in `internal/auth/scope.go` + the handlers:
+   - **Single-resource gates** — `EnforceDeviceScopeOnBaseTier` /
+     `EnforceUserScopeOrSelf` for handlers acting on one device/user id (Get,
+     Delete, Dispatch, inventory, logs, compliance, the user gates, …). The
+     `:assigned` / `:self` tier passes through to the existing owner SQL filter.
+   - **Group-id direct-match gates** — `EnforceDeviceGroupScope` /
+     `EnforceUserGroupScope` for group-management handlers (rename, delete,
+     description, windows, get): the GROUP id itself must be one of the caller's
+     scope ids — a direct match, not a membership lookup.
+   - **List-row filters** — `DeviceScopeListFilter` / `UserScopeListFilter`
+     return `(groupIDs, restricted)`; list queries gain a `(scope_restricted
+     bool, scope_group_ids text[])` parameter pair and confine rows by membership
+     (devices/users/executions) or by direct id-match (group lists). The matching
+     COUNT query takes the same restriction so pagination totals stay honest and
+     don't leak the out-of-scope count. `ListActiveTerminalSessions` filters its
+     merged in-memory list the same way.
+   - **Dispatch fan-out** — `enforceDeviceScopeAll` checks *every* target device
+     and fails the whole request closed if any is out of scope (dispatch is
+     mutating; partial/silent execution is worse than a clear denial).
+   - **Reconciler cohort** — `TerminalAdminLimited` / `TerminalAdminFull` are
+     enforced by the per-scope sudo-cohort computation in `system_actions.go`
+     (`switch g.Permission`), not a request-time gate (ADR 0000).
+
+2. **De-scope what cannot be enforced.** Group CREATION
+   (`CreateStaticDeviceGroup`, `CreateStaticUserGroup`) is now **org-tier**
+   (`TargetUnspecified`): a brand-new group has no id and no members, so there is
+   nothing to confine a scope against at create time. Marking it scopable would
+   be advisory-only. Scope is enforced on the downstream management + membership
+   operations instead. (Dynamic-group create was already org-tier per T-S2.)
+
+3. **Membership check on member-add, to stop a scope escape.**
+   `AddDeviceToGroup` / `AddUserToGroup` check BOTH the target group (direct
+   id-match) AND that every device/user being added is **already within the
+   caller's scope** (membership). Without the member check a scope-limited admin
+   could pull any fleet device/user into a group they control and so expand their
+   own scope. Removal needs only the group check — it cannot expand scope.
+
+4. **Self-discovering parity (the load-bearing guard, #19).**
+   `TestScopablePermissions_AllEnforced` AST-scans `internal/api` for permission
+   string-literals passed to the recognized scope functions (and the reconciler's
+   `switch g.Permission`) and asserts the enforced set EQUALS the scopable set
+   from `auth.AllPermissions()`, in both directions. A new TargetDevice/TargetUser
+   permission added without enforcement fails the test; so does enforcing a
+   permission the registry no longer marks scopable (a stale TargetKind). Only the
+   small set of enforcement *mechanisms* is enumerated — forgetting to register a
+   new mechanism fails the test CLOSED (its permissions read as unenforced).
+
+## Consequences
+
+- A scope-limited admin is now genuinely confined to their device/user groups on
+  every read, list, mutation, dispatch, terminal op, and the TTY sudo cohort —
+  not just `StartTerminal`. "Scopable" is now an honest, testable claim.
+- Shared queries used by the scope resolver itself (`ListGroupsForDevice`,
+  `ListUserGroupsForUser`) stay UNFILTERED in SQL — filtering them would corrupt
+  scope resolution — and their handlers filter in Go instead.
+- The scope checks fail closed on an unauthenticated context, so handler tests
+  that drive a handler with a bare `context.Background()` now see
+  `Unauthenticated` / empty results; such tests are given an auth context. This
+  is the intended fail-closed behavior, not a regression.
+- List queries grew a `(scope_restricted, scope_group_ids)` parameter pair; the
+  boolean carries the restrict-or-not decision so SQL behavior never depends on
+  pgx's nil-vs-empty array encoding. Regenerated via `make sqlc-generate`.
+- Scope enforcement and the grant-ceiling removal are orthogonal and both hold:
+  *what* you may confer is gated solely by the role-management permission; *which
+  targets* you may act on is gated by scope.

--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -351,6 +351,25 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 	}), nil
 }
 
+// enforceDeviceScopeAll confines a fan-out dispatch to the caller's device-group
+// scope: every target device must be reachable under `perm` (base-tier scope),
+// or the WHOLE request fails closed with the first denial. Dispatch is a
+// mutating, potentially destructive action, so a partial/silent execution is
+// worse than a clear denial — a scope-limited admin must target devices/groups
+// fully within their scope. The per-device DispatchAction gate the fan-outs
+// delegate to is NOT sufficient: it keys off the "DispatchAction" permission,
+// which a holder of (say) DispatchToMultiple need not have, so it would wave the
+// fan-out through unconfined.
+func (h *ActionHandler) enforceDeviceScopeAll(ctx context.Context, perm string, deviceIDs []string) error {
+	resolver := newScopeResolver(h.store)
+	for _, deviceID := range deviceIDs {
+		if err := auth.EnforceDeviceScopeOnBaseTier(ctx, resolver, perm, deviceID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // dispatchTask is a single fan-out element consumed by dispatchEach:
 // the wire request to issue and the structured log fields that
 // identify it on the failure path. Extracted to deduplicate the
@@ -386,6 +405,10 @@ func (h *ActionHandler) dispatchEach(ctx context.Context, rpc string, tasks []di
 // DispatchToMultiple dispatches an action to multiple devices.
 func (h *ActionHandler) DispatchToMultiple(ctx context.Context, req *connect.Request[pm.DispatchToMultipleRequest]) (*connect.Response[pm.DispatchToMultipleResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
+	if err := h.enforceDeviceScopeAll(ctx, "DispatchToMultiple", req.Msg.DeviceIds); err != nil {
 		return nil, err
 	}
 
@@ -457,6 +480,10 @@ func (h *ActionHandler) DispatchActionSet(ctx context.Context, req *connect.Requ
 		return nil, err
 	}
 
+	if err := h.enforceDeviceScopeAll(ctx, "DispatchActionSet", []string{req.Msg.DeviceId}); err != nil {
+		return nil, err
+	}
+
 	actions, err := h.store.Queries().ListActionsInSet(ctx, req.Msg.ActionSetId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get actions in set")
@@ -485,6 +512,10 @@ func (h *ActionHandler) DispatchActionSet(ctx context.Context, req *connect.Requ
 // DispatchDefinition dispatches all actions from a definition to a device.
 func (h *ActionHandler) DispatchDefinition(ctx context.Context, req *connect.Request[pm.DispatchDefinitionRequest]) (*connect.Response[pm.DispatchDefinitionResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
+	if err := h.enforceDeviceScopeAll(ctx, "DispatchDefinition", []string{req.Msg.DeviceId}); err != nil {
 		return nil, err
 	}
 
@@ -533,6 +564,18 @@ func (h *ActionHandler) DispatchToGroup(ctx context.Context, req *connect.Reques
 	devices, err := h.store.Queries().ListDevicesInGroup(ctx, req.Msg.GroupId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get devices in group")
+	}
+
+	// Scope (#3): every member device must be within the caller's DispatchToGroup
+	// scope — fail the whole fan-out closed otherwise. The delegated DispatchAction
+	// gate keys off "DispatchAction" (which a DispatchToGroup holder need not have)
+	// and so would not confine this fan-out on its own.
+	memberIDs := make([]string, len(devices))
+	for i, d := range devices {
+		memberIDs[i] = d.ID
+	}
+	if err := h.enforceDeviceScopeAll(ctx, "DispatchToGroup", memberIDs); err != nil {
+		return nil, err
 	}
 
 	executions := make([]*pm.ActionExecution, 0)
@@ -659,12 +702,18 @@ func (h *ActionHandler) ListExecutions(ctx context.Context, req *connect.Request
 	typeFilter := int32(req.Msg.TypeFilter)
 	searchQuery := strings.TrimSpace(req.Msg.Search)
 
-	execs, err := h.store.Repos().Execution.List(ctx, store.ListExecutionsFilter{DeviceID: req.Msg.DeviceId, Status: statusFilter, ActionTypeFilter: typeFilter, Search: searchQuery, Limit: pageSize, Offset: offset})
+	// Device-group scope (#3): a scope-limited ListExecutions holder sees only
+	// executions whose device is in their scope groups. Same restriction drives
+	// the count so pagination totals stay honest.
+	scopeGroups, scopeRestricted := auth.DeviceScopeListFilter(ctx, "ListExecutions")
+	scope := store.ScopeGroupFilter{Restricted: scopeRestricted, GroupIDs: scopeGroups}
+
+	execs, err := h.store.Repos().Execution.List(ctx, store.ListExecutionsFilter{DeviceID: req.Msg.DeviceId, Status: statusFilter, ActionTypeFilter: typeFilter, Search: searchQuery, Limit: pageSize, Offset: offset, Scope: scope})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list executions")
 	}
 
-	count, err := h.store.Repos().Execution.Count(ctx, store.CountExecutionsFilter{DeviceID: req.Msg.DeviceId, Status: statusFilter, ActionTypeFilter: typeFilter, Search: searchQuery})
+	count, err := h.store.Repos().Execution.Count(ctx, store.CountExecutionsFilter{DeviceID: req.Msg.DeviceId, Status: statusFilter, ActionTypeFilter: typeFilter, Search: searchQuery, Scope: scope})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count executions")
 	}

--- a/internal/api/device_group_handler.go
+++ b/internal/api/device_group_handler.go
@@ -121,6 +121,10 @@ func (h *DeviceGroupHandler) GetDeviceGroup(ctx context.Context, req *connect.Re
 		return nil, err
 	}
 
+	if err := auth.EnforceDeviceGroupScope(ctx, "GetDeviceGroup", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	group, err := h.store.Repos().DeviceGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDeviceGroupNotFound, "device group not found")
@@ -163,12 +167,18 @@ func (h *DeviceGroupHandler) ListDeviceGroups(ctx context.Context, req *connect.
 		return nil, err
 	}
 
-	groups, err := h.store.Repos().DeviceGroup.List(ctx, store.ListDeviceGroupsFilter{Limit: pageSize, Offset: offset})
+	// Device-group scope (#3): a scope-limited ListDeviceGroups holder sees only
+	// the groups in their scope (direct id-match); a global holder is unrestricted.
+	// Same restriction drives the count so pagination totals stay honest.
+	scopeGroups, scopeRestricted := auth.DeviceScopeListFilter(ctx, "ListDeviceGroups")
+	scope := store.ScopeGroupFilter{Restricted: scopeRestricted, GroupIDs: scopeGroups}
+
+	groups, err := h.store.Repos().DeviceGroup.List(ctx, store.ListDeviceGroupsFilter{Limit: pageSize, Offset: offset, Scope: scope})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list device groups")
 	}
 
-	count, err := h.store.Repos().DeviceGroup.Count(ctx)
+	count, err := h.store.Repos().DeviceGroup.Count(ctx, scope)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count device groups")
 	}
@@ -198,6 +208,23 @@ func (h *DeviceGroupHandler) ListDeviceGroupsForDevice(ctx context.Context, req 
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list groups for device")
 	}
 
+	// Device-group scope (#3): restrict the returned groups to the caller's scope
+	// in Go — the underlying ListForDevice query is shared with the scope resolver
+	// and must stay unfiltered there. A global holder keeps all groups.
+	if scopeGroups, restricted := auth.DeviceScopeListFilter(ctx, "ListDeviceGroupsForDevice"); restricted {
+		allowed := make(map[string]struct{}, len(scopeGroups))
+		for _, id := range scopeGroups {
+			allowed[id] = struct{}{}
+		}
+		kept := groups[:0]
+		for _, g := range groups {
+			if _, ok := allowed[g.ID]; ok {
+				kept = append(kept, g)
+			}
+		}
+		groups = kept
+	}
+
 	protoGroups := make([]*pm.DeviceGroup, len(groups))
 	for i, g := range groups {
 		protoGroups[i] = h.deviceGroupToProto(g)
@@ -216,6 +243,10 @@ func (h *DeviceGroupHandler) RenameDeviceGroup(ctx context.Context, req *connect
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceDeviceGroupScope(ctx, "RenameDeviceGroup", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -253,6 +284,10 @@ func (h *DeviceGroupHandler) UpdateDeviceGroupDescription(ctx context.Context, r
 		return nil, err
 	}
 
+	if err := auth.EnforceDeviceGroupScope(ctx, "UpdateDeviceGroupDescription", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "device_group",
 		StreamID:   req.Msg.Id,
@@ -284,6 +319,10 @@ func (h *DeviceGroupHandler) DeleteDeviceGroup(ctx context.Context, req *connect
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceDeviceGroupScope(ctx, "DeleteDeviceGroup", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -325,6 +364,22 @@ func (h *DeviceGroupHandler) AddDeviceToGroup(ctx context.Context, req *connect.
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Scope (#3): the target group must be in the caller's device-group scope
+	// (direct id-match), AND every device being added must already be within the
+	// caller's scope (membership). The device check is load-bearing: without it a
+	// device-group-scoped admin could pull any fleet device into a group they
+	// control and thereby expand their own scope — a scope escape. RemoveDevice
+	// needs only the group check (removal cannot expand scope).
+	if err := auth.EnforceDeviceGroupScope(ctx, "AddDeviceToGroup", req.Msg.GroupId); err != nil {
+		return nil, err
+	}
+	resolver := newScopeResolver(h.store)
+	for _, deviceID := range deviceIDs {
+		if err := auth.EnforceDeviceScopeOnBaseTier(ctx, resolver, "AddDeviceToGroup", deviceID); err != nil {
+			return nil, err
+		}
 	}
 
 	q := h.store.Queries()
@@ -382,6 +437,10 @@ func (h *DeviceGroupHandler) RemoveDeviceFromGroup(ctx context.Context, req *con
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceDeviceGroupScope(ctx, "RemoveDeviceFromGroup", req.Msg.GroupId); err != nil {
 		return nil, err
 	}
 
@@ -574,6 +633,10 @@ func (h *DeviceGroupHandler) SetDeviceGroupSyncInterval(ctx context.Context, req
 		return nil, err
 	}
 
+	if err := auth.EnforceDeviceGroupScope(ctx, "SetDeviceGroupSyncInterval", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	// Validate interval (0 = default, max 1440 = 24 hours)
 	if req.Msg.SyncIntervalMinutes < 0 || req.Msg.SyncIntervalMinutes > 1440 {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "sync interval must be between 0 and 1440 minutes")
@@ -620,6 +683,10 @@ func (h *DeviceGroupHandler) SetDeviceGroupMaintenanceWindow(ctx context.Context
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceDeviceGroupScope(ctx, "SetDeviceGroupMaintenanceWindow", req.Msg.Id); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -69,6 +69,13 @@ func (h *DeviceHandler) ListDevices(ctx context.Context, req *connect.Request[pm
 		}
 	}
 
+	// Device-group scope (#3): orthogonal to the :assigned OwnerScope above. A
+	// scope-limited ListDevices holder sees only devices in their scope groups; a
+	// global holder is unrestricted. The same restriction drives the count query
+	// so pagination totals stay honest and don't leak the out-of-scope count.
+	scopeGroups, scopeRestricted := auth.DeviceScopeListFilter(ctx, "ListDevices")
+	scope := store.ScopeGroupFilter{Restricted: scopeRestricted, GroupIDs: scopeGroups}
+
 	var devices []store.Device
 
 	deviceRepo := h.store.Repos().Device
@@ -76,6 +83,7 @@ func (h *DeviceHandler) ListDevices(ctx context.Context, req *connect.Request[pm
 		Limit:      pageSize,
 		Offset:     offset,
 		OwnerScope: filterUID,
+		Scope:      scope,
 	}
 	switch req.Msg.StatusFilter {
 	case pm.DeviceStatus_DEVICE_STATUS_ONLINE:
@@ -93,11 +101,11 @@ func (h *DeviceHandler) ListDevices(ctx context.Context, req *connect.Request[pm
 	var count int64
 	switch req.Msg.StatusFilter {
 	case pm.DeviceStatus_DEVICE_STATUS_ONLINE:
-		count, err = deviceRepo.CountOnline(ctx, filterUID)
+		count, err = deviceRepo.CountOnline(ctx, filterUID, scope)
 	case pm.DeviceStatus_DEVICE_STATUS_OFFLINE:
-		count, err = deviceRepo.CountOffline(ctx, filterUID)
+		count, err = deviceRepo.CountOffline(ctx, filterUID, scope)
 	default:
-		count, err = deviceRepo.Count(ctx, filterUID)
+		count, err = deviceRepo.Count(ctx, filterUID, scope)
 	}
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count devices")

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"context"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// ScopedSessionsForTest exposes the unexported device-scope session filter so the
+// external api_test package can exercise it without standing up the gateway
+// fan-out plumbing ListActiveTerminalSessions otherwise requires.
+func (h *TerminalHandler) ScopedSessionsForTest(ctx context.Context, sessions []*pm.TerminalSessionInfo) ([]*pm.TerminalSessionInfo, error) {
+	return h.scopedSessions(ctx, sessions)
+}

--- a/internal/api/scope_enforcement_dispatch_test.go
+++ b/internal/api/scope_enforcement_dispatch_test.go
@@ -1,0 +1,109 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// Finding #3 (dispatch fan-out): the multi-device dispatch RPCs must scope-check
+// EACH target device against the caller's device-group scope, failing the whole
+// request closed if any target is out of scope. Before enforcement they relied
+// on the per-device DispatchAction gate, which waves through a caller who holds
+// the fan-out permission but not DispatchAction — leaving the fan-out unscoped.
+func TestDispatchFanout_DeviceScopeEnforced(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	dgX := testutil.CreateTestDeviceGroup(t, st, actor, "Plant X") // in scope
+	dgY := testutil.CreateTestDeviceGroup(t, st, actor, "Plant Y") // out of scope
+	devIn := testutil.CreateTestDevice(t, st, "in-scope")
+	devOut := testutil.CreateTestDevice(t, st, "out-of-scope")
+	testutil.AddDeviceToTestGroup(t, st, actor, dgX, devIn)
+	testutil.AddDeviceToTestGroup(t, st, actor, dgY, devOut)
+
+	// Caller holds each dispatch permission scoped ONLY to dgX.
+	perms := []string{"DispatchToMultiple", "DispatchActionSet", "DispatchDefinition", "DispatchToGroup"}
+	grants := make([]auth.ScopedGrant, len(perms))
+	for i, p := range perms {
+		grants[i] = auth.ScopedGrant{Permission: p, ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgX}
+	}
+	scoped := func() context.Context {
+		return testutil.AuthContextScoped(testutil.NewID(), "scoped@test.com", perms, grants)
+	}
+
+	t.Run("DispatchToMultiple denies an out-of-scope device", func(t *testing.T) {
+		_, err := h.DispatchToMultiple(scoped(), connect.NewRequest(&pm.DispatchToMultipleRequest{
+			DeviceIds:    []string{devOut},
+			ActionSource: &pm.DispatchToMultipleRequest_ActionId{ActionId: testutil.NewID()},
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("DispatchToMultiple denies a mixed in/out batch (fail closed)", func(t *testing.T) {
+		_, err := h.DispatchToMultiple(scoped(), connect.NewRequest(&pm.DispatchToMultipleRequest{
+			DeviceIds:    []string{devIn, devOut},
+			ActionSource: &pm.DispatchToMultipleRequest_ActionId{ActionId: testutil.NewID()},
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("DispatchActionSet denies an out-of-scope device", func(t *testing.T) {
+		_, err := h.DispatchActionSet(scoped(), connect.NewRequest(&pm.DispatchActionSetRequest{
+			DeviceId: devOut, ActionSetId: testutil.NewID(),
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("DispatchDefinition denies an out-of-scope device", func(t *testing.T) {
+		_, err := h.DispatchDefinition(scoped(), connect.NewRequest(&pm.DispatchDefinitionRequest{
+			DeviceId: devOut, DefinitionId: testutil.NewID(),
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("DispatchToGroup denies a group of out-of-scope devices", func(t *testing.T) {
+		_, err := h.DispatchToGroup(scoped(), connect.NewRequest(&pm.DispatchToGroupRequest{
+			GroupId:      dgY,
+			ActionSource: &pm.DispatchToGroupRequest_ActionId{ActionId: testutil.NewID()},
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	// In-scope targets must NOT be denied by scope (they may no-op for unrelated
+	// reasons — missing action set, no task queue — but never PermissionDenied).
+	t.Run("DispatchToGroup allows a group of in-scope devices", func(t *testing.T) {
+		_, err := h.DispatchToGroup(scoped(), connect.NewRequest(&pm.DispatchToGroupRequest{
+			GroupId:      dgX,
+			ActionSource: &pm.DispatchToGroupRequest_ActionId{ActionId: testutil.NewID()},
+		}))
+		if err != nil {
+			assert.NotEqual(t, connect.CodePermissionDenied, connect.CodeOf(err))
+		}
+	})
+
+	t.Run("DispatchToMultiple allows in-scope devices", func(t *testing.T) {
+		_, err := h.DispatchToMultiple(scoped(), connect.NewRequest(&pm.DispatchToMultipleRequest{
+			DeviceIds:    []string{devIn},
+			ActionSource: &pm.DispatchToMultipleRequest_ActionId{ActionId: testutil.NewID()},
+		}))
+		if err != nil {
+			assert.NotEqual(t, connect.CodePermissionDenied, connect.CodeOf(err))
+		}
+	})
+}

--- a/internal/api/scope_enforcement_group_test.go
+++ b/internal/api/scope_enforcement_group_test.go
@@ -1,0 +1,287 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// deviceGroupScopeGrants builds a scoped-caller context holding each device-group
+// management permission scoped ONLY to the given device groups.
+func deviceGroupScopeGrants(perms, groupIDs []string) context.Context {
+	var grants []auth.ScopedGrant
+	for _, p := range perms {
+		for _, g := range groupIDs {
+			grants = append(grants, auth.ScopedGrant{Permission: p, ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: g})
+		}
+	}
+	return testutil.AuthContextScoped(testutil.NewID(), "scoped@test.com", perms, grants)
+}
+
+// Finding #3 (device-group management): a caller holding a group-management
+// permission scoped to device group dgX may act ONLY on dgX itself — a DIRECT
+// scope-id match, not a membership lookup. Before enforcement these handlers had
+// no scope gate at all, so a device-group-scoped admin could rename/delete ANY
+// group. Each gate now confines via auth.EnforceDeviceGroupScope.
+func TestDeviceGroupGates_GroupScopeEnforced(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	dgX := testutil.CreateTestDeviceGroup(t, st, actor, "Plant X") // in scope
+	dgY := testutil.CreateTestDeviceGroup(t, st, actor, "Plant Y") // out of scope
+
+	perms := []string{
+		"GetDeviceGroup", "RenameDeviceGroup", "UpdateDeviceGroupDescription",
+		"DeleteDeviceGroup", "SetDeviceGroupSyncInterval", "SetDeviceGroupMaintenanceWindow",
+	}
+	scoped := func() context.Context { return deviceGroupScopeGrants(perms, []string{dgX}) }
+
+	gates := []struct {
+		name   string
+		invoke func(ctx context.Context, groupID string) error
+	}{
+		{"GetDeviceGroup", func(ctx context.Context, id string) error {
+			_, err := h.GetDeviceGroup(ctx, connect.NewRequest(&pm.GetDeviceGroupRequest{Id: id}))
+			return err
+		}},
+		{"RenameDeviceGroup", func(ctx context.Context, id string) error {
+			_, err := h.RenameDeviceGroup(ctx, connect.NewRequest(&pm.RenameDeviceGroupRequest{Id: id, Name: "renamed"}))
+			return err
+		}},
+		{"UpdateDeviceGroupDescription", func(ctx context.Context, id string) error {
+			_, err := h.UpdateDeviceGroupDescription(ctx, connect.NewRequest(&pm.UpdateDeviceGroupDescriptionRequest{Id: id, Description: "d"}))
+			return err
+		}},
+		{"DeleteDeviceGroup", func(ctx context.Context, id string) error {
+			_, err := h.DeleteDeviceGroup(ctx, connect.NewRequest(&pm.DeleteDeviceGroupRequest{Id: id}))
+			return err
+		}},
+		{"SetDeviceGroupSyncInterval", func(ctx context.Context, id string) error {
+			_, err := h.SetDeviceGroupSyncInterval(ctx, connect.NewRequest(&pm.SetDeviceGroupSyncIntervalRequest{Id: id, SyncIntervalMinutes: 30}))
+			return err
+		}},
+		{"SetDeviceGroupMaintenanceWindow", func(ctx context.Context, id string) error {
+			_, err := h.SetDeviceGroupMaintenanceWindow(ctx, connect.NewRequest(&pm.SetDeviceGroupMaintenanceWindowRequest{Id: id}))
+			return err
+		}},
+	}
+
+	for _, g := range gates {
+		t.Run(g.name+" denies out-of-scope group", func(t *testing.T) {
+			err := g.invoke(scoped(), dgY)
+			require.Error(t, err, "a device-group-scoped caller must not manage a group outside the scope")
+			assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+		})
+		t.Run(g.name+" allows in-scope group", func(t *testing.T) {
+			err := g.invoke(scoped(), dgX)
+			// May fail for an unrelated reason (e.g. an empty maintenance window),
+			// but it must NOT be denied by scope.
+			if err != nil {
+				assert.NotEqual(t, connect.CodePermissionDenied, connect.CodeOf(err),
+					"in-scope group must not be denied by scope")
+			}
+		})
+	}
+}
+
+// AddDeviceToGroup must scope-check BOTH the target group (direct id-match) AND
+// each device added (membership) — otherwise a device-group-scoped admin could
+// pull any fleet device into a group they control and so expand their own scope
+// (a scope escape). The device check confines them to organizing devices ALREADY
+// in their scope.
+func TestAddDeviceToGroup_ScopeEnforced(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	dgTarget := testutil.CreateTestDeviceGroup(t, st, actor, "Sub Group") // target, in scope
+	dgBroad := testutil.CreateTestDeviceGroup(t, st, actor, "Broad")      // in scope, holds in-scope devices
+	dgOther := testutil.CreateTestDeviceGroup(t, st, actor, "Other")      // out of scope
+
+	devInScope := testutil.CreateTestDevice(t, st, "in-scope")
+	testutil.AddDeviceToTestGroup(t, st, actor, dgBroad, devInScope)
+	devOutOfScope := testutil.CreateTestDevice(t, st, "out-of-scope")
+
+	// Caller is scoped to BOTH the target sub-group and the broad group that holds
+	// in-scope devices, modelling the "organize my scoped devices into sub-groups"
+	// use case the permissions.go note describes.
+	scoped := func() context.Context {
+		return deviceGroupScopeGrants([]string{"AddDeviceToGroup"}, []string{dgTarget, dgBroad})
+	}
+
+	t.Run("allows adding an in-scope device to an in-scope group", func(t *testing.T) {
+		_, err := h.AddDeviceToGroup(scoped(), connect.NewRequest(&pm.AddDeviceToGroupRequest{GroupId: dgTarget, DeviceId: devInScope}))
+		require.NoError(t, err)
+	})
+
+	t.Run("denies an out-of-scope target group", func(t *testing.T) {
+		_, err := h.AddDeviceToGroup(scoped(), connect.NewRequest(&pm.AddDeviceToGroupRequest{GroupId: dgOther, DeviceId: devInScope}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("denies pulling an out-of-scope device into an in-scope group (scope escape)", func(t *testing.T) {
+		_, err := h.AddDeviceToGroup(scoped(), connect.NewRequest(&pm.AddDeviceToGroupRequest{GroupId: dgTarget, DeviceId: devOutOfScope}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+}
+
+// RemoveDeviceFromGroup confines to in-scope groups (direct id-match). Removal
+// cannot expand scope, so only the group is gated.
+func TestRemoveDeviceFromGroup_ScopeEnforced(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	dgX := testutil.CreateTestDeviceGroup(t, st, actor, "Plant X")
+	dgY := testutil.CreateTestDeviceGroup(t, st, actor, "Plant Y")
+	dev := testutil.CreateTestDevice(t, st, "host")
+	testutil.AddDeviceToTestGroup(t, st, actor, dgX, dev)
+
+	scoped := func() context.Context {
+		return deviceGroupScopeGrants([]string{"RemoveDeviceFromGroup"}, []string{dgX})
+	}
+
+	t.Run("allows removing from an in-scope group", func(t *testing.T) {
+		_, err := h.RemoveDeviceFromGroup(scoped(), connect.NewRequest(&pm.RemoveDeviceFromGroupRequest{GroupId: dgX, DeviceId: dev}))
+		require.NoError(t, err)
+	})
+	t.Run("denies an out-of-scope group", func(t *testing.T) {
+		_, err := h.RemoveDeviceFromGroup(scoped(), connect.NewRequest(&pm.RemoveDeviceFromGroupRequest{GroupId: dgY, DeviceId: dev}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+}
+
+// userGroupScopeGrants is the user-group symmetric of deviceGroupScopeGrants.
+func userGroupScopeGrants(perms, groupIDs []string) context.Context {
+	var grants []auth.ScopedGrant
+	for _, p := range perms {
+		for _, g := range groupIDs {
+			grants = append(grants, auth.ScopedGrant{Permission: p, ScopeKind: auth.ScopeKindUserGroup, ScopeID: g})
+		}
+	}
+	return testutil.AuthContextScoped(testutil.NewID(), "scoped@test.com", perms, grants)
+}
+
+// Finding #3 (user-group management): symmetric with the device-group case.
+func TestUserGroupGates_GroupScopeEnforced(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	ugX := testutil.CreateTestUserGroup(t, st, actor, "Team X")
+	ugY := testutil.CreateTestUserGroup(t, st, actor, "Team Y")
+
+	perms := []string{"GetUserGroup", "UpdateUserGroup", "DeleteUserGroup", "SetUserGroupMaintenanceWindow"}
+	scoped := func() context.Context { return userGroupScopeGrants(perms, []string{ugX}) }
+
+	gates := []struct {
+		name   string
+		invoke func(ctx context.Context, groupID string) error
+	}{
+		{"GetUserGroup", func(ctx context.Context, id string) error {
+			_, err := h.GetUserGroup(ctx, connect.NewRequest(&pm.GetUserGroupRequest{Id: id}))
+			return err
+		}},
+		{"UpdateUserGroup", func(ctx context.Context, id string) error {
+			_, err := h.UpdateUserGroup(ctx, connect.NewRequest(&pm.UpdateUserGroupRequest{GroupId: id, Name: "renamed"}))
+			return err
+		}},
+		{"DeleteUserGroup", func(ctx context.Context, id string) error {
+			_, err := h.DeleteUserGroup(ctx, connect.NewRequest(&pm.DeleteUserGroupRequest{Id: id}))
+			return err
+		}},
+		{"SetUserGroupMaintenanceWindow", func(ctx context.Context, id string) error {
+			_, err := h.SetUserGroupMaintenanceWindow(ctx, connect.NewRequest(&pm.SetUserGroupMaintenanceWindowRequest{Id: id}))
+			return err
+		}},
+	}
+
+	for _, g := range gates {
+		t.Run(g.name+" denies out-of-scope group", func(t *testing.T) {
+			err := g.invoke(scoped(), ugY)
+			require.Error(t, err, "a user-group-scoped caller must not manage a group outside the scope")
+			assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+		})
+		t.Run(g.name+" allows in-scope group", func(t *testing.T) {
+			err := g.invoke(scoped(), ugX)
+			if err != nil {
+				assert.NotEqual(t, connect.CodePermissionDenied, connect.CodeOf(err),
+					"in-scope group must not be denied by scope")
+			}
+		})
+	}
+}
+
+// AddUserToGroup mirrors AddDeviceToGroup: group id-match AND per-user membership
+// check to prevent pulling out-of-scope users into a group the admin controls.
+func TestAddUserToGroup_ScopeEnforced(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	ugTarget := testutil.CreateTestUserGroup(t, st, actor, "Sub Team")
+	ugBroad := testutil.CreateTestUserGroup(t, st, actor, "Broad Team")
+	ugOther := testutil.CreateTestUserGroup(t, st, actor, "Other Team")
+
+	userInScope := testutil.CreateTestUser(t, st, testutil.NewID()+"@in.com", "pass", "user")
+	testutil.AddUserToTestGroup(t, st, actor, ugBroad, userInScope)
+	userOutOfScope := testutil.CreateTestUser(t, st, testutil.NewID()+"@out.com", "pass", "user")
+
+	scoped := func() context.Context {
+		return userGroupScopeGrants([]string{"AddUserToGroup"}, []string{ugTarget, ugBroad})
+	}
+
+	t.Run("allows adding an in-scope user to an in-scope group", func(t *testing.T) {
+		_, err := h.AddUserToGroup(scoped(), connect.NewRequest(&pm.AddUserToGroupRequest{GroupId: ugTarget, UserId: userInScope}))
+		require.NoError(t, err)
+	})
+	t.Run("denies an out-of-scope target group", func(t *testing.T) {
+		_, err := h.AddUserToGroup(scoped(), connect.NewRequest(&pm.AddUserToGroupRequest{GroupId: ugOther, UserId: userInScope}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+	t.Run("denies pulling an out-of-scope user into an in-scope group (scope escape)", func(t *testing.T) {
+		_, err := h.AddUserToGroup(scoped(), connect.NewRequest(&pm.AddUserToGroupRequest{GroupId: ugTarget, UserId: userOutOfScope}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+}
+
+// RemoveUserFromGroup confines to in-scope groups (direct id-match).
+func TestRemoveUserFromGroup_ScopeEnforced(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	ugX := testutil.CreateTestUserGroup(t, st, actor, "Team X")
+	ugY := testutil.CreateTestUserGroup(t, st, actor, "Team Y")
+	member := testutil.CreateTestUser(t, st, testutil.NewID()+"@m.com", "pass", "user")
+	testutil.AddUserToTestGroup(t, st, actor, ugX, member)
+
+	scoped := func() context.Context {
+		return userGroupScopeGrants([]string{"RemoveUserFromGroup"}, []string{ugX})
+	}
+
+	t.Run("allows removing from an in-scope group", func(t *testing.T) {
+		_, err := h.RemoveUserFromGroup(scoped(), connect.NewRequest(&pm.RemoveUserFromGroupRequest{GroupId: ugX, UserId: member}))
+		require.NoError(t, err)
+	})
+	t.Run("denies an out-of-scope group", func(t *testing.T) {
+		_, err := h.RemoveUserFromGroup(scoped(), connect.NewRequest(&pm.RemoveUserFromGroupRequest{GroupId: ugY, UserId: member}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+}

--- a/internal/api/scope_enforcement_list_test.go
+++ b/internal/api/scope_enforcement_list_test.go
@@ -1,0 +1,297 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+func deviceScoped(actorID string, perm, groupID string) context.Context {
+	return testutil.AuthContextScoped(actorID, "scoped@test.com", []string{perm},
+		[]auth.ScopedGrant{{Permission: perm, ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: groupID}})
+}
+
+func userScoped(actorID string, perm, groupID string) context.Context {
+	return testutil.AuthContextScoped(actorID, "scoped@test.com", []string{perm},
+		[]auth.ScopedGrant{{Permission: perm, ScopeKind: auth.ScopeKindUserGroup, ScopeID: groupID}})
+}
+
+func globalCtx(actorID, perm string) context.Context {
+	return testutil.AuthContextScoped(actorID, "g@test.com", []string{perm},
+		[]auth.ScopedGrant{{Permission: perm}})
+}
+
+// Finding #3 (list filters): a device-group-scoped caller listing devices sees
+// ONLY devices that are members of a group in their scope; a global caller sees
+// all. Membership-based.
+func TestListDevices_DeviceScopeFiltered(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, nil, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	dgX := testutil.CreateTestDeviceGroup(t, st, actor, "Plant X")
+	devIn := testutil.CreateTestDevice(t, st, "in-scope")
+	devOut := testutil.CreateTestDevice(t, st, "out-of-scope")
+	testutil.AddDeviceToTestGroup(t, st, actor, dgX, devIn)
+
+	list := func(ctx context.Context) []string {
+		resp, err := h.ListDevices(ctx, connect.NewRequest(&pm.ListDevicesRequest{PageSize: 100}))
+		require.NoError(t, err)
+		ids := make([]string, len(resp.Msg.Devices))
+		for i, d := range resp.Msg.Devices {
+			ids[i] = d.Id
+		}
+		// Count parity: the page holds every matching row (pageSize 100), so a
+		// correct, identically-scoped COUNT must equal the returned length.
+		assert.Equal(t, int32(len(ids)), resp.Msg.TotalCount, "TotalCount must apply the same scope filter as the list")
+		return ids
+	}
+
+	t.Run("scoped caller sees only in-scope devices", func(t *testing.T) {
+		ids := list(deviceScoped(actor, "ListDevices", dgX))
+		assert.Contains(t, ids, devIn)
+		assert.NotContains(t, ids, devOut)
+	})
+	t.Run("global caller sees all devices", func(t *testing.T) {
+		ids := list(globalCtx(actor, "ListDevices"))
+		assert.Contains(t, ids, devIn)
+		assert.Contains(t, ids, devOut)
+	})
+}
+
+// ListUsers: membership-based on user groups.
+func TestListUsers_UserScopeFiltered(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserHandler(st, slog.Default(), nil)
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	ugX := testutil.CreateTestUserGroup(t, st, actor, "Team X")
+	userIn := testutil.CreateTestUser(t, st, testutil.NewID()+"@in.com", "pass", "user")
+	userOut := testutil.CreateTestUser(t, st, testutil.NewID()+"@out.com", "pass", "user")
+	testutil.AddUserToTestGroup(t, st, actor, ugX, userIn)
+
+	list := func(ctx context.Context) []string {
+		resp, err := h.ListUsers(ctx, connect.NewRequest(&pm.ListUsersRequest{PageSize: 100}))
+		require.NoError(t, err)
+		ids := make([]string, len(resp.Msg.Users))
+		for i, u := range resp.Msg.Users {
+			ids[i] = u.Id
+		}
+		assert.Equal(t, int32(len(ids)), resp.Msg.TotalCount, "TotalCount must apply the same scope filter as the list")
+		return ids
+	}
+
+	t.Run("scoped caller sees only in-scope users", func(t *testing.T) {
+		ids := list(userScoped(actor, "ListUsers", ugX))
+		assert.Contains(t, ids, userIn)
+		assert.NotContains(t, ids, userOut)
+	})
+	t.Run("global caller sees all users", func(t *testing.T) {
+		ids := list(globalCtx(actor, "ListUsers"))
+		assert.Contains(t, ids, userIn)
+		assert.Contains(t, ids, userOut)
+	})
+}
+
+// ListExecutions: membership-based on the execution's device.
+func TestListExecutions_DeviceScopeFiltered(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	dgX := testutil.CreateTestDeviceGroup(t, st, actor, "Plant X")
+	devIn := testutil.CreateTestDevice(t, st, "in-scope")
+	devOut := testutil.CreateTestDevice(t, st, "out-of-scope")
+	testutil.AddDeviceToTestGroup(t, st, actor, dgX, devIn)
+
+	execIn := seedExecution(t, st, actor, devIn)
+	execOut := seedExecution(t, st, actor, devOut)
+
+	list := func(ctx context.Context) []string {
+		resp, err := h.ListExecutions(ctx, connect.NewRequest(&pm.ListExecutionsRequest{PageSize: 100}))
+		require.NoError(t, err)
+		ids := make([]string, len(resp.Msg.Executions))
+		for i, e := range resp.Msg.Executions {
+			ids[i] = e.Id
+		}
+		assert.Equal(t, int32(len(ids)), resp.Msg.TotalCount, "TotalCount must apply the same scope filter as the list")
+		return ids
+	}
+
+	t.Run("scoped caller sees only in-scope executions", func(t *testing.T) {
+		ids := list(deviceScoped(actor, "ListExecutions", dgX))
+		assert.Contains(t, ids, execIn)
+		assert.NotContains(t, ids, execOut)
+	})
+	t.Run("global caller sees all executions", func(t *testing.T) {
+		ids := list(globalCtx(actor, "ListExecutions"))
+		assert.Contains(t, ids, execIn)
+		assert.Contains(t, ids, execOut)
+	})
+}
+
+// ListDeviceGroups: DIRECT id-match — the scoped caller sees only their scope
+// groups.
+func TestListDeviceGroups_DirectScopeFiltered(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	dgX := testutil.CreateTestDeviceGroup(t, st, actor, "Plant X")
+	dgY := testutil.CreateTestDeviceGroup(t, st, actor, "Plant Y")
+
+	list := func(ctx context.Context) []string {
+		resp, err := h.ListDeviceGroups(ctx, connect.NewRequest(&pm.ListDeviceGroupsRequest{PageSize: 100}))
+		require.NoError(t, err)
+		ids := make([]string, len(resp.Msg.Groups))
+		for i, g := range resp.Msg.Groups {
+			ids[i] = g.Id
+		}
+		assert.Equal(t, int32(len(ids)), resp.Msg.TotalCount, "TotalCount must apply the same scope filter as the list")
+		return ids
+	}
+
+	t.Run("scoped caller sees only the in-scope group", func(t *testing.T) {
+		ids := list(deviceScoped(actor, "ListDeviceGroups", dgX))
+		assert.Equal(t, []string{dgX}, ids)
+	})
+	t.Run("global caller sees all groups", func(t *testing.T) {
+		ids := list(globalCtx(actor, "ListDeviceGroups"))
+		assert.Contains(t, ids, dgX)
+		assert.Contains(t, ids, dgY)
+	})
+}
+
+// ListUserGroups: DIRECT id-match.
+func TestListUserGroups_DirectScopeFiltered(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	ugX := testutil.CreateTestUserGroup(t, st, actor, "Team X")
+	ugY := testutil.CreateTestUserGroup(t, st, actor, "Team Y")
+
+	list := func(ctx context.Context) []string {
+		resp, err := h.ListUserGroups(ctx, connect.NewRequest(&pm.ListUserGroupsRequest{PageSize: 100}))
+		require.NoError(t, err)
+		ids := make([]string, len(resp.Msg.Groups))
+		for i, g := range resp.Msg.Groups {
+			ids[i] = g.Id
+		}
+		assert.Equal(t, int32(len(ids)), resp.Msg.TotalCount, "TotalCount must apply the same scope filter as the list")
+		return ids
+	}
+
+	t.Run("scoped caller sees only the in-scope group", func(t *testing.T) {
+		ids := list(userScoped(actor, "ListUserGroups", ugX))
+		assert.Equal(t, []string{ugX}, ids)
+	})
+	t.Run("global caller sees all groups", func(t *testing.T) {
+		ids := list(globalCtx(actor, "ListUserGroups"))
+		assert.Contains(t, ids, ugX)
+		assert.Contains(t, ids, ugY)
+	})
+}
+
+// ListDeviceGroupsForDevice: returned groups restricted to the caller's scope
+// (DIRECT id-match).
+func TestListDeviceGroupsForDevice_DirectScopeFiltered(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	dgX := testutil.CreateTestDeviceGroup(t, st, actor, "Plant X")
+	dgY := testutil.CreateTestDeviceGroup(t, st, actor, "Plant Y")
+	dev := testutil.CreateTestDevice(t, st, "host")
+	testutil.AddDeviceToTestGroup(t, st, actor, dgX, dev)
+	testutil.AddDeviceToTestGroup(t, st, actor, dgY, dev)
+
+	list := func(ctx context.Context) []string {
+		resp, err := h.ListDeviceGroupsForDevice(ctx, connect.NewRequest(&pm.ListDeviceGroupsForDeviceRequest{DeviceId: dev}))
+		require.NoError(t, err)
+		ids := make([]string, len(resp.Msg.Groups))
+		for i, g := range resp.Msg.Groups {
+			ids[i] = g.Id
+		}
+		return ids
+	}
+
+	t.Run("scoped caller sees only the in-scope group for the device", func(t *testing.T) {
+		ids := list(deviceScoped(actor, "ListDeviceGroupsForDevice", dgX))
+		assert.Equal(t, []string{dgX}, ids)
+	})
+	t.Run("global caller sees all groups for the device", func(t *testing.T) {
+		ids := list(globalCtx(actor, "ListDeviceGroupsForDevice"))
+		assert.ElementsMatch(t, []string{dgX, dgY}, ids)
+	})
+}
+
+// ListUserGroupsForUser: DIRECT id-match.
+func TestListUserGroupsForUser_DirectScopeFiltered(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	ugX := testutil.CreateTestUserGroup(t, st, actor, "Team X")
+	ugY := testutil.CreateTestUserGroup(t, st, actor, "Team Y")
+	member := testutil.CreateTestUser(t, st, testutil.NewID()+"@m.com", "pass", "user")
+	testutil.AddUserToTestGroup(t, st, actor, ugX, member)
+	testutil.AddUserToTestGroup(t, st, actor, ugY, member)
+
+	list := func(ctx context.Context) []string {
+		resp, err := h.ListUserGroupsForUser(ctx, connect.NewRequest(&pm.ListUserGroupsForUserRequest{UserId: member}))
+		require.NoError(t, err)
+		ids := make([]string, len(resp.Msg.Groups))
+		for i, g := range resp.Msg.Groups {
+			ids[i] = g.Id
+		}
+		return ids
+	}
+
+	t.Run("scoped caller sees only the in-scope group for the user", func(t *testing.T) {
+		ids := list(userScoped(actor, "ListUserGroupsForUser", ugX))
+		assert.Equal(t, []string{ugX}, ids)
+	})
+	t.Run("global caller sees all groups for the user", func(t *testing.T) {
+		ids := list(globalCtx(actor, "ListUserGroupsForUser"))
+		assert.ElementsMatch(t, []string{ugX, ugY}, ids)
+	})
+}
+
+// seedExecution materialises an executions_projection row for deviceID by
+// appending an ExecutionCreated event, returning the execution id.
+func seedExecution(t *testing.T, st *store.Store, actorID, deviceID string) string {
+	t.Helper()
+	id := ulid.Make().String()
+	at := int32(pm.ActionType_ACTION_TYPE_SHELL)
+	ds := int32(pm.DesiredState_DESIRED_STATE_PRESENT)
+	to := int32(60)
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "execution",
+		StreamID:   id,
+		EventType:  string(eventtypes.ExecutionCreated),
+		Data: payloads.ExecutionCreated{
+			DeviceID:       deviceID,
+			ActionType:     &at,
+			DesiredState:   &ds,
+			Params:         []byte(`{}`),
+			TimeoutSeconds: &to,
+		},
+		ActorType: "user",
+		ActorID:   actorID,
+	}))
+	return id
+}

--- a/internal/api/scope_enforcement_parity_test.go
+++ b/internal/api/scope_enforcement_parity_test.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/stretchr/testify/require"
+)
+
+// recognizedScopeFns lists the handler-layer functions whose string-literal
+// PERMISSION argument marks that permission as scope-ENFORCED. Each entry is a
+// distinct enforcement MECHANISM:
+//   - single-resource gates           (auth.EnforceDeviceScope* / EnforceUserScope*)
+//   - group-id direct-match gates     (auth.EnforceDeviceGroupScope / EnforceUserGroupScope)
+//   - list-row filters                (auth.DeviceScopeListFilter / UserScopeListFilter,
+//     and auth.DeviceScopeFilterFor for the in-memory
+//     terminal-session filter)
+//   - dispatch fan-out                (api.enforceDeviceScopeAll)
+//
+// Only the small set of MECHANISMS is enumerated here; the PERMISSIONS are
+// discovered from auth.AllPermissions(). Forgetting to register a NEW mechanism
+// fails this test CLOSED — its permissions surface as "unenforced" — never open.
+//
+// Group CREATION (CreateStaticDeviceGroup / CreateStaticUserGroup) is
+// intentionally NOT scopable: a brand-new group has no id and no members, so
+// there is nothing to confine a scope against at create time. It is org-tier
+// (TargetUnspecified); scope is enforced on the downstream group-management and
+// membership operations instead. If a future change re-adds a TargetKind to a
+// create permission, this test fails until the create path is genuinely enforced.
+var recognizedScopeFns = map[string]bool{
+	"EnforceDeviceScope":           true,
+	"EnforceDeviceScopeOnBaseTier": true,
+	"EnforceUserScope":             true,
+	"EnforceUserScopeOrSelf":       true,
+	"EnforceDeviceGroupScope":      true,
+	"EnforceUserGroupScope":        true,
+	"DeviceScopeListFilter":        true,
+	"UserScopeListFilter":          true,
+	"DeviceScopeFilterFor":         true,
+	"enforceDeviceScopeAll":        true,
+}
+
+// TestScopablePermissions_AllEnforced is the load-bearing self-discovering guard
+// for finding #3/#19: the set of SCOPABLE permissions (those carrying a
+// TargetKind in auth.AllPermissions) must EQUAL the set of permissions actually
+// scope-enforced somewhere in the api handler layer. "Scopable == enforced" is
+// kept honest — there is no advisory-scope allowlist. A permission that cannot
+// be enforced must be de-scoped (its TargetKind removed in permissions.go), not
+// excused here.
+//
+// It discovers the enforced set by AST-scanning every non-test .go file in this
+// package for permission-string literals passed to a recognized scope-enforcement
+// function (see recognizedScopeFns) or handled as a case in the reconciler's
+// `switch g.Permission` (the TerminalAdmin* cohort mechanism). Both sides derive
+// from their sources — neither is a hardcoded list that can fall stale — so the
+// test fails when a new TargetDevice/TargetUser permission is added without
+// enforcement, or when a permission is enforced that the registry no longer marks
+// scopable (a stale TargetKind).
+func TestScopablePermissions_AllEnforced(t *testing.T) {
+	scopable := map[string]bool{}
+	for _, p := range auth.AllPermissions() {
+		if p.TargetKind != auth.TargetUnspecified {
+			scopable[p.Key] = true
+		}
+	}
+	require.NotEmpty(t, scopable, "no scopable permissions discovered — the parity check would vacuously pass")
+
+	validPerm := auth.ValidPermissionKeys()
+
+	enforced := map[string]bool{}
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err, "read package dir")
+
+	sawFile := false
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		sawFile = true
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		require.NoErrorf(t, err, "parse %s", name)
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.CallExpr:
+				if recognizedScopeFns[calleeName(node.Fun)] {
+					for _, arg := range node.Args {
+						if s, ok := stringLit(arg); ok && validPerm[s] {
+							enforced[s] = true
+						}
+					}
+				}
+			case *ast.SwitchStmt:
+				// The reconciler's `switch g.Permission { case "TerminalAdmin*": }`
+				// enforces those device-target permissions via per-scope cohort
+				// computation rather than a request-time gate. Recognize a case
+				// value as enforcement ONLY when the switch tag is a permission
+				// expression, so unrelated string switches don't count.
+				if node.Tag != nil && exprMentions(node.Tag, "Permission") {
+					for _, stmt := range node.Body.List {
+						cc, ok := stmt.(*ast.CaseClause)
+						if !ok {
+							continue
+						}
+						for _, expr := range cc.List {
+							if s, ok := stringLit(expr); ok && validPerm[s] {
+								enforced[s] = true
+							}
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
+	require.True(t, sawFile, "scanned zero source files — the discovery is broken")
+
+	var missing []string
+	for p := range scopable {
+		if !enforced[p] {
+			missing = append(missing, p)
+		}
+	}
+	sort.Strings(missing)
+
+	var stale []string // enforced but not scopable → a TargetKind that should be restored, or a mis-typed perm
+	for p := range enforced {
+		if !scopable[p] {
+			stale = append(stale, p)
+		}
+	}
+	sort.Strings(stale)
+
+	require.Emptyf(t, missing,
+		"scopable permissions with NO handler-level scope enforcement (#3/#19):\n  %s\n"+
+			"Each must be enforced (single-resource gate / group-id match / list filter / dispatch fan-out / reconciler cohort) "+
+			"OR de-scoped (remove its TargetKind in auth/permissions.go).",
+		strings.Join(missing, "\n  "))
+	require.Emptyf(t, stale,
+		"permissions scope-enforced in handlers but NOT marked scopable in auth/permissions.go (stale TargetKind / mis-typed perm):\n  %s",
+		strings.Join(stale, "\n  "))
+}
+
+// calleeName returns the called function's identifier — the selector's final
+// name for a qualified call (auth.EnforceDeviceScope → "EnforceDeviceScope") or
+// the bare identifier for an unqualified call.
+func calleeName(fn ast.Expr) string {
+	switch f := fn.(type) {
+	case *ast.SelectorExpr:
+		return f.Sel.Name
+	case *ast.Ident:
+		return f.Name
+	}
+	return ""
+}
+
+// stringLit unquotes a string-literal expression.
+func stringLit(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	s, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return s, true
+}
+
+// exprMentions reports whether e references an identifier named name (as a bare
+// ident or the selector field, e.g. `g.Permission` mentions "Permission").
+func exprMentions(e ast.Expr, name string) bool {
+	found := false
+	ast.Inspect(e, func(n ast.Node) bool {
+		switch id := n.(type) {
+		case *ast.Ident:
+			if id.Name == name {
+				found = true
+			}
+		case *ast.SelectorExpr:
+			if id.Sel.Name == name {
+				found = true
+			}
+		}
+		return !found
+	})
+	return found
+}

--- a/internal/api/scope_enforcement_terminal_test.go
+++ b/internal/api/scope_enforcement_terminal_test.go
@@ -1,0 +1,147 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// Finding #3 (terminal session ops): StopTerminal and TerminateTerminalSession
+// resolve a session id to its device and must confine a device-group-scoped
+// caller to sessions on in-scope devices.
+func TestStopTerminal_DeviceScopeEnforced(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _ := newTerminalHandler(t, st)
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, userID, "alice")
+	dgX := testutil.CreateTestDeviceGroup(t, st, userID, "Plant X")
+	devIn := testutil.CreateTestDevice(t, st, "in-scope")
+	devOut := testutil.CreateTestDevice(t, st, "out-of-scope")
+	testutil.AddDeviceToTestGroup(t, st, userID, dgX, devIn)
+
+	// The caller may OPEN a session anywhere (StartTerminal unscoped) but may only
+	// STOP sessions on devices in dgX (StopTerminal scoped to dgX).
+	scopedCtx := testutil.AuthContextScoped(userID, "u@test.com",
+		[]string{"StartTerminal", "StopTerminal"},
+		[]auth.ScopedGrant{
+			{Permission: "StartTerminal"},
+			{Permission: "StopTerminal", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgX},
+		})
+
+	openSession := func(deviceID string) string {
+		resp, err := h.StartTerminal(scopedCtx, connect.NewRequest(&pm.StartTerminalRequest{DeviceId: deviceID}))
+		require.NoError(t, err)
+		return resp.Msg.SessionId
+	}
+
+	t.Run("denies stopping a session on an out-of-scope device", func(t *testing.T) {
+		sid := openSession(devOut)
+		_, err := h.StopTerminal(scopedCtx, connect.NewRequest(&pm.StopTerminalRequest{SessionId: sid}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("allows stopping a session on an in-scope device", func(t *testing.T) {
+		sid := openSession(devIn)
+		_, err := h.StopTerminal(scopedCtx, connect.NewRequest(&pm.StopTerminalRequest{SessionId: sid}))
+		require.NoError(t, err)
+	})
+}
+
+func TestTerminateTerminalSession_DeviceScopeEnforced(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _ := newTerminalHandler(t, st)
+
+	// A separate owner opens the sessions.
+	ownerID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setLinuxUsername(t, st, ownerID, "owner")
+	ownerCtx := testutil.AuthContextScoped(ownerID, "owner@test.com",
+		[]string{"StartTerminal"}, []auth.ScopedGrant{{Permission: "StartTerminal"}})
+
+	dgX := testutil.CreateTestDeviceGroup(t, st, ownerID, "Plant X")
+	devIn := testutil.CreateTestDevice(t, st, "in-scope")
+	devOut := testutil.CreateTestDevice(t, st, "out-of-scope")
+	testutil.AddDeviceToTestGroup(t, st, ownerID, dgX, devIn)
+
+	openSession := func(deviceID string) string {
+		resp, err := h.StartTerminal(ownerCtx, connect.NewRequest(&pm.StartTerminalRequest{DeviceId: deviceID}))
+		require.NoError(t, err)
+		return resp.Msg.SessionId
+	}
+
+	// The admin terminator is scoped to dgX for TerminateTerminalSession.
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	terminator := testutil.AuthContextScoped(adminID, "admin@test.com",
+		[]string{"TerminateTerminalSession"},
+		[]auth.ScopedGrant{{Permission: "TerminateTerminalSession", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgX}})
+
+	t.Run("denies terminating a session on an out-of-scope device", func(t *testing.T) {
+		sid := openSession(devOut)
+		_, err := h.TerminateTerminalSession(terminator, connect.NewRequest(&pm.TerminateTerminalSessionRequest{SessionId: sid, Reason: "x"}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("in-scope device passes scope (fails later only for unconfigured registry)", func(t *testing.T) {
+		sid := openSession(devIn)
+		// registry/internalHTTPClient are nil in the test handler, so an in-scope
+		// session proceeds past the scope gate and then fails Unavailable — never
+		// PermissionDenied.
+		_, err := h.TerminateTerminalSession(terminator, connect.NewRequest(&pm.TerminateTerminalSessionRequest{SessionId: sid, Reason: "x"}))
+		if err != nil {
+			assert.NotEqual(t, connect.CodePermissionDenied, connect.CodeOf(err))
+		}
+	})
+}
+
+// ListActiveTerminalSessions filters the merged session list to devices in the
+// caller's ListActiveTerminalSessions device-group scope.
+func TestScopedSessions_FiltersByDeviceScope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _ := newTerminalHandler(t, st)
+
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+	dgX := testutil.CreateTestDeviceGroup(t, st, actor, "Plant X")
+	devIn := testutil.CreateTestDevice(t, st, "in-scope")
+	devOut := testutil.CreateTestDevice(t, st, "out-of-scope")
+	testutil.AddDeviceToTestGroup(t, st, actor, dgX, devIn)
+
+	sessions := []*pm.TerminalSessionInfo{
+		{SessionId: "s-in", DeviceId: devIn},
+		{SessionId: "s-out", DeviceId: devOut},
+	}
+
+	scoped := testutil.AuthContextScoped(actor, "u@test.com",
+		[]string{"ListActiveTerminalSessions"},
+		[]auth.ScopedGrant{{Permission: "ListActiveTerminalSessions", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgX}})
+
+	t.Run("scoped caller sees only in-scope sessions", func(t *testing.T) {
+		got, err := h.ScopedSessionsForTest(scoped, sessions)
+		require.NoError(t, err)
+		require.Len(t, got, 1)
+		assert.Equal(t, "s-in", got[0].SessionId)
+	})
+
+	t.Run("global caller sees all sessions", func(t *testing.T) {
+		global := testutil.AuthContextScoped(actor, "u@test.com",
+			[]string{"ListActiveTerminalSessions"},
+			[]auth.ScopedGrant{{Permission: "ListActiveTerminalSessions"}})
+		got, err := h.ScopedSessionsForTest(global, sessions)
+		require.NoError(t, err)
+		assert.Len(t, got, 2)
+	})
+
+	t.Run("unauthenticated caller sees nothing (fail closed)", func(t *testing.T) {
+		got, err := h.ScopedSessionsForTest(context.Background(), sessions)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -426,6 +426,13 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 			"only the session owner may stop a terminal session; admins must use TerminateTerminalSession")
 	}
 
+	// Scope (#3): a device-group-scoped StopTerminal holder may stop only sessions
+	// on devices within their scope. Ordinary users hold StopTerminal unscoped, so
+	// this is a no-op for them.
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "StopTerminal", session.DeviceID); err != nil {
+		return nil, err
+	}
+
 	// CQRS: event first (source of truth), then Valkey revoke
 	// (derived state). If the event fails, the session stays active
 	// — no silent stop without an audit trail. If the revoke fails,
@@ -542,13 +549,54 @@ func (h *TerminalHandler) ListActiveTerminalSessions(ctx context.Context, req *c
 	}
 	wg.Wait()
 
+	// Scope (#3): confine the merged list to sessions on devices in the caller's
+	// ListActiveTerminalSessions device-group scope. A global holder sees all.
+	scoped, err := h.scopedSessions(ctx, all)
+	if err != nil {
+		return nil, err
+	}
+
 	// TODO: enrich with user email / device hostname from DB for
 	// the admin view. For now the IDs are returned directly.
 
 	return connect.NewResponse(&pm.ListActiveTerminalSessionsResponse{
-		Sessions:   all,
-		TotalCount: int32(len(all)),
+		Sessions:   scoped,
+		TotalCount: int32(len(scoped)),
 	}), nil
+}
+
+// scopedSessions filters a merged terminal-session list to those on devices
+// within the caller's ListActiveTerminalSessions device-group scope. A global (or
+// no-scoping-grant) caller is unrestricted; a scope-limited caller keeps only
+// sessions whose device is a member of one of their scope groups; a caller with
+// only a wrong-kind grant or no auth context sees nothing (fail closed).
+func (h *TerminalHandler) scopedSessions(ctx context.Context, sessions []*pm.TerminalSessionInfo) ([]*pm.TerminalSessionInfo, error) {
+	groupIDs, restricted := auth.DeviceScopeListFilter(ctx, "ListActiveTerminalSessions")
+	if !restricted {
+		return sessions, nil
+	}
+	if len(groupIDs) == 0 {
+		return nil, nil // wrong-kind grant / no auth → restrict to nothing
+	}
+	scopeSet := make(map[string]struct{}, len(groupIDs))
+	for _, id := range groupIDs {
+		scopeSet[id] = struct{}{}
+	}
+	resolver := newScopeResolver(h.store)
+	out := make([]*pm.TerminalSessionInfo, 0, len(sessions))
+	for _, s := range sessions {
+		devGroups, err := resolver.DeviceGroupsForDevice(ctx, s.DeviceId)
+		if err != nil {
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to resolve session device scope")
+		}
+		for _, g := range devGroups {
+			if _, ok := scopeSet[g]; ok {
+				out = append(out, s)
+				break
+			}
+		}
+	}
+	return out, nil
 }
 
 // TerminateTerminalSession finds which gateway hosts the session
@@ -569,12 +617,9 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 		return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodeUnauthenticated, "not authenticated")
 	}
 
-	if h.registry == nil || h.internalHTTPClient == nil {
-		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
-			"terminal admin RPCs require a configured registry and internal HTTP client")
-	}
-
-	// Look up the session to find the device, then the gateway.
+	// Look up the session to find the device, then authorize the scope BEFORE the
+	// infra-config check below — a caller must be told "denied" for an
+	// out-of-scope session regardless of whether the gateway plumbing is wired.
 	session, err := h.tokenStore.Lookup(ctx, req.Msg.SessionId)
 	if err != nil {
 		if errors.Is(err, terminal.ErrTokenNotFound) {
@@ -583,6 +628,17 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal,
 			"failed to look up session")
+	}
+
+	// Scope (#3): a device-group-scoped TerminateTerminalSession holder may
+	// terminate only sessions on devices within their scope.
+	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "TerminateTerminalSession", session.DeviceID); err != nil {
+		return nil, err
+	}
+
+	if h.registry == nil || h.internalHTTPClient == nil {
+		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
+			"terminal admin RPCs require a configured registry and internal HTTP client")
 	}
 
 	gatewayID, err := h.registry.LookupDeviceGateway(ctx, session.DeviceID)

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -127,6 +127,10 @@ func (h *UserGroupHandler) GetUserGroup(ctx context.Context, req *connect.Reques
 		return nil, err
 	}
 
+	if err := auth.EnforceUserGroupScope(ctx, "GetUserGroup", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	group, err := h.store.Repos().UserGroup.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrUserGroupNotFound, "user group not found")
@@ -170,12 +174,18 @@ func (h *UserGroupHandler) ListUserGroups(ctx context.Context, req *connect.Requ
 		return nil, err
 	}
 
-	groups, err := h.store.Repos().UserGroup.List(ctx, store.ListUserGroupsFilter{Limit: pageSize, Offset: offset})
+	// User-group scope (#3): a scope-limited ListUserGroups holder sees only the
+	// groups in their scope (direct id-match); a global holder is unrestricted.
+	// Same restriction drives the count so pagination totals stay honest.
+	scopeGroups, scopeRestricted := auth.UserScopeListFilter(ctx, "ListUserGroups")
+	scope := store.ScopeGroupFilter{Restricted: scopeRestricted, GroupIDs: scopeGroups}
+
+	groups, err := h.store.Repos().UserGroup.List(ctx, store.ListUserGroupsFilter{Limit: pageSize, Offset: offset, Scope: scope})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list user groups")
 	}
 
-	count, err := h.store.Repos().UserGroup.Count(ctx)
+	count, err := h.store.Repos().UserGroup.Count(ctx, scope)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count user groups")
 	}
@@ -209,6 +219,10 @@ func (h *UserGroupHandler) UpdateUserGroup(ctx context.Context, req *connect.Req
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceUserGroupScope(ctx, "UpdateUserGroup", req.Msg.GroupId); err != nil {
 		return nil, err
 	}
 
@@ -252,6 +266,10 @@ func (h *UserGroupHandler) SetUserGroupMaintenanceWindow(ctx context.Context, re
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceUserGroupScope(ctx, "SetUserGroupMaintenanceWindow", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -315,6 +333,10 @@ func (h *UserGroupHandler) DeleteUserGroup(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
+	if err := auth.EnforceUserGroupScope(ctx, "DeleteUserGroup", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	appendDelete := func() error {
 		return appendEvent(ctx, h.store, h.logger, store.Event{
 			StreamType: "user_group",
@@ -374,6 +396,22 @@ func (h *UserGroupHandler) AddUserToGroup(ctx context.Context, req *connect.Requ
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// Scope (#3): the target group must be in the caller's user-group scope
+	// (direct id-match), AND every user being added must already be within the
+	// caller's scope (membership). The user check is load-bearing: without it a
+	// user-group-scoped admin could pull any user into a group they control and
+	// thereby gain user-target authority over them — a scope escape. RemoveUser
+	// needs only the group check (removal cannot expand scope).
+	if err := auth.EnforceUserGroupScope(ctx, "AddUserToGroup", req.Msg.GroupId); err != nil {
+		return nil, err
+	}
+	resolver := newScopeResolver(h.store)
+	for _, userID := range userIDs {
+		if err := auth.EnforceUserScopeOrSelf(ctx, resolver, "AddUserToGroup", userID); err != nil {
+			return nil, err
+		}
 	}
 
 	q := h.store.Queries()
@@ -455,6 +493,19 @@ func (h *UserGroupHandler) RemoveUserFromGroup(ctx context.Context, req *connect
 		return nil, apiErrorCtx(ctx, ErrDynamicGroupManualModify, connect.CodeFailedPrecondition, "cannot manually modify members of a dynamic group")
 	}
 
+	// Authenticate and scope-check BEFORE the membership probe so an out-of-scope
+	// group is denied with PermissionDenied rather than leaking membership state
+	// (a non-member would otherwise surface as NotFound first). Removal only needs
+	// the group id-match — it cannot expand the caller's scope.
+	userCtx, err := requireAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceUserGroupScope(ctx, "RemoveUserFromGroup", req.Msg.GroupId); err != nil {
+		return nil, err
+	}
+
 	// Verify membership
 	isMember, err := h.store.Queries().IsUserInGroup(ctx, db.IsUserInGroupParams{
 		GroupID: req.Msg.GroupId,
@@ -465,11 +516,6 @@ func (h *UserGroupHandler) RemoveUserFromGroup(ctx context.Context, req *connect
 	}
 	if !isMember {
 		return nil, apiErrorCtx(ctx, ErrUserNotFound, connect.CodeNotFound, "user is not a member of this group")
-	}
-
-	userCtx, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
 	}
 
 	streamID := req.Msg.GroupId + ":" + req.Msg.UserId
@@ -720,6 +766,23 @@ func (h *UserGroupHandler) ListUserGroupsForUser(ctx context.Context, req *conne
 	groups, err := h.store.Repos().UserGroup.ListForUser(ctx, req.Msg.UserId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list user groups")
+	}
+
+	// User-group scope (#3): restrict the returned groups to the caller's scope in
+	// Go — ListForUser is shared with the scope resolver and must stay unfiltered
+	// there. A global holder keeps all groups.
+	if scopeGroups, restricted := auth.UserScopeListFilter(ctx, "ListUserGroupsForUser"); restricted {
+		allowed := make(map[string]struct{}, len(scopeGroups))
+		for _, id := range scopeGroups {
+			allowed[id] = struct{}{}
+		}
+		kept := groups[:0]
+		for _, g := range groups {
+			if _, ok := allowed[g.ID]; ok {
+				kept = append(kept, g)
+			}
+		}
+		groups = kept
 	}
 
 	protoGroups := make([]*pm.UserGroup, len(groups))

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -238,12 +238,18 @@ func (h *UserHandler) ListUsers(ctx context.Context, req *connect.Request[pm.Lis
 		return nil, err
 	}
 
-	users, err := h.store.Repos().User.List(ctx, store.ListUsersFilter{Limit: pageSize, Offset: offset})
+	// User-group scope (#3): a scope-limited ListUsers holder sees only users in
+	// their scope groups; a global holder is unrestricted. Same restriction drives
+	// the count so pagination totals stay honest.
+	scopeGroups, scopeRestricted := auth.UserScopeListFilter(ctx, "ListUsers")
+	scope := store.ScopeGroupFilter{Restricted: scopeRestricted, GroupIDs: scopeGroups}
+
+	users, err := h.store.Repos().User.List(ctx, store.ListUsersFilter{Limit: pageSize, Offset: offset, Scope: scope})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list users")
 	}
 
-	count, err := h.store.Repos().User.Count(ctx)
+	count, err := h.store.Repos().User.Count(ctx, scope)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to count users")
 	}

--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -137,13 +137,18 @@ func AllPermissions() []PermissionInfo {
 		// Device Groups
 		//
 		// CreateDeviceGroup was split into a static and a dynamic
-		// variant in server #7. Static-group creation is safe to
-		// scope (the scoped admin can only organize devices already
-		// within their scope into sub-groups). Dynamic-group
-		// creation stays unscopable because the query language
-		// matches arbitrary device sets and could perturb other
-		// actors' scopes — see T-S2 in the #7 design.
-		{"CreateStaticDeviceGroup", "Device Groups", "Create static device groups", TargetDevice},
+		// variant in server #7. BOTH creation permissions are
+		// org-tier (TargetUnspecified, NOT scopable): a brand-new
+		// group has no id and no members, so there is nothing for a
+		// scope to confine at create time. Making create "scopable"
+		// would be advisory-only — exactly the dishonesty the
+		// scopable==enforced rule forbids. Scope is enforced on the
+		// downstream group-management + membership operations instead
+		// (GetDeviceGroup, RenameDeviceGroup, AddDeviceToGroup, …).
+		// Dynamic-group creation additionally stays org-tier because
+		// the query language matches arbitrary device sets and could
+		// perturb other actors' scopes — see T-S2 in the #7 design.
+		{"CreateStaticDeviceGroup", "Device Groups", "Create static device groups", TargetUnspecified},
 		{"CreateDynamicDeviceGroup", "Device Groups", "Create dynamic device groups", TargetUnspecified},
 		{"GetDeviceGroup", "Device Groups", "View device groups", TargetDevice},
 		{"ListDeviceGroups", "Device Groups", "List device groups", TargetDevice},
@@ -232,8 +237,11 @@ func AllPermissions() []PermissionInfo {
 		// User Groups
 		//
 		// CreateUserGroup split into static + dynamic variants in
-		// server #7, same rationale as CreateDeviceGroup. T-S2.
-		{"CreateStaticUserGroup", "User Groups", "Create static user groups", TargetUser},
+		// server #7. BOTH are org-tier (TargetUnspecified, NOT
+		// scopable), same rationale as CreateDeviceGroup: nothing to
+		// confine at create time; scope is enforced on the downstream
+		// group-management + membership operations. T-S2.
+		{"CreateStaticUserGroup", "User Groups", "Create static user groups", TargetUnspecified},
 		{"CreateDynamicUserGroup", "User Groups", "Create dynamic user groups", TargetUnspecified},
 		{"GetUserGroup", "User Groups", "View user groups", TargetUser},
 		{"ListUserGroups", "User Groups", "List user groups", TargetUser},

--- a/internal/auth/permissions_test.go
+++ b/internal/auth/permissions_test.go
@@ -279,7 +279,6 @@ var v1ScopableDeviceTargeted = []string{
 	"GetDeviceCompliancePolicyStatus",
 	"AddDeviceToGroup",
 	"RemoveDeviceFromGroup",
-	"CreateStaticDeviceGroup",
 	"RenameDeviceGroup",
 	"UpdateDeviceGroupDescription",
 	"DeleteDeviceGroup",
@@ -306,7 +305,6 @@ var v1ScopableUserTargeted = []string{
 	"RemoveUserSshKey",
 	"AddUserToGroup",
 	"RemoveUserFromGroup",
-	"CreateStaticUserGroup",
 	"UpdateUserGroup",
 	"DeleteUserGroup",
 	"SetUserGroupMaintenanceWindow",
@@ -344,6 +342,12 @@ var v1NonScopableDangerous = []string{
 	"UpdateDynamicUserGroupQuery",
 	"EvaluateDynamicUserGroup",
 	"ValidateUserGroupQuery",
+	// Group CREATION is org-tier: a brand-new group has no id and no
+	// members, so nothing can confine a scope at create time. Marking
+	// create "scopable" would be advisory-only — scope is enforced on
+	// the downstream group-management + membership ops instead.
+	"CreateStaticDeviceGroup",
+	"CreateStaticUserGroup",
 	// Scope-authority itself is org-tier — V1 stance per T-S7
 	"AssignRoleScope",
 	// Role management is org-tier
@@ -474,11 +478,17 @@ func TestAllPermissions_RemovesLegacyCreateAndUpdateKeys(t *testing.T) {
 	}
 }
 
-func TestCreateStaticDeviceGroup_TargetsDevice(t *testing.T) {
+func TestCreateStaticDeviceGroup_NotScopable(t *testing.T) {
+	// Reversed from the original #7 stance: group CREATION is org-tier. A
+	// brand-new group has no id and no members, so there is nothing for a scope
+	// to confine at create time — making it scopable would be advisory-only,
+	// which the scopable==enforced rule forbids. Scope is enforced on the
+	// downstream group-management + membership ops (RenameDeviceGroup,
+	// AddDeviceToGroup, …) instead.
 	info, ok := indexAllByKey(t)["CreateStaticDeviceGroup"]
 	require.True(t, ok)
-	assert.Equal(t, TargetDevice, info.TargetKind,
-		"CreateStaticDeviceGroup must be TargetDevice so a scope-confined admin can organize their scoped devices into sub-groups")
+	assert.Equal(t, TargetUnspecified, info.TargetKind,
+		"CreateStaticDeviceGroup must be org-tier (TargetUnspecified) — nothing to confine a scope against at create time")
 }
 
 func TestCreateDynamicDeviceGroup_NotScopable(t *testing.T) {
@@ -488,11 +498,14 @@ func TestCreateDynamicDeviceGroup_NotScopable(t *testing.T) {
 		"CreateDynamicDeviceGroup must stay unscopable — dynamic queries can match arbitrary devices and perturb other scopes (T-S2)")
 }
 
-func TestCreateStaticUserGroup_TargetsUser(t *testing.T) {
+func TestCreateStaticUserGroup_NotScopable(t *testing.T) {
+	// Org-tier, symmetric with CreateStaticDeviceGroup: nothing to confine a
+	// scope against at create time; scope is enforced on the downstream
+	// group-management + membership ops.
 	info, ok := indexAllByKey(t)["CreateStaticUserGroup"]
 	require.True(t, ok)
-	assert.Equal(t, TargetUser, info.TargetKind,
-		"CreateStaticUserGroup must be TargetUser, symmetric with the device-group split")
+	assert.Equal(t, TargetUnspecified, info.TargetKind,
+		"CreateStaticUserGroup must be org-tier (TargetUnspecified) — nothing to confine a scope against at create time")
 }
 
 func TestCreateDynamicUserGroup_NotScopable(t *testing.T) {

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -301,6 +301,107 @@ func EnforceDeviceScopeOnBaseTier(ctx context.Context, resolver ScopeResolver, p
 	return nil
 }
 
+// EnforceDeviceGroupScope authorizes a group-management action on a SPECIFIC
+// device GROUP (rename, delete, description, membership, windows). Unlike
+// EnforceDeviceScope — which asks "is this DEVICE in one of my scope groups" —
+// this asks "is this device GROUP itself one of my device-group scope ids": a
+// DIRECT scope-id match, no membership lookup. Group-management permissions have
+// no :assigned tier, so a caller lacking the base permission is denied outright.
+//
+//   - unauthenticated                  → Unauthenticated
+//   - lacks the base permission        → PermissionDenied (no owner-filter fallback)
+//   - base, unscoped (Global)          → allowed (any group)
+//   - base, no scoping grant at all    → allowed (fixture / unrestricted)
+//   - base, device_group-scoped        → allowed iff groupID is among the scope ids
+//   - base, only wrong-kind scope      → PermissionDenied (fail closed)
+func EnforceDeviceGroupScope(ctx context.Context, permission, groupID string) error {
+	return enforceGroupScope(ctx, DeviceScopeFilterFor(ctx, permission), permission, groupID)
+}
+
+// EnforceUserGroupScope is the user-group symmetric of EnforceDeviceGroupScope:
+// a direct scope-id match of groupID against the caller's user-group scope ids.
+func EnforceUserGroupScope(ctx context.Context, permission, groupID string) error {
+	return enforceGroupScope(ctx, UserScopeFilterFor(ctx, permission), permission, groupID)
+}
+
+// enforceGroupScope is the shared body for the device/user group-id gates. f is
+// the same-kind ScopeFilter for permission (already reduced to the relevant scope
+// kind by the caller).
+func enforceGroupScope(ctx context.Context, f ScopeFilter, permission, groupID string) error {
+	if _, ok := UserFromContext(ctx); !ok {
+		return connect.NewError(connect.CodeUnauthenticated, errors.New("not authenticated"))
+	}
+	if !HasPermission(ctx, permission) {
+		return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+	}
+	if f.Global {
+		return nil
+	}
+	if len(f.GroupIDs) > 0 {
+		for _, id := range f.GroupIDs {
+			if id == groupID {
+				return nil
+			}
+		}
+		return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+	}
+	// Base holder with no same-kind scoped grant: a wrong-kind grant fails CLOSED;
+	// only a complete absence of scoping grants is unrestricted (fixture / prod
+	// unscoped grant already produced Global above).
+	if hasScopedGrant(ctx, permission) {
+		return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+	}
+	return nil
+}
+
+// DeviceScopeListFilter reduces the caller's device-group scope for a device-row
+// LIST permission to (groupIDs, restricted), mirroring EnforceDeviceScopeOnBaseTier's
+// tier logic for the list path:
+//   - restricted=false ⇒ NO device-group row filtering — the caller is global, has
+//     no scoping grant, or holds only the :assigned tier (the assigned-owner SQL
+//     filter confines that case separately);
+//   - restricted=true  ⇒ restrict rows to devices in groupIDs; groupIDs may be
+//     empty (a wrong-kind/irrelevant grant, or no authenticated caller) ⇒ restrict
+//     to NOTHING (fail closed).
+//
+// The query keys its membership/id check off `restricted` (a boolean), not off
+// groupIDs being nil-vs-empty, so the SQL is unambiguous and pgx array encoding
+// never decides access.
+func DeviceScopeListFilter(ctx context.Context, permission string) (groupIDs []string, restricted bool) {
+	return scopeListFilter(ctx, permission, DeviceScopeFilterFor)
+}
+
+// UserScopeListFilter is the user-group symmetric of DeviceScopeListFilter.
+func UserScopeListFilter(ctx context.Context, permission string) (groupIDs []string, restricted bool) {
+	return scopeListFilter(ctx, permission, UserScopeFilterFor)
+}
+
+// scopeListFilter is the shared body for the device/user list filters. filterFor
+// selects the relevant scope kind (DeviceScopeFilterFor / UserScopeFilterFor).
+func scopeListFilter(ctx context.Context, permission string, filterFor func(context.Context, string) ScopeFilter) (groupIDs []string, restricted bool) {
+	if _, ok := UserFromContext(ctx); !ok {
+		// No caller to resolve — fail closed (no rows), never fail open. List
+		// handlers run behind the auth interceptor, so this is defensive.
+		return nil, true
+	}
+	if !HasPermission(ctx, permission) {
+		// :assigned tier (owner SQL filter confines) or no access at all — no
+		// device/user-group row filter applies here.
+		return nil, false
+	}
+	f := filterFor(ctx, permission)
+	if f.Global {
+		return nil, false
+	}
+	if len(f.GroupIDs) > 0 {
+		return f.GroupIDs, true
+	}
+	if hasScopedGrant(ctx, permission) {
+		return nil, true // wrong-kind grant → restrict to nothing
+	}
+	return nil, false // no scoping grant → unrestricted (fixture / prod unscoped)
+}
+
 // hasScopedGrant reports whether the caller holds ANY scoped grant for the
 // permission, regardless of scope kind. The base-tier scope checks use it to
 // fail closed when a base holder has a grant of a non-matching kind, rather than

--- a/internal/auth/scope_group_test.go
+++ b/internal/auth/scope_group_test.go
@@ -1,0 +1,214 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// EnforceDeviceGroupScope confines a group-management action to a SPECIFIC
+// device group by a DIRECT scope-id match (is this group one of the caller's
+// device-group scope ids), not a membership lookup. Group-management permissions
+// (GetDeviceGroup, RenameDeviceGroup, …) have no :assigned tier, so a caller who
+// does not hold the base permission is denied outright.
+func TestEnforceDeviceGroupScope(t *testing.T) {
+	t.Run("unrestricted base allows any group", func(t *testing.T) {
+		ctx := ctxWith([]string{"RenameDeviceGroup"}, ScopedGrant{Permission: "RenameDeviceGroup"})
+		assert.NoError(t, EnforceDeviceGroupScope(ctx, "RenameDeviceGroup", "dgZ"))
+	})
+
+	t.Run("base perm with no scoped grant is unrestricted", func(t *testing.T) {
+		ctx := ctxWith([]string{"RenameDeviceGroup"})
+		assert.NoError(t, EnforceDeviceGroupScope(ctx, "RenameDeviceGroup", "dgZ"))
+	})
+
+	t.Run("device-group-scoped allows the matching group, denies others", func(t *testing.T) {
+		ctx := ctxWith([]string{"RenameDeviceGroup"}, ScopedGrant{Permission: "RenameDeviceGroup", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		assert.NoError(t, EnforceDeviceGroupScope(ctx, "RenameDeviceGroup", "dg1"))
+		err := EnforceDeviceGroupScope(ctx, "RenameDeviceGroup", "dg2")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	// A direct-id match, NOT membership: a device-group grant for dg1 does not let
+	// the caller manage dg2 even if dg2 happens to share member devices with dg1.
+	t.Run("matches the group id directly, not by shared members", func(t *testing.T) {
+		ctx := ctxWith([]string{"DeleteDeviceGroup"},
+			ScopedGrant{Permission: "DeleteDeviceGroup", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"},
+			ScopedGrant{Permission: "DeleteDeviceGroup", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg3"})
+		assert.NoError(t, EnforceDeviceGroupScope(ctx, "DeleteDeviceGroup", "dg3"))
+		err := EnforceDeviceGroupScope(ctx, "DeleteDeviceGroup", "dg2")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("wrong-kind scoped grant fails closed", func(t *testing.T) {
+		ctx := ctxWith([]string{"RenameDeviceGroup"}, ScopedGrant{Permission: "RenameDeviceGroup", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		err := EnforceDeviceGroupScope(ctx, "RenameDeviceGroup", "dg1")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("lacking the base permission is denied", func(t *testing.T) {
+		ctx := ctxWith([]string{"SomethingElse"})
+		err := EnforceDeviceGroupScope(ctx, "RenameDeviceGroup", "dg1")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("unauthenticated is denied", func(t *testing.T) {
+		err := EnforceDeviceGroupScope(context.Background(), "RenameDeviceGroup", "dg1")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnauthenticated, codeOf(err))
+	})
+}
+
+// EnforceUserGroupScope is the user-group symmetric of EnforceDeviceGroupScope.
+func TestEnforceUserGroupScope(t *testing.T) {
+	t.Run("unrestricted base allows any group", func(t *testing.T) {
+		ctx := ctxWith([]string{"DeleteUserGroup"}, ScopedGrant{Permission: "DeleteUserGroup"})
+		assert.NoError(t, EnforceUserGroupScope(ctx, "DeleteUserGroup", "ugZ"))
+	})
+
+	t.Run("base perm with no scoped grant is unrestricted", func(t *testing.T) {
+		ctx := ctxWith([]string{"DeleteUserGroup"})
+		assert.NoError(t, EnforceUserGroupScope(ctx, "DeleteUserGroup", "ugZ"))
+	})
+
+	t.Run("user-group-scoped allows the matching group, denies others", func(t *testing.T) {
+		ctx := ctxWith([]string{"DeleteUserGroup"}, ScopedGrant{Permission: "DeleteUserGroup", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		assert.NoError(t, EnforceUserGroupScope(ctx, "DeleteUserGroup", "ug1"))
+		err := EnforceUserGroupScope(ctx, "DeleteUserGroup", "ug2")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	// A direct-id match, NOT membership: a user-group grant for ug1/ug3 does not
+	// let the caller manage ug2.
+	t.Run("matches the group id directly, not by shared members", func(t *testing.T) {
+		ctx := ctxWith([]string{"DeleteUserGroup"},
+			ScopedGrant{Permission: "DeleteUserGroup", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"},
+			ScopedGrant{Permission: "DeleteUserGroup", ScopeKind: ScopeKindUserGroup, ScopeID: "ug3"})
+		assert.NoError(t, EnforceUserGroupScope(ctx, "DeleteUserGroup", "ug3"))
+		err := EnforceUserGroupScope(ctx, "DeleteUserGroup", "ug2")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("wrong-kind scoped grant fails closed", func(t *testing.T) {
+		ctx := ctxWith([]string{"DeleteUserGroup"}, ScopedGrant{Permission: "DeleteUserGroup", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		err := EnforceUserGroupScope(ctx, "DeleteUserGroup", "ug1")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("lacking the base permission is denied", func(t *testing.T) {
+		ctx := ctxWith([]string{"SomethingElse"})
+		err := EnforceUserGroupScope(ctx, "DeleteUserGroup", "ug1")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, codeOf(err))
+	})
+
+	t.Run("unauthenticated is denied", func(t *testing.T) {
+		err := EnforceUserGroupScope(context.Background(), "DeleteUserGroup", "ug1")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeUnauthenticated, codeOf(err))
+	})
+}
+
+// DeviceScopeListFilter reduces the caller's device-group scope for a list
+// permission to (groupIDs, restricted). restricted=false ⇒ no group filtering;
+// restricted=true ⇒ restrict rows to devices in groupIDs (empty ⇒ nothing).
+func TestDeviceScopeListFilter(t *testing.T) {
+	t.Run("unrestricted base → not restricted", func(t *testing.T) {
+		ctx := ctxWith([]string{"ListDevices"}, ScopedGrant{Permission: "ListDevices"})
+		ids, restricted := DeviceScopeListFilter(ctx, "ListDevices")
+		assert.False(t, restricted)
+		assert.Empty(t, ids)
+	})
+
+	t.Run("base perm with no scoped grant → not restricted", func(t *testing.T) {
+		ctx := ctxWith([]string{"ListDevices"})
+		_, restricted := DeviceScopeListFilter(ctx, "ListDevices")
+		assert.False(t, restricted)
+	})
+
+	t.Run("device-group-scoped → restricted to those groups", func(t *testing.T) {
+		ctx := ctxWith([]string{"ListDevices"},
+			ScopedGrant{Permission: "ListDevices", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"},
+			ScopedGrant{Permission: "ListDevices", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg2"})
+		ids, restricted := DeviceScopeListFilter(ctx, "ListDevices")
+		assert.True(t, restricted)
+		assert.ElementsMatch(t, []string{"dg1", "dg2"}, ids)
+	})
+
+	// :assigned-only callers don't hold the base perm; the owner SQL filter
+	// confines them, so the group filter must NOT also apply (it would be a
+	// second, wrong restriction).
+	t.Run("assigned-only tier → not restricted (owner filter handles it)", func(t *testing.T) {
+		ctx := ctxWith([]string{"ListDevices:assigned"})
+		_, restricted := DeviceScopeListFilter(ctx, "ListDevices")
+		assert.False(t, restricted)
+	})
+
+	// Defense-in-depth: a base holder with only a wrong-kind grant must restrict
+	// to NOTHING, never read as unrestricted.
+	t.Run("wrong-kind scoped grant → restricted to nothing", func(t *testing.T) {
+		ctx := ctxWith([]string{"ListDevices"}, ScopedGrant{Permission: "ListDevices", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		ids, restricted := DeviceScopeListFilter(ctx, "ListDevices")
+		assert.True(t, restricted)
+		assert.Empty(t, ids)
+	})
+
+	// No caller in context ⇒ fail closed (restrict to nothing), never fail open.
+	t.Run("unauthenticated → restricted to nothing", func(t *testing.T) {
+		ids, restricted := DeviceScopeListFilter(context.Background(), "ListDevices")
+		assert.True(t, restricted)
+		assert.Empty(t, ids)
+	})
+}
+
+// UserScopeListFilter is the user-group symmetric of DeviceScopeListFilter.
+func TestUserScopeListFilter(t *testing.T) {
+	t.Run("unrestricted base → not restricted", func(t *testing.T) {
+		ctx := ctxWith([]string{"ListUsers"}, ScopedGrant{Permission: "ListUsers"})
+		_, restricted := UserScopeListFilter(ctx, "ListUsers")
+		assert.False(t, restricted)
+	})
+
+	t.Run("base perm with no scoped grant → not restricted", func(t *testing.T) {
+		ctx := ctxWith([]string{"ListUsers"})
+		_, restricted := UserScopeListFilter(ctx, "ListUsers")
+		assert.False(t, restricted)
+	})
+
+	// Lacking the base permission (e.g. only a :self tier) ⇒ the group filter does
+	// not apply here; the caller is confined by other means (or denied upstream).
+	t.Run("no base permission → not restricted", func(t *testing.T) {
+		ctx := ctxWith([]string{"GetUser:self"})
+		_, restricted := UserScopeListFilter(ctx, "ListUsers")
+		assert.False(t, restricted)
+	})
+
+	t.Run("user-group-scoped → restricted to those groups", func(t *testing.T) {
+		ctx := ctxWith([]string{"ListUsers"}, ScopedGrant{Permission: "ListUsers", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"})
+		ids, restricted := UserScopeListFilter(ctx, "ListUsers")
+		assert.True(t, restricted)
+		assert.ElementsMatch(t, []string{"ug1"}, ids)
+	})
+
+	t.Run("wrong-kind scoped grant → restricted to nothing", func(t *testing.T) {
+		ctx := ctxWith([]string{"ListUsers"}, ScopedGrant{Permission: "ListUsers", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"})
+		ids, restricted := UserScopeListFilter(ctx, "ListUsers")
+		assert.True(t, restricted)
+		assert.Empty(t, ids)
+	})
+
+	t.Run("unauthenticated → restricted to nothing", func(t *testing.T) {
+		_, restricted := UserScopeListFilter(context.Background(), "ListUsers")
+		assert.True(t, restricted)
+	})
+}

--- a/internal/store/device.go
+++ b/internal/store/device.go
@@ -55,11 +55,14 @@ type GetDeviceKey struct {
 }
 
 // ListDevicesFilter pairs pagination with the same `:self`-scoped
-// owner filter that GetDeviceKey uses.
+// owner filter that GetDeviceKey uses, plus the #3 device-group scope
+// restriction (orthogonal to OwnerScope: OwnerScope is the :assigned
+// tier, Scope is the device-group tier).
 type ListDevicesFilter struct {
 	Limit      int32
 	Offset     int32
 	OwnerScope *string
+	Scope      ScopeGroupFilter
 }
 
 // DeviceRepo reads device-projection state. Writes flow through
@@ -91,13 +94,13 @@ type DeviceRepo interface {
 	ListOffline(ctx context.Context, filter ListDevicesFilter) ([]Device, error)
 
 	// Count returns the total non-deleted device count (optionally
-	// scoped). Pairs with List.
-	Count(ctx context.Context, ownerScope *string) (int64, error)
+	// scoped by owner and/or device-group scope). Pairs with List.
+	Count(ctx context.Context, ownerScope *string, scope ScopeGroupFilter) (int64, error)
 
 	// CountOnline / CountOffline mirror their ListXxx counterparts
 	// for pagination totals.
-	CountOnline(ctx context.Context, ownerScope *string) (int64, error)
-	CountOffline(ctx context.Context, ownerScope *string) (int64, error)
+	CountOnline(ctx context.Context, ownerScope *string, scope ScopeGroupFilter) (int64, error)
+	CountOffline(ctx context.Context, ownerScope *string, scope ScopeGroupFilter) (int64, error)
 
 	// HostnamesByIDs returns the (id, hostname) pairs for the given
 	// device IDs in a single round-trip. Used by response builders

--- a/internal/store/device_group.go
+++ b/internal/store/device_group.go
@@ -40,6 +40,9 @@ type DeviceGroupMember struct {
 type ListDeviceGroupsFilter struct {
 	Limit  int32
 	Offset int32
+	// Scope is the #3 device-group restriction: a direct id-match —
+	// when Restricted, only groups whose id is in GroupIDs are listed.
+	Scope ScopeGroupFilter
 }
 
 // DeviceGroupRepo reads device-group state from the projection.
@@ -58,8 +61,9 @@ type DeviceGroupRepo interface {
 	// List returns a page of groups.
 	List(ctx context.Context, filter ListDeviceGroupsFilter) ([]DeviceGroup, error)
 
-	// Count returns the total non-deleted group count.
-	Count(ctx context.Context) (int64, error)
+	// Count returns the total non-deleted group count, scoped to the
+	// caller's device-group scope when restricted.
+	Count(ctx context.Context, scope ScopeGroupFilter) (int64, error)
 
 	// ListForDevice returns every group the device belongs to
 	// (direct + dynamic-materialized membership).

--- a/internal/store/execution.go
+++ b/internal/store/execution.go
@@ -58,6 +58,9 @@ type ListExecutionsFilter struct {
 	Search           string
 	Limit            int32
 	Offset           int32
+	// Scope is the #3 device-group restriction: when Restricted, only
+	// executions whose device is a member of a scope group are returned.
+	Scope ScopeGroupFilter
 }
 
 // CountExecutionsFilter mirrors ListExecutionsFilter's filter
@@ -68,6 +71,7 @@ type CountExecutionsFilter struct {
 	Status           string
 	ActionTypeFilter int32
 	Search           string
+	Scope            ScopeGroupFilter
 }
 
 // WarmFilter is the narrow pagination shape used by the search

--- a/internal/store/generated/actions.sql.go
+++ b/internal/store/generated/actions.sql.go
@@ -41,13 +41,20 @@ WHERE ($1::TEXT = '' OR device_id = $1)
   ) OR EXISTS (
     SELECT 1 FROM devices_projection d WHERE d.id = executions_projection.device_id AND d.hostname ILIKE '%' || $4 || '%'
   ))
+  -- Device-group scope (#3): when @scope_restricted, the execution's device must
+  -- be a member of a group in @scope_group_ids. Empty array restricts to nothing.
+  AND (NOT $5::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = executions_projection.device_id AND dgm.group_id = ANY($6::text[]))
+  )
 `
 
 type CountExecutionsParams struct {
-	Column1 string `json:"column_1"`
-	Column2 string `json:"column_2"`
-	Column3 int32  `json:"column_3"`
-	Column4 string `json:"column_4"`
+	Column1         string   `json:"column_1"`
+	Column2         string   `json:"column_2"`
+	Column3         int32    `json:"column_3"`
+	Column4         string   `json:"column_4"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
 }
 
 func (q *Queries) CountExecutions(ctx context.Context, arg CountExecutionsParams) (int64, error) {
@@ -56,6 +63,8 @@ func (q *Queries) CountExecutions(ctx context.Context, arg CountExecutionsParams
 		arg.Column2,
 		arg.Column3,
 		arg.Column4,
+		arg.ScopeRestricted,
+		arg.ScopeGroupIds,
 	)
 	var count int64
 	err := row.Scan(&count)
@@ -542,17 +551,24 @@ WHERE ($1::TEXT = '' OR device_id = $1)
   ) OR EXISTS (
     SELECT 1 FROM devices_projection d WHERE d.id = executions_projection.device_id AND d.hostname ILIKE '%' || $4 || '%'
   ))
+  -- Device-group scope (#3): when @scope_restricted, the execution's device must
+  -- be a member of a group in @scope_group_ids. Empty array restricts to nothing.
+  AND (NOT $7::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = executions_projection.device_id AND dgm.group_id = ANY($8::text[]))
+  )
 ORDER BY created_at DESC
 LIMIT $5 OFFSET $6
 `
 
 type ListExecutionsParams struct {
-	Column1 string `json:"column_1"`
-	Column2 string `json:"column_2"`
-	Column3 int32  `json:"column_3"`
-	Column4 string `json:"column_4"`
-	Limit   int32  `json:"limit"`
-	Offset  int32  `json:"offset"`
+	Column1         string   `json:"column_1"`
+	Column2         string   `json:"column_2"`
+	Column3         int32    `json:"column_3"`
+	Column4         string   `json:"column_4"`
+	Limit           int32    `json:"limit"`
+	Offset          int32    `json:"offset"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
 }
 
 func (q *Queries) ListExecutions(ctx context.Context, arg ListExecutionsParams) ([]ExecutionsProjection, error) {
@@ -563,6 +579,8 @@ func (q *Queries) ListExecutions(ctx context.Context, arg ListExecutionsParams) 
 		arg.Column4,
 		arg.Limit,
 		arg.Offset,
+		arg.ScopeRestricted,
+		arg.ScopeGroupIds,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/store/generated/device_groups.sql.go
+++ b/internal/store/generated/device_groups.sql.go
@@ -56,10 +56,16 @@ func (q *Queries) ClaimDeviceGroupForMembership(ctx context.Context, arg ClaimDe
 const countDeviceGroups = `-- name: CountDeviceGroups :one
 SELECT COUNT(*) FROM device_groups_projection
 WHERE is_deleted = FALSE
+  AND (NOT $1::boolean OR id = ANY($2::text[]))
 `
 
-func (q *Queries) CountDeviceGroups(ctx context.Context) (int64, error) {
-	row := q.db.QueryRow(ctx, countDeviceGroups)
+type CountDeviceGroupsParams struct {
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
+}
+
+func (q *Queries) CountDeviceGroups(ctx context.Context, arg CountDeviceGroupsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countDeviceGroups, arg.ScopeRestricted, arg.ScopeGroupIds)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -514,17 +520,27 @@ func (q *Queries) ListDeviceGroupMembershipsByDevice(ctx context.Context, device
 const listDeviceGroups = `-- name: ListDeviceGroups :many
 SELECT id, name, description, member_count, created_at, created_by, is_deleted, projection_version, is_dynamic, dynamic_query, sync_interval_minutes, maintenance_window FROM device_groups_projection
 WHERE is_deleted = FALSE
+  -- Device-group scope (#3): a direct id-match — when @scope_restricted, the
+  -- group itself must be one of @scope_group_ids. Empty array restricts to nothing.
+  AND (NOT $3::boolean OR id = ANY($4::text[]))
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
 `
 
 type ListDeviceGroupsParams struct {
-	Limit  int32 `json:"limit"`
-	Offset int32 `json:"offset"`
+	Limit           int32    `json:"limit"`
+	Offset          int32    `json:"offset"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
 }
 
 func (q *Queries) ListDeviceGroups(ctx context.Context, arg ListDeviceGroupsParams) ([]DeviceGroupsProjection, error) {
-	rows, err := q.db.Query(ctx, listDeviceGroups, arg.Limit, arg.Offset)
+	rows, err := q.db.Query(ctx, listDeviceGroups,
+		arg.Limit,
+		arg.Offset,
+		arg.ScopeRestricted,
+		arg.ScopeGroupIds,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -734,6 +750,9 @@ WHERE m.device_id = $1 AND g.is_deleted = FALSE
 ORDER BY g.name ASC
 `
 
+// NOTE: also used by the scope resolver (DeviceGroupsForDevice) to compute a
+// device's groups for scope checks, so it MUST stay UNFILTERED. The
+// ListDeviceGroupsForDevice handler applies device-group scope in Go.
 func (q *Queries) ListGroupsForDevice(ctx context.Context, deviceID string) ([]DeviceGroupsProjection, error) {
 	rows, err := q.db.Query(ctx, listGroupsForDevice, deviceID)
 	if err != nil {

--- a/internal/store/generated/devices.sql.go
+++ b/internal/store/generated/devices.sql.go
@@ -54,10 +54,21 @@ WHERE is_deleted = FALSE
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = $1)
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = $1)
   )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT $2::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY($3::text[]))
+  )
 `
 
-func (q *Queries) CountDevices(ctx context.Context, filterUserID *string) (int64, error) {
-	row := q.db.QueryRow(ctx, countDevices, filterUserID)
+type CountDevicesParams struct {
+	FilterUserID    *string  `json:"filter_user_id"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
+}
+
+func (q *Queries) CountDevices(ctx context.Context, arg CountDevicesParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countDevices, arg.FilterUserID, arg.ScopeRestricted, arg.ScopeGroupIds)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -71,10 +82,21 @@ WHERE is_deleted = FALSE
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = $1)
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = $1)
   )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT $2::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY($3::text[]))
+  )
 `
 
-func (q *Queries) CountDevicesOffline(ctx context.Context, filterUserID *string) (int64, error) {
-	row := q.db.QueryRow(ctx, countDevicesOffline, filterUserID)
+type CountDevicesOfflineParams struct {
+	FilterUserID    *string  `json:"filter_user_id"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
+}
+
+func (q *Queries) CountDevicesOffline(ctx context.Context, arg CountDevicesOfflineParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countDevicesOffline, arg.FilterUserID, arg.ScopeRestricted, arg.ScopeGroupIds)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -88,10 +110,21 @@ WHERE is_deleted = FALSE
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = $1)
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = $1)
   )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT $2::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY($3::text[]))
+  )
 `
 
-func (q *Queries) CountDevicesOnline(ctx context.Context, filterUserID *string) (int64, error) {
-	row := q.db.QueryRow(ctx, countDevicesOnline, filterUserID)
+type CountDevicesOnlineParams struct {
+	FilterUserID    *string  `json:"filter_user_id"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
+}
+
+func (q *Queries) CountDevicesOnline(ctx context.Context, arg CountDevicesOnlineParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countDevicesOnline, arg.FilterUserID, arg.ScopeRestricted, arg.ScopeGroupIds)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -207,15 +240,27 @@ WHERE id = $1 AND is_deleted = FALSE
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = $2)
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = $2)
   )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT $3::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY($4::text[]))
+  )
 `
 
 type GetDeviceByIDParams struct {
-	ID           string  `json:"id"`
-	FilterUserID *string `json:"filter_user_id"`
+	ID              string   `json:"id"`
+	FilterUserID    *string  `json:"filter_user_id"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
 }
 
 func (q *Queries) GetDeviceByID(ctx context.Context, arg GetDeviceByIDParams) (DevicesProjection, error) {
-	row := q.db.QueryRow(ctx, getDeviceByID, arg.ID, arg.FilterUserID)
+	row := q.db.QueryRow(ctx, getDeviceByID,
+		arg.ID,
+		arg.FilterUserID,
+		arg.ScopeRestricted,
+		arg.ScopeGroupIds,
+	)
 	var i DevicesProjection
 	err := row.Scan(
 		&i.ID,
@@ -746,18 +791,31 @@ WHERE is_deleted = FALSE
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = $3)
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = $3)
   )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT $4::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY($5::text[]))
+  )
 ORDER BY last_seen_at DESC
 LIMIT $1 OFFSET $2
 `
 
 type ListDevicesParams struct {
-	Limit        int32   `json:"limit"`
-	Offset       int32   `json:"offset"`
-	FilterUserID *string `json:"filter_user_id"`
+	Limit           int32    `json:"limit"`
+	Offset          int32    `json:"offset"`
+	FilterUserID    *string  `json:"filter_user_id"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
 }
 
 func (q *Queries) ListDevices(ctx context.Context, arg ListDevicesParams) ([]DevicesProjection, error) {
-	rows, err := q.db.Query(ctx, listDevices, arg.Limit, arg.Offset, arg.FilterUserID)
+	rows, err := q.db.Query(ctx, listDevices,
+		arg.Limit,
+		arg.Offset,
+		arg.FilterUserID,
+		arg.ScopeRestricted,
+		arg.ScopeGroupIds,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -800,18 +858,31 @@ WHERE is_deleted = FALSE
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = $3)
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = $3)
   )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT $4::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY($5::text[]))
+  )
 ORDER BY last_seen_at DESC
 LIMIT $1 OFFSET $2
 `
 
 type ListDevicesOfflineParams struct {
-	Limit        int32   `json:"limit"`
-	Offset       int32   `json:"offset"`
-	FilterUserID *string `json:"filter_user_id"`
+	Limit           int32    `json:"limit"`
+	Offset          int32    `json:"offset"`
+	FilterUserID    *string  `json:"filter_user_id"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
 }
 
 func (q *Queries) ListDevicesOffline(ctx context.Context, arg ListDevicesOfflineParams) ([]DevicesProjection, error) {
-	rows, err := q.db.Query(ctx, listDevicesOffline, arg.Limit, arg.Offset, arg.FilterUserID)
+	rows, err := q.db.Query(ctx, listDevicesOffline,
+		arg.Limit,
+		arg.Offset,
+		arg.FilterUserID,
+		arg.ScopeRestricted,
+		arg.ScopeGroupIds,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -854,18 +925,31 @@ WHERE is_deleted = FALSE
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = $3)
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = $3)
   )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT $4::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY($5::text[]))
+  )
 ORDER BY last_seen_at DESC
 LIMIT $1 OFFSET $2
 `
 
 type ListDevicesOnlineParams struct {
-	Limit        int32   `json:"limit"`
-	Offset       int32   `json:"offset"`
-	FilterUserID *string `json:"filter_user_id"`
+	Limit           int32    `json:"limit"`
+	Offset          int32    `json:"offset"`
+	FilterUserID    *string  `json:"filter_user_id"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
 }
 
 func (q *Queries) ListDevicesOnline(ctx context.Context, arg ListDevicesOnlineParams) ([]DevicesProjection, error) {
-	rows, err := q.db.Query(ctx, listDevicesOnline, arg.Limit, arg.Offset, arg.FilterUserID)
+	rows, err := q.db.Query(ctx, listDevicesOnline,
+		arg.Limit,
+		arg.Offset,
+		arg.FilterUserID,
+		arg.ScopeRestricted,
+		arg.ScopeGroupIds,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/generated/user_groups.sql.go
+++ b/internal/store/generated/user_groups.sql.go
@@ -99,11 +99,18 @@ func (q *Queries) CountGroupsWithRole(ctx context.Context, roleID string) (int64
 }
 
 const countUserGroups = `-- name: CountUserGroups :one
-SELECT count(*) FROM user_groups_projection WHERE is_deleted = FALSE
+SELECT count(*) FROM user_groups_projection
+WHERE is_deleted = FALSE
+  AND (NOT $1::boolean OR id = ANY($2::text[]))
 `
 
-func (q *Queries) CountUserGroups(ctx context.Context) (int64, error) {
-	row := q.db.QueryRow(ctx, countUserGroups)
+type CountUserGroupsParams struct {
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
+}
+
+func (q *Queries) CountUserGroups(ctx context.Context, arg CountUserGroupsParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countUserGroups, arg.ScopeRestricted, arg.ScopeGroupIds)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -692,16 +699,28 @@ func (q *Queries) ListUserGroupMembers(ctx context.Context, groupID string) ([]L
 }
 
 const listUserGroups = `-- name: ListUserGroups :many
-SELECT id, name, description, member_count, created_at, created_by, updated_at, is_deleted, projection_version, is_dynamic, dynamic_query, maintenance_window FROM user_groups_projection WHERE is_deleted = FALSE ORDER BY name LIMIT $1 OFFSET $2
+SELECT id, name, description, member_count, created_at, created_by, updated_at, is_deleted, projection_version, is_dynamic, dynamic_query, maintenance_window FROM user_groups_projection
+WHERE is_deleted = FALSE
+  AND (NOT $3::boolean OR id = ANY($4::text[]))
+ORDER BY name LIMIT $1 OFFSET $2
 `
 
 type ListUserGroupsParams struct {
-	Limit  int32 `json:"limit"`
-	Offset int32 `json:"offset"`
+	Limit           int32    `json:"limit"`
+	Offset          int32    `json:"offset"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
 }
 
+// User-group scope (#3): direct id-match — when @scope_restricted, the group
+// itself must be one of @scope_group_ids. Empty array restricts to nothing.
 func (q *Queries) ListUserGroups(ctx context.Context, arg ListUserGroupsParams) ([]UserGroupsProjection, error) {
-	rows, err := q.db.Query(ctx, listUserGroups, arg.Limit, arg.Offset)
+	rows, err := q.db.Query(ctx, listUserGroups,
+		arg.Limit,
+		arg.Offset,
+		arg.ScopeRestricted,
+		arg.ScopeGroupIds,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/generated/users.sql.go
+++ b/internal/store/generated/users.sql.go
@@ -13,10 +13,18 @@ import (
 const countUsers = `-- name: CountUsers :one
 SELECT COUNT(*) FROM users_projection
 WHERE is_deleted = FALSE
+  AND (NOT $1::boolean
+    OR EXISTS (SELECT 1 FROM user_group_members_projection ugm WHERE ugm.user_id = users_projection.id AND ugm.group_id = ANY($2::text[]))
+  )
 `
 
-func (q *Queries) CountUsers(ctx context.Context) (int64, error) {
-	row := q.db.QueryRow(ctx, countUsers)
+type CountUsersParams struct {
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
+}
+
+func (q *Queries) CountUsers(ctx context.Context, arg CountUsersParams) (int64, error) {
+	row := q.db.QueryRow(ctx, countUsers, arg.ScopeRestricted, arg.ScopeGroupIds)
 	var count int64
 	err := row.Scan(&count)
 	return count, err
@@ -574,17 +582,29 @@ func (q *Queries) ListUserSshKeysBatch(ctx context.Context, userIds []string) ([
 const listUsers = `-- name: ListUsers :many
 SELECT id, email, password_hash, role, created_at, updated_at, last_login_at, disabled, is_deleted, projection_version, session_version, has_password, totp_enabled, display_name, given_name, family_name, preferred_username, picture, locale, linux_username, linux_uid, ssh_access_enabled, ssh_allow_pubkey, ssh_allow_password, system_user_action_id, system_ssh_action_id, user_provisioning_enabled, system_tty_action_id FROM users_projection
 WHERE is_deleted = FALSE
+  -- User-group scope (#3): when @scope_restricted, the user must be a member of a
+  -- group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT $3::boolean
+    OR EXISTS (SELECT 1 FROM user_group_members_projection ugm WHERE ugm.user_id = users_projection.id AND ugm.group_id = ANY($4::text[]))
+  )
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2
 `
 
 type ListUsersParams struct {
-	Limit  int32 `json:"limit"`
-	Offset int32 `json:"offset"`
+	Limit           int32    `json:"limit"`
+	Offset          int32    `json:"offset"`
+	ScopeRestricted bool     `json:"scope_restricted"`
+	ScopeGroupIds   []string `json:"scope_group_ids"`
 }
 
 func (q *Queries) ListUsers(ctx context.Context, arg ListUsersParams) ([]UsersProjection, error) {
-	rows, err := q.db.Query(ctx, listUsers, arg.Limit, arg.Offset)
+	rows, err := q.db.Query(ctx, listUsers,
+		arg.Limit,
+		arg.Offset,
+		arg.ScopeRestricted,
+		arg.ScopeGroupIds,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/postgres/device.go
+++ b/internal/store/postgres/device.go
@@ -46,9 +46,11 @@ func (d *Device) IsDeleted(ctx context.Context, id string) (bool, error) {
 
 func (d *Device) List(ctx context.Context, filter store.ListDevicesFilter) ([]store.Device, error) {
 	rows, err := d.q.ListDevices(ctx, generated.ListDevicesParams{
-		Limit:        filter.Limit,
-		Offset:       filter.Offset,
-		FilterUserID: filter.OwnerScope,
+		Limit:           filter.Limit,
+		Offset:          filter.Offset,
+		FilterUserID:    filter.OwnerScope,
+		ScopeRestricted: filter.Scope.Restricted,
+		ScopeGroupIds:   filter.Scope.GroupIDs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("device: list: %w", err)
@@ -58,9 +60,11 @@ func (d *Device) List(ctx context.Context, filter store.ListDevicesFilter) ([]st
 
 func (d *Device) ListOnline(ctx context.Context, filter store.ListDevicesFilter) ([]store.Device, error) {
 	rows, err := d.q.ListDevicesOnline(ctx, generated.ListDevicesOnlineParams{
-		Limit:        filter.Limit,
-		Offset:       filter.Offset,
-		FilterUserID: filter.OwnerScope,
+		Limit:           filter.Limit,
+		Offset:          filter.Offset,
+		FilterUserID:    filter.OwnerScope,
+		ScopeRestricted: filter.Scope.Restricted,
+		ScopeGroupIds:   filter.Scope.GroupIDs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("device: list online: %w", err)
@@ -70,9 +74,11 @@ func (d *Device) ListOnline(ctx context.Context, filter store.ListDevicesFilter)
 
 func (d *Device) ListOffline(ctx context.Context, filter store.ListDevicesFilter) ([]store.Device, error) {
 	rows, err := d.q.ListDevicesOffline(ctx, generated.ListDevicesOfflineParams{
-		Limit:        filter.Limit,
-		Offset:       filter.Offset,
-		FilterUserID: filter.OwnerScope,
+		Limit:           filter.Limit,
+		Offset:          filter.Offset,
+		FilterUserID:    filter.OwnerScope,
+		ScopeRestricted: filter.Scope.Restricted,
+		ScopeGroupIds:   filter.Scope.GroupIDs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("device: list offline: %w", err)
@@ -80,24 +86,36 @@ func (d *Device) ListOffline(ctx context.Context, filter store.ListDevicesFilter
 	return d.deviceRowsToSlice(ctx, rows)
 }
 
-func (d *Device) Count(ctx context.Context, ownerScope *string) (int64, error) {
-	n, err := d.q.CountDevices(ctx, ownerScope)
+func (d *Device) Count(ctx context.Context, ownerScope *string, scope store.ScopeGroupFilter) (int64, error) {
+	n, err := d.q.CountDevices(ctx, generated.CountDevicesParams{
+		FilterUserID:    ownerScope,
+		ScopeRestricted: scope.Restricted,
+		ScopeGroupIds:   scope.GroupIDs,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("device: count: %w", translateNotFound(err))
 	}
 	return n, nil
 }
 
-func (d *Device) CountOnline(ctx context.Context, ownerScope *string) (int64, error) {
-	n, err := d.q.CountDevicesOnline(ctx, ownerScope)
+func (d *Device) CountOnline(ctx context.Context, ownerScope *string, scope store.ScopeGroupFilter) (int64, error) {
+	n, err := d.q.CountDevicesOnline(ctx, generated.CountDevicesOnlineParams{
+		FilterUserID:    ownerScope,
+		ScopeRestricted: scope.Restricted,
+		ScopeGroupIds:   scope.GroupIDs,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("device: count online: %w", translateNotFound(err))
 	}
 	return n, nil
 }
 
-func (d *Device) CountOffline(ctx context.Context, ownerScope *string) (int64, error) {
-	n, err := d.q.CountDevicesOffline(ctx, ownerScope)
+func (d *Device) CountOffline(ctx context.Context, ownerScope *string, scope store.ScopeGroupFilter) (int64, error) {
+	n, err := d.q.CountDevicesOffline(ctx, generated.CountDevicesOfflineParams{
+		FilterUserID:    ownerScope,
+		ScopeRestricted: scope.Restricted,
+		ScopeGroupIds:   scope.GroupIDs,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("device: count offline: %w", translateNotFound(err))
 	}

--- a/internal/store/postgres/device_group.go
+++ b/internal/store/postgres/device_group.go
@@ -39,8 +39,10 @@ func (g *DeviceGroup) GetByName(ctx context.Context, name string) (store.DeviceG
 
 func (g *DeviceGroup) List(ctx context.Context, filter store.ListDeviceGroupsFilter) ([]store.DeviceGroup, error) {
 	rows, err := g.q.ListDeviceGroups(ctx, generated.ListDeviceGroupsParams{
-		Limit:  filter.Limit,
-		Offset: filter.Offset,
+		Limit:           filter.Limit,
+		Offset:          filter.Offset,
+		ScopeRestricted: filter.Scope.Restricted,
+		ScopeGroupIds:   filter.Scope.GroupIDs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("device_group: list: %w", err)
@@ -52,8 +54,11 @@ func (g *DeviceGroup) List(ctx context.Context, filter store.ListDeviceGroupsFil
 	return out, nil
 }
 
-func (g *DeviceGroup) Count(ctx context.Context) (int64, error) {
-	n, err := g.q.CountDeviceGroups(ctx)
+func (g *DeviceGroup) Count(ctx context.Context, scope store.ScopeGroupFilter) (int64, error) {
+	n, err := g.q.CountDeviceGroups(ctx, generated.CountDeviceGroupsParams{
+		ScopeRestricted: scope.Restricted,
+		ScopeGroupIds:   scope.GroupIDs,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("device_group: count: %w", translateNotFound(err))
 	}

--- a/internal/store/postgres/execution.go
+++ b/internal/store/postgres/execution.go
@@ -32,12 +32,14 @@ func (e *Execution) Get(ctx context.Context, id string) (store.Execution, error)
 
 func (e *Execution) List(ctx context.Context, filter store.ListExecutionsFilter) ([]store.Execution, error) {
 	rows, err := e.q.ListExecutions(ctx, generated.ListExecutionsParams{
-		Column1: filter.DeviceID,
-		Column2: filter.Status,
-		Column3: filter.ActionTypeFilter,
-		Column4: filter.Search,
-		Limit:   filter.Limit,
-		Offset:  filter.Offset,
+		Column1:         filter.DeviceID,
+		Column2:         filter.Status,
+		Column3:         filter.ActionTypeFilter,
+		Column4:         filter.Search,
+		Limit:           filter.Limit,
+		Offset:          filter.Offset,
+		ScopeRestricted: filter.Scope.Restricted,
+		ScopeGroupIds:   filter.Scope.GroupIDs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("execution: list: %w", err)
@@ -51,10 +53,12 @@ func (e *Execution) List(ctx context.Context, filter store.ListExecutionsFilter)
 
 func (e *Execution) Count(ctx context.Context, filter store.CountExecutionsFilter) (int64, error) {
 	n, err := e.q.CountExecutions(ctx, generated.CountExecutionsParams{
-		Column1: filter.DeviceID,
-		Column2: filter.Status,
-		Column3: filter.ActionTypeFilter,
-		Column4: filter.Search,
+		Column1:         filter.DeviceID,
+		Column2:         filter.Status,
+		Column3:         filter.ActionTypeFilter,
+		Column4:         filter.Search,
+		ScopeRestricted: filter.Scope.Restricted,
+		ScopeGroupIds:   filter.Scope.GroupIDs,
 	})
 	if err != nil {
 		return 0, fmt.Errorf("execution: count: %w", translateNotFound(err))

--- a/internal/store/postgres/user.go
+++ b/internal/store/postgres/user.go
@@ -104,8 +104,10 @@ func (u *User) NextLinuxUID(ctx context.Context) (int32, error) {
 
 func (u *User) List(ctx context.Context, filter store.ListUsersFilter) ([]store.User, error) {
 	rows, err := u.q.ListUsers(ctx, generated.ListUsersParams{
-		Limit:  filter.Limit,
-		Offset: filter.Offset,
+		Limit:           filter.Limit,
+		Offset:          filter.Offset,
+		ScopeRestricted: filter.Scope.Restricted,
+		ScopeGroupIds:   filter.Scope.GroupIDs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("user: list: %w", err)
@@ -122,8 +124,11 @@ func (u *User) List(ctx context.Context, filter store.ListUsersFilter) ([]store.
 	return out, nil
 }
 
-func (u *User) Count(ctx context.Context) (int64, error) {
-	n, err := u.q.CountUsers(ctx)
+func (u *User) Count(ctx context.Context, scope store.ScopeGroupFilter) (int64, error) {
+	n, err := u.q.CountUsers(ctx, generated.CountUsersParams{
+		ScopeRestricted: scope.Restricted,
+		ScopeGroupIds:   scope.GroupIDs,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("user: count: %w", translateNotFound(err))
 	}

--- a/internal/store/postgres/user_group.go
+++ b/internal/store/postgres/user_group.go
@@ -60,8 +60,10 @@ func (g *UserGroup) GetWithMembers(ctx context.Context, id string) (store.UserGr
 
 func (g *UserGroup) List(ctx context.Context, filter store.ListUserGroupsFilter) ([]store.UserGroup, error) {
 	rows, err := g.q.ListUserGroups(ctx, generated.ListUserGroupsParams{
-		Limit:  filter.Limit,
-		Offset: filter.Offset,
+		Limit:           filter.Limit,
+		Offset:          filter.Offset,
+		ScopeRestricted: filter.Scope.Restricted,
+		ScopeGroupIds:   filter.Scope.GroupIDs,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("user_group: list: %w", err)
@@ -73,8 +75,11 @@ func (g *UserGroup) List(ctx context.Context, filter store.ListUserGroupsFilter)
 	return out, nil
 }
 
-func (g *UserGroup) Count(ctx context.Context) (int64, error) {
-	n, err := g.q.CountUserGroups(ctx)
+func (g *UserGroup) Count(ctx context.Context, scope store.ScopeGroupFilter) (int64, error) {
+	n, err := g.q.CountUserGroups(ctx, generated.CountUserGroupsParams{
+		ScopeRestricted: scope.Restricted,
+		ScopeGroupIds:   scope.GroupIDs,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("user_group: count: %w", translateNotFound(err))
 	}

--- a/internal/store/queries/actions.sql
+++ b/internal/store/queries/actions.sql
@@ -247,6 +247,11 @@ WHERE ($1::TEXT = '' OR device_id = $1)
   ) OR EXISTS (
     SELECT 1 FROM devices_projection d WHERE d.id = executions_projection.device_id AND d.hostname ILIKE '%' || $4 || '%'
   ))
+  -- Device-group scope (#3): when @scope_restricted, the execution's device must
+  -- be a member of a group in @scope_group_ids. Empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = executions_projection.device_id AND dgm.group_id = ANY(@scope_group_ids::text[]))
+  )
 ORDER BY created_at DESC
 LIMIT $5 OFFSET $6;
 
@@ -259,7 +264,12 @@ WHERE ($1::TEXT = '' OR device_id = $1)
     SELECT 1 FROM actions_projection a WHERE a.id = executions_projection.action_id AND a.name ILIKE '%' || $4 || '%'
   ) OR EXISTS (
     SELECT 1 FROM devices_projection d WHERE d.id = executions_projection.device_id AND d.hostname ILIKE '%' || $4 || '%'
-  ));
+  ))
+  -- Device-group scope (#3): when @scope_restricted, the execution's device must
+  -- be a member of a group in @scope_group_ids. Empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = executions_projection.device_id AND dgm.group_id = ANY(@scope_group_ids::text[]))
+  );
 
 -- name: ListPendingExecutionsForDevice :many
 -- Include both 'pending' and 'dispatched' statuses, since dispatched executions

--- a/internal/store/queries/device_groups.sql
+++ b/internal/store/queries/device_groups.sql
@@ -11,12 +11,16 @@ WHERE name = $1 AND is_deleted = FALSE;
 -- name: ListDeviceGroups :many
 SELECT * FROM device_groups_projection
 WHERE is_deleted = FALSE
+  -- Device-group scope (#3): a direct id-match — when @scope_restricted, the
+  -- group itself must be one of @scope_group_ids. Empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean OR id = ANY(@scope_group_ids::text[]))
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2;
 
 -- name: CountDeviceGroups :one
 SELECT COUNT(*) FROM device_groups_projection
-WHERE is_deleted = FALSE;
+WHERE is_deleted = FALSE
+  AND (NOT @scope_restricted::boolean OR id = ANY(@scope_group_ids::text[]));
 
 -- Device Group Members queries
 
@@ -39,6 +43,9 @@ WHERE m.group_id = $1 AND d.is_deleted = FALSE
 ORDER BY d.hostname ASC;
 
 -- name: ListGroupsForDevice :many
+-- NOTE: also used by the scope resolver (DeviceGroupsForDevice) to compute a
+-- device's groups for scope checks, so it MUST stay UNFILTERED. The
+-- ListDeviceGroupsForDevice handler applies device-group scope in Go.
 SELECT g.* FROM device_groups_projection g
 JOIN device_group_members_projection m ON g.id = m.group_id
 WHERE m.device_id = $1 AND g.is_deleted = FALSE

--- a/internal/store/queries/devices.sql
+++ b/internal/store/queries/devices.sql
@@ -4,6 +4,11 @@ WHERE id = $1 AND is_deleted = FALSE
   AND (sqlc.narg('filter_user_id')::TEXT IS NULL
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = sqlc.narg('filter_user_id'))
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = sqlc.narg('filter_user_id'))
+  )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY(@scope_group_ids::text[]))
   );
 
 -- name: IsDeviceDeleted :one
@@ -20,6 +25,11 @@ WHERE is_deleted = FALSE
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = sqlc.narg('filter_user_id'))
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = sqlc.narg('filter_user_id'))
   )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY(@scope_group_ids::text[]))
+  )
 ORDER BY last_seen_at DESC
 LIMIT $1 OFFSET $2;
 
@@ -30,6 +40,11 @@ WHERE is_deleted = FALSE
   AND (sqlc.narg('filter_user_id')::TEXT IS NULL
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = sqlc.narg('filter_user_id'))
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = sqlc.narg('filter_user_id'))
+  )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY(@scope_group_ids::text[]))
   )
 ORDER BY last_seen_at DESC
 LIMIT $1 OFFSET $2;
@@ -42,6 +57,11 @@ WHERE is_deleted = FALSE
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = sqlc.narg('filter_user_id'))
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = sqlc.narg('filter_user_id'))
   )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY(@scope_group_ids::text[]))
+  )
 ORDER BY last_seen_at DESC
 LIMIT $1 OFFSET $2;
 
@@ -51,6 +71,11 @@ WHERE is_deleted = FALSE
   AND (sqlc.narg('filter_user_id')::TEXT IS NULL
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = sqlc.narg('filter_user_id'))
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = sqlc.narg('filter_user_id'))
+  )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY(@scope_group_ids::text[]))
   );
 
 -- name: CountDevicesOnline :one
@@ -60,6 +85,11 @@ WHERE is_deleted = FALSE
   AND (sqlc.narg('filter_user_id')::TEXT IS NULL
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = sqlc.narg('filter_user_id'))
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = sqlc.narg('filter_user_id'))
+  )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY(@scope_group_ids::text[]))
   );
 
 -- name: CountDevicesOffline :one
@@ -69,6 +99,11 @@ WHERE is_deleted = FALSE
   AND (sqlc.narg('filter_user_id')::TEXT IS NULL
     OR EXISTS (SELECT 1 FROM device_assigned_users_projection dau WHERE dau.device_id = devices_projection.id AND dau.user_id = sqlc.narg('filter_user_id'))
     OR EXISTS (SELECT 1 FROM device_assigned_groups_projection dag JOIN user_group_members_projection ugm ON ugm.group_id = dag.group_id WHERE dag.device_id = devices_projection.id AND ugm.user_id = sqlc.narg('filter_user_id'))
+  )
+  -- Device-group scope (#3): when @scope_restricted, the device must be a member
+  -- of a group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM device_group_members_projection dgm WHERE dgm.device_id = devices_projection.id AND dgm.group_id = ANY(@scope_group_ids::text[]))
   );
 
 -- name: ListDeviceAssignedUserIDsBatch :many

--- a/internal/store/queries/user_groups.sql
+++ b/internal/store/queries/user_groups.sql
@@ -5,10 +5,17 @@ SELECT * FROM user_groups_projection WHERE id = $1 AND is_deleted = FALSE;
 SELECT * FROM user_groups_projection WHERE name = $1 AND is_deleted = FALSE;
 
 -- name: ListUserGroups :many
-SELECT * FROM user_groups_projection WHERE is_deleted = FALSE ORDER BY name LIMIT $1 OFFSET $2;
+-- User-group scope (#3): direct id-match — when @scope_restricted, the group
+-- itself must be one of @scope_group_ids. Empty array restricts to nothing.
+SELECT * FROM user_groups_projection
+WHERE is_deleted = FALSE
+  AND (NOT @scope_restricted::boolean OR id = ANY(@scope_group_ids::text[]))
+ORDER BY name LIMIT $1 OFFSET $2;
 
 -- name: CountUserGroups :one
-SELECT count(*) FROM user_groups_projection WHERE is_deleted = FALSE;
+SELECT count(*) FROM user_groups_projection
+WHERE is_deleted = FALSE
+  AND (NOT @scope_restricted::boolean OR id = ANY(@scope_group_ids::text[]));
 
 -- name: ListUserGroupMembers :many
 SELECT ugm.user_id, u.email, ugm.added_at

--- a/internal/store/queries/users.sql
+++ b/internal/store/queries/users.sql
@@ -9,12 +9,20 @@ WHERE email = $1 AND is_deleted = FALSE;
 -- name: ListUsers :many
 SELECT * FROM users_projection
 WHERE is_deleted = FALSE
+  -- User-group scope (#3): when @scope_restricted, the user must be a member of a
+  -- group in @scope_group_ids. An empty array restricts to nothing.
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM user_group_members_projection ugm WHERE ugm.user_id = users_projection.id AND ugm.group_id = ANY(@scope_group_ids::text[]))
+  )
 ORDER BY created_at DESC
 LIMIT $1 OFFSET $2;
 
 -- name: CountUsers :one
 SELECT COUNT(*) FROM users_projection
-WHERE is_deleted = FALSE;
+WHERE is_deleted = FALSE
+  AND (NOT @scope_restricted::boolean
+    OR EXISTS (SELECT 1 FROM user_group_members_projection ugm WHERE ugm.user_id = users_projection.id AND ugm.group_id = ANY(@scope_group_ids::text[]))
+  );
 
 -- name: ListAllUsers :many
 SELECT * FROM users_projection

--- a/internal/store/scope_filter.go
+++ b/internal/store/scope_filter.go
@@ -1,0 +1,16 @@
+package store
+
+// ScopeGroupFilter carries device/user-group scope restriction for a list or
+// count query (#3). Restricted=false ⇒ no row filtering (caller is global, has no
+// scoping grant, or is confined by a separate owner filter). Restricted=true ⇒
+// rows are confined to GroupIDs; an empty GroupIDs restricts to NOTHING (a
+// wrong-kind grant or an unauthenticated caller — fail closed).
+//
+// The generated queries key their membership / id-match predicate off Restricted
+// (a boolean), not off GroupIDs being nil-vs-empty, so the SQL is unambiguous and
+// pgx array encoding never decides access. Mirrors the (groupIDs, restricted)
+// output of auth.DeviceScopeListFilter / auth.UserScopeListFilter.
+type ScopeGroupFilter struct {
+	Restricted bool
+	GroupIDs   []string
+}

--- a/internal/store/user.go
+++ b/internal/store/user.go
@@ -63,10 +63,12 @@ type UserSessionInfo struct {
 	IsDeleted      bool
 }
 
-// ListUsersFilter is the pagination shape for the user list endpoint.
+// ListUsersFilter is the pagination shape for the user list endpoint,
+// plus the #3 user-group scope restriction.
 type ListUsersFilter struct {
 	Limit  int32
 	Offset int32
+	Scope  ScopeGroupFilter
 }
 
 // ScopedGrant is one (permission, scope) tuple a user holds. ScopeKind
@@ -118,8 +120,9 @@ type UserRepo interface {
 	// List returns a page of users.
 	List(ctx context.Context, filter ListUsersFilter) ([]User, error)
 
-	// Count returns the total non-deleted user count.
-	Count(ctx context.Context) (int64, error)
+	// Count returns the total non-deleted user count, scoped to the
+	// caller's user-group scope when restricted.
+	Count(ctx context.Context, scope ScopeGroupFilter) (int64, error)
 
 	// ListAllNonDeleted returns every non-deleted user. Used by
 	// the server-settings handler's batch-enable propagation

--- a/internal/store/user_group.go
+++ b/internal/store/user_group.go
@@ -45,6 +45,9 @@ type UserGroupMember struct {
 type ListUserGroupsFilter struct {
 	Limit  int32
 	Offset int32
+	// Scope is the #3 user-group restriction: a direct id-match — when
+	// Restricted, only groups whose id is in GroupIDs are listed.
+	Scope ScopeGroupFilter
 }
 
 // UserGroupRepo reads user-group state from the projection. Writes
@@ -69,8 +72,9 @@ type UserGroupRepo interface {
 	// List returns a page of groups.
 	List(ctx context.Context, filter ListUserGroupsFilter) ([]UserGroup, error)
 
-	// Count returns the total non-deleted group count.
-	Count(ctx context.Context) (int64, error)
+	// Count returns the total non-deleted group count, scoped to the
+	// caller's user-group scope when restricted.
+	Count(ctx context.Context, scope ScopeGroupFilter) (int64, error)
 
 	// ListForUser returns every group the user belongs to (direct
 	// membership only — dynamic-group membership is materialized


### PR DESCRIPTION
## Summary

Part 2 of the WS3 scope-enforcement work. Part 1 (#406) landed the single-resource gate layer; this makes scope enforcement **uniform across every scopable permission** and pins **scopable == enforced** with a self-discovering parity test — so no scopable permission can silently stay advisory.

Builds on #405 (the role-management permission is the sole grant gate; no grant-only-what-you-hold ceiling). Scope enforcement is the orthogonal axis: *what* you may confer is gated by the role-mgmt permission; *which targets* you may act on is gated by scope.

## What's enforced now (was advisory everywhere but StartTerminal)

- **Group mutation** — Get/Rename/Description/Delete/windows + Add/Remove member, via new `EnforceDeviceGroupScope` / `EnforceUserGroupScope` (direct group-id match). `Add*` also checks each member is **already in the caller's scope**, closing a scope-escape (pulling an out-of-scope device/user into a group you control to widen your reach).
- **Dispatch fan-out** — `DispatchToMultiple/ActionSet/Definition/ToGroup` via `enforceDeviceScopeAll`: every target device checked, the whole request fails closed if any is out of scope.
- **Terminal session ops** — `StopTerminal` / `TerminateTerminalSession` resolve the session's device; `ListActiveTerminalSessions` filters the merged list.
- **List filters** — `ListDevices/Online/Offline`, `ListExecutions`, `ListUsers`, `ListDeviceGroups`, `ListUserGroups`, `ListDeviceGroupsForDevice`, `ListUserGroupsForUser`. sqlc gains a `(scope_restricted, scope_group_ids)` param pair; the matching **COUNT** query takes the same restriction so pagination totals stay honest and don't leak the out-of-scope count. `ListGroupsForDevice` / `ListUserGroupsForUser` stay UNFILTERED in SQL (the scope resolver depends on them) and are filtered in Go in their handlers.

## De-scope (decision: org-tier create)

`CreateStaticDeviceGroup` / `CreateStaticUserGroup` → `TargetUnspecified`. A brand-new group has no id/members, so there is nothing to confine a scope against at create time — making it scopable would be advisory-only. Scope is enforced on the downstream management + membership ops instead. (No auto-grant machinery, no global-admin special case.)

## The forcing function (#19)

`TestScopablePermissions_AllEnforced` AST-scans `internal/api` for permission string-literals passed to the recognized scope functions (and the reconciler's `switch g.Permission` for the TerminalAdmin cohort) and asserts the **enforced set equals the scopable set** from `auth.AllPermissions()`, both directions. A new TargetDevice/TargetUser permission added without enforcement fails the build; so does enforcing a permission the registry no longer marks scopable. Only the enforcement *mechanisms* are enumerated — forgetting to register one fails **closed**.

## Model

Flat permission set is the AUTHORITY (do you hold the base?); scoped grants only CONFINE (which targets?). Base + no scoping grant ⇒ unrestricted; base + same-kind grant ⇒ confined; base + only a wrong-kind grant ⇒ **denied** (fail closed). The `:assigned`/`:self` tier falls through to the existing owner SQL filter.

## Tests / gates

- New unit tests for all auth primitives (`internal/auth/scope_group_test.go`), and integration tests per cluster (`internal/api/scope_enforcement_*_test.go`) asserting in-scope allowed / out-of-scope `PermissionDenied`, plus list-count parity.
- Full server suite green (`auth`, `store`, `api`); no regressions from the fail-closed scope checks.
- `make sqlc-generate` (pinned image), `go vet`, `gofmt`, build all clean.

## Docs

ADR `0006-scope-enforcement-handler-level-uniform.md`; `server/README.md` + `cmd/control/README.md` updated for scope enforcement and the sole-gate grant-authority model.

Advances manchtools/power-manage-server#7.