### PR TITLE
fix(rbac): serialize dynamic-group queue drain across replicas + WS3 verification charters

### DIFF
--- a/internal/api/refresh_token_revocation_test.go
+++ b/internal/api/refresh_token_revocation_test.go
@@ -1,0 +1,102 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// loginForRefresh logs a fresh user in and returns the auth handler, the user's
+// id, and a valid refresh token to exercise the RefreshToken revocation paths.
+func loginForRefresh(t *testing.T, st *store.Store) (*api.AuthHandler, string, string) {
+	t.Helper()
+	h := api.NewAuthHandler(st, slog.Default(), testutil.NewJWTManager(), true)
+	// A separate enabled admin so disabling/deleting the test user can't trip the
+	// last-admin guard (which requires >=1 enabled admin to remain).
+	testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	// The user under test is a non-admin.
+	email := testutil.NewID() + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "correct-password", "user")
+	resp, err := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{Email: email, Password: "correct-password"}))
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Msg.RefreshToken)
+	return h, userID, resp.Msg.RefreshToken
+}
+
+// TestRefreshToken_SessionVersionMismatch_Rejected pins finding #4/#6: once a
+// user's session_version is bumped (a role/permission change), a refresh token
+// minted at the old version is rejected — the enforcement point for revocation.
+func TestRefreshToken_SessionVersionMismatch_Rejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, userID, refresh := loginForRefresh(t, st)
+
+	// Bump session_version out from under the issued token.
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "user",
+		StreamID:   userID,
+		EventType:  string(eventtypes.UserSessionInvalidated),
+		Data:       map[string]any{},
+		ActorType:  "user",
+		ActorID:    userID,
+	}))
+
+	_, err := h.RefreshToken(context.Background(), connect.NewRequest(&pm.RefreshTokenRequest{RefreshToken: refresh}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+// TestRefreshToken_DisabledUser_Rejected: a disabled account can't refresh.
+func TestRefreshToken_DisabledUser_Rejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, userID, refresh := loginForRefresh(t, st)
+
+	userH := api.NewUserHandler(st, slog.Default(), nil)
+	_, err := userH.SetUserDisabled(testutil.AdminContext(testutil.NewID()),
+		connect.NewRequest(&pm.SetUserDisabledRequest{Id: userID, Disabled: true}))
+	require.NoError(t, err)
+
+	_, err = h.RefreshToken(context.Background(), connect.NewRequest(&pm.RefreshTokenRequest{RefreshToken: refresh}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+// TestRefreshToken_DeletedUser_Rejected: a deleted account can't refresh.
+func TestRefreshToken_DeletedUser_Rejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, userID, refresh := loginForRefresh(t, st)
+
+	userH := api.NewUserHandler(st, slog.Default(), nil)
+	_, err := userH.DeleteUser(testutil.AdminContext(testutil.NewID()),
+		connect.NewRequest(&pm.DeleteUserRequest{Id: userID}))
+	require.NoError(t, err)
+
+	_, err = h.RefreshToken(context.Background(), connect.NewRequest(&pm.RefreshTokenRequest{RefreshToken: refresh}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}
+
+// TestRefreshToken_SingleUse_SecondCallRejected pins that a refresh token is
+// single-use: the first refresh revokes the old JTI, so replaying it fails.
+func TestRefreshToken_SingleUse_SecondCallRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h, _, refresh := loginForRefresh(t, st)
+
+	first, err := h.RefreshToken(context.Background(), connect.NewRequest(&pm.RefreshTokenRequest{RefreshToken: refresh}))
+	require.NoError(t, err, "first refresh must succeed")
+	require.NotEmpty(t, first.Msg.RefreshToken)
+
+	// Replaying the SAME (now-spent) token must be rejected.
+	_, err = h.RefreshToken(context.Background(), connect.NewRequest(&pm.RefreshTokenRequest{RefreshToken: refresh}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+}

--- a/internal/auth/authorizer_test.go
+++ b/internal/auth/authorizer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ============================================================================
@@ -273,14 +274,45 @@ func TestAuthorize_DeviceHeartbeat(t *testing.T) {
 	}
 }
 
-func TestAuthorize_DeviceDeniedAdminActions(t *testing.T) {
-	denied := []string{"CreateUser", "DeleteDevice", "DispatchAction", "ListUsers"}
-	for _, action := range denied {
-		allowed := Authorize(AuthzInput{
-			IsDevice:  true,
-			SubjectID: "device-1",
-			Action:    action,
-		})
-		assert.False(t, allowed, "device should be denied %s", action)
+// TestAuthorize_DeviceAllowed_ExactSet pins the EXACT set of actions a device
+// cert may invoke and proves every other registered permission is denied —
+// self-discoveringly, so a new permission can never silently become
+// device-reachable (#11). Replaces the old hand-picked denied-actions sample.
+//
+// The allowed set is sourced from the device trust model (a device may read
+// itself, read definitions to execute, read its own executions, and report
+// status), NOT from authorizeDevice — so a change to authorizeDevice that widens
+// device reach fails this test.
+func TestAuthorize_DeviceAllowed_ExactSet(t *testing.T) {
+	const self = "device-1"
+	allowed := map[string]AuthzInput{
+		"GetDevice":       {IsDevice: true, SubjectID: self, Action: "GetDevice", ResourceID: self},
+		"ListDefinitions": {IsDevice: true, SubjectID: self, Action: "ListDefinitions"},
+		"GetDefinition":   {IsDevice: true, SubjectID: self, Action: "GetDefinition"},
+		"ListExecutions":  {IsDevice: true, SubjectID: self, Action: "ListExecutions", DeviceID: self},
+		"GetExecution":    {IsDevice: true, SubjectID: self, Action: "GetExecution", DeviceID: self},
+		"Heartbeat":       {IsDevice: true, SubjectID: self, Action: "Heartbeat"},
+		"UpdateStatus":    {IsDevice: true, SubjectID: self, Action: "UpdateStatus"},
 	}
+	require.NotEmpty(t, allowed)
+
+	for name, in := range allowed {
+		assert.Truef(t, Authorize(in), "device must be allowed %s with its correct binding", name)
+	}
+
+	// Self-discovering deny: every registered RBAC permission NOT in the allow-set
+	// must be denied for a device — even handed a self-binding, a device must not
+	// gain a permission merely because it was added to the registry.
+	perms := AllPermissions()
+	require.NotEmpty(t, perms, "no permissions discovered — the deny sweep would be vacuous")
+	denied := 0
+	for _, p := range perms {
+		if _, ok := allowed[p.Key]; ok {
+			continue
+		}
+		in := AuthzInput{IsDevice: true, SubjectID: self, Action: p.Key, ResourceID: self, DeviceID: self}
+		assert.Falsef(t, Authorize(in), "device must be denied %s (not in the device allow-list)", p.Key)
+		denied++
+	}
+	require.Greater(t, denied, len(allowed), "deny sweep must cover more permissions than the allow-list")
 }

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -602,3 +602,52 @@ func TestAuthInterceptor_ListAuthMethodsThrottled(t *testing.T) {
 	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
 	assert.Contains(t, err.Error(), "too many", "must trip the AuthMethods limiter, not some other gate")
 }
+
+// setupDeviceInterceptorTest wires the REAL AuthzInterceptor behind a tiny
+// interceptor that injects a device context (mirroring what the mTLS device-auth
+// path produces in production), so the interceptor's device branch is exercised
+// end-to-end through WrapUnary rather than unit-testing authorizeDevice in
+// isolation (#10).
+func setupDeviceInterceptorTest(t *testing.T, procedure string) string {
+	t.Helper()
+
+	deviceInjector := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			return next(WithDevice(ctx, &DeviceContext{ID: "device-1"}), req)
+		}
+	})
+	authzIc := NewAuthzInterceptor()
+
+	mux := http.NewServeMux()
+	handler := connect.NewUnaryHandler(
+		procedure,
+		func(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+			return connect.NewResponse(&emptypb.Empty{}), nil
+		},
+		connect.WithInterceptors(deviceInjector, authzIc),
+	)
+	mux.Handle(procedure, handler)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server.URL
+}
+
+func TestAuthzInterceptor_DeviceContext_AllowsDeviceAction(t *testing.T) {
+	const procedure = "/pm.v1.ControlService/Heartbeat"
+	serverURL := setupDeviceInterceptorTest(t, procedure)
+
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, serverURL+procedure)
+	_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.NoError(t, err, "a device must be allowed Heartbeat through the real interceptor device branch")
+}
+
+func TestAuthzInterceptor_DeviceContext_DeniesAdminAction(t *testing.T) {
+	const procedure = "/pm.v1.ControlService/DeleteDevice"
+	serverURL := setupDeviceInterceptorTest(t, procedure)
+
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, serverURL+procedure)
+	_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.Error(t, err, "a device must be denied an admin action through the real interceptor")
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}

--- a/internal/dyngroupeval/evaluator.go
+++ b/internal/dyngroupeval/evaluator.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"strings"
 	"time"
@@ -30,6 +31,32 @@ import (
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
+
+// Per-group advisory-lock namespaces for the drain (#15). The high 32 bits hold
+// a fixed namespace so a derived key can never collide with the api last-admin
+// lock (advisoryKeyAdminMutation, whose high 32 bits are 0x61); device and user
+// queues use distinct namespaces so a device group and a user group with the same
+// id-hash don't exclude each other. The low 32 bits are an FNV-1a hash of the
+// group id — a hash collision only causes an occasional redundant skip (the
+// skipped group's queue row survives and is re-evaluated), never incorrect
+// membership.
+const (
+	dynDeviceGroupLockNamespace int64 = 0x64796e64 << 32 // "dynd"
+	dynUserGroupLockNamespace   int64 = 0x64796e75 << 32 // "dynu"
+)
+
+func deviceGroupLockKey(groupID string) int64 {
+	return dynDeviceGroupLockNamespace | int64(groupIDHash(groupID))
+}
+func userGroupLockKey(groupID string) int64 {
+	return dynUserGroupLockNamespace | int64(groupIDHash(groupID))
+}
+
+func groupIDHash(groupID string) uint32 {
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(groupID))
+	return h.Sum32()
+}
 
 // Evaluator is the in-process group-membership recalculator. Construct
 // once per server boot (alongside the handlers / inbox worker) and call
@@ -247,12 +274,22 @@ func (e *Evaluator) DrainDeviceGroupQueue(ctx context.Context) (DrainResult, err
 	}
 	var count int32
 	for _, id := range ids {
-		if err := e.EvaluateDeviceGroup(ctx, id); err != nil {
+		// Claim the group with a per-group advisory lock so two control replicas
+		// never evaluate the same group concurrently (#15). A skip (ran=false)
+		// means another replica holds it — leave the queue row; it (or a later
+		// drain) handles it. At-least-once: evaluation is idempotent, so a crash
+		// mid-eval releases the lock and the surviving row is re-evaluated.
+		ran, err := e.store.TryWithAdvisoryLock(ctx, deviceGroupLockKey(id), func() error {
+			return e.EvaluateDeviceGroup(ctx, id)
+		})
+		if err != nil {
 			e.logger.Warn("dyngroupeval: failed to evaluate queued device group; skipping",
 				"group_id", id, "error", err)
 			continue
 		}
-		count++
+		if ran {
+			count++
+		}
 	}
 	more, err := q.HasDynamicDeviceGroupQueueEntries(ctx)
 	if err != nil {
@@ -270,12 +307,18 @@ func (e *Evaluator) DrainUserGroupQueue(ctx context.Context) (DrainResult, error
 	}
 	var count int32
 	for _, id := range ids {
-		if err := e.EvaluateUserGroup(ctx, id); err != nil {
+		// Per-group advisory claim — see DrainDeviceGroupQueue (#15).
+		ran, err := e.store.TryWithAdvisoryLock(ctx, userGroupLockKey(id), func() error {
+			return e.EvaluateUserGroup(ctx, id)
+		})
+		if err != nil {
 			e.logger.Warn("dyngroupeval: failed to evaluate queued user group; skipping",
 				"group_id", id, "error", err)
 			continue
 		}
-		count++
+		if ran {
+			count++
+		}
 	}
 	more, err := q.HasDynamicUserGroupQueueEntries(ctx)
 	if err != nil {

--- a/internal/dyngroupeval/evaluator_test.go
+++ b/internal/dyngroupeval/evaluator_test.go
@@ -1,0 +1,110 @@
+package dyngroupeval_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/dyngroupeval"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+func enqueueDeviceGroup(t *testing.T, st *store.Store, groupID string) {
+	t.Helper()
+	reason := "test"
+	require.NoError(t, st.Queries().EnqueueDynamicDeviceGroupEvaluation(context.Background(),
+		db.EnqueueDynamicDeviceGroupEvaluationParams{GroupID: groupID, Reason: &reason}))
+}
+
+// TestDrainDeviceGroupQueue_DrainsUnderLock pins that the per-group advisory
+// claim (#15) does not break the normal drain: an enqueued group is evaluated
+// and its queue row consumed.
+func TestDrainDeviceGroupQueue_DrainsUnderLock(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ev := dyngroupeval.New(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	// A static group is a valid drain target: EvaluateDeviceGroup clears the
+	// queue row for a non-dynamic group. That exercises the lock-wrapped drain
+	// loop + dequeue without depending on dynamic-query membership recompute
+	// (unchanged by #15).
+	g := testutil.CreateTestDeviceGroup(t, st, actor, "Plant X")
+	enqueueDeviceGroup(t, st, g)
+
+	res, err := ev.DrainDeviceGroupQueue(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), res.Count, "the enqueued group must be evaluated under the lock")
+	assert.False(t, res.More, "queue must be drained")
+
+	has, err := st.Queries().HasDynamicDeviceGroupQueueEntries(context.Background())
+	require.NoError(t, err)
+	assert.False(t, has, "queue row must be consumed")
+}
+
+// TestDrainDeviceGroupQueue_ConcurrentDrainsSafe pins that two concurrent drains
+// (modelling two control replicas) neither error nor leave the queue partially
+// drained — the per-group advisory claim serializes same-group evaluation.
+func TestDrainDeviceGroupQueue_ConcurrentDrainsSafe(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ev := dyngroupeval.New(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	for i := 0; i < 8; i++ {
+		enqueueDeviceGroup(t, st, testutil.CreateTestDeviceGroup(t, st, actor, "G"))
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				res, err := ev.DrainDeviceGroupQueue(context.Background())
+				if err != nil {
+					errs <- err
+					return
+				}
+				if !res.More {
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+
+	has, err := st.Queries().HasDynamicDeviceGroupQueueEntries(context.Background())
+	require.NoError(t, err)
+	assert.False(t, has, "concurrent drains must fully consume the queue")
+}
+
+// TestDrainUserGroupQueue_DrainsUnderLock is the user-group sibling.
+func TestDrainUserGroupQueue_DrainsUnderLock(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ev := dyngroupeval.New(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	g := testutil.CreateTestUserGroup(t, st, actor, "Team X")
+	reason := "test"
+	require.NoError(t, st.Queries().EnqueueDynamicUserGroupEvaluation(context.Background(),
+		db.EnqueueDynamicUserGroupEvaluationParams{GroupID: g, Reason: &reason}))
+
+	res, err := ev.DrainUserGroupQueue(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), res.Count)
+	assert.False(t, res.More)
+
+	has, err := st.Queries().HasDynamicUserGroupQueueEntries(context.Background())
+	require.NoError(t, err)
+	assert.False(t, has, "queue row must be consumed")
+}

--- a/internal/projectors/eventtype_parity_test.go
+++ b/internal/projectors/eventtype_parity_test.go
@@ -1,0 +1,103 @@
+package projectors
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/stretchr/testify/require"
+)
+
+// unprojectedAllowlist is the EXACT set of event types that are intentionally
+// NOT handled by a projector listener in this package. Each is consumed
+// elsewhere (a live-stream sink, an api-side handler/listener, or an async
+// dispatch trigger) rather than projected into a *_projection table. Keeping the
+// set explicit means a NEW event type that nobody projects fails
+// TestEventTypes_AllHandledByProjectorOrAllowlisted instead of silently becoming
+// an orphan; and an entry here that later DOES get a projector (or isn't a real
+// event) also fails, so the allowlist can't go stale.
+var unprojectedAllowlist = map[eventtypes.EventType]string{
+	eventtypes.OutputChunk:                      "live execution output — sunk by control/inbox_worker, never projected",
+	eventtypes.TerminalSessionStarted:           "terminal_sessions written directly by api/terminal_handler",
+	eventtypes.TerminalSessionStopped:           "terminal_sessions written directly by api/terminal_handler",
+	eventtypes.TerminalSessionTerminated:        "terminal_sessions written directly by api/terminal_handler",
+	eventtypes.TerminalAdminMembershipRevoked:   "consumed by api/system_actions reconciler, not a projection",
+	eventtypes.LuksDeviceKeyRevocationRequested: "triggers async revocation dispatch in api/device_handler, no projection",
+}
+
+// TestEventTypes_AllHandledByProjectorOrAllowlisted is a self-discovering guard
+// (#13) that every event in eventtypes.All() is either handled by a projector
+// listener in this package OR explicitly allow-listed as intentionally
+// unprojected. It discovers the handled set by AST-scanning this package for
+// `eventtypes.<Name>` references (listeners and their Apply* bodies dispatch on
+// these), so it can't fall stale against a hardcoded list. A new orphan event
+// fails here; so does a stale allowlist entry.
+func TestEventTypes_AllHandledByProjectorOrAllowlisted(t *testing.T) {
+	all := eventtypes.All()
+	require.NotEmpty(t, all, "eventtypes.All() is empty — the parity check would be vacuous")
+
+	handled := handledEventTypes(t)
+	require.NotEmpty(t, handled, "no eventtypes.<X> references found in projectors — the scan is broken")
+
+	// Every registered event must be projected here or allow-listed.
+	var orphans []string
+	for _, e := range all {
+		if handled[string(e)] {
+			continue
+		}
+		if _, ok := unprojectedAllowlist[e]; ok {
+			continue
+		}
+		orphans = append(orphans, string(e))
+	}
+	sort.Strings(orphans)
+	require.Emptyf(t, orphans,
+		"event types with NO projector and not allow-listed (#13):\n  %s\n"+
+			"Wire a projector listener, or add an entry to unprojectedAllowlist with the reason it is intentionally unprojected.",
+		strings.Join(orphans, "\n  "))
+
+	// Keep the allowlist honest: every entry must be a real event AND not also
+	// handled by a projector (else it's stale).
+	allSet := make(map[string]bool, len(all))
+	for _, e := range all {
+		allSet[string(e)] = true
+	}
+	for e := range unprojectedAllowlist {
+		require.Truef(t, allSet[string(e)], "allowlisted %q is not in eventtypes.All() — remove the stale entry", e)
+		require.Falsef(t, handled[string(e)], "allowlisted %q IS handled by a projector — remove it from unprojectedAllowlist", e)
+	}
+}
+
+// handledEventTypes returns the set of event-type names referenced as
+// `eventtypes.<Name>` in non-test .go files of this package.
+func handledEventTypes(t *testing.T) map[string]bool {
+	t.Helper()
+	handled := map[string]bool{}
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+	for _, ent := range entries {
+		name := ent.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		require.NoErrorf(t, err, "parse %s", name)
+		ast.Inspect(f, func(n ast.Node) bool {
+			sel, ok := n.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			if x, ok := sel.X.(*ast.Ident); ok && x.Name == "eventtypes" {
+				handled[sel.Sel.Name] = true
+			}
+			return true
+		})
+	}
+	return handled
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -458,6 +458,45 @@ func (s *Store) WithAdvisoryLock(ctx context.Context, key int64, fn func() error
 	return fn()
 }
 
+// TryWithAdvisoryLock is the non-blocking sibling of WithAdvisoryLock. It runs
+// fn while holding a session-level advisory lock on key ONLY IF the lock is free
+// across the whole database; if another session already holds it (e.g. another
+// control replica), it reports ran=false WITHOUT running fn. Used by the
+// dynamic-group drain so two replicas never evaluate the same group concurrently
+// — the second skips it and the queue row it leaves behind is picked up later
+// (at-least-once; evaluation is idempotent).
+//
+// Same local-mutex discipline as WithAdvisoryLock: the mutex is taken only for
+// the brief try (and across fn when acquired) so a skipping caller releases it
+// immediately. Cross-process exclusion is pg_try_advisory_lock's job — within a
+// single process the mutex already serializes callers, so the skip path matters
+// across replicas (the actual concern).
+func (s *Store) TryWithAdvisoryLock(ctx context.Context, key int64, fn func() error) (ran bool, err error) {
+	s.advisoryMu.Lock()
+	defer s.advisoryMu.Unlock()
+
+	conn, err := s.pool.Acquire(ctx)
+	if err != nil {
+		return false, fmt.Errorf("acquire connection for advisory lock: %w", err)
+	}
+	defer conn.Release()
+
+	var got bool
+	if err := conn.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", key).Scan(&got); err != nil {
+		return false, fmt.Errorf("try advisory lock %d: %w", key, err)
+	}
+	if !got {
+		return false, nil
+	}
+	defer func() {
+		if _, uerr := conn.Exec(context.WithoutCancel(ctx), "SELECT pg_advisory_unlock($1)", key); uerr != nil && err == nil {
+			err = fmt.Errorf("release advisory lock %d: %w", key, uerr)
+		}
+	}()
+
+	return true, fn()
+}
+
 // WithTx runs a function within a transaction.
 func (s *Store) WithTx(ctx context.Context, fn func(*Queries) error) error {
 	tx, err := s.pool.Begin(ctx)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -596,3 +596,38 @@ func TestWithAdvisoryLock_NoDeadlockUnderPoolPressure(t *testing.T) {
 		}
 	}
 }
+
+// TestTryWithAdvisoryLock_SkipsWhenHeldElsewhere pins the cross-session skip
+// semantics the dynamic-group drain relies on (#15): when another database
+// session already holds the advisory lock — i.e. another control replica is
+// evaluating that group — TryWithAdvisoryLock must report ran=false and NOT run
+// fn, so the second replica skips it (the queue row survives and is re-evaluated;
+// at-least-once). When the lock is free it runs fn and reports ran=true.
+func TestTryWithAdvisoryLock_SkipsWhenHeldElsewhere(t *testing.T) {
+	st := testutil.SetupPostgresPool(t, 4)
+	ctx := context.Background()
+	const key int64 = 0x64796e6701 // namespaced drain-style key
+
+	// Simulate "another replica" by holding the lock on a separate session.
+	holder, err := st.TestingPool().Acquire(ctx)
+	require.NoError(t, err)
+	defer holder.Release()
+	var got bool
+	require.NoError(t, holder.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", key).Scan(&got))
+	require.True(t, got, "holder session must acquire the lock")
+
+	ran, err := st.TryWithAdvisoryLock(ctx, key, func() error {
+		t.Fatal("fn must not run while the lock is held by another session")
+		return nil
+	})
+	require.NoError(t, err)
+	assert.False(t, ran, "TryWithAdvisoryLock must skip when the lock is held elsewhere")
+
+	// Release the holder's lock; now the try must succeed and run fn.
+	require.NoError(t, holder.QueryRow(ctx, "SELECT pg_advisory_unlock($1)", key).Scan(&got))
+	called := false
+	ran, err = st.TryWithAdvisoryLock(ctx, key, func() error { called = true; return nil })
+	require.NoError(t, err)
+	assert.True(t, ran, "TryWithAdvisoryLock must run when the lock is free")
+	assert.True(t, called, "fn must run when the lock is acquired")
+}


### PR DESCRIPTION
## Summary

The WS3 follow-ups after the scope-enforcement work (#407): the dynamic-group queue concurrency fix (#15) plus the verification-only charters (#4/#6/#10/#11/#13) and a confirmation of #7's existing coverage.

## #15 — dynamic-group drain race across replicas

`DrainDeviceGroupQueue` / `DrainUserGroupQueue` claimed each queued group with a plain `SELECT`, so two control replicas (HA) could evaluate the same group concurrently. Within one process the drain is already sequential; the race is across replicas.

**Decision — at-least-once via `pg_try_advisory_lock` (not FOR UPDATE SKIP LOCKED):** new `Store.TryWithAdvisoryLock` (non-blocking sibling of `WithAdvisoryLock`, same local-mutex discipline). Each per-group evaluation runs under a per-group, per-queue **namespaced** key (`"dynd"/"dynu" << 32 | fnv32a(groupID)` — high bits can't collide with the admin-mutation lock). `ran=false` ⇒ another replica holds it ⇒ skip; the queue row survives and is re-evaluated later. At-least-once is the right semantics because evaluation is idempotent (recompute from scratch), so a crash mid-eval just re-evaluates; the 24h full re-enqueue backstop is unchanged. No `EvaluateGroup` tx refactor needed.

## Verification charters (behavior already present — tests pin it)

- **#4/#6 RefreshToken revocation** — session-version mismatch, disabled, deleted, and single-use replay are each rejected with `Unauthenticated`.
- **#11 device authz exact-set** — replaces the hand-picked denied-actions sample with a **self-discovering** test: every registered permission NOT in the device allow-list is denied, so a new permission can't silently become device-reachable.
- **#13 eventtypes parity** — every `eventtypes.All()` entry is handled by a projector listener (AST-discovered) or explicitly allow-listed as intentionally unprojected; the 6 allow-listed (terminal sessions, OutputChunk, TerminalAdminMembershipRevoked, LuksDeviceKeyRevocationRequested) were each verified to be consumed by inbox/api/dispatch paths.
- **#10 AuthzInterceptor device branch** — exercised end-to-end through the real `WrapUnary` (a device-context-injecting interceptor + the real authz interceptor): a device may Heartbeat, is denied `DeleteDevice`.
- **#7** — terminal revocation-listener already covered (`DisableDelete` / `RoleRevoke` / `RecoversPanic`); no new test needed.

## Tests / gates

New: `Store.TryWithAdvisoryLock` unit test (second-session ⇒ `ran=false`), dyngroup drain tests (drains-under-lock + concurrent-drains-safe, device + user), the four RefreshToken revocation tests, the device-authz exact-set test, the eventtypes parity test, and the two interceptor device-context tests. Full server suite green (`store`, `auth`, `dyngroupeval`, `projectors`, `api`); `go vet` / `gofmt` / build clean; local `cr review` clean (its only findings were on an unrelated untracked audit file). No proto/sqlc changes.

Advances manchtools/power-manage-server#7; closes the #15 dynamic-group drain race.