### PR TITLE
feat(crypto): bind at-rest secrets to row context via AES-GCM AAD (WS5 #8)

### DIFF
--- a/docs/adr/0009-at-rest-secret-aad-binding.md
+++ b/docs/adr/0009-at-rest-secret-aad-binding.md
@@ -1,0 +1,48 @@
+# 0009 — At-rest secrets are context-bound via AES-GCM AAD
+
+- Status: accepted
+- Date: 2026-06-13
+- Related: WS5 #8 of the SECURITY_HARDENING_WORKPLAN; the 2026-06-12 audits;
+  ADR 0008 (SCIM/SSO identity boundary — sibling WS5 hardening).
+
+## Context
+
+LUKS passphrases and LPS passwords are encrypted at rest with AES-256-GCM
+(`internal/crypto`). They were sealed with **nil AAD**, so a ciphertext was not
+bound to the row it belongs to: an attacker with database access could relocate
+a ciphertext from one device/action row to another and it would still decrypt,
+returning the wrong device's secret under a different identity.
+
+## Decision
+
+Bind each at-rest secret to its row context via the GCM additional
+authenticated data (AAD), with a versioned prefix so the change is non-breaking.
+
+- `EncryptWithContext(plaintext, aad)` seals with `aad` and tags the output
+  `enc:v2:`. `DecryptWithContext(value, aad)` opens `enc:v2:` with the same aad,
+  falls back to opening legacy `enc:v1:` with nil aad, and passes non-prefixed
+  values through. The original `Encrypt`/`Decrypt` (v1, nil aad) are unchanged
+  for callers that don't carry row context (e.g. IdP client secrets).
+- The AAD is `SecretAAD(deviceID, actionID, secretType)` =
+  `deviceID|actionID|type`. deviceID and actionID are ULIDs (Crockford base32 —
+  they cannot contain the `|` separator) and type is a fixed literal
+  (`luks`/`lps`), so the concatenation is unambiguous.
+- The LUKS/LPS at-rest call-sites (`internal/api/device_handler.go`,
+  `internal/api/internal_handler.go`) write `enc:v2:` bound to the row's
+  device/action/type and read via `DecryptWithContext`. Reads of pre-migration
+  `enc:v1:` rows succeed via the nil-AAD fallback — **no backfill is required**.
+
+## Consequences
+
+- A relocated ciphertext (moved to a different device/action row) fails GCM
+  `Open` — the secret is cryptographically pinned to its context, not just to
+  the row's primary key. GCM integrity continues to reject byte-tampered
+  ciphertext.
+- Non-breaking: legacy `enc:v1:` rows keep decrypting; the migration is lazy
+  (rows become `enc:v2:` as they're next rotated/written). The shared crypto key
+  contract (control + gateway) is unchanged.
+- Username is intentionally NOT in the LPS AAD: the primary threat
+  (cross-device/action relocation) is closed by `device|action|type`; a
+  within-action username swap is a minor residual inside a single trusted
+  rotation batch.
+- Server-only; no SDK/agent/proto/migration changes.

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -724,7 +724,7 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 	resp := &pm.GetDeviceLpsPasswordsResponse{}
 
 	for _, p := range current {
-		decPassword, err := h.encryptor.Decrypt(p.Password)
+		decPassword, err := h.encryptor.DecryptWithContext(p.Password, crypto.SecretAAD(p.DeviceID, p.ActionID, "lps"))
 		if err != nil {
 			// Decrypt failure on stored material is alarming —
 			// possible key-rotation drift, corrupted ciphertext,
@@ -748,7 +748,7 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 	}
 
 	for _, p := range history {
-		decPassword, err := h.encryptor.Decrypt(p.Password)
+		decPassword, err := h.encryptor.DecryptWithContext(p.Password, crypto.SecretAAD(p.DeviceID, p.ActionID, "lps"))
 		if err != nil {
 			h.logger.Error("failed to decrypt LPS password (history)",
 				"device_id", p.DeviceID, "action_id", p.ActionID, "error", err)
@@ -803,7 +803,7 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 	resp := &pm.GetDeviceLuksKeysResponse{}
 
 	for _, k := range current {
-		decPassphrase, err := h.encryptor.Decrypt(k.Passphrase)
+		decPassphrase, err := h.encryptor.DecryptWithContext(k.Passphrase, crypto.SecretAAD(k.DeviceID, k.ActionID, "luks"))
 		if err != nil {
 			h.logger.Error("failed to decrypt LUKS passphrase (current)",
 				"device_id", k.DeviceID, "action_id", k.ActionID, "device_path", k.DevicePath, "error", err)
@@ -832,7 +832,7 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 	}
 
 	for _, k := range history {
-		decPassphrase, err := h.encryptor.Decrypt(k.Passphrase)
+		decPassphrase, err := h.encryptor.DecryptWithContext(k.Passphrase, crypto.SecretAAD(k.DeviceID, k.ActionID, "luks"))
 		if err != nil {
 			h.logger.Error("failed to decrypt LUKS passphrase (history)",
 				"device_id", k.DeviceID, "action_id", k.ActionID, "device_path", k.DevicePath, "error", err)

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -407,7 +407,7 @@ func (h *InternalHandler) ProxyGetLuksKey(ctx context.Context, req *connect.Requ
 		return nil, apiErrorCtx(ctx, ErrLuksKeyNotFound, connect.CodeNotFound, "no LUKS key found for this action")
 	}
 
-	passphrase, err := h.encryptor.Decrypt(key.Passphrase)
+	passphrase, err := h.encryptor.DecryptWithContext(key.Passphrase, crypto.SecretAAD(req.Msg.DeviceId, req.Msg.ActionId, "luks"))
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt passphrase")
 	}
@@ -430,7 +430,7 @@ func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Re
 		return nil, err
 	}
 
-	encPassphrase, err := h.encryptor.Encrypt(req.Msg.Passphrase)
+	encPassphrase, err := h.encryptor.EncryptWithContext(req.Msg.Passphrase, crypto.SecretAAD(req.Msg.DeviceId, req.Msg.ActionId, "luks"))
 	if err != nil {
 		h.logger.Error("failed to encrypt LUKS passphrase", "error", err)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to encrypt passphrase")
@@ -492,7 +492,7 @@ func (h *InternalHandler) ProxyStoreLpsPasswords(ctx context.Context, req *conne
 		firstErr  error
 	)
 	for _, r := range req.Msg.Rotations {
-		encPassword, err := h.encryptor.Encrypt(r.Password)
+		encPassword, err := h.encryptor.EncryptWithContext(r.Password, crypto.SecretAAD(req.Msg.DeviceId, req.Msg.ActionId, "lps"))
 		if err != nil {
 			h.logger.Error("failed to encrypt LPS password", "error", err, "username", r.Username)
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to encrypt password")

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -18,10 +18,24 @@ import (
 )
 
 const (
-	// prefix identifies encrypted values so they can be distinguished
-	// from plaintext during migration.
+	// prefix (v1) identifies encrypted values sealed with NIL AAD. Kept for
+	// backward compatibility: every row written before the AAD-binding change
+	// (WS5 #8) carries this prefix and must keep decrypting.
 	prefix = "enc:v1:"
+	// prefixV2 identifies values sealed WITH context AAD (EncryptWithContext).
+	// The AAD binds the ciphertext to its row context (device|action|type), so
+	// a DB-level attacker cannot relocate a secret from one row to another and
+	// have it decrypt.
+	prefixV2 = "enc:v2:"
 )
+
+// SecretAAD builds the additional-authenticated-data that binds an at-rest
+// secret to its row context. deviceID and actionID are ULIDs (Crockford
+// base32 — they can never contain the '|' separator), and secretType is a fixed
+// literal ("luks" / "lps"), so the concatenation is unambiguous.
+func SecretAAD(deviceID, actionID, secretType string) []byte {
+	return []byte(deviceID + "|" + actionID + "|" + secretType)
+}
 
 // Encryptor handles AES-256-GCM encryption and decryption of secret values.
 type Encryptor struct {
@@ -72,6 +86,25 @@ func (e *Encryptor) Encrypt(plaintext string) (string, error) {
 	return prefix + base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
+// EncryptWithContext encrypts plaintext bound to aad and returns an
+// "enc:v2:<base64>" string. The aad is authenticated (not stored in the
+// ciphertext) — DecryptWithContext must be given the SAME aad to open it, so a
+// secret sealed for one row context cannot be opened in another. Returns
+// plaintext unchanged if e is nil (encryption disabled) or plaintext is empty.
+func (e *Encryptor) EncryptWithContext(plaintext string, aad []byte) (string, error) {
+	if e == nil || plaintext == "" {
+		return plaintext, nil
+	}
+
+	nonce := make([]byte, e.gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("generate nonce: %w", err)
+	}
+
+	ciphertext := e.gcm.Seal(nonce, nonce, []byte(plaintext), aad)
+	return prefixV2 + base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
 // Decrypt decrypts an "enc:v1:<base64>" string back to plaintext.
 // Returns the input unchanged if it doesn't have the encryption prefix
 // (supports reading pre-encryption plaintext data).
@@ -102,4 +135,39 @@ func (e *Encryptor) Decrypt(value string) (string, error) {
 	}
 
 	return string(plaintext), nil
+}
+
+// DecryptWithContext decrypts a value that may be either AAD-bound (enc:v2,
+// opened with aad) or legacy nil-AAD (enc:v1, opened with no aad). A
+// non-prefixed value is returned unchanged (pre-encryption plaintext). This is
+// the read path for the LUKS/LPS at-rest secrets: new rows are enc:v2 bound to
+// SecretAAD(device, action, type); rows written before the migration are still
+// enc:v1 and open via the legacy fallback — no backfill required.
+func (e *Encryptor) DecryptWithContext(value string, aad []byte) (string, error) {
+	if e == nil {
+		return value, nil
+	}
+	switch {
+	case strings.HasPrefix(value, prefixV2):
+		data, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, prefixV2))
+		if err != nil {
+			return "", fmt.Errorf("decode ciphertext: %w", err)
+		}
+		nonceSize := e.gcm.NonceSize()
+		if len(data) < nonceSize {
+			return "", errors.New("ciphertext too short")
+		}
+		nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+		plaintext, err := e.gcm.Open(nil, nonce, ciphertext, aad)
+		if err != nil {
+			return "", fmt.Errorf("decrypt: %w", err)
+		}
+		return string(plaintext), nil
+	case strings.HasPrefix(value, prefix):
+		// Legacy nil-AAD ciphertext (written before WS5 #8).
+		return e.Decrypt(value)
+	default:
+		// Pre-encryption plaintext.
+		return value, nil
+	}
 }

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -153,3 +153,86 @@ func TestNilEncryptor_Passthrough(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "hello", pt)
 }
+
+// WS5 #8 — AES-GCM AAD binds an at-rest secret to its row context.
+
+func TestEncryptWithContext_AADBindsContext(t *testing.T) {
+	enc, err := crypto.NewEncryptor(testKey())
+	require.NoError(t, err)
+
+	aadA := crypto.SecretAAD("01HDEVICEA", "01HACTIONA", "luks")
+	aadB := crypto.SecretAAD("01HDEVICEB", "01HACTIONA", "luks") // different device
+
+	ct, err := enc.EncryptWithContext("super-secret", aadA)
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(ct, "enc:v2:"), "AAD-bound ciphertext uses the v2 prefix")
+
+	// Correct AAD round-trips.
+	pt, err := enc.DecryptWithContext(ct, aadA)
+	require.NoError(t, err)
+	assert.Equal(t, "super-secret", pt)
+
+	// Wrong AAD (a different row context) must fail to open — the secret is
+	// bound to its row and cannot be relocated.
+	_, err = enc.DecryptWithContext(ct, aadB)
+	require.Error(t, err, "a secret sealed for one context must not open under another")
+}
+
+func TestDecryptWithContext_ByteTamperedFails(t *testing.T) {
+	enc, err := crypto.NewEncryptor(testKey())
+	require.NoError(t, err)
+	aad := crypto.SecretAAD("01HDEV", "01HACT", "lps")
+
+	ct, err := enc.EncryptWithContext("rotate-me", aad)
+	require.NoError(t, err)
+
+	// Flip a mid-string char of the base64 body — GCM integrity must reject.
+	body := strings.TrimPrefix(ct, "enc:v2:")
+	b := []byte(body)
+	idx := len(b) / 2
+	if b[idx] == 'A' {
+		b[idx] = 'B'
+	} else {
+		b[idx] = 'A'
+	}
+	tampered := "enc:v2:" + string(b)
+	_, err = enc.DecryptWithContext(tampered, aad)
+	require.Error(t, err, "a byte-tampered ciphertext must fail GCM integrity")
+}
+
+func TestDecryptWithContext_LegacyV1StillDecrypts(t *testing.T) {
+	enc, err := crypto.NewEncryptor(testKey())
+	require.NoError(t, err)
+
+	// A legacy row was sealed with the nil-AAD Encrypt (enc:v1).
+	legacy, err := enc.Encrypt("old-secret")
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(legacy, "enc:v1:"))
+
+	// DecryptWithContext must still open it (migration is non-breaking; no
+	// backfill). The aad is ignored for v1 values.
+	pt, err := enc.DecryptWithContext(legacy, crypto.SecretAAD("any", "any", "luks"))
+	require.NoError(t, err)
+	assert.Equal(t, "old-secret", pt)
+}
+
+func TestDecryptWithContext_PlaintextPassthrough(t *testing.T) {
+	enc, err := crypto.NewEncryptor(testKey())
+	require.NoError(t, err)
+	pt, err := enc.DecryptWithContext("not-encrypted", crypto.SecretAAD("d", "a", "luks"))
+	require.NoError(t, err)
+	assert.Equal(t, "not-encrypted", pt)
+}
+
+func TestDecryptWithContext_WrongKeyFails(t *testing.T) {
+	encA, err := crypto.NewEncryptor(testKey())
+	require.NoError(t, err)
+	encB, err := crypto.NewEncryptor(differentKey())
+	require.NoError(t, err)
+	aad := crypto.SecretAAD("d", "a", "luks")
+
+	ct, err := encA.EncryptWithContext("x", aad)
+	require.NoError(t, err)
+	_, err = encB.DecryptWithContext(ct, aad)
+	require.Error(t, err, "a different key must not open the ciphertext")
+}


### PR DESCRIPTION
## WS5 #8 — context-bound at-rest secrets

LUKS passphrases and LPS passwords were sealed with **nil AAD**, so a ciphertext was not bound to its row: a DB-level attacker could relocate a secret from one device/action row to another and it would still decrypt. See ADR 0009.

### Change
- `EncryptWithContext(pt, aad)` / `DecryptWithContext(value, aad)` seal/open with an AAD of `SecretAAD(deviceID, actionID, secretType)` and an **`enc:v2:`** prefix.
- `DecryptWithContext` opens `enc:v2` (with aad), **falls back to legacy `enc:v1`** (nil aad), and passes non-prefixed plaintext through — pre-migration rows keep decrypting with **no backfill**. Original `Encrypt`/`Decrypt` unchanged for context-less callers (e.g. IdP client secrets).
- Migrated the LUKS/LPS at-rest call-sites (device_handler reads; internal_handler get/store/rotate) to write `enc:v2` bound to the row's device/action/type and read via `DecryptWithContext`.

### Tests
AAD round-trip; **wrong-AAD (relocated row) fails to open**; byte-tampered ciphertext fails GCM integrity; legacy `enc:v1` still decrypts; plaintext passthrough; wrong-key fails. The existing LUKS/LPS handler round-trip tests confirm the end-to-end write/read AAD match.

Non-breaking, server-only, no migration. Closes manchtools/power-manage-server#413.