### PR TITLE
feat(idp): wire trust_email_assertions through Create/Update API (WS5)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260613181723-1ad0db61fb70
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260613210347-f27483614d62

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260613181723-1ad0db61fb70 h1:NDaNpG3EdAnnyDaDmXIb2wIhF7YnASWlXUBrzxYThrk=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260613181723-1ad0db61fb70/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260613210347-f27483614d62 h1:NhTkHCbogmXJQPB+q4ImRQ3K8prl41aJb05TIMGf/XU=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260613210347-f27483614d62/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/idp_handler.go
+++ b/internal/api/idp_handler.go
@@ -88,6 +88,7 @@ func (h *IDPHandler) CreateIdentityProvider(ctx context.Context, req *connect.Re
 			// victim's email address. Document this in operator
 			// guidance before flipping the default.
 			AutoLinkByEmail:          req.Msg.AutoLinkByEmail,
+			TrustEmailAssertions:     req.Msg.TrustEmailAssertions,
 			DefaultRoleID:            req.Msg.DefaultRoleId,
 			DisablePasswordForLinked: req.Msg.DisablePasswordForLinked,
 			GroupClaim:               req.Msg.GroupClaim,
@@ -185,6 +186,7 @@ func (h *IDPHandler) UpdateIdentityProvider(ctx context.Context, req *connect.Re
 		"enabled":                     req.Msg.Enabled,
 		"auto_create_users":           req.Msg.AutoCreateUsers,
 		"auto_link_by_email":          req.Msg.AutoLinkByEmail,
+		"trust_email_assertions":      req.Msg.TrustEmailAssertions,
 		"default_role_id":             req.Msg.DefaultRoleId,
 		"disable_password_for_linked": req.Msg.DisablePasswordForLinked,
 		"group_claim":                 req.Msg.GroupClaim,
@@ -484,6 +486,7 @@ func (h *IDPHandler) idpToProto(p store.IdentityProvider) *pm.IdentityProvider {
 		Scopes:                   p.Scopes,
 		AutoCreateUsers:          p.AutoCreateUsers,
 		AutoLinkByEmail:          p.AutoLinkByEmail,
+		TrustEmailAssertions:     p.TrustEmailAssertions,
 		DefaultRoleId:            p.DefaultRoleID,
 		DisablePasswordForLinked: p.DisablePasswordForLinked,
 		GroupClaim:               p.GroupClaim,

--- a/internal/api/idp_handler_test.go
+++ b/internal/api/idp_handler_test.go
@@ -372,3 +372,55 @@ func TestRotateSCIMToken_NotEnabled(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
 }
+
+// TestIdentityProvider_TrustEmailAssertions_RoundTrip pins WS5: the
+// trust_email_assertions opt-in is settable via Create/Update and reflected in
+// the response (and thus the projection the SCIM gate reads). Default false.
+func TestIdentityProvider_TrustEmailAssertions_RoundTrip(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	h := api.NewIDPHandler(st, enc, "http://localhost:8081", slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	// Create with the flag ON.
+	created, err := h.CreateIdentityProvider(ctx, connect.NewRequest(&pm.CreateIdentityProviderRequest{
+		Name:                 "TrustIdP",
+		Slug:                 "trustidp" + testutil.NewID()[:6],
+		ProviderType:         pm.IdentityProviderType_IDENTITY_PROVIDER_TYPE_OIDC,
+		ClientId:             "cid",
+		ClientSecret:         "secret",
+		IssuerUrl:            "https://idp.example.com",
+		TrustEmailAssertions: true,
+	}))
+	require.NoError(t, err)
+	assert.True(t, created.Msg.Provider.TrustEmailAssertions, "Create must persist trust_email_assertions=true")
+	providerID := created.Msg.Provider.Id
+
+	// Read back.
+	got, err := h.GetIdentityProvider(ctx, connect.NewRequest(&pm.GetIdentityProviderRequest{Id: providerID}))
+	require.NoError(t, err)
+	assert.True(t, got.Msg.Provider.TrustEmailAssertions, "Get must reflect the stored flag")
+
+	// Update the flag OFF.
+	updated, err := h.UpdateIdentityProvider(ctx, connect.NewRequest(&pm.UpdateIdentityProviderRequest{
+		Id:                   providerID,
+		Name:                 "TrustIdP",
+		Enabled:              true,
+		TrustEmailAssertions: false,
+	}))
+	require.NoError(t, err)
+	assert.False(t, updated.Msg.Provider.TrustEmailAssertions, "Update must be able to turn the flag off")
+
+	// Default: a provider created without the flag is false.
+	def, err := h.CreateIdentityProvider(ctx, connect.NewRequest(&pm.CreateIdentityProviderRequest{
+		Name:         "DefaultIdP",
+		Slug:         "defaultidp" + testutil.NewID()[:6],
+		ProviderType: pm.IdentityProviderType_IDENTITY_PROVIDER_TYPE_OIDC,
+		ClientId:     "cid",
+		ClientSecret: "secret",
+		IssuerUrl:    "https://idp2.example.com",
+	}))
+	require.NoError(t, err)
+	assert.False(t, def.Msg.Provider.TrustEmailAssertions, "default must be false (secure)")
+}

--- a/internal/eventtypes/payloads/idp.go
+++ b/internal/eventtypes/payloads/idp.go
@@ -36,6 +36,7 @@ type IdentityProviderCreated struct {
 	Scopes                   []string        `json:"scopes,omitempty"`
 	AutoCreateUsers          bool            `json:"auto_create_users"`
 	AutoLinkByEmail          bool            `json:"auto_link_by_email"`
+	TrustEmailAssertions     bool            `json:"trust_email_assertions"`
 	DefaultRoleID            string          `json:"default_role_id,omitempty"`
 	DisablePasswordForLinked bool            `json:"disable_password_for_linked"`
 	GroupClaim               string          `json:"group_claim,omitempty"`


### PR DESCRIPTION
Completes the WS5 `trust_email_assertions` opt-in: PR #412 added the flag + the SCIM AutoLinkByEmail account-takeover gate, but the flag had **no Create/Update RPC field** (settable only via a raw event). With the sdk proto field (manchtools/power-manage-sdk#98), this maps `req.Msg.TrustEmailAssertions` into the IdentityProviderCreated/Updated events and returns it on the `IdentityProvider` response — so operators can enable it via API/UI. Default false (secure).

Bumps sdk to the proto field. Test: create-with-flag / read-back / update-off / default-false round-trip. Closes manchtools/power-manage-server#415.