### PR TITLE
feat(api): require CA-signed expected_sha256 for agent-update; mandatory app checksum (WS7)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260613210347-f27483614d62
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260613210347-f27483614d62 h1:NhTkHCbogmXJQPB+q4ImRQ3K8prl41aJb05TIMGf/XU=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260613210347-f27483614d62/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b h1:pbMiax9QoJNlKqcV7FxoIliFijWxrGPRkwAUKtkbrsI=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/action_validators.go
+++ b/internal/api/action_validators.go
@@ -48,9 +48,47 @@ func validateParamsMsg(ctx context.Context, msg proto.Message) error {
 		return validateShellScriptChoice(ctx, p)
 	case *pm.AgentUpdateParams:
 		return validateAgentUpdateParams(ctx, p)
+	case *pm.AppInstallParams:
+		return validateAppInstallParams(ctx, p)
 	default:
 		return Validate(ctx, msg)
 	}
+}
+
+// isLowerHex64 reports whether s is exactly 64 lowercase hex characters —
+// the canonical SHA-256 form. The struct-tag `hexadecimal` validator also
+// accepts UPPERCASE, so this explicit check pins the lowercase form the
+// agent's comparison and the design expect (defense in depth: the agent
+// compares case-insensitively, but the control plane stores canonical).
+func isLowerHex64(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// validateAppInstallParams enforces, for deb/rpm/appimage download-and-
+// install actions, that the url is https and a 64-lowercase-hex
+// checksum_sha256 is present (WS7 #2 — mandatory integrity; without it the
+// only authenticity is TLS to a possibly-compromised origin). The
+// required-checksum + valid-url tags run via Validate; the https + lower-
+// hex rules are the explicit additions.
+func validateAppInstallParams(ctx context.Context, p *pm.AppInstallParams) error {
+	if err := Validate(ctx, p); err != nil {
+		return err
+	}
+	if !strings.HasPrefix(strings.ToLower(p.Url), "https://") {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "url must use HTTPS")
+	}
+	if !isLowerHex64(p.ChecksumSha256) {
+		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "checksum_sha256 must be 64 lowercase hex characters")
+	}
+	return nil
 }
 
 // validateCreateActionParams validates the params oneof of a CreateActionRequest.
@@ -150,6 +188,13 @@ func validateAgentUpdateParams(ctx context.Context, p *pm.AgentUpdateParams) err
 		}
 		if !strings.HasPrefix(strings.ToLower(arch.ChecksumUrl), "https://") {
 			return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "checksum_url must use HTTPS")
+		}
+		// WS7 #1: the CA-signed hash that gates the binary swap. Explicit
+		// 64-lowercase-hex check for a precise error code (the struct-tag
+		// `hexadecimal` rule also accepts uppercase, which the agent's
+		// canonical comparison must not depend on).
+		if !isLowerHex64(arch.ExpectedSha256) {
+			return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "expected_sha256 must be 64 lowercase hex characters")
 		}
 	}
 	return nil

--- a/internal/api/action_validators_test.go
+++ b/internal/api/action_validators_test.go
@@ -1,0 +1,137 @@
+package api
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+const validSha = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" // 64 hex
+const validURL = "https://example.com/agent"
+
+func archOK() *pm.AgentUpdateArch {
+	return &pm.AgentUpdateArch{
+		BinaryUrl:      validURL,
+		ChecksumUrl:    validURL + ".sha256",
+		ExpectedSha256: validSha,
+	}
+}
+
+// WS7 #1: every set arch entry MUST carry a 64-char lowercase-hex
+// expected_sha256, so the hash that gates the self-update swap is inside
+// the CA-signed payload. Driven through the REAL validateParamsMsg
+// dispatch (the shared Create/Update/inline boundary), proving the rule
+// runs at the action boundary, not just on the bare struct.
+func TestValidateAgentUpdateParams_ExpectedSha256(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("correct accepted", func(t *testing.T) {
+		err := validateParamsMsg(ctx, &pm.AgentUpdateParams{Amd64: archOK()})
+		if err != nil {
+			t.Fatalf("valid agent-update params rejected: %v", err)
+		}
+	})
+
+	// "wrong" sourced from intent (sha256 is 64 lowercase-hex chars), not
+	// from the validation tag.
+	bad := map[string]string{
+		"absent":    "",
+		"too short": strings.Repeat("a", 63),
+		"too long":  strings.Repeat("a", 65),
+		"uppercase": strings.ToUpper(validSha),
+		"non-hex":   strings.Repeat("g", 64),
+	}
+	for name, sha := range bad {
+		t.Run("rejects "+name+" expected_sha256", func(t *testing.T) {
+			arch := archOK()
+			arch.ExpectedSha256 = sha
+			if err := validateParamsMsg(ctx, &pm.AgentUpdateParams{Amd64: arch}); err == nil {
+				t.Errorf("expected_sha256=%q must be rejected", sha)
+			}
+		})
+	}
+
+	t.Run("http binary_url still rejected", func(t *testing.T) {
+		arch := archOK()
+		arch.BinaryUrl = "http://example.com/agent"
+		if err := validateParamsMsg(ctx, &pm.AgentUpdateParams{Amd64: arch}); err == nil {
+			t.Error("http binary_url must be rejected")
+		}
+	})
+
+	t.Run("http checksum_url still rejected", func(t *testing.T) {
+		arch := archOK()
+		arch.ChecksumUrl = "http://example.com/agent.sha256"
+		if err := validateParamsMsg(ctx, &pm.AgentUpdateParams{Amd64: arch}); err == nil {
+			t.Error("http checksum_url must be rejected")
+		}
+	})
+}
+
+func TestValidateAgentUpdateParams_AtLeastOneArch(t *testing.T) {
+	if err := validateParamsMsg(context.Background(), &pm.AgentUpdateParams{}); err == nil {
+		t.Error("agent-update with no arch must be rejected")
+	}
+}
+
+// WS7 #2: deb/rpm/appimage download-and-install actions (the shared
+// AppInstallParams `app` oneof) must carry a mandatory 64-hex
+// checksum_sha256 and an https url. Driven through validateParamsMsg.
+func TestValidateAppInstallParams_ChecksumMandatoryAndHTTPS(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("correct accepted", func(t *testing.T) {
+		err := validateParamsMsg(ctx, &pm.AppInstallParams{
+			Url:            "https://example.com/app.deb",
+			ChecksumSha256: validSha,
+		})
+		if err != nil {
+			t.Fatalf("valid app-install params rejected: %v", err)
+		}
+	})
+
+	cases := []struct {
+		name string
+		p    *pm.AppInstallParams
+	}{
+		{"absent checksum", &pm.AppInstallParams{Url: "https://example.com/app.deb"}},
+		{"short checksum", &pm.AppInstallParams{Url: "https://example.com/app.deb", ChecksumSha256: strings.Repeat("a", 63)}},
+		{"non-hex checksum", &pm.AppInstallParams{Url: "https://example.com/app.deb", ChecksumSha256: strings.Repeat("z", 64)}},
+		{"http url", &pm.AppInstallParams{Url: "http://example.com/app.deb", ChecksumSha256: validSha}},
+		{"absent url", &pm.AppInstallParams{ChecksumSha256: validSha}},
+	}
+	for _, tc := range cases {
+		t.Run("rejects "+tc.name, func(t *testing.T) {
+			if err := validateParamsMsg(ctx, tc.p); err == nil {
+				t.Errorf("%s must be rejected", tc.name)
+			}
+		})
+	}
+}
+
+// WS7 #1/#2 against silent drift: every exported field of the
+// download-authenticity param structs must carry a validate gotag, so a
+// future field can't land without a rule. Self-discovering: fails if zero
+// fields are found, or any exported field lacks a `validate` tag.
+func TestActionParamFields_HaveValidationRule(t *testing.T) {
+	for _, msg := range []any{pm.AgentUpdateArch{}, pm.AppInstallParams{}} {
+		typ := reflect.TypeOf(msg)
+		checked := 0
+		for i := 0; i < typ.NumField(); i++ {
+			f := typ.Field(i)
+			if f.PkgPath != "" {
+				continue // unexported proto-internal field (state/sizeCache/unknownFields)
+			}
+			checked++
+			if _, ok := f.Tag.Lookup("validate"); !ok {
+				t.Errorf("%s.%s has no validate gotag", typ.Name(), f.Name)
+			}
+		}
+		if checked == 0 {
+			t.Errorf("%s: no exported fields discovered (reflection guard tripped)", typ.Name())
+		}
+	}
+}


### PR DESCRIPTION
The server validation half of **WS7** (agent self-update authenticity). Drives the merged `manchtools/power-manage-sdk` proto rules at the action boundary, advancing `manchtools/power-manage-server#80`.

## Changes
- **`validateAgentUpdateParams`**: every set arch entry must carry a 64-**lowercase**-hex `expected_sha256` — the hash that gates the agent's self-update binary swap, bound to the CA signature (closes the server half of "self-update authenticity reduces to TLS + same-origin checksum"). Explicit lower-hex check because go-playground's `hexadecimal` rule also accepts uppercase, and the canonical stored form is lowercase.
- **`validateAppInstallParams`** (new, wired into the shared `validateParamsMsg` dispatch that covers deb/rpm/appimage's `app` oneof): https-only `url` + mandatory 64-lowercase-hex `checksum_sha256`.
- **`TestActionParamFields_HaveValidationRule`**: self-discovering guard — every exported field of `AgentUpdateArch` + `AppInstallParams` must carry a `validate` gotag (fails if zero fields found, or a field lacks a rule).

Uses `ErrValidationFailed` (consistent with the existing agent-update URL checks; messages are descriptive) — no new error codes, so the server↔TS error-code parity guard stays satisfied.

Tests written **red-first**; full standalone suite green (`GOWORK=off`), `gofmt`/`go vet` clean, local CodeRabbit review clean.

#3 (signing the release SHA256SUMS) is a separate deferred follow-up.