### PR TITLE
fix(api): agent-update integrity is operator choice (checksum_url or pinned hash)

### DIFF
--- a/docs/adr/0011-agent-update-authenticity.md
+++ b/docs/adr/0011-agent-update-authenticity.md
@@ -28,43 +28,68 @@ properly but is a larger effort (key management, build-pipeline integration).
 
 ## Decision
 
-Bind the expected hash to the **CA-signed action** as the interim authenticity
-control, reusing the existing action-signing trust root (ADR 0003) — no new
-baked key.
+Make agent-update integrity a deliberate **operator choice** between
+hands-off and pinned, with a floor that an update can never run with *no*
+integrity check. The action is already CA-signed (ADR 0003), so its fields
+(URLs, hash) cannot be tampered in transit — the only residual concern is a
+**manipulated hash at the download origin**.
 
-- **`AgentUpdateArch.expected_sha256`** (required, 64 lowercase hex) is the
-  AUTHORITATIVE integrity gate. It rides inside the CA-signed action, so the
-  agent verifies the downloaded binary against a hash bound to the control
-  server's signature. The agent does **not** download or trust a same-origin
-  checksum file; `checksum_url` remains only as operator-facing metadata. A
-  compromised origin cannot forge the CA signature over the hash.
-- **HTTPS-only** downloads, fail-closed before any request, at the single
-  `downloadFile` chokepoint (deb/rpm/appimage) and for the agent binary.
-- **`AppInstallParams.checksum_sha256` is required** — mandatory integrity for
-  download-and-install actions; the agent also rejects an empty checksum
-  defense-in-depth.
+- **`AgentUpdateArch.checksum_url`** (default) — the agent fetches this
+  SHA256SUMS file and verifies the binary against it. This lets an action
+  point `binary_url` + `checksum_url` at `releases/latest/...` and have the
+  fleet **track new releases hands-off**. Authenticity is origin-trust; an
+  operator who wants to remove the single-origin assumption can host the
+  checksum file on a **separate host** from the binary.
+- **`AgentUpdateArch.expected_sha256`** (optional, 64 lowercase hex) — when
+  set, the AUTHORITATIVE gate that **overrides** `checksum_url`. It rides
+  inside the CA-signed action, so the agent verifies against a hash bound to
+  the control server's signature, not a file from the download origin. Use it
+  to pin an exact binary (staged rollouts) or for stronger authenticity. The
+  trade-off is that a new version requires updating + re-signing the action,
+  so it is opt-in rather than the default.
+- **At least one** of `checksum_url` / `expected_sha256` must be set —
+  enforced by the server validator AND the agent — so an update is never
+  installed with no integrity verification.
+- **HTTPS-only** downloads, fail-closed before any request, for the agent
+  binary, the checksum file, and the deb/rpm/appimage `downloadFile`
+  chokepoint. `AppInstallParams.checksum_sha256` stays **required** (a
+  separate path; its mandatory integrity is unchanged).
 - **Anti-rollback**: the agent refuses a candidate older than the running
   version (`vYYYY.MM.PP`); an unparseable version fails closed. The bypass,
-  `AgentUpdateParams.allow_downgrade`, rides inside the CA-signed action — a
-  downgrade is an explicit, authenticated operator decision.
-- **Server validation** enforces these at the action boundary (every set arch
-  carries a lowercase-hex `expected_sha256`; app installs are https + checksum),
-  with a self-discovering test pinning that every param field has a rule.
+  `AgentUpdateParams.allow_downgrade`, rides inside the CA-signed action.
 
 A future binary code-signing key MUST be **operator-pinnable** (self-host
 overridable), never a hardcoded project key.
 
+## Accepted risk
+
+In the default (`checksum_url`) mode, a **compromised download origin** that
+serves a malicious binary *and* a matching checksum file is not detected — the
+checksum is self-attesting. This is an accepted risk for prebuilt binaries:
+
+- The control plane provides ease-of-use; the action signature already
+  prevents tampering of the action itself. The publisher owns the build
+  pipeline and `install.sh`, so signing would not defend against the publisher
+  anyway, and out-of-band signing keys are explicitly not planned.
+- Operators who need a stronger guarantee have two in-product levers
+  (`expected_sha256` pin; a separate-host `checksum_url`), and — since the
+  project is open source — the ultimate answer is to **build and distribute
+  the binaries themselves** and pin hashes as they require.
+
+This is the same posture as the **initial install** (`install.sh`): TLS + a
+self-attesting checksum, no release-`SHA256SUMS` signature. The operator-facing
+statement of this lives in the agent README (Auto-Update / install sections).
+
 ## Consequences
 
-- Compromise of (or MITM on) the binary download origin no longer yields code
-  execution: the tampered binary fails the CA-bound hash check. The relay/
-  gateway being untrusted (ADR 0005) is consistent — the hash is signed by
-  control, relayed opaquely.
-- Operators must populate `expected_sha256` per arch and `checksum_sha256` for
-  app installs; actions without them are rejected at create/update time.
-- A genuine downgrade now requires `allow_downgrade` on the signed action.
+- The hands-off "track latest" update workflow is preserved (default
+  `checksum_url`), while `expected_sha256` remains available as an opt-in pin.
+- The CA-signed pin (`expected_sha256`) neutralises an origin/MITM hash
+  manipulation for operators who choose it — consistent with the relay being
+  untrusted (ADR 0005); the hash is signed by control, relayed opaquely.
 - **Out of scope / deferred** (tracked on agent#108): signing the *release*
-  `SHA256SUMS` in a separate identity and verifying it in `install.sh` (the
-  initial-install integrity, distinct from self-update), plus an install-time
-  update-source allowlist. Both need a real release and a key-management
-  decision (cosign keyless vs minisign) to validate end-to-end.
+  `SHA256SUMS` in a separate identity + verifying it in `install.sh`, and an
+  install-time update-source allowlist. Per the accepted-risk above these are
+  not planned while distribution stays on the publisher's GitHub pipeline with
+  no out-of-band keys; revisit only if distribution moves to mirrors the
+  publisher does not control, or an out-of-band signing key is adopted.

--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b h1:pbMiax9QoJNlKqcV7FxoIliFijWxrGPRkwAUKtkbrsI=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260614074439-f08e3153fa4b/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e h1:C6DZ7+Zh8T8v70V9UdS6s05Zc7vhyKbmNsXEzmlKaCE=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/action_validators.go
+++ b/internal/api/action_validators.go
@@ -186,14 +186,22 @@ func validateAgentUpdateParams(ctx context.Context, p *pm.AgentUpdateParams) err
 		if !strings.HasPrefix(strings.ToLower(arch.BinaryUrl), "https://") {
 			return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "binary_url must use HTTPS")
 		}
-		if !strings.HasPrefix(strings.ToLower(arch.ChecksumUrl), "https://") {
+		// WS7: integrity is required, but the operator chooses the source.
+		// At least one of checksum_url (default — track "latest", verified
+		// against the operator's checksum file) or expected_sha256 (an
+		// exact pinned hash inside the CA-signed action) must be set, so an
+		// update can never run with no integrity check at all.
+		if arch.ChecksumUrl == "" && arch.ExpectedSha256 == "" {
+			return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "each architecture must set checksum_url or expected_sha256")
+		}
+		if arch.ChecksumUrl != "" && !strings.HasPrefix(strings.ToLower(arch.ChecksumUrl), "https://") {
 			return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "checksum_url must use HTTPS")
 		}
-		// WS7 #1: the CA-signed hash that gates the binary swap. Explicit
-		// 64-lowercase-hex check for a precise error code (the struct-tag
-		// `hexadecimal` rule also accepts uppercase, which the agent's
-		// canonical comparison must not depend on).
-		if !isLowerHex64(arch.ExpectedSha256) {
+		// When pinned, expected_sha256 is the CA-signed hash that overrides
+		// the checksum file. Explicit 64-lowercase-hex check (the struct-tag
+		// `hexadecimal` rule also accepts uppercase, which the canonical
+		// stored form must not).
+		if arch.ExpectedSha256 != "" && !isLowerHex64(arch.ExpectedSha256) {
 			return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "expected_sha256 must be 64 lowercase hex characters")
 		}
 	}

--- a/internal/api/action_validators_test.go
+++ b/internal/api/action_validators_test.go
@@ -20,25 +20,43 @@ func archOK() *pm.AgentUpdateArch {
 	}
 }
 
-// WS7 #1: every set arch entry MUST carry a 64-char lowercase-hex
-// expected_sha256, so the hash that gates the self-update swap is inside
-// the CA-signed payload. Driven through the REAL validateParamsMsg
-// dispatch (the shared Create/Update/inline boundary), proving the rule
-// runs at the action boundary, not just on the bare struct.
-func TestValidateAgentUpdateParams_ExpectedSha256(t *testing.T) {
+// WS7 (revised): an arch must carry an integrity source — at least one of
+// checksum_url (default; track "latest") or expected_sha256 (optional
+// pinned hash). Neither is individually required, but BOTH-absent is
+// rejected. Driven through the REAL validateParamsMsg dispatch (the shared
+// Create/Update/inline boundary).
+func TestValidateAgentUpdateParams_IntegritySource(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("correct accepted", func(t *testing.T) {
-		err := validateParamsMsg(ctx, &pm.AgentUpdateParams{Amd64: archOK()})
-		if err != nil {
-			t.Fatalf("valid agent-update params rejected: %v", err)
+	accepted := map[string]*pm.AgentUpdateArch{
+		"checksum_url + expected_sha256": archOK(),
+		"checksum_url only (track latest)": {
+			BinaryUrl:   validURL,
+			ChecksumUrl: validURL + ".sha256",
+		},
+		"expected_sha256 only (pinned)": {
+			BinaryUrl:      validURL,
+			ExpectedSha256: validSha,
+		},
+	}
+	for name, arch := range accepted {
+		t.Run("accepts "+name, func(t *testing.T) {
+			if err := validateParamsMsg(ctx, &pm.AgentUpdateParams{Amd64: arch}); err != nil {
+				t.Errorf("%s should be accepted, got: %v", name, err)
+			}
+		})
+	}
+
+	t.Run("rejects neither checksum_url nor expected_sha256", func(t *testing.T) {
+		arch := &pm.AgentUpdateArch{BinaryUrl: validURL}
+		if err := validateParamsMsg(ctx, &pm.AgentUpdateParams{Amd64: arch}); err == nil {
+			t.Error("an arch with no integrity source must be rejected")
 		}
 	})
 
-	// "wrong" sourced from intent (sha256 is 64 lowercase-hex chars), not
-	// from the validation tag.
+	// A pinned expected_sha256, when present, must be 64 lowercase hex
+	// ("wrong" sourced from intent, not the validation tag).
 	bad := map[string]string{
-		"absent":    "",
 		"too short": strings.Repeat("a", 63),
 		"too long":  strings.Repeat("a", 65),
 		"uppercase": strings.ToUpper(validSha),
@@ -54,7 +72,7 @@ func TestValidateAgentUpdateParams_ExpectedSha256(t *testing.T) {
 		})
 	}
 
-	t.Run("http binary_url still rejected", func(t *testing.T) {
+	t.Run("http binary_url rejected", func(t *testing.T) {
 		arch := archOK()
 		arch.BinaryUrl = "http://example.com/agent"
 		if err := validateParamsMsg(ctx, &pm.AgentUpdateParams{Amd64: arch}); err == nil {
@@ -62,7 +80,7 @@ func TestValidateAgentUpdateParams_ExpectedSha256(t *testing.T) {
 		}
 	})
 
-	t.Run("http checksum_url still rejected", func(t *testing.T) {
+	t.Run("http checksum_url rejected when present", func(t *testing.T) {
 		arch := archOK()
 		arch.ChecksumUrl = "http://example.com/agent.sha256"
 		if err := validateParamsMsg(ctx, &pm.AgentUpdateParams{Amd64: arch}); err == nil {


### PR DESCRIPTION
WS7 follow-up to #417. The required `expected_sha256` forced version-pinning and broke the hands-off "point at latest, track new releases" update workflow. `validateAgentUpdateParams` now requires **at least one** of `{checksum_url, expected_sha256}` per arch — so an update never runs with no integrity check — instead of a mandatory pin:

- `checksum_url` present → must be https (the default: track latest, origin-trust authenticity).
- `expected_sha256` present → must be 64 lowercase hex (opt-in CA-signed exact pin).
- **neither → rejected** (this is the cross-field constraint CodeRabbit flagged on the SDK PR; enforced here + in the agent).

Revises **ADR 0011** to the operator-choice model and documents the **accepted risk**: the default `checksum_url` mode is origin-trust (the action is CA-signed, so only an origin-manipulated hash is a concern; an operator can host the checksum file on a separate host, pin `expected_sha256`, or — since it's open source — build and distribute the binaries themselves). Release-`SHA256SUMS` signing stays deferred (#108).

Bumps the SDK to the merged optional-field proto. `go test`/`vet`/`gofmt` green standalone; local CodeRabbit clean (only the untracked audit doc). Pairs with `power-manage-agent` (checksum_url fallback).