### PR TITLE
feat(server): secrets-at-rest hardening — LUKS token hash, CA signer/perm checks, TOTP audit redaction, /health (#419)

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -53,6 +53,16 @@ const maxAgentMessageBytes = 64 << 20
 // the cert's 1-year natural expiry.
 const crlRefreshInterval = 30 * time.Second
 
+// opsHealthHandler serves the unauthenticated ops-port /health endpoint.
+// It reports liveness ONLY — it must NOT disclose fleet telemetry such as
+// the connected-agent count, which previously leaked the live device
+// count to anyone able to reach the ops port (WS10 #12).
+func opsHealthHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, `{"status":"healthy"}`)
+}
+
 func main() {
 	// Parse flags — TLS is always required for mTLS agent connections
 	tlsCert := flag.String("tls-cert", "", "path to server certificate (required)")
@@ -592,11 +602,7 @@ func main() {
 
 	// Separate mux for health checks (accessible without mTLS)
 	opsMux := http.NewServeMux()
-	opsMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, `{"status":"healthy","agents":%d}`, manager.Count())
-	})
+	opsMux.HandleFunc("/health", opsHealthHandler)
 	opsMux.HandleFunc("/ready", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))

--- a/cmd/gateway/ops_health_test.go
+++ b/cmd/gateway/ops_health_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestOpsHealth_DoesNotDiscloseAgentCount pins WS10 #12: the
+// unauthenticated ops /health endpoint reports liveness only and must
+// not leak fleet telemetry (the connected-agent count).
+func TestOpsHealth_DoesNotDiscloseAgentCount(t *testing.T) {
+	rec := httptest.NewRecorder()
+	opsHealthHandler(rec, httptest.NewRequest("GET", "/health", nil))
+
+	body := rec.Body.String()
+	if rec.Code != 200 {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+	if body != `{"status":"healthy"}` {
+		t.Errorf("body = %q, want %q", body, `{"status":"healthy"}`)
+	}
+	if strings.Contains(body, "agents") {
+		t.Errorf("health body must not disclose the agent count: %q", body)
+	}
+}

--- a/internal/api/audit_handler.go
+++ b/internal/api/audit_handler.go
@@ -124,6 +124,15 @@ var eventRedactionSchemas = map[string]map[string]redactionSchema{
 		// `passphrase` at the top level.
 		"LuksKeyRotated": {paths: []string{"passphrase"}},
 	},
+	"totp": {
+		// WS10 #8: TOTP setup persists the AES-GCM secret ciphertext and
+		// the backup-code bcrypt hashes; regeneration persists fresh
+		// backup-code hashes. Keep both out of the audit view. The
+		// self-discovering TestEveryTOTPEventClassifiedForRedaction pins
+		// that every secret-bearing TOTP event is covered here.
+		string(eventtypes.TOTPSetupInitiated):         {paths: []string{"secret_encrypted", "backup_codes_hash"}},
+		string(eventtypes.TOTPBackupCodesRegenerated): {paths: []string{"backup_codes_hash"}},
+	},
 }
 
 // actionRedactionSchemas maps an action's `params.type` value to the

--- a/internal/api/audit_totp_redaction_test.go
+++ b/internal/api/audit_totp_redaction_test.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+)
+
+// TestTOTPSecretAndBackupCodesRedacted pins WS10 #8: TOTP setup and
+// backup-code regeneration events must not expose the secret ciphertext
+// or the backup-code hashes through the audit log.
+func TestTOTPSecretAndBackupCodesRedacted(t *testing.T) {
+	setup, err := json.Marshal(payloads.TOTPSetupInitiated{
+		SecretEncrypted: "enc:v2:totpsecretblob",
+		BackupCodesHash: []string{"$2a$bchash1", "$2a$bchash2"},
+	})
+	assert.NoError(t, err)
+	out := redactEventData("totp", string(eventtypes.TOTPSetupInitiated), setup)
+	assert.Contains(t, out, "[REDACTED]")
+	assert.NotContains(t, out, "totpsecretblob")
+	assert.NotContains(t, out, "bchash1")
+
+	regen, err := json.Marshal(payloads.TOTPBackupCodesRegenerated{BackupCodesHash: []string{"$2a$regenhash"}})
+	assert.NoError(t, err)
+	out2 := redactEventData("totp", string(eventtypes.TOTPBackupCodesRegenerated), regen)
+	assert.Contains(t, out2, "[REDACTED]")
+	assert.NotContains(t, out2, "regenhash")
+
+	// A TOTP event with no secret payload passes through unchanged.
+	out3 := redactEventData("totp", string(eventtypes.TOTPVerified), []byte(`{"verified":true}`))
+	assert.Contains(t, out3, "verified")
+}
+
+// TestEveryTOTPEventClassifiedForRedaction is the self-discovering,
+// fail-closed guard (#8): every TOTP event whose payload struct carries a
+// secret-bearing field (secret_encrypted / backup_codes_hash) MUST have a
+// matching redaction-schema path. The secret detection is reflective, so
+// adding such a field to a TOTP payload without updating the schema fails
+// here; the All()-enumeration guard fails if a new TOTP eventtype isn't
+// classified in this test at all.
+func TestEveryTOTPEventClassifiedForRedaction(t *testing.T) {
+	secretTags := map[string]bool{"secret_encrypted": true, "backup_codes_hash": true}
+
+	// Every eventtypes TOTP constant must appear here (nil = no secret
+	// payload). A new TOTP event trips the All() guard below until added.
+	payloadFor := map[eventtypes.EventType]any{
+		eventtypes.TOTPSetupInitiated:         payloads.TOTPSetupInitiated{},
+		eventtypes.TOTPBackupCodesRegenerated: payloads.TOTPBackupCodesRegenerated{},
+		eventtypes.TOTPVerified:               nil,
+		eventtypes.TOTPDisabled:               nil,
+		eventtypes.TOTPBackupCodeUsed:         nil,
+	}
+
+	totpEvents := 0
+	for _, et := range eventtypes.All() {
+		if !strings.HasPrefix(string(et), "TOTP") {
+			continue
+		}
+		totpEvents++
+		if _, ok := payloadFor[et]; !ok {
+			t.Errorf("TOTP event %q is not classified in this test — add it to payloadFor and decide redaction", et)
+		}
+	}
+	if totpEvents == 0 {
+		t.Fatal("found no TOTP events to classify — eventtypes enumeration broke")
+	}
+
+	totpSchemas := eventRedactionSchemas["totp"]
+	for et, payload := range payloadFor {
+		if payload == nil {
+			continue
+		}
+		rt := reflect.TypeOf(payload)
+		for i := 0; i < rt.NumField(); i++ {
+			tag := strings.Split(rt.Field(i).Tag.Get("json"), ",")[0]
+			if !secretTags[tag] {
+				continue
+			}
+			schema, ok := totpSchemas[string(et)]
+			if !ok {
+				t.Errorf("TOTP event %q carries secret field %q but has no redaction schema", et, tag)
+				continue
+			}
+			covered := false
+			for _, p := range schema.paths {
+				if p == tag {
+					covered = true
+					break
+				}
+			}
+			if !covered {
+				t.Errorf("TOTP event %q redaction schema does not cover secret field %q", et, tag)
+			}
+		}
+	}
+}

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"log/slog"
@@ -853,6 +854,15 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 	return connect.NewResponse(resp), nil
 }
 
+// hashLuksToken returns the hex SHA-256 of a one-time LUKS token — the
+// form stored at rest and matched on validation (WS10 #3), so the
+// plaintext token never persists. Single source for the create and
+// validate (ProxyValidateLuksToken) sides.
+func hashLuksToken(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
 // CreateLuksToken creates a one-time token for setting a user-defined LUKS passphrase.
 // Only the device's assigned owner can create a token (admins cannot).
 func (h *DeviceHandler) CreateLuksToken(ctx context.Context, req *connect.Request[pm.CreateLuksTokenRequest]) (*connect.Response[pm.CreateLuksTokenResponse], error) {
@@ -915,8 +925,11 @@ func (h *DeviceHandler) CreateLuksToken(ctx context.Context, req *connect.Reques
 	}
 	token := hex.EncodeToString(tokenBytes)
 
-	// Store in DB
-	_, err = h.store.Repos().Luks.CreateToken(ctx, store.CreateLuksTokenParams{DeviceID: req.Msg.DeviceId, ActionID: req.Msg.ActionId, Token: token, MinLength: minLength, Complexity: complexity})
+	// WS10 #3: store only the SHA-256 hash of the token, never the
+	// plaintext (consistent with registration/terminal tokens). The
+	// plaintext is returned to the caller exactly once below; an attacker
+	// who reads the DB cannot replay it to set a LUKS passphrase.
+	_, err = h.store.Repos().Luks.CreateToken(ctx, store.CreateLuksTokenParams{DeviceID: req.Msg.DeviceId, ActionID: req.Msg.ActionId, Token: hashLuksToken(token), MinLength: minLength, Complexity: complexity})
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to create token")
 	}

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -367,7 +367,9 @@ func (h *InternalHandler) ProxyValidateLuksToken(ctx context.Context, req *conne
 		return nil, err
 	}
 
-	token, err := h.store.Repos().Luks.ConsumeToken(ctx, store.ConsumeLuksTokenParams{Token: req.Msg.Token, DeviceID: req.Msg.DeviceId})
+	// WS10 #3: tokens are stored hashed — hash the presented plaintext
+	// before lookup so the at-rest column never holds a usable token.
+	token, err := h.store.Repos().Luks.ConsumeToken(ctx, store.ConsumeLuksTokenParams{Token: hashLuksToken(req.Msg.Token), DeviceID: req.Msg.DeviceId})
 	if err != nil {
 		h.logger.Warn("LUKS token validation failed", "device_id", req.Msg.DeviceId, "error", err)
 		return nil, apiErrorCtx(ctx, ErrTokenNotFound, connect.CodeNotFound, "token is invalid or has expired")

--- a/internal/api/luks_token_hash_test.go
+++ b/internal/api/luks_token_hash_test.go
@@ -1,0 +1,61 @@
+package api_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// TestCreateLuksToken_PersistsHashNotPlaintext pins WS10 #3: the LUKS
+// one-time token is stored hashed. Observable behavior: a consume by the
+// raw plaintext token FAILS (no plaintext at rest), while a consume by
+// the SHA-256 hash of the returned token SUCCEEDS (the stored value is
+// the hash, and the plaintext is returned to the caller only once).
+func TestCreateLuksToken_PersistsHashNotPlaintext(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "luks-hash-device")
+	actionID := testutil.CreateTestAction(t, st, userID, "Encrypt Disk", int(pm.ActionType_ACTION_TYPE_ENCRYPTION))
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
+	ctx := testutil.UserContext(userID)
+
+	create := func() string {
+		resp, err := h.CreateLuksToken(ctx, connect.NewRequest(&pm.CreateLuksTokenRequest{
+			DeviceId: deviceID, ActionId: actionID,
+		}))
+		require.NoError(t, err)
+		return resp.Msg.Token
+	}
+
+	// Raw plaintext token must NOT consume — it is not what is stored.
+	plaintext := create()
+	_, err := st.Repos().Luks.ConsumeToken(ctx, store.ConsumeLuksTokenParams{Token: plaintext, DeviceID: deviceID})
+	require.Error(t, err, "the plaintext token must not match the at-rest value (it is stored hashed)")
+
+	// The SHA-256 hash of the returned token DOES consume — proving the
+	// stored value is the hash.
+	plaintext2 := create()
+	_, err = st.Repos().Luks.ConsumeToken(ctx, store.ConsumeLuksTokenParams{Token: sha256Hex(plaintext2), DeviceID: deviceID})
+	require.NoError(t, err, "the stored value must be the SHA-256 hash of the returned token")
+
+	// And it is one-time: a replay of the same hash fails.
+	_, err = st.Repos().Luks.ConsumeToken(ctx, store.ConsumeLuksTokenParams{Token: sha256Hex(plaintext2), DeviceID: deviceID})
+	require.Error(t, err, "a consumed token must not be replayable")
+}

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -3,13 +3,16 @@ package ca
 
 import (
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"net/url"
 	"os"
@@ -53,6 +56,15 @@ func New(certPath, keyPath string, validity time.Duration, opts ...Option) (*CA,
 		return nil, fmt.Errorf("read CA key: %w", err)
 	}
 
+	// WS10 #11: the CA private key is the root of all trust — warn loudly
+	// (but do not block startup) if it is group/world-accessible. A hard
+	// failure here would break an existing deployment with a looser key
+	// mode; the operator must tighten it to owner-only (0600).
+	if info, statErr := os.Stat(keyPath); statErr == nil && info.Mode().Perm()&0o077 != 0 {
+		slog.Warn("CA private key file is group/world-accessible — restrict it to owner-only (chmod 0600)",
+			"path", keyPath, "mode", fmt.Sprintf("%#o", info.Mode().Perm()))
+	}
+
 	return NewFromPEM(certPEM, keyPEM, validity, opts...)
 }
 
@@ -76,6 +88,18 @@ func NewFromPEM(certPEM, keyPEM []byte, validity time.Duration, opts ...Option) 
 	key, err := parsePrivateKey(keyBlock.Bytes)
 	if err != nil {
 		return nil, fmt.Errorf("parse CA key: %w", err)
+	}
+
+	// WS10 #7: the CA key signs BOTH issued certificates and dispatched
+	// actions (verify.ActionSigner), which supports only ECDSA and RSA.
+	// parsePrivateKey accepts any crypto.Signer (e.g. an Ed25519 PKCS8
+	// key) — reject a signer-incompatible key at boot rather than load it
+	// and silently break action dispatch later.
+	switch key.(type) {
+	case *ecdsa.PrivateKey, *rsa.PrivateKey:
+		// supported
+	default:
+		return nil, fmt.Errorf("unsupported CA signing key type %T (the action signer requires ECDSA or RSA)", key)
 	}
 
 	pool := x509.NewCertPool()

--- a/internal/ca/ca_ws10_test.go
+++ b/internal/ca/ca_ws10_test.go
@@ -1,0 +1,88 @@
+package ca_test
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/ca"
+)
+
+func pkcs8PEM(t *testing.T, key any) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+}
+
+// TestNewFromPEM_RejectsSignerIncompatibleCAKey pins WS10 #7: the CA key
+// signs both issued certs AND dispatched actions (the action signer
+// supports only ECDSA/RSA). A signer-incompatible key (Ed25519 — valid
+// PKCS8, implements crypto.Signer, accepted by parsePrivateKey) must be
+// rejected at boot rather than load and silently break action dispatch.
+func TestNewFromPEM_RejectsSignerIncompatibleCAKey(t *testing.T) {
+	certPEM, ecdsaKeyPEM := generateTestCA(t)
+
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	_, ed25519Key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	t.Run("ECDSA accepted", func(t *testing.T) {
+		_, err := ca.NewFromPEM(certPEM, ecdsaKeyPEM, time.Hour)
+		require.NoError(t, err)
+	})
+	t.Run("RSA accepted", func(t *testing.T) {
+		_, err := ca.NewFromPEM(certPEM, pkcs8PEM(t, rsaKey), time.Hour)
+		require.NoError(t, err)
+	})
+	t.Run("Ed25519 rejected", func(t *testing.T) {
+		_, err := ca.NewFromPEM(certPEM, pkcs8PEM(t, ed25519Key), time.Hour)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unsupported CA signing key type")
+	})
+}
+
+// TestNew_WarnsOnGroupOrWorldReadableKeyFile pins WS10 #11: New warns
+// loudly (but does not fail) when the CA private key file is
+// group/world-accessible. A 0600 key is silent; a 0644 key warns with
+// the path.
+func TestNew_WarnsOnGroupOrWorldReadableKeyFile(t *testing.T) {
+	certPEM, keyPEM := generateTestCA(t)
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "ca.crt")
+	keyPath := filepath.Join(dir, "ca.key")
+	require.NoError(t, os.WriteFile(certPath, certPEM, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPEM, 0o600))
+
+	var buf bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	t.Run("0600 owner-only is silent", func(t *testing.T) {
+		buf.Reset()
+		require.NoError(t, os.Chmod(keyPath, 0o600))
+		_, err := ca.New(certPath, keyPath, time.Hour)
+		require.NoError(t, err)
+		require.NotContains(t, buf.String(), "group/world")
+	})
+	t.Run("0644 world-readable warns with the path", func(t *testing.T) {
+		buf.Reset()
+		require.NoError(t, os.Chmod(keyPath, 0o644))
+		_, err := ca.New(certPath, keyPath, time.Hour)
+		require.NoError(t, err) // warn-only, not a hard failure
+		require.Contains(t, buf.String(), "group/world")
+		require.Contains(t, buf.String(), keyPath)
+	})
+}

--- a/internal/store/migrations/013_luks_token_hash.sql
+++ b/internal/store/migrations/013_luks_token_hash.sql
@@ -1,0 +1,22 @@
+-- 013_luks_token_hash.sql
+--
+-- WS10 #3: LUKS one-time tokens are now stored as a SHA-256 hash at rest
+-- (consistent with registration/terminal tokens), so the plaintext token
+-- no longer persists in luks_tokens.token. The column shape is unchanged
+-- (still text) — only the value written by the handler changed
+-- (device_handler.CreateLuksToken stores hashLuksToken(token);
+-- ProxyValidateLuksToken hashes the presented token before lookup).
+--
+-- Any rows written before this change hold PLAINTEXT tokens that would
+-- (a) never match the now-hashed lookup and (b) leave a usable secret at
+-- rest. They are one-time and expire after 15 minutes, so clearing them
+-- is safe — an operator simply re-creates the token. No schema or
+-- PL/pgSQL change is needed.
+
+-- +goose Up
+DELETE FROM public.luks_tokens;
+
+-- +goose Down
+-- No-op: deleted one-time tokens cannot be restored, and the column
+-- shape is unchanged.
+SELECT 1;


### PR DESCRIPTION
Closes #419. WS10 server cheap wins.

| # | Fix |
|---|-----|
| #3 | LUKS one-time token stored as **SHA-256 hash** at rest (shared `hashLuksToken`; migration 013 clears lingering plaintext) |
| #7 | `NewFromPEM` rejects a signer-incompatible CA key (Ed25519) at boot — the CA key also signs actions (ECDSA/RSA only) |
| #11 | `New` **warns** (not fails) when the CA private key file is group/world-accessible |
| #8 | redact TOTP `secret_encrypted` + `backup_codes_hash` from the audit log + self-discovering coverage test |
| #12 | unauthenticated ops `/health` no longer discloses the connected-agent count |

## Deliberate scope (per maintainer)
- **idp/totp AAD wiring deferred**: WS5 already AAD-bound the relay-exposed secrets (luks/lps via the untrusted gateway). idp/totp secrets live only in the control DB; AAD there is marginal defense-in-depth and a mis-paired decrypt site would break **SSO login / 2FA** — high blast radius for low value. Documented in ADR 0014.
- **Credential-store KDF (#1) + reuse-hash salting (#4)**: accepted residual (store is already root-only 0600/0700; a same-disk key file doesn't defend offline theft — FDE does). ADR 0014.

## Tests
- `ca`: signer-compat (ECDSA/RSA ok, Ed25519 rejected); key-perm warn (0600 silent, 0644 warns).
- `api`: TOTP redaction + self-discovering classification; LUKS token persists-hash / consumes-by-hash / no-replay (DB).
- `gateway`: /health does not disclose the agent count.

Local cr: 2 findings, both non-actionable (one on the untracked SECURITY_AUDIT doc; one a same-package false positive — `hashLuksToken` is defined in device_handler.go, same `package api`).