### PR TITLE
WS11: auth hardening (JWT alg pin, per-user RPC rate limits, credential floors, terminal-token transport, login no-enumeration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,19 @@ The Control Server exposes a Connect-RPC API (`pm.v1.ControlService`); the Gatew
 | `Logout` | Revoke the presented refresh token. |
 | `GetCurrentUser` | Return the authenticated user's profile from JWT claims. |
 
+JWTs are signed with **HS256 only** — alg-confusion tokens (`none`, HS384/HS512,
+RS256) are rejected. `Login` returns the same generic *invalid credentials* for a
+wrong password, a non-existent account, and a **disabled** account, so a
+credential holder can't probe account state.
+
+**Rate limiting & client IP.** Unauthenticated endpoints (login, refresh,
+register, logout, cert renewal, auth-methods lookup) are throttled per client IP;
+authenticated RPCs are throttled per user, with a tighter ceiling on heavy
+operations (query evaluation, search, projector rebuild, log/osquery fan-out).
+Client-IP attribution honours `X-Forwarded-For` / `X-Real-IP` **only** when the
+direct peer is in `CONTROL_TRUSTED_PROXIES` (CIDRs or bare IPs); otherwise the
+peer address is used, so proxy headers can't be spoofed to evade per-IP limits.
+
 ### Users
 
 | Method | Description |

--- a/cmd/control/README.md
+++ b/cmd/control/README.md
@@ -57,18 +57,18 @@ Environment variables override command-line flags:
 |----------|-------------|
 | `CONTROL_LISTEN_ADDR` | Listen address |
 | `CONTROL_DATABASE_URL` | PostgreSQL connection URL |
-| `CONTROL_JWT_SECRET` | JWT signing secret |
+| `CONTROL_JWT_SECRET` | JWT signing secret. **Must decode (hex or base64) to ≥32 random bytes** — a bare passphrase is rejected at boot. Generate with `openssl rand -base64 48` or `openssl rand -hex 32`. |
 | `CONTROL_CA_CERT` | CA certificate path |
 | `CONTROL_CA_KEY` | CA private key path |
 | `CONTROL_GATEWAY_URL` | Gateway URL returned to agents during registration |
 | `CONTROL_ADMIN_EMAIL` | Bootstrap admin email (first-boot only; see [Bootstrap Admin](#bootstrap-admin)) |
-| `CONTROL_ADMIN_PASSWORD` | Bootstrap admin password (first-boot only; see [Bootstrap Admin](#bootstrap-admin)) |
+| `CONTROL_ADMIN_PASSWORD` | Bootstrap admin password (first-boot only; see [Bootstrap Admin](#bootstrap-admin)). When set it must be **≥12 characters**; leave empty after first boot to skip bootstrap. |
 | `CONTROL_DYNAMIC_GROUP_EVAL_INTERVAL` | Interval for evaluating queued dynamic groups (e.g., `30m`, `1h`, `4h`) |
 | `CONTROL_SCIM_BASE_URL` | Base URL for SCIM v2 endpoints (e.g., `https://control.example.com:8081`) |
 | `CONTROL_CA_TRUST_BUNDLE` | PEM file with trusted CA certificates for verification (supports CA rotation) |
-| `CONTROL_ENCRYPTION_KEY` | AES-256 encryption key for identity provider client secrets (hex-encoded, 32 bytes) |
+| `CONTROL_ENCRYPTION_KEY` | **Mandatory.** AES-256 key for secrets at rest (IdP client secrets, TOTP secrets, LUKS keys, LPS passwords); hex-encoded 32 bytes (`openssl rand -hex 32`). The server refuses to boot without it — there is no plaintext opt-out. |
 | `CONTROL_PASSWORD_AUTH_ENABLED` | Enable password-based login (default: `true`). Set to `false` for SSO-only. |
-| `CONTROL_TRUSTED_PROXIES` | Comma-separated trusted proxy IPs/CIDRs for client IP parsing |
+| `CONTROL_TRUSTED_PROXIES` | Comma-separated trusted proxy IPs/CIDRs. `X-Forwarded-For` / `X-Real-IP` are honoured **only** when the direct peer is in this set; otherwise the peer address is used. Bare IPs are treated as `/32` (IPv4) or `/128` (IPv6); malformed entries are skipped. |
 | `CONTROL_SSH_ACCESS_FOR_ALL` | Grant SSH access to all devices by default (default: `false`) |
 | `CONTROL_VALKEY_ADDR` | Valkey/Redis address for Asynq task queue (e.g., `localhost:6379`) |
 | `CONTROL_VALKEY_PASSWORD` | Valkey/Redis password |
@@ -109,14 +109,17 @@ Create real users once you're logged in as the bootstrap admin — via the web U
 ### Running Locally
 
 ```bash
-# Run with environment variables
+# Run with environment variables. Generate the secrets with a CSPRNG — the
+# server rejects a weak JWT secret / admin password and refuses to boot without
+# an encryption key.
 export CONTROL_DATABASE_URL="postgres://powermanage:powermanage@localhost:5432/powermanage?sslmode=disable"
-export CONTROL_JWT_SECRET="your-secret-key"
+export CONTROL_JWT_SECRET="$(openssl rand -base64 48)"
+export CONTROL_ENCRYPTION_KEY="$(openssl rand -hex 32)"
 export CONTROL_CA_CERT="./dev/certs/ca.crt"
 export CONTROL_CA_KEY="./dev/certs/ca.key"
 export CONTROL_GATEWAY_URL="https://gateway.example.com"
 export CONTROL_ADMIN_EMAIL="admin@localhost.com"
-export CONTROL_ADMIN_PASSWORD="admin"
+export CONTROL_ADMIN_PASSWORD="$(openssl rand -base64 18)"   # ≥12 chars; rotate after first login
 
 go run ./server/cmd/control
 ```
@@ -755,12 +758,24 @@ RLS is enabled on all projection tables:
 
 ### Security Best Practices
 
-1. **JWT Secret**: Always set a strong `CONTROL_JWT_SECRET` in production
-2. **Database**: Use SSL for PostgreSQL connections in production
-3. **CA Key**: Protect the CA private key - it signs all agent certificates
-4. **Admin Credentials**: Change default admin credentials immediately
-5. **Network**: Consider running behind a reverse proxy with TLS termination
-6. **RLS**: The database enforces permissions even if application code is compromised
+1. **JWT Secret**: `CONTROL_JWT_SECRET` must decode (hex or base64) to ≥32 random bytes — generate with `openssl rand -base64 48`. A bare passphrase is rejected at boot.
+2. **Encryption key**: `CONTROL_ENCRYPTION_KEY` is mandatory (`openssl rand -hex 32`); the server refuses to boot without it and there is no plaintext opt-out for secrets at rest.
+3. **Database**: Use SSL for PostgreSQL connections in production
+4. **CA Key**: Protect the CA private key - it signs all agent certificates
+5. **Admin Credentials**: Set a strong bootstrap `CONTROL_ADMIN_PASSWORD` (≥12 chars) and rotate it after the first login; drop it from the environment thereafter
+6. **Trusted proxies**: Set `CONTROL_TRUSTED_PROXIES` so `X-Forwarded-For` / `X-Real-IP` are honoured only from your proxy — otherwise rate-limit IP attribution can be spoofed
+7. **Network**: Consider running behind a reverse proxy with TLS termination
+8. **RLS**: The database enforces permissions even if application code is compromised
+
+### Rate limiting
+
+Beyond the per-IP throttles on the unauthenticated endpoints (login, refresh,
+register, logout, cert renewal, auth-methods lookup), authenticated control RPCs
+are rate-limited **per user** (keyed by user ID, not IP): a generous general
+ceiling on every call plus a tighter ceiling on heavy operations (dynamic-group
+query evaluation, search, projector rebuild, log/osquery fan-out). This bounds a
+stolen access token or a runaway client. The ceilings are fixed defaults; over a
+limit the RPC returns `CodeResourceExhausted`.
 
 ## CA Rotation
 

--- a/cmd/control/config_guard_test.go
+++ b/cmd/control/config_guard_test.go
@@ -5,7 +5,9 @@ import (
 	"testing"
 )
 
-const validJWTSecret = "0123456789abcdef0123456789abcdef" // 32 chars
+// validJWTSecret is 64 hex chars = 32 decoded bytes, the entropy floor
+// CONTROL_JWT_SECRET now requires (WS11 finding 4).
+const validJWTSecret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 
 // TestValidateConfig_RefusesAllowAllInProd pins WS5 #7: CORS allow-all is
 // dev-only — validateConfig must refuse to boot it when TLS is enabled or the
@@ -65,5 +67,67 @@ func TestValidateConfig_JWTSecret(t *testing.T) {
 	}
 	if err := validateConfig(&Config{JWTSecret: validJWTSecret, ListenAddr: "127.0.0.1:8081"}); err != nil {
 		t.Fatalf("valid minimal config should pass: %v", err)
+	}
+}
+
+// TestValidateConfig_JWTSecretEntropyFloor pins WS11 finding 4: the secret must
+// decode (hex or base64) to >= 32 random bytes, not merely be >= 32 characters.
+// "wrong" is sourced from the intent ("32 RANDOM bytes"), not the old length
+// rule — so a 32-char value that passed before is now rejected.
+func TestValidateConfig_JWTSecretEntropyFloor(t *testing.T) {
+	cases := []struct {
+		name    string
+		secret  string
+		wantErr bool
+	}{
+		{"absent", "", true},
+		{"32 hex chars decode to only 16 bytes (passed the old rule)", "0123456789abcdef0123456789abcdef", true},
+		{"40-char low-entropy all-a decodes under 32 bytes", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true},
+		{"non-encoded 32-char passphrase is rejected", "this is a passphrase not base64!", true},
+		{"64 hex chars = 32 bytes", validJWTSecret, false},
+		{"44-char base64 = 33 bytes", "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8g", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateConfig(&Config{JWTSecret: tc.secret, ListenAddr: "127.0.0.1:8081"})
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected %q to be rejected by the entropy floor", tc.secret)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected %q to pass the entropy floor, got: %v", tc.secret, err)
+			}
+		})
+	}
+}
+
+// TestValidateConfig_AdminPasswordFloor pins WS11 finding 9: a bootstrap admin
+// password must clear a minimum-length floor (the documented "admin" example is
+// rejected). An admin email with NO password is the no-bootstrap path (allowed)
+// so an operator can drop the password from the env after first boot without
+// the server refusing to start.
+func TestValidateConfig_AdminPasswordFloor(t *testing.T) {
+	base := func(email, pw string) *Config {
+		return &Config{JWTSecret: validJWTSecret, ListenAddr: "127.0.0.1:8081", AdminEmail: email, AdminPassword: pw}
+	}
+	cases := []struct {
+		name    string
+		cfg     *Config
+		wantErr bool
+	}{
+		{"weak admin example rejected", base("admin@example.com", "admin"), true},
+		{"empty password with email set is the no-bootstrap path", base("admin@example.com", ""), false},
+		{"strong password accepted", base("admin@example.com", "a-strong-bootstrap-secret"), false},
+		{"no admin configured at all", base("", ""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateConfig(tc.cfg)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected the admin-password floor to reject this config")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected this config to pass, got: %v", err)
+			}
+		})
 	}
 }

--- a/cmd/control/flags.go
+++ b/cmd/control/flags.go
@@ -5,6 +5,8 @@
 package main
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"flag"
 	"fmt"
 	"net"
@@ -128,8 +130,11 @@ func validateConfig(cfg *Config) error {
 	if cfg.JWTSecret == "" {
 		return fmt.Errorf("CONTROL_JWT_SECRET (or -jwt-secret) is required")
 	}
-	if len(cfg.JWTSecret) < 32 {
-		return fmt.Errorf("CONTROL_JWT_SECRET must be at least 32 characters")
+	if err := validateJWTSecretStrength(cfg.JWTSecret); err != nil {
+		return err
+	}
+	if err := validateAdminPassword(cfg.AdminPassword); err != nil {
+		return err
 	}
 	if cfg.TLSEnabled && (cfg.TLSCert == "" || cfg.TLSKey == "") {
 		return fmt.Errorf("-tls-cert and -tls-key are required when TLS is enabled")
@@ -140,6 +145,67 @@ func validateConfig(cfg *Config) error {
 	// expose a credential-less reflect-any-origin CORS policy to the internet.
 	if cfg.CORSAllowAll && (cfg.TLSEnabled || !listenAddrIsLocalhost(cfg.ListenAddr)) {
 		return fmt.Errorf("CONTROL_CORS_ALLOW_ALL is development-only and must not be set when TLS is enabled or the listen address is not localhost (got %q); set CONTROL_CORS_ORIGINS to an explicit allow-list instead", cfg.ListenAddr)
+	}
+	return nil
+}
+
+// jwtSecretMinBytes is the entropy floor for the HMAC signing secret: 256 bits.
+const jwtSecretMinBytes = 32
+
+// adminPasswordMinLen is the floor for the bootstrap admin password. It is a
+// throwaway first-login credential meant to be rotated immediately, but it
+// must still resist a trivial guess (the docs once shipped "admin").
+const adminPasswordMinLen = 12
+
+// validateJWTSecretStrength enforces that CONTROL_JWT_SECRET decodes (hex or
+// base64) to at least 32 random bytes (WS11 finding 4) — not merely that it is
+// >= 32 characters. A bare passphrase no longer passes: operators must supply a
+// CSPRNG-generated secret (`openssl rand -base64 48` or `openssl rand -hex 32`),
+// mirroring the CONTROL_ENCRYPTION_KEY handling. The raw string still signs
+// tokens (HMAC takes its entropy from the bytes either way); this only gates
+// operator input so a weak secret can't be brute-forced into forging tokens.
+func validateJWTSecretStrength(secret string) error {
+	if decodedSecretLen(secret) < jwtSecretMinBytes {
+		return fmt.Errorf(
+			"CONTROL_JWT_SECRET must decode (hex or base64) to at least %d random bytes; generate one with `openssl rand -base64 48` or `openssl rand -hex 32`",
+			jwtSecretMinBytes)
+	}
+	return nil
+}
+
+// decodedSecretLen returns the largest decoded byte length of s across the hex
+// and base64 (std/url, padded/raw) encodings, or 0 if it decodes under none.
+// Taking the max is deliberate: an operator may legitimately supply either
+// encoding, and a high-entropy value will satisfy the floor in at least one.
+func decodedSecretLen(s string) int {
+	best := 0
+	if b, err := hex.DecodeString(s); err == nil && len(b) > best {
+		best = len(b)
+	}
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding, base64.RawStdEncoding,
+		base64.URLEncoding, base64.RawURLEncoding,
+	} {
+		if b, err := enc.DecodeString(s); err == nil && len(b) > best {
+			best = len(b)
+		}
+	}
+	return best
+}
+
+// validateAdminPassword enforces a minimum length on the bootstrap admin
+// password (WS11 finding 9). An EMPTY password is the no-bootstrap path
+// (main() only seeds an admin when both email and password are set), so an
+// operator can drop the password from the environment after first boot without
+// the server refusing to start. A non-empty but too-weak password is fatal.
+func validateAdminPassword(pw string) error {
+	if pw == "" {
+		return nil
+	}
+	if len(pw) < adminPasswordMinLen {
+		return fmt.Errorf(
+			"CONTROL_ADMIN_PASSWORD must be at least %d characters; it is a first-login bootstrap credential — set a strong value and rotate it after the first login",
+			adminPasswordMinLen)
 	}
 	return nil
 }

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -177,14 +177,10 @@ func main() {
 		}
 	}, false)
 
-	// Initialize secret encryptor.
-	//
-	// rc3 note: previously read unprefixed PM_ENCRYPTION_KEY /
-	// PM_ENCRYPTION_KEY_REQUIRED. Now namespaced as
-	// CONTROL_ENCRYPTION_KEY / CONTROL_ENCRYPTION_KEY_REQUIRED so all
-	// control-server knobs live under one prefix. Operators upgrading
-	// from rc2 must rename their .env entries — the old names are no
-	// longer read.
+	// Initialize secret encryptor. CONTROL_ENCRYPTION_KEY is MANDATORY —
+	// the former CONTROL_ENCRYPTION_KEY_REQUIRED=false plaintext opt-out was
+	// removed (WS11 #4); a missing key is a fatal boot error so secrets at
+	// rest can never be stored unencrypted, even by accident.
 	encryptor, err := initEncryptor(logger)
 	if err != nil {
 		logger.Error("failed to initialize encryptor", "error", err)

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -268,6 +268,14 @@ func main() {
 		Logout:      auth.NewRateLimiter(30, 1*time.Minute), // legitimate multi-session logout ceiling
 		RenewCert:   auth.NewRateLimiter(5, 1*time.Minute),  // cert rotation = once/lifetime, not in tight loop
 		AuthMethods: auth.NewRateLimiter(30, 1*time.Minute), // unauth email-lookup oracle — bound bulk enumeration
+		// WS11 #6 — per-USER ceilings on authenticated control RPCs (keyed by
+		// user ID, not IP). Authenticated is a generous general ceiling
+		// (~10 rps sustained per user) that bounds a stolen token / runaway
+		// client; Expensive is a tighter ceiling applied on top for the
+		// self-discovered heavy set (query evaluation, search, rebuild,
+		// log/osquery fan-out).
+		Authenticated: auth.NewRateLimiter(600, 1*time.Minute),
+		Expensive:     auth.NewRateLimiter(60, 1*time.Minute),
 	}
 
 	interceptors := connect.WithInterceptors(

--- a/cmd/control/setup.go
+++ b/cmd/control/setup.go
@@ -63,39 +63,28 @@ func bootstrapAllDevicesGroup(ctx context.Context, st *store.Store, logger *slog
 }
 
 // errEncryptionKeyRequired is the boot-time fatal returned when
-// CONTROL_ENCRYPTION_KEY is unset and the operator did not opt out
-// via CONTROL_ENCRYPTION_KEY_REQUIRED=false. The error type is the
-// only signal main() needs to log+exit; the helper handles the
-// "opt out" warn-and-continue case internally.
-var errEncryptionKeyRequired = errors.New("CONTROL_ENCRYPTION_KEY is required (set CONTROL_ENCRYPTION_KEY_REQUIRED=false to opt out)")
+// CONTROL_ENCRYPTION_KEY is unset. The error type is the only signal
+// main() needs to log+exit.
+var errEncryptionKeyRequired = errors.New("CONTROL_ENCRYPTION_KEY is required (32-byte key; generate one with `openssl rand -hex 32`)")
 
-// initEncryptor reads CONTROL_ENCRYPTION_KEY (and its REQUIRED opt-out)
-// from the environment and returns the constructed Encryptor.
+// initEncryptor reads CONTROL_ENCRYPTION_KEY from the environment and returns
+// the constructed Encryptor.
 //
-// Returns (nil, nil) only when the operator explicitly opted out via
-// CONTROL_ENCRYPTION_KEY_REQUIRED=false; a Warn line is logged on that
-// path so the unencrypted-secrets state is visible in boot logs.
+// The encryption key is MANDATORY — there is NO plaintext opt-out (WS11 #4: the
+// former CONTROL_ENCRYPTION_KEY_REQUIRED=false escape was removed so no
+// deployment, not even by accident, can store IdP client secrets, TOTP secrets,
+// LUKS keys, or LPS passwords unencrypted at rest).
 //
-// Returns (nil, errEncryptionKeyRequired) when the key is unset and
-// the operator did NOT opt out — main() must log+exit.
-//
-// Returns (nil, err) for malformed-key errors from crypto.NewEncryptor.
-//
-// Why "fail closed": IdP client secrets, LUKS keys, and other
-// secrets-at-rest rely on this encryptor. Running without a key
-// would silently degrade security in production. The opt-out is
-// kept available for dev / single-tenant deployments that genuinely
-// store no secrets.
-func initEncryptor(logger *slog.Logger) (*crypto.Encryptor, error) {
+// Returns (nil, errEncryptionKeyRequired) when the key is unset — main() must
+// log+exit. Returns (nil, err) for malformed-key errors from
+// crypto.NewEncryptor (surfaced as-is so an operator sees a typo'd key rather
+// than mistaking it for a missing one). On success returns the encryptor.
+func initEncryptor(_ *slog.Logger) (*crypto.Encryptor, error) {
 	enc, err := crypto.NewEncryptor(os.Getenv("CONTROL_ENCRYPTION_KEY"))
 	if err != nil {
 		return nil, err
 	}
 	if enc == nil {
-		if os.Getenv("CONTROL_ENCRYPTION_KEY_REQUIRED") == "false" {
-			logger.Warn("CONTROL_ENCRYPTION_KEY not set and CONTROL_ENCRYPTION_KEY_REQUIRED=false - secrets will be stored unencrypted")
-			return nil, nil
-		}
 		return nil, errEncryptionKeyRequired
 	}
 	return enc, nil

--- a/cmd/control/setup_test.go
+++ b/cmd/control/setup_test.go
@@ -25,33 +25,33 @@ func quietLogger() *slog.Logger {
 // initEncryptor
 // =============================================================================
 
-func TestInitEncryptor_MissingKeyAndNotOptedOut_ReturnsRequiredErr(t *testing.T) {
-	// CRITICAL: missing key + no explicit opt-out MUST fail-closed.
-	// Returning (nil, nil) here would silently boot a control server
-	// that stores LUKS keys / IdP secrets / LPS passwords as
-	// plaintext. The errEncryptionKeyRequired sentinel is what main()
-	// matches to log+exit.
+func TestInitEncryptor_MissingKey_ReturnsRequiredErr(t *testing.T) {
+	// CRITICAL: a missing key MUST fail-closed. Returning (nil, nil) here
+	// would silently boot a control server that stores LUKS keys / IdP
+	// secrets / LPS passwords as plaintext. The errEncryptionKeyRequired
+	// sentinel is what main() matches to log+exit.
 	t.Setenv("CONTROL_ENCRYPTION_KEY", "")
-	t.Setenv("CONTROL_ENCRYPTION_KEY_REQUIRED", "")
 
 	enc, err := initEncryptor(quietLogger())
 	require.Error(t, err)
 	assert.Nil(t, enc)
 	assert.True(t, errors.Is(err, errEncryptionKeyRequired),
-		"missing key without opt-out MUST return errEncryptionKeyRequired sentinel — main() exit hinges on this")
+		"missing key MUST return errEncryptionKeyRequired sentinel — main() exit hinges on this")
 }
 
-func TestInitEncryptor_MissingKeyButOptedOut_ReturnsNilNil(t *testing.T) {
-	// Operator explicit opt-out via CONTROL_ENCRYPTION_KEY_REQUIRED=false.
-	// Returns (nil, nil) — main() proceeds without encryption.
-	// A Warn line is emitted (not asserted here; testing log lines
-	// would couple the test to the log format).
+// TestInitEncryptor_OptOutNoLongerHonored pins WS11 finding 4: the
+// CONTROL_ENCRYPTION_KEY_REQUIRED=false plaintext opt-out was REMOVED. Even
+// with the legacy opt-out set, a missing key must still fail-closed — no path
+// may ever store IdP/TOTP/LUKS secrets unencrypted, "even by accident".
+func TestInitEncryptor_OptOutNoLongerHonored(t *testing.T) {
 	t.Setenv("CONTROL_ENCRYPTION_KEY", "")
-	t.Setenv("CONTROL_ENCRYPTION_KEY_REQUIRED", "false")
+	t.Setenv("CONTROL_ENCRYPTION_KEY_REQUIRED", "false") // legacy opt-out, must be ignored
 
 	enc, err := initEncryptor(quietLogger())
-	require.NoError(t, err)
-	assert.Nil(t, enc, "explicit opt-out returns nil encryptor; downstream code uses the no-op path")
+	require.Error(t, err)
+	assert.Nil(t, enc)
+	assert.True(t, errors.Is(err, errEncryptionKeyRequired),
+		"the plaintext opt-out is removed — =false must NOT escape the fail-closed gate")
 }
 
 func TestInitEncryptor_ValidKey_ReturnsEncryptor(t *testing.T) {
@@ -59,7 +59,6 @@ func TestInitEncryptor_ValidKey_ReturnsEncryptor(t *testing.T) {
 	// accepts hex / base64 / raw; the hex form is what the deploy
 	// scripts emit so we test it explicitly.
 	t.Setenv("CONTROL_ENCRYPTION_KEY", "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff")
-	t.Setenv("CONTROL_ENCRYPTION_KEY_REQUIRED", "")
 
 	enc, err := initEncryptor(quietLogger())
 	require.NoError(t, err)
@@ -73,7 +72,6 @@ func TestInitEncryptor_MalformedKey_ReturnsError(t *testing.T) {
 	// problem (operator typo'd the key) behind a fail-closed gate
 	// the operator can't immediately diagnose.
 	t.Setenv("CONTROL_ENCRYPTION_KEY", "way-too-short-for-aes")
-	t.Setenv("CONTROL_ENCRYPTION_KEY_REQUIRED", "")
 
 	enc, err := initEncryptor(quietLogger())
 	require.Error(t, err)

--- a/cmd/control/valkey.go
+++ b/cmd/control/valkey.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/hibiken/asynq"
 	"github.com/oklog/ulid/v2"
@@ -251,7 +252,10 @@ func configureTerminalAdminFanout(cfg *Config, termHandler *api.TerminalHandler,
 			MinVersion:   tls.VersionTLS13,
 		},
 	}
-	termHandler.SetInternalHTTPClient(&http.Client{Transport: transport})
+	// A client-level Timeout backstops the per-call context deadlines on the
+	// terminal admin fan-out (WS11 #8) so a half-open connection to a gateway
+	// can't pin a request goroutine indefinitely.
+	termHandler.SetInternalHTTPClient(&http.Client{Transport: transport, Timeout: 30 * time.Second})
 	logger.Info("terminal admin fan-out enabled (mTLS client configured)")
 	return nil
 }

--- a/cmd/gateway/README.md
+++ b/cmd/gateway/README.md
@@ -71,6 +71,16 @@ The Gateway Server:
 
 > **rc3 migration:** the previously unprefixed `VALKEY_ADDR` / `VALKEY_PASSWORD` / `VALKEY_DB` / `LOG_LEVEL` knobs now live under the `GATEWAY_*` namespace. The old names are no longer read.
 
+#### Terminal WebSocket authentication
+
+The TTY WebSocket endpoint requires the session bearer token in the
+`Sec-WebSocket-Protocol: bearer.<token>` request header — the gateway echoes the
+same subprotocol back to complete the handshake. The legacy `?token=<token>`
+query-string form is **rejected** with `401` before any validation (WS11):
+query strings leak into reverse-proxy access logs, browser `Referer` headers,
+and devtools network panels. `session_id` still travels as a query parameter (it
+is not a secret).
+
 #### Traefik self-registration (Redis KV)
 
 When enabled, each gateway replica publishes its own routing entries into Traefik's Redis KV provider. This removes the need for per-replica Traefik labels in compose and lets `docker compose up --scale gateway=N` (or k8s replica sets) add instances with zero operator touch per replica. The shared mTLS TCP router is load-balanced across all replicas; each replica owns a `/gw/<id>` path on the TTY host for session-specific routing.
@@ -296,10 +306,11 @@ Credential-bearing operations are proxied via Connect-RPC (`InternalService`) to
 
 ```bash
 curl http://localhost:8080/health
-# Returns: {"status":"healthy","agents":5}
+# Returns: {"status":"healthy"}
 ```
 
-The health endpoint returns the number of connected agents.
+The health endpoint reports liveness only. The connected-agent count was
+removed (WS10) so the unauthenticated probe doesn't leak fleet size.
 
 ### Ready Check
 

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -36,9 +36,10 @@ VALKEY_PASSWORD=CHANGE_ME_generate_a_strong_password
 # =============================================================================
 # Authentication
 # =============================================================================
-# JWT secret for session tokens (minimum 32 characters)
-# Generate with: openssl rand -base64 48
-JWT_SECRET=CHANGE_ME_generate_a_strong_secret_min_32_chars
+# JWT secret for session tokens. Must decode (hex or base64) to at least 32
+# random bytes — a bare passphrase is rejected at boot. Generate one with:
+#   openssl rand -base64 48   (or: openssl rand -hex 32)
+JWT_SECRET=CHANGE_ME_run_openssl_rand_base64_48
 
 # Initial admin account (created on first startup only).
 #
@@ -93,17 +94,13 @@ ACME_EMAIL=admin@example.com
 # =============================================================================
 # Encryption
 # =============================================================================
-# AES-256 key for encrypting secrets at rest (IdP client secrets, LUKS keys,
-# LPS passwords). Must be exactly 64 hex characters (32 bytes).
+# AES-256 key for encrypting secrets at rest (IdP client secrets, TOTP secrets,
+# LUKS keys, LPS passwords). MANDATORY — exactly 64 hex characters (32 bytes).
 # Generate with: openssl rand -hex 32
-# WARNING: Changing this key after data has been encrypted will make existing
-# encrypted secrets unrecoverable. If not set (and CONTROL_ENCRYPTION_KEY_REQUIRED
-# is false), secrets are stored unencrypted.
+# The control server REFUSES TO START without it — there is no plaintext opt-out.
+# WARNING: changing this key after data has been encrypted makes existing
+# encrypted secrets unrecoverable.
 CONTROL_ENCRYPTION_KEY=
-
-# Set to "false" to opt out of the fail-closed check above. Default: unset,
-# which makes the control server refuse to start without CONTROL_ENCRYPTION_KEY.
-# CONTROL_ENCRYPTION_KEY_REQUIRED=false
 
 # HMAC key shared between control, gateway, and indexer for the Asynq
 # task-queue envelope. Every service that touches the Valkey-backed

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -147,8 +147,10 @@ services:
       - CONTROL_DYNAMIC_GROUP_EVAL_INTERVAL=${DYNAMIC_GROUP_EVAL_INTERVAL:-1h}
       - CONTROL_SSO_CALLBACK_BASE_URL=${CONTROL_SSO_CALLBACK_BASE_URL:-}
       - CONTROL_SCIM_BASE_URL=${CONTROL_SCIM_BASE_URL:-}
-      - CONTROL_ENCRYPTION_KEY=${CONTROL_ENCRYPTION_KEY:-}
-      - CONTROL_ENCRYPTION_KEY_REQUIRED=${CONTROL_ENCRYPTION_KEY_REQUIRED:-}
+      # CONTROL_ENCRYPTION_KEY is mandatory (32-byte AES key, hex-encoded:
+      # `openssl rand -hex 32`). The control server refuses to boot without it —
+      # there is no plaintext opt-out.
+      - CONTROL_ENCRYPTION_KEY=${CONTROL_ENCRYPTION_KEY:?CONTROL_ENCRYPTION_KEY is required}
       - CONTROL_INTERNAL_LISTEN_ADDR=:8082
       - CONTROL_INTERNAL_TLS_CERT=/certs/control.crt
       - CONTROL_INTERNAL_TLS_KEY=/certs/control.key

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -75,15 +75,15 @@ check_env() {
         missing=1
     fi
 
-    # AES-256-GCM key for at-rest secret encryption. Must be exactly
-    # 64 hex chars (32 bytes). Interactive mode's prompt_secret already
-    # length-checks this; the check_env mirror is what catches a
-    # --no-prompt run against a malformed .env. Empty is allowed only
-    # when the operator explicitly opted out via
-    # CONTROL_ENCRYPTION_KEY_REQUIRED=false (handled at control-server
-    # boot, not here).
-    if [[ -n "${CONTROL_ENCRYPTION_KEY:-}" ]] && [[ ! "$CONTROL_ENCRYPTION_KEY" =~ ^[0-9a-fA-F]{64}$ ]]; then
-        log_error "CONTROL_ENCRYPTION_KEY must be exactly 64 hex characters when set"
+    # AES-256-GCM key for at-rest secret encryption. MANDATORY — exactly
+    # 64 hex chars (32 bytes). The control server refuses to boot without it
+    # (no plaintext opt-out, WS11), so the check_env mirror flags both an
+    # empty and a malformed value on a --no-prompt run.
+    if [[ -z "${CONTROL_ENCRYPTION_KEY:-}" ]]; then
+        log_error "CONTROL_ENCRYPTION_KEY is required (generate with: openssl rand -hex 32)"
+        missing=1
+    elif [[ ! "$CONTROL_ENCRYPTION_KEY" =~ ^[0-9a-fA-F]{64}$ ]]; then
+        log_error "CONTROL_ENCRYPTION_KEY must be exactly 64 hex characters"
         missing=1
     fi
 

--- a/docs/adr/0015-auth-hardening.md
+++ b/docs/adr/0015-auth-hardening.md
@@ -1,0 +1,102 @@
+# 0015 — Auth hardening: JWT alg pinning, per-user RPC rate limits, credential floors, terminal-token transport, login no-enumeration
+
+- Status: accepted
+- Date: 2026-06-14
+- Related: the 2026-06-12 audits (WS11 of the SECURITY_HARDENING_WORKPLAN);
+  manchtools/power-manage-server#82 (auth-hardening umbrella) and #391
+  (terminal-close-on-revoke); ADR 0009 / 0014 (secrets at rest — this removes
+  the last plaintext-secrets escape); ADR 0005 (gateway is an untrusted relay).
+
+## Context
+
+WS11 swept the request-auth boundary: JWT validation, the rate limiters, client
+IP attribution, the terminal-session WebSocket transport, bootstrap-credential
+strength, the login enumeration surface, and the gateway session registry. Most
+findings were missing tests over already-correct behaviour; a few were real
+gaps. This ADR records the decisions that change behaviour or contract.
+
+## Decision
+
+### JWT — HS256 only (findings 2)
+
+`ValidateToken` already pins `token.Method == HS256`; regression tests now lock
+that `alg:none`, HS384/HS512 (even signed with the real secret), and RS256
+(RS↔HS confusion) are rejected on the signing-method check, not on expiry/type.
+A future loosening of the keyfunc fails those tests.
+
+### Credential entropy floors (findings 4, 9)
+
+- **`CONTROL_JWT_SECRET` must decode (hex or base64) to ≥32 random bytes**, not
+  merely be ≥32 characters. A bare passphrase no longer boots; operators
+  generate a secret with `openssl rand -base64 48` / `openssl rand -hex 32`,
+  mirroring `CONTROL_ENCRYPTION_KEY`. The raw string still signs tokens — this
+  gates operator input so a weak secret can't be brute-forced into forging JWTs.
+- **`CONTROL_ADMIN_PASSWORD` ≥ 12 chars when set** (the docs once shipped
+  `admin`). An empty password with an admin email is the no-bootstrap path, so
+  an operator can drop the password from the environment after first boot.
+- **Encryption is mandatory — the `CONTROL_ENCRYPTION_KEY_REQUIRED=false`
+  plaintext opt-out is removed.** A missing key is now a fatal boot error, so no
+  deployment can store IdP/TOTP/LUKS/LPS secrets unencrypted "even by accident"
+  (operator decision). This closes the last escape left open by ADR 0009/0014.
+
+### Per-user authenticated-RPC rate limiting (finding 6)
+
+After a token validates, every authenticated control RPC is throttled **per
+user** (keyed by user ID, not IP — the caller is authenticated). A generous
+general ceiling bounds a stolen token / runaway client; a tighter ceiling
+applies on top to the **self-discovered** expensive set — `isExpensiveProcedure`
+matches `Evaluate*` / `Search*` / `Rebuild*` / `Query*` / `*Query` (query
+evaluation, search, projector rebuild, log/osquery fan-out). Self-discovery
+(vs a hand-maintained list that fails open) is guarded by a test that walks the
+ControlService descriptor and asserts the matcher recognises ≥1 real procedure.
+Unauthenticated client-IP attribution (`X-Forwarded-For` / `X-Real-IP`) is
+honoured only from `CONTROL_TRUSTED_PROXIES`, so per-IP limits can't be spoofed.
+
+### Terminal-token transport (finding 5)
+
+The TTY WebSocket bearer token must travel in `Sec-WebSocket-Protocol:
+bearer.<token>`. The legacy `?token=` query form is **hard-rejected (401) before
+any validation** — query strings leak into reverse-proxy access logs, `Referer`
+headers, and devtools. `session_id` stays a query parameter (not a secret). The
+web client was migrated in the same change.
+
+### Login no-enumeration (finding 11)
+
+A disabled account with the CORRECT password now returns the same generic
+*invalid credentials* (`CodeUnauthenticated`) as a wrong password or a
+non-existent account, instead of a distinguishable *account is disabled*
+(`CodePermissionDenied`) — a credential holder must not learn account state. The
+post-2FA disabled check in `VerifyLoginTOTP` keeps its explicit error (the
+second factor is already proven).
+
+### Other hardening
+
+- **Audit redaction of SCIM token hashes (finding 1).** A self-discovering AST
+  sweep over the `eventtypes/payloads` structs found `scim_token_hash` (bcrypt of
+  the SCIM bearer token) leaking through `ListAuditEvents` — the same class as
+  the already-redacted `password_hash` / `backup_codes_hash`. Both SCIM events
+  are now redacted; the sweep guards every future secret-bearing payload field.
+- **Bounded terminate fan-out (finding 8).** `TerminateTerminalSession` now calls
+  the gateway under a 10s context deadline (the bare request ctx had none) with a
+  client-level `Timeout` backstop.
+- **Session-bump terminal close (server#391 gap).** The terminal revocation
+  listener now also handles `UserSessionInvalidated` (emitted by the role/group
+  session-version bump), closing live sessions iff `StartTerminal` was lost — not
+  only on `UserRoleRevoked`.
+- **Coverage-only locks:** trusted-proxy/XFF attribution, rate-limiter key-cap
+  LRU eviction, a real-proto request through the validation interceptor, and
+  `TerminalSessionRegistry` concurrency under `-race`.
+
+## Consequences
+
+- **Breaking (boot):** deployments using a weak/short `CONTROL_JWT_SECRET`, a
+  `<12`-char `CONTROL_ADMIN_PASSWORD`, or relying on
+  `CONTROL_ENCRYPTION_KEY_REQUIRED=false` will fail to start until they supply a
+  CSPRNG-generated JWT secret, a stronger admin password, and an encryption key.
+  This is intentional and documented (control/gateway READMEs, deploy compose /
+  setup.sh / .env.example).
+- **Breaking (terminal):** clients must send the token via the WebSocket
+  subprotocol; the migrated web client already does.
+- No proto/SDK/agent changes. The rate-limit and disabled-login responses reuse
+  the existing `rate_limited` / `invalid_credentials` error codes, so no new
+  i18n keys were needed.

--- a/internal/api/audit_handler.go
+++ b/internal/api/audit_handler.go
@@ -106,6 +106,13 @@ var eventRedactionSchemas = map[string]map[string]redactionSchema{
 	"identity_provider": {
 		string(eventtypes.IdentityProviderCreated): {paths: []string{"client_secret_encrypted"}},
 		string(eventtypes.IdentityProviderUpdated): {paths: []string{"client_secret_encrypted"}},
+		// WS11 #1: SCIM enable/rotate persist the bcrypt hash of the SCIM
+		// bearer token. Like password_hash / backup_codes_hash, a
+		// credential-derived hash must not surface through ListAuditEvents.
+		// The self-discovering TestEveryEventPayloadSecretFieldCovered pins
+		// that every secret-bearing payload field has a path here.
+		string(eventtypes.IdentityProviderSCIMEnabled):      {paths: []string{"scim_token_hash"}},
+		string(eventtypes.IdentityProviderSCIMTokenRotated): {paths: []string{"scim_token_hash"}},
 	},
 	"user": {
 		string(eventtypes.UserPasswordChanged):  {paths: []string{"password_hash"}},

--- a/internal/api/audit_payload_coverage_test.go
+++ b/internal/api/audit_payload_coverage_test.go
@@ -4,7 +4,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/fs"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -32,12 +33,25 @@ import (
 func TestEveryEventPayloadSecretFieldCovered(t *testing.T) {
 	const payloadsDir = "../eventtypes/payloads"
 
+	// Parse the payload source files directly. os.ReadDir + parser.ParseFile is
+	// used instead of the deprecated parser.ParseDir (SA1019), staying
+	// pure-stdlib (the project's archtest convention; go/packages is too
+	// fragile here) and avoiding the runtime-reflection problem that there is
+	// no registry enumerating payload types.
 	fset := token.NewFileSet()
-	pkgs, err := parser.ParseDir(fset, payloadsDir, func(fi fs.FileInfo) bool {
-		return !strings.HasSuffix(fi.Name(), "_test.go")
-	}, 0)
+	entries, err := os.ReadDir(payloadsDir)
 	require.NoError(t, err)
-	require.NotEmpty(t, pkgs, "no packages parsed under %s", payloadsDir)
+	var files []*ast.File
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, filepath.Join(payloadsDir, name), nil, 0)
+		require.NoError(t, perr)
+		files = append(files, f)
+	}
+	require.NotEmpty(t, files, "no payload source files parsed under %s", payloadsDir)
 
 	// event-type name -> set of redaction paths (union across all streams).
 	covered := map[string]map[string]bool{}
@@ -53,40 +67,38 @@ func TestEveryEventPayloadSecretFieldCovered(t *testing.T) {
 	}
 
 	scanned := 0
-	for _, pkg := range pkgs {
-		for _, file := range pkg.Files {
-			for _, decl := range file.Decls {
-				gd, ok := decl.(*ast.GenDecl)
-				if !ok || gd.Tok != token.TYPE {
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			gd, ok := decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.TYPE {
+				continue
+			}
+			for _, spec := range gd.Specs {
+				ts, ok := spec.(*ast.TypeSpec)
+				if !ok || !ts.Name.IsExported() {
 					continue
 				}
-				for _, spec := range gd.Specs {
-					ts, ok := spec.(*ast.TypeSpec)
-					if !ok || !ts.Name.IsExported() {
+				st, ok := ts.Type.(*ast.StructType)
+				if !ok {
+					continue
+				}
+				structName := ts.Name.Name
+				for _, field := range st.Fields.List {
+					if field.Tag == nil || !isStringishType(field.Type) {
 						continue
 					}
-					st, ok := ts.Type.(*ast.StructType)
-					if !ok {
+					tag := reflect.StructTag(strings.Trim(field.Tag.Value, "`"))
+					jsonName := strings.Split(tag.Get("json"), ",")[0]
+					if jsonName == "" || jsonName == "-" {
 						continue
 					}
-					structName := ts.Name.Name
-					for _, field := range st.Fields.List {
-						if field.Tag == nil || !isStringishType(field.Type) {
-							continue
-						}
-						tag := reflect.StructTag(strings.Trim(field.Tag.Value, "`"))
-						jsonName := strings.Split(tag.Get("json"), ",")[0]
-						if jsonName == "" || jsonName == "-" {
-							continue
-						}
-						if !isSensitiveParamField(jsonName) {
-							continue
-						}
-						scanned++
-						require.Truef(t, covered[structName][jsonName],
-							"payload %s field %s (json:%q) looks secret but no redaction schema covers event %q path %q — add it to eventRedactionSchemas in audit_handler.go",
-							structName, astFieldName(field), jsonName, structName, jsonName)
+					if !isSensitiveParamField(jsonName) {
+						continue
 					}
+					scanned++
+					require.Truef(t, covered[structName][jsonName],
+						"payload %s field %s (json:%q) looks secret but no redaction schema covers event %q path %q — add it to eventRedactionSchemas in audit_handler.go",
+						structName, astFieldName(field), jsonName, structName, jsonName)
 				}
 			}
 		}

--- a/internal/api/audit_payload_coverage_test.go
+++ b/internal/api/audit_payload_coverage_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestEveryEventPayloadSecretFieldCovered is the self-discovering, fail-closed
+// guard for finding 1 (WS11). It AST-walks EVERY exported struct in
+// internal/eventtypes/payloads and, for any string-ish field whose JSON tag
+// looks secret (isSensitiveParamField), asserts a redaction path exists in
+// eventRedactionSchemas for an event whose name matches the struct.
+//
+// By convention the payload struct name IS the event-type string, so coverage
+// is checked against the event's ACTUAL schema (scanned across all streams)
+// without a hardcoded struct->stream map that could fail open. This generalises
+// the TOTP-specific guard (audit_totp_redaction_test.go) to the whole payload
+// surface: a secret field added to ANY future payload struct without a matching
+// redaction schema fails here. require.Positive(scanned) prevents the scan
+// matching zero and passing open.
+//
+// A pure-stdlib AST walk (not go/packages) matches the project's archtest
+// convention and avoids the runtime-reflection problem that there is no
+// registry enumerating payload types.
+func TestEveryEventPayloadSecretFieldCovered(t *testing.T) {
+	const payloadsDir = "../eventtypes/payloads"
+
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, payloadsDir, func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	require.NoError(t, err)
+	require.NotEmpty(t, pkgs, "no packages parsed under %s", payloadsDir)
+
+	// event-type name -> set of redaction paths (union across all streams).
+	covered := map[string]map[string]bool{}
+	for _, streamSchemas := range eventRedactionSchemas {
+		for eventType, schema := range streamSchemas {
+			if covered[eventType] == nil {
+				covered[eventType] = map[string]bool{}
+			}
+			for _, p := range schema.paths {
+				covered[eventType][p] = true
+			}
+		}
+	}
+
+	scanned := 0
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				gd, ok := decl.(*ast.GenDecl)
+				if !ok || gd.Tok != token.TYPE {
+					continue
+				}
+				for _, spec := range gd.Specs {
+					ts, ok := spec.(*ast.TypeSpec)
+					if !ok || !ts.Name.IsExported() {
+						continue
+					}
+					st, ok := ts.Type.(*ast.StructType)
+					if !ok {
+						continue
+					}
+					structName := ts.Name.Name
+					for _, field := range st.Fields.List {
+						if field.Tag == nil || !isStringishType(field.Type) {
+							continue
+						}
+						tag := reflect.StructTag(strings.Trim(field.Tag.Value, "`"))
+						jsonName := strings.Split(tag.Get("json"), ",")[0]
+						if jsonName == "" || jsonName == "-" {
+							continue
+						}
+						if !isSensitiveParamField(jsonName) {
+							continue
+						}
+						scanned++
+						require.Truef(t, covered[structName][jsonName],
+							"payload %s field %s (json:%q) looks secret but no redaction schema covers event %q path %q — add it to eventRedactionSchemas in audit_handler.go",
+							structName, astFieldName(field), jsonName, structName, jsonName)
+					}
+				}
+			}
+		}
+	}
+	require.Positive(t, scanned,
+		"self-discovering payload scan matched zero secret fields — isSensitiveParamField or the AST walk is broken")
+}
+
+// isStringishType reports whether an AST field type is string / *string /
+// []string / []*string (and deeper nestings thereof). Non-string types
+// (bool, int, time.Time, json.RawMessage, maps) are excluded so a secret-LOOKING
+// name on a bool field (e.g. ssh_allow_password) is not flagged.
+func isStringishType(expr ast.Expr) bool {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name == "string"
+	case *ast.StarExpr:
+		return isStringishType(t.X)
+	case *ast.ArrayType:
+		return isStringishType(t.Elt)
+	}
+	return false
+}
+
+// astFieldName returns the first declared name of a struct field for error
+// messages (or a placeholder for an embedded field).
+func astFieldName(f *ast.Field) string {
+	if len(f.Names) > 0 {
+		return f.Names[0].Name
+	}
+	return "<embedded>"
+}

--- a/internal/api/audit_redactor_internal_test.go
+++ b/internal/api/audit_redactor_internal_test.go
@@ -196,6 +196,30 @@ func TestRedactEventData_NonActionStreams(t *testing.T) {
 	}
 }
 
+// TestRedactEventData_SCIMTokenHash locks WS11 #1: the bcrypt hash of a SCIM
+// bearer token must be scrubbed from the IdentityProviderSCIMEnabled and
+// IdentityProviderSCIMTokenRotated events. The secret is sourced from intent
+// (the payloads.IdentityProviderSCIMEnabled `scim_token_hash` JSON tag), not
+// from the schema map.
+func TestRedactEventData_SCIMTokenHash(t *testing.T) {
+	cases := []struct {
+		name      string
+		eventType string
+	}{
+		{"SCIM enabled", "IdentityProviderSCIMEnabled"},
+		{"SCIM token rotated", "IdentityProviderSCIMTokenRotated"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(map[string]any{"scim_token_hash": "SENTINEL_SCIM_BCRYPT"})
+			require.NoError(t, err)
+			out := redactEventData("identity_provider", tc.eventType, raw)
+			assert.NotContains(t, out, "SENTINEL_SCIM_BCRYPT", "SCIM token hash must be redacted")
+			assert.Contains(t, out, "[REDACTED]")
+		})
+	}
+}
+
 // TestRedactEventData_UnknownShapesPassThrough locks the design contract that
 // the redactor is conservative for NON action/execution streams: an unknown
 // (stream,event) combination passes through unchanged.
@@ -309,13 +333,19 @@ func isSensitiveParamField(name string) bool {
 	case "ca_cert", "client_cert", // public PEM certificates
 		"ssh_authorized_keys",   // public keys
 		"gpg_key_url", "gpgkey", // repository key URLs, not key material
-		"checksum_sha256":
+		"checksum_sha256",
+		"description": // "deSCRIPTion" matches the "script" fragment but is not secret
 		return false
 	}
 	for _, frag := range []string{
 		"script", "content", "custom_config",
 		"psk", "preshared_key", "client_key", "private_key", "gpg_key",
 		"passphrase", "password", "secret",
+		// "hash" catches credential-DERIVED material that still must not
+		// reach the operator-facing audit log: password_hash,
+		// backup_codes_hash, scim_token_hash. The redaction policy already
+		// scrubs the first two, so consistency demands the third.
+		"hash",
 	} {
 		if strings.Contains(name, frag) {
 			return true

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -129,8 +129,17 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 		return nil, apiErrorCtx(ctx, ErrInvalidCredentials, connect.CodeUnauthenticated, "invalid credentials")
 	}
 
+	// WS11 #11: a disabled account with the correct password must be
+	// INDISTINGUISHABLE from a wrong password to a credential holder — a
+	// distinct "account is disabled" / CodePermissionDenied response is a
+	// user-enumeration oracle. Collapse it into the generic
+	// invalid-credentials path and account the failure toward the per-account
+	// ceiling like the other rejection branches. (The post-2FA disabled check
+	// in totp_handler.VerifyLoginTOTP intentionally keeps the explicit error —
+	// the caller has already proven the second factor there.)
 	if user.Disabled {
-		return nil, apiErrorCtx(ctx, ErrNotAuthenticated, connect.CodePermissionDenied, "account is disabled")
+		h.loginAccountLimiter.Allow(acctKey)
+		return nil, apiErrorCtx(ctx, ErrInvalidCredentials, connect.CodeUnauthenticated, "invalid credentials")
 	}
 
 	// If TOTP is enabled, return a challenge instead of tokens

--- a/internal/api/auth_handler_test.go
+++ b/internal/api/auth_handler_test.go
@@ -158,24 +158,57 @@ func TestLogin_GlobalPasswordAuthDisabled(t *testing.T) {
 	assert.Contains(t, err.Error(), "password login is disabled")
 }
 
-func TestLogin_DisabledUser(t *testing.T) {
+// TestLogin_DisabledAccountIsEnumerationSafe pins WS11 finding 11: a disabled
+// account with the CORRECT password must return the SAME generic
+// invalid-credentials response as a wrong password — NOT a distinguishable
+// "account is disabled" (CodePermissionDenied), which is a user-enumeration
+// oracle for a credential holder. The "correct password on a disabled account"
+// case is sourced from intent (a credential holder must not learn account
+// state), not from the handler's prior branch.
+func TestLogin_DisabledAccountIsEnumerationSafe(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	jwtMgr := testutil.NewJWTManager()
 	h := api.NewAuthHandler(st, slog.Default(), jwtMgr, true)
 
-	email := testutil.NewID() + "@test.com"
-	userID := testutil.CreateTestUser(t, st, email, "password", "user")
-
-	// Disable the user
-	err := st.AppendEvent(context.Background(), testutil.DisableEvent(userID))
-	require.NoError(t, err)
-
-	_, err = h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
-		Email:    email,
-		Password: "password",
+	// Baseline: an ENABLED account with the correct password still succeeds.
+	enabledEmail := testutil.NewID() + "@test.com"
+	testutil.CreateTestUser(t, st, enabledEmail, "correct-password", "user")
+	resp, err := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email: enabledEmail, Password: "correct-password",
 	}))
-	require.Error(t, err)
-	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Msg.AccessToken)
+
+	// Disabled account WITH the correct password.
+	disabledEmail := testutil.NewID() + "@test.com"
+	disabledID := testutil.CreateTestUser(t, st, disabledEmail, "correct-password", "user")
+	require.NoError(t, st.AppendEvent(context.Background(), testutil.DisableEvent(disabledID)))
+
+	_, disabledErr := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email: disabledEmail, Password: "correct-password",
+	}))
+	require.Error(t, disabledErr)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(disabledErr),
+		"a disabled account must not be distinguishable via a PermissionDenied code")
+	assert.Contains(t, disabledErr.Error(), "invalid credentials")
+	assert.NotContains(t, disabledErr.Error(), "disabled",
+		"the disabled state must not leak to a credential holder")
+
+	// Wrong password on the SAME disabled account → byte-identical response.
+	_, wrongErr := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email: disabledEmail, Password: "wrong-password",
+	}))
+	require.Error(t, wrongErr)
+	assert.Equal(t, disabledErr.Error(), wrongErr.Error(),
+		"disabled+correct and disabled+wrong must be indistinguishable")
+
+	// Nonexistent account → same generic response (parity).
+	_, missingErr := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email: testutil.NewID() + "@test.com", Password: "any-password",
+	}))
+	require.Error(t, missingErr)
+	assert.Equal(t, disabledErr.Error(), missingErr.Error(),
+		"a nonexistent account must be indistinguishable from a disabled one")
 }
 
 func TestLogin_NoCookiesSet(t *testing.T) {

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -670,9 +670,14 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 		return connect.NewResponse(&pm.TerminateTerminalSessionResponse{}), nil
 	}
 
-	// Call the gateway to terminate the session.
+	// Call the gateway to terminate the session under a bounded context
+	// (WS11 #8): the bare request ctx carries no deadline, so a stuck or slow
+	// gateway would hang this admin RPC indefinitely. Matches the 10s bound
+	// used by the ListActiveTerminalSessions fan-out above.
+	gwCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
 	client := pmv1connect.NewGatewayServiceClient(h.internalHTTPClient, gwURL)
-	resp, err := client.TerminateGatewayTerminalSession(ctx, connect.NewRequest(&pm.TerminateGatewayTerminalSessionRequest{
+	resp, err := client.TerminateGatewayTerminalSession(gwCtx, connect.NewRequest(&pm.TerminateGatewayTerminalSessionRequest{
 		SessionId: req.Msg.SessionId,
 		Reason:    req.Msg.Reason,
 	}))

--- a/internal/api/terminal_handler_timeout_test.go
+++ b/internal/api/terminal_handler_timeout_test.go
@@ -1,0 +1,89 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
+	"github.com/manchtools/power-manage/server/internal/terminal"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// deadlineRequiringGateway rejects any TerminateGatewayTerminalSession call
+// whose context carries no deadline. Connect propagates a client-side deadline
+// to the handler ctx (Connect-Timeout-Ms), so this fails fast and observably
+// when the caller used the bare request context, and succeeds only when the
+// call is bounded.
+type deadlineRequiringGateway struct {
+	pmv1connect.UnimplementedGatewayServiceHandler
+}
+
+func (deadlineRequiringGateway) TerminateGatewayTerminalSession(
+	ctx context.Context, _ *connect.Request[pm.TerminateGatewayTerminalSessionRequest],
+) (*connect.Response[pm.TerminateGatewayTerminalSessionResponse], error) {
+	if _, ok := ctx.Deadline(); !ok {
+		return nil, connect.NewError(connect.CodeInternal,
+			errors.New("gateway terminate call arrived without a propagated deadline"))
+	}
+	return connect.NewResponse(&pm.TerminateGatewayTerminalSessionResponse{Found: true}), nil
+}
+
+// TestTerminateTerminalSession_UsesBoundedContext pins WS11 finding 8: the
+// gateway terminate fan-out must run under a deadline, not the bare request
+// context, so a stuck/slow gateway can't hang the admin RPC. The fake gateway
+// rejects a deadline-less call, so this is RED until TerminateTerminalSession
+// wraps the call in a timeout.
+func TestTerminateTerminalSession_UsesBoundedContext(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	tokenStore := terminal.NewTokenStore(terminal.NewFakeBackend(nil))
+	reg := registry.New(registry.NewFakeBackend(nil), slog.Default())
+	h := api.NewTerminalHandler(st, tokenStore, reg, "", slog.Default())
+
+	path, gwHandler := pmv1connect.NewGatewayServiceHandler(deadlineRequiringGateway{})
+	mux := http.NewServeMux()
+	mux.Handle(path, gwHandler)
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	h.SetInternalHTTPClient(srv.Client())
+
+	ctx := context.Background()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	device := testutil.CreateTestDevice(t, st, "host-term")
+	const gwID = "gw-term"
+	require.NoError(t, reg.AttachDevice(ctx, device, gwID, registry.DefaultDeviceTTL))
+	require.NoError(t, reg.RegisterGatewayInternal(ctx, gwID, srv.URL, registry.DefaultGatewayTTL))
+
+	mint, err := tokenStore.MintWithID(ctx, testutil.NewID(), terminal.MintParams{
+		UserID: userID, DeviceID: device, TtyUser: "pm-tty-alice", Cols: 80, Rows: 24,
+	})
+	require.NoError(t, err)
+
+	adminCtx := testutil.AuthContext(userID, "u@test.com", []string{"TerminateTerminalSession"})
+	done := make(chan error, 1)
+	go func() {
+		_, terr := h.TerminateTerminalSession(adminCtx, connect.NewRequest(&pm.TerminateTerminalSessionRequest{
+			SessionId: mint.SessionID,
+			Reason:    "admin terminate",
+		}))
+		done <- terr
+	}()
+
+	select {
+	case terr := <-done:
+		require.NoError(t, terr,
+			"terminate must succeed; the fake gateway requires a propagated deadline (RED if the call used the bare request ctx)")
+	case <-time.After(15 * time.Second):
+		t.Fatal("TerminateTerminalSession did not return — the gateway call is not bounded")
+	}
+}

--- a/internal/api/terminal_revocation_listener.go
+++ b/internal/api/terminal_revocation_listener.go
@@ -68,6 +68,17 @@ func TerminalRevocationListener(term userSessionTerminator, perms userPermission
 			}
 			userID = p.UserID
 			recheckStartTerminal = true
+		case string(eventtypes.UserSessionInvalidated):
+			// Role grants are revoked/updated via RoleHandler.bumpUserSessionVersion
+			// (and the user-group equivalent), which emits UserSessionInvalidated —
+			// NOT UserRoleRevoked. Treat it like a role revoke: recheck effective
+			// permissions and close iff StartTerminal is gone. The stream is "user"
+			// and StreamID is the userID (#391 gap closed in WS11).
+			if ev.StreamType != "user" {
+				return
+			}
+			userID = ev.StreamID
+			recheckStartTerminal = true
 		default:
 			return
 		}

--- a/internal/api/terminal_revocation_listener_test.go
+++ b/internal/api/terminal_revocation_listener_test.go
@@ -108,6 +108,55 @@ func TestTerminalRevocationListener_RoleRevoke(t *testing.T) {
 	})
 }
 
+// sessionInvalidatedEvent builds the event emitted by
+// RoleHandler.bumpUserSessionVersion (the role-update / session-version-bump
+// path): stream "user", StreamID = userID, empty payload.
+func sessionInvalidatedEvent(userID string) store.PersistedEvent {
+	return store.PersistedEvent{
+		StreamType: "user",
+		EventType:  "UserSessionInvalidated",
+		StreamID:   userID,
+		Data:       []byte("{}"),
+	}
+}
+
+// TestTerminalRevocationListener_SessionInvalidatedClosesWhenStartTerminalLost
+// pins the #391 gap unique to WS11: role grants are revoked/updated via
+// bumpUserSessionVersion, which emits UserSessionInvalidated — NOT
+// UserRoleRevoked. The listener must treat it like a role revoke: recheck
+// effective permissions and close live sessions iff StartTerminal is gone.
+// RED today (the switch has no UserSessionInvalidated case, so it returns early
+// and never closes).
+func TestTerminalRevocationListener_SessionInvalidatedClosesWhenStartTerminalLost(t *testing.T) {
+	t.Run("StartTerminal lost via session bump -> close", func(t *testing.T) {
+		ft := &fakeSessionTerminator{ch: make(chan string, 1)}
+		l := api.TerminalRevocationListener(ft, fakePermsChecker{perms: []string{"ListDevices"}}, slog.Default())
+		l(context.Background(), sessionInvalidatedEvent("u1"))
+		expectClose(t, ft.ch, "u1")
+	})
+
+	t.Run("still holds StartTerminal after bump -> no close", func(t *testing.T) {
+		ft := &fakeSessionTerminator{ch: make(chan string, 1)}
+		l := api.TerminalRevocationListener(ft, fakePermsChecker{perms: []string{"StartTerminal"}}, slog.Default())
+		l(context.Background(), sessionInvalidatedEvent("u2"))
+		expectNoClose(t, ft.ch)
+	})
+
+	t.Run("permission recheck errors -> no close (fail-safe)", func(t *testing.T) {
+		ft := &fakeSessionTerminator{ch: make(chan string, 1)}
+		l := api.TerminalRevocationListener(ft, fakePermsChecker{err: assert.AnError}, slog.Default())
+		l(context.Background(), sessionInvalidatedEvent("u3"))
+		expectNoClose(t, ft.ch)
+	})
+
+	t.Run("non-user stream is ignored", func(t *testing.T) {
+		ft := &fakeSessionTerminator{ch: make(chan string, 1)}
+		l := api.TerminalRevocationListener(ft, fakePermsChecker{perms: []string{"ListDevices"}}, slog.Default())
+		l(context.Background(), store.PersistedEvent{StreamType: "device", EventType: "UserSessionInvalidated", StreamID: "d1", Data: []byte("{}")})
+		expectNoClose(t, ft.ch)
+	})
+}
+
 // panicTerminator panics, but signals (via defer) that it ran.
 type panicTerminator struct{ done chan struct{} }
 

--- a/internal/api/validation_interceptor_test.go
+++ b/internal/api/validation_interceptor_test.go
@@ -7,6 +7,8 @@ import (
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 )
 
 type validationInterceptorFixture struct {
@@ -27,6 +29,46 @@ func TestValidationInterceptor_RejectsInvalidUnaryRequestBeforeHandler(t *testin
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 	assert.False(t, called, "invalid boundary input must not reach the RPC handler")
+}
+
+// TestValidationInterceptor_RejectsRealProtoRequestWithMalformedField drives a
+// REAL generated pm.*Request (not the synthetic fixture) through the
+// interceptor, so it regresses if the generated `validate` tags are ever
+// stripped — something the synthetic-struct test cannot catch. GetUserRequest.Id
+// carries `validate:"required,ulid"`; the malformed value is sourced from intent
+// (ids are ULIDs), not from the tag under test.
+func TestValidationInterceptor_RejectsRealProtoRequestWithMalformedField(t *testing.T) {
+	cases := []struct {
+		name      string
+		id        string
+		wantCalls bool
+	}{
+		{"valid ULID reaches the handler", "01ARZ3NDEKTSV4RRFFQ69G5FAV", true},
+		{"absent id is rejected", "", false},
+		{"present-but-malformed id is rejected", "not-a-ulid", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			interceptor := NewValidationInterceptor()
+			called := false
+			next := func(_ context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+				called = true
+				return connect.NewResponse(&pm.GetUserResponse{}), nil
+			}
+
+			_, err := interceptor.WrapUnary(next)(context.Background(),
+				connect.NewRequest(&pm.GetUserRequest{Id: tc.id}))
+
+			if tc.wantCalls {
+				require.NoError(t, err)
+				assert.True(t, called, "a valid real proto request must reach the handler")
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			assert.False(t, called, "an invalid real proto request must not reach the handler")
+		})
+	}
 }
 
 func TestValidationInterceptor_AllowsValidUnaryRequest(t *testing.T) {

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -257,6 +257,40 @@ type RateLimiters struct {
 	// reflects whether an email exists and its auth config — an enumeration
 	// oracle if left unthrottled (audit). Keyed by client IP.
 	AuthMethods *RateLimiter
+	// Authenticated is the general per-user ceiling applied to EVERY
+	// authenticated control RPC after the token validates (WS11 #6). It bounds
+	// a compromised token or a runaway client from hammering the API. Keyed by
+	// the authenticated user ID, so two users never share a bucket.
+	Authenticated *RateLimiter
+	// Expensive is a tighter per-user ceiling applied ON TOP of Authenticated
+	// to the self-discovered set of heavy procedures (query evaluation, search,
+	// projector rebuild, log/osquery fan-out — see isExpensiveProcedure). Keyed
+	// by the authenticated user ID.
+	Expensive *RateLimiter
+}
+
+// isExpensiveProcedure reports whether an authenticated control procedure runs
+// a heavy operation — dynamic-group query evaluation, search, a projector
+// rebuild, or a log/osquery fan-out — that warrants a tighter per-user ceiling
+// than ordinary reads. It is self-discovered from the action name so a newly
+// added Evaluate* / Search* / Rebuild* / Query* / *Query RPC is covered
+// automatically rather than from a hand-maintained list that fails open. A test
+// (TestIsExpensiveProcedure_MatchesRealProcedures) walks the ControlService
+// descriptor and asserts the matcher recognises at least one real procedure, so
+// it can never silently match zero.
+func isExpensiveProcedure(action string) bool {
+	return strings.HasPrefix(action, "Evaluate") ||
+		strings.HasPrefix(action, "Search") ||
+		strings.HasPrefix(action, "Rebuild") ||
+		strings.HasPrefix(action, "Query") ||
+		strings.HasSuffix(action, "Query")
+}
+
+// procedureAction extracts the trailing method name from a Connect procedure
+// path ("/pm.v1.ControlService/EvaluateDynamicGroup" -> "EvaluateDynamicGroup").
+func procedureAction(procedure string) string {
+	parts := strings.Split(procedure, "/")
+	return parts[len(parts)-1]
 }
 
 // AuthInterceptor provides Connect-RPC authentication interceptor.
@@ -374,6 +408,25 @@ func (i *AuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 				return nil, authErrorCtx(ctx, errTokenExpired, connect.CodeUnauthenticated, "token expired")
 			}
 			return nil, authErrorCtx(ctx, errNotAuthenticated, connect.CodeUnauthenticated, "invalid token")
+		}
+
+		// Authenticated-RPC rate limiting (WS11 #6). The caller is now
+		// authenticated, so key per-user: a stolen token or a misbehaving
+		// client cannot exhaust the API, and two users never share a bucket.
+		// The general ceiling counts every authenticated call; the tighter
+		// "expensive" ceiling additionally gates the self-discovered heavy set.
+		// Both run BEFORE next so the limiter gates ahead of any handler work.
+		if i.limiters.Authenticated != nil {
+			if !i.limiters.Authenticated.Allow("uid:" + claims.UserID) {
+				i.logger.Warn("rate limit exceeded", "limiter", "authenticated", "user_id", claims.UserID, "procedure", procedure)
+				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many requests, try again later")
+			}
+		}
+		if i.limiters.Expensive != nil && isExpensiveProcedure(procedureAction(procedure)) {
+			if !i.limiters.Expensive.Allow("uid:" + claims.UserID) {
+				i.logger.Warn("rate limit exceeded", "limiter", "expensive", "user_id", claims.UserID, "procedure", procedure)
+				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many expensive requests, try again later")
+			}
 		}
 
 		// Add user context with permissions + scoped grants from JWT

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/emptypb"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 )
 
 var testLogger = slog.Default()
@@ -650,6 +652,95 @@ func TestAuthzInterceptor_DeviceContext_DeniesAdminAction(t *testing.T) {
 	_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
 	require.Error(t, err, "a device must be denied an admin action through the real interceptor")
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+// setupAuthRateLimitTest mounts the EvaluateDynamicGroup (expensive) procedure
+// behind the REAL AuthInterceptor with the supplied limiters, recording whether
+// the handler ran via a per-request header. Returns the server URL + manager.
+func setupAuthRateLimitTest(t *testing.T, limiters RateLimiters) (string, *JWTManager) {
+	t.Helper()
+	jwtMgr := NewJWTManager(JWTConfig{
+		Secret:            []byte("test-secret-for-interceptor-test"),
+		AccessTokenExpiry: 15 * time.Minute,
+	})
+	interceptor := NewAuthInterceptor(testLogger, jwtMgr, limiters)
+
+	const procedure = "/pm.v1.ControlService/EvaluateDynamicGroup"
+	mux := http.NewServeMux()
+	mux.Handle(procedure, connect.NewUnaryHandler(
+		procedure,
+		func(_ context.Context, _ *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+			resp := connect.NewResponse(&emptypb.Empty{})
+			resp.Header().Set("X-Handler-Ran", "true")
+			return resp, nil
+		},
+		connect.WithInterceptors(interceptor),
+	))
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server.URL, jwtMgr
+}
+
+// TestAuthInterceptor_AuthenticatedRPCRateLimited pins WS11 finding 6: the
+// per-user authenticated limiter gates ahead of the handler, and buckets are
+// keyed per user (two users on the same connection do not share a budget).
+func TestAuthInterceptor_AuthenticatedRPCRateLimited(t *testing.T) {
+	const ceiling = 3
+	serverURL, jwtMgr := setupAuthRateLimitTest(t, RateLimiters{
+		Authenticated: NewRateLimiter(ceiling, time.Minute),
+	})
+	const procedure = "/pm.v1.ControlService/EvaluateDynamicGroup"
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, serverURL+procedure)
+
+	call := func(t *testing.T, userID string) (*connect.Response[emptypb.Empty], error) {
+		t.Helper()
+		tokens, err := jwtMgr.GenerateTokens(userID, userID+"@x", []string{"EvaluateDynamicGroup"}, nil, 1)
+		require.NoError(t, err)
+		req := connect.NewRequest(&emptypb.Empty{})
+		req.Header().Set("Authorization", "Bearer "+tokens.AccessToken)
+		return client.CallUnary(context.Background(), req)
+	}
+
+	// First `ceiling` calls for user A reach the handler.
+	for i := 0; i < ceiling; i++ {
+		resp, err := call(t, "userA")
+		require.NoError(t, err, "call %d within the ceiling must succeed", i+1)
+		assert.Equal(t, "true", resp.Header().Get("X-Handler-Ran"))
+	}
+
+	// The next call from the SAME user is rejected BEFORE the handler runs.
+	_, err := call(t, "userA")
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "too many")
+
+	// A DIFFERENT user on the same connection has an independent bucket — the
+	// limiter must not collapse per-user budgets onto one axis.
+	resp, err := call(t, "userB")
+	require.NoError(t, err, "a distinct user must have an independent per-user bucket")
+	assert.Equal(t, "true", resp.Header().Get("X-Handler-Ran"))
+}
+
+// TestIsExpensiveProcedure_MatchesRealProcedures is the self-discovering guard
+// for the expensive matcher: it walks the real ControlService descriptor and
+// asserts the matcher recognises at least one actual procedure (so the patterns
+// can never silently match zero), and that an ordinary read (GetUser) is NOT
+// classified as expensive.
+func TestIsExpensiveProcedure_MatchesRealProcedures(t *testing.T) {
+	svc := pm.File_pm_v1_control_proto.Services().ByName("ControlService")
+	require.NotNil(t, svc, "ControlService descriptor must resolve")
+
+	matched := []string{}
+	methods := svc.Methods()
+	for i := 0; i < methods.Len(); i++ {
+		name := string(methods.Get(i).Name())
+		if isExpensiveProcedure(name) {
+			matched = append(matched, name)
+		}
+	}
+	require.NotEmpty(t, matched,
+		"isExpensiveProcedure matched zero real ControlService procedures — the patterns drifted")
+	assert.False(t, isExpensiveProcedure("GetUser"), "an ordinary read must not be classified expensive")
 }
 
 // TestClientIPFromHTTP_TrustAttribution pins the rate-limit spoof surface

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -651,3 +651,112 @@ func TestAuthzInterceptor_DeviceContext_DeniesAdminAction(t *testing.T) {
 	require.Error(t, err, "a device must be denied an admin action through the real interceptor")
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 }
+
+// TestClientIPFromHTTP_TrustAttribution pins the rate-limit spoof surface
+// (finding 3): X-Forwarded-For / X-Real-IP are honoured ONLY when the direct
+// peer is in the configured trusted-proxy set, and malformed config is dropped
+// rather than widening trust. Every attacker-supplied header value is sourced
+// from intent (an arbitrary spoofed address), never from the function's own
+// output. TrustedProxies is a package global; the cleanup resets it.
+func TestClientIPFromHTTP_TrustAttribution(t *testing.T) {
+	t.Cleanup(func() { SetTrustedProxies(nil) })
+
+	const spoofed = "203.0.113.66" // attacker-chosen XFF value
+
+	cases := []struct {
+		name       string
+		trusted    []string
+		remoteAddr string
+		xff        string
+		xri        string
+		want       string
+	}{
+		{
+			name:       "untrusted peer + spoofed XFF returns the peer, not the XFF",
+			remoteAddr: "198.51.100.5:443",
+			xff:        spoofed,
+			want:       "198.51.100.5",
+		},
+		{
+			name:       "trusted /8 peer + XFF returns the first XFF hop",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			xff:        spoofed + ", 10.9.9.9",
+			want:       spoofed,
+		},
+		{
+			name:       "trusted peer + X-Real-IP (no XFF) returns X-Real-IP",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			xri:        "192.0.2.7",
+			want:       "192.0.2.7",
+		},
+		{
+			name:       "trusted peer + malformed XFF falls through to X-Real-IP",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			xff:        "not-an-ip",
+			xri:        "192.0.2.7",
+			want:       "192.0.2.7",
+		},
+		{
+			name:       "trusted peer + malformed XFF + no X-Real-IP falls through to the peer",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			xff:        "not-an-ip",
+			want:       "10.1.2.3",
+		},
+		{
+			name:       "bare-IP trusted entry parsed as /32 (IPv4) trusts the exact peer",
+			trusted:    []string{"172.16.0.9"},
+			remoteAddr: "172.16.0.9:5555",
+			xff:        spoofed,
+			want:       spoofed,
+		},
+		{
+			name:       "bare-IP /32 does not widen to a neighbouring address",
+			trusted:    []string{"172.16.0.9"},
+			remoteAddr: "172.16.0.10:5555", // one off — not trusted
+			xff:        spoofed,
+			want:       "172.16.0.10",
+		},
+		{
+			name:       "bare-IP trusted entry parsed as /128 (IPv6) trusts the exact peer",
+			trusted:    []string{"2001:db8::1"},
+			remoteAddr: "[2001:db8::1]:5555",
+			xff:        spoofed,
+			want:       spoofed,
+		},
+		{
+			name:       "malformed CIDR entries are skipped, not fatal, and do not widen trust",
+			trusted:    []string{"10.0.0.0/999", "garbage"},
+			remoteAddr: "10.1.2.3:1234",
+			xff:        spoofed,
+			want:       "10.1.2.3", // peer untrusted because the bad CIDRs were dropped
+		},
+		{
+			name:       "RemoteAddr without a port parses to the bare IP",
+			remoteAddr: "198.51.100.5",
+			want:       "198.51.100.5",
+		},
+		{
+			name:       "no parsable IP anywhere returns the empty string",
+			remoteAddr: "",
+			want:       "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			SetTrustedProxies(tc.trusted)
+			r := &http.Request{RemoteAddr: tc.remoteAddr, Header: http.Header{}}
+			if tc.xff != "" {
+				r.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			if tc.xri != "" {
+				r.Header.Set("X-Real-IP", tc.xri)
+			}
+			assert.Equal(t, tc.want, ClientIPFromHTTP(r))
+		})
+	}
+}

--- a/internal/auth/jwt_test.go
+++ b/internal/auth/jwt_test.go
@@ -1,15 +1,98 @@
 package auth
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/base64"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// algConfusionClaims builds a minimal valid access-token claims body for the
+// alg-confusion tests. Only the signing algorithm varies between cases; the
+// claims are always well-formed and unexpired so a failure can only be the
+// signing-method rejection, never expiry/type.
+func algConfusionClaims() *Claims {
+	now := time.Now()
+	return &Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			ID:        "01ARZ3NDEKTSV4RRFFQ69G5FAV",
+			Issuer:    "test",
+			Subject:   "user-1",
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+		},
+		UserID:    "user-1",
+		Email:     "a@b.com",
+		TokenType: TokenTypeAccess,
+	}
+}
+
+// TestValidateToken_RejectsAlgNone pins that a token whose header advertises
+// alg:none (unsigned, RFC-7519 §6) is rejected. Issuance is always HS256, so
+// an unsigned token is by definition forged. The "wrong" algorithm is sourced
+// from intent (the literal `none` method), not from the keyfunc under test.
+// Correct path is the HS256 token from GenerateTokens (covered elsewhere);
+// this is the present-but-WRONG case.
+func TestValidateToken_RejectsAlgNone(t *testing.T) {
+	m := newTestJWTManager()
+
+	tok, err := jwt.NewWithClaims(jwt.SigningMethodNone, algConfusionClaims()).
+		SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+
+	_, err = m.ValidateToken(tok, TokenTypeAccess)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected signing method",
+		"alg:none must be rejected on the HS256 signing-method pin, not on expiry/type")
+}
+
+// TestValidateToken_RejectsHSFamilyConfusion pins HS384/HS512 rejection EVEN
+// THOUGH the same shared secret would verify them. Signing with the manager's
+// own secret proves the pin is on token.Method != HS256, not merely on whether
+// the secret matches.
+func TestValidateToken_RejectsHSFamilyConfusion(t *testing.T) {
+	m := newTestJWTManager()
+	secret := []byte("test-secret-for-jwt") // the manager's own secret
+
+	for _, method := range []*jwt.SigningMethodHMAC{jwt.SigningMethodHS384, jwt.SigningMethodHS512} {
+		t.Run(method.Alg(), func(t *testing.T) {
+			tok, err := jwt.NewWithClaims(method, algConfusionClaims()).SignedString(secret)
+			require.NoError(t, err)
+
+			_, err = m.ValidateToken(tok, TokenTypeAccess)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "unexpected signing method",
+				"%s signed with the real secret must still be rejected — the pin is on the method, not the key", method.Alg())
+		})
+	}
+}
+
+// TestValidateToken_RejectsRS256PublicKeyConfusion pins the classic RS↔HS
+// algorithm-confusion attack: an RS256-signed token must be rejected, NOT
+// verified by treating the HMAC secret as an RSA public key. The wrong
+// algorithm is sourced from intent (issuance is always HS256), never from the
+// keyfunc.
+func TestValidateToken_RejectsRS256PublicKeyConfusion(t *testing.T) {
+	m := newTestJWTManager()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tok, err := jwt.NewWithClaims(jwt.SigningMethodRS256, algConfusionClaims()).SignedString(key)
+	require.NoError(t, err)
+
+	_, err = m.ValidateToken(tok, TokenTypeAccess)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected signing method",
+		"RS256 must be rejected on the signing-method pin, not silently treated as an HMAC key")
+}
 
 // decodeJWTPayload base64url-decodes the claims segment of a JWT so a
 // test can assert on the raw wire shape (e.g. an omitempty claim's

--- a/internal/auth/ratelimit.go
+++ b/internal/auth/ratelimit.go
@@ -29,6 +29,11 @@ type RateLimiter struct {
 	window   time.Duration
 	stopCh   chan struct{}
 	now      func() time.Time // clock seam; defaults to time.Now, overridden in tests
+	// maxKeys caps the attempts map size (audit F-20). Defaults to
+	// maxRateLimiterKeys; the test seam newRateLimiterWithCap lowers it so the
+	// LRU eviction path can be exercised deterministically without inserting
+	// 100k keys.
+	maxKeys int
 }
 
 // RateLimiterOption configures a RateLimiter.
@@ -50,11 +55,24 @@ func NewRateLimiter(limit int, window time.Duration, opts ...RateLimiterOption) 
 		window:   window,
 		stopCh:   make(chan struct{}),
 		now:      time.Now,
+		maxKeys:  maxRateLimiterKeys,
 	}
 	for _, opt := range opts {
 		opt(rl)
 	}
 	go rl.cleanup()
+	return rl
+}
+
+// newRateLimiterWithCap is a test seam (audit F-20): identical to
+// NewRateLimiter but with a settable per-instance key cap so the LRU eviction
+// branch in Allow can be exercised deterministically with a handful of keys
+// instead of the 100k production ceiling. Not for production use.
+func newRateLimiterWithCap(limit int, window time.Duration, maxKeys int, opts ...RateLimiterOption) *RateLimiter {
+	rl := NewRateLimiter(limit, window, opts...)
+	rl.mu.Lock()
+	rl.maxKeys = maxKeys
+	rl.mu.Unlock()
 	return rl
 }
 
@@ -86,7 +104,7 @@ func (rl *RateLimiter) Allow(key string) bool {
 	// the ceiling AND this is a never-seen-before key, evict the
 	// eldest entry. Existing keys are exempt — they just get a fresh
 	// timestamp.
-	if _, exists := rl.attempts[key]; !exists && len(rl.attempts) >= maxRateLimiterKeys {
+	if _, exists := rl.attempts[key]; !exists && len(rl.attempts) >= rl.maxKeys {
 		rl.evictEldestLocked()
 	}
 

--- a/internal/auth/ratelimit_test.go
+++ b/internal/auth/ratelimit_test.go
@@ -1,11 +1,13 @@
 package auth
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRateLimiter_AllowWithinLimit(t *testing.T) {
@@ -121,4 +123,59 @@ func TestRateLimiter_Blocked(t *testing.T) {
 
 	// Keys are independent.
 	assert.False(t, rl.Blocked("other"))
+}
+
+// TestRateLimiter_KeyCapEvictsEldest pins audit F-20: at the per-instance key
+// ceiling, inserting a never-seen key evicts the single eldest-seen key, the
+// map stays bounded (never grows to cap+1), and re-touching an EXISTING key at
+// the ceiling is exempt from eviction. "Eldest" is sourced from the insertion
+// order under an injected clock, not from reading evictEldestLocked's output.
+func TestRateLimiter_KeyCapEvictsEldest(t *testing.T) {
+	now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	const capKeys = 4
+	rl := newRateLimiterWithCap(10, time.Hour, capKeys, WithClock(func() time.Time { return now }))
+	defer rl.Stop()
+
+	// Insert `capKeys` distinct keys, advancing the clock between each so k0 is
+	// provably the eldest by lastSeen and k{capKeys-1} the newest.
+	for i := 0; i < capKeys; i++ {
+		require.True(t, rl.Allow(fmt.Sprintf("k%d", i)))
+		now = now.Add(time.Minute)
+	}
+	require.Len(t, rl.attempts, capKeys, "map should be exactly at the cap before the over-limit insert")
+
+	// Insert one never-seen key at the ceiling: the eldest (k0) is evicted.
+	require.True(t, rl.Allow("kNew"))
+	assert.Len(t, rl.attempts, capKeys, "map must stay bounded at the cap, not grow to cap+1")
+	_, k0Present := rl.attempts["k0"]
+	assert.False(t, k0Present, "the eldest-seen key k0 must be the one evicted")
+	_, kNewPresent := rl.attempts["kNew"]
+	assert.True(t, kNewPresent, "the newly inserted key must be present after eviction")
+
+	// Re-touch an EXISTING key at the ceiling: it gets a fresh timestamp and
+	// nothing is evicted (size unchanged, no other key dropped).
+	now = now.Add(time.Minute)
+	require.True(t, rl.Allow("k1"))
+	assert.Len(t, rl.attempts, capKeys, "re-touching an existing key must not change the map size")
+	for _, k := range []string{"k1", "k2", "k3", "kNew"} {
+		_, ok := rl.attempts[k]
+		assert.Truef(t, ok, "existing key %q must survive an existing-key re-touch (no spurious eviction)", k)
+	}
+}
+
+// TestRateLimiter_KeyCapDoesNotEvictBelowCeiling pins the rejection path: when
+// the map is below the cap, inserting a new key must NOT evict anything.
+func TestRateLimiter_KeyCapDoesNotEvictBelowCeiling(t *testing.T) {
+	now := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	rl := newRateLimiterWithCap(10, time.Hour, 8, WithClock(func() time.Time { return now }))
+	defer rl.Stop()
+
+	for i := 0; i < 5; i++ { // 5 < cap (8)
+		require.True(t, rl.Allow(fmt.Sprintf("k%d", i)))
+		now = now.Add(time.Minute)
+	}
+	require.True(t, rl.Allow("kNew"))
+	assert.Len(t, rl.attempts, 6, "no eviction below the ceiling — every inserted key is retained")
+	_, k0 := rl.attempts["k0"]
+	assert.True(t, k0, "k0 must NOT be evicted while the map is below the ceiling")
 }

--- a/internal/connection/terminal_sessions_test.go
+++ b/internal/connection/terminal_sessions_test.go
@@ -1,0 +1,145 @@
+package connection
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+func newTestSession(id string) *TerminalSession {
+	return NewTerminalSession(id, "dev-1", "user-1", "pm-tty-alice", 80, 24)
+}
+
+func outputMsg() *pm.AgentMessage {
+	return &pm.AgentMessage{
+		Payload: &pm.AgentMessage_TerminalOutput{
+			TerminalOutput: &pm.TerminalOutput{SessionId: "s1", Data: []byte("x")},
+		},
+	}
+}
+
+// TestTerminalSessionRegistry_ConcurrentRouteAndUnregister pins the
+// lock-discipline contract (finding 12): RouteAgentMessage holds the RLock
+// through the channel send and Unregister takes the write lock before close(),
+// so a concurrent route/unregister can never panic with send-on-closed-channel.
+// Run under -race; the goroutine hammer + the absence of a panic is the proof.
+func TestTerminalSessionRegistry_ConcurrentRouteAndUnregister(t *testing.T) {
+	for iter := 0; iter < 200; iter++ {
+		r := NewTerminalSessionRegistry()
+		s := newTestSession("s1")
+		r.Register(s)
+
+		// Drain the buffered channel so RouteAgentMessage actually attempts
+		// sends rather than only hitting the full-channel default branch.
+		drainDone := make(chan struct{})
+		go func() {
+			for range s.OutputCh {
+			}
+			close(drainDone)
+		}()
+
+		var wg sync.WaitGroup
+		for i := 0; i < 8; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for j := 0; j < 50; j++ {
+					r.RouteAgentMessage("s1", outputMsg())
+				}
+			}()
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			r.Unregister("s1")
+		}()
+		wg.Wait()
+
+		// Unregister closes OutputCh, so the drainer terminates.
+		r.Unregister("s1") // idempotent second close-attempt guard
+		<-drainDone
+	}
+}
+
+// TestTerminalSessionRegistry_ReregisterSameIDClosesOldChannel pins the
+// line 89-91 path: re-Registering the SAME id closes the old channel while a
+// reader on the NEW channel still receives, with no send-on-closed panic.
+func TestTerminalSessionRegistry_ReregisterSameIDClosesOldChannel(t *testing.T) {
+	r := NewTerminalSessionRegistry()
+	old := newTestSession("s1")
+	r.Register(old)
+
+	// Concurrent routing on s1 while it is being re-registered.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 100; j++ {
+			r.RouteAgentMessage("s1", outputMsg())
+		}
+	}()
+
+	fresh := newTestSession("s1")
+	r.Register(fresh) // closes old.OutputCh, installs fresh
+	wg.Wait()
+
+	// The old channel must be closed: draining it (buffered frames may
+	// remain) terminates only because Register closed it. A non-closed
+	// channel would deadlock here and trip the timeout.
+	drained := make(chan struct{})
+	go func() {
+		for range old.OutputCh { //nolint:revive // intentional drain-until-closed
+		}
+		close(drained)
+	}()
+	select {
+	case <-drained:
+	case <-time.After(time.Second):
+		t.Fatal("re-register must close the old session's channel")
+	}
+
+	// A reader on the NEW channel still receives a routed frame.
+	require.True(t, r.RouteAgentMessage("s1", outputMsg()))
+	select {
+	case msg := <-fresh.OutputCh:
+		assert.NotNil(t, msg)
+	case <-time.After(time.Second):
+		t.Fatal("reader on the new channel did not receive a routed frame")
+	}
+}
+
+// TestTerminalSessionRegistry_UnregisterIdempotent pins that a double
+// Unregister of the same id does not double-close (panic) the channel.
+func TestTerminalSessionRegistry_UnregisterIdempotent(t *testing.T) {
+	r := NewTerminalSessionRegistry()
+	r.Register(newTestSession("s1"))
+
+	assert.NotPanics(t, func() {
+		r.Unregister("s1")
+		r.Unregister("s1")
+		r.Unregister("never-registered")
+	})
+}
+
+// TestTerminalSessionRegistry_RouteAfterUnregisterReturnsFalse pins that
+// routing to an unregistered / already-removed id returns false and never
+// panics — covering correct, absent-session, and post-close cases.
+func TestTerminalSessionRegistry_RouteAfterUnregisterReturnsFalse(t *testing.T) {
+	r := NewTerminalSessionRegistry()
+
+	// Absent session.
+	assert.False(t, r.RouteAgentMessage("missing", outputMsg()))
+
+	// Registered → routes true.
+	r.Register(newTestSession("s1"))
+	assert.True(t, r.RouteAgentMessage("s1", outputMsg()))
+
+	// After Unregister → routes false, no panic.
+	r.Unregister("s1")
+	assert.False(t, r.RouteAgentMessage("s1", outputMsg()))
+}

--- a/internal/handler/terminal_bridge.go
+++ b/internal/handler/terminal_bridge.go
@@ -79,12 +79,14 @@ func NewTerminalBridgeHandler(
 const terminalSubprotocolPrefix = "bearer."
 
 // extractTerminalToken returns the session token from (a) the
-// Sec-WebSocket-Protocol header with the `bearer.<token>` shape,
-// preferred; or (b) the legacy `?token=` query parameter. When the
-// subprotocol form is used, the chosen subprotocol is returned so
-// the Accept call can echo it back — browsers reject a handshake
-// response that does not echo one of the client's offered
-// protocols.
+// Sec-WebSocket-Protocol header with the `bearer.<token>` shape — the
+// only ACCEPTED transport; or (b) the legacy `?token=` query parameter,
+// which is surfaced ONLY so ServeHTTP can hard-reject it explicitly
+// (WS11 finding 5). When the subprotocol form is used, the chosen
+// subprotocol is returned so the Accept call can echo it back — browsers
+// reject a handshake response that does not echo one of the client's
+// offered protocols. A non-empty token with an empty chosenSubprotocol
+// therefore means "token arrived in the URL" and must be refused.
 func extractTerminalToken(r *http.Request) (token, chosenSubprotocol string) {
 	// Sec-WebSocket-Protocol can be comma-separated with multiple
 	// offers. We scan for any entry starting with `bearer.` and
@@ -112,17 +114,21 @@ func (h *TerminalBridgeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request
 	sessionID := r.URL.Query().Get("session_id")
 	token, chosenSubprotocol := extractTerminalToken(r)
 	if sessionID == "" || token == "" {
-		http.Error(w, "session_id and token are required (use Sec-WebSocket-Protocol: bearer.<token> or ?token=...)", http.StatusBadRequest)
+		http.Error(w, "session_id and token are required (send the token via Sec-WebSocket-Protocol: bearer.<token>)", http.StatusBadRequest)
 		return
 	}
 	if chosenSubprotocol == "" {
-		// Legacy path — token travelled in the URL. Warn so the
-		// operator can trace old clients. Once all clients have
-		// migrated, we can turn this into a hard reject.
-		h.logger.Warn("terminal token received via query parameter; switch client to Sec-WebSocket-Protocol: bearer.<token>",
+		// Token arrived via the legacy `?token=` query parameter. Hard-reject
+		// it (WS11 finding 5): query strings leak into reverse-proxy access
+		// logs, browser Referer headers, and devtools network panels, so the
+		// bearer token MUST travel in the Sec-WebSocket-Protocol header. Do
+		// NOT consult the control server — refuse before any validation work.
+		h.logger.Warn("rejected terminal token presented via query parameter; client must use Sec-WebSocket-Protocol: bearer.<token>",
 			"session_id", sessionID,
 			"remote_addr", r.RemoteAddr,
 		)
+		http.Error(w, "terminal token must be sent via Sec-WebSocket-Protocol: bearer.<token>, not the URL query string", http.StatusUnauthorized)
+		return
 	}
 
 	logger := h.logger.With("session_id", sessionID)

--- a/internal/handler/terminal_bridge_test.go
+++ b/internal/handler/terminal_bridge_test.go
@@ -1,0 +1,107 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+)
+
+// spyInternalClient records whether ProxyValidateTerminalToken was called so a
+// test can prove the bridge does NOT consult control when a token arrives via
+// the rejected ?token= query transport. Embedding the interface means any other
+// method call would nil-panic (none are exercised here).
+type spyInternalClient struct {
+	pmv1connect.InternalServiceClient
+	validateCalls int
+	validateErr   error
+}
+
+func (s *spyInternalClient) ProxyValidateTerminalToken(
+	context.Context, *connect.Request[pm.InternalValidateTerminalTokenRequest],
+) (*connect.Response[pm.InternalValidateTerminalTokenResponse], error) {
+	s.validateCalls++
+	if s.validateErr != nil {
+		return nil, s.validateErr
+	}
+	return connect.NewResponse(&pm.InternalValidateTerminalTokenResponse{}), nil
+}
+
+func bridgeWithSpy(spy *spyInternalClient) *TerminalBridgeHandler {
+	return &TerminalBridgeHandler{
+		controlProxy: &ControlProxy{client: spy, gatewayID: "gw"},
+		logger:       slog.Default(),
+	}
+}
+
+// TestExtractTerminalToken_SubprotocolPreferred pins the correct path: a
+// Sec-WebSocket-Protocol: bearer.<tok> offer yields the token and the chosen
+// subprotocol to echo.
+func TestExtractTerminalToken_SubprotocolPreferred(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/terminal?session_id=s1", nil)
+	r.Header.Set("Sec-WebSocket-Protocol", "bearer.opaque-token-123")
+
+	tok, chosen := extractTerminalToken(r)
+	assert.Equal(t, "opaque-token-123", tok)
+	assert.Equal(t, "bearer.opaque-token-123", chosen)
+}
+
+// TestServeHTTP_QueryStringTokenRejected pins WS11 finding 5: a token presented
+// ONLY via the legacy ?token= query parameter is hard-rejected (401) and the
+// control server is NEVER consulted — the bearer token must travel in the
+// Sec-WebSocket-Protocol header where it does not leak into access logs /
+// Referer / devtools.
+func TestServeHTTP_QueryStringTokenRejected(t *testing.T) {
+	spy := &spyInternalClient{}
+	h := bridgeWithSpy(spy)
+
+	r := httptest.NewRequest(http.MethodGet, "/terminal?session_id=s1&token=leaky-url-token", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+
+	assert.Equal(t, http.StatusUnauthorized, rec.Code,
+		"a ?token= query transport must be hard-rejected, not validated")
+	assert.Zero(t, spy.validateCalls,
+		"ValidateTerminalToken must NOT be called for a query-string token")
+}
+
+// TestServeHTTP_SubprotocolTokenReachesValidation pins the contrast: a token in
+// the subprotocol header IS passed through to validation (it is not caught by
+// the transport gate). The spy returns an error so the flow stops at the
+// invalid-token 401 without needing a live agent/WebSocket upgrade.
+func TestServeHTTP_SubprotocolTokenReachesValidation(t *testing.T) {
+	spy := &spyInternalClient{validateErr: errors.New("invalid token")}
+	h := bridgeWithSpy(spy)
+
+	r := httptest.NewRequest(http.MethodGet, "/terminal?session_id=s1", nil)
+	r.Header.Set("Sec-WebSocket-Protocol", "bearer.opaque-token-123")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+
+	require.Equal(t, 1, spy.validateCalls,
+		"a subprotocol-borne token must reach ValidateTerminalToken")
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+}
+
+// TestServeHTTP_NoTokenIsBadRequest pins that a request with neither transport
+// is a 400 and never consults control.
+func TestServeHTTP_NoTokenIsBadRequest(t *testing.T) {
+	spy := &spyInternalClient{}
+	h := bridgeWithSpy(spy)
+
+	r := httptest.NewRequest(http.MethodGet, "/terminal?session_id=s1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, r)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Zero(t, spy.validateCalls)
+}


### PR DESCRIPTION
WS11 of the SECURITY_HARDENING_WORKPLAN — the request-auth boundary. Server-only (no proto/SDK/agent changes). Every item is RED-first where behaviour changed; pure-regression locks where the behaviour was already correct.

## Findings

| # | sev | what |
|---|-----|------|
| 2 | med | **JWT HS256-only** regression locks: `alg:none`, HS384/HS512 (even signed with the real secret), RS256 (RS↔HS confusion) all rejected on the signing-method check. |
| 1 | med | **Real leak fixed:** `scim_token_hash` (bcrypt of the SCIM bearer token) rode `IdentityProviderSCIMEnabled`/`…SCIMTokenRotated` through `ListAuditEvents` unredacted — same class as the already-redacted `password_hash`/`backup_codes_hash`. Redacted + a self-discovering AST sweep over every `eventtypes/payloads` struct so a future secret-bearing field with no redaction path fails a test (fail-closed). |
| 3 | med | **XFF/trusted-proxy attribution** table-locked: proxy headers honoured only from `CONTROL_TRUSTED_PROXIES`; bare IPs as /32 & /128; malformed CIDRs dropped. |
| 6 | low | **Per-user authenticated-RPC rate limiting**: general ceiling on every authenticated call + a tighter ceiling on a self-discovered "expensive" set (`Evaluate*`/`Search*`/`Rebuild*`/`*Query`). Keyed by user ID; gates before the handler. Guard test walks the ControlService descriptor so the matcher can't silently match zero. |
| 5 | low | **Terminal `?token=` rejected (401)** before any validation — the bearer token must travel in `Sec-WebSocket-Protocol: bearer.<token>`. |
| 4/9 | low | **Credential floors:** `CONTROL_JWT_SECRET` must decode (hex/base64) to ≥32 random bytes (not just ≥32 chars); `CONTROL_ADMIN_PASSWORD` ≥12 chars when set. **The `CONTROL_ENCRYPTION_KEY_REQUIRED=false` plaintext opt-out is removed** — the key is mandatory; a missing key is fatal. |
| 8 | low | **`TerminateTerminalSession`** gateway fan-out now runs under a 10s context deadline + a client `Timeout` backstop. |
| 10 | low | **Rate-limiter key-cap LRU eviction** (audit F-20) now covered via a test seam. |
| 11 | info | **Login no-enumeration:** a disabled account with the correct password returns the generic *invalid credentials*, indistinguishable from a wrong password / non-existent account. |
| 12 | info | **`TerminalSessionRegistry`** route/unregister/re-register concurrency locked under `-race`. |
| — | — | **server#391 gap:** the terminal revocation listener now also handles `UserSessionInvalidated` (the role/group session-version bump), closing live sessions iff `StartTerminal` was lost. |
| 7 | low | Validation interceptor now exercised with a **real `pm.*Request`** (catches stripped `validate` tags). |

ADR 0015 records the decisions.

## ⚠️ Breaking (intentional, documented)

Existing deployments must, before upgrading:
- supply a CSPRNG-generated `CONTROL_JWT_SECRET` (`openssl rand -base64 48`) — a weak/short secret no longer boots;
- set `CONTROL_ADMIN_PASSWORD` ≥12 chars if bootstrapping;
- set `CONTROL_ENCRYPTION_KEY` — the `…_REQUIRED=false` opt-out is gone.

Control/gateway READMEs, deploy compose / setup.sh / .env.example updated.

## Verification
- `go vet ./...` clean; full `go test ./...` green; `-race` green on auth/connection/handler; gofmt clean.
- Local CodeRabbit review: no findings.

Closes #421, closes #422. Advances #82; completes the #391 session-bump gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-user rate limiting for authenticated API requests and computationally expensive operations to improve system stability.
  * Enhanced terminal WebSocket authentication requiring bearer token in secure header instead of query parameter.

* **Security**
  * Made encryption key mandatory for server startup; plaintext operation is no longer supported.
  * Strengthened JWT secret requirements with minimum entropy validation.
  * Enforced 12-character minimum length for admin passwords.
  * Restricted JWT validation to HS256 algorithm only.
  * Disabled account login attempts now return generic error message to prevent account enumeration.

* **Documentation**
  * Updated deployment guides with new security requirements and configuration best practices.
  * Added architecture documentation for authentication hardening decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->