### PR TITLE
WS12: CRL fail-closed at boot and on the internal mTLS plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ RS256) are rejected. `Login` returns the same generic *invalid credentials* for 
 wrong password, a non-existent account, and a **disabled** account, so a
 credential holder can't probe account state.
 
+**Certificate revocation (mTLS plane).** Revoked agent/gateway/control
+certificate fingerprints are published to a shared Valkey CRL. Both the
+gateway's agent listener and the **internal mTLS listeners** consult it: the
+control server's `InternalService` (credential-bearing proxy RPCs) and the
+gateway's control-class `GatewayService` reject a revoked peer cert at connect
+time — immediate revocation, not waiting for the cert's natural expiry. The
+revocation gate fails closed: if the CRL has not loaded (Valkey unavailable at
+boot) the listener refuses connections rather than admitting an unverifiable
+cert.
+
 **Rate limiting & client IP.** Unauthenticated endpoints (login, refresh,
 register, logout, cert renewal, auth-methods lookup) are throttled per client IP;
 authenticated RPCs are throttled per user, with a tighter ceiling on heavy

--- a/cmd/control/README.md
+++ b/cmd/control/README.md
@@ -777,6 +777,18 @@ query evaluation, search, projector rebuild, log/osquery fan-out). This bounds a
 stolen access token or a runaway client. The ceilings are fixed defaults; over a
 limit the RPC returns `CodeResourceExhausted`.
 
+## Certificate Revocation
+
+When a certificate is superseded (`RenewCertificate`) or a device is deleted, the
+Control Server publishes the old fingerprint to a shared Valkey CRL. Beyond the
+gateway's agent listener, the **InternalService mTLS listener now consults the
+CRL too**: a revoked gateway certificate is rejected at connect time on the
+credential-bearing proxy plane, giving operators immediate revocation instead of
+waiting for the certificate's natural expiry. The gate fails closed — if the CRL
+cache cannot load at boot (Valkey unavailable) the subsystem refuses to start
+rather than admitting unverifiable certs. A no-Valkey dev deployment runs the
+internal listener with an explicit, WARN-logged no-op checker.
+
 ## CA Rotation
 
 The Control Server supports CA certificate rotation without re-registering agents. This is done via a **trust bundle** approach:

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -342,8 +342,20 @@ func main() {
 	// cert must NOT be usable here — only gateway replicas, which
 	// present certs issued out of band by setup.sh with a spiffe://
 	// peer-class URI, are admitted.
+	// Revocation gate on the internal listener (WS12 #2): a revoked gateway
+	// cert must not be able to call the credential-bearing proxy RPCs. With
+	// Valkey the loaded CRL cache backs it; a no-Valkey dev control server has
+	// no CRL, so it gets the explicit, WARN-logged NoopRevocationChecker rather
+	// than a silent nil (which would fail closed and break the dev path).
+	var internalRevocation mtls.RevocationChecker
+	if valkey != nil && valkey.CRLCache != nil {
+		internalRevocation = valkey.CRLCache
+	} else {
+		logger.Warn("InternalService mTLS listener running WITHOUT certificate revocation (no Valkey CRL configured) — dev only")
+		internalRevocation = mtls.NoopRevocationChecker{}
+	}
 	internalMux := http.NewServeMux()
-	internalMux.Handle(internalPath, mtls.RequirePeerClass(logger, mtls.PeerClassGateway)(internalH))
+	internalMux.Handle(internalPath, mtls.RequirePeerClassNotRevoked(logger, internalRevocation, mtls.PeerClassGateway)(internalH))
 	internalMux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))

--- a/cmd/control/valkey.go
+++ b/cmd/control/valkey.go
@@ -43,6 +43,11 @@ import (
 	"github.com/manchtools/power-manage/server/internal/terminal"
 )
 
+// controlCRLRefreshInterval is how often the control server reloads the CRL
+// cache that gates its InternalService mTLS listener. Matches the gateway's
+// cadence; revocations propagate to the internal plane within one interval.
+const controlCRLRefreshInterval = 30 * time.Second
+
 // valkeySubsystem owns every long-lived component constructed when
 // the operator configures Valkey. Close() unwinds them in reverse
 // construction order; nil components are skipped so a partial-init
@@ -71,6 +76,13 @@ type valkeySubsystem struct {
 	// it to the ControlService so renewal/device-deletion revoke the old cert;
 	// gateways read the same Valkey key to enforce it on mTLS connections.
 	CRLStore *crl.Store
+
+	// CRLCache is a loaded, in-memory snapshot of CRLStore used to gate the
+	// InternalService mTLS listener (WS12 #2: a revoked gateway cert must not
+	// be able to call ProxyGetLuksKey / ProxyStoreLpsPasswords). It is loaded
+	// synchronously at subsystem init — a failed initial load fails the whole
+	// subsystem (fail-closed, mirroring the gateway's boot).
+	CRLCache *crl.Cache
 
 	// GatewayRegistry is the device→gateway routing registry. main() hands it to
 	// the InternalHandler (SetDeviceGatewayResolver) so every device-origin
@@ -151,6 +163,14 @@ func newValkeySubsystem(ctx context.Context, cfg *Config, st *store.Store, svc *
 	v.TerminalTokenStore = terminal.NewTokenStore(terminal.NewValkeyBackend(v.rdb))
 	v.CRLStore = crl.NewStore(v.rdb)
 	svc.SetCRLStore(v.CRLStore)
+	// Load the CRL cache that gates the InternalService mTLS listener. Fail the
+	// subsystem if the initial load errors — symmetry with the gateway's
+	// fail-closed boot: never admit gateway certs against an unloaded CRL.
+	v.CRLCache = crl.NewCache(v.CRLStore, logger.With("component", "crl"))
+	if err := v.CRLCache.Refresh(ctx); err != nil {
+		return nil, fmt.Errorf("initial CRL load failed (refusing to start the internal mTLS listener without a loaded revocation list): %w", err)
+	}
+	go v.CRLCache.Run(ctx, controlCRLRefreshInterval)
 	gatewayReg := registry.New(registry.NewValkeyBackend(v.rdb), logger.With("component", "gateway_registry"))
 	v.GatewayRegistry = gatewayReg
 	termHandler := api.NewTerminalHandler(

--- a/cmd/gateway/README.md
+++ b/cmd/gateway/README.md
@@ -319,6 +319,20 @@ curl http://localhost:8080/ready
 # Returns: ok
 ```
 
+## Certificate revocation (CRL)
+
+The control server publishes superseded/deleted certificate fingerprints to a
+shared Valkey CRL; the gateway caches it in memory and checks every mTLS
+connection against it (a local map lookup, refreshed on a ticker).
+
+The gateway **fails closed**: it refuses to start if the initial CRL load does
+not succeed (after a bounded retry), rather than booting with an empty list and
+admitting a revoked cert while Valkey is down. At runtime a not-yet-loaded or
+unavailable revocation list rejects connections (it cannot prove a cert is
+unrevoked); a successfully-loaded-but-empty list admits normally. The
+control-class `GatewayService` listener (admin list/terminate fan-out) consults
+the same CRL, so a revoked control cert is rejected at connect time.
+
 ## Action Types
 
 The Gateway forwards these action types from Control Server to agents:

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -63,6 +63,47 @@ func opsHealthHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprint(w, `{"status":"healthy"}`)
 }
 
+// initialCRLAttempts / initialCRLBackoff bound the boot-time CRL load so a brief
+// Valkey hiccup retries but a hard outage still gives up quickly enough that
+// SIGTERM is honoured. Tunable here; the helper takes them as params for tests.
+const (
+	initialCRLAttempts = 3
+	initialCRLBackoff  = time.Second
+)
+
+// crlRefresher is the subset of *crl.Cache loadInitialCRL needs — a seam so the
+// boot-fatal decision is unit-testable without standing up the full gateway.
+type crlRefresher interface {
+	Refresh(context.Context) error
+}
+
+// loadInitialCRL performs a bounded series of synchronous CRL refreshes at boot.
+// It returns nil as soon as one succeeds (the cache is now Loaded()), or a
+// non-nil error after exhausting attempts. The caller MUST treat a non-nil
+// return as FATAL (os.Exit) — the gateway must never begin admitting mTLS
+// connections with an unloaded revocation list, or a revoked cert sails through
+// at boot when Valkey is down (WS12 #1, fail closed). Aborts early if ctx is
+// cancelled (SIGTERM during startup).
+func loadInitialCRL(ctx context.Context, cache crlRefresher, attempts int, backoff time.Duration, logger *slog.Logger) error {
+	var lastErr error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if err := cache.Refresh(ctx); err == nil {
+			return nil
+		} else {
+			lastErr = err
+			logger.Warn("initial CRL load attempt failed", "attempt", attempt, "max", attempts, "error", err)
+		}
+		if attempt < attempts {
+			select {
+			case <-time.After(backoff):
+			case <-ctx.Done():
+				return fmt.Errorf("initial CRL load aborted during startup: %w", ctx.Err())
+			}
+		}
+	}
+	return fmt.Errorf("initial CRL load failed after %d attempts: %w", attempts, lastErr)
+}
+
 func main() {
 	// Parse flags — TLS is always required for mTLS agent connections
 	tlsCert := flag.String("tls-cert", "", "path to server certificate (required)")
@@ -573,8 +614,12 @@ func main() {
 	})
 	defer crlRDB.Close()
 	crlCache := crl.NewCache(crl.NewStore(crlRDB), logger.With("component", "crl"))
-	if err := crlCache.Refresh(shutdownCtx); err != nil {
-		logger.Warn("initial CRL load failed; starting with empty revocation list (will retry)", "error", err)
+	// Fail CLOSED at boot (WS12 #1): if the initial CRL load never succeeds we
+	// refuse to start rather than admit connections with an unloaded revocation
+	// list — a revoked cert must never sail through because Valkey was down.
+	if err := loadInitialCRL(shutdownCtx, crlCache, initialCRLAttempts, initialCRLBackoff, logger); err != nil {
+		logger.Error("refusing to start without a loaded revocation list", "error", err)
+		os.Exit(1)
 	}
 	go crlCache.Run(shutdownCtx, crlRefreshInterval)
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -640,7 +640,10 @@ func main() {
 	// internal CA cannot invoke admin fan-out RPCs.
 	gwSvcHandler := handler.NewGatewayServiceHandler(terminalSessions, manager, logger.With("component", "gateway_service"))
 	gwSvcPath, gwSvcH := pmv1connect.NewGatewayServiceHandler(gwSvcHandler)
-	mux.Handle(gwSvcPath, mtls.RequirePeerClass(logger, mtls.PeerClassControl)(gwSvcH))
+	// Revocation gate (WS12 #2): a revoked control cert must not be able to
+	// drive admin list/terminate fan-out. The same loaded CRL cache the agent
+	// path uses backs it (Valkey is mandatory on the gateway, so it's never nil).
+	mux.Handle(gwSvcPath, mtls.RequirePeerClassNotRevoked(logger, crlCache, mtls.PeerClassControl)(gwSvcH))
 
 	// Wrap with security headers
 	securedMux := middleware.RequestID(middleware.SecurityHeaders(mux))

--- a/cmd/gateway/main_crl_test.go
+++ b/cmd/gateway/main_crl_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/crl"
+)
+
+func quietLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+// TestGatewayBoot_InitialCRLLoadFailureIsFatal pins WS12 #1: the gateway boot
+// path treats an initial CRL load error as fatal (returns a non-nil error the
+// caller os.Exit(1)s on) rather than continuing to ListenAndServeTLS with an
+// unloaded, empty revocation list.
+func TestGatewayBoot_InitialCRLLoadFailureIsFatal(t *testing.T) {
+	t.Run("successful load → nil, cache loaded (boot proceeds)", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		t.Cleanup(func() { _ = rdb.Close() })
+		cache := crl.NewCache(crl.NewStore(rdb), quietLogger())
+
+		err := loadInitialCRL(context.Background(), cache, 3, time.Millisecond, quietLogger())
+		require.NoError(t, err)
+		assert.True(t, cache.Loaded(),
+			"after a successful initial load the cache MUST report loaded — no boot path may continue with Loaded()==false")
+	})
+
+	t.Run("backend down → non-nil error (caller exits, never admits)", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		t.Cleanup(func() { _ = rdb.Close() })
+		mr.Close() // backend unreachable → every Refresh errors
+		cache := crl.NewCache(crl.NewStore(rdb), quietLogger())
+
+		err := loadInitialCRL(context.Background(), cache, 3, time.Millisecond, quietLogger())
+		require.Error(t, err, "an initial CRL load that never succeeds MUST surface a fatal error, not be swallowed")
+		assert.False(t, cache.Loaded(), "a failed initial load must leave the cache not-loaded (the middleware then fails closed)")
+	})
+
+	t.Run("cancelled context aborts the retry loop", func(t *testing.T) {
+		mr := miniredis.RunT(t)
+		rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		t.Cleanup(func() { _ = rdb.Close() })
+		mr.Close()
+		cache := crl.NewCache(crl.NewStore(rdb), quietLogger())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // already cancelled (SIGTERM during startup)
+		err := loadInitialCRL(ctx, cache, 5, time.Hour, quietLogger())
+		require.Error(t, err, "a cancelled startup context must abort the retry loop promptly, not block on backoff")
+	})
+}

--- a/docs/adr/0016-crl-fail-closed.md
+++ b/docs/adr/0016-crl-fail-closed.md
@@ -1,0 +1,71 @@
+# 0016 — CRL is fail-closed at boot and on the internal mTLS plane
+
+- Status: accepted
+- Date: 2026-06-14
+- Related: WS12 of the SECURITY_HARDENING_WORKPLAN; manchtools/power-manage-server#424;
+  PR #389 (the base CRL plane this hardens); ADR 0005 (gateway is an untrusted
+  relay — revocation is how a compromised gateway/control cert is cut off).
+
+## Context
+
+PR #389 added the Valkey-backed CRL plane: a control-side writer
+(`RenewCertificate`/`DeleteDevice` publish fingerprints), a gateway-side
+in-memory `crl.Cache` (fail-static refresh), and the gateway AGENT mTLS path
+(`MTLSMiddleware`) consulting it. WS12 closes four gaps in that plane.
+
+## Decision
+
+### Fail-closed until loaded (#1, #3, #4)
+
+- `crl.Cache` gains `Loaded()`: false on a brand-new cache and after a refresh
+  that only ever errored; true after the first SUCCESSFUL refresh and sticky
+  thereafter. This distinguishes "never loaded" (cannot prove anything) from
+  "loaded, empty" (a genuinely empty CRL).
+- `MTLSMiddleware` now treats a nil checker OR `!Loaded()` as **fail-closed**
+  (403 "client certificate revocation unavailable") — we cannot prove the cert
+  is unrevoked, so we do not admit. Previously `if revocation != nil { … }`
+  silently admitted on both an absent checker and an unloaded cache.
+- The only no-CRL path is an explicit, typed `NoopRevocationChecker`
+  (`Loaded()==true`) that the caller logs at WARN — never a bare nil.
+
+### Fatal boot (#1)
+
+The gateway refuses to start if the initial CRL load never succeeds (bounded
+retry, then `os.Exit(1)`), rather than continuing `ListenAndServeTLS` with an
+empty list — a revoked cert must never sail through because Valkey was down at
+boot. The decision lives in a testable `loadInitialCRL` helper.
+
+### Internal mTLS plane consults the CRL (#2)
+
+A new `mtls.RequirePeerClassNotRevoked` wraps `RequirePeerClass` with the same
+fail-closed revocation gate (peer-class enforced first — additive, not
+replaced). It is wired onto:
+- the control server's `InternalService` listener (credential-bearing proxy
+  RPCs — `ProxyGetLuksKey`, `ProxyStoreLpsPasswords`, …), backed by a
+  synchronously-loaded `crl.Cache` that fails the subsystem on initial-load
+  error; and
+- the gateway's control-class `GatewayService` listener (admin list/terminate
+  fan-out).
+
+So a revoked gateway or control certificate is rejected at connect time across
+both the agent and internal planes, not usable until natural expiry.
+
+### One RevocationChecker (layering)
+
+The `RevocationChecker` interface and `NoopRevocationChecker` live in `mtls`
+(`handler.MTLSMiddleware` consumes `mtls.RevocationChecker`); the prior duplicate
+in `handler` was removed. `mtls` cannot import `handler` or `ca` (both import
+`mtls` — a cycle), so the fingerprint (`hex(sha256(DER))`, identical to
+`ca.FingerprintFromCert`) is computed inline in `mtls`.
+
+## Consequences
+
+- **Operational:** the gateway (and the control internal subsystem) will not
+  start if Valkey/CRL is unreachable at boot. This is intentional fail-closed
+  behaviour; documented in the gateway/control READMEs.
+- A revoked gateway/control cert loses internal-plane access immediately.
+- No proto/SDK/web changes. The revocation rejections are mTLS-layer 403s
+  (`http.Error`), not Connect `apiError`s, so no new error codes / i18n keys.
+- The "concurrent-renewal version-guard / CAS" item carried forward from the
+  2026-06-10 audit is a separate verification task (not a WS12 finding) and is
+  not addressed here.

--- a/internal/crl/crl.go
+++ b/internal/crl/crl.go
@@ -89,14 +89,25 @@ func (s *Store) LoadActive(ctx context.Context) (map[string]struct{}, error) {
 // fingerprint check. It refreshes from the Store on a ticker; on a refresh
 // error it KEEPS the previous snapshot (fail-static, never fail-open-to-empty),
 // so a transient Valkey outage cannot silently drop revocation enforcement.
+//
+// A freshly-constructed Cache is NOT yet loaded: Loaded() reports false until
+// the first SUCCESSFUL Refresh. This is the "fail-closed until loaded at least
+// once" invariant — admitting callers (the mTLS middleware) treat a not-loaded
+// cache as "cannot prove this cert is unrevoked" and reject, distinct from a
+// loaded-but-empty cache (a genuinely empty CRL, which admits).
 type Cache struct {
 	store   *Store
 	logger  *slog.Logger
 	mu      sync.RWMutex
 	revoked map[string]struct{}
+	// loaded becomes true only after the first successful Refresh and never
+	// reverts: once we have ANY good snapshot, fail-static (keep it) covers
+	// subsequent refresh errors. It is the boot fail-open footing — a
+	// never-refreshed cache must not be mistaken for an empty revocation list.
+	loaded bool
 }
 
-// NewCache creates an empty cache over the given store.
+// NewCache creates an empty, not-yet-loaded cache over the given store.
 func NewCache(store *Store, logger *slog.Logger) *Cache {
 	return &Cache{store: store, logger: logger, revoked: map[string]struct{}{}}
 }
@@ -109,8 +120,20 @@ func (c *Cache) IsRevoked(fingerprint string) bool {
 	return ok
 }
 
+// Loaded reports whether the cache has completed at least one successful
+// Refresh. False on a brand-new cache and after a refresh that only ever
+// errored; true once a snapshot has been loaded (and stays true thereafter,
+// per the fail-static contract).
+func (c *Cache) Loaded() bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.loaded
+}
+
 // Refresh reloads the snapshot from the Store. Exported so the gateway can do
-// one synchronous load at startup before it starts admitting connections.
+// one synchronous load at startup before it starts admitting connections. On
+// error the previous snapshot and the loaded flag are left unchanged (a failed
+// refresh never counts as "loaded").
 func (c *Cache) Refresh(ctx context.Context) error {
 	next, err := c.store.LoadActive(ctx)
 	if err != nil {
@@ -118,6 +141,7 @@ func (c *Cache) Refresh(ctx context.Context) error {
 	}
 	c.mu.Lock()
 	c.revoked = next
+	c.loaded = true
 	c.mu.Unlock()
 	return nil
 }

--- a/internal/crl/crl.go
+++ b/internal/crl/crl.go
@@ -10,6 +10,15 @@
 //     mTLS expiry anyway, so it never needs to stay revoked), and
 //   - the gateway caches the set in memory, so the per-connection check is a
 //     local map lookup — no per-connection RPC — and survives a Valkey blip.
+//
+// Two invariants protect the cached read path:
+//   - fail-static: a refresh error KEEPS the previous snapshot (never fail-open
+//     to empty), so a transient Valkey outage cannot silently drop enforcement.
+//   - fail-closed-until-loaded: a Cache reports Loaded()==false until its first
+//     SUCCESSFUL refresh; callers (the mTLS middleware) treat a not-yet-loaded
+//     cache as "cannot prove this cert is unrevoked" and reject, distinct from a
+//     loaded-but-empty cache (a genuinely empty CRL, which admits). The gateway
+//     therefore fails its boot if the initial load never succeeds.
 package crl
 
 import (

--- a/internal/crl/crl_test.go
+++ b/internal/crl/crl_test.go
@@ -79,6 +79,38 @@ func TestCache_IsRevokedAfterRefresh(t *testing.T) {
 	assert.False(t, c.IsRevoked("fp-unknown"))
 }
 
+// TestCache_NotLoadedUntilFirstSuccessfulRefresh pins WS12 #1/#3: the
+// "loaded vs never-loaded" distinction that the mTLS fail-closed gate keys on.
+// Sourced from intent ("fail closed until the list has loaded at least once"),
+// NOT from the revoked==nil/empty artifact.
+func TestCache_NotLoadedUntilFirstSuccessfulRefresh(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	s, mr, _ := testStore(t, func() time.Time { return now })
+
+	c := NewCache(s, slog.Default())
+	// ABSENT: a brand-new cache with no Refresh is NOT loaded (boot fail-open
+	// footing) — distinct from "loaded and empty".
+	assert.False(t, c.Loaded(), "a never-refreshed cache must report not-loaded")
+
+	// present-but-WRONG: a refresh against a closed backend errors → still not
+	// loaded (a FAILED refresh does not count as loaded).
+	mr.Close()
+	require.Error(t, c.Refresh(context.Background()))
+	assert.False(t, c.Loaded(), "a failed refresh must not flip Loaded() to true")
+}
+
+func TestCache_LoadedTrueAfterSuccessfulRefresh(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	s, _, _ := testStore(t, func() time.Time { return now })
+
+	c := NewCache(s, slog.Default())
+	require.NoError(t, c.Refresh(context.Background()))
+	assert.True(t, c.Loaded(), "after one successful Refresh the cache is loaded")
+	// loaded-and-empty is a valid state: the CRL had no entries, but the cache
+	// IS loaded, so the gate admits non-revoked certs.
+	assert.False(t, c.IsRevoked("anything"))
+}
+
 func TestCache_FailStaticOnRefreshError(t *testing.T) {
 	now := time.Unix(1_000_000, 0)
 	s, mr, _ := testStore(t, func() time.Time { return now })
@@ -93,4 +125,8 @@ func TestCache_FailStaticOnRefreshError(t *testing.T) {
 	mr.Close()
 	require.Error(t, c.Refresh(context.Background()))
 	assert.True(t, c.IsRevoked("fp-x"), "must retain the previous snapshot on a refresh error")
+	// WS12 #1: after a successful load, a later failed refresh keeps Loaded()
+	// true (fail-static) — the two states (never-loaded vs loaded-then-stale)
+	// must not collapse.
+	assert.True(t, c.Loaded(), "a failed refresh after a good load must keep Loaded() true (fail-static)")
 }

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -139,38 +139,12 @@ func (h *AgentHandler) SetTerminalSessions(reg *connection.TerminalSessionRegist
 // does not carry the "agent" peer-class URI SAN — the AgentService
 // listener is for managed devices only, and a leaked gateway or
 // control cert must not be usable here.
-// RevocationChecker reports whether an agent cert (by SHA-256 fingerprint) has
-// been revoked, and whether the underlying revocation list has loaded at least
-// once. The gateway's crl.Cache satisfies it.
-//
-// A nil checker, or one whose Loaded() is false, is treated as FAIL-CLOSED by
-// MTLSMiddleware: if we cannot consult a loaded revocation list we cannot prove
-// the presented cert is *not* revoked, so the request is rejected rather than
-// admitted. The only way to run without real revocation data is to pass an
-// explicit NoopRevocationChecker (a typed, dev-only opt-out the caller logs at
-// WARN) — never a bare nil and never an unloaded cache.
-type RevocationChecker interface {
-	IsRevoked(fingerprint string) bool
-	// Loaded reports whether the revocation list has been successfully loaded
-	// at least once. Until it has, MTLSMiddleware fails closed.
-	Loaded() bool
-}
-
-// NoopRevocationChecker is the explicit, typed dev-only opt-out from the
-// revocation gate: it reports nothing revoked and always "loaded", so
-// MTLSMiddleware admits non-revoked certs without a real CRL. Use it ONLY on
-// non-mTLS dev paths and log at WARN where it is wired — it is deliberately
-// distinct from a bare nil (which fails closed) so disabling revocation is a
-// visible, intentional choice in the code, never an accident.
-type NoopRevocationChecker struct{}
-
-// IsRevoked always returns false (nothing is known-revoked).
-func (NoopRevocationChecker) IsRevoked(string) bool { return false }
-
-// Loaded always returns true (the no-op list is trivially "loaded").
-func (NoopRevocationChecker) Loaded() bool { return true }
-
-func MTLSMiddleware(next http.Handler, revocation RevocationChecker, logger *slog.Logger) http.Handler {
+// MTLSMiddleware gates the gateway's AgentService listener. The revocation
+// checker is mtls.RevocationChecker (the gateway's *crl.Cache satisfies it); a
+// nil or not-yet-loaded checker fails CLOSED — see mtls.RevocationChecker and
+// the fail-closed block below. The only no-CRL path is an explicit
+// mtls.NoopRevocationChecker, logged at WARN by the caller.
+func MTLSMiddleware(next http.Handler, revocation mtls.RevocationChecker, logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip TLS check for health endpoints
 		if r.URL.Path == "/health" || r.URL.Path == "/ready" {

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -140,11 +140,35 @@ func (h *AgentHandler) SetTerminalSessions(reg *connection.TerminalSessionRegist
 // listener is for managed devices only, and a leaked gateway or
 // control cert must not be usable here.
 // RevocationChecker reports whether an agent cert (by SHA-256 fingerprint) has
-// been revoked. The gateway's crl.Cache satisfies it; a nil checker disables the
-// revocation gate (e.g. when no Valkey is configured).
+// been revoked, and whether the underlying revocation list has loaded at least
+// once. The gateway's crl.Cache satisfies it.
+//
+// A nil checker, or one whose Loaded() is false, is treated as FAIL-CLOSED by
+// MTLSMiddleware: if we cannot consult a loaded revocation list we cannot prove
+// the presented cert is *not* revoked, so the request is rejected rather than
+// admitted. The only way to run without real revocation data is to pass an
+// explicit NoopRevocationChecker (a typed, dev-only opt-out the caller logs at
+// WARN) — never a bare nil and never an unloaded cache.
 type RevocationChecker interface {
 	IsRevoked(fingerprint string) bool
+	// Loaded reports whether the revocation list has been successfully loaded
+	// at least once. Until it has, MTLSMiddleware fails closed.
+	Loaded() bool
 }
+
+// NoopRevocationChecker is the explicit, typed dev-only opt-out from the
+// revocation gate: it reports nothing revoked and always "loaded", so
+// MTLSMiddleware admits non-revoked certs without a real CRL. Use it ONLY on
+// non-mTLS dev paths and log at WARN where it is wired — it is deliberately
+// distinct from a bare nil (which fails closed) so disabling revocation is a
+// visible, intentional choice in the code, never an accident.
+type NoopRevocationChecker struct{}
+
+// IsRevoked always returns false (nothing is known-revoked).
+func (NoopRevocationChecker) IsRevoked(string) bool { return false }
+
+// Loaded always returns true (the no-op list is trivially "loaded").
+func (NoopRevocationChecker) Loaded() bool { return true }
 
 func MTLSMiddleware(next http.Handler, revocation RevocationChecker, logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -197,20 +221,32 @@ func MTLSMiddleware(next http.Handler, revocation RevocationChecker, logger *slo
 			return
 		}
 
-		// Reject revoked certs. The chain already verified against the CA above;
-		// this is the revocation gate that makes a leaked or superseded cert stop
-		// working before its (1-year) natural expiry. r.TLS.PeerCertificates[0]
-		// is the same leaf the peer-class check used, so it's non-nil here.
-		if revocation != nil {
-			fp := ca.FingerprintFromCert(r.TLS.PeerCertificates[0])
-			if revocation.IsRevoked(fp) {
-				logger.Warn("mTLS rejected: certificate revoked",
-					"device_id", deviceID,
-					"remote_addr", r.RemoteAddr,
-				)
-				http.Error(w, "client certificate revoked", http.StatusForbidden)
-				return
-			}
+		// Revocation gate (fail CLOSED). The chain already verified against the CA
+		// above; this is what makes a leaked or superseded cert stop working
+		// before its (1-year) natural expiry. r.TLS.PeerCertificates[0] is the
+		// same leaf the peer-class check used, so it's non-nil here.
+		//
+		// A nil checker or one whose list has not loaded means we CANNOT prove
+		// this cert is unrevoked → reject, never admit. Running without real
+		// revocation data requires an explicit NoopRevocationChecker (Loaded()
+		// true), which the caller logs at WARN — a bare nil is never tolerated.
+		if revocation == nil || !revocation.Loaded() {
+			logger.Warn("mTLS rejected: certificate revocation unavailable (fail-closed)",
+				"device_id", deviceID,
+				"remote_addr", r.RemoteAddr,
+				"checker_nil", revocation == nil,
+			)
+			http.Error(w, "client certificate revocation unavailable", http.StatusForbidden)
+			return
+		}
+		fp := ca.FingerprintFromCert(r.TLS.PeerCertificates[0])
+		if revocation.IsRevoked(fp) {
+			logger.Warn("mTLS rejected: certificate revoked",
+				"device_id", deviceID,
+				"remote_addr", r.RemoteAddr,
+			)
+			http.Error(w, "client certificate revoked", http.StatusForbidden)
+			return
 		}
 
 		// Add device ID to context

--- a/internal/handler/agent_middleware_test.go
+++ b/internal/handler/agent_middleware_test.go
@@ -288,7 +288,7 @@ func TestMTLSMiddleware_AgentClassReachesInnerWithDeviceIDInContext(t *testing.T
 	// Explicit NoopRevocationChecker (the typed dev opt-out) — a bare nil now
 	// fails closed (see TestMTLSMiddleware_NilRevocationChecker), so the happy
 	// path must pass an explicit loaded checker.
-	mw := MTLSMiddleware(inner, NoopRevocationChecker{}, newTestLogger())
+	mw := MTLSMiddleware(inner, mtls.NoopRevocationChecker{}, newTestLogger())
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	agent := mtls.PeerClassAgent
@@ -475,7 +475,7 @@ func TestMTLSMiddleware_NilRevocationChecker(t *testing.T) {
 	// explicit NoopRevocationChecker → admits non-revoked (typed dev opt-out).
 	called := false
 	innerOK := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true })
-	mwNoop := MTLSMiddleware(innerOK, NoopRevocationChecker{}, newTestLogger())
+	mwNoop := MTLSMiddleware(innerOK, mtls.NoopRevocationChecker{}, newTestLogger())
 	reqNoop := httptest.NewRequest(http.MethodGet, "/api", nil)
 	reqNoop.TLS = fakeTLSStateWithPeerClass(t, "device-1", &agent)
 	recNoop := httptest.NewRecorder()

--- a/internal/handler/agent_middleware_test.go
+++ b/internal/handler/agent_middleware_test.go
@@ -11,21 +11,72 @@ package handler
 // One of the cases here pins that fix in place.
 
 import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"io"
 	"log/slog"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/crl"
 	"github.com/manchtools/power-manage/server/internal/mtls"
 )
+
+// newRealAgentCert builds a real x509 agent cert (populated .Raw, agent SPIFFE
+// URI SAN) so the production crl.Cache + ca.FingerprintFromCert path can be
+// exercised end to end — unlike fakeTLSStateWithPeerClass, whose cert has no
+// DER. Each call yields a distinct cert (distinct key → distinct fingerprint).
+func newRealAgentCert(t *testing.T) (*x509.Certificate, *tls.ConnectionState) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	agentURI, err := mtls.PeerClassURI(mtls.PeerClassAgent)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "device-real"},
+		NotBefore:    time.Unix(1_000_000, 0),
+		NotAfter:     time.Unix(2_000_000_000, 0),
+		URIs:         []*url.URL{agentURI},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert, &tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}
+}
+
+// loadedCacheWithRevoked returns a real, already-loaded crl.Cache (miniredis
+// backed) with the given fingerprints revoked, under a fixed clock (no
+// time.Now()).
+func loadedCacheWithRevoked(t *testing.T, now time.Time, fps ...string) *crl.Cache {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	store := crl.NewStore(rdb, crl.WithClock(func() time.Time { return now }))
+	for _, fp := range fps {
+		require.NoError(t, store.Revoke(context.Background(), fp, now.Add(time.Hour)))
+	}
+	cache := crl.NewCache(store, newTestLogger())
+	require.NoError(t, cache.Refresh(context.Background()))
+	return cache
+}
 
 func newOKHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -234,7 +285,10 @@ func TestMTLSMiddleware_AgentClassReachesInnerWithDeviceIDInContext(t *testing.T
 	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		gotDeviceID, gotOK = DeviceIDFromContext(r.Context())
 	})
-	mw := MTLSMiddleware(inner, nil, newTestLogger())
+	// Explicit NoopRevocationChecker (the typed dev opt-out) — a bare nil now
+	// fails closed (see TestMTLSMiddleware_NilRevocationChecker), so the happy
+	// path must pass an explicit loaded checker.
+	mw := MTLSMiddleware(inner, NoopRevocationChecker{}, newTestLogger())
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	agent := mtls.PeerClassAgent
@@ -267,10 +321,12 @@ func TestBootstrapRedirectMiddleware_IPv6HostHeaderHandledCorrectly(t *testing.T
 }
 
 // fakeRevocation is a RevocationChecker whose verdict is fixed, so a CRL test
-// doesn't have to predict the synthetic cert's fingerprint.
+// doesn't have to predict the synthetic cert's fingerprint. It reports loaded so
+// it exercises the IsRevoked branch (not the fail-closed-unloaded branch).
 type fakeRevocation struct{ revoked bool }
 
 func (f fakeRevocation) IsRevoked(string) bool { return f.revoked }
+func (f fakeRevocation) Loaded() bool          { return true }
 
 // TestMTLSMiddleware_RevokedCertRejected pins the CRL gate (audit #6): an
 // agent cert whose fingerprint is on the revocation list is rejected at the
@@ -299,4 +355,131 @@ func TestMTLSMiddleware_RevokedCertRejected(t *testing.T) {
 	mw2.ServeHTTP(rec2, req2)
 	assert.Equal(t, http.StatusOK, rec2.Code)
 	assert.True(t, called, "a non-revoked agent cert must reach AgentService")
+}
+
+// TestMTLSMiddleware_RealCacheRevokesByFingerprint pins WS12 #3: the production
+// crl.Cache (not the fakeRevocation stub) rejects a cert whose real DER
+// fingerprint was revoked, and the match is over the EXACT DER. "Revoked" is
+// sourced via ca.FingerprintFromCert into a real Store, never from the value the
+// middleware computes.
+func TestMTLSMiddleware_RealCacheRevokesByFingerprint(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	revokedCert, revokedTLS := newRealAgentCert(t)
+	fp := ca.FingerprintFromCert(revokedCert)
+	cache := loadedCacheWithRevoked(t, now, fp)
+
+	called := false
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true })
+	mw := MTLSMiddleware(inner, cache, newTestLogger())
+
+	// correct: revoked fp → 403, inner NOT reached.
+	req := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req.TLS = revokedTLS
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "the real Cache must reject a cert whose DER fingerprint is revoked")
+	assert.False(t, called)
+
+	// ABSENT: a different non-revoked agent cert through the SAME cache → 200
+	// (the gate keys on the actual fingerprint, not a blanket deny).
+	called = false
+	_, otherTLS := newRealAgentCert(t)
+	req2 := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req2.TLS = otherTLS
+	rec2 := httptest.NewRecorder()
+	mw.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	assert.True(t, called, "a non-revoked cert through a loaded cache must be admitted")
+
+	// present-but-WRONG (tampered cert): the same revoked cert with one DER byte
+	// flipped → its fingerprint no longer matches the revoked entry → admitted
+	// (proves the match is over the exact DER, not a prefix/length check). The
+	// in-memory URIs are intact, so peer-class still passes.
+	called = false
+	tampered := *revokedCert
+	tampered.Raw = append([]byte(nil), revokedCert.Raw...)
+	tampered.Raw[len(tampered.Raw)-1] ^= 0xFF
+	req3 := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req3.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{&tampered}}
+	rec3 := httptest.NewRecorder()
+	mw.ServeHTTP(rec3, req3)
+	assert.Equal(t, http.StatusOK, rec3.Code, "flipping a DER byte changes the fingerprint so it no longer matches the revoked entry")
+
+	// present-but-WRONG (tampered seed): a flipped fingerprint string seeded into
+	// the CRL can never equal a real cert's fingerprint, so the unflipped cert is
+	// admitted — proves the binding is the exact fingerprint, sourced from intent.
+	flipped := []byte(fp)
+	flipped[len(flipped)-1] ^= 0xFF // any mutation makes the seed differ from every real fingerprint
+	cacheBadSeed := loadedCacheWithRevoked(t, now, string(flipped))
+	called = false
+	mw4 := MTLSMiddleware(inner, cacheBadSeed, newTestLogger())
+	req4 := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req4.TLS = revokedTLS
+	rec4 := httptest.NewRecorder()
+	mw4.ServeHTTP(rec4, req4)
+	assert.Equal(t, http.StatusOK, rec4.Code, "a tampered seed fingerprint matches no real cert → admitted")
+}
+
+// TestMTLSMiddleware_NotLoadedCacheFailsClosed is the RED→GREEN pivot for
+// WS12 #1/#4 at the middleware seam: a never-loaded (or only-errored) CRL cache
+// cannot prove a cert is unrevoked, so the middleware must fail CLOSED. RED
+// today (an empty cache reports IsRevoked==false → admits).
+func TestMTLSMiddleware_NotLoadedCacheFailsClosed(t *testing.T) {
+	now := time.Unix(1_000_000, 0)
+	agent := mtls.PeerClassAgent
+
+	// never-loaded cache: Refresh never called → Loaded()==false.
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	notLoaded := crl.NewCache(crl.NewStore(rdb, crl.WithClock(func() time.Time { return now })), newTestLogger())
+	require.False(t, notLoaded.Loaded())
+
+	called := false
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true })
+	mw := MTLSMiddleware(inner, notLoaded, newTestLogger())
+	req := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req.TLS = fakeTLSStateWithPeerClass(t, "device-1", &agent)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusForbidden, rec.Code, "a not-yet-loaded CRL must fail closed — cannot prove the cert is unrevoked")
+	assert.False(t, called, "an unloaded CRL must not admit")
+
+	// loaded-but-empty cache → admits (a genuinely empty CRL still admits).
+	called = false
+	loadedEmpty := loadedCacheWithRevoked(t, now)
+	mw2 := MTLSMiddleware(inner, loadedEmpty, newTestLogger())
+	req2 := httptest.NewRequest(http.MethodGet, "/api", nil)
+	req2.TLS = fakeTLSStateWithPeerClass(t, "device-1", &agent)
+	rec2 := httptest.NewRecorder()
+	mw2.ServeHTTP(rec2, req2)
+	assert.Equal(t, http.StatusOK, rec2.Code, "a loaded-but-empty CRL must still admit non-revoked certs")
+	assert.True(t, called)
+}
+
+// TestMTLSMiddleware_NilRevocationChecker pins WS12 #4: a bare nil checker fails
+// closed; only the explicit, typed NoopRevocationChecker admits without a real
+// CRL. RED today (a nil checker is silently skipped → admits).
+func TestMTLSMiddleware_NilRevocationChecker(t *testing.T) {
+	agent := mtls.PeerClassAgent
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+
+	// bare nil → fail closed (403).
+	mwNil := MTLSMiddleware(inner, nil, newTestLogger())
+	reqNil := httptest.NewRequest(http.MethodGet, "/api", nil)
+	reqNil.TLS = fakeTLSStateWithPeerClass(t, "device-1", &agent)
+	recNil := httptest.NewRecorder()
+	mwNil.ServeHTTP(recNil, reqNil)
+	assert.Equal(t, http.StatusForbidden, recNil.Code, "a bare nil checker must fail closed, never silently admit")
+
+	// explicit NoopRevocationChecker → admits non-revoked (typed dev opt-out).
+	called := false
+	innerOK := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true })
+	mwNoop := MTLSMiddleware(innerOK, NoopRevocationChecker{}, newTestLogger())
+	reqNoop := httptest.NewRequest(http.MethodGet, "/api", nil)
+	reqNoop.TLS = fakeTLSStateWithPeerClass(t, "device-1", &agent)
+	recNoop := httptest.NewRecorder()
+	mwNoop.ServeHTTP(recNoop, reqNoop)
+	assert.Equal(t, http.StatusOK, recNoop.Code, "the explicit NoopRevocationChecker is the dev opt-out and admits non-revoked")
+	assert.True(t, called)
 }

--- a/internal/mtls/peer_class.go
+++ b/internal/mtls/peer_class.go
@@ -1,8 +1,10 @@
 package mtls
 
 import (
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -159,6 +161,95 @@ func RequirePeerClass(logger *slog.Logger, allowed ...PeerClass) func(http.Handl
 			}
 			next.ServeHTTP(w, r)
 		})
+	}
+}
+
+// RevocationChecker reports whether a peer cert (by SHA-256 DER fingerprint) is
+// revoked, and whether the revocation list has loaded at least once. The
+// gateway's *crl.Cache satisfies it structurally. This interface lives in mtls
+// (not handler) so the internal-listener wrappers here can consult the CRL
+// without importing handler — handler imports mtls, so the reverse would be an
+// import cycle.
+//
+// A nil checker, or one whose Loaded() is false, is treated as FAIL-CLOSED:
+// without a loaded list we cannot prove the cert is unrevoked, so we reject. The
+// only no-CRL path is an explicit NoopRevocationChecker, which the caller logs
+// at WARN — never a bare nil.
+type RevocationChecker interface {
+	IsRevoked(fingerprint string) bool
+	Loaded() bool
+}
+
+// NoopRevocationChecker is the explicit, typed dev-only opt-out from the
+// revocation gate: nothing revoked, always loaded. Use it ONLY where there is
+// genuinely no CRL (a no-Valkey dev control server) and log at WARN where wired.
+// It is deliberately distinct from a bare nil (which fails closed) so disabling
+// revocation is a visible, intentional choice in the code.
+type NoopRevocationChecker struct{}
+
+// IsRevoked always returns false.
+func (NoopRevocationChecker) IsRevoked(string) bool { return false }
+
+// Loaded always returns true.
+func (NoopRevocationChecker) Loaded() bool { return true }
+
+// fingerprintFromCert returns hex(sha256(cert.Raw)), matching
+// ca.FingerprintFromCert. Reimplemented here (rather than imported) because ca
+// imports mtls — see RevocationChecker. Empty for a nil cert (fails safe: an
+// empty fingerprint matches no revoked entry, and nil certs are already rejected
+// upstream by the peer-class / TLS checks).
+func fingerprintFromCert(cert *x509.Certificate) string {
+	if cert == nil {
+		return ""
+	}
+	sum := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// RequirePeerClassNotRevoked is RequirePeerClass plus a fail-closed CRL gate, for
+// the internal mTLS listeners (control's InternalService, gateway's control-class
+// GatewayService). After the peer-class checks pass it consults the revocation
+// list, so a revoked gateway/control cert is rejected at connect time rather
+// than usable until its natural expiry (WS12 #2). Health endpoints bypass as in
+// RequirePeerClass.
+//
+// Revocation is ADDITIVE: a wrong-class cert is still rejected first by the
+// peer-class check. A nil/unloaded checker fails closed (403) — pass an explicit
+// NoopRevocationChecker (logged at WARN) to run without a CRL.
+func RequirePeerClassNotRevoked(logger *slog.Logger, revocation RevocationChecker, allowed ...PeerClass) func(http.Handler) http.Handler {
+	peerClass := RequirePeerClass(logger, allowed...)
+	return func(next http.Handler) http.Handler {
+		// Wrap the existing peer-class middleware so class is enforced FIRST,
+		// then revocation. The revocation check sees only requests that already
+		// passed the class gate (and the health bypass).
+		revocationGate := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/health" || r.URL.Path == "/ready" {
+				next.ServeHTTP(w, r)
+				return
+			}
+			// r.TLS and PeerCertificates are guaranteed non-nil here:
+			// RequirePeerClass rejected a nil r.TLS / class-less cert before
+			// delegating to this handler.
+			if revocation == nil || !revocation.Loaded() {
+				if logger != nil {
+					logger.Warn("internal mTLS rejected: certificate revocation unavailable (fail-closed)",
+						"remote_addr", r.RemoteAddr, "path", r.URL.Path, "checker_nil", revocation == nil)
+				}
+				http.Error(w, "client certificate revocation unavailable", http.StatusForbidden)
+				return
+			}
+			fp := fingerprintFromCert(r.TLS.PeerCertificates[0])
+			if revocation.IsRevoked(fp) {
+				if logger != nil {
+					logger.Warn("internal mTLS rejected: certificate revoked",
+						"remote_addr", r.RemoteAddr, "path", r.URL.Path)
+				}
+				http.Error(w, "client certificate revoked", http.StatusForbidden)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+		return peerClass(revocationGate)
 	}
 }
 

--- a/internal/mtls/peer_class_test.go
+++ b/internal/mtls/peer_class_test.go
@@ -1,16 +1,71 @@
 package mtls
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"io"
 	"log/slog"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
+
+// fakeRev is a RevocationChecker with a fixed revoked-set and loaded flag.
+type fakeRev struct {
+	revoked map[string]bool
+	loaded  bool
+}
+
+func (f fakeRev) IsRevoked(fp string) bool { return f.revoked[fp] }
+func (f fakeRev) Loaded() bool             { return f.loaded }
+
+// realCertWithClass builds a real x509 cert (populated .Raw) carrying the given
+// peer-class SPIFFE URI, so the revocation gate's DER fingerprint is meaningful.
+func realCertWithClass(t *testing.T, class PeerClass) *x509.Certificate {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	u, err := PeerClassURI(class)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		URIs:         []*url.URL{u},
+		NotBefore:    time.Unix(1_000_000, 0),
+		NotAfter:     time.Unix(2_000_000_000, 0),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}
+
+// indepFingerprint computes hex(sha256(DER)) via an INDEPENDENT code path from
+// the middleware's fingerprintFromCert, so a bug in the latter (e.g. a wrong
+// hash) is caught rather than masked — "wrong" is sourced from intent.
+func indepFingerprint(cert *x509.Certificate) string {
+	sum := sha256.Sum256(cert.Raw)
+	return hex.EncodeToString(sum[:])
+}
 
 func mustURL(t *testing.T, s string) *url.URL {
 	t.Helper()
@@ -124,6 +179,71 @@ func TestRequirePeerClass_HealthBypass(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRequirePeerClassNotRevoked_RejectsRevokedFingerprint pins WS12 #2: the
+// CRL-consulting wrapper for the internal mTLS listeners. Peer-class is enforced
+// FIRST (additive, not replaced), then revocation; a nil/unloaded checker fails
+// closed; the match is the exact DER fingerprint; health bypasses.
+func TestRequirePeerClassNotRevoked_RejectsRevokedFingerprint(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	gwCert := realCertWithClass(t, PeerClassGateway)
+	revokedFP := indepFingerprint(gwCert) // sourced independently of the middleware
+
+	callWith := func(rev RevocationChecker, cert *x509.Certificate, path string) int {
+		h := RequirePeerClassNotRevoked(logger, rev, PeerClassGateway)(next)
+		req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(""))
+		if cert != nil {
+			req.TLS = &tls.ConnectionState{PeerCertificates: []*x509.Certificate{cert}}
+		}
+		rr := httptest.NewRecorder()
+		h.ServeHTTP(rr, req)
+		return rr.Code
+	}
+
+	loaded := func(fps ...string) fakeRev {
+		set := map[string]bool{}
+		for _, fp := range fps {
+			set[fp] = true
+		}
+		return fakeRev{revoked: set, loaded: true}
+	}
+
+	t.Run("gateway class, not revoked, loaded → 200", func(t *testing.T) {
+		assert.Equal(t, http.StatusOK, callWith(loaded(), gwCert, "/x"))
+	})
+	t.Run("gateway class, revoked → 403", func(t *testing.T) {
+		assert.Equal(t, http.StatusForbidden, callWith(loaded(revokedFP), gwCert, "/x"),
+			"a revoked gateway cert must be rejected at the internal listener (no ProxyGetLuksKey/LPS)")
+	})
+	t.Run("wrong class rejected first (peer-class is additive)", func(t *testing.T) {
+		controlCert := realCertWithClass(t, PeerClassControl)
+		// Even with an empty revocation set, a control-class cert on a
+		// gateway-only listener is 403 from the peer-class gate.
+		assert.Equal(t, http.StatusForbidden, callWith(loaded(), controlCert, "/x"))
+	})
+	t.Run("byte-tampered seed → real cert admitted (exact-fingerprint binding)", func(t *testing.T) {
+		flipped := []byte(revokedFP)
+		flipped[len(flipped)-1] ^= 0xFF
+		assert.Equal(t, http.StatusOK, callWith(loaded(string(flipped)), gwCert, "/x"),
+			"a tampered seed fingerprint matches no real cert → admitted")
+	})
+	t.Run("not-loaded cache fails closed even for a non-revoked cert", func(t *testing.T) {
+		assert.Equal(t, http.StatusForbidden, callWith(fakeRev{loaded: false}, gwCert, "/x"),
+			"an unloaded CRL must fail closed on the internal listener too")
+	})
+	t.Run("nil checker fails closed", func(t *testing.T) {
+		assert.Equal(t, http.StatusForbidden, callWith(nil, gwCert, "/x"),
+			"a bare nil checker must fail closed, never silently admit")
+	})
+	t.Run("health bypasses with no cert", func(t *testing.T) {
+		for _, p := range []string{"/health", "/ready"} {
+			assert.Equal(t, http.StatusOK, callWith(fakeRev{loaded: false}, nil, p),
+				"%s must bypass both peer-class and revocation", p)
+		}
+	})
 }
 
 // TestRequirePeerClass_RejectsMissingTLS asserts a request without


### PR DESCRIPTION
WS12 of the SECURITY_HARDENING_WORKPLAN — hardening on top of the base CRL plane (PR #389). Server-only; no proto/sqlc/web changes. RED-first throughout.

## Findings (manchtools/power-manage-server#424)

| # | sev | what |
|---|-----|------|
| 1 | med | **Gateway boot now fails CLOSED.** An initial `crl.Cache` refresh failure used to log-and-continue `ListenAndServeTLS` with an empty list → revoked certs admitted at boot when Valkey was down. Extracted a testable `loadInitialCRL` helper (bounded retry, honours SIGTERM) that returns fatal; `main()` `os.Exit(1)`s. |
| 4 | info | **`MTLSMiddleware` fails CLOSED** on a nil OR not-yet-loaded checker (was a silent `if revocation != nil` skip). The only no-CRL path is the explicit, typed `NoopRevocationChecker` (logged at WARN) — never a bare nil. |
| 1/3 | — | `crl.Cache.Loaded()` readiness: false on a brand-new cache and after an only-errored refresh, true after the first successful one (sticky/fail-static). Distinguishes "never loaded" from "loaded, empty". Real-`Cache`↔middleware integration now tested by exact DER fingerprint (replacing the `fakeRevocation` stub). |
| 2 | low | **Internal mTLS listeners consult the CRL.** New `mtls.RequirePeerClassNotRevoked` (peer-class first, then fail-closed revocation gate) wired onto control's `InternalService` and the gateway's control-class `GatewayService`, so a revoked gateway/control cert is rejected at connect time, not usable until natural expiry. Control's Valkey subsystem loads a `crl.Cache` synchronously and **fails the subsystem on initial-load error** (mirrors the gateway boot). |

The `RevocationChecker` interface + `NoopRevocationChecker` were consolidated into `mtls` (the duplicate in `handler` removed); `mtls` can't import `handler`/`ca` (cycle), so it computes `hex(sha256(DER))` inline.

## Tests (RED-first)
- `crl_test.go`: `Loaded()` three-state (never-loaded / loaded-empty / loaded-then-stale).
- `agent_middleware_test.go`: real-cache revoke-by-fingerprint (revoked→403, different→200, byte-flipped cert/seed→200); not-loaded→403 / loaded-empty→200; bare-nil→403 / Noop→200. The not-loaded + nil cases were RED (admitted 200) before the fail-closed block.
- `peer_class_test.go`: `RequirePeerClassNotRevoked` — revoked→403, non-revoked→200, wrong-class-first, tampered-seed→admitted, nil/unloaded→403, health bypass. Fingerprints sourced independently of the middleware's own helper.
- `main_crl_test.go`: boot helper — success→nil+Loaded; backend-down→fatal error+not-loaded; cancelled-ctx aborts.

## ⚠️ Operational note
The gateway, and the control internal subsystem, now **refuse to start if the CRL cannot load at boot** (Valkey unavailable). This is intentional fail-closed behaviour; documented in the gateway/control READMEs. ADR 0016 records the decisions.

## Verification
`go vet ./...` clean; full `go test ./...` green; gofmt clean; local CodeRabbit review: no findings.

The carried-forward "concurrent-renewal version-guard / CAS" item (2026-06-10 audit) is a separate verification task, not a WS12 finding — not addressed here.

Closes #424.