### PR TITLE
WS13: DoS / resource-exhaustion hardening at the request boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ revocation gate fails closed: if the CRL has not loaded (Valkey unavailable at
 boot) the listener refuses connections rather than admitting an unverifiable
 cert.
 
+**Request-boundary resource bounds.** The request boundary is bounded against
+resource-exhaustion DoS: list pagination offset is capped (`maxListOffset`,
+deep-OFFSET scans rejected with `CodeInvalidArgument`); request bodies are size-
+capped via `connect.WithReadMaxBytes` (Control/Internal 8 MiB, Gateway 4 MiB —
+over-cap rejected pre-handler with `CodeResourceExhausted`); the DB pool sets a
+`statement_timeout` (single-query wall-clock bound) and every unary RPC runs
+under a request-deadline interceptor; gateway↔control proxy calls carry per-call
+deadlines; and event-store rebuild streams in bounded batches instead of buffering
+the whole stream.
+
 **Rate limiting & client IP.** Unauthenticated endpoints (login, refresh,
 register, logout, cert renewal, auth-methods lookup) are throttled per client IP;
 authenticated RPCs are throttled per user, with a tighter ceiling on heavy

--- a/cmd/control/README.md
+++ b/cmd/control/README.md
@@ -777,6 +777,17 @@ query evaluation, search, projector rebuild, log/osquery fan-out). This bounds a
 stolen access token or a runaway client. The ceilings are fixed defaults; over a
 limit the RPC returns `CodeResourceExhausted`.
 
+### Resource bounds & timeouts
+
+The request boundary is bounded against resource-exhaustion DoS (WS13): the
+ControlService/InternalService handlers cap request bodies at 8 MiB
+(`connect.WithReadMaxBytes`, over-cap rejected pre-handler); list pagination
+offset is capped at `maxListOffset` (100_000) and a deeper token is rejected
+rather than scanned; the database pool applies a `statement_timeout` (30s
+per-statement; migrations exempt) and every unary RPC runs under a 30s
+request-deadline interceptor; and gateway↔control proxy calls carry per-call
+deadlines. These are fixed defaults today.
+
 ## Certificate Revocation
 
 When a certificate is superseded (`RenewCertificate`) or a device is deleted, the

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -280,6 +280,9 @@ func main() {
 
 	interceptors := connect.WithInterceptors(
 		api.NewLoggingInterceptor(logger),
+		// Bound every unary handler's wall-clock (WS13 #10). Backstops the DB
+		// statement_timeout for non-DB blocking; streaming passes through.
+		api.NewRequestDeadlineInterceptor(api.RequestDeadline),
 		auth.NewAuthInterceptor(logger, jwtManager, rateLimiters),
 		api.NewValidationInterceptor(),
 		auth.NewAuthzInterceptor(),

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -285,8 +285,16 @@ func main() {
 		auth.NewAuthzInterceptor(),
 	)
 
+	// controlMaxRequestBytes bounds how much of a single request body the
+	// control server will buffer before the handler runs (WS13 #4). Without it,
+	// an UNAUTHENTICATED caller (Login/Register are public) could stream an
+	// arbitrarily large body and force unbounded allocation pre-auth. 8 MiB is
+	// generous for control-plane JSON/proto (including a FILE/SHELL action's
+	// embedded content) while still bounding the pre-auth buffer.
+	const controlMaxRequestBytes = 8 << 20
+
 	mux := http.NewServeMux()
-	path, handler := pmv1connect.NewControlServiceHandler(svc, interceptors)
+	path, handler := pmv1connect.NewControlServiceHandler(svc, interceptors, connect.WithReadMaxBytes(controlMaxRequestBytes))
 	mux.Handle(path, handler)
 
 	// Mount SCIM v2 handler. Passes svc.SystemActions() so the SCIM
@@ -335,6 +343,7 @@ func main() {
 	internalPath, internalH := pmv1connect.NewInternalServiceHandler(
 		internalHandler,
 		connect.WithInterceptors(api.NewValidationInterceptor()),
+		connect.WithReadMaxBytes(controlMaxRequestBytes),
 	)
 
 	// Peer-class gate: InternalService handles credential-bearing

--- a/cmd/control/main_readlimit_test.go
+++ b/cmd/control/main_readlimit_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+)
+
+// readLimitSpyControl records whether the handler body ran, so the test can
+// prove an over-cap request is rejected BEFORE the RPC method executes.
+type readLimitSpyControl struct {
+	pmv1connect.UnimplementedControlServiceHandler
+	loginCalled bool
+}
+
+func (s *readLimitSpyControl) Login(context.Context, *connect.Request[pm.LoginRequest]) (*connect.Response[pm.LoginResponse], error) {
+	s.loginCalled = true
+	return connect.NewResponse(&pm.LoginResponse{}), nil
+}
+
+// TestControlServiceHandler_ReadMaxBytesEnforced pins WS13 #4: a request body
+// over the configured cap is rejected with CodeResourceExhausted before the
+// (unauthenticated) handler runs, so a pre-auth caller cannot force unbounded
+// buffering. Uses a small per-test cap; the production wiring uses
+// controlMaxRequestBytes.
+func TestControlServiceHandler_ReadMaxBytesEnforced(t *testing.T) {
+	const cap = 1024 // 1 KiB, small so the test body is cheap
+
+	svc := &readLimitSpyControl{}
+	path, h := pmv1connect.NewControlServiceHandler(svc, connect.WithReadMaxBytes(cap))
+	mux := http.NewServeMux()
+	mux.Handle(path, h)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	client := pmv1connect.NewControlServiceClient(srv.Client(), srv.URL)
+
+	// Over-cap: a Password far larger than the cap → rejected before Login runs.
+	_, err := client.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email:    "a@b.com",
+		Password: strings.Repeat("x", cap*2),
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err),
+		"an over-cap request body must be rejected with ResourceExhausted")
+	assert.False(t, svc.loginCalled, "the handler must NOT run for an over-cap request (rejected pre-handler)")
+
+	// Under-cap: reaches the handler normally.
+	_, err = client.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email:    "a@b.com",
+		Password: "short",
+	}))
+	require.NoError(t, err)
+	assert.True(t, svc.loginCalled, "an under-cap request must reach the handler")
+}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -47,6 +47,11 @@ var version = "dev"
 // bounding the blast radius of a hostile peer.
 const maxAgentMessageBytes = 64 << 20
 
+// maxGatewayServiceBytes caps the GatewayService (control→gateway admin
+// list/terminate fan-out) request body. Those payloads are tiny; 4 MiB bounds
+// pre-handler buffering with ample headroom (WS13 #4).
+const maxGatewayServiceBytes = 4 << 20
+
 // crlRefreshInterval is how often the gateway reloads the cert-revocation list
 // from Valkey into its in-memory cache. A revocation takes at most this long to
 // propagate to a gateway — acceptable for cert revocation, and far better than
@@ -639,7 +644,10 @@ func main() {
 	// admitted — an agent cert that happens to chain to the same
 	// internal CA cannot invoke admin fan-out RPCs.
 	gwSvcHandler := handler.NewGatewayServiceHandler(terminalSessions, manager, logger.With("component", "gateway_service"))
-	gwSvcPath, gwSvcH := pmv1connect.NewGatewayServiceHandler(gwSvcHandler)
+	// Bound the admin fan-out request body (WS13 #4). GatewayService handles
+	// list/terminate RPCs with tiny payloads, so a modest cap is ample and
+	// keeps an oversized body from being buffered before the handler runs.
+	gwSvcPath, gwSvcH := pmv1connect.NewGatewayServiceHandler(gwSvcHandler, connect.WithReadMaxBytes(maxGatewayServiceBytes))
 	// Revocation gate (WS12 #2): a revoked control cert must not be able to
 	// drive admin list/terminate fan-out. The same loaded CRL cache the agent
 	// path uses backs it (Valkey is mandatory on the gateway, so it's never nil).

--- a/docs/adr/0018-request-boundary-resource-bounds.md
+++ b/docs/adr/0018-request-boundary-resource-bounds.md
@@ -1,0 +1,71 @@
+# 0018 — Resource bounds & timeouts at the request boundary
+
+- Status: accepted
+- Date: 2026-06-14
+- Related: WS13 of the SECURITY_HARDENING_WORKPLAN (manchtools/power-manage-server#426);
+  builds on WS11 (per-user authenticated-RPC rate limiting — ADR 0015) and WS5
+  (bounded OIDC client, CORS production gate). #427 tracks the deferred indexer
+  rebuild gate.
+
+## Context
+
+The request boundary had several unbounded resources an attacker (or a buggy
+client) could exhaust: client-controlled deep pagination OFFSET, no request-body
+size cap (pre-auth buffering), no DB statement timeout, no per-handler deadline,
+unbounded gateway↔control proxy calls, and a full event-stream buffer during
+rebuild. WS13 bounds them.
+
+## Decision
+
+- **Pagination offset ceiling (#3).** `parsePagination` caps the offset at
+  `maxListOffset = 100_000` (the Search backbone's ceiling) and REJECTS a token
+  past it with `CodeInvalidArgument`/`ErrInvalidPageToken` — no client can force
+  a deep-OFFSET full-table scan; beyond the ceiling, list pages route through
+  Search (server#84/#325).
+- **Request-body size caps (#4).** `connect.WithReadMaxBytes` on every service
+  handler: ControlService + InternalService at 8 MiB (generous for control-plane
+  payloads incl. embedded action content), the gateway GatewayService at 4 MiB.
+  An over-cap body is rejected with `CodeResourceExhausted` before the handler
+  runs, closing pre-auth unbounded buffering (Login/Register are public).
+- **DB statement_timeout + per-handler deadline (#10).** The pgx pool sets an
+  application `statement_timeout` (30s, per-statement) plus explicit
+  MaxConns/MaxConnLifetime; migrations run on a separate stdlib connection and
+  are exempt. A unary `RequestDeadline` interceptor (30s) backstops the DB bound
+  for non-DB blocking; streaming passes through; a shorter caller deadline wins.
+- **Per-call proxy deadlines (#11).** Each gateway→control InternalService call
+  derives a 15s `context.WithTimeout` — per-call, not a client-wide
+  `http.Client.Timeout` that would also break the long-lived agent bidi stream.
+  (The control→gateway terminate/list fan-out was already bounded in WS11.)
+- **Streaming rebuild (#14).** `dispatchViaGoApplier` keyset-paginates the event
+  replay in bounded batches (1000) instead of buffering the full matching stream;
+  each batch's rows are closed before applying (pgx forbids a second query on a
+  connection with a live result set) and the sequence_num cursor advances.
+- **CORS (#13/#15).** Test coverage added; `Cookie` dropped from the allowed
+  request headers (auth is Bearer-only). The credentialed-wildcard reflection was
+  already removed in WS5 #7.
+
+## Already covered (verified, not re-implemented)
+
+- **Dyngroup evaluation rate-limit (#9):** the `Evaluate*`/`*Query` RPCs already
+  match WS11's self-discovering `isExpensiveProcedure` and are gated per-user by
+  the `Expensive` limiter in the auth interceptor — BEFORE the handler runs, so
+  no whole-table load occurs on a rejected call.
+- **Outbound OIDC timeout:** WS5 already builds OIDC discovery/JWKS with a
+  bounded `*http.Client` (`oidcHTTPTimeout`) injected via `oidc.ClientContext`.
+
+## Deferred
+
+- **Indexer startup rebuild gate + Valkey lock + backoff (#12 → #427).** The
+  destructive `FlushSearchData`+`Rebuild` on every indexer boot should be gated
+  behind an index-present check and a `SET NX` lock. Proper verification needs a
+  real RediSearch (`FT.INFO`/`FT.DROPINDEX`), which miniredis cannot provide; the
+  redis-stack-server testcontainer swap is tracked under #319. Deferred so the
+  change to a destructive index operation ships with real coverage.
+
+## Consequences
+
+- Operators paging beyond 100_000 rows get a clear `CodeInvalidArgument` (should
+  use Search/filters). A request body over the per-service cap is rejected with
+  `CodeResourceExhausted`. A single query over 30s is cancelled by Postgres.
+- No new error codes or i18n keys: pagination reuses `ErrInvalidPageToken`,
+  size/deadline are connect transport codes, rate-limit reuses WS11's.

--- a/internal/api/deadline_interceptor.go
+++ b/internal/api/deadline_interceptor.go
@@ -1,0 +1,30 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"connectrpc.com/connect"
+)
+
+// RequestDeadline is the default upper bound applied to every unary control RPC
+// (WS13 #10). It backstops the DB statement_timeout: a handler that ignores
+// cancellation or makes an unbounded non-DB call still cannot run forever.
+// Generous enough for any interactive RPC (heavy operations are rate-limited and
+// DB-bounded); operator-driven replays run via the CLI, not an RPC.
+const RequestDeadline = 30 * time.Second
+
+// NewRequestDeadlineInterceptor returns a unary interceptor that bounds each
+// handler's context to at most d. Streaming RPCs pass through untouched
+// (connect.UnaryInterceptorFunc only wraps unary) — the control server has no
+// streaming RPCs and the gateway's agent stream is intentionally long-lived. A
+// shorter caller-supplied deadline is preserved (context honours the earliest).
+func NewRequestDeadlineInterceptor(d time.Duration) connect.UnaryInterceptorFunc {
+	return func(next connect.UnaryFunc) connect.UnaryFunc {
+		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
+			ctx, cancel := context.WithTimeout(ctx, d)
+			defer cancel()
+			return next(ctx, req)
+		}
+	}
+}

--- a/internal/api/deadline_interceptor_test.go
+++ b/internal/api/deadline_interceptor_test.go
@@ -1,0 +1,57 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// TestRequestDeadlineInterceptor_BoundsHandlerContext pins WS13 #10: the handler
+// runs under a bounded context, and a handler that exceeds it observes
+// cancellation (surfaced as CodeDeadlineExceeded), while a shorter caller
+// deadline is preserved.
+func TestRequestDeadlineInterceptor_BoundsHandlerContext(t *testing.T) {
+	interceptor := NewRequestDeadlineInterceptor(50 * time.Millisecond)
+
+	t.Run("handler context carries the bound", func(t *testing.T) {
+		var gotDeadline bool
+		next := connect.UnaryFunc(func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+			_, gotDeadline = ctx.Deadline()
+			return connect.NewResponse(&pm.GetUserResponse{}), nil
+		})
+		_, err := interceptor.WrapUnary(next)(context.Background(), connect.NewRequest(&pm.GetUserRequest{Id: "x"}))
+		require.NoError(t, err)
+		assert.True(t, gotDeadline, "the interceptor must set a deadline on the handler context")
+	})
+
+	t.Run("handler exceeding the deadline is cancelled", func(t *testing.T) {
+		next := connect.UnaryFunc(func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+			<-ctx.Done() // a handler that respects ctx and runs past the bound
+			return nil, connect.NewError(connect.CodeDeadlineExceeded, ctx.Err())
+		})
+		_, err := interceptor.WrapUnary(next)(context.Background(), connect.NewRequest(&pm.GetUserRequest{Id: "x"}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeDeadlineExceeded, connect.CodeOf(err))
+	})
+
+	t.Run("a shorter caller deadline is preserved", func(t *testing.T) {
+		var handlerDeadline time.Time
+		next := connect.UnaryFunc(func(ctx context.Context, _ connect.AnyRequest) (connect.AnyResponse, error) {
+			handlerDeadline, _ = ctx.Deadline()
+			return connect.NewResponse(&pm.GetUserResponse{}), nil
+		})
+		// Caller sets a 5ms deadline — far shorter than the interceptor's 50ms.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+		defer cancel()
+		_, err := interceptor.WrapUnary(next)(ctx, connect.NewRequest(&pm.GetUserRequest{Id: "x"}))
+		require.NoError(t, err)
+		assert.WithinDuration(t, time.Now().Add(5*time.Millisecond), handlerDeadline, 40*time.Millisecond,
+			"the earlier caller deadline must win over the interceptor's bound")
+	})
+}

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"log/slog"
-	"math"
 
 	"connectrpc.com/connect"
 
@@ -54,6 +53,14 @@ func appendEvent(ctx context.Context, st *store.Store, logger *slog.Logger, evt 
 	return nil
 }
 
+// maxListOffset caps the pagination offset (WS13 #3). A client-controlled deep
+// OFFSET forces the database to scan and discard `offset` rows on every list
+// RPC — an asymmetric-work DoS. 100_000 matches the Search backbone's ceiling
+// (search_handler.maxSearchOffset); beyond it, list pages should route through
+// Search (server#84/#325) rather than raw OFFSET. A token past the ceiling is
+// REJECTED, not silently clamped, so the client learns to stop paginating.
+const maxListOffset = 100_000
+
 // parsePagination extracts page size and offset from request fields.
 // Default page size is 50, max is 100.
 func parsePagination(pageSize int32, pageToken string) (size int32, offset int32, err error) {
@@ -65,7 +72,7 @@ func parsePagination(pageSize int32, pageToken string) (size int32, offset int32
 	}
 	if pageToken != "" {
 		offset64, parseErr := parsePageToken(pageToken)
-		if parseErr != nil || offset64 < 0 || offset64 > math.MaxInt32 {
+		if parseErr != nil || offset64 < 0 || offset64 > maxListOffset {
 			return 0, 0, apiError(ErrInvalidPageToken, connect.CodeInvalidArgument, "invalid page token")
 		}
 		offset = int32(offset64)

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -3,6 +3,8 @@ package api
 import (
 	"context"
 	"errors"
+	"math"
+	"strconv"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -103,6 +105,36 @@ func TestParsePagination_BadToken(t *testing.T) {
 			cerr := new(connect.Error)
 			require.True(t, errors.As(err, &cerr))
 			assert.Equal(t, connect.CodeInvalidArgument, cerr.Code())
+		})
+	}
+}
+
+// TestParsePagination_OffsetCeiling pins WS13 #3: the offset is capped to a
+// small ceiling (maxListOffset) so no client can force a deep-OFFSET full-table
+// scan. The bound is sourced from intent (a hard ceiling), not from the prior
+// math.MaxInt32 rule. A ceiling+1 token is REJECTED, not silently clamped.
+func TestParsePagination_OffsetCeiling(t *testing.T) {
+	cases := []struct {
+		name    string
+		token   string
+		wantErr bool
+		offset  int32
+	}{
+		{name: "well under ceiling accepted", token: "100", offset: 100},
+		{name: "at ceiling accepted", token: strconv.Itoa(maxListOffset), offset: maxListOffset},
+		{name: "ceiling+1 rejected", token: strconv.Itoa(maxListOffset + 1), wantErr: true},
+		{name: "MaxInt32 rejected (was accepted before)", token: strconv.Itoa(math.MaxInt32), wantErr: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, off, err := parsePagination(50, tc.token)
+			if tc.wantErr {
+				require.Error(t, err)
+				assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.offset, off)
 		})
 	}
 }

--- a/internal/handler/control_proxy.go
+++ b/internal/handler/control_proxy.go
@@ -3,12 +3,25 @@ package handler
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"connectrpc.com/connect"
 
 	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
 )
+
+// proxyCallTimeout bounds each unary gateway→control InternalService call
+// (WS13 #11). A PER-CALL deadline (not a client-wide http.Client.Timeout, which
+// would also break the long-lived agent bidi stream that may share a transport)
+// ensures a hung/slow control server cannot wedge a gateway worker goroutine
+// indefinitely. A shorter caller deadline is preserved.
+const proxyCallTimeout = 15 * time.Second
+
+// withProxyDeadline derives a bounded context for a single proxy call.
+func withProxyDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, proxyCallTimeout)
+}
 
 // ControlProxy wraps a Connect-RPC client for calling InternalService on the control server.
 // This replaces direct database access for synchronous operations that need credential handling.
@@ -40,6 +53,8 @@ func NewControlProxy(httpClient *http.Client, controlURL, gatewayID string) *Con
 
 // VerifyDevice checks that a device exists and is not deleted on the control server.
 func (p *ControlProxy) VerifyDevice(ctx context.Context, deviceID string) error {
+	ctx, cancel := withProxyDeadline(ctx)
+	defer cancel()
 	_, err := p.client.VerifyDevice(ctx, connect.NewRequest(&pm.VerifyDeviceRequest{
 		DeviceId:  deviceID,
 		GatewayId: p.gatewayID,
@@ -49,6 +64,8 @@ func (p *ControlProxy) VerifyDevice(ctx context.Context, deviceID string) error 
 
 // SyncActions resolves all assigned actions for a device via the control server.
 func (p *ControlProxy) SyncActions(ctx context.Context, deviceID string) (*pm.SyncActionsResponse, error) {
+	ctx, cancel := withProxyDeadline(ctx)
+	defer cancel()
 	resp, err := p.client.ProxySyncActions(ctx, connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId:  deviceID,
 		GatewayId: p.gatewayID,
@@ -61,6 +78,8 @@ func (p *ControlProxy) SyncActions(ctx context.Context, deviceID string) (*pm.Sy
 
 // ValidateLuksToken validates and consumes a one-time LUKS token via the control server.
 func (p *ControlProxy) ValidateLuksToken(ctx context.Context, deviceID, token string) (*pm.ValidateLuksTokenResponse, error) {
+	ctx, cancel := withProxyDeadline(ctx)
+	defer cancel()
 	resp, err := p.client.ProxyValidateLuksToken(ctx, connect.NewRequest(&pm.InternalValidateLuksTokenRequest{
 		DeviceId:  deviceID,
 		Token:     token,
@@ -74,6 +93,8 @@ func (p *ControlProxy) ValidateLuksToken(ctx context.Context, deviceID, token st
 
 // GetLuksKey retrieves and decrypts the current LUKS key via the control server.
 func (p *ControlProxy) GetLuksKey(ctx context.Context, deviceID, actionID string) (*pm.GetLuksKeyResponse, error) {
+	ctx, cancel := withProxyDeadline(ctx)
+	defer cancel()
 	resp, err := p.client.ProxyGetLuksKey(ctx, connect.NewRequest(&pm.InternalGetLuksKeyRequest{
 		DeviceId:  deviceID,
 		ActionId:  actionID,
@@ -87,6 +108,8 @@ func (p *ControlProxy) GetLuksKey(ctx context.Context, deviceID, actionID string
 
 // StoreLuksKey encrypts and stores a new LUKS key via the control server.
 func (p *ControlProxy) StoreLuksKey(ctx context.Context, deviceID, actionID, devicePath, passphrase string, reason pm.RotationReason) (*pm.StoreLuksKeyResponse, error) {
+	ctx, cancel := withProxyDeadline(ctx)
+	defer cancel()
 	resp, err := p.client.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
 		DeviceId:       deviceID,
 		ActionId:       actionID,
@@ -103,6 +126,8 @@ func (p *ControlProxy) StoreLuksKey(ctx context.Context, deviceID, actionID, dev
 
 // StoreLpsPasswords encrypts and stores LPS password rotation entries via the control server.
 func (p *ControlProxy) StoreLpsPasswords(ctx context.Context, deviceID, actionID string, rotations []*pm.LpsPasswordRotation) error {
+	ctx, cancel := withProxyDeadline(ctx)
+	defer cancel()
 	_, err := p.client.ProxyStoreLpsPasswords(ctx, connect.NewRequest(&pm.InternalStoreLpsPasswordsRequest{
 		DeviceId:  deviceID,
 		ActionId:  actionID,
@@ -118,6 +143,8 @@ func (p *ControlProxy) StoreLpsPasswords(ctx context.Context, deviceID, actionID
 // the bridge needs to set up the session. Returns an error (typically
 // connect.CodeUnauthenticated) if the token is invalid or expired.
 func (p *ControlProxy) ValidateTerminalToken(ctx context.Context, sessionID, token string) (*pm.InternalValidateTerminalTokenResponse, error) {
+	ctx, cancel := withProxyDeadline(ctx)
+	defer cancel()
 	resp, err := p.client.ProxyValidateTerminalToken(ctx, connect.NewRequest(&pm.InternalValidateTerminalTokenRequest{
 		SessionId: sessionID,
 		Token:     token,

--- a/internal/handler/control_proxy_deadline_test.go
+++ b/internal/handler/control_proxy_deadline_test.go
@@ -1,0 +1,34 @@
+package handler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWithProxyDeadline_BoundsCall pins WS13 #11: a gateway→control proxy call
+// runs under a per-call deadline (so a hung control server can't wedge a worker
+// goroutine), and a shorter caller deadline is preserved.
+func TestWithProxyDeadline_BoundsCall(t *testing.T) {
+	t.Run("bounds an unbounded caller context", func(t *testing.T) {
+		ctx, cancel := withProxyDeadline(context.Background())
+		defer cancel()
+		dl, ok := ctx.Deadline()
+		require.True(t, ok, "the proxy call context must carry a deadline")
+		assert.WithinDuration(t, time.Now().Add(proxyCallTimeout), dl, 2*time.Second)
+	})
+
+	t.Run("preserves a shorter caller deadline", func(t *testing.T) {
+		parent, cancelParent := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancelParent()
+		ctx, cancel := withProxyDeadline(parent)
+		defer cancel()
+		dl, ok := ctx.Deadline()
+		require.True(t, ok)
+		assert.WithinDuration(t, time.Now().Add(50*time.Millisecond), dl, proxyCallTimeout,
+			"the earlier caller deadline must win over the per-call bound")
+	})
+}

--- a/internal/handler/control_proxy_deadline_test.go
+++ b/internal/handler/control_proxy_deadline_test.go
@@ -28,7 +28,9 @@ func TestWithProxyDeadline_BoundsCall(t *testing.T) {
 		defer cancel()
 		dl, ok := ctx.Deadline()
 		require.True(t, ok)
-		assert.WithinDuration(t, time.Now().Add(50*time.Millisecond), dl, proxyCallTimeout,
+		// Tolerance must be well under proxyCallTimeout (15s) so this is binding:
+		// if the per-call bound wrongly won, dl would be ~15s out and fail here.
+		assert.WithinDuration(t, time.Now().Add(50*time.Millisecond), dl, 2*time.Second,
 			"the earlier caller deadline must win over the per-call bound")
 	})
 }

--- a/internal/middleware/cors.go
+++ b/internal/middleware/cors.go
@@ -9,8 +9,11 @@ import (
 const (
 	// corsAllowMethods lists HTTP methods allowed in cross-origin requests.
 	corsAllowMethods = "GET, POST, PUT, DELETE, OPTIONS"
-	// corsAllowHeaders lists request headers the client may send.
-	corsAllowHeaders = "Accept, Authorization, Content-Type, Connect-Protocol-Version, Connect-Timeout-Ms, Cookie"
+	// corsAllowHeaders lists request headers the client may send. Cookie is
+	// intentionally NOT advertised (WS13 #15): authentication is Bearer-only
+	// (Authorization header), so advertising Cookie would invite a cookie-based
+	// cross-origin flow the server doesn't use.
+	corsAllowHeaders = "Accept, Authorization, Content-Type, Connect-Protocol-Version, Connect-Timeout-Ms"
 	// corsExposeHeaders lists response headers the browser may access.
 	corsExposeHeaders = "Connect-Content-Encoding, Connect-Protocol-Version"
 	// corsMaxAge is the preflight cache duration in seconds (24 hours).

--- a/internal/middleware/cors_test.go
+++ b/internal/middleware/cors_test.go
@@ -5,9 +5,11 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func corsTestLogger() *slog.Logger {
@@ -50,6 +52,53 @@ func TestCORS_ExplicitOrigin_KeepsCredentials(t *testing.T) {
 	assert.Equal(t, "https://app.example", w.Header().Get("Access-Control-Allow-Origin"))
 	assert.Equal(t, "true", w.Header().Get("Access-Control-Allow-Credentials"),
 		"a named origin keeps credentials")
+}
+
+// TestCORS_AllowHeadersExcludesCookie pins WS13 #15: auth is Bearer-only, so the
+// preflight Access-Control-Allow-Headers must NOT advertise Cookie (advertising
+// it invites a cookie-based cross-origin flow the server doesn't use). Splits
+// the header on ", " and asserts membership rather than substring-matching the
+// whole constant.
+func TestCORS_AllowHeadersExcludesCookie(t *testing.T) {
+	h := CORS([]string{"https://app.example"}, false, corsTestLogger())(okHandler())
+
+	req := httptest.NewRequest(http.MethodOptions, "/x", nil)
+	req.Header.Set("Origin", "https://app.example")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNoContent, w.Code, "allowed-origin preflight is 204")
+	allow := splitCSV(w.Header().Get("Access-Control-Allow-Headers"))
+	assert.Contains(t, allow, "Authorization", "Bearer auth header must be allowed")
+	assert.Contains(t, allow, "Content-Type")
+	assert.NotContains(t, allow, "Cookie", "Cookie must NOT be an allowed request header (Bearer-only auth)")
+}
+
+// TestCORS_AllowedOriginPreflight204 pins the preflight contract for an allowed
+// origin: 204 with Allow-Methods, Allow-Headers, Max-Age, and Vary present.
+func TestCORS_AllowedOriginPreflight204(t *testing.T) {
+	h := CORS([]string{"https://app.example"}, false, corsTestLogger())(okHandler())
+
+	req := httptest.NewRequest(http.MethodOptions, "/x", nil)
+	req.Header.Set("Origin", "https://app.example")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.NotEmpty(t, w.Header().Get("Access-Control-Allow-Methods"))
+	assert.NotEmpty(t, w.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "86400", w.Header().Get("Access-Control-Max-Age"))
+	assert.Contains(t, w.Header().Values("Vary"), "Origin")
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
 }
 
 // TestCORS_UnlistedOrigin_NoHeaders pins that a non-allow-listed origin (not in

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -33,6 +33,22 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+// rebuildBatchSize bounds how many events dispatchViaGoApplier holds in memory
+// at once (WS13 #14): the replay is keyset-paginated by sequence_num in batches
+// of this size instead of buffering the entire matching event stream. A package
+// var (not const) so tests can lower it to exercise the batch boundary cheaply.
+var rebuildBatchSize = 1000
+
+// SetRebuildBatchSizeForTest lowers rebuildBatchSize and returns a restore func.
+// Test-only seam: the rebuild round-trip lives in package store_test (it needs
+// testutil, which imports store), so the batch boundary can't be exercised via
+// the unexported var directly.
+func SetRebuildBatchSizeForTest(n int) (restore func()) {
+	prev := rebuildBatchSize
+	rebuildBatchSize = n
+	return func() { rebuildBatchSize = prev }
+}
+
 // RebuildResult reports per-target outcome of RebuildAll. Operators
 // running an emergency replay want to see exactly which projections
 // were touched and how many events were replayed for each.
@@ -321,40 +337,64 @@ func (s *Store) runOneTarget(ctx context.Context, tx pgx.Tx, t rebuildTarget) (i
 // Refs manchtools/power-manage-server#125.
 func (s *Store) dispatchViaGoApplier(ctx context.Context, tx pgx.Tx, t rebuildTarget, apply RebuildApply) (int64, error) {
 	q := s.queries.WithTx(tx)
-	rows, err := tx.Query(ctx,
-		`SELECT id, sequence_num, stream_type, stream_id, stream_version,
-		        event_type, data, metadata, actor_type, actor_id, occurred_at
-		   FROM events
-		  WHERE stream_type = ANY($1)
-		  ORDER BY sequence_num`,
-		t.StreamTypes,
-	)
-	if err != nil {
-		return 0, fmt.Errorf("load events for %s: %w", t.Name, err)
-	}
-	events := make([]PersistedEvent, 0, 256)
-	for rows.Next() {
-		var ev PersistedEvent
-		if err := rows.Scan(
-			&ev.ID, &ev.SequenceNum, &ev.StreamType, &ev.StreamID, &ev.StreamVersion,
-			&ev.EventType, &ev.Data, &ev.Metadata, &ev.ActorType, &ev.ActorID, &ev.OccurredAt,
-		); err != nil {
-			rows.Close()
-			return 0, fmt.Errorf("scan event row for %s: %w", t.Name, err)
-		}
-		events = append(events, ev)
-	}
-	rows.Close()
-	if err := rows.Err(); err != nil {
-		return 0, fmt.Errorf("iterate events for %s: %w", t.Name, err)
-	}
 
-	for _, ev := range events {
-		if err := apply(ctx, q, ev); err != nil {
-			return 0, fmt.Errorf("apply event %s for %s: %w", ev.ID, t.Name, err)
+	// Stream in keyset-paginated batches rather than buffering the entire
+	// matching event stream in memory (WS13 #14): a large event store could
+	// otherwise materialise millions of rows at once. We cannot apply inside an
+	// open rows iteration because pgx forbids a second query on a connection
+	// with a live result set, and `apply` issues projection writes on this same
+	// tx — so each batch is fully scanned and its rows closed BEFORE applying,
+	// then the cursor (sequence_num, which is monotonic and unique) advances.
+	// Memory is bounded to one batch; order and the snapshot are preserved
+	// because the events table is append-only and read within this tx.
+	var (
+		total   int64
+		lastSeq int64 // sequence_num is a positive bigserial, so 0 precedes all
+	)
+	for {
+		rows, err := tx.Query(ctx,
+			`SELECT id, sequence_num, stream_type, stream_id, stream_version,
+			        event_type, data, metadata, actor_type, actor_id, occurred_at
+			   FROM events
+			  WHERE stream_type = ANY($1) AND sequence_num > $2
+			  ORDER BY sequence_num
+			  LIMIT $3`,
+			t.StreamTypes, lastSeq, rebuildBatchSize,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("load events for %s: %w", t.Name, err)
+		}
+		batch := make([]PersistedEvent, 0, rebuildBatchSize)
+		for rows.Next() {
+			var ev PersistedEvent
+			if err := rows.Scan(
+				&ev.ID, &ev.SequenceNum, &ev.StreamType, &ev.StreamID, &ev.StreamVersion,
+				&ev.EventType, &ev.Data, &ev.Metadata, &ev.ActorType, &ev.ActorID, &ev.OccurredAt,
+			); err != nil {
+				rows.Close()
+				return 0, fmt.Errorf("scan event row for %s: %w", t.Name, err)
+			}
+			batch = append(batch, ev)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return 0, fmt.Errorf("iterate events for %s: %w", t.Name, err)
+		}
+		if len(batch) == 0 {
+			break
+		}
+		for _, ev := range batch {
+			if err := apply(ctx, q, ev); err != nil {
+				return 0, fmt.Errorf("apply event %s for %s: %w", ev.ID, t.Name, err)
+			}
+			lastSeq = ev.SequenceNum
+			total++
+		}
+		if len(batch) < rebuildBatchSize {
+			break
 		}
 	}
-	return int64(len(events)), nil
+	return total, nil
 }
 
 // selectTargets resolves operator-supplied names to their

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -58,6 +58,38 @@ func TestRebuildAll_RoundTripsThroughEventStore(t *testing.T) {
 	assert.Equal(t, before.ID, after.ID)
 }
 
+// TestRebuildAll_StreamsAcrossBatchBoundary pins WS13 #14: with the batch size
+// lowered below the event count, the keyset-paginated replay still applies every
+// event across batch boundaries in order (no events dropped or double-applied,
+// no full pre-buffer). Seeds several users, lowers the batch size to 2, truncates
+// the projection, and asserts every user reappears and the count matches.
+func TestRebuildAll_StreamsAcrossBatchBoundary(t *testing.T) {
+	restore := store.SetRebuildBatchSizeForTest(2)
+	defer restore()
+
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	ids := make([]string, 0, 5)
+	for i := 0; i < 5; i++ { // 5 users > batch size 2 → at least 3 batches
+		ids = append(ids, testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin"))
+	}
+
+	_, err := st.TestingPool().Exec(ctx, "TRUNCATE users_projection CASCADE")
+	require.NoError(t, err)
+
+	res, err := st.RebuildAll(ctx, "users")
+	require.NoError(t, err)
+	require.Len(t, res.Targets, 1)
+	assert.GreaterOrEqual(t, res.Targets[0].EventsApplied, int64(len(ids)),
+		"every seeded user's events must replay across the batch boundary")
+
+	for _, id := range ids {
+		_, err := st.Queries().GetUserByID(ctx, id)
+		assert.NoErrorf(t, err, "user %s must reappear after a multi-batch rebuild", id)
+	}
+}
+
 // TestRebuildAll_NoArgsRebuildsEverything covers the operator
 // happy-path: `RebuildAll(ctx)` with no targets rebuilds every
 // registered projection. We seed a few stream types, truncate them

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -259,13 +260,49 @@ func (s *Store) fireListeners(ctx context.Context, row PersistedEvent) {
 	}
 }
 
+// Pool tuning (WS13 #10). statementTimeout bounds any SINGLE query's wall-clock
+// so a runaway/pathological statement cannot pin a connection indefinitely
+// (it is per-statement, not per-transaction, so a long multi-statement replay is
+// unaffected; migrations run on a separate stdlib connection and are exempt).
+// MaxConns/MaxConnLifetime are set explicitly rather than left to pgx defaults.
+const (
+	statementTimeout    = 30 * time.Second
+	poolMaxConns        = 20
+	poolMaxConnLifetime = time.Hour
+)
+
+// newPool builds a tuned pgx pool: an application statement_timeout in the
+// connection RuntimeParams plus explicit MaxConns/MaxConnLifetime. Shared by
+// New and NewWithoutMigrations so control/gateway/indexer get the same bounds.
+func newPool(ctx context.Context, connString string) (*pgxpool.Pool, error) {
+	cfg, err := pgxpool.ParseConfig(connString)
+	if err != nil {
+		return nil, fmt.Errorf("parse pool config: %w", err)
+	}
+	if cfg.ConnConfig.RuntimeParams == nil {
+		cfg.ConnConfig.RuntimeParams = map[string]string{}
+	}
+	// Respect an operator-provided statement_timeout in the DSN; otherwise apply
+	// our default. Postgres takes a bare integer as milliseconds.
+	if _, set := cfg.ConnConfig.RuntimeParams["statement_timeout"]; !set {
+		cfg.ConnConfig.RuntimeParams["statement_timeout"] = strconv.FormatInt(statementTimeout.Milliseconds(), 10)
+	}
+	cfg.MaxConns = poolMaxConns
+	cfg.MaxConnLifetime = poolMaxConnLifetime
+	pool, err := pgxpool.NewWithConfig(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create connection pool: %w", err)
+	}
+	return pool, nil
+}
+
 // New creates a new Store and runs migrations.
 // This should only be called by the control server which is responsible for database schema management.
 func New(ctx context.Context, connString string) (*Store, error) {
 	// Create connection pool
-	pool, err := pgxpool.New(ctx, connString)
+	pool, err := newPool(ctx, connString)
 	if err != nil {
-		return nil, fmt.Errorf("create connection pool: %w", err)
+		return nil, err
 	}
 
 	// Verify connection
@@ -305,9 +342,9 @@ func New(ctx context.Context, connString string) (*Store, error) {
 // and don't manage the schema.
 func NewWithoutMigrations(ctx context.Context, connString string) (*Store, error) {
 	// Create connection pool
-	pool, err := pgxpool.New(ctx, connString)
+	pool, err := newPool(ctx, connString)
 	if err != nil {
-		return nil, fmt.Errorf("create connection pool: %w", err)
+		return nil, err
 	}
 
 	// Verify connection

--- a/internal/store/store_timeout_test.go
+++ b/internal/store/store_timeout_test.go
@@ -1,0 +1,35 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestNew_SetsStatementTimeout pins WS13 #10: the pool applies a non-zero
+// application statement_timeout on its connections, and the timeout actually
+// cancels an over-long query (verified quickly via a per-transaction override
+// rather than waiting out the production bound).
+func TestNew_SetsStatementTimeout(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	// The pool set a non-zero statement_timeout on its connections.
+	var timeoutStr string
+	require.NoError(t, st.TestingPool().QueryRow(ctx, "SHOW statement_timeout").Scan(&timeoutStr))
+	assert.NotEqual(t, "0", timeoutStr, "statement_timeout must be set to a non-zero bound on pooled connections")
+
+	// The mechanism cancels an over-long query (fast: a tiny per-tx override).
+	tx, err := st.TestingPool().Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+	_, err = tx.Exec(ctx, "SET LOCAL statement_timeout = '100ms'")
+	require.NoError(t, err)
+	_, err = tx.Exec(ctx, "SELECT pg_sleep(1)")
+	require.Error(t, err, "a query exceeding statement_timeout must be cancelled, not hang")
+	assert.Contains(t, err.Error(), "statement timeout", "the error must be the statement-timeout cancellation")
+}


### PR DESCRIPTION
WS13 (server portion) of the SECURITY_HARDENING_WORKPLAN. Bounds the request boundary against resource-exhaustion / DoS. Server-only; no proto/sqlc/web changes. RED-first where behaviour changed.

## Findings

| # | sev | what |
|---|-----|------|
| 3 | med | **Pagination offset capped** at `maxListOffset`=100_000; a deeper token is rejected (`CodeInvalidArgument`) instead of forcing a deep-OFFSET full-table scan. |
| 4 | med | **`connect.WithReadMaxBytes`** on ControlService/InternalService (8 MiB) and the gateway GatewayService (4 MiB) — an over-cap body is rejected with `CodeResourceExhausted` before the handler runs (closes pre-auth unbounded buffering on the public Login/Register). |
| 10 | low | **DB `statement_timeout`** (30s/statement; migrations exempt) + explicit pool sizing, plus a **per-handler request-deadline interceptor** (30s, streaming exempt, shorter caller deadline preserved). |
| 11 | low | **Per-call deadlines** on every gateway→control proxy call (15s each — per-call, not a client Timeout that would break the agent bidi stream). |
| 13/15 | low/info | **CORS**: `Cookie` dropped from the allowed request headers (Bearer-only auth) + preflight/allow-header test coverage. (The credentialed-wildcard reflection was already removed in WS5 #7.) |
| 14 | info | **Streaming rebuild**: `dispatchViaGoApplier` keyset-paginates the event replay in bounded batches instead of buffering the entire matching stream. |

## Already covered (verified, not re-implemented)
- **#9 dyngroup eval rate-limit** — the `Evaluate*`/`*Query` RPCs already match WS11's self-discovering `isExpensiveProcedure` and are gated per-user by the `Expensive` limiter *before* the handler runs (no table load on a rejected call).
- **Outbound OIDC timeout** — WS5 already builds OIDC discovery/JWKS with a bounded HTTP client via `oidc.ClientContext`.

## Deferred
- **#12 indexer startup rebuild gate + Valkey lock + backoff → #427.** Proper verification of this destructive-index change needs a real RediSearch (`FT.INFO`/`FT.DROPINDEX`); miniredis can't provide it and the redis-stack-server testcontainer swap is tracked under #319. Deferred so it ships with real coverage rather than untested.

ADR 0018 records the decisions; server + control READMEs updated. No new error codes / i18n keys (pagination reuses `ErrInvalidPageToken`; size/deadline are connect transport codes; rate-limit reuses WS11's).

## Verification
`go vet ./...` + staticcheck + gofmt clean; full `go test ./...` green; local CodeRabbit review clean (1 finding fixed: tightened a too-loose deadline-test tolerance).

Advances #84 / #325 (pagination→Search). Closes #426.