### PR TITLE
WS13 #12: gate indexer startup rebuild behind index-present check + Valkey lock

### DIFF
--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -91,20 +91,20 @@ func main() {
 	// Initialize search index (nil aqClient — indexer doesn't enqueue tasks)
 	searchIdx := search.New(rdb, st, nil, logger.With("component", "search"))
 
-	// Ensure indexes exist
-	if err := searchIdx.EnsureIndexes(ctx); err != nil {
-		logger.Error("failed to ensure search indexes", "error", err)
+	// Bring the search index up at boot WITHOUT an unconditional destructive
+	// flush on every restart (WS13 #12). If the indexes already exist we warm
+	// without flushing; only when they're missing do we flush + rebuild, and
+	// that destructive path is serialised by a Valkey lock so concurrent /
+	// crash-looping indexers can't race repeated wipes. (Rebuild creates the
+	// indexes internally via EnsureIndexes, so no separate ensure step is
+	// needed.) The present-check must run BEFORE any create, or the indexes
+	// would always look present.
+	locker := newValkeyRebuildLocker(rdb)
+	if err := startupSearchSync(ctx, searchIdx, locker, logger); err != nil {
+		logger.Error("initial search index sync failed", "error", err)
 		os.Exit(1)
 	}
-	logger.Info("search indexes ensured")
-
-	// Full rebuild from PG on startup (flushes stale data, then rewarms)
-	logger.Info("starting initial search index rebuild")
-	if err := searchIdx.Rebuild(ctx); err != nil {
-		logger.Error("initial search index rebuild failed", "error", err)
-		os.Exit(1)
-	}
-	logger.Info("initial search index rebuild complete")
+	logger.Info("search index startup sync complete")
 
 	// Start periodic reconciliation
 	if cfg.ReconcileInterval > 0 {

--- a/cmd/indexer/rebuild_gate.go
+++ b/cmd/indexer/rebuild_gate.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Indexer startup rebuild gate (WS13 #12). The indexer used to run a destructive
+// FlushSearchData + full Rebuild on EVERY boot, so a crash-loop or concurrent
+// indexers could repeatedly wipe the search index. Now:
+//   - if the indexes are already present, warm-without-flush (no destructive op);
+//   - otherwise acquire a Valkey lock so only ONE indexer flushes+rebuilds while
+//     the others warm — concurrent boots can't race repeated destructive wipes.
+const (
+	rebuildLockKey = "pm:indexer:rebuild:lock"
+	// rebuildLockTTL bounds how long a crashed lock holder blocks others. Longer
+	// than a worst-case rebuild, but finite so a crash can't wedge rebuilds
+	// forever; the holder also releases explicitly on success.
+	rebuildLockTTL = 15 * time.Minute
+)
+
+// searchGate is the subset of *search.Index the startup decision needs — a seam
+// so the gate logic is unit-testable without a real RediSearch backend.
+type searchGate interface {
+	IndexesPresent(ctx context.Context) (bool, error)
+	Warm(ctx context.Context) error
+	Rebuild(ctx context.Context) error
+}
+
+// rebuildLocker coordinates the destructive rebuild across concurrent indexers.
+type rebuildLocker interface {
+	// TryLock attempts to acquire the rebuild lock without blocking. On success
+	// it returns acquired=true and a release func; on contention acquired=false.
+	TryLock(ctx context.Context) (acquired bool, release func(), err error)
+}
+
+// startupSearchSync decides how to bring the search index up at boot WITHOUT an
+// unconditional destructive flush (WS13 #12):
+//   - indexes present            → warm only (no flush);
+//   - indexes missing, lock won  → flush + rebuild under the lock;
+//   - indexes missing, lock lost → another indexer is rebuilding, so warm only.
+//
+// IndexesPresent failing is fatal (returned) rather than treated as "missing":
+// guessing "missing" on a transient backend error would trigger an unwarranted
+// destructive flush. Fail closed.
+func startupSearchSync(ctx context.Context, gate searchGate, locker rebuildLocker, logger *slog.Logger) error {
+	present, err := gate.IndexesPresent(ctx)
+	if err != nil {
+		return fmt.Errorf("check search indexes present: %w", err)
+	}
+	if present {
+		logger.Info("search indexes already present; warming without destructive flush")
+		return gate.Warm(ctx)
+	}
+
+	acquired, release, err := locker.TryLock(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire rebuild lock: %w", err)
+	}
+	if !acquired {
+		logger.Info("another indexer holds the rebuild lock; warming without flush")
+		return gate.Warm(ctx)
+	}
+	defer release()
+
+	logger.Info("search indexes missing; performing destructive rebuild under lock")
+	return gate.Rebuild(ctx)
+}
+
+// valkeyRebuildLocker is a Valkey SET NX EX rebuild lock.
+type valkeyRebuildLocker struct {
+	rdb   *redis.Client
+	value string // unique per process so release only deletes our own lock
+}
+
+// newValkeyRebuildLocker builds a locker with a random per-process owner value.
+func newValkeyRebuildLocker(rdb *redis.Client) *valkeyRebuildLocker {
+	var b [16]byte
+	// crypto/rand.Read never returns a short read; ignore the error per its
+	// contract. A zero value would still be correct (just not unique), but a
+	// random owner makes the CAS-release robust against TTL expiry races.
+	_, _ = rand.Read(b[:])
+	return &valkeyRebuildLocker{rdb: rdb, value: hex.EncodeToString(b[:])}
+}
+
+// casDeleteScript deletes the lock only if we still own it, so an expired-then-
+// reacquired lock held by another indexer is never deleted out from under it.
+const casDeleteScript = `if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end`
+
+func (l *valkeyRebuildLocker) TryLock(ctx context.Context) (bool, func(), error) {
+	ok, err := l.rdb.SetNX(ctx, rebuildLockKey, l.value, rebuildLockTTL).Result()
+	if err != nil {
+		return false, nil, err
+	}
+	if !ok {
+		return false, func() {}, nil
+	}
+	release := func() {
+		_ = l.rdb.Eval(ctx, casDeleteScript, []string{rebuildLockKey}, l.value).Err()
+	}
+	return true, release, nil
+}

--- a/cmd/indexer/rebuild_gate_test.go
+++ b/cmd/indexer/rebuild_gate_test.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func gateTestLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+type fakeGate struct {
+	present      bool
+	presentErr   error
+	warmCalls    int
+	rebuildCalls int
+}
+
+func (f *fakeGate) IndexesPresent(context.Context) (bool, error) { return f.present, f.presentErr }
+func (f *fakeGate) Warm(context.Context) error                   { f.warmCalls++; return nil }
+func (f *fakeGate) Rebuild(context.Context) error                { f.rebuildCalls++; return nil }
+
+type fakeLocker struct {
+	acquired bool
+	err      error
+	released int
+}
+
+func (f *fakeLocker) TryLock(context.Context) (bool, func(), error) {
+	return f.acquired, func() { f.released++ }, f.err
+}
+
+// TestStartupSearchSync_GatesDestructiveRebuild pins WS13 #12: the destructive
+// flush+rebuild only happens when the indexes are MISSING and this indexer wins
+// the lock; otherwise it warms without flushing. A present-check error fails
+// closed (no flush).
+func TestStartupSearchSync_GatesDestructiveRebuild(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("indexes present → warm only, never rebuild", func(t *testing.T) {
+		g := &fakeGate{present: true}
+		l := &fakeLocker{acquired: true} // would acquire, but must not be consulted
+		require.NoError(t, startupSearchSync(ctx, g, l, gateTestLogger()))
+		assert.Equal(t, 1, g.warmCalls, "present indexes must be warmed")
+		assert.Equal(t, 0, g.rebuildCalls, "present indexes must NOT be destructively rebuilt")
+	})
+
+	t.Run("indexes missing + lock won → rebuild under lock", func(t *testing.T) {
+		g := &fakeGate{present: false}
+		l := &fakeLocker{acquired: true}
+		require.NoError(t, startupSearchSync(ctx, g, l, gateTestLogger()))
+		assert.Equal(t, 1, g.rebuildCalls, "missing indexes + lock held → rebuild")
+		assert.Equal(t, 0, g.warmCalls)
+		assert.Equal(t, 1, l.released, "the lock must be released after rebuild")
+	})
+
+	t.Run("indexes missing + lock lost → warm only (no racing wipe)", func(t *testing.T) {
+		g := &fakeGate{present: false}
+		l := &fakeLocker{acquired: false}
+		require.NoError(t, startupSearchSync(ctx, g, l, gateTestLogger()))
+		assert.Equal(t, 1, g.warmCalls, "a contender that lost the lock warms instead of flushing")
+		assert.Equal(t, 0, g.rebuildCalls, "only the lock holder may flush+rebuild")
+	})
+
+	t.Run("present-check error fails closed (no flush)", func(t *testing.T) {
+		g := &fakeGate{presentErr: errors.New("backend down")}
+		l := &fakeLocker{acquired: true}
+		require.Error(t, startupSearchSync(ctx, g, l, gateTestLogger()),
+			"a present-check error must be fatal, not treated as 'missing' (which would flush)")
+		assert.Equal(t, 0, g.rebuildCalls, "must NOT flush/rebuild on an indeterminate present-check")
+		assert.Equal(t, 0, g.warmCalls)
+	})
+}
+
+// TestValkeyRebuildLocker_TryLock pins the SET NX EX mutual exclusion: a second
+// indexer cannot acquire while the lock is held, and the lock is reacquirable
+// after the holder releases it (CAS-delete).
+func TestValkeyRebuildLocker_TryLock(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rdb.Close() })
+	ctx := context.Background()
+
+	l1 := newValkeyRebuildLocker(rdb)
+	l2 := newValkeyRebuildLocker(rdb)
+	require.NotEqual(t, l1.value, l2.value, "each locker has a distinct owner value")
+
+	ok1, release1, err := l1.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok1, "the first indexer acquires the lock")
+
+	ok2, _, err := l2.TryLock(ctx)
+	require.NoError(t, err)
+	require.False(t, ok2, "a second indexer must NOT acquire while the lock is held")
+
+	release1()
+
+	ok3, release3, err := l2.TryLock(ctx)
+	require.NoError(t, err)
+	require.True(t, ok3, "the lock is reacquirable after the holder releases it")
+	release3()
+}

--- a/cmd/indexer/rebuild_gate_test.go
+++ b/cmd/indexer/rebuild_gate_test.go
@@ -66,6 +66,7 @@ func TestStartupSearchSync_GatesDestructiveRebuild(t *testing.T) {
 		require.NoError(t, startupSearchSync(ctx, g, l, gateTestLogger()))
 		assert.Equal(t, 1, g.warmCalls, "a contender that lost the lock warms instead of flushing")
 		assert.Equal(t, 0, g.rebuildCalls, "only the lock holder may flush+rebuild")
+		assert.Equal(t, 0, l.released, "release must not be called when the lock was not acquired")
 	})
 
 	t.Run("present-check error fails closed (no flush)", func(t *testing.T) {
@@ -94,6 +95,21 @@ func TestValkeyRebuildLocker_TryLock(t *testing.T) {
 	ok1, release1, err := l1.TryLock(ctx)
 	require.NoError(t, err)
 	require.True(t, ok1, "the first indexer acquires the lock")
+
+	// The lock key must carry a TTL so a crashed holder can't deadlock all
+	// other indexers forever.
+	ttl, err := rdb.TTL(ctx, rebuildLockKey).Result()
+	require.NoError(t, err)
+	require.Greater(t, ttl.Seconds(), 0.0, "the rebuild lock must have a TTL (no permanent deadlock on crash)")
+
+	// CAS-delete: a NON-owner releasing must NOT delete the lock (otherwise a
+	// buggy/racing indexer could free another's lock and trigger concurrent
+	// destructive rebuilds). Run the release script with l2's (wrong) owner
+	// value and assert the lock is still held.
+	require.NoError(t, rdb.Eval(ctx, casDeleteScript, []string{rebuildLockKey}, l2.value).Err())
+	stillHeld, _, err := l2.TryLock(ctx)
+	require.NoError(t, err)
+	require.False(t, stillHeld, "a non-owner must NOT be able to release the lock")
 
 	ok2, _, err := l2.TryLock(ctx)
 	require.NoError(t, err)

--- a/docs/adr/0019-indexer-startup-rebuild-gate.md
+++ b/docs/adr/0019-indexer-startup-rebuild-gate.md
@@ -1,0 +1,57 @@
+# 0019 — Indexer startup rebuild: gate + lock instead of always-flush
+
+- Status: accepted
+- Date: 2026-06-15
+- Related: WS13 #12 (manchtools/power-manage-server#427, split out of #426/#428);
+  ADR 0018 (the rest of WS13's resource bounds); #319 (redis-stack-server test
+  infra).
+
+## Context
+
+The indexer ran a destructive `FlushSearchData` (FT.DROPINDEX + key SCAN/DEL)
+followed by a full `Rebuild` on EVERY boot. A crash-loop, or several indexer
+replicas starting together, could repeatedly wipe and rebuild the search index —
+wasted work and a window where search returns nothing on each restart.
+
+## Decision
+
+Gate the destructive path behind an index-present check and a Valkey lock
+(`cmd/indexer/rebuild_gate.go`, `startupSearchSync`):
+
+- **Present check first.** `search.Index.IndexesPresent` runs `FT.INFO` for every
+  configured index. If all exist, the indexer **warms without flushing** — a
+  normal restart no longer drops the index. A present-check error is **fatal**
+  (fail closed): guessing "missing" on a transient backend error would trigger an
+  unwarranted destructive flush.
+- **Lock the destructive path.** When indexes are missing, the indexer acquires a
+  Valkey `SET NX EX` lock (`pm:indexer:rebuild:lock`, 15-min TTL, CAS-release)
+  before `Rebuild`. A replica that loses the race **warms without flushing**, so
+  concurrent/crash-looping indexers can't race repeated destructive wipes — at
+  most one flushes.
+
+This replaces the unconditional `EnsureIndexes` + `Rebuild` at boot (Rebuild
+creates the indexes internally, so no separate ensure step is needed).
+
+## Crash-loop protection ("backoff")
+
+The original finding asked for "backoff so a crash-loop can't hammer destructive
+rebuilds." The gate provides this structurally rather than via a timer: once a
+rebuild succeeds the indexes are present, so every subsequent boot takes the
+warm-without-flush path — the destructive flush happens at most once, not on every
+restart. The lock bounds the pre-first-success window to a single flusher.
+
+## Testing & the #319 dependency
+
+The decision logic (`startupSearchSync`) is unit-tested with fakes
+(present→warm; missing+lock-won→rebuild; missing+lock-lost→warm; present-check
+error→fail-closed-no-flush). The Valkey lock (`valkeyRebuildLocker`) is tested
+against miniredis (mutual exclusion + CAS-release). The real `IndexesPresent`
+(`FT.INFO`) path needs a real RediSearch backend, which miniredis cannot provide;
+that integration coverage lands with the redis-stack-server testcontainer swap
+tracked under #319.
+
+## Consequences
+
+- A normal indexer restart no longer drops the search index (warm-only).
+- No proto/sqlc/web changes. No new error codes (these are operator-facing log
+  lines + a fatal boot, not RPC errors).

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -314,6 +314,29 @@ func (idx *Index) EnsureIndexes(ctx context.Context) error {
 	return nil
 }
 
+// IndexesPresent reports whether ALL configured search indexes already exist in
+// the backend (WS13 #12). It is the gate that lets the indexer warm-without-flush
+// on a normal restart instead of destructively dropping + rebuilding on every
+// boot. A definitively-missing index returns (false, nil); any other backend
+// error is surfaced so the caller fails closed rather than wrongly assuming the
+// indexes are gone and flushing.
+func (idx *Index) IndexesPresent(ctx context.Context) (bool, error) {
+	for _, ix := range IndexSchemas {
+		err := idx.rdb.Do(ctx, "FT.INFO", ix.Name).Err()
+		if err == nil {
+			continue
+		}
+		// "Unknown index name" (RediSearch) / "no such index" (valkey-search)
+		// both mean the index is absent — a definite not-present, not an error.
+		lower := strings.ToLower(err.Error())
+		if strings.Contains(lower, "unknown index") || strings.Contains(lower, "no such index") {
+			return false, nil
+		}
+		return false, fmt.Errorf("FT.INFO %s: %w", ix.Name, err)
+	}
+	return true, nil
+}
+
 // Warm performs a full rebuild of all search data from PostgreSQL.
 // This is the only operation that reads from PG for search purposes.
 func (idx *Index) Warm(ctx context.Context) error {


### PR DESCRIPTION
WS13 #12 — closes #427. The indexer ran a destructive `FlushSearchData` + full `Rebuild` on EVERY boot, so a crash-loop or concurrent replicas could repeatedly wipe the search index.

- **`search.Index.IndexesPresent`** (FT.INFO over every configured index) gates the destructive path: if all indexes exist the indexer **warms without flushing**; a present-check error is **fatal** (fail closed — never flush on an indeterminate check).
- **`startupSearchSync`**: present → warm; missing + Valkey `SET NX` lock won → flush + rebuild under the lock; missing + lock lost → warm. So concurrent/crash-looping indexers can't race repeated destructive wipes (at most one flushes). Replaces the unconditional `EnsureIndexes` + `Rebuild` at boot.
- **Crash-loop "backoff"**: once a rebuild succeeds the indexes are present, so every later boot is warm-only — the destructive flush happens at most once.

## Tests
- Decision logic with fakes: present→warm; missing+won→rebuild (lock released); missing+lost→warm (release not called); present-check error→fail-closed-no-flush.
- Valkey lock (miniredis): mutual exclusion, TTL present (no permanent deadlock), CAS-delete is owner-only (a non-owner can't release).

## #319 dependency
The real `FT.INFO` present-check needs a RediSearch backend; miniredis can't provide it, so that integration coverage lands with the redis-stack-server testcontainer swap tracked under #319. ADR 0019.

Verification: `go vet` + staticcheck + gofmt clean; the new tests pass; local CodeRabbit clean (3 test-strengthening findings applied; 2 were the untracked audit-doc false-positive).