### PR TITLE
fix(indexer): IndexesPresent must treat valkey-search 'not found' as not-present

### DIFF
--- a/docs/adr/0019-indexer-startup-rebuild-gate.md
+++ b/docs/adr/0019-indexer-startup-rebuild-gate.md
@@ -3,8 +3,9 @@
 - Status: accepted
 - Date: 2026-06-15
 - Related: WS13 #12 (manchtools/power-manage-server#427, split out of #426/#428);
-  ADR 0018 (the rest of WS13's resource bounds); #319 (redis-stack-server test
-  infra).
+  ADR 0018 (the rest of WS13's resource bounds); #319 (the now-merged deploy
+  migration to valkey-search, whose testcontainer harness this ADR's
+  integration test reuses).
 
 ## Context
 
@@ -40,15 +41,24 @@ rebuild succeeds the indexes are present, so every subsequent boot takes the
 warm-without-flush path — the destructive flush happens at most once, not on every
 restart. The lock bounds the pre-first-success window to a single flusher.
 
-## Testing & the #319 dependency
+## Testing
 
 The decision logic (`startupSearchSync`) is unit-tested with fakes
 (present→warm; missing+lock-won→rebuild; missing+lock-lost→warm; present-check
 error→fail-closed-no-flush). The Valkey lock (`valkeyRebuildLocker`) is tested
-against miniredis (mutual exclusion + CAS-release). The real `IndexesPresent`
-(`FT.INFO`) path needs a real RediSearch backend, which miniredis cannot provide;
-that integration coverage lands with the redis-stack-server testcontainer swap
-tracked under #319.
+against miniredis (mutual exclusion + TTL + owner-only CAS-release). The real
+`IndexesPresent` (`FT.INFO`) path is integration-tested against a real
+valkey-search backend via the existing testcontainer harness
+(`TestIndexesPresent`, valkey-bundle).
+
+That integration test caught a real cold-start bug: valkey-search reports a
+missing index as `Index with name 'X' not found in database 0`, which matched
+neither of the originally-guessed substrings (`unknown index` / `no such index`),
+so `IndexesPresent` returned a hard error instead of "not present" — meaning a
+fresh deploy (no indexes) would have failed boot instead of rebuilding.
+`IndexesPresent` now also matches `not found`. (The earlier belief that this path
+could only be covered "later, under #319" was wrong — #319 was the production
+deploy migration to valkey-search, and the testcontainer harness already exists.)
 
 ## Consequences
 

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -326,10 +326,17 @@ func (idx *Index) IndexesPresent(ctx context.Context) (bool, error) {
 		if err == nil {
 			continue
 		}
-		// "Unknown index name" (RediSearch) / "no such index" (valkey-search)
-		// both mean the index is absent — a definite not-present, not an error.
+		// A missing index is "not present", NOT a hard error. The wording differs
+		// by backend, so match all known shapes (verified against the real
+		// backend by TestIndexesPresent):
+		//   valkey-search: "Index with name 'X' not found in database 0"
+		//   RediSearch:    "Unknown index name"
+		// Any OTHER FT.INFO error (e.g. backend unreachable) is surfaced so the
+		// caller fails closed and never flushes on an indeterminate result.
 		lower := strings.ToLower(err.Error())
-		if strings.Contains(lower, "unknown index") || strings.Contains(lower, "no such index") {
+		if strings.Contains(lower, "not found") ||
+			strings.Contains(lower, "unknown index") ||
+			strings.Contains(lower, "no such index") {
 			return false, nil
 		}
 		return false, fmt.Errorf("FT.INFO %s: %w", ix.Name, err)

--- a/internal/search/indexer_test.go
+++ b/internal/search/indexer_test.go
@@ -82,6 +82,35 @@ func TestEnsureIndexes(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestIndexesPresent pins WS13 #12's gate against a REAL valkey-search backend
+// (the part that miniredis can't cover): IndexesPresent must classify a missing
+// index as not-present (false, nil) — NOT a hard error — which validates the
+// FT.INFO "index missing" error-substring matching against the real backend, and
+// must report present once all indexes exist. The fail-closed direction (any
+// OTHER FT.INFO error -> error, never a wrong "not present" that would flush) is
+// what makes the gate safe.
+func TestIndexesPresent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	rdb := setupRedis(t)
+	ctx := context.Background()
+
+	idx := search.New(rdb, nil, nil, testLogger())
+
+	// Fresh backend: no indexes yet. The real "unknown index" error must be
+	// classified as not-present, not surfaced as a hard error.
+	present, err := idx.IndexesPresent(ctx)
+	require.NoError(t, err, "a missing index must classify as not-present, not a hard error (FT.INFO substring must match the real backend)")
+	assert.False(t, present, "no indexes exist on a fresh backend")
+
+	// After EnsureIndexes, every configured index exists → present.
+	require.NoError(t, idx.EnsureIndexes(ctx))
+	present, err = idx.IndexesPresent(ctx)
+	require.NoError(t, err)
+	assert.True(t, present, "after EnsureIndexes all indexes must be reported present")
+}
+
 func TestWarmActions(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")


### PR DESCRIPTION
Closes #430. Follow-up to #427 (WS13 #12).

`search.Index.IndexesPresent` matched only `unknown index` (RediSearch) / `no such index` for a missing index, but **valkey-search** reports `Index with name 'X' not found in database 0` — matching neither — so a missing index fell through to the hard-error branch.

**Impact:** on a fresh deploy (or after index loss) all indexes are missing → `IndexesPresent` returns an error → `startupSearchSync` returns it → indexer `os.Exit(1)`. **The indexer could never cold-start its own indexes** (search broken until manual intervention). Fail-closed (no wrong flush), but a real bootstrap break.

**Fix:** also match `not found`. **Add `TestIndexesPresent`** — an integration test against the real valkey-search testcontainer (the existing `setupRedis` harness) — which **caught this bug**.

**Why it was missed:** #12 deferred the `FT.INFO` integration test on the wrong premise that no real-search test harness existed; `internal/search/indexer_test.go` already had one. ADR 0019's "testing" section corrected accordingly.

Verification: `go vet` + staticcheck clean; `go test ./internal/search/` green (incl. the new integration test against valkey-bundle); local CodeRabbit clean.