### PR TITLE
WS14: event-store integrity tests + audit-filter literal match (CA SAN, write-once, action_set stale-replay)

### DIFF
--- a/cmd/control/README.md
+++ b/cmd/control/README.md
@@ -604,6 +604,13 @@ WHERE actor_type = 'user' AND actor_id = 'ADMIN_ID'
 ORDER BY occurred_at DESC;
 ```
 
+The `ListAuditEvents` RPC's `event_type` filter is a **literal substring match**:
+`%` and `_` in the filter value are matched as those exact characters, not as
+SQL wildcards (they are escaped before the `ILIKE`). So filtering `User_Created`
+returns only events whose type literally contains `User_Created`, never
+`UserXCreated`. The `events` table is append-only at the DB layer (migration 011
+trigger; see ADR 0005), so no audit row can be mutated or deleted after commit.
+
 ### Time Travel
 
 Query state at any point in time:

--- a/internal/ca/ca_test.go
+++ b/internal/ca/ca_test.go
@@ -8,6 +8,8 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"net"
+	"net/url"
 	"testing"
 	"time"
 
@@ -15,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/mtls"
 )
 
 // generateTestCA creates a self-signed CA cert and key for testing.
@@ -147,6 +150,87 @@ func TestIssueCertificateFromCSR_Success(t *testing.T) {
 	assert.Nil(t, cert.KeyPEM, "private key should stay on agent")
 	assert.NotEmpty(t, cert.Fingerprint)
 	assert.True(t, cert.NotAfter.After(time.Now()))
+}
+
+// generateCSRWithSAN builds a CSR for deviceID after letting the caller stamp a
+// subject-alternative-name onto the template — used to prove the CA rejects any
+// caller-supplied SAN (which would otherwise let an enrolling agent mint a
+// non-agent peer-class identity).
+func generateCSRWithSAN(t *testing.T, deviceID string, modify func(*x509.CertificateRequest)) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.CertificateRequest{Subject: pkix.Name{CommonName: deviceID}}
+	modify(tmpl)
+	der, err := x509.CreateCertificateRequest(rand.Reader, tmpl, key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
+}
+
+// TestIssueCertificateFromCSR_RejectsSAN pins WS14 #1: the CA must reject ANY
+// CSR carrying a SAN. "Wrong" cases are sourced from intent — identities an
+// enrolling agent must never be able to mint (a gateway/control peer class, a
+// server hostname/IP) — not from the validation rule. The load-bearing one is
+// the spiffe gateway URI: without the SAN rejection an agent could request a
+// gateway peer class and reach the InternalService.
+func TestIssueCertificateFromCSR_RejectsSAN(t *testing.T) {
+	certPEM, keyPEM := generateTestCA(t)
+	c, err := ca.NewFromPEM(certPEM, keyPEM, 24*time.Hour)
+	require.NoError(t, err)
+
+	mustURL := func(s string) *url.URL {
+		u, perr := url.Parse(s)
+		require.NoError(t, perr)
+		return u
+	}
+	cases := map[string]func(*x509.CertificateRequest){
+		"spiffe gateway URI": func(r *x509.CertificateRequest) { r.URIs = []*url.URL{mustURL("spiffe://power-manage/gateway")} },
+		"spiffe control URI": func(r *x509.CertificateRequest) { r.URIs = []*url.URL{mustURL("spiffe://power-manage/control")} },
+		"dns name":           func(r *x509.CertificateRequest) { r.DNSNames = []string{"control-server.example.com"} },
+		"ip address":         func(r *x509.CertificateRequest) { r.IPAddresses = []net.IP{net.ParseIP("10.0.0.1")} },
+		"email":              func(r *x509.CertificateRequest) { r.EmailAddresses = []string{"x@y"} },
+	}
+	for name, modify := range cases {
+		t.Run(name, func(t *testing.T) {
+			csrPEM := generateCSRWithSAN(t, "device-001", modify)
+			cert, err := c.IssueCertificateFromCSR("device-001", csrPEM)
+			require.Error(t, err, "a CSR with a SAN must be rejected")
+			assert.Contains(t, err.Error(), "must not request subject alternative names")
+			assert.Nil(t, cert, "no certificate must be issued for a SAN-bearing CSR")
+		})
+	}
+
+	// Correct/absent: a plain CSR (no SAN) still issues.
+	csrPEM, _ := generateCSR(t, "device-001")
+	cert, err := c.IssueCertificateFromCSR("device-001", csrPEM)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+}
+
+// TestIssueCertificateFromCSR_StampsExactlyAgentPeerClass pins WS14 #1's
+// positive half: an issued cert carries EXACTLY one URI SAN, the agent peer
+// class — so an enrolling agent can never obtain a non-agent class, even via a
+// CN/name collision.
+func TestIssueCertificateFromCSR_StampsExactlyAgentPeerClass(t *testing.T) {
+	certPEM, keyPEM := generateTestCA(t)
+	c, err := ca.NewFromPEM(certPEM, keyPEM, 24*time.Hour)
+	require.NoError(t, err)
+
+	csrPEM, _ := generateCSR(t, "device-001")
+	cert, err := c.IssueCertificateFromCSR("device-001", csrPEM)
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(cert.CertPEM)
+	require.NotNil(t, block)
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	require.Len(t, parsed.URIs, 1, "an issued agent cert must carry exactly one URI SAN")
+	assert.Equal(t, "spiffe://power-manage/agent", parsed.URIs[0].String())
+
+	class, err := mtls.PeerClassFromCert(parsed)
+	require.NoError(t, err)
+	assert.Equal(t, mtls.PeerClassAgent, class, "an issued cert must always be the agent peer class")
 }
 
 // TestIssueCertificateFromCSR_ValidityWindowFromClock pins that the

--- a/internal/projectors/action_set_test.go
+++ b/internal/projectors/action_set_test.go
@@ -398,6 +398,124 @@ func TestActionSetListener_MemberReorderUpdatesRow(t *testing.T) {
 		"reorder bumps parent projection_version + updated_at")
 }
 
+// TestActionSetListener_StaleMemberRemovedDoesNotWipeLiveMembership pins the
+// DELETE-branch half of #163's stale-replay guard (mirror of the add-branch
+// coverage): a late ActionSetMemberRemoved whose SequenceNum is older than the
+// parent's projection_version must NOT remove a live member. Threat: an
+// out-of-order/replayed event must never silently drop membership.
+func TestActionSetListener_StaleMemberRemovedDoesNotWipeLiveMembership(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data: map[string]any{"name": "stale-remove"}, ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data: map[string]any{"action_id": "act-A", "sort_order": 0}, ActorType: "user", ActorID: "u",
+	}))
+
+	before, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), before.MemberCount)
+
+	// Drive the REAL listener with a stale MemberRemoved (SequenceNum older than
+	// the parent's current projection_version).
+	older := before.ProjectionVersion - 5
+	listener := projectors.ActionSetListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID: uuid.New(), SequenceNum: older,
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberRemoved",
+		Data: jsonOrFail(t, map[string]any{"action_id": "act-A"}), ActorType: "user", ActorID: "u",
+	})
+
+	_, err = st.Queries().GetActionSetMember(ctx, db.GetActionSetMemberParams{SetID: setID, ActionID: "act-A"})
+	require.NoError(t, err, "a live member must survive a stale MemberRemoved (the Claim guard must short-circuit the DELETE branch)")
+	after, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), after.MemberCount, "member_count must be unchanged by a stale removal")
+	assert.Equal(t, before.ProjectionVersion, after.ProjectionVersion, "a stale event must not bump projection_version")
+}
+
+// TestActionSetListener_StaleMemberReorderedDoesNotClobberPosition pins the
+// reorder branch of the stale-replay guard (#163): a stale ActionSetMemberReordered
+// must not overwrite a fresher sort_order (both the parent Claim guard and the
+// per-member version guard reject it).
+func TestActionSetListener_StaleMemberReorderedDoesNotClobberPosition(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data: map[string]any{"name": "stale-reorder"}, ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data: map[string]any{"action_id": "act-A", "sort_order": 0}, ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberReordered",
+		Data: map[string]any{"action_id": "act-A", "sort_order": 5}, ActorType: "user", ActorID: "u",
+	}))
+
+	before, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+
+	older := before.ProjectionVersion - 5
+	listener := projectors.ActionSetListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID: uuid.New(), SequenceNum: older,
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberReordered",
+		Data: jsonOrFail(t, map[string]any{"action_id": "act-A", "sort_order": 99}), ActorType: "user", ActorID: "u",
+	})
+
+	member, err := st.Queries().GetActionSetMember(ctx, db.GetActionSetMemberParams{SetID: setID, ActionID: "act-A"})
+	require.NoError(t, err)
+	assert.Equal(t, int32(5), member.SortOrder, "a stale reorder must not clobber the fresher sort_order")
+}
+
+// TestActionSetListener_RecountAfterStaleEventStaysCorrect pins that a rejected
+// stale event leaves no counter drift (#163): after a stale MemberAdded is
+// skipped, a fresh valid MemberAdded yields the correct member_count.
+func TestActionSetListener_RecountAfterStaleEventStaysCorrect(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	setID := testutil.NewID()
+
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetCreated",
+		Data: map[string]any{"name": "recount"}, ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data: map[string]any{"action_id": "act-A", "sort_order": 0}, ActorType: "user", ActorID: "u",
+	}))
+
+	before, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+
+	// A stale MemberAdded (rejected by the parent Claim guard).
+	older := before.ProjectionVersion - 5
+	listener := projectors.ActionSetListener(st, slog.Default())
+	listener(ctx, store.PersistedEvent{
+		ID: uuid.New(), SequenceNum: older,
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data: jsonOrFail(t, map[string]any{"action_id": "act-STALE", "sort_order": 0}), ActorType: "user", ActorID: "u",
+	})
+
+	// A fresh valid MemberAdded must recount to exactly 2 (no drift from the skip).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
+		Data: map[string]any{"action_id": "act-B", "sort_order": 1}, ActorType: "user", ActorID: "u",
+	}))
+	after, err := st.Queries().GetActionSetByID(ctx, setID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), after.MemberCount, "member_count must be 2 (act-A + act-B); the skipped stale event must leave no drift")
+}
+
 // TestActionSetListener_DeleteCascadesMembersAndDefinitions confirms
 // ActionSetDeleted soft-deletes the set, wipes every member row, AND
 // (the cross-stream cascade that makes this projector trickier than

--- a/internal/store/audit_filter_test.go
+++ b/internal/store/audit_filter_test.go
@@ -1,0 +1,45 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestListAuditEvents_EventTypeFilterIsLiteralMatch pins WS14 #11: the audit
+// event_type filter is a literal substring match — `%`/`_` typed in the filter
+// value match those exact characters, not as SQL wildcards. The two seeded types
+// differ only at the position a LIKE `_` would wildcard-match, so a raw-ILIKE
+// filter ("User_Created") would wrongly return both; with the wildcard escaped,
+// only the literal-underscore row matches.
+func TestListAuditEvents_EventTypeFilterIsLiteralMatch(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+
+	for _, et := range []string{"User_Created", "UserXCreated"} {
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "test", StreamID: testutil.NewID(), EventType: et,
+			Data: map[string]any{}, ActorType: "system", ActorID: "a",
+		}))
+	}
+
+	rows, err := st.Queries().ListAuditEvents(ctx, db.ListAuditEventsParams{
+		Column3: "User_Created", Limit: 100, Offset: 0,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "the '_' in the filter must match literally, not as a wildcard (raw ILIKE would also return UserXCreated)")
+	assert.Equal(t, "User_Created", rows[0].EventType)
+
+	// And a literal substring still matches (the outer %-wrap is intentional).
+	rows, err = st.Queries().ListAuditEvents(ctx, db.ListAuditEventsParams{
+		Column3: "Created", Limit: 100, Offset: 0,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 2, "a normal substring filter still matches both Created events")
+}

--- a/internal/store/eventstore_writeonce_test.go
+++ b/internal/store/eventstore_writeonce_test.go
@@ -1,0 +1,102 @@
+package store_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestEvents_RowIsWriteOnce pins the event store's append-only invariant at the
+// DATABASE layer (migration 011's BEFORE UPDATE/DELETE/TRUNCATE trigger), not
+// just in application code. Threat: a compromised relay or a SQL-capable insider
+// must not be able to rewrite history or forge actor attribution — only INSERT
+// (append) and SELECT succeed. Each mutation is driven via raw SQL on the pool
+// (bypassing the app layer) so it actually exercises the trigger.
+func TestEvents_RowIsWriteOnce(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	pool := st.TestingPool()
+
+	streamID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "test",
+		StreamID:   streamID,
+		EventType:  "WriteOnceProbe",
+		Data:       map[string]any{"original": true},
+		ActorType:  "system",
+		ActorID:    "orig-actor",
+	}))
+
+	var id string
+	require.NoError(t, pool.QueryRow(ctx, "SELECT id FROM events WHERE stream_id = $1", streamID).Scan(&id))
+
+	// Each forbidden mutation must (a) error with an append-only message and
+	// (b) leave the row untouched.
+	mutations := []struct {
+		name   string
+		sql    string
+		verify func(t *testing.T)
+	}{
+		{
+			name: "forge actor_id",
+			sql:  "UPDATE events SET actor_id = 'forged' WHERE id = $1",
+			verify: func(t *testing.T) {
+				var got string
+				require.NoError(t, pool.QueryRow(ctx, "SELECT actor_id FROM events WHERE id = $1", id).Scan(&got))
+				assert.Equal(t, "orig-actor", got, "actor attribution must be immutable")
+			},
+		},
+		{
+			name: "tamper payload",
+			sql:  `UPDATE events SET data = '{"tampered":true}' WHERE id = $1`,
+			verify: func(t *testing.T) {
+				var original bool
+				require.NoError(t, pool.QueryRow(ctx, "SELECT (data->>'original')::bool FROM events WHERE id = $1", id).Scan(&original))
+				assert.True(t, original, "event payload must be immutable")
+			},
+		},
+		{
+			name: "move stream_id",
+			sql:  "UPDATE events SET stream_id = 'other' WHERE id = $1",
+			verify: func(t *testing.T) {
+				var got string
+				require.NoError(t, pool.QueryRow(ctx, "SELECT stream_id FROM events WHERE id = $1", id).Scan(&got))
+				assert.Equal(t, streamID, got, "stream binding must be immutable")
+			},
+		},
+		{
+			name: "delete row",
+			sql:  "DELETE FROM events WHERE id = $1",
+			verify: func(t *testing.T) {
+				var n int
+				require.NoError(t, pool.QueryRow(ctx, "SELECT COUNT(*) FROM events WHERE id = $1", id).Scan(&n))
+				assert.Equal(t, 1, n, "a committed event must not be deletable")
+			},
+		},
+	}
+	for _, m := range mutations {
+		t.Run(m.name, func(t *testing.T) {
+			_, err := pool.Exec(ctx, m.sql, id)
+			require.Error(t, err, "the append-only trigger must reject this mutation")
+			assert.Contains(t, strings.ToLower(err.Error()), "append-only",
+				"the rejection must come from the append-only guard")
+			m.verify(t)
+		})
+	}
+
+	// Correct path: append still works (the guard blocks mutation, not append).
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "test",
+		StreamID:   streamID,
+		EventType:  "WriteOnceProbe2",
+		Data:       map[string]any{},
+		ActorType:  "system",
+		ActorID:    "orig-actor",
+	}), "append must still succeed — the guard blocks mutation, not INSERT")
+}

--- a/internal/store/generated/events.sql.go
+++ b/internal/store/generated/events.sql.go
@@ -63,7 +63,7 @@ const countAuditEvents = `-- name: CountAuditEvents :one
 SELECT COUNT(*) FROM events
 WHERE ($1::TEXT = '' OR actor_id = $1)
   AND ($2::TEXT = '' OR stream_type = $2)
-  AND ($3::TEXT = '' OR event_type ILIKE '%' || $3 || '%')
+  AND ($3::TEXT = '' OR event_type ILIKE '%' || replace(replace(replace($3, '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!')
 `
 
 type CountAuditEventsParams struct {
@@ -136,7 +136,7 @@ const listAuditEvents = `-- name: ListAuditEvents :many
 SELECT id, sequence_num, stream_type, stream_id, stream_version, event_type, data, metadata, actor_type, actor_id, occurred_at FROM events
 WHERE ($1::TEXT = '' OR actor_id = $1)
   AND ($2::TEXT = '' OR stream_type = $2)
-  AND ($3::TEXT = '' OR event_type ILIKE '%' || $3 || '%')
+  AND ($3::TEXT = '' OR event_type ILIKE '%' || replace(replace(replace($3, '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!')
 ORDER BY occurred_at DESC
 LIMIT $4 OFFSET $5
 `

--- a/internal/store/queries/events.sql
+++ b/internal/store/queries/events.sql
@@ -58,7 +58,7 @@ SELECT COALESCE(MAX(sequence_num), 0)::BIGINT as sequence_num FROM events;
 SELECT * FROM events
 WHERE ($1::TEXT = '' OR actor_id = $1)
   AND ($2::TEXT = '' OR stream_type = $2)
-  AND ($3::TEXT = '' OR event_type ILIKE '%' || $3 || '%')
+  AND ($3::TEXT = '' OR event_type ILIKE '%' || replace(replace(replace($3, '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!')
 ORDER BY occurred_at DESC
 LIMIT $4 OFFSET $5;
 
@@ -66,7 +66,7 @@ LIMIT $4 OFFSET $5;
 SELECT COUNT(*) FROM events
 WHERE ($1::TEXT = '' OR actor_id = $1)
   AND ($2::TEXT = '' OR stream_type = $2)
-  AND ($3::TEXT = '' OR event_type ILIKE '%' || $3 || '%');
+  AND ($3::TEXT = '' OR event_type ILIKE '%' || replace(replace(replace($3, '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!');
 
 -- name: LoadOutputChunks :many
 -- Load all output chunks for an execution, ordered by sequence


### PR DESCRIPTION
WS14 (server portion) — **Closes #163, advances #82.** Mostly test additions pinning already-correct behaviour; one behaviour fix (#11). Server-only; no proto/web changes.

| Item | What |
|---|---|
| **#1 CA** | `TestIssueCertificateFromCSR_RejectsSAN` (every SAN class — spiffe gateway/control URI, DNS, IP, email — rejected; plain CSR still issues) + `_StampsExactlyAgentPeerClass` (issued cert carries exactly one URI SAN = `spiffe://power-manage/agent`). Prod already enforced this (ca.go:147); these pin it. |
| **write-once** | `TestEvents_RowIsWriteOnce` — DB-level: raw `UPDATE`(actor_id/data/stream_id)/`DELETE` are rejected by migration 011's trigger and leave the row unchanged; append still works. Complements the app-layer `TestNoSQLCQueryMutatesEvents`. Advances #82. |
| **#163** | `action_set` symmetric stale-replay guard: `StaleMemberRemovedDoesNotWipeLiveMembership`, `StaleMemberReorderedDoesNotClobberPosition`, `RecountAfterStaleEventStaysCorrect` — the remove/reorder/recount branches the suite skipped. Prod guards already correct. |
| **#11** | Audit `event_type` filter now escapes `%`/`_` in the value (literal substring match) — they no longer act as SQL wildcards. Uses a `!` escape char (no backslashes → independent of `standard_conforming_strings`). Regenerated sqlc; `TestListAuditEvents_EventTypeFilterIsLiteralMatch` pins it (a raw-ILIKE filter would wrongly match `UserXCreated` for `User_Created`). Control README documents the semantics. |

The append-only trigger itself (migration 011) + its ADR (0005) already shipped in WS2; this PR adds the DB-level test that pins it. No new ADR/error-codes/i18n.

Verification: full `go test ./...` green; `go vet` + staticcheck + gofmt clean; local CodeRabbit reviewed (escape made setting-independent; the pre-existing `$3::TEXT=''` NULL-vs-empty pattern is unchanged — the generated param is a non-nullable Go `string`, so NULL is unreachable via the API, and it's consistent across `$1`/`$2`/`$3`).