### PR TITLE
fix(api,auth,projectors,handler): error-discipline & dead-authz removal (WS16)

### DIFF
--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -29,6 +29,15 @@ import (
 )
 
 // DeviceHandler handles device management RPCs.
+// deviceAssignmentLister reads a device's already-assigned user/group IDs for
+// AssignDevice's dedup. It is a seam (defaulting to the store's queries) so a
+// test can drive the infra-failure path that must fail closed rather than
+// proceed blind on empty dedup sets (WS16 #8).
+type deviceAssignmentLister interface {
+	ListDeviceAssignedUserIDs(ctx context.Context, deviceID string) ([]string, error)
+	ListDeviceAssignedGroupIDs(ctx context.Context, deviceID string) ([]string, error)
+}
+
 type DeviceHandler struct {
 	taskQueueHolder
 	store     *store.Store
@@ -37,13 +46,14 @@ type DeviceHandler struct {
 	signer    ca.ActionSigner // signs LUKS device-key revocation dispatches (WS4)
 	// crl, when set, receives a deleted device's cert fingerprint so the cert
 	// stops working at the gateway. nil disables it (no Valkey / tests).
-	crl *crl.Store
-	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
+	crl              *crl.Store
+	assignmentLister deviceAssignmentLister // dedup-read seam (WS16 #8); defaults to store queries
+	now              func() time.Time       // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewDeviceHandler creates a new device handler.
 func NewDeviceHandler(st *store.Store, enc *crypto.Encryptor, logger *slog.Logger, signer ca.ActionSigner) *DeviceHandler {
-	return &DeviceHandler{store: st, encryptor: enc, logger: logger, signer: signer, now: time.Now}
+	return &DeviceHandler{store: st, encryptor: enc, logger: logger, signer: signer, assignmentLister: st.Queries(), now: time.Now}
 }
 
 // SetCRLStore wires the certificate revocation list (post-construction).
@@ -351,13 +361,21 @@ func (h *DeviceHandler) AssignDevice(ctx context.Context, req *connect.Request[p
 		return nil, handleGetError(ctx, err, ErrDeviceNotFound, "device not found")
 	}
 
-	// Build sets of already-assigned user/group IDs to prevent duplicate events
-	existingUserIDs, _ := q.ListDeviceAssignedUserIDs(ctx, req.Msg.DeviceId)
+	// Build sets of already-assigned user/group IDs to prevent duplicate
+	// events. WS16 #8: a DB error here must abort — proceeding with empty
+	// dedup sets on infra failure re-emits duplicate DeviceAssigned events.
+	existingUserIDs, err := h.assignmentLister.ListDeviceAssignedUserIDs(ctx, req.Msg.DeviceId)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list device assignments")
+	}
 	existingUserSet := make(map[string]bool, len(existingUserIDs))
 	for _, id := range existingUserIDs {
 		existingUserSet[id] = true
 	}
-	existingGroupIDs, _ := q.ListDeviceAssignedGroupIDs(ctx, req.Msg.DeviceId)
+	existingGroupIDs, err := h.assignmentLister.ListDeviceAssignedGroupIDs(ctx, req.Msg.DeviceId)
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list device assignments")
+	}
 	existingGroupSet := make(map[string]bool, len(existingGroupIDs))
 	for _, id := range existingGroupIDs {
 		existingGroupSet[id] = true
@@ -906,10 +924,17 @@ func (h *DeviceHandler) CreateLuksToken(ctx context.Context, req *connect.Reques
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "action is not an encryption action")
 	}
 
-	// Parse LUKS params to get complexity requirements
+	// Parse LUKS params to get complexity requirements. WS16 #10: a decode
+	// failure must fail closed — silently falling back to the floor policy
+	// (min 16, complexity 0) would weaken a security-gating token whenever the
+	// stored params are corrupt.
 	var luksParams pm.EncryptionParams
 	if len(action.Params) > 0 {
-		protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(action.Params, &luksParams)
+		if err := (protojson.UnmarshalOptions{DiscardUnknown: true}).Unmarshal(action.Params, &luksParams); err != nil {
+			h.logger.Error("encryption action params decode failed",
+				"action_id", req.Msg.ActionId, "error", err)
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "encryption action params are corrupt")
+		}
 	}
 
 	minLength := luksParams.UserPassphraseMinLength

--- a/internal/api/error_discipline_seams_test.go
+++ b/internal/api/error_discipline_seams_test.go
@@ -1,0 +1,104 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// WS16 #8: AssignDevice discarded DB errors from its dedup lookups and
+// proceeded blind on infra failure, which would re-emit duplicate
+// DeviceAssigned events. The lookups must fail closed with CodeInternal and
+// emit no event.
+
+type failingAssignmentLister struct{}
+
+func (failingAssignmentLister) ListDeviceAssignedUserIDs(context.Context, string) ([]string, error) {
+	return nil, errors.New("simulated dedup DB failure")
+}
+func (failingAssignmentLister) ListDeviceAssignedGroupIDs(context.Context, string) ([]string, error) {
+	return nil, errors.New("simulated dedup DB failure")
+}
+
+func TestAssignDevice_DedupLookupDBError_ReturnsInternal_NotBlind(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	h := NewDeviceHandler(st, enc, slog.Default(), NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "dedup-fail-host")
+	targetUser := testutil.CreateTestUser(t, st, testutil.NewID()+"@target.com", "pass", "user")
+
+	// Force the dedup lookups to error.
+	h.assignmentLister = failingAssignmentLister{}
+
+	// Count DeviceAssigned events before.
+	before := deviceEventCount(t, st, deviceID)
+
+	_, err := h.AssignDevice(ctx, connect.NewRequest(&pm.AssignDeviceRequest{
+		DeviceId: deviceID,
+		UserId:   targetUser,
+	}))
+	require.Error(t, err, "a dedup DB failure must abort the assignment")
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+
+	after := deviceEventCount(t, st, deviceID)
+	assert.Equal(t, before, after, "no DeviceAssigned event may be emitted when the dedup lookup failed")
+}
+
+// deviceEventCount counts events on a device stream (DeviceAssigned etc.).
+func deviceEventCount(t *testing.T, st *store.Store, deviceID string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, st.TestingPool().QueryRow(context.Background(),
+		"SELECT count(*) FROM events WHERE stream_type='device' AND stream_id=$1", deviceID).Scan(&n))
+	return n
+}
+
+// WS16 #9: a panic inside the detached settings fan-out goroutine must be
+// recovered and logged, not propagate and crash the control process.
+
+type panicSyncer struct{}
+
+func (panicSyncer) SyncAllUsersSystemActions(context.Context) error {
+	panic("simulated panic in settings fan-out")
+}
+
+func TestUpdateServerSettings_FanoutGoroutinePanic_DoesNotCrashProcess(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := NewSettingsHandler(st, slog.Default(), nil)
+
+	done := make(chan struct{})
+	h.onPropagationDone = func() { close(done) }
+	h.systemActions = panicSyncer{} // panics when the fan-out reaches it
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	// Both flags false so only the (panicking) syncer runs — isolates the panic.
+	resp, err := h.UpdateServerSettings(ctx, connect.NewRequest(&pm.UpdateServerSettingsRequest{
+		UserProvisioningEnabled: false,
+		SshAccessForAll:         false,
+	}))
+	require.NoError(t, err, "the RPC must still return success despite a fan-out panic")
+	require.NotNil(t, resp)
+
+	select {
+	case <-done:
+		// The goroutine finished — meaning the panic was recovered and the
+		// process survived (a propagated panic would have killed the test binary).
+	case <-time.After(5 * time.Second):
+		t.Fatal("settings fan-out goroutine never completed — panic not recovered?")
+	}
+}

--- a/internal/api/luks_token_failclosed_test.go
+++ b/internal/api/luks_token_failclosed_test.go
@@ -1,0 +1,99 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// setActionParams overwrites an action's stored params JSONB directly, so a
+// test can plant params that are valid JSON (the column accepts them) but are
+// not a decodable EncryptionParams message.
+func setActionParams(t *testing.T, st *store.Store, ctx context.Context, actionID string, paramsJSON string) {
+	t.Helper()
+	_, err := st.TestingPool().Exec(ctx,
+		"UPDATE actions_projection SET params = $1::jsonb WHERE id = $2", paramsJSON, actionID)
+	require.NoError(t, err)
+}
+
+// WS16 #10: CreateLuksToken silently ignored a protojson.Unmarshal error on the
+// encryption action's Params, falling back to the floor policy (min 16,
+// complexity 0) on a security-gating token. Corrupt params must fail closed.
+func TestCreateLuksToken_ParamsUnmarshalFailure_FailsClosed(t *testing.T) {
+	t.Run("corrupt params → CodeInternal, no floor fallback", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+		userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+		deviceID := testutil.CreateTestDevice(t, st, "luks-corrupt-device")
+		actionID := testutil.CreateTestAction(t, st, userID, "Encrypt Disk", int(pm.ActionType_ACTION_TYPE_ENCRYPTION))
+		testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
+		ctx := testutil.UserContext(userID)
+
+		// Valid JSON, but not a decodable EncryptionParams message.
+		setActionParams(t, st, ctx, actionID, `"this is not an encryption params object"`)
+
+		_, err := h.CreateLuksToken(ctx, connect.NewRequest(&pm.CreateLuksTokenRequest{
+			DeviceId: deviceID, ActionId: actionID,
+		}))
+		require.Error(t, err, "corrupt encryption params must not silently produce a floor-policy token")
+		assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+	})
+
+	t.Run("valid params → token carries the configured policy", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+		userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+		deviceID := testutil.CreateTestDevice(t, st, "luks-valid-device")
+		actionID := testutil.CreateTestAction(t, st, userID, "Encrypt Disk", int(pm.ActionType_ACTION_TYPE_ENCRYPTION))
+		testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
+		ctx := testutil.UserContext(userID)
+
+		setActionParams(t, st, ctx, actionID, `{"userPassphraseMinLength":24}`)
+
+		resp, err := h.CreateLuksToken(ctx, connect.NewRequest(&pm.CreateLuksTokenRequest{
+			DeviceId: deviceID, ActionId: actionID,
+		}))
+		require.NoError(t, err)
+
+		tok, err := st.Repos().Luks.ConsumeToken(ctx, store.ConsumeLuksTokenParams{
+			Token: sha256Hex(resp.Msg.Token), DeviceID: deviceID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(24), tok.MinLength, "configured min length must round-trip into the token, not the floor")
+	})
+
+	t.Run("empty params → floor policy preserved", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+		userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+		deviceID := testutil.CreateTestDevice(t, st, "luks-floor-device")
+		actionID := testutil.CreateTestAction(t, st, userID, "Encrypt Disk", int(pm.ActionType_ACTION_TYPE_ENCRYPTION))
+		testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
+		ctx := testutil.UserContext(userID)
+
+		setActionParams(t, st, ctx, actionID, `{}`)
+
+		resp, err := h.CreateLuksToken(ctx, connect.NewRequest(&pm.CreateLuksTokenRequest{
+			DeviceId: deviceID, ActionId: actionID,
+		}))
+		require.NoError(t, err)
+
+		tok, err := st.Repos().Luks.ConsumeToken(ctx, store.ConsumeLuksTokenParams{
+			Token: sha256Hex(resp.Msg.Token), DeviceID: deviceID,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int32(16), tok.MinLength, "empty params keeps the min-16 floor")
+	})
+}

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -176,6 +176,12 @@ func (h *OSQueryHandler) GetOSQueryResult(ctx context.Context, req *connect.Requ
 			for _, row := range rawRows {
 				resp.Rows = append(resp.Rows, &pm.OSQueryRow{Data: row})
 			}
+		} else {
+			// WS16 #11: a decode failure must not masquerade as a clean,
+			// empty success — surface it so corrupt/malformed result rows are
+			// observable instead of silently dropped.
+			h.logger.Warn("osquery result rows decode failed",
+				"query_id", result.QueryID, "error", err)
 		}
 	}
 
@@ -219,6 +225,12 @@ func (h *OSQueryHandler) GetDeviceInventory(ctx context.Context, req *connect.Re
 			for _, r := range rawRows {
 				table.Rows = append(table.Rows, &pm.OSQueryRow{Data: r})
 			}
+		} else {
+			// WS16 #11: log a corrupt inventory table rather than emit it as
+			// an empty (but present) table that looks like the device has no
+			// data for it.
+			h.logger.Warn("inventory table rows decode failed",
+				"device_id", msg.DeviceId, "table", row.TableName, "error", err)
 		}
 
 		resp.Tables = append(resp.Tables, table)

--- a/internal/api/osquery_unmarshal_log_test.go
+++ b/internal/api/osquery_unmarshal_log_test.go
@@ -1,0 +1,98 @@
+package api_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// captureHandler records every slog record so tests can assert that a code
+// path logged (and at what level / with which attrs) instead of swallowing.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+// hasRecordAtLeast reports whether any captured record at >= minLevel mentions
+// substr (in its message or any attribute value).
+func (h *captureHandler) hasRecordAtLeast(minLevel slog.Level, substr string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if r.Level < minLevel {
+			continue
+		}
+		rendered := r.Message
+		r.Attrs(func(a slog.Attr) bool {
+			rendered += " " + a.Key + "=" + fmt.Sprint(a.Value.Any())
+			return true
+		})
+		if substr == "" || strings.Contains(rendered, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// WS16 #11: GetOSQueryResult (and the device-inventory path) swallowed a JSONB
+// decode error (`if err == nil { ... }` with no else), returning empty success
+// as if the device reported no rows. A corrupt result must be LOGGED with its
+// query_id, not silently reported clean.
+func TestGetOSQueryResult_RowsUnmarshalFailure_IsLoggedNotSilentlyEmpty(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	cap := &captureHandler{}
+	h := api.NewOSQueryHandler(st, slog.New(cap), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "corrupt-rows-host")
+
+	dispatchResp, err := h.DispatchOSQuery(ctx, connect.NewRequest(&pm.DispatchOSQueryRequest{
+		DeviceId: deviceID,
+		Table:    "processes",
+	}))
+	require.NoError(t, err)
+	queryID := dispatchResp.Msg.QueryId
+
+	// Complete the result with INVALID JSON in Rows (a device/relay could send
+	// malformed bytes; the column is JSONB-typed but `"…"` is valid JSON that
+	// is not the expected array-of-objects).
+	_, err = st.Queries().CompleteOSQueryResult(ctx, generated.CompleteOSQueryResultParams{
+		QueryID:  queryID,
+		Success:  true,
+		Error:    "",
+		Rows:     []byte(`"not-an-array-of-rows"`),
+		DeviceID: deviceID,
+	})
+	require.NoError(t, err)
+
+	resp, err := h.GetOSQueryResult(ctx, connect.NewRequest(&pm.GetOSQueryResultRequest{QueryId: queryID}))
+	require.NoError(t, err)
+	assert.Empty(t, resp.Msg.Rows, "corrupt rows cannot decode into proto rows")
+
+	assert.True(t, cap.hasRecordAtLeast(slog.LevelWarn, queryID),
+		"a JSONB rows-decode failure must be logged at Warn/Error with the query_id, not silently returned as a clean empty result")
+}

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -14,20 +14,36 @@ import (
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
+// systemActionSyncer is the slice of SystemActionManager the settings fan-out
+// depends on. Narrowing it to an interface lets a test inject a panicking
+// implementation to prove the fan-out goroutine recovers (WS16 #9).
+type systemActionSyncer interface {
+	SyncAllUsersSystemActions(ctx context.Context) error
+}
+
 // SettingsHandler handles server settings RPCs.
 type SettingsHandler struct {
 	store         *store.Store
 	logger        *slog.Logger
-	systemActions *SystemActionManager
+	systemActions systemActionSyncer
+	// onPropagationDone, when set (tests only), is invoked after the detached
+	// settings fan-out goroutine finishes — including after a recovered panic —
+	// so a test can observe completion without racing.
+	onPropagationDone func()
 }
 
 // NewSettingsHandler creates a new settings handler.
 func NewSettingsHandler(st *store.Store, logger *slog.Logger, systemActions *SystemActionManager) *SettingsHandler {
-	return &SettingsHandler{
-		store:         st,
-		logger:        logger.With("component", "settings_handler"),
-		systemActions: systemActions,
+	h := &SettingsHandler{
+		store:  st,
+		logger: logger.With("component", "settings_handler"),
 	}
+	// Avoid a typed-nil interface: a nil *SystemActionManager must leave the
+	// field nil so the `!= nil` guard in the fan-out stays correct.
+	if systemActions != nil {
+		h.systemActions = systemActions
+	}
+	return h
 }
 
 // GetServerSettings returns the current server settings.
@@ -84,25 +100,7 @@ func (h *SettingsHandler) UpdateServerSettings(ctx context.Context, req *connect
 	// a potentially-slow fan-out. bgCtx is bounded by a hard timeout
 	// so a wedged downstream (DB outage, hanging action dispatch) can
 	// never leak the goroutine forever.
-	go func() {
-		bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
-		if req.Msg.UserProvisioningEnabled {
-			if err := h.enableProvisioningForAllUsers(bgCtx); err != nil {
-				h.logger.Error("failed to propagate provisioning to users", "error", err)
-			}
-		}
-		if req.Msg.SshAccessForAll {
-			if err := h.enableSshAccessForAllUsers(bgCtx); err != nil {
-				h.logger.Error("failed to propagate SSH access to users", "error", err)
-			}
-		}
-		if h.systemActions != nil {
-			if err := h.systemActions.SyncAllUsersSystemActions(bgCtx); err != nil {
-				h.logger.Error("failed to sync system actions after settings update", "error", err)
-			}
-		}
-	}()
+	go h.runSettingsPropagation(req.Msg)
 
 	return connect.NewResponse(&pm.UpdateServerSettingsResponse{
 		Settings: &pm.ServerSettings{
@@ -110,6 +108,41 @@ func (h *SettingsHandler) UpdateServerSettings(ctx context.Context, req *connect
 			SshAccessForAll:         settings.SshAccessForAll,
 		},
 	}), nil
+}
+
+// runSettingsPropagation performs the detached post-update fan-out under panic
+// recovery (WS16 #9): a panic in any propagation path — e.g. a downstream nil
+// deref — would otherwise crash the whole control process, since a panic in a
+// bare goroutine is unrecoverable by the parent. bgCtx is bounded by a hard
+// timeout so a wedged downstream can never leak the goroutine forever.
+func (h *SettingsHandler) runSettingsPropagation(msg *pm.UpdateServerSettingsRequest) {
+	defer func() {
+		if r := recover(); r != nil {
+			h.logger.Error("settings fan-out panic recovered", "panic", r)
+		}
+		if h.onPropagationDone != nil {
+			h.onPropagationDone()
+		}
+	}()
+
+	bgCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	if msg.UserProvisioningEnabled {
+		if err := h.enableProvisioningForAllUsers(bgCtx); err != nil {
+			h.logger.Error("failed to propagate provisioning to users", "error", err)
+		}
+	}
+	if msg.SshAccessForAll {
+		if err := h.enableSshAccessForAllUsers(bgCtx); err != nil {
+			h.logger.Error("failed to propagate SSH access to users", "error", err)
+		}
+	}
+	if h.systemActions != nil {
+		if err := h.systemActions.SyncAllUsersSystemActions(bgCtx); err != nil {
+			h.logger.Error("failed to sync system actions after settings update", "error", err)
+		}
+	}
 }
 
 // enableProvisioningForAllUsers sets user_provisioning_enabled=true on every user

--- a/internal/auth/authorizer.go
+++ b/internal/auth/authorizer.go
@@ -6,17 +6,12 @@ type AuthzInput struct {
 	SubjectID   string   `json:"subject_id"`
 	Action      string   `json:"action"`
 	ResourceID  string   `json:"resource_id,omitempty"`
-	DeviceID    string   `json:"device_id,omitempty"` // device context for execution queries
-	IsDevice    bool     `json:"is_device,omitempty"` // true when caller is a device
 }
 
-// Authorize checks whether the given input is authorized.
-// It implements the same four user rules and four device rules
-// that were previously expressed in OPA Rego.
+// Authorize checks whether the given input is authorized. Agents authenticate
+// to the gateway over mTLS and never reach this control-plane interceptor, so
+// authorization here is permission-based user access only.
 func Authorize(input AuthzInput) bool {
-	if input.IsDevice {
-		return authorizeDevice(input)
-	}
 	return authorizeUser(input)
 }
 
@@ -46,28 +41,4 @@ func authorizeUser(input AuthzInput) bool {
 		}
 	}
 	return false
-}
-
-// authorizeDevice checks hardcoded device access rules.
-func authorizeDevice(input AuthzInput) bool {
-	switch input.Action {
-	case "GetDevice":
-		// Devices can only view themselves
-		return input.ResourceID == input.SubjectID
-
-	case "ListDefinitions", "GetDefinition":
-		// Devices can view definitions (needed to execute actions)
-		return true
-
-	case "ListExecutions", "GetExecution":
-		// Devices can view their own executions
-		return input.DeviceID == input.SubjectID
-
-	case "Heartbeat", "UpdateStatus":
-		// Devices can send heartbeats and status updates
-		return true
-
-	default:
-		return false
-	}
 }

--- a/internal/auth/authorizer_deadcode_test.go
+++ b/internal/auth/authorizer_deadcode_test.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// WS16 #14: the device-authz machinery (DeviceContext, WithDevice,
+// DeviceFromContext, SubjectFromContext, authorizeDevice and the AuthzInput
+// device fields) was dead — agents authenticate to the gateway over mTLS and
+// never reach this control-plane interceptor. It was removed. This
+// self-discovering guard fails if any of it is reintroduced, so the path can
+// never silently rot back into ambiguous, live-looking authz code.
+//
+// It scans the whole server module's production (non-_test.go) source rather
+// than a hardcoded file list, and refuses to pass if it matched zero files.
+func TestDeviceAuthz_NoProductionCallerOrSymbol_GuardsAgainstRot(t *testing.T) {
+	// Identifiers that lived only in the removed device-authz path. A bare
+	// match in any production source means the machinery came back. Note: an
+	// unrelated `DeviceContext` type exists in dyngroupeval/dynamicquery, so we
+	// only flag the auth-qualified form module-wide and the bare form inside
+	// internal/auth.
+	deadAuthSymbols := []string{"authorizeDevice", "WithDevice", "DeviceFromContext", "SubjectFromContext"}
+	deadQualified := []string{"auth.WithDevice", "auth.DeviceFromContext", "auth.SubjectFromContext", "auth.DeviceContext"}
+
+	moduleRoot := filepath.Join("..", "..") // internal/auth -> server module root
+
+	scanned := 0
+	for _, sub := range []string{"internal", "cmd"} {
+		root := filepath.Join(moduleRoot, sub)
+		err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			// Don't flag this guard's own source.
+			if strings.HasSuffix(path, "authorizer_deadcode_test.go") {
+				return nil
+			}
+			data, rerr := os.ReadFile(path)
+			if rerr != nil {
+				return rerr
+			}
+			src := string(data)
+			scanned++
+
+			inAuthPkg := strings.Contains(filepath.ToSlash(path), "/internal/auth/")
+			if inAuthPkg {
+				for _, sym := range deadAuthSymbols {
+					require.NotContainsf(t, src, sym,
+						"%s: dead device-authz symbol %q reintroduced in the auth package (WS16 #14)", path, sym)
+				}
+			}
+			for _, q := range deadQualified {
+				require.NotContainsf(t, src, q,
+					"%s: reference to removed device-authz API %q (WS16 #14)", path, q)
+			}
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	require.Greater(t, scanned, 100, "device-authz guard matched too few files — the walk is broken, the check would pass vacuously")
+}

--- a/internal/auth/authorizer_test.go
+++ b/internal/auth/authorizer_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // ============================================================================
@@ -214,105 +213,4 @@ func TestAuthorize_DefaultUserPermissions(t *testing.T) {
 		SubjectID:   "user-1",
 		Action:      "DeleteDevice",
 	}))
-}
-
-// ============================================================================
-// Device access
-// ============================================================================
-
-func TestAuthorize_DeviceGetOwnInfo(t *testing.T) {
-	allowed := Authorize(AuthzInput{
-		IsDevice:   true,
-		SubjectID:  "device-1",
-		Action:     "GetDevice",
-		ResourceID: "device-1",
-	})
-	assert.True(t, allowed)
-}
-
-func TestAuthorize_DeviceGetOtherDevice(t *testing.T) {
-	allowed := Authorize(AuthzInput{
-		IsDevice:   true,
-		SubjectID:  "device-1",
-		Action:     "GetDevice",
-		ResourceID: "device-2",
-	})
-	assert.False(t, allowed)
-}
-
-func TestAuthorize_DeviceViewDefinitions(t *testing.T) {
-	for _, action := range []string{"ListDefinitions", "GetDefinition"} {
-		allowed := Authorize(AuthzInput{
-			IsDevice:  true,
-			SubjectID: "device-1",
-			Action:    action,
-		})
-		assert.True(t, allowed, "device should be allowed %s", action)
-	}
-}
-
-func TestAuthorize_DeviceViewOwnExecutions(t *testing.T) {
-	for _, action := range []string{"ListExecutions", "GetExecution"} {
-		allowed := Authorize(AuthzInput{
-			IsDevice:  true,
-			SubjectID: "device-1",
-			Action:    action,
-			DeviceID:  "device-1",
-		})
-		assert.True(t, allowed, "device should be allowed %s for own executions", action)
-	}
-}
-
-func TestAuthorize_DeviceHeartbeat(t *testing.T) {
-	for _, action := range []string{"Heartbeat", "UpdateStatus"} {
-		allowed := Authorize(AuthzInput{
-			IsDevice:  true,
-			SubjectID: "device-1",
-			Action:    action,
-		})
-		assert.True(t, allowed, "device should be allowed %s", action)
-	}
-}
-
-// TestAuthorize_DeviceAllowed_ExactSet pins the EXACT set of actions a device
-// cert may invoke and proves every other registered permission is denied —
-// self-discoveringly, so a new permission can never silently become
-// device-reachable (#11). Replaces the old hand-picked denied-actions sample.
-//
-// The allowed set is sourced from the device trust model (a device may read
-// itself, read definitions to execute, read its own executions, and report
-// status), NOT from authorizeDevice — so a change to authorizeDevice that widens
-// device reach fails this test.
-func TestAuthorize_DeviceAllowed_ExactSet(t *testing.T) {
-	const self = "device-1"
-	allowed := map[string]AuthzInput{
-		"GetDevice":       {IsDevice: true, SubjectID: self, Action: "GetDevice", ResourceID: self},
-		"ListDefinitions": {IsDevice: true, SubjectID: self, Action: "ListDefinitions"},
-		"GetDefinition":   {IsDevice: true, SubjectID: self, Action: "GetDefinition"},
-		"ListExecutions":  {IsDevice: true, SubjectID: self, Action: "ListExecutions", DeviceID: self},
-		"GetExecution":    {IsDevice: true, SubjectID: self, Action: "GetExecution", DeviceID: self},
-		"Heartbeat":       {IsDevice: true, SubjectID: self, Action: "Heartbeat"},
-		"UpdateStatus":    {IsDevice: true, SubjectID: self, Action: "UpdateStatus"},
-	}
-	require.NotEmpty(t, allowed)
-
-	for name, in := range allowed {
-		assert.Truef(t, Authorize(in), "device must be allowed %s with its correct binding", name)
-	}
-
-	// Self-discovering deny: every registered RBAC permission NOT in the allow-set
-	// must be denied for a device — even handed a self-binding, a device must not
-	// gain a permission merely because it was added to the registry.
-	perms := AllPermissions()
-	require.NotEmpty(t, perms, "no permissions discovered — the deny sweep would be vacuous")
-	denied := 0
-	for _, p := range perms {
-		if _, ok := allowed[p.Key]; ok {
-			continue
-		}
-		in := AuthzInput{IsDevice: true, SubjectID: self, Action: p.Key, ResourceID: self, DeviceID: self}
-		assert.Falsef(t, Authorize(in), "device must be denied %s (not in the device allow-list)", p.Key)
-		denied++
-	}
-	require.Greater(t, denied, len(allowed), "deny sweep must cover more permissions than the allow-list")
 }

--- a/internal/auth/context.go
+++ b/internal/auth/context.go
@@ -10,8 +10,7 @@ import (
 type contextKey string
 
 const (
-	userContextKey   contextKey = "user"
-	deviceContextKey contextKey = "device"
+	userContextKey contextKey = "user"
 )
 
 // UserContext holds authenticated user information.
@@ -23,13 +22,6 @@ type UserContext struct {
 	SessionVersion int32
 }
 
-// DeviceContext holds authenticated device information.
-type DeviceContext struct {
-	ID          string
-	Hostname    string
-	Fingerprint string
-}
-
 // WithUser adds user context to the context.
 func WithUser(ctx context.Context, user *UserContext) context.Context {
 	return context.WithValue(ctx, userContextKey, user)
@@ -39,17 +31,6 @@ func WithUser(ctx context.Context, user *UserContext) context.Context {
 func UserFromContext(ctx context.Context) (*UserContext, bool) {
 	user, ok := ctx.Value(userContextKey).(*UserContext)
 	return user, ok
-}
-
-// WithDevice adds device context to the context.
-func WithDevice(ctx context.Context, device *DeviceContext) context.Context {
-	return context.WithValue(ctx, deviceContextKey, device)
-}
-
-// DeviceFromContext retrieves device context from the context.
-func DeviceFromContext(ctx context.Context) (*DeviceContext, bool) {
-	device, ok := ctx.Value(deviceContextKey).(*DeviceContext)
-	return device, ok
 }
 
 // HasPermission checks if the user in context has a specific permission (exact match).
@@ -84,16 +65,4 @@ func EnforceSelfScope(ctx context.Context, action, resourceID string) error {
 		return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
 	}
 	return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
-}
-
-// SubjectFromContext returns the subject ID from context.
-// It checks for user first, then device.
-func SubjectFromContext(ctx context.Context) (id string, isDevice bool, ok bool) {
-	if user, ok := UserFromContext(ctx); ok {
-		return user.ID, false, true
-	}
-	if device, ok := DeviceFromContext(ctx); ok {
-		return device.ID, true, true
-	}
-	return "", false, false
 }

--- a/internal/auth/context_test.go
+++ b/internal/auth/context_test.go
@@ -24,59 +24,6 @@ func TestUserFromContext_Empty(t *testing.T) {
 	assert.False(t, ok)
 }
 
-func TestWithDevice_DeviceFromContext(t *testing.T) {
-	device := &DeviceContext{ID: "d1", Hostname: "test-host", Fingerprint: "abc123"}
-	ctx := WithDevice(context.Background(), device)
-
-	got, ok := DeviceFromContext(ctx)
-	require.True(t, ok)
-	assert.Equal(t, "d1", got.ID)
-	assert.Equal(t, "test-host", got.Hostname)
-	assert.Equal(t, "abc123", got.Fingerprint)
-}
-
-func TestDeviceFromContext_Empty(t *testing.T) {
-	_, ok := DeviceFromContext(context.Background())
-	assert.False(t, ok)
-}
-
-func TestSubjectFromContext_User(t *testing.T) {
-	user := &UserContext{ID: "u1", Email: "a@b.com"}
-	ctx := WithUser(context.Background(), user)
-
-	id, isDevice, ok := SubjectFromContext(ctx)
-	require.True(t, ok)
-	assert.Equal(t, "u1", id)
-	assert.False(t, isDevice)
-}
-
-func TestSubjectFromContext_Device(t *testing.T) {
-	device := &DeviceContext{ID: "d1", Hostname: "host", Fingerprint: "fp"}
-	ctx := WithDevice(context.Background(), device)
-
-	id, isDevice, ok := SubjectFromContext(ctx)
-	require.True(t, ok)
-	assert.Equal(t, "d1", id)
-	assert.True(t, isDevice)
-}
-
-func TestSubjectFromContext_UserPrecedence(t *testing.T) {
-	// If both user and device are in context, user takes precedence
-	user := &UserContext{ID: "u1", Email: "a@b.com"}
-	device := &DeviceContext{ID: "d1", Hostname: "host", Fingerprint: "fp"}
-	ctx := WithUser(WithDevice(context.Background(), device), user)
-
-	id, isDevice, ok := SubjectFromContext(ctx)
-	require.True(t, ok)
-	assert.Equal(t, "u1", id)
-	assert.False(t, isDevice)
-}
-
-func TestSubjectFromContext_Empty(t *testing.T) {
-	_, _, ok := SubjectFromContext(context.Background())
-	assert.False(t, ok)
-}
-
 func TestHasPermission_Found(t *testing.T) {
 	user := &UserContext{ID: "u1", Permissions: []string{"ListDevices", "GetUser:self"}}
 	ctx := WithUser(context.Background(), user)

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -480,19 +480,6 @@ func (i *AuthzInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 		parts := strings.Split(procedure, "/")
 		action := parts[len(parts)-1]
 
-		// Check if device context
-		if deviceCtx, ok := DeviceFromContext(ctx); ok {
-			input := AuthzInput{
-				IsDevice:  true,
-				SubjectID: deviceCtx.ID,
-				Action:    action,
-			}
-			if !Authorize(input) {
-				return nil, authErrorCtx(ctx, errPermissionDenied, connect.CodePermissionDenied, "permission denied")
-			}
-			return next(ctx, req)
-		}
-
 		// User context — permissions already on UserContext from JWT
 		userCtx, ok := UserFromContext(ctx)
 		if !ok {

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -605,55 +605,6 @@ func TestAuthInterceptor_ListAuthMethodsThrottled(t *testing.T) {
 	assert.Contains(t, err.Error(), "too many", "must trip the AuthMethods limiter, not some other gate")
 }
 
-// setupDeviceInterceptorTest wires the REAL AuthzInterceptor behind a tiny
-// interceptor that injects a device context (mirroring what the mTLS device-auth
-// path produces in production), so the interceptor's device branch is exercised
-// end-to-end through WrapUnary rather than unit-testing authorizeDevice in
-// isolation (#10).
-func setupDeviceInterceptorTest(t *testing.T, procedure string) string {
-	t.Helper()
-
-	deviceInjector := connect.UnaryInterceptorFunc(func(next connect.UnaryFunc) connect.UnaryFunc {
-		return func(ctx context.Context, req connect.AnyRequest) (connect.AnyResponse, error) {
-			return next(WithDevice(ctx, &DeviceContext{ID: "device-1"}), req)
-		}
-	})
-	authzIc := NewAuthzInterceptor()
-
-	mux := http.NewServeMux()
-	handler := connect.NewUnaryHandler(
-		procedure,
-		func(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
-			return connect.NewResponse(&emptypb.Empty{}), nil
-		},
-		connect.WithInterceptors(deviceInjector, authzIc),
-	)
-	mux.Handle(procedure, handler)
-
-	server := httptest.NewServer(mux)
-	t.Cleanup(server.Close)
-	return server.URL
-}
-
-func TestAuthzInterceptor_DeviceContext_AllowsDeviceAction(t *testing.T) {
-	const procedure = "/pm.v1.ControlService/Heartbeat"
-	serverURL := setupDeviceInterceptorTest(t, procedure)
-
-	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, serverURL+procedure)
-	_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
-	require.NoError(t, err, "a device must be allowed Heartbeat through the real interceptor device branch")
-}
-
-func TestAuthzInterceptor_DeviceContext_DeniesAdminAction(t *testing.T) {
-	const procedure = "/pm.v1.ControlService/DeleteDevice"
-	serverURL := setupDeviceInterceptorTest(t, procedure)
-
-	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, serverURL+procedure)
-	_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
-	require.Error(t, err, "a device must be denied an admin action through the real interceptor")
-	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
-}
-
 // setupAuthRateLimitTest mounts the EvaluateDynamicGroup (expensive) procedure
 // behind the REAL AuthInterceptor with the supplied limiters, recording whether
 // the handler ran via a per-request header. Returns the server URL + manager.

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"time"
 
 	"connectrpc.com/connect"
@@ -440,6 +442,13 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 	for {
 		msg, err := stream.Receive()
 		if err != nil {
+			// WS16 server#331: classify a clean agent shutdown as graceful
+			// instead of re-emitting it up the stack as an error (which logged
+			// every normal disconnect at error severity).
+			if isStreamClosed(err) {
+				h.logger.Info("agent stream closed", "device_id", deviceID)
+				return nil
+			}
 			return err
 		}
 
@@ -452,6 +461,31 @@ func (h *AgentHandler) Stream(ctx context.Context, stream *connect.BidiStream[pm
 			)
 		}
 	}
+}
+
+// isStreamClosed reports whether a bidi-stream Receive error represents a
+// clean end-of-stream / cancellation rather than a real transport fault.
+// connect-go v1.18.1 wraps a clean agent shutdown over h2c as
+// *connect.Error{CodeUnknown, "EOF"} instead of plain io.EOF (server#331), so
+// that shape is classified too — otherwise every graceful disconnect would be
+// re-emitted up the stack as an error.
+func isStreamClosed(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	var ce *connect.Error
+	if errors.As(err, &ce) {
+		if ce.Code() == connect.CodeCanceled {
+			return true
+		}
+		if ce.Code() == connect.CodeUnknown && strings.Contains(ce.Message(), "EOF") {
+			return true
+		}
+	}
+	return false
 }
 
 // handleAgentMessage processes messages from the agent.

--- a/internal/handler/agent_stream_close_test.go
+++ b/internal/handler/agent_stream_close_test.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+)
+
+// WS16 server#331: a clean agent shutdown must be classified as graceful, not
+// re-emitted as an error. isStreamClosed is the classifier; pin every shape it
+// must accept and, crucially, that a genuine mid-stream transport error is NOT
+// swallowed.
+func TestIsStreamClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not a close", nil, false},
+		{"bare io.EOF", io.EOF, true},
+		{"wrapped io.EOF", fmt.Errorf("receive: %w", io.EOF), true},
+		{"context canceled", context.Canceled, true},
+		{"wrapped context canceled", fmt.Errorf("ctx: %w", context.Canceled), true},
+		{"connect CodeCanceled", connect.NewError(connect.CodeCanceled, errors.New("canceled")), true},
+		{"connect CodeUnknown + EOF (v1.18.1 clean-shutdown shape)", connect.NewError(connect.CodeUnknown, errors.New("EOF")), true},
+		// present-but-WRONG: real faults must stay errors.
+		{"connect CodeInternal", connect.NewError(connect.CodeInternal, errors.New("boom")), false},
+		{"connect CodeUnknown without EOF", connect.NewError(connect.CodeUnknown, errors.New("protocol error: unexpected frame")), false},
+		{"plain transport error", errors.New("connection reset by peer"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, isStreamClosed(tc.err))
+		})
+	}
+}

--- a/internal/handler/agent_stream_test.go
+++ b/internal/handler/agent_stream_test.go
@@ -280,15 +280,18 @@ func TestStream_HappyPathRegistersStartsWorkerAndSendsWelcome(t *testing.T) {
 	assert.Empty(t, stopped)
 
 	require.NoError(t, stream.CloseRequest())
-	// Drain the response side so the handler's Stream() goroutine
-	// observes the request-side EOF and unwinds before we snapshot
-	// worker state below. The terminal error itself is not asserted
-	// here — Connect-Go v1.18.1 wraps a clean bidi stream shutdown
-	// over httptest as *connect.Error{CodeUnknown, "EOF"} instead
-	// of plain io.EOF (see #331 for the open investigation). The
-	// load-bearing assertion is the worker.stopped check below,
-	// which proves Stream() returned and ran its cleanup.
-	_ = recvErr(stream)
+	// Drain the response side so the handler's Stream() goroutine observes the
+	// request-side EOF and unwinds before we snapshot worker state below.
+	// WS16 server#331: the handler now classifies the clean shutdown (which
+	// connect-go v1.18.1 surfaces to the server as *connect.Error{CodeUnknown,
+	// "EOF"}) as graceful and returns nil, so the client sees a clean io.EOF
+	// terminal status rather than an inherited error.
+	// recvErr maps a clean io.EOF terminal status to nil, so a graceful close
+	// surfaces as no error here; the pre-fix handler returned the raw
+	// CodeUnknown/"EOF" error, which recvErr would surface as non-nil.
+	termErr := recvErr(stream)
+	assert.NoError(t, termErr,
+		"a clean agent shutdown must terminate the stream gracefully (handler returns nil), not re-emit an error (#331)")
 
 	_, stopped = f.worker.snapshot()
 	assert.Equal(t, []string{"01HZX9DEFGH000000000000000"}, stopped)

--- a/internal/projectors/user_role_listener.go
+++ b/internal/projectors/user_role_listener.go
@@ -74,10 +74,11 @@ func applyUserRoleRevoked(ctx context.Context, st *store.Store, logger *slog.Log
 		return
 	}
 	if err := st.Queries().DeleteUserRoleProjection(ctx, db.DeleteUserRoleProjectionParams{
-		UserID:    payload.UserID,
-		RoleID:    payload.RoleID,
-		ScopeKind: payload.ScopeKind,
-		ScopeID:   payload.ScopeID,
+		UserID:            payload.UserID,
+		RoleID:            payload.RoleID,
+		ScopeKind:         payload.ScopeKind,
+		ScopeID:           payload.ScopeID,
+		ProjectionVersion: e.SequenceNum,
 	}); err != nil {
 		logger.Warn("user_role projector: failed to delete user_roles_projection row",
 			"event_id", e.ID,

--- a/internal/projectors/user_role_listener_test.go
+++ b/internal/projectors/user_role_listener_test.go
@@ -1,0 +1,97 @@
+package projectors_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// WS16 #7: applyUserRoleRevoked deletes the grant row with no projection_version
+// guard (unlike sibling delete listeners e.g. DeleteDeviceAssignedUser). A
+// UserRoleRevoked replayed out of order after a re-grant would wipe the newer
+// grant. These pin the asymmetric-guard fix.
+
+// seedUserRoleGrant inserts a user_roles_projection row directly at a chosen
+// projection_version so the stale-replay scenarios are fully controlled.
+func seedUserRoleGrant(t *testing.T, st *store.Store, ctx context.Context, userID, roleID string, version int64) {
+	t.Helper()
+	require.NoError(t, st.Queries().InsertUserRoleProjection(ctx, db.InsertUserRoleProjectionParams{
+		UserID:            userID,
+		RoleID:            roleID,
+		AssignedAt:        time.Unix(0, 0).UTC(),
+		AssignedBy:        "seed",
+		ProjectionVersion: version,
+	}))
+}
+
+func TestApplyUserRoleRevoked_StaleReplayDoesNotDeleteNewerGrant(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	revoke := func(userID, roleID string, seq int64) {
+		projectors.UserRoleListener(st, logger)(ctx, store.PersistedEvent{
+			StreamType:  "user_role",
+			EventType:   "UserRoleRevoked",
+			SequenceNum: seq,
+			Data:        jsonOrFail(t, map[string]any{"user_id": userID, "role_id": roleID}),
+		})
+	}
+
+	t.Run("stale revoke (seq < grant version) must NOT delete", func(t *testing.T) {
+		userID := testutil.NewID()
+		roleID := testutil.NewID()
+		seedUserRoleGrant(t, st, ctx, userID, roleID, 100)
+
+		revoke(userID, roleID, 50) // replayed out of order, older than the grant
+
+		has, err := st.Queries().UserHasRole(ctx, dbUserHasRoleParams(userID, roleID))
+		require.NoError(t, err)
+		assert.True(t, has, "a stale UserRoleRevoked (seq 50 < grant version 100) must not wipe the newer grant")
+	})
+
+	t.Run("current revoke (seq >= grant version) deletes", func(t *testing.T) {
+		userID := testutil.NewID()
+		roleID := testutil.NewID()
+		seedUserRoleGrant(t, st, ctx, userID, roleID, 100)
+
+		revoke(userID, roleID, 100)
+
+		has, err := st.Queries().UserHasRole(ctx, dbUserHasRoleParams(userID, roleID))
+		require.NoError(t, err)
+		assert.False(t, has, "a current UserRoleRevoked (seq 100 >= grant version 100) must delete the grant")
+	})
+}
+
+// TestUserRoleDelete_HasProjectionVersionGuard is a self-discovering guard: it
+// reads the DeleteUserRoleProjection query source and fails if the stale-replay
+// predicate is ever dropped (e.g. by a regen or edit). Guards against matching
+// zero query blocks.
+func TestUserRoleDelete_HasProjectionVersionGuard(t *testing.T) {
+	src, err := os.ReadFile("../store/queries/roles.sql")
+	require.NoError(t, err)
+
+	const marker = "-- name: DeleteUserRoleProjection "
+	idx := strings.Index(string(src), marker)
+	require.NotEqual(t, -1, idx, "DeleteUserRoleProjection query not found — self-discovering guard matched zero")
+
+	// The query body runs from the marker to the next named query block.
+	rest := string(src)[idx+len(marker):]
+	if next := strings.Index(rest, "\n-- name:"); next != -1 {
+		rest = rest[:next]
+	}
+	assert.Contains(t, rest, "projection_version",
+		"DeleteUserRoleProjection must carry a projection_version stale-replay guard (WS16 #7)")
+}

--- a/internal/store/generated/roles.sql.go
+++ b/internal/store/generated/roles.sql.go
@@ -38,13 +38,15 @@ WHERE user_id = $1
   AND role_id = $2
   AND scope_kind IS NOT DISTINCT FROM $3::TEXT
   AND scope_id   IS NOT DISTINCT FROM $4::TEXT
+  AND projection_version <= $5
 `
 
 type DeleteUserRoleProjectionParams struct {
-	UserID    string  `json:"user_id"`
-	RoleID    string  `json:"role_id"`
-	ScopeKind *string `json:"scope_kind"`
-	ScopeID   *string `json:"scope_id"`
+	UserID            string  `json:"user_id"`
+	RoleID            string  `json:"role_id"`
+	ScopeKind         *string `json:"scope_kind"`
+	ScopeID           *string `json:"scope_id"`
+	ProjectionVersion int64   `json:"projection_version"`
 }
 
 // UserRoleRevoked handler — 4-tuple revoke grammar (server #7 S5).
@@ -54,12 +56,17 @@ type DeleteUserRoleProjectionParams struct {
 // grant); when the caller passes concrete values it targets the
 // specific scoped row. A miss is a silent no-op, matching the
 // prior projector behaviour.
+// Stale-replay guard (WS16 #7, mirrors DeleteDeviceAssignedUser): the
+// caller passes the revoke event's sequence_num as projection_version;
+// a row whose projection_version is newer (a re-grant that bumped it)
+// survives an out-of-order replay of an older UserRoleRevoked.
 func (q *Queries) DeleteUserRoleProjection(ctx context.Context, arg DeleteUserRoleProjectionParams) error {
 	_, err := q.db.Exec(ctx, deleteUserRoleProjection,
 		arg.UserID,
 		arg.RoleID,
 		arg.ScopeKind,
 		arg.ScopeID,
+		arg.ProjectionVersion,
 	)
 	return err
 }

--- a/internal/store/queries/roles.sql
+++ b/internal/store/queries/roles.sql
@@ -196,8 +196,13 @@ ON CONFLICT DO NOTHING;
 -- grant); when the caller passes concrete values it targets the
 -- specific scoped row. A miss is a silent no-op, matching the
 -- prior projector behaviour.
+-- Stale-replay guard (WS16 #7, mirrors DeleteDeviceAssignedUser): the
+-- caller passes the revoke event's sequence_num as projection_version;
+-- a row whose projection_version is newer (a re-grant that bumped it)
+-- survives an out-of-order replay of an older UserRoleRevoked.
 DELETE FROM user_roles_projection
 WHERE user_id = $1
   AND role_id = $2
   AND scope_kind IS NOT DISTINCT FROM sqlc.narg('scope_kind')::TEXT
-  AND scope_id   IS NOT DISTINCT FROM sqlc.narg('scope_id')::TEXT;
+  AND scope_id   IS NOT DISTINCT FROM sqlc.narg('scope_id')::TEXT
+  AND projection_version <= sqlc.arg('projection_version');


### PR DESCRIPTION
## WS16 error-discipline — server (findings #7, #8, #9, #10, #11, #14, server#331)

Each fix is verified red-first (reverted the guard, observed RED — including the #9 panic crashing the test process without recovery).

### #7 — projection_version stale-replay guard (closes #433)
`DeleteUserRoleProjection` gains `AND projection_version <= sqlc.arg('projection_version')` (mirrors `DeleteDeviceAssignedUser`); `applyUserRoleRevoked` threads the revoke event's `SequenceNum`. An out-of-order `UserRoleRevoked` replay can no longer wipe a newer re-grant. sqlc regenerated; self-discovering guard pins the SQL predicate.

### #8 / #9 / #10 / #11 — fail-closed error discipline (closes #434)
- **AssignDevice** fails closed (`CodeInternal`) on a dedup-lookup DB error instead of proceeding with empty dedup sets (which re-emits duplicate `DeviceAssigned` events). Dedup reads routed through an injectable `deviceAssignmentLister` seam.
- **UpdateServerSettings** fan-out goroutine runs under panic recovery (`runSettingsPropagation`) — a downstream panic no longer crashes the control process. `systemActions` narrowed to an interface so a test can inject a panicking syncer.
- **CreateLuksToken** fails closed on a corrupt encryption-action `Params` decode instead of silently degrading the passphrase policy to the floor (min 16 / complexity 0).
- **GetOSQueryResult / GetDeviceInventory** log a JSONB rows-decode failure (with `query_id` / table) instead of returning an empty success as if the device reported no rows.

### #14 — remove dead device-authz machinery (closes #435)
Removed `DeviceContext`, `WithDevice`, `DeviceFromContext`, `SubjectFromContext`, `authorizeDevice`, the `AuthzInput` device fields, and the interceptor device branch — **zero production callers**; agents authenticate to the gateway over mTLS and never reach this control-plane interceptor. A self-discovering guard (`TestDeviceAuthz_NoProductionCallerOrSymbol_GuardsAgainstRot`) scans the module's production source and fails if any of it returns.

### server#331 — classify clean agent-stream shutdown (advances #331)
The `Stream` receive loop now classifies a clean shutdown (`io.EOF` / `context.Canceled` / connect `CodeUnknown`+"EOF") as graceful and returns `nil` instead of re-emitting it as an error. New `isStreamClosed` helper unit-tested across shapes (incl. genuine faults stay errors); the e2e happy-path test's `_ = recvErr` workaround is replaced with a graceful-termination assertion.

### Gates
`gofmt` / `go vet` / `staticcheck` clean; `go build ./...` ok; touched suites green (api 216s, auth, handler, projectors). sqlc regenerated and committed. Local CodeRabbit clean (its one finding — `sha256Hex` 'undefined' — is a cross-file same-package false positive; defined in `luks_token_hash_test.go`, package compiles).

Part of the security/RBAC hardening work plan (WS16).