### PR TITLE
refactor(projectors): single-source decodePayload[T] + DRY completeness guard (WS16b)

### DIFF
--- a/docs/adr/0021-single-source-helpers-dry.md
+++ b/docs/adr/0021-single-source-helpers-dry.md
@@ -1,0 +1,69 @@
+# 0021 — Single-source helpers + DRY discipline
+
+- Status: accepted
+- Date: 2026-06-15
+- Related: WS16b of the SECURITY_HARDENING_WORKPLAN
+  (manchtools/power-manage-server#437; the cert/CSR fixture row lands in the
+  sdk + agent repos); ADR 0020 (the WS16 fail-closed sweep, whose silent-decode
+  fixes motivated centralizing the projector decode).
+
+## Context
+
+DRY in this codebase is enforced *as code is written* — "extract before you
+duplicate" is the Definition of Done, and each feature stream collapses the
+duplication clusters in the files it touches, in the same PR. WS16b owns only
+the residual clusters no single feature stream spans:
+
+1. **Projector payload decode.** ~90 `*FromEvent` decoders in
+   `internal/projectors/` each hand-rolled the identical shape: a
+   `(stream_type, event_type)` guard returning `ErrIgnoredEvent`, an
+   empty-payload guard, a `json.Unmarshal(e.Data, &p)`, and the canonical
+   `"projector: invalid <event> payload: %w"` error wrap. No feature stream
+   touches all projectors, so the duplication never collapsed inline.
+2. **Cert/CSR test fixtures.** ECDSA P-256 CA/cert generation was re-implemented
+   in sdk and agent test files (device/user fixtures were already centralized in
+   `server/internal/testutil`).
+
+## Decision
+
+- **The strongest DRY mechanism is a single-source helper plus a
+  self-discovering completeness test, not a generic similarity tool.** Each
+  cluster collapses to one helper that everything consumes, and an AST guard
+  makes the *specific* duplication structurally impossible to reintroduce.
+
+- **`decodePayload[T]` (server).** One generic helper centralizes the
+  projector decode boilerplate; per-event field validation stays in the caller.
+  `TestDecodePayloadHelperUsedByAllProjectors` AST-walks the package and fails
+  the build if any `*FromEvent` hand-rolls `json.Unmarshal` without routing
+  through the helper, unless it is a recorded exception. The exception
+  allowlist is guarded against stale entries and against a vacuous (zero-match)
+  walk. The legitimate exceptions are decoders whose payload is empty-valid
+  (the event carries no body), whose guard spans two stream types or a runtime
+  event-type parameter, or that build a DB-params struct keyed off the
+  envelope — shapes the fixed-argument helper cannot express. Decoders that
+  route through a shared per-cluster sub-decoder carry no direct
+  `json.Unmarshal` and are neither flagged nor allowlisted.
+
+- **Shared cert/CSR test fixtures (sdk-first).** The CA/cert builders move to a
+  shared exported helper in the sdk so agent and sdk tests consume one
+  implementation.
+
+- **The `dupl` CI backstop is deferred, not adopted.** The work plan specified a
+  `dupl` duplication-detection CI job as a *secondary, allowlisted* backstop,
+  explicitly blunt on legitimately-similar code. The primary mechanism — the
+  single-source helper + self-discovering completeness test above — is stronger
+  and noise-free, so we ship that and do not add the `dupl` job (it would
+  generate false positives on the many structurally-similar projector/handler
+  functions). If a future cluster cannot be guarded by a specific completeness
+  test, the `dupl` job is the documented fallback.
+
+## Consequences
+
+- A new projector decoder cannot hand-roll the decode — it must use
+  `decodePayload[T]` or justify an allowlist entry under review. The projector
+  decode boilerplate shrank by ~300 lines.
+- Centralizing the decode also centralizes the error-message form, so a future
+  change to the projector decode contract happens in one place.
+- The exception allowlist is the honest record of the shapes the helper does
+  not cover; the stale-entry guard keeps it shrinking as those shapes are
+  refactored.

--- a/internal/projectors/action.go
+++ b/internal/projectors/action.go
@@ -53,15 +53,9 @@ type ActionCreatedPayload struct {
 // for any other (stream, event_type) so the listener wrapper can
 // silently no-op.
 func ActionCreatedFromEvent(e store.PersistedEvent) (ActionCreatedPayload, error) {
-	if e.StreamType != "action" || e.EventType != string(eventtypes.ActionCreated) {
-		return ActionCreatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ActionCreatedPayload{}, fmt.Errorf("projector: empty ActionCreated payload")
-	}
-	var raw payloads.ActionCreated
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ActionCreatedPayload{}, fmt.Errorf("projector: invalid ActionCreated payload: %w", err)
+	raw, err := decodePayload[payloads.ActionCreated](e, "action", eventtypes.ActionCreated)
+	if err != nil {
+		return ActionCreatedPayload{}, err
 	}
 	if raw.Name == "" {
 		return ActionCreatedPayload{}, fmt.Errorf("projector: ActionCreated requires name")
@@ -108,15 +102,9 @@ type ActionRenamedPayload struct {
 
 // ActionRenamedFromEvent decodes ActionRenamed.
 func ActionRenamedFromEvent(e store.PersistedEvent) (ActionRenamedPayload, error) {
-	if e.StreamType != "action" || e.EventType != string(eventtypes.ActionRenamed) {
-		return ActionRenamedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ActionRenamedPayload{}, fmt.Errorf("projector: empty ActionRenamed payload")
-	}
-	var raw payloads.ActionRenamed
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ActionRenamedPayload{}, fmt.Errorf("projector: invalid ActionRenamed payload: %w", err)
+	raw, err := decodePayload[payloads.ActionRenamed](e, "action", eventtypes.ActionRenamed)
+	if err != nil {
+		return ActionRenamedPayload{}, err
 	}
 	if raw.Name == "" {
 		return ActionRenamedPayload{}, fmt.Errorf("projector: ActionRenamed requires name")

--- a/internal/projectors/action_set.go
+++ b/internal/projectors/action_set.go
@@ -41,15 +41,9 @@ type actionSetCreatedRaw struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func ActionSetCreatedFromEvent(e store.PersistedEvent) (ActionSetCreatedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetCreated) {
-		return ActionSetCreatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ActionSetCreatedPayload{}, fmt.Errorf("projector: empty ActionSetCreated payload")
-	}
-	var raw actionSetCreatedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ActionSetCreatedPayload{}, fmt.Errorf("projector: invalid ActionSetCreated payload: %w", err)
+	raw, err := decodePayload[actionSetCreatedRaw](e, "action_set", eventtypes.ActionSetCreated)
+	if err != nil {
+		return ActionSetCreatedPayload{}, err
 	}
 	if raw.Name == "" {
 		return ActionSetCreatedPayload{}, fmt.Errorf("projector: ActionSetCreated requires name")
@@ -89,15 +83,9 @@ type actionSetRenamedRaw struct {
 
 // ActionSetRenamedFromEvent decodes ActionSetRenamed.
 func ActionSetRenamedFromEvent(e store.PersistedEvent) (ActionSetRenamedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetRenamed) {
-		return ActionSetRenamedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ActionSetRenamedPayload{}, fmt.Errorf("projector: empty ActionSetRenamed payload")
-	}
-	var raw actionSetRenamedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ActionSetRenamedPayload{}, fmt.Errorf("projector: invalid ActionSetRenamed payload: %w", err)
+	raw, err := decodePayload[actionSetRenamedRaw](e, "action_set", eventtypes.ActionSetRenamed)
+	if err != nil {
+		return ActionSetRenamedPayload{}, err
 	}
 	if raw.Name == "" {
 		return ActionSetRenamedPayload{}, fmt.Errorf("projector: ActionSetRenamed requires name")
@@ -190,15 +178,9 @@ type actionSetMemberRaw struct {
 
 // ActionSetMemberAddedFromEvent decodes ActionSetMemberAdded.
 func ActionSetMemberAddedFromEvent(e store.PersistedEvent) (ActionSetMemberAddedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetMemberAdded) {
-		return ActionSetMemberAddedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ActionSetMemberAddedPayload{}, fmt.Errorf("projector: empty ActionSetMemberAdded payload")
-	}
-	var raw actionSetMemberRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ActionSetMemberAddedPayload{}, fmt.Errorf("projector: invalid ActionSetMemberAdded payload: %w", err)
+	raw, err := decodePayload[actionSetMemberRaw](e, "action_set", eventtypes.ActionSetMemberAdded)
+	if err != nil {
+		return ActionSetMemberAddedPayload{}, err
 	}
 	if raw.ActionID == "" {
 		return ActionSetMemberAddedPayload{}, fmt.Errorf("projector: ActionSetMemberAdded requires action_id")
@@ -223,15 +205,9 @@ type actionSetMemberRemovedRaw struct {
 
 // ActionSetMemberRemovedFromEvent decodes ActionSetMemberRemoved.
 func ActionSetMemberRemovedFromEvent(e store.PersistedEvent) (ActionSetMemberRemovedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetMemberRemoved) {
-		return ActionSetMemberRemovedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ActionSetMemberRemovedPayload{}, fmt.Errorf("projector: empty ActionSetMemberRemoved payload")
-	}
-	var raw actionSetMemberRemovedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ActionSetMemberRemovedPayload{}, fmt.Errorf("projector: invalid ActionSetMemberRemoved payload: %w", err)
+	raw, err := decodePayload[actionSetMemberRemovedRaw](e, "action_set", eventtypes.ActionSetMemberRemoved)
+	if err != nil {
+		return ActionSetMemberRemovedPayload{}, err
 	}
 	if raw.ActionID == "" {
 		return ActionSetMemberRemovedPayload{}, fmt.Errorf("projector: ActionSetMemberRemoved requires action_id")
@@ -247,15 +223,9 @@ type ActionSetMemberReorderedPayload = ActionSetMemberAddedPayload
 // Same field set as ActionSetMemberAdded plus the same default-zero
 // behaviour for sort_order.
 func ActionSetMemberReorderedFromEvent(e store.PersistedEvent) (ActionSetMemberReorderedPayload, error) {
-	if e.StreamType != "action_set" || e.EventType != string(eventtypes.ActionSetMemberReordered) {
-		return ActionSetMemberReorderedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ActionSetMemberReorderedPayload{}, fmt.Errorf("projector: empty ActionSetMemberReordered payload")
-	}
-	var raw actionSetMemberRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ActionSetMemberReorderedPayload{}, fmt.Errorf("projector: invalid ActionSetMemberReordered payload: %w", err)
+	raw, err := decodePayload[actionSetMemberRaw](e, "action_set", eventtypes.ActionSetMemberReordered)
+	if err != nil {
+		return ActionSetMemberReorderedPayload{}, err
 	}
 	if raw.ActionID == "" {
 		return ActionSetMemberReorderedPayload{}, fmt.Errorf("projector: ActionSetMemberReordered requires action_id")

--- a/internal/projectors/assignment.go
+++ b/internal/projectors/assignment.go
@@ -40,15 +40,9 @@ type AssignmentCreatedPayload struct {
 // failure surface in the listener log instead of producing a half-
 // applied row.
 func AssignmentCreatedFromEvent(e store.PersistedEvent) (AssignmentCreatedPayload, error) {
-	if e.StreamType != "assignment" || e.EventType != string(eventtypes.AssignmentCreated) {
-		return AssignmentCreatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return AssignmentCreatedPayload{}, fmt.Errorf("projector: empty AssignmentCreated payload")
-	}
-	var raw payloads.AssignmentCreated
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return AssignmentCreatedPayload{}, fmt.Errorf("projector: invalid AssignmentCreated payload: %w", err)
+	raw, err := decodePayload[payloads.AssignmentCreated](e, "assignment", eventtypes.AssignmentCreated)
+	if err != nil {
+		return AssignmentCreatedPayload{}, err
 	}
 	switch {
 	case raw.SourceType == "":

--- a/internal/projectors/compliance.go
+++ b/internal/projectors/compliance.go
@@ -47,15 +47,9 @@ type complianceResultUpdatedRaw struct {
 // Returns ErrIgnoredEvent for any other (stream, event_type) so the
 // listener wrapper can silently no-op.
 func ComplianceResultUpdatedFromEvent(e store.PersistedEvent) (ComplianceResultUpdatedPayload, error) {
-	if e.StreamType != "compliance" || e.EventType != string(eventtypes.ComplianceResultUpdated) {
-		return ComplianceResultUpdatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ComplianceResultUpdatedPayload{}, fmt.Errorf("projector: empty ComplianceResultUpdated payload")
-	}
-	var raw complianceResultUpdatedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ComplianceResultUpdatedPayload{}, fmt.Errorf("projector: invalid ComplianceResultUpdated payload: %w", err)
+	raw, err := decodePayload[complianceResultUpdatedRaw](e, "compliance", eventtypes.ComplianceResultUpdated)
+	if err != nil {
+		return ComplianceResultUpdatedPayload{}, err
 	}
 	if raw.DeviceID == "" {
 		return ComplianceResultUpdatedPayload{}, fmt.Errorf("projector: ComplianceResultUpdated requires device_id")
@@ -95,15 +89,9 @@ type complianceResultRemovedRaw struct {
 
 // ComplianceResultRemovedFromEvent decodes ComplianceResultRemoved.
 func ComplianceResultRemovedFromEvent(e store.PersistedEvent) (ComplianceResultRemovedPayload, error) {
-	if e.StreamType != "compliance" || e.EventType != string(eventtypes.ComplianceResultRemoved) {
-		return ComplianceResultRemovedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ComplianceResultRemovedPayload{}, fmt.Errorf("projector: empty ComplianceResultRemoved payload")
-	}
-	var raw complianceResultRemovedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ComplianceResultRemovedPayload{}, fmt.Errorf("projector: invalid ComplianceResultRemoved payload: %w", err)
+	raw, err := decodePayload[complianceResultRemovedRaw](e, "compliance", eventtypes.ComplianceResultRemoved)
+	if err != nil {
+		return ComplianceResultRemovedPayload{}, err
 	}
 	if raw.DeviceID == "" {
 		return ComplianceResultRemovedPayload{}, fmt.Errorf("projector: ComplianceResultRemoved requires device_id")

--- a/internal/projectors/compliance_policy.go
+++ b/internal/projectors/compliance_policy.go
@@ -34,15 +34,9 @@ type compliancePolicyCreatedRaw struct {
 // Returns ErrIgnoredEvent for any other (stream, event_type) so the
 // listener wrapper can silently no-op.
 func CompliancePolicyCreatedFromEvent(e store.PersistedEvent) (CompliancePolicyCreatedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyCreated) {
-		return CompliancePolicyCreatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return CompliancePolicyCreatedPayload{}, fmt.Errorf("projector: empty CompliancePolicyCreated payload")
-	}
-	var raw compliancePolicyCreatedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return CompliancePolicyCreatedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyCreated payload: %w", err)
+	raw, err := decodePayload[compliancePolicyCreatedRaw](e, "compliance_policy", eventtypes.CompliancePolicyCreated)
+	if err != nil {
+		return CompliancePolicyCreatedPayload{}, err
 	}
 	if raw.Name == "" {
 		return CompliancePolicyCreatedPayload{}, fmt.Errorf("projector: CompliancePolicyCreated requires name")
@@ -73,15 +67,9 @@ type compliancePolicyRenamedRaw struct {
 
 // CompliancePolicyRenamedFromEvent decodes CompliancePolicyRenamed.
 func CompliancePolicyRenamedFromEvent(e store.PersistedEvent) (CompliancePolicyRenamedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyRenamed) {
-		return CompliancePolicyRenamedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return CompliancePolicyRenamedPayload{}, fmt.Errorf("projector: empty CompliancePolicyRenamed payload")
-	}
-	var raw compliancePolicyRenamedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return CompliancePolicyRenamedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyRenamed payload: %w", err)
+	raw, err := decodePayload[compliancePolicyRenamedRaw](e, "compliance_policy", eventtypes.CompliancePolicyRenamed)
+	if err != nil {
+		return CompliancePolicyRenamedPayload{}, err
 	}
 	if raw.Name == "" {
 		return CompliancePolicyRenamedPayload{}, fmt.Errorf("projector: CompliancePolicyRenamed requires name")
@@ -148,15 +136,9 @@ type compliancePolicyRuleAddedRaw struct {
 
 // CompliancePolicyRuleAddedFromEvent decodes CompliancePolicyRuleAdded.
 func CompliancePolicyRuleAddedFromEvent(e store.PersistedEvent) (CompliancePolicyRuleAddedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyRuleAdded) {
-		return CompliancePolicyRuleAddedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return CompliancePolicyRuleAddedPayload{}, fmt.Errorf("projector: empty CompliancePolicyRuleAdded payload")
-	}
-	var raw compliancePolicyRuleAddedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return CompliancePolicyRuleAddedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyRuleAdded payload: %w", err)
+	raw, err := decodePayload[compliancePolicyRuleAddedRaw](e, "compliance_policy", eventtypes.CompliancePolicyRuleAdded)
+	if err != nil {
+		return CompliancePolicyRuleAddedPayload{}, err
 	}
 	if raw.ActionID == "" {
 		return CompliancePolicyRuleAddedPayload{}, fmt.Errorf("projector: CompliancePolicyRuleAdded requires action_id")
@@ -188,15 +170,9 @@ type compliancePolicyRuleRemovedRaw struct {
 
 // CompliancePolicyRuleRemovedFromEvent decodes CompliancePolicyRuleRemoved.
 func CompliancePolicyRuleRemovedFromEvent(e store.PersistedEvent) (CompliancePolicyRuleRemovedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyRuleRemoved) {
-		return CompliancePolicyRuleRemovedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return CompliancePolicyRuleRemovedPayload{}, fmt.Errorf("projector: empty CompliancePolicyRuleRemoved payload")
-	}
-	var raw compliancePolicyRuleRemovedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return CompliancePolicyRuleRemovedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyRuleRemoved payload: %w", err)
+	raw, err := decodePayload[compliancePolicyRuleRemovedRaw](e, "compliance_policy", eventtypes.CompliancePolicyRuleRemoved)
+	if err != nil {
+		return CompliancePolicyRuleRemovedPayload{}, err
 	}
 	if raw.ActionID == "" {
 		return CompliancePolicyRuleRemovedPayload{}, fmt.Errorf("projector: CompliancePolicyRuleRemoved requires action_id")
@@ -226,15 +202,9 @@ type compliancePolicyRuleUpdatedRaw struct {
 
 // CompliancePolicyRuleUpdatedFromEvent decodes CompliancePolicyRuleUpdated.
 func CompliancePolicyRuleUpdatedFromEvent(e store.PersistedEvent) (CompliancePolicyRuleUpdatedPayload, error) {
-	if e.StreamType != "compliance_policy" || e.EventType != string(eventtypes.CompliancePolicyRuleUpdated) {
-		return CompliancePolicyRuleUpdatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return CompliancePolicyRuleUpdatedPayload{}, fmt.Errorf("projector: empty CompliancePolicyRuleUpdated payload")
-	}
-	var raw compliancePolicyRuleUpdatedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return CompliancePolicyRuleUpdatedPayload{}, fmt.Errorf("projector: invalid CompliancePolicyRuleUpdated payload: %w", err)
+	raw, err := decodePayload[compliancePolicyRuleUpdatedRaw](e, "compliance_policy", eventtypes.CompliancePolicyRuleUpdated)
+	if err != nil {
+		return CompliancePolicyRuleUpdatedPayload{}, err
 	}
 	if raw.ActionID == "" {
 		return CompliancePolicyRuleUpdatedPayload{}, fmt.Errorf("projector: CompliancePolicyRuleUpdated requires action_id")

--- a/internal/projectors/decode.go
+++ b/internal/projectors/decode.go
@@ -1,0 +1,43 @@
+package projectors
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// decodePayload is the single-source projector payload decoder (WS16b). Every
+// `*FromEvent` decoder that JSON-decodes a non-empty event payload routes
+// through it, replacing the ~100 hand-rolled copies of the same shape:
+//
+//   - verify the event's (stream_type, event_type); any other event returns
+//     ErrIgnoredEvent so the listener wrapper silently no-ops;
+//   - reject an empty payload with the canonical "empty <event> payload" error;
+//   - json.Unmarshal e.Data into T with the canonical
+//     "invalid <event> payload: <err>" wrap.
+//
+// Per-event field validation (required ids, scope pairing, etc.) stays in the
+// caller — only the boilerplate decode is centralized. The
+// TestDecodePayloadHelperUsedByAllProjectors guard fails the build if a
+// projector decodes a JSON payload without going through this helper.
+//
+// Decoders whose payload is legitimately allowed to be empty (the event
+// carries no body and the projection derives everything from the envelope) do
+// NOT use this helper — they handle the empty case explicitly and are recorded
+// in that guard's allowlist.
+func decodePayload[T any](e store.PersistedEvent, streamType string, eventType eventtypes.EventType) (T, error) {
+	var zero T
+	if e.StreamType != streamType || e.EventType != string(eventType) {
+		return zero, ErrIgnoredEvent
+	}
+	if len(e.Data) == 0 {
+		return zero, fmt.Errorf("projector: empty %s payload", eventType)
+	}
+	var p T
+	if err := json.Unmarshal(e.Data, &p); err != nil {
+		return zero, fmt.Errorf("projector: invalid %s payload: %w", eventType, err)
+	}
+	return p, nil
+}

--- a/internal/projectors/decode_completeness_test.go
+++ b/internal/projectors/decode_completeness_test.go
@@ -1,0 +1,162 @@
+package projectors_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// WS16b: decodePayload is the single-source projector payload decoder. This
+// self-discovering guard makes the *specific* duplication it replaces —
+// hand-rolling json.Unmarshal of an event payload inside a projector decoder —
+// structurally impossible to reintroduce: every `*FromEvent` function in this
+// package must either route its decode through decodePayload (so it carries no
+// direct json.Unmarshal) or be a recorded exception below. A new standard
+// decoder that hand-rolls the decode fails this test; an exception that is
+// later collapsed onto decodePayload makes its allowlist entry stale and also
+// fails it.
+//
+// The allowlist is the set of `*FromEvent` decoders that legitimately call
+// json.Unmarshal directly:
+//   - empty payload is VALID: the event carries no body and the decoder
+//     returns an envelope-derived default on len(e.Data)==0 (decodePayload
+//     rejects empty), then decodes when a body is present; and
+//   - non-canonical shape: the decoder builds a DB-params/struct keyed off the
+//     envelope with its own validation, not the payload-struct + canonical
+//     error form decodePayload provides.
+//
+// Decoders that don't decode JSON at all, or that route their decode through a
+// shared per-cluster sub-decoder (decodeDeviceUserAssignment, decodeTerminal,
+// decodeLuksRevocation, decodeUserGroupMember, …), carry no direct
+// json.Unmarshal and so are neither flagged nor allowlisted.
+var decodePayloadHandRolledAllowlist = map[string]bool{
+	// empty-payload-valid (rule: returns an envelope-derived default on empty)
+	"ActionDescriptionUpdatedFromEvent":           true,
+	"ActionParamsUpdatedFromEvent":                true,
+	"ActionSetDescriptionUpdatedFromEvent":        true,
+	"ActionSetScheduleUpdatedFromEvent":           true,
+	"AssignmentModeChangedFromEvent":              true,
+	"AssignmentSortOrderChangedFromEvent":         true,
+	"CompliancePolicyDescriptionUpdatedFromEvent": true,
+	"DefinitionDescriptionUpdatedFromEvent":       true,
+	"DefinitionScheduleUpdatedFromEvent":          true,
+	"DeviceSeenFromEvent":                         true,
+	"DeviceHeartbeatFromEvent":                    true,
+	"DeviceLabelsUpdatedFromEvent":                true,
+	"DeviceSyncIntervalSetFromEvent":              true,
+	"DeviceGroupDescriptionUpdatedFromEvent":      true,
+	"DeviceGroupQueryUpdatedFromEvent":            true,
+	"DeviceGroupSyncIntervalSetFromEvent":         true,
+	"DeviceGroupMaintenanceWindowSetFromEvent":    true,
+	"ExecutionTimedOutFromEvent":                  true,
+	"IdentityProviderUpdatedFromEvent":            true,
+	"RoleUpdatedFromEvent":                        true,
+	"ServerSettingsUpdatedFromEvent":              true,
+	"UserProfileUpdatedFromEvent":                 true,
+	"UserSshSettingsUpdatedFromEvent":             true,
+	"UserProvisioningSettingsUpdatedFromEvent":    true,
+	"UserGroupQueryUpdatedFromEvent":              true,
+	"UserGroupMaintenanceWindowSetFromEvent":      true,
+	"UserGroupMembersRebuiltFromEvent":            true,
+	// non-canonical shape (rule: builds DB-params/struct keyed off the envelope)
+	"SecurityAlertProjectionFromEvent": true,
+	"SecurityAlertAckParamsFromEvent":  true,
+	// multi-stream / runtime-eventType: decodePayload takes a single fixed
+	// (streamType, eventType); these accept two stream types or a runtime
+	// eventType param, so the fixed-arg helper cannot express their guard.
+	"DefinitionCreatedFromEvent": true, // streams "definition" OR "action"
+	"DefinitionRenamedFromEvent": true, // streams "definition" OR "action"
+	"SCIMTokenFromEvent":         true, // eventType is a runtime parameter
+}
+
+func TestDecodePayloadHelperUsedByAllProjectors(t *testing.T) {
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("read projectors dir: %v", err)
+	}
+
+	var fromEventFns int
+	var sawDecodePayload bool
+	handRolled := map[string]bool{} // *FromEvent funcs with a direct json.Unmarshal
+
+	for _, ent := range entries {
+		name := ent.Name()
+		if ent.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, perr := parser.ParseFile(fset, name, nil, 0)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", name, perr)
+		}
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil || !strings.HasSuffix(fn.Name.Name, "FromEvent") {
+				continue
+			}
+			fromEventFns++
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				// decodePayload[...](...) — the Fun is an IndexExpr/IndexListExpr
+				// whose base is the Ident "decodePayload".
+				switch fun := call.Fun.(type) {
+				case *ast.IndexExpr:
+					if id, ok := fun.X.(*ast.Ident); ok && id.Name == "decodePayload" {
+						sawDecodePayload = true
+					}
+				case *ast.IndexListExpr:
+					if id, ok := fun.X.(*ast.Ident); ok && id.Name == "decodePayload" {
+						sawDecodePayload = true
+					}
+				case *ast.SelectorExpr:
+					if pkg, ok := fun.X.(*ast.Ident); ok && pkg.Name == "json" && fun.Sel.Name == "Unmarshal" {
+						handRolled[fn.Name.Name] = true
+					}
+				}
+				return true
+			})
+		}
+	}
+
+	// Matches-zero guards: the walk must reach real code.
+	if fromEventFns < 50 {
+		t.Fatalf("matches-zero guard: only %d *FromEvent decoders found — the AST walk is mis-scoped", fromEventFns)
+	}
+	if !sawDecodePayload {
+		t.Fatal("matches-zero guard: no decoder uses decodePayload — the helper is unused, the guard would be vacuous")
+	}
+
+	// Every hand-rolled decode must be a recorded exception.
+	var unexpected []string
+	for fn := range handRolled {
+		if !decodePayloadHandRolledAllowlist[fn] {
+			unexpected = append(unexpected, fn)
+		}
+	}
+	sort.Strings(unexpected)
+	if len(unexpected) > 0 {
+		t.Errorf("these *FromEvent decoders hand-roll json.Unmarshal instead of routing through decodePayload "+
+			"(use decodePayload[T], or if the payload is legitimately empty-valid / non-canonical add them to "+
+			"decodePayloadHandRolledAllowlist with a reason): %v", unexpected)
+	}
+
+	// No stale allowlist entry: every entry must still be a hand-rolling decoder.
+	var stale []string
+	for fn := range decodePayloadHandRolledAllowlist {
+		if !handRolled[fn] {
+			stale = append(stale, fn)
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("stale decodePayloadHandRolledAllowlist entries (the function was removed or now routes through "+
+			"decodePayload — delete the entry): %v", stale)
+	}
+}

--- a/internal/projectors/definition.go
+++ b/internal/projectors/definition.go
@@ -252,15 +252,9 @@ type definitionMemberRaw struct {
 
 // DefinitionMemberAddedFromEvent decodes DefinitionMemberAdded.
 func DefinitionMemberAddedFromEvent(e store.PersistedEvent) (DefinitionMemberAddedPayload, error) {
-	if e.StreamType != "definition" || e.EventType != string(eventtypes.DefinitionMemberAdded) {
-		return DefinitionMemberAddedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return DefinitionMemberAddedPayload{}, fmt.Errorf("projector: empty DefinitionMemberAdded payload")
-	}
-	var raw definitionMemberRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return DefinitionMemberAddedPayload{}, fmt.Errorf("projector: invalid DefinitionMemberAdded payload: %w", err)
+	raw, err := decodePayload[definitionMemberRaw](e, "definition", eventtypes.DefinitionMemberAdded)
+	if err != nil {
+		return DefinitionMemberAddedPayload{}, err
 	}
 	if raw.ActionSetID == "" {
 		return DefinitionMemberAddedPayload{}, fmt.Errorf("projector: DefinitionMemberAdded requires action_set_id")
@@ -285,15 +279,9 @@ type definitionMemberRemovedRaw struct {
 
 // DefinitionMemberRemovedFromEvent decodes DefinitionMemberRemoved.
 func DefinitionMemberRemovedFromEvent(e store.PersistedEvent) (DefinitionMemberRemovedPayload, error) {
-	if e.StreamType != "definition" || e.EventType != string(eventtypes.DefinitionMemberRemoved) {
-		return DefinitionMemberRemovedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return DefinitionMemberRemovedPayload{}, fmt.Errorf("projector: empty DefinitionMemberRemoved payload")
-	}
-	var raw definitionMemberRemovedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return DefinitionMemberRemovedPayload{}, fmt.Errorf("projector: invalid DefinitionMemberRemoved payload: %w", err)
+	raw, err := decodePayload[definitionMemberRemovedRaw](e, "definition", eventtypes.DefinitionMemberRemoved)
+	if err != nil {
+		return DefinitionMemberRemovedPayload{}, err
 	}
 	if raw.ActionSetID == "" {
 		return DefinitionMemberRemovedPayload{}, fmt.Errorf("projector: DefinitionMemberRemoved requires action_set_id")
@@ -306,15 +294,9 @@ type DefinitionMemberReorderedPayload = DefinitionMemberAddedPayload
 
 // DefinitionMemberReorderedFromEvent decodes DefinitionMemberReordered.
 func DefinitionMemberReorderedFromEvent(e store.PersistedEvent) (DefinitionMemberReorderedPayload, error) {
-	if e.StreamType != "definition" || e.EventType != string(eventtypes.DefinitionMemberReordered) {
-		return DefinitionMemberReorderedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return DefinitionMemberReorderedPayload{}, fmt.Errorf("projector: empty DefinitionMemberReordered payload")
-	}
-	var raw definitionMemberRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return DefinitionMemberReorderedPayload{}, fmt.Errorf("projector: invalid DefinitionMemberReordered payload: %w", err)
+	raw, err := decodePayload[definitionMemberRaw](e, "definition", eventtypes.DefinitionMemberReordered)
+	if err != nil {
+		return DefinitionMemberReorderedPayload{}, err
 	}
 	if raw.ActionSetID == "" {
 		return DefinitionMemberReorderedPayload{}, fmt.Errorf("projector: DefinitionMemberReordered requires action_set_id")

--- a/internal/projectors/device.go
+++ b/internal/projectors/device.go
@@ -68,15 +68,9 @@ type DeviceRegisteredPayload struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func DeviceRegisteredFromEvent(e store.PersistedEvent) (DeviceRegisteredPayload, error) {
-	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceRegistered) {
-		return DeviceRegisteredPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return DeviceRegisteredPayload{}, fmt.Errorf("projector: empty DeviceRegistered payload")
-	}
-	var raw payloads.DeviceRegistered
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return DeviceRegisteredPayload{}, fmt.Errorf("projector: invalid DeviceRegistered payload: %w", err)
+	raw, err := decodePayload[payloads.DeviceRegistered](e, "device", eventtypes.DeviceRegistered)
+	if err != nil {
+		return DeviceRegisteredPayload{}, err
 	}
 	out := DeviceRegisteredPayload{
 		ID:                  e.StreamID,
@@ -199,15 +193,9 @@ type DeviceCertRenewedPayload struct {
 
 // DeviceCertRenewedFromEvent decodes DeviceCertRenewed.
 func DeviceCertRenewedFromEvent(e store.PersistedEvent) (DeviceCertRenewedPayload, error) {
-	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceCertRenewed) {
-		return DeviceCertRenewedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return DeviceCertRenewedPayload{}, fmt.Errorf("projector: empty DeviceCertRenewed payload")
-	}
-	var raw payloads.DeviceCertRenewed
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return DeviceCertRenewedPayload{}, fmt.Errorf("projector: invalid DeviceCertRenewed payload: %w", err)
+	raw, err := decodePayload[payloads.DeviceCertRenewed](e, "device", eventtypes.DeviceCertRenewed)
+	if err != nil {
+		return DeviceCertRenewedPayload{}, err
 	}
 	if raw.CertFingerprint == nil || *raw.CertFingerprint == "" {
 		return DeviceCertRenewedPayload{}, fmt.Errorf("projector: DeviceCertRenewed requires cert_fingerprint")
@@ -271,15 +259,9 @@ type DeviceLabelSetPayload struct {
 
 // DeviceLabelSetFromEvent decodes DeviceLabelSet.
 func DeviceLabelSetFromEvent(e store.PersistedEvent) (DeviceLabelSetPayload, error) {
-	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceLabelSet) {
-		return DeviceLabelSetPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return DeviceLabelSetPayload{}, fmt.Errorf("projector: empty DeviceLabelSet payload")
-	}
-	var raw payloads.DeviceLabelSet
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return DeviceLabelSetPayload{}, fmt.Errorf("projector: invalid DeviceLabelSet payload: %w", err)
+	raw, err := decodePayload[payloads.DeviceLabelSet](e, "device", eventtypes.DeviceLabelSet)
+	if err != nil {
+		return DeviceLabelSetPayload{}, err
 	}
 	if raw.Key == nil || *raw.Key == "" {
 		return DeviceLabelSetPayload{}, fmt.Errorf("projector: DeviceLabelSet requires key")
@@ -300,15 +282,9 @@ type DeviceLabelRemovedPayload struct {
 
 // DeviceLabelRemovedFromEvent decodes DeviceLabelRemoved.
 func DeviceLabelRemovedFromEvent(e store.PersistedEvent) (DeviceLabelRemovedPayload, error) {
-	if e.StreamType != "device" || e.EventType != string(eventtypes.DeviceLabelRemoved) {
-		return DeviceLabelRemovedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return DeviceLabelRemovedPayload{}, fmt.Errorf("projector: empty DeviceLabelRemoved payload")
-	}
-	var raw payloads.DeviceLabelRemoved
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return DeviceLabelRemovedPayload{}, fmt.Errorf("projector: invalid DeviceLabelRemoved payload: %w", err)
+	raw, err := decodePayload[payloads.DeviceLabelRemoved](e, "device", eventtypes.DeviceLabelRemoved)
+	if err != nil {
+		return DeviceLabelRemovedPayload{}, err
 	}
 	if raw.Key == nil || *raw.Key == "" {
 		return DeviceLabelRemovedPayload{}, fmt.Errorf("projector: DeviceLabelRemoved requires key")

--- a/internal/projectors/device_group.go
+++ b/internal/projectors/device_group.go
@@ -49,15 +49,9 @@ type deviceGroupCreatedRaw struct {
 // otherwise fail the INSERT, surfacing as a Postgres constraint
 // violation rather than a projector-level validation error.
 func DeviceGroupCreatedFromEvent(e store.PersistedEvent) (DeviceGroupCreatedPayload, error) {
-	if e.StreamType != "device_group" || e.EventType != string(eventtypes.DeviceGroupCreated) {
-		return DeviceGroupCreatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return DeviceGroupCreatedPayload{}, fmt.Errorf("projector: empty DeviceGroupCreated payload")
-	}
-	var raw deviceGroupCreatedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return DeviceGroupCreatedPayload{}, fmt.Errorf("projector: invalid DeviceGroupCreated payload: %w", err)
+	raw, err := decodePayload[deviceGroupCreatedRaw](e, "device_group", eventtypes.DeviceGroupCreated)
+	if err != nil {
+		return DeviceGroupCreatedPayload{}, err
 	}
 	if raw.Name == "" {
 		return DeviceGroupCreatedPayload{}, fmt.Errorf("projector: DeviceGroupCreated requires name")
@@ -94,15 +88,9 @@ type deviceGroupRenamedRaw struct {
 
 // DeviceGroupRenamedFromEvent decodes DeviceGroupRenamed.
 func DeviceGroupRenamedFromEvent(e store.PersistedEvent) (DeviceGroupRenamedPayload, error) {
-	if e.StreamType != "device_group" || e.EventType != string(eventtypes.DeviceGroupRenamed) {
-		return DeviceGroupRenamedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return DeviceGroupRenamedPayload{}, fmt.Errorf("projector: empty DeviceGroupRenamed payload")
-	}
-	var raw deviceGroupRenamedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return DeviceGroupRenamedPayload{}, fmt.Errorf("projector: invalid DeviceGroupRenamed payload: %w", err)
+	raw, err := decodePayload[deviceGroupRenamedRaw](e, "device_group", eventtypes.DeviceGroupRenamed)
+	if err != nil {
+		return DeviceGroupRenamedPayload{}, err
 	}
 	if raw.Name == "" {
 		return DeviceGroupRenamedPayload{}, fmt.Errorf("projector: DeviceGroupRenamed requires name")

--- a/internal/projectors/execution.go
+++ b/internal/projectors/execution.go
@@ -54,15 +54,9 @@ type ExecutionCreatedPayload struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func ExecutionCreatedFromEvent(e store.PersistedEvent) (ExecutionCreatedPayload, error) {
-	if e.StreamType != "execution" || e.EventType != string(eventtypes.ExecutionCreated) {
-		return ExecutionCreatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ExecutionCreatedPayload{}, fmt.Errorf("projector: empty ExecutionCreated payload")
-	}
-	var raw payloads.ExecutionCreated
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ExecutionCreatedPayload{}, fmt.Errorf("projector: invalid ExecutionCreated payload: %w", err)
+	raw, err := decodePayload[payloads.ExecutionCreated](e, "execution", eventtypes.ExecutionCreated)
+	if err != nil {
+		return ExecutionCreatedPayload{}, err
 	}
 	if raw.DeviceID == "" {
 		return ExecutionCreatedPayload{}, fmt.Errorf("projector: ExecutionCreated requires device_id")
@@ -122,15 +116,9 @@ type ExecutionScheduledPayload struct {
 // emitter that builds this event populates it unconditionally
 // (action_handler.go RunAt branch); a missing key is an emitter bug.
 func ExecutionScheduledFromEvent(e store.PersistedEvent) (ExecutionScheduledPayload, error) {
-	if e.StreamType != "execution" || e.EventType != string(eventtypes.ExecutionScheduled) {
-		return ExecutionScheduledPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return ExecutionScheduledPayload{}, fmt.Errorf("projector: empty ExecutionScheduled payload")
-	}
-	var raw payloads.ExecutionScheduled
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return ExecutionScheduledPayload{}, fmt.Errorf("projector: invalid ExecutionScheduled payload: %w", err)
+	raw, err := decodePayload[payloads.ExecutionScheduled](e, "execution", eventtypes.ExecutionScheduled)
+	if err != nil {
+		return ExecutionScheduledPayload{}, err
 	}
 	if raw.DeviceID == "" {
 		return ExecutionScheduledPayload{}, fmt.Errorf("projector: ExecutionScheduled requires device_id")

--- a/internal/projectors/identity_provider.go
+++ b/internal/projectors/identity_provider.go
@@ -133,15 +133,9 @@ type idpCreatedRaw struct {
 // IdentityProviderCreatedFromEvent decodes IdentityProviderCreated.
 // Returns ErrIgnoredEvent for any other (stream, event_type).
 func IdentityProviderCreatedFromEvent(e store.PersistedEvent) (IdentityProviderCreatedPayload, error) {
-	if e.StreamType != "identity_provider" || e.EventType != string(eventtypes.IdentityProviderCreated) {
-		return IdentityProviderCreatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return IdentityProviderCreatedPayload{}, fmt.Errorf("projector: empty IdentityProviderCreated payload")
-	}
-	var raw idpCreatedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return IdentityProviderCreatedPayload{}, fmt.Errorf("projector: invalid IdentityProviderCreated payload: %w", err)
+	raw, err := decodePayload[idpCreatedRaw](e, "identity_provider", eventtypes.IdentityProviderCreated)
+	if err != nil {
+		return IdentityProviderCreatedPayload{}, err
 	}
 	switch {
 	case raw.Name == "":
@@ -265,21 +259,15 @@ func IdentityProviderUpdatedFromEvent(e store.PersistedEvent) (IdentityProviderU
 // IdentityLinkedFromEvent decodes IdentityLinked. user_id, provider_id
 // and external_id are required (composite key on the projection).
 func IdentityLinkedFromEvent(e store.PersistedEvent) (IdentityLinkPayload, error) {
-	if e.StreamType != "identity_provider" || e.EventType != string(eventtypes.IdentityLinked) {
-		return IdentityLinkPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return IdentityLinkPayload{}, fmt.Errorf("projector: empty IdentityLinked payload")
-	}
-	var raw struct {
+	raw, err := decodePayload[struct {
 		UserID        string  `json:"user_id"`
 		ProviderID    string  `json:"provider_id"`
 		ExternalID    string  `json:"external_id"`
 		ExternalEmail *string `json:"external_email,omitempty"`
 		ExternalName  *string `json:"external_name,omitempty"`
-	}
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return IdentityLinkPayload{}, fmt.Errorf("projector: invalid IdentityLinked payload: %w", err)
+	}](e, "identity_provider", eventtypes.IdentityLinked)
+	if err != nil {
+		return IdentityLinkPayload{}, err
 	}
 	switch {
 	case raw.UserID == "":
@@ -305,20 +293,14 @@ func IdentityLinkedFromEvent(e store.PersistedEvent) (IdentityLinkPayload, error
 // provider_id + external_id are the lookup key; external_email and
 // external_name are NULLIF-semantic (empty preserves existing).
 func IdentityLinkLoginUpdatedFromEvent(e store.PersistedEvent) (IdentityLinkPayload, error) {
-	if e.StreamType != "identity_provider" || e.EventType != string(eventtypes.IdentityLinkLoginUpdated) {
-		return IdentityLinkPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return IdentityLinkPayload{}, fmt.Errorf("projector: empty IdentityLinkLoginUpdated payload")
-	}
-	var raw struct {
+	raw, err := decodePayload[struct {
 		ProviderID    string `json:"provider_id"`
 		ExternalID    string `json:"external_id"`
 		ExternalEmail string `json:"external_email"`
 		ExternalName  string `json:"external_name"`
-	}
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return IdentityLinkPayload{}, fmt.Errorf("projector: invalid IdentityLinkLoginUpdated payload: %w", err)
+	}](e, "identity_provider", eventtypes.IdentityLinkLoginUpdated)
+	if err != nil {
+		return IdentityLinkPayload{}, err
 	}
 	switch {
 	case raw.ProviderID == "":

--- a/internal/projectors/lps_password.go
+++ b/internal/projectors/lps_password.go
@@ -1,7 +1,6 @@
 package projectors
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -24,15 +23,9 @@ type LpsPasswordRotatedPayload = payloads.LpsPasswordRotated
 // Reuse from a handler that wants to mirror the projection state in
 // memory while the listener writes to the DB.
 func LpsPasswordRotatedFromEvent(e store.PersistedEvent) (LpsPasswordRotatedPayload, error) {
-	if e.StreamType != "lps_password" || e.EventType != string(eventtypes.LpsPasswordRotated) {
-		return LpsPasswordRotatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: empty LpsPasswordRotated payload")
-	}
-	var p LpsPasswordRotatedPayload
-	if err := json.Unmarshal(e.Data, &p); err != nil {
-		return LpsPasswordRotatedPayload{}, fmt.Errorf("projector: invalid LpsPasswordRotated payload: %w", err)
+	p, err := decodePayload[LpsPasswordRotatedPayload](e, "lps_password", eventtypes.LpsPasswordRotated)
+	if err != nil {
+		return LpsPasswordRotatedPayload{}, err
 	}
 	// Every field below was implicitly required by the deleted
 	// PL/pgSQL projector — `(event.data->>'rotated_at')::TIMESTAMPTZ`

--- a/internal/projectors/luks_key.go
+++ b/internal/projectors/luks_key.go
@@ -34,15 +34,9 @@ type LuksRevocationPayload struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func LuksKeyRotatedFromEvent(e store.PersistedEvent) (LuksKeyRotatedPayload, error) {
-	if e.StreamType != "luks_key" || e.EventType != string(eventtypes.LuksKeyRotated) {
-		return LuksKeyRotatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return LuksKeyRotatedPayload{}, fmt.Errorf("projector: empty LuksKeyRotated payload")
-	}
-	var p LuksKeyRotatedPayload
-	if err := json.Unmarshal(e.Data, &p); err != nil {
-		return LuksKeyRotatedPayload{}, fmt.Errorf("projector: invalid LuksKeyRotated payload: %w", err)
+	p, err := decodePayload[LuksKeyRotatedPayload](e, "luks_key", eventtypes.LuksKeyRotated)
+	if err != nil {
+		return LuksKeyRotatedPayload{}, err
 	}
 	switch {
 	case p.DeviceID == "":

--- a/internal/projectors/role.go
+++ b/internal/projectors/role.go
@@ -60,15 +60,9 @@ type roleCreatedRaw struct {
 // Defaults match the PL/pgSQL projector: missing description → "";
 // missing permissions → empty slice; missing is_system → false.
 func RoleCreatedFromEvent(e store.PersistedEvent) (RoleCreatedPayload, error) {
-	if e.StreamType != "role" || e.EventType != string(eventtypes.RoleCreated) {
-		return RoleCreatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return RoleCreatedPayload{}, fmt.Errorf("projector: empty RoleCreated payload")
-	}
-	var raw roleCreatedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return RoleCreatedPayload{}, fmt.Errorf("projector: invalid RoleCreated payload: %w", err)
+	raw, err := decodePayload[roleCreatedRaw](e, "role", eventtypes.RoleCreated)
+	if err != nil {
+		return RoleCreatedPayload{}, err
 	}
 	if raw.Name == "" {
 		return RoleCreatedPayload{}, fmt.Errorf("projector: RoleCreated requires name")

--- a/internal/projectors/scim_group_mapping.go
+++ b/internal/projectors/scim_group_mapping.go
@@ -1,7 +1,6 @@
 package projectors
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -36,20 +35,14 @@ type SCIMGroupMappingUpdatedPayload struct {
 
 // SCIMGroupMappedFromEvent decodes SCIMGroupMapped.
 func SCIMGroupMappedFromEvent(e store.PersistedEvent) (SCIMGroupMappedPayload, error) {
-	if e.StreamType != "scim_group_mapping" || e.EventType != string(eventtypes.SCIMGroupMapped) {
-		return SCIMGroupMappedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return SCIMGroupMappedPayload{}, fmt.Errorf("projector: empty SCIMGroupMapped payload")
-	}
-	var raw struct {
+	raw, err := decodePayload[struct {
 		ProviderID      string  `json:"provider_id"`
 		SCIMGroupID     string  `json:"scim_group_id"`
 		SCIMDisplayName *string `json:"scim_display_name,omitempty"`
 		UserGroupID     string  `json:"user_group_id"`
-	}
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return SCIMGroupMappedPayload{}, fmt.Errorf("projector: invalid SCIMGroupMapped payload: %w", err)
+	}](e, "scim_group_mapping", eventtypes.SCIMGroupMapped)
+	if err != nil {
+		return SCIMGroupMappedPayload{}, err
 	}
 	switch {
 	case raw.ProviderID == "":
@@ -73,18 +66,12 @@ func SCIMGroupMappedFromEvent(e store.PersistedEvent) (SCIMGroupMappedPayload, e
 
 // SCIMGroupUnmappedFromEvent decodes SCIMGroupUnmapped.
 func SCIMGroupUnmappedFromEvent(e store.PersistedEvent) (SCIMGroupUnmappedPayload, error) {
-	if e.StreamType != "scim_group_mapping" || e.EventType != string(eventtypes.SCIMGroupUnmapped) {
-		return SCIMGroupUnmappedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return SCIMGroupUnmappedPayload{}, fmt.Errorf("projector: empty SCIMGroupUnmapped payload")
-	}
-	var raw struct {
+	raw, err := decodePayload[struct {
 		ProviderID  string `json:"provider_id"`
 		SCIMGroupID string `json:"scim_group_id"`
-	}
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return SCIMGroupUnmappedPayload{}, fmt.Errorf("projector: invalid SCIMGroupUnmapped payload: %w", err)
+	}](e, "scim_group_mapping", eventtypes.SCIMGroupUnmapped)
+	if err != nil {
+		return SCIMGroupUnmappedPayload{}, err
 	}
 	switch {
 	case raw.ProviderID == "":
@@ -99,19 +86,13 @@ func SCIMGroupUnmappedFromEvent(e store.PersistedEvent) (SCIMGroupUnmappedPayloa
 // Only scim_display_name is updatable; pointer field preserves
 // "missing → no update" via COALESCE.
 func SCIMGroupMappingUpdatedFromEvent(e store.PersistedEvent) (SCIMGroupMappingUpdatedPayload, error) {
-	if e.StreamType != "scim_group_mapping" || e.EventType != string(eventtypes.SCIMGroupMappingUpdated) {
-		return SCIMGroupMappingUpdatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return SCIMGroupMappingUpdatedPayload{}, fmt.Errorf("projector: empty SCIMGroupMappingUpdated payload")
-	}
-	var raw struct {
+	raw, err := decodePayload[struct {
 		ProviderID      string  `json:"provider_id"`
 		SCIMGroupID     string  `json:"scim_group_id"`
 		SCIMDisplayName *string `json:"scim_display_name,omitempty"`
-	}
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return SCIMGroupMappingUpdatedPayload{}, fmt.Errorf("projector: invalid SCIMGroupMappingUpdated payload: %w", err)
+	}](e, "scim_group_mapping", eventtypes.SCIMGroupMappingUpdated)
+	if err != nil {
+		return SCIMGroupMappingUpdatedPayload{}, err
 	}
 	switch {
 	case raw.ProviderID == "":

--- a/internal/projectors/token.go
+++ b/internal/projectors/token.go
@@ -1,7 +1,6 @@
 package projectors
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -44,15 +43,9 @@ type tokenCreatedRaw struct {
 // missing max_uses → 0; missing expires_at → nil (stays NULL); missing
 // owner_id → nil. value_hash is required (UNIQUE NOT NULL).
 func TokenCreatedFromEvent(e store.PersistedEvent) (TokenCreatedPayload, error) {
-	if e.StreamType != "token" || e.EventType != string(eventtypes.TokenCreated) {
-		return TokenCreatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return TokenCreatedPayload{}, fmt.Errorf("projector: empty TokenCreated payload")
-	}
-	var raw tokenCreatedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return TokenCreatedPayload{}, fmt.Errorf("projector: invalid TokenCreated payload: %w", err)
+	raw, err := decodePayload[tokenCreatedRaw](e, "token", eventtypes.TokenCreated)
+	if err != nil {
+		return TokenCreatedPayload{}, err
 	}
 	if raw.ValueHash == "" {
 		return TokenCreatedPayload{}, fmt.Errorf("projector: TokenCreated requires value_hash")
@@ -89,17 +82,11 @@ func TokenCreatedFromEvent(e store.PersistedEvent) (TokenCreatedPayload, error) 
 // the rename handler always supplies it; an empty payload would be
 // a programmer error.
 func TokenRenamedFromEvent(e store.PersistedEvent) (TokenRenamedPayload, error) {
-	if e.StreamType != "token" || e.EventType != string(eventtypes.TokenRenamed) {
-		return TokenRenamedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return TokenRenamedPayload{}, fmt.Errorf("projector: empty TokenRenamed payload")
-	}
-	var raw struct {
+	raw, err := decodePayload[struct {
 		Name string `json:"name"`
-	}
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return TokenRenamedPayload{}, fmt.Errorf("projector: invalid TokenRenamed payload: %w", err)
+	}](e, "token", eventtypes.TokenRenamed)
+	if err != nil {
+		return TokenRenamedPayload{}, err
 	}
 	if raw.Name == "" {
 		return TokenRenamedPayload{}, fmt.Errorf("projector: TokenRenamed requires name")

--- a/internal/projectors/user.go
+++ b/internal/projectors/user.go
@@ -63,15 +63,9 @@ type UserCreatedWithRolesPayload struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func UserCreatedWithRolesFromEvent(e store.PersistedEvent) (UserCreatedWithRolesPayload, error) {
-	if e.StreamType != "user" || e.EventType != string(eventtypes.UserCreatedWithRoles) {
-		return UserCreatedWithRolesPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserCreatedWithRolesPayload{}, fmt.Errorf("projector: empty UserCreatedWithRoles payload")
-	}
-	var raw payloads.UserCreatedWithRoles
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserCreatedWithRolesPayload{}, fmt.Errorf("projector: invalid UserCreatedWithRoles payload: %w", err)
+	raw, err := decodePayload[payloads.UserCreatedWithRoles](e, "user", eventtypes.UserCreatedWithRoles)
+	if err != nil {
+		return UserCreatedWithRolesPayload{}, err
 	}
 	// PL/pgSQL parity: a missing email key would have produced SQL
 	// NULL and crashed the NOT NULL constraint at INSERT time. Surface
@@ -186,15 +180,9 @@ type UserEmailChangedPayload struct {
 // NOT NULL, so the original projector relied on the emitter always
 // supplying a non-empty value. Keep that contract here.
 func UserEmailChangedFromEvent(e store.PersistedEvent) (UserEmailChangedPayload, error) {
-	if e.StreamType != "user" || e.EventType != string(eventtypes.UserEmailChanged) {
-		return UserEmailChangedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserEmailChangedPayload{}, fmt.Errorf("projector: empty UserEmailChanged payload")
-	}
-	var raw payloads.UserEmailChanged
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserEmailChangedPayload{}, fmt.Errorf("projector: invalid UserEmailChanged payload: %w", err)
+	raw, err := decodePayload[payloads.UserEmailChanged](e, "user", eventtypes.UserEmailChanged)
+	if err != nil {
+		return UserEmailChangedPayload{}, err
 	}
 	// PL/pgSQL parity: missing key → SQL NULL → NOT NULL violation
 	// at UPDATE time. Surface earlier here. Explicit "" is preserved
@@ -216,15 +204,9 @@ type UserPasswordChangedPayload struct {
 
 // UserPasswordChangedFromEvent decodes UserPasswordChanged.
 func UserPasswordChangedFromEvent(e store.PersistedEvent) (UserPasswordChangedPayload, error) {
-	if e.StreamType != "user" || e.EventType != string(eventtypes.UserPasswordChanged) {
-		return UserPasswordChangedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserPasswordChangedPayload{}, fmt.Errorf("projector: empty UserPasswordChanged payload")
-	}
-	var raw payloads.UserPasswordChanged
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserPasswordChangedPayload{}, fmt.Errorf("projector: invalid UserPasswordChanged payload: %w", err)
+	raw, err := decodePayload[payloads.UserPasswordChanged](e, "user", eventtypes.UserPasswordChanged)
+	if err != nil {
+		return UserPasswordChangedPayload{}, err
 	}
 	if raw.PasswordHash == nil {
 		return UserPasswordChangedPayload{}, fmt.Errorf("projector: UserPasswordChanged requires password_hash")
@@ -241,15 +223,9 @@ type UserRoleChangedPayload struct {
 
 // UserRoleChangedFromEvent decodes UserRoleChanged.
 func UserRoleChangedFromEvent(e store.PersistedEvent) (UserRoleChangedPayload, error) {
-	if e.StreamType != "user" || e.EventType != string(eventtypes.UserRoleChanged) {
-		return UserRoleChangedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserRoleChangedPayload{}, fmt.Errorf("projector: empty UserRoleChanged payload")
-	}
-	var raw payloads.UserRoleChanged
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserRoleChangedPayload{}, fmt.Errorf("projector: invalid UserRoleChanged payload: %w", err)
+	raw, err := decodePayload[payloads.UserRoleChanged](e, "user", eventtypes.UserRoleChanged)
+	if err != nil {
+		return UserRoleChangedPayload{}, err
 	}
 	// PL/pgSQL parity: missing key → SQL NULL → NOT NULL violation.
 	// Explicit "" is preserved verbatim.
@@ -282,15 +258,9 @@ type UserSshKeyAddedPayload struct {
 // default to "" so callers that omit them still produce a valid
 // element shape in the JSONB array.
 func UserSshKeyAddedFromEvent(e store.PersistedEvent) (UserSshKeyAddedPayload, error) {
-	if e.StreamType != "user" || e.EventType != string(eventtypes.UserSshKeyAdded) {
-		return UserSshKeyAddedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserSshKeyAddedPayload{}, fmt.Errorf("projector: empty UserSshKeyAdded payload")
-	}
-	var raw payloads.UserSshKeyAdded
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserSshKeyAddedPayload{}, fmt.Errorf("projector: invalid UserSshKeyAdded payload: %w", err)
+	raw, err := decodePayload[payloads.UserSshKeyAdded](e, "user", eventtypes.UserSshKeyAdded)
+	if err != nil {
+		return UserSshKeyAddedPayload{}, err
 	}
 	if raw.KeyID == nil || *raw.KeyID == "" {
 		return UserSshKeyAddedPayload{}, fmt.Errorf("projector: UserSshKeyAdded requires key_id")
@@ -316,15 +286,9 @@ type UserSshKeyRemovedPayload struct {
 
 // UserSshKeyRemovedFromEvent decodes UserSshKeyRemoved.
 func UserSshKeyRemovedFromEvent(e store.PersistedEvent) (UserSshKeyRemovedPayload, error) {
-	if e.StreamType != "user" || e.EventType != string(eventtypes.UserSshKeyRemoved) {
-		return UserSshKeyRemovedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserSshKeyRemovedPayload{}, fmt.Errorf("projector: empty UserSshKeyRemoved payload")
-	}
-	var raw payloads.UserSshKeyRemoved
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserSshKeyRemovedPayload{}, fmt.Errorf("projector: invalid UserSshKeyRemoved payload: %w", err)
+	raw, err := decodePayload[payloads.UserSshKeyRemoved](e, "user", eventtypes.UserSshKeyRemoved)
+	if err != nil {
+		return UserSshKeyRemovedPayload{}, err
 	}
 	if raw.KeyID == nil || *raw.KeyID == "" {
 		return UserSshKeyRemovedPayload{}, fmt.Errorf("projector: UserSshKeyRemoved requires key_id")
@@ -376,15 +340,9 @@ type UserLinuxUsernameChangedPayload struct {
 
 // UserLinuxUsernameChangedFromEvent decodes UserLinuxUsernameChanged.
 func UserLinuxUsernameChangedFromEvent(e store.PersistedEvent) (UserLinuxUsernameChangedPayload, error) {
-	if e.StreamType != "user" || e.EventType != string(eventtypes.UserLinuxUsernameChanged) {
-		return UserLinuxUsernameChangedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserLinuxUsernameChangedPayload{}, fmt.Errorf("projector: empty UserLinuxUsernameChanged payload")
-	}
-	var raw payloads.UserLinuxUsernameChanged
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserLinuxUsernameChangedPayload{}, fmt.Errorf("projector: invalid UserLinuxUsernameChanged payload: %w", err)
+	raw, err := decodePayload[payloads.UserLinuxUsernameChanged](e, "user", eventtypes.UserLinuxUsernameChanged)
+	if err != nil {
+		return UserLinuxUsernameChangedPayload{}, err
 	}
 	if raw.LinuxUsername == nil {
 		return UserLinuxUsernameChangedPayload{}, fmt.Errorf("projector: UserLinuxUsernameChanged requires linux_username")
@@ -418,15 +376,9 @@ const (
 // action_id defaults to "" so an explicit "unlink" can still flow
 // through (matches PL/pgSQL `COALESCE(event.data->>"action_id", "")`).
 func UserSystemActionLinkedFromEvent(e store.PersistedEvent) (UserSystemActionLinkedPayload, error) {
-	if e.StreamType != "user" || e.EventType != string(eventtypes.UserSystemActionLinked) {
-		return UserSystemActionLinkedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserSystemActionLinkedPayload{}, fmt.Errorf("projector: empty UserSystemActionLinked payload")
-	}
-	var raw payloads.UserSystemActionLinked
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserSystemActionLinkedPayload{}, fmt.Errorf("projector: invalid UserSystemActionLinked payload: %w", err)
+	raw, err := decodePayload[payloads.UserSystemActionLinked](e, "user", eventtypes.UserSystemActionLinked)
+	if err != nil {
+		return UserSystemActionLinkedPayload{}, err
 	}
 	if raw.Field == nil || *raw.Field == "" {
 		return UserSystemActionLinkedPayload{}, fmt.Errorf("projector: UserSystemActionLinked requires field")

--- a/internal/projectors/user_group.go
+++ b/internal/projectors/user_group.go
@@ -49,15 +49,9 @@ type userGroupCreatedRaw struct {
 // otherwise fail the INSERT, surfacing as a Postgres constraint
 // violation rather than a projector-level validation error.
 func UserGroupCreatedFromEvent(e store.PersistedEvent) (UserGroupCreatedPayload, error) {
-	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupCreated) {
-		return UserGroupCreatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserGroupCreatedPayload{}, fmt.Errorf("projector: empty UserGroupCreated payload")
-	}
-	var raw userGroupCreatedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserGroupCreatedPayload{}, fmt.Errorf("projector: invalid UserGroupCreated payload: %w", err)
+	raw, err := decodePayload[userGroupCreatedRaw](e, "user_group", eventtypes.UserGroupCreated)
+	if err != nil {
+		return UserGroupCreatedPayload{}, err
 	}
 	if raw.Name == "" {
 		return UserGroupCreatedPayload{}, fmt.Errorf("projector: UserGroupCreated requires name")
@@ -102,15 +96,9 @@ type userGroupUpdatedRaw struct {
 // Description signals "update" vs "preserve": non-nil = update with
 // the value (incl. empty string); nil = preserve.
 func UserGroupUpdatedFromEvent(e store.PersistedEvent) (UserGroupUpdatedPayload, error) {
-	if e.StreamType != "user_group" || e.EventType != string(eventtypes.UserGroupUpdated) {
-		return UserGroupUpdatedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserGroupUpdatedPayload{}, fmt.Errorf("projector: empty UserGroupUpdated payload")
-	}
-	var raw userGroupUpdatedRaw
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserGroupUpdatedPayload{}, fmt.Errorf("projector: invalid UserGroupUpdated payload: %w", err)
+	raw, err := decodePayload[userGroupUpdatedRaw](e, "user_group", eventtypes.UserGroupUpdated)
+	if err != nil {
+		return UserGroupUpdatedPayload{}, err
 	}
 	if raw.Name == "" {
 		return UserGroupUpdatedPayload{}, fmt.Errorf("projector: UserGroupUpdated requires name")

--- a/internal/projectors/user_role.go
+++ b/internal/projectors/user_role.go
@@ -1,7 +1,6 @@
 package projectors
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -37,15 +36,9 @@ type UserRoleRevokedPayload struct {
 // ErrIgnoredEvent for any other (stream, event_type) so the listener
 // wrapper can silently no-op.
 func UserRoleAssignedFromEvent(e store.PersistedEvent) (UserRoleAssignedPayload, error) {
-	if e.StreamType != "user_role" || e.EventType != string(eventtypes.UserRoleAssigned) {
-		return UserRoleAssignedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserRoleAssignedPayload{}, fmt.Errorf("projector: empty UserRoleAssigned payload")
-	}
-	var p UserRoleAssignedPayload
-	if err := json.Unmarshal(e.Data, &p); err != nil {
-		return UserRoleAssignedPayload{}, fmt.Errorf("projector: invalid UserRoleAssigned payload: %w", err)
+	p, err := decodePayload[UserRoleAssignedPayload](e, "user_role", eventtypes.UserRoleAssigned)
+	if err != nil {
+		return UserRoleAssignedPayload{}, err
 	}
 	switch {
 	case p.UserID == "":
@@ -63,15 +56,9 @@ func UserRoleAssignedFromEvent(e store.PersistedEvent) (UserRoleAssignedPayload,
 // UserRoleRevokedFromEvent decodes UserRoleRevoked. Same validation
 // shape as UserRoleAssigned — both composite-key fields required.
 func UserRoleRevokedFromEvent(e store.PersistedEvent) (UserRoleRevokedPayload, error) {
-	if e.StreamType != "user_role" || e.EventType != string(eventtypes.UserRoleRevoked) {
-		return UserRoleRevokedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserRoleRevokedPayload{}, fmt.Errorf("projector: empty UserRoleRevoked payload")
-	}
-	var p UserRoleRevokedPayload
-	if err := json.Unmarshal(e.Data, &p); err != nil {
-		return UserRoleRevokedPayload{}, fmt.Errorf("projector: invalid UserRoleRevoked payload: %w", err)
+	p, err := decodePayload[UserRoleRevokedPayload](e, "user_role", eventtypes.UserRoleRevoked)
+	if err != nil {
+		return UserRoleRevokedPayload{}, err
 	}
 	switch {
 	case p.UserID == "":

--- a/internal/projectors/user_selection.go
+++ b/internal/projectors/user_selection.go
@@ -1,7 +1,6 @@
 package projectors
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -29,20 +28,14 @@ type UserSelectionChangedPayload struct {
 
 // UserSelectionChangedFromEvent decodes UserSelectionChanged.
 func UserSelectionChangedFromEvent(e store.PersistedEvent) (UserSelectionChangedPayload, error) {
-	if e.StreamType != "user_selection" || e.EventType != string(eventtypes.UserSelectionChanged) {
-		return UserSelectionChangedPayload{}, ErrIgnoredEvent
-	}
-	if len(e.Data) == 0 {
-		return UserSelectionChangedPayload{}, fmt.Errorf("projector: empty UserSelectionChanged payload")
-	}
-	var raw struct {
+	raw, err := decodePayload[struct {
 		DeviceID   string `json:"device_id"`
 		SourceType string `json:"source_type"`
 		SourceID   string `json:"source_id"`
 		Selected   *bool  `json:"selected,omitempty"`
-	}
-	if err := json.Unmarshal(e.Data, &raw); err != nil {
-		return UserSelectionChangedPayload{}, fmt.Errorf("projector: invalid UserSelectionChanged payload: %w", err)
+	}](e, "user_selection", eventtypes.UserSelectionChanged)
+	if err != nil {
+		return UserSelectionChangedPayload{}, err
 	}
 	switch {
 	case raw.DeviceID == "":


### PR DESCRIPTION
## WS16b DRY-discipline — projector decode collapse (closes #437)

The ~90 `*FromEvent` decoders in `internal/projectors/` each hand-rolled the identical shape:
`(stream_type, event_type)` guard → `ErrIgnoredEvent`; empty-payload guard; `json.Unmarshal(e.Data, &p)`; canonical `"projector: invalid <event> payload: %w"` wrap.

### What changed
- **`decodePayload[T]`** (new `decode.go`) centralizes that boilerplate; per-event field validation stays in the caller. **40 decoders converted, −305 LOC net** across 18 files. Error-message forms are byte-identical (the comprehensive projector suite asserts them — all green).
- **`TestDecodePayloadHelperUsedByAllProjectors`** (self-discovering AST guard) fails the build if any `*FromEvent` hand-rolls `json.Unmarshal` without routing through the helper, unless it's a recorded exception. The allowlist is guarded against **stale entries** and a **vacuous (zero-match) walk**. It empirically caught 3 decoders during authoring.
- Legitimate exceptions (allowlisted with reasons): **empty-payload-valid** (decoder returns an envelope-derived default on empty), **multi-stream / runtime-eventType** (guard spans two stream types or a runtime event-type param — the fixed-arg helper can't express it), and **non-canonical DB-params shape**. Decoders that route through a shared per-cluster sub-decoder carry no direct `json.Unmarshal` and are neither flagged nor allowlisted.
- **ADR 0021** records the single-source-helper + completeness-test DRY policy and the decision to **defer the noisy `dupl` CI backstop** in favor of specific completeness tests.

### Gates
`gofmt` / `go vet` clean; full `go test ./internal/projectors/` green (37s, asserts exact error strings); local CodeRabbit: **no findings**.

Part of the security/RBAC hardening work plan (WS16b). The cert/CSR test-fixture row lands separately in sdk + agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added architectural decision record documenting a code quality enforcement strategy for payload decoding.

* **Refactor**
  * Standardized internal payload decoding across multiple event handlers using a shared helper function for improved code consistency and maintainability.

* **Tests**
  * Added automated test to enforce consistent payload decoding patterns across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->