### PR TITLE
test: exhaustive rejection-path + self-discovering hardening for ca/auth/api/compliance/dyngroupeval/search/store (WS17b)

### DIFF
--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -121,15 +121,15 @@ func main() {
 		logger.Error("failed to load task signer", "error", err)
 		os.Exit(1)
 	}
-	if taskSigner == nil {
-		logger.Error("PM_TASK_SIGNING_KEY is required (audit F-02 — Asynq task verification is mandatory)")
+
+	// Assemble the search worker mux with the F-02 verify-middleware mounted
+	// first. BuildSearchWorkerMux fails closed if the signer is nil (empty
+	// PM_TASK_SIGNING_KEY) — task verification is mandatory.
+	mux, err := search.BuildSearchWorkerMux(rdb, taskSigner, logger.With("component", "search_worker"))
+	if err != nil {
+		logger.Error("failed to build search worker mux", "error", err)
 		os.Exit(1)
 	}
-
-	// Initialize and start Asynq worker for search task processing
-	searchWorker := search.NewWorker(rdb, taskSigner, logger.With("component", "search_worker"))
-	mux := asynq.NewServeMux()
-	searchWorker.RegisterHandlers(mux)
 
 	aqLogger := logger.With("component", "asynq_server")
 	aqServer := asynq.NewServer(

--- a/docs/adr/0022-ws17b-boundary-hardening.md
+++ b/docs/adr/0022-ws17b-boundary-hardening.md
@@ -1,0 +1,75 @@
+# 0022 — WS17b boundary hardening: cert-CN binding, search-field sanitization, reconciler-owned role seed
+
+Status: Accepted
+Date: 2026-06-15
+
+## Context
+
+WS17b is the server/sdk test-coverage-hardening stream. Most of it adds
+rejection-path and self-discovering tests, but four findings flipped or tightened
+production behaviour and are recorded here.
+
+## Decisions
+
+### 1. `ValidateLuksToken` enforces the mTLS cert-CN binding (#7)
+
+`AgentHandler.ValidateLuksToken` relayed the caller-supplied `device_id` to the
+control proxy without the certificate-identity check that `SyncActions` already
+enforced. A compromised agent presenting **device A's** certificate could redeem
+a one-time LUKS token issued for **device B** and unlock that device's encrypted
+volume.
+
+The cert/`device_id` binding is now a shared `assertDeviceMatchesCert(ctx,
+deviceID)` helper that **every** device-scoped agent connect RPC calls before
+doing work (currently `ValidateLuksToken` + `SyncActions`, the only two). It is a
+no-op when mTLS is not required (dev/test). This is defence-in-depth alongside
+the one-time token's TTL + single-use semantics.
+
+### 2. Search warm/index treats agent-controlled fields as untrusted (#17)
+
+`hostname`, `labels`, `os_*`, `kernel`, and `agent_version` are agent-reported
+and were written into the Valkey search index verbatim. A malicious or buggy
+agent could report a multi-KB value (index bloat / memory pressure) or one
+embedding ASCII control characters or `<markup>` (which a UI rendering raw
+search-result fields could execute).
+
+A `sanitizeSearchField(s, max)` helper drops control characters, angle brackets,
+and invalid UTF-8 and caps length. It is applied on **both** the warm path
+(`Index.warmDevices`) and the live path (`worker.entityFields`) so they cannot
+drift. `linux_username` and `actor_id` are **operator-set, trusted-by-policy**
+and deliberately NOT routed through it.
+
+### 3. System-role permissions are reconciler-owned, not SQL literals (#18)
+
+The Admin/User permission arrays were seeded as SQL literals (`008_seeds.sql`,
+patched by `009`/`010`). Each frozen snapshot drifts from the Go source of truth
+(`auth.AdminPermissions` / `auth.DefaultUserPermissions`) as permissions are
+added/renamed — the Admin literal had already drifted 18 added + 6 renamed
+permissions behind. `auth.ReconcileSystemRoles` overwrites them from the Go sets
+on every boot, so the literals were runtime-irrelevant but misleading and
+un-guardable.
+
+Migration `014` blanks the system-role permission arrays. The reconciler is now
+the single source of truth; a self-discovering test asserts no migration leaves a
+non-empty frozen literal for the system roles.
+
+### 4. `BuildSearchWorkerMux` is fail-closed and testable (#15)
+
+The indexer's mux+signer assembly moved from inline `cmd/indexer/main.go` into
+`search.BuildSearchWorkerMux(rdb, signer, logger)`, which returns an error when
+the signer is nil (empty `PM_TASK_SIGNING_KEY`) instead of building an unsigned
+mux. `RegisterHandlers` mounts the F-02 `VerifyMiddleware` ahead of every
+handler, so a forged-key or unsigned `search:*` task dead-letters (SkipRetry)
+before any `HSET` — pinned by tests driving forged-key tasks through the real
+mux.
+
+## Consequences
+
+- Device-scoped agent RPCs share one cert-binding helper; adding a new one must
+  call it (the LUKS-token test pins the pattern).
+- Search index fields are bounded and stripped; operator-trusted fields are
+  documented as the exception.
+- System-role permissions can no longer drift in SQL; the reconciler owns them.
+- The sdk request-field validate-tag gate (sdk #121) is now enforced server-side
+  via the bumped pin — the validation interceptor rejects out-of-bound request
+  fields before the handler runs.

--- a/docs/adr/0022-ws17b-boundary-hardening.md
+++ b/docs/adr/0022-ws17b-boundary-hardening.md
@@ -53,6 +53,18 @@ Migration `014` blanks the system-role permission arrays. The reconciler is now
 the single source of truth; a self-discovering test asserts no migration leaves a
 non-empty frozen literal for the system roles.
 
+### 4b. Compliance evaluator recognizes "no row" via `store.IsNotFound` (#6)
+
+Writing the grace-period/rollup/first_failed_at coverage surfaced a real bug: the
+evaluator resolved "no result yet → UNKNOWN" and "first-ever non-compliant → seed
+first_failed_at" with `errors.Is(err, store.ErrNotFound)`. The generated queries
+return the backend's `pgx.ErrNoRows` — a *different* sentinel — so those branches
+never fired; a rule with no result yet, or failing for the first time, errored
+instead and aborted the whole device evaluation. Per `store/notfound.go`, callers
+outside the store package must use `store.IsNotFound(err)` (it matches both
+sentinels); the evaluator now does. A sibling sweep found no other caller with the
+pattern.
+
 ### 4. `BuildSearchWorkerMux` is fail-closed and testable (#15)
 
 The indexer's mux+signer assembly moved from inline `cmd/indexer/main.go` into

--- a/go.mod
+++ b/go.mod
@@ -106,4 +106,4 @@ require (
 // whatever happens to be in a local ../sdk checkout. Developers who
 // want to iterate against a local SDK override this with a per-dev
 // go.work at their workspace root — see server/README.md for setup.
-replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e
+replace github.com/manchtools/power-manage/sdk => github.com/manchtools/power-manage-sdk v0.4.1-0.20260615161849-1b3d68039a55

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e h1:C6DZ7+Zh8T8v70V9UdS6s05Zc7vhyKbmNsXEzmlKaCE=
 github.com/manchtools/power-manage-sdk v0.4.1-0.20260614093038-dcaee55a819e/go.mod h1:qFWK6xophsVYsUqQm5+e5UquvpWpXMzIPqeHGO8GqXs=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260615161849-1b3d68039a55 h1:YObNEsUJBRvTl737iXNMXzAcQoCZnmSCx/N2I0BMi0o=
+github.com/manchtools/power-manage-sdk v0.4.1-0.20260615161849-1b3d68039a55/go.mod h1:4YgWcixbkSLTu5Ds8m/b/EfwGNRqUsOaC/nMgTyAwxo=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/control_boundary_sweep_test.go
+++ b/internal/api/control_boundary_sweep_test.go
@@ -1,0 +1,120 @@
+package api_test
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/sdk/gen/go/pm/v1/pmv1connect"
+)
+
+// validateExemptControlRPCs lists the ControlService RPCs whose ZERO request is
+// LEGITIMATELY valid — every field is optional, so validation has nothing to
+// reject and the sweep below would otherwise expect a rejection that never
+// comes. Most are list/read RPCs (only optional pagination/filters) or no-field
+// RPCs. Membership is intentional; TestValidateExemptControlRPCsAreRealRPCs
+// guards it against rot, and the sweep itself FAILS if a non-exempt RPC stops
+// rejecting its zero request (a dropped validate tag).
+var validateExemptControlRPCs = map[string]bool{
+	"GetCurrentUser":         true,
+	"ListUsers":              true,
+	"ListDevices":            true,
+	"ListActions":            true,
+	"ListActionSets":         true,
+	"ListDefinitions":        true,
+	"ListDeviceGroups":       true,
+	"ListUserGroups":         true,
+	"ListRoles":              true,
+	"ListPermissions":        true,
+	"ListTokens":             true,
+	"ListExecutions":         true,
+	"ListCompliancePolicies": true,
+	"ListIdentityProviders":  true,
+	"ListAuditEvents":        true,
+	"ListAssignments":        true,
+	"ListAuthMethods":        true,
+	"GetServerSettings":      true,
+	"Search":                 true,
+	"GetTOTPStatus":          true,
+	"RebuildSearchIndex":     true,
+	// No-required-field RPCs scoped to the current user / instance.
+	"ListActiveTerminalSessions": true,
+	"ListIdentityLinks":          true,
+	"SetupTOTP":                  true,
+	// UpdateServerSettings is a partial update — every field is optional.
+	"UpdateServerSettings": true,
+	// Validate* RPCs return the verdict in their RESPONSE; an empty query is a
+	// valid REQUEST (the handler reports invalidity, it is not a request error).
+	"ValidateDynamicQuery":   true,
+	"ValidateUserGroupQuery": true,
+}
+
+// TestEveryControlRPCRunsValidateBeforeWork is a self-discovering boundary
+// guard: for every ControlService RPC whose request carries a required/bounded
+// field, sending a ZERO request through the REAL client → interceptor chain
+// (logging → auth → validation → authz) with a valid admin token MUST surface
+// CodeInvalidArgument — proving Validate() runs before the handler does any
+// work. RPCs whose zero request is legitimately valid are exempted via
+// validateExemptControlRPCs. The reflection drive constructs each request
+// generically so a newly-added RPC is covered automatically.
+func TestEveryControlRPCRunsValidateBeforeWork(t *testing.T) {
+	f := newControlRPCFixture(t)
+	ctx := context.Background()
+
+	clientVal := reflect.ValueOf(f.client)
+	ifaceType := reflect.TypeOf((*pmv1connect.ControlServiceClient)(nil)).Elem()
+	require.NotZero(t, ifaceType.NumMethod(), "no ControlService RPCs discovered — sweep would pass vacuously")
+
+	checked := 0
+	for i := 0; i < ifaceType.NumMethod(); i++ {
+		name := ifaceType.Method(i).Name
+		t.Run(name, func(t *testing.T) {
+			method := clientVal.MethodByName(name)
+			// In(1) is *connect.Request[FooRequest].
+			reqPtr := reflect.New(method.Type().In(1).Elem())
+			// connect.Request.Msg is an exported *FooRequest — set the zero value.
+			msgField := reqPtr.Elem().FieldByName("Msg")
+			msgField.Set(reflect.New(msgField.Type().Elem()))
+			// Attach the admin bearer so authz can never be the rejecter.
+			hdr := reqPtr.MethodByName("Header").Call(nil)[0].Interface().(http.Header)
+			hdr.Set("Authorization", "Bearer "+f.accessToken)
+
+			out := method.Call([]reflect.Value{reflect.ValueOf(ctx), reqPtr})
+			var err error
+			if e := out[1].Interface(); e != nil {
+				err = e.(error)
+			}
+			code := connect.CodeOf(err)
+
+			if validateExemptControlRPCs[name] {
+				assert.NotEqualf(t, connect.CodeInvalidArgument, code,
+					"%s is exempt (zero request expected valid) but returned CodeInvalidArgument — remove it from validateExemptControlRPCs", name)
+				return
+			}
+			checked++
+			assert.Equalf(t, connect.CodeInvalidArgument, code,
+				"%s zero request must be rejected with CodeInvalidArgument before the handler runs (got %v, err=%v) — add a validate tag, or exempt it if its zero request is legitimately valid", name, code, err)
+		})
+	}
+	require.Positive(t, checked, "no non-exempt RPCs were validated — the exempt list swallowed everything")
+}
+
+// TestValidateExemptControlRPCsAreRealRPCs guards the exempt allowlist against
+// rot: every entry must name a live ControlService RPC, so a renamed/removed RPC
+// can't leave a stale exemption that silently widens the gap.
+func TestValidateExemptControlRPCsAreRealRPCs(t *testing.T) {
+	ifaceType := reflect.TypeOf((*pmv1connect.ControlServiceClient)(nil)).Elem()
+	real := make(map[string]bool, ifaceType.NumMethod())
+	for i := 0; i < ifaceType.NumMethod(); i++ {
+		real[ifaceType.Method(i).Name] = true
+	}
+	require.NotEmpty(t, validateExemptControlRPCs)
+	for name := range validateExemptControlRPCs {
+		assert.Truef(t, real[name], "validateExemptControlRPCs names %q but no such ControlService RPC — stale exemption", name)
+	}
+}

--- a/internal/api/control_boundary_test.go
+++ b/internal/api/control_boundary_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
@@ -102,6 +103,40 @@ func TestControlRPCBoundaryAuthzStillRunsAfterValidation(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 	assert.NotEmpty(t, errorDetailRequestID(t, err), "authz errors must carry request correlation IDs")
+}
+
+// TestRegister_FieldBounds_OverlongRejectedByValidation pins the pre-auth field
+// bounds for the public Register RPC: an over-bound Token / Hostname /
+// AgentVersion is rejected by the validation interceptor with
+// CodeInvalidArgument BEFORE the handler does its token lookup. (The ABSENT/zero
+// case is covered by the self-discovering sweep above.) Lengths are sourced from
+// the documented caps (255 / 253 / 32), one character over each — not from the
+// validate tag.
+func TestRegister_FieldBounds_OverlongRejectedByValidation(t *testing.T) {
+	f := newControlRPCFixture(t)
+	valid := func() *pm.RegisterRequest {
+		return &pm.RegisterRequest{Token: "tok", Hostname: "host", AgentVersion: "1.0.0", Csr: []byte("csr")}
+	}
+	cases := []struct {
+		name string
+		mut  func(*pm.RegisterRequest)
+	}{
+		{"token over 255", func(r *pm.RegisterRequest) { r.Token = strings.Repeat("a", 256) }},
+		{"hostname over 253", func(r *pm.RegisterRequest) { r.Hostname = strings.Repeat("a", 254) }},
+		{"agent_version over 32", func(r *pm.RegisterRequest) { r.AgentVersion = strings.Repeat("a", 33) }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := valid()
+			tc.mut(req)
+			// Register is public — no bearer needed; validation runs before the
+			// token lookup regardless.
+			_, err := f.client.Register(context.Background(), connect.NewRequest(req))
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
+				"an overlong %s must be rejected by validation before the token lookup", tc.name)
+		})
+	}
 }
 
 func errorDetailRequestID(t *testing.T, err error) string {

--- a/internal/api/registration_handler_test.go
+++ b/internal/api/registration_handler_test.go
@@ -79,6 +79,72 @@ func generateCSR(t *testing.T) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
 }
 
+// generateCSRWithTemplate builds a CSR after letting the caller stamp fields
+// (CN, SANs) onto the template — used to prove the issued identity comes from
+// the server, not the CSR, and that a SAN-bearing CSR is refused.
+func generateCSRWithTemplate(t *testing.T, modify func(*x509.CertificateRequest)) []byte {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.CertificateRequest{Subject: pkix.Name{CommonName: "default-cn"}}
+	modify(tmpl)
+	der, err := x509.CreateCertificateRequest(rand.Reader, tmpl, key)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
+}
+
+// TestRegister_IssuedCertBindsServerDeviceIDNotCSRCN drives the real handler and
+// pins that the issued cert's CN is the SERVER-minted device id, never the
+// attacker-controlled CSR Subject, and that no CSR SAN leaks into the cert.
+func TestRegister_IssuedCertBindsServerDeviceIDNotCSRCN(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	testCA := newTestCA(t)
+	h := api.NewRegistrationHandler(st, testCA, "https://gateway.test:8080", slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	_, tokenValue := createTestTokenWithValue(t, st, adminID, false)
+
+	csr := generateCSRWithTemplate(t, func(c *x509.CertificateRequest) {
+		c.Subject.CommonName = "victim-device-id" // attacker-chosen
+	})
+	resp, err := h.Register(context.Background(), connect.NewRequest(&pm.RegisterRequest{
+		Token: tokenValue, Hostname: "h", AgentVersion: "1.0.0", Csr: csr,
+	}))
+	require.NoError(t, err)
+
+	block, _ := pem.Decode(resp.Msg.Certificate)
+	require.NotNil(t, block)
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	assert.Equal(t, resp.Msg.DeviceId.Value, parsed.Subject.CommonName,
+		"issued CN must be the server-minted device id")
+	assert.NotEqual(t, "victim-device-id", parsed.Subject.CommonName,
+		"the attacker-controlled CSR CN must never become the cert identity")
+	assert.Empty(t, parsed.DNSNames)
+	assert.Empty(t, parsed.IPAddresses)
+	assert.Empty(t, parsed.EmailAddresses)
+}
+
+// TestRegister_SANBearingCSRRejected drives the real handler with a SAN-bearing
+// CSR and asserts no certificate is issued (the CA refuses any caller-supplied
+// SAN, so an enrolling agent cannot mint a non-agent peer-class identity).
+func TestRegister_SANBearingCSRRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	testCA := newTestCA(t)
+	h := api.NewRegistrationHandler(st, testCA, "https://gateway.test:8080", slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	_, tokenValue := createTestTokenWithValue(t, st, adminID, false)
+
+	csr := generateCSRWithTemplate(t, func(c *x509.CertificateRequest) {
+		c.DNSNames = []string{"control-server.example.com"}
+	})
+	_, err := h.Register(context.Background(), connect.NewRequest(&pm.RegisterRequest{
+		Token: tokenValue, Hostname: "h", AgentVersion: "1.0.0", Csr: csr,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err),
+		"a SAN-bearing CSR must not yield a certificate (CA refuses it -> handler maps to Internal)")
+}
+
 // createTestTokenWithValue creates a registration token and returns both the
 // token ID and the plaintext token value (needed for registration).
 func createTestTokenWithValue(t *testing.T, st *store.Store, actorID string, oneTime bool) (tokenID, tokenValue string) {

--- a/internal/api/system_actor_canary_test.go
+++ b/internal/api/system_actor_canary_test.go
@@ -10,42 +10,49 @@ import (
 	"testing"
 )
 
-// TestSystemActorCanary scans internal/api for every location that
-// writes an audit event with ActorID="system", lists them with file:
-// line, and emits a warning (t.Logf, not t.Error) for anything that
-// isn't in the documented known-cases list below.
+// TestSystemActorCanary scans internal/api for every location that writes an
+// audit event with ActorID="system", keyed by ENCLOSING FUNCTION, and FAILS the
+// suite for any site that is not in the documented known-cases list below (and
+// for any stale list entry).
 //
-// Rationale: ActorID="system" labels an audit event as "not a human
-// action" and should be reserved for deliberate, documented cases
-// — bootstrap events, system-action auto-creation, settings
-// migration. A silent fallback from "auth context missing" to
-// "system" misattributes bugs to the system itself and hides them
-// (see the rc7 terminal_handler and device_handler cleanups). This
-// test is the canary: it does NOT fail the suite on an unknown
-// site, it warns, so the next reviewer investigates and either
-// adds an entry to knownSystemActorSites with a rationale or
-// replaces the fallback with requireAuth.
+// Rationale: ActorID="system" labels an audit event as "not a human action" and
+// must be reserved for deliberate, documented cases — bootstrap events,
+// system-action auto-creation, settings migration, system-generated
+// compensating events. A silent fallback from "auth context missing" to
+// "system" misattributes bugs to the system itself and hides them (see the rc7
+// terminal_handler and device_handler cleanups). The canary forces every new
+// system-actor write to be reviewed: a reviewer either adds an entry here with a
+// rationale or replaces the fallback with requireAuth.
 //
-// Run with -v to see the warnings on every CI run.
-//
-// When you intentionally add a new system-actor append, also add a
-// row to knownSystemActorSites with a one-line rationale.
+// Sites are keyed by `<file>:<enclosing-func>` (not a line number) so the
+// allowlist is stable across unrelated edits.
 var knownSystemActorSites = map[string]string{
-	// Settings — initial seed + schema migrations run by the control
-	// server itself, not by any user. These are legitimately "system"
-	// actions: there is no user to attribute them to at bootstrap time.
-	"settings_handler.go:57":  "initial settings seeded at control-server boot",
-	"settings_handler.go:123": "settings schema migration on server start",
-	"settings_handler.go:158": "settings schema migration on server start",
+	// System action store — the control server owns the lifecycle of
+	// server-managed actions (pm-tty-*, SSH access, etc.); there is no user to
+	// attribute these writes to.
+	"system_action_store.go:CreateAction":       "system action store creates a server-owned action",
+	"system_action_store.go:UpdateAction":       "system action store updates a server-owned action",
+	"system_action_store.go:DeleteAction":       "system action store deletes a server-owned action",
+	"system_action_store.go:LinkAction":         "system action store links a server-owned action into a set/definition",
+	"system_action_store.go:AssignActionToUser": "system action store assigns a server-owned action to a user",
 
-	// System actions — pm-tty-* and SSH-access actions auto-created /
-	// re-bound by the control server. Not user-initiated; the server
-	// owns the lifecycle.
-	"system_actions.go:394": "auto-created pm-tty-* user action (first-time provision)",
-	"system_actions.go:419": "auto-created pm-tty-* user action (rebind on config change)",
-	"system_actions.go:439": "auto-created SSH access action (first-time provision)",
-	"system_actions.go:451": "auto-created SSH access action (rebuild)",
-	"system_actions.go:467": "auto-created SSH access action (schema migration)",
+	// Terminal-admin membership is server-managed, not user-initiated.
+	"system_actions.go:emitTerminalAdminMembershipRevoked": "server emits terminal-admin membership revocation",
+
+	// Dispatch compensating events — the SERVER records an ExecutionFailed when
+	// the dispatch enqueue itself fails; it is a system event, not the
+	// dispatching user's action.
+	"action_dispatch.go:DispatchAction":        "system-generated ExecutionFailed compensating event on enqueue failure",
+	"action_dispatch.go:DispatchInstantAction": "system-generated ExecutionFailed compensating event on enqueue failure",
+
+	// LUKS device-key revocation lifecycle is recorded by the server.
+	"device_handler.go:RevokeLuksDeviceKey": "server records the LUKS device-key revocation lifecycle event",
+
+	// Settings changes that cascade into server-owned system actions at boot or
+	// on a bulk toggle — no per-user actor.
+	"settings_handler.go:UpdateServerSettings":          "settings change cascades server-owned system actions",
+	"settings_handler.go:enableSshAccessForAllUsers":    "bulk SSH-access enablement creates server-owned actions",
+	"settings_handler.go:enableProvisioningForAllUsers": "bulk provisioning enablement creates server-owned actions",
 }
 
 func TestSystemActorCanary(t *testing.T) {
@@ -56,36 +63,44 @@ func TestSystemActorCanary(t *testing.T) {
 
 	t.Logf("SystemActor canary: found %d site(s) with ActorID=\"system\"", len(sites))
 
+	// Matches-zero guard: the scan walks the package source for the literal
+	// pattern. If it ever finds NOTHING (a regex/path drift, or the file moved),
+	// the canary would silently pass while no longer guarding anything.
+	if len(sites) == 0 {
+		t.Fatal(`SystemActor canary found ZERO ActorID="system" sites — the scanner drifted and can no longer catch an unreviewed system-actor write`)
+	}
+
 	for _, site := range sites {
-		// Key format is `<file-basename>:<line>`. file-basename is
-		// used rather than a full path so a test running from
-		// different working directories stays consistent.
+		// Key format is `<file-basename>:<enclosing-func>` — file basename (not a
+		// full path) so the key is working-directory-independent, and the
+		// enclosing function (not a line number) so it survives unrelated edits.
 		if rationale, known := knownSystemActorSites[site]; known {
 			t.Logf("  [known ] %s — %s", site, rationale)
 		} else {
-			// The warning. Not a failure. A reviewer reading `go test
-			// -v` output will see this and investigate.
-			t.Logf("  [WARN  ] %s — UNKNOWN; verify this is intentional and update knownSystemActorSites with a rationale", site)
+			// A new, unreviewed system-actor write site is a FAILURE: every such
+			// site bypasses the actor-authorization model and must be reviewed
+			// and recorded in knownSystemActorSites with a rationale.
+			t.Errorf(`UNKNOWN ActorID="system" site %s — verify it is intentional and add it to knownSystemActorSites with a rationale`, site)
 		}
 	}
 
-	// Also flag removals: entries in knownSystemActorSites that no
-	// longer exist in the source indicate the call site was deleted
-	// or moved. Warn so the entry can be cleaned up.
+	// A stale exemption (listed but no longer in source) is real drift, not a
+	// warning: left in place it could later mask a genuine new site at the same
+	// key. Fail so it is cleaned up.
 	siteSet := make(map[string]struct{}, len(sites))
 	for _, s := range sites {
 		siteSet[s] = struct{}{}
 	}
 	for expected := range knownSystemActorSites {
 		if _, found := siteSet[expected]; !found {
-			t.Logf("  [stale ] %s — listed in knownSystemActorSites but no longer in source; remove the entry", expected)
+			t.Errorf("stale knownSystemActorSites entry %s — listed but no longer in source; remove it", expected)
 		}
 	}
 }
 
-// scanSystemActorSites walks dir for non-test .go files and returns
-// every `<file-basename>:<line>` whose contents match the literal
-// `ActorID: "system"` pattern (whitespace tolerant).
+// scanSystemActorSites walks dir for non-test .go files and returns the
+// DEDUPED set of `<file-basename>:<enclosing-func>` for every line matching the
+// literal `ActorID: "system"` pattern (whitespace tolerant).
 func scanSystemActorSites(t *testing.T, dir string) []string {
 	t.Helper()
 
@@ -94,8 +109,13 @@ func scanSystemActorSites(t *testing.T, dir string) []string {
 	//     ActorID:    "system"
 	// Tolerant of any whitespace between ActorID, :, and the string.
 	re := regexp.MustCompile(`ActorID\s*:\s*"system"`)
+	// Enclosing function: `func Name(` or `func (recv) Name(`. Keying sites by
+	// their enclosing function rather than a line number keeps the allowlist
+	// STABLE across unrelated edits — a line-number key drifts on every change
+	// above the site, turning the gate into churn.
+	funcRe := regexp.MustCompile(`^func\s+(?:\([^)]*\)\s+)?([A-Za-z0-9_]+)\s*\(`)
 
-	var hits []string
+	seen := map[string]struct{}{}
 	err := filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -113,14 +133,15 @@ func scanSystemActorSites(t *testing.T, dir string) []string {
 		defer f.Close()
 
 		scanner := bufio.NewScanner(f)
-		lineNo := 0
-		// Default buf is fine; api/ files are not enormous but bump
-		// anyway to tolerate a few oversized generated stubs.
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		currentFunc := "<file-scope>"
 		for scanner.Scan() {
-			lineNo++
-			if re.MatchString(scanner.Text()) {
-				hits = append(hits, filepath.Base(path)+":"+itoa(lineNo))
+			line := scanner.Text()
+			if m := funcRe.FindStringSubmatch(line); m != nil {
+				currentFunc = m[1]
+			}
+			if re.MatchString(line) {
+				seen[filepath.Base(path)+":"+currentFunc] = struct{}{}
 			}
 		}
 		return scanner.Err()
@@ -128,29 +149,9 @@ func scanSystemActorSites(t *testing.T, dir string) []string {
 	if err != nil {
 		t.Fatalf("scan failed: %v", err)
 	}
-	return hits
-}
-
-// itoa is a tiny strconv.Itoa shim; avoids another import just for
-// one call.
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
 	}
-	var buf [20]byte
-	i := len(buf)
-	neg := n < 0
-	if neg {
-		n = -n
-	}
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
+	return out
 }

--- a/internal/auth/permissions_parity_test.go
+++ b/internal/auth/permissions_parity_test.go
@@ -20,6 +20,12 @@ func rpcMethodNames(t *testing.T) map[string]bool {
 	for i := 0; i < iface.NumMethod(); i++ {
 		out[iface.Method(i).Name] = true
 	}
+	// Matches-zero guard: every parity test below iterates this set. If
+	// reflection ever surfaces no RPCs (a generated-handler refactor), the
+	// parity assertions would all pass VACUOUSLY — fail loudly instead.
+	if len(out) == 0 {
+		t.Fatal("rpcMethodNames discovered ZERO RPCs on ControlServiceHandler — parity tests would pass vacuously")
+	}
 	return out
 }
 
@@ -77,6 +83,9 @@ var nonRPCBackedPermissions = map[string]bool{
 //     gates /CreateDeviceGroup via the alternatives map).
 func TestEveryPermissionMatchesAnRPC(t *testing.T) {
 	rpcs := rpcMethodNames(t)
+	if len(auth.AllPermissions()) == 0 {
+		t.Fatal("AllPermissions() is empty — this parity test would pass vacuously")
+	}
 	for _, p := range auth.AllPermissions() {
 		base := stripScope(p.Key)
 		if nonRPCBackedPermissions[base] {
@@ -144,6 +153,9 @@ func TestEveryPublicProcedureIsAnRPC(t *testing.T) {
 // Catches new RPCs added without permission wiring.
 func TestEveryRPCIsCoveredByPermissionOrPublic(t *testing.T) {
 	rpcs := rpcMethodNames(t)
+	if len(auth.AllPermissions()) == 0 {
+		t.Fatal("AllPermissions() is empty — this parity test would pass vacuously")
+	}
 
 	// Build the inverse map: RPC name → covered (bool).
 	covered := make(map[string]bool, len(rpcs))

--- a/internal/auth/reconcile_test.go
+++ b/internal/auth/reconcile_test.go
@@ -60,19 +60,24 @@ func TestReconcileSystemRoles_UpdatesDB(t *testing.T) {
 	assert.ElementsMatch(t, auth.DefaultUserPermissions(), userRole.Permissions)
 }
 
-// TestUserSeedRole_MatchesDefaultPermissions pins the RAW migration seed (before
-// any reconcile) against the code-defined set, so a fresh install is correct
-// even in the window before the first boot reconcile. The seed previously
-// granted UpdateUserLinuxUsername:self (admin-only, #354) and omitted
-// StopTerminal — masked only by the non-fatal reconciler (#16).
-func TestUserSeedRole_MatchesDefaultPermissions(t *testing.T) {
+// TestSystemRoleSeed_IsReconcilerOwned pins that the migration seed leaves the
+// system-role permissions EMPTY (WS17b #18). The Go reconciler
+// (auth.ReconcileSystemRoles, validated by TestReconcileSystemRoles_UpdatesDB)
+// is the single source of truth, so there is no SQL literal to drift from
+// AdminPermissions/DefaultUserPermissions. Earlier the seed hard-coded literals
+// that DID drift — granting the admin-only UpdateUserLinuxUsername:self and
+// omitting newer permissions — masked only by the non-fatal reconciler (#16).
+// The fresh-install window before the first boot reconcile is intentionally
+// permission-less for the system roles.
+func TestSystemRoleSeed_IsReconcilerOwned(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	userRole, err := st.Queries().GetRoleByID(context.Background(), auth.UserRoleID)
-	require.NoError(t, err)
-	assert.ElementsMatch(t, auth.DefaultUserPermissions(), userRole.Permissions,
-		"the User-role seed literal must match DefaultUserPermissions()")
-	assert.NotContains(t, userRole.Permissions, "UpdateUserLinuxUsername:self",
-		"linux_username is admin-only — the seed must not self-service it (#354/#16)")
+	ctx := context.Background()
+	for _, id := range []string{auth.AdminRoleID, auth.UserRoleID} {
+		role, err := st.Queries().GetRoleByID(ctx, id)
+		require.NoError(t, err)
+		assert.Emptyf(t, role.Permissions,
+			"system role %s seed must be reconciler-owned (empty) so it cannot drift from the Go set", id)
+	}
 }
 
 // TestReconcileSystemRoles_FailClosedOnError pins that the reconcile SURFACES

--- a/internal/ca/ca_test.go
+++ b/internal/ca/ca_test.go
@@ -152,6 +152,43 @@ func TestIssueCertificateFromCSR_Success(t *testing.T) {
 	assert.True(t, cert.NotAfter.After(time.Now()))
 }
 
+// TestIssueCertificateFromCSR_IdentityComesFromServerNotCSR pins the
+// anti-impersonation contract: the issued identity (CN + Subject.SerialNumber)
+// is taken from the SERVER-supplied deviceID, never the attacker-controlled CSR
+// Subject. The CSR CN is set to a DIFFERENT value than the server id so the test
+// cannot pass by coincidence — the Success test above used the same string for
+// both, which could not distinguish "id from server" from "id from CSR".
+func TestIssueCertificateFromCSR_IdentityComesFromServerNotCSR(t *testing.T) {
+	certPEM, keyPEM := generateTestCA(t)
+	c, err := ca.NewFromPEM(certPEM, keyPEM, 24*time.Hour)
+	require.NoError(t, err)
+
+	const csrChosenID = "attacker-chosen-id"      // whatever the agent put in the CSR
+	const serverAuthoritativeID = "real-device-7" // the server's own authoritative id
+	csrPEM, _ := generateCSR(t, csrChosenID)
+
+	cert, err := c.IssueCertificateFromCSR(serverAuthoritativeID, csrPEM)
+	require.NoError(t, err)
+
+	got, err := c.VerifyCertificate(cert.CertPEM)
+	require.NoError(t, err)
+	assert.Equal(t, serverAuthoritativeID, got, "VerifyCertificate must report the SERVER id")
+	assert.NotEqual(t, csrChosenID, got)
+
+	gotPEM, err := ca.DeviceIDFromPEM(cert.CertPEM)
+	require.NoError(t, err)
+	assert.Equal(t, serverAuthoritativeID, gotPEM)
+
+	// Parse the issued cert: BOTH identity fields must be the server id.
+	block, _ := pem.Decode(cert.CertPEM)
+	require.NotNil(t, block)
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	assert.Equal(t, serverAuthoritativeID, parsed.Subject.CommonName, "CN must be the server id, not the CSR CN")
+	assert.Equal(t, serverAuthoritativeID, parsed.Subject.SerialNumber, "Subject.SerialNumber must be the server id")
+	assert.NotEqual(t, csrChosenID, parsed.Subject.CommonName, "the attacker-controlled CSR CN must never become the cert identity")
+}
+
 // generateCSRWithSAN builds a CSR for deviceID after letting the caller stamp a
 // subject-alternative-name onto the template — used to prove the CA rejects any
 // caller-supplied SAN (which would otherwise let an enrolling agent mint a

--- a/internal/compliance/evaluator.go
+++ b/internal/compliance/evaluator.go
@@ -19,7 +19,6 @@ package compliance
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"time"
@@ -161,7 +160,13 @@ func (e *Evaluator) evalOne(ctx context.Context, q *store.Queries, deviceID stri
 		ActionID: rule.ActionID,
 	})
 	switch {
-	case errors.Is(err, store.ErrNotFound):
+	// store.IsNotFound — NOT errors.Is(err, store.ErrNotFound): the generated
+	// query returns the backend's pgx.ErrNoRows, which is a DIFFERENT sentinel
+	// from store.ErrNotFound. Per store/notfound.go, callers outside the store
+	// package must recognise "no row" via store.IsNotFound (it matches both).
+	// The earlier errors.Is check never fired, so a rule with no result yet
+	// errored instead of resolving to UNKNOWN.
+	case store.IsNotFound(err):
 		// No result yet — UNKNOWN. Persist a placeholder row so the
 		// device-list UI can surface "waiting for first check" per
 		// rule.
@@ -206,7 +211,7 @@ func (e *Evaluator) evalOne(ctx context.Context, q *store.Queries, deviceID stri
 	})
 	firstFailedAt := now
 	switch {
-	case errors.Is(err, store.ErrNotFound):
+	case store.IsNotFound(err):
 		// First-ever non-compliant state for this rule.
 	case err != nil:
 		return 0, fmt.Errorf("compliance: read first_failed_at for %s/%s/%s: %w", deviceID, rule.PolicyID, rule.ActionID, err)

--- a/internal/compliance/evaluator_test.go
+++ b/internal/compliance/evaluator_test.go
@@ -1,0 +1,251 @@
+package compliance_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/compliance"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// seedRule assigns a compliance policy rule (action + grace) to a device by
+// inserting directly into the projections the evaluator reads — no event replay
+// needed for a focused evaluator test.
+func seedRule(t *testing.T, st *store.Store, deviceID, policyID, actionID string, graceHours int32) {
+	t.Helper()
+	ctx := context.Background()
+	pool := st.TestingPool()
+	_, err := pool.Exec(ctx,
+		`INSERT INTO compliance_policies_projection (id, name) VALUES ($1, 'test-policy') ON CONFLICT (id) DO NOTHING`, policyID)
+	require.NoError(t, err)
+	_, err = pool.Exec(ctx,
+		`INSERT INTO compliance_policy_rules_projection (policy_id, action_id, grace_period_hours) VALUES ($1, $2, $3)`,
+		policyID, actionID, graceHours)
+	require.NoError(t, err)
+	// One policy→device assignment regardless of how many rules the policy has.
+	_, err = pool.Exec(ctx,
+		`INSERT INTO assignments_projection (id, source_type, source_id, target_type, target_id)
+		 VALUES ($1, 'compliance_policy', $2, 'device', $3)
+		 ON CONFLICT (source_type, source_id, target_type, target_id) DO NOTHING`,
+		testutil.NewID(), policyID, deviceID)
+	require.NoError(t, err)
+}
+
+// seedResult records the latest compliance check result for (device, action).
+func seedResult(t *testing.T, st *store.Store, deviceID, actionID string, compliant bool, checkedAt time.Time) {
+	t.Helper()
+	_, err := st.TestingPool().Exec(context.Background(),
+		`INSERT INTO compliance_results_projection (device_id, action_id, compliant, checked_at)
+		 VALUES ($1, $2, $3, $4)`,
+		deviceID, actionID, compliant, checkedAt)
+	require.NoError(t, err)
+}
+
+func deviceStatus(t *testing.T, st *store.Store, deviceID string) (status, total, passing int32) {
+	t.Helper()
+	require.NoError(t, st.TestingPool().QueryRow(context.Background(),
+		`SELECT compliance_status, compliance_total, compliance_passing FROM devices_projection WHERE id = $1`,
+		deviceID).Scan(&status, &total, &passing))
+	return
+}
+
+func evalFirstFailedAt(t *testing.T, st *store.Store, deviceID, policyID, actionID string) *time.Time {
+	t.Helper()
+	var ts *time.Time
+	require.NoError(t, st.TestingPool().QueryRow(context.Background(),
+		`SELECT first_failed_at FROM compliance_policy_evaluation_projection
+		 WHERE device_id=$1 AND policy_id=$2 AND action_id=$3`,
+		deviceID, policyID, actionID).Scan(&ts))
+	return ts
+}
+
+// TestEvaluator_GracePeriodBoundary pins the IN_GRACE_PERIOD -> NON_COMPLIANT
+// transition at exactly first_failed_at + grace, evaluated on both sides of the
+// boundary with the clock seam.
+func TestEvaluator_GracePeriodBoundary(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := testutil.CreateTestDevice(t, st, "grace-host")
+	policyID, actionID := testutil.NewID(), testutil.NewID()
+	seedRule(t, st, deviceID, policyID, actionID, 24) // 24h grace
+
+	t0 := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	seedResult(t, st, deviceID, actionID, false, t0) // failing check
+
+	e := compliance.New(slog.Default())
+
+	// At t0: failing, first_failed_at seeded = t0, within grace -> IN_GRACE.
+	e.SetClock(func() time.Time { return t0 })
+	require.NoError(t, e.EvaluateInTx(ctx, st.Queries(), deviceID))
+	status, _, _ := deviceStatus(t, st, deviceID)
+	assert.Equal(t, compliance.StatusInGracePeriod, status, "fresh failure within grace must be IN_GRACE_PERIOD")
+
+	// One nanosecond before the boundary: still in grace.
+	e.SetClock(func() time.Time { return t0.Add(24 * time.Hour).Add(-time.Nanosecond) })
+	require.NoError(t, e.EvaluateInTx(ctx, st.Queries(), deviceID))
+	status, _, _ = deviceStatus(t, st, deviceID)
+	assert.Equal(t, compliance.StatusInGracePeriod, status, "just before grace expiry must still be IN_GRACE_PERIOD")
+
+	// Exactly at the boundary: graduates to NON_COMPLIANT (now is NOT before graceUntil).
+	e.SetClock(func() time.Time { return t0.Add(24 * time.Hour) })
+	require.NoError(t, e.EvaluateInTx(ctx, st.Queries(), deviceID))
+	status, _, _ = deviceStatus(t, st, deviceID)
+	assert.Equal(t, compliance.StatusNonCompliant, status, "at exactly first_failed_at+grace must be NON_COMPLIANT")
+}
+
+// TestEvaluator_FirstFailedAtPreservedAcrossReeval pins that the first-failed
+// timestamp sticks across repeated failing evaluations (it is not re-seeded to
+// the later now), which is what makes the grace window anchored.
+func TestEvaluator_FirstFailedAtPreservedAcrossReeval(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	deviceID := testutil.CreateTestDevice(t, st, "ffa-host")
+	policyID, actionID := testutil.NewID(), testutil.NewID()
+	seedRule(t, st, deviceID, policyID, actionID, 24)
+
+	t0 := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	seedResult(t, st, deviceID, actionID, false, t0)
+
+	e := compliance.New(slog.Default())
+	e.SetClock(func() time.Time { return t0 })
+	require.NoError(t, e.EvaluateInTx(ctx, st.Queries(), deviceID))
+	first := evalFirstFailedAt(t, st, deviceID, policyID, actionID)
+	require.NotNil(t, first)
+	require.WithinDuration(t, t0, *first, time.Second)
+
+	// Re-evaluate later — still failing. first_failed_at must NOT move.
+	e.SetClock(func() time.Time { return t0.Add(5 * time.Hour) })
+	require.NoError(t, e.EvaluateInTx(ctx, st.Queries(), deviceID))
+	again := evalFirstFailedAt(t, st, deviceID, policyID, actionID)
+	require.NotNil(t, again)
+	assert.WithinDuration(t, *first, *again, time.Second, "first_failed_at must be preserved across re-evaluation, not re-seeded to the later now")
+}
+
+// TestEvaluator_StatusRollupPrecedence pins the device-level rollup: any
+// NON_COMPLIANT rule wins; else any IN_GRACE wins; all compliant -> COMPLIANT;
+// an UNKNOWN (no result yet) keeps the device out of COMPLIANT. Also checks the
+// total/passing counters.
+func TestEvaluator_StatusRollupPrecedence(t *testing.T) {
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	t.Run("non-compliant beats grace and compliant", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		deviceID := testutil.CreateTestDevice(t, st, "rollup-nc")
+		pol := testutil.NewID()
+		aOK, aGrace, aBad := testutil.NewID(), testutil.NewID(), testutil.NewID()
+		seedRule(t, st, deviceID, pol, aOK, 0)
+		seedRule(t, st, deviceID, pol, aGrace, 24)
+		seedRule(t, st, deviceID, pol, aBad, 0) // grace 0 -> immediately non-compliant
+		seedResult(t, st, deviceID, aOK, true, now)
+		seedResult(t, st, deviceID, aGrace, false, now)
+		seedResult(t, st, deviceID, aBad, false, now)
+
+		e := compliance.New(slog.Default())
+		e.SetClock(func() time.Time { return now })
+		require.NoError(t, e.EvaluateInTx(context.Background(), st.Queries(), deviceID))
+		status, total, passing := deviceStatus(t, st, deviceID)
+		assert.Equal(t, compliance.StatusNonCompliant, status)
+		assert.Equal(t, int32(3), total)
+		assert.Equal(t, int32(1), passing)
+	})
+
+	t.Run("grace beats compliant when none non-compliant", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		deviceID := testutil.CreateTestDevice(t, st, "rollup-grace")
+		pol := testutil.NewID()
+		aOK, aGrace := testutil.NewID(), testutil.NewID()
+		seedRule(t, st, deviceID, pol, aOK, 0)
+		seedRule(t, st, deviceID, pol, aGrace, 24)
+		seedResult(t, st, deviceID, aOK, true, now)
+		seedResult(t, st, deviceID, aGrace, false, now)
+
+		e := compliance.New(slog.Default())
+		e.SetClock(func() time.Time { return now })
+		require.NoError(t, e.EvaluateInTx(context.Background(), st.Queries(), deviceID))
+		status, _, passing := deviceStatus(t, st, deviceID)
+		assert.Equal(t, compliance.StatusInGracePeriod, status)
+		assert.Equal(t, int32(1), passing)
+	})
+
+	t.Run("all compliant -> COMPLIANT", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		deviceID := testutil.CreateTestDevice(t, st, "rollup-ok")
+		pol := testutil.NewID()
+		a1, a2 := testutil.NewID(), testutil.NewID()
+		seedRule(t, st, deviceID, pol, a1, 0)
+		seedRule(t, st, deviceID, pol, a2, 0)
+		seedResult(t, st, deviceID, a1, true, now)
+		seedResult(t, st, deviceID, a2, true, now)
+
+		e := compliance.New(slog.Default())
+		e.SetClock(func() time.Time { return now })
+		require.NoError(t, e.EvaluateInTx(context.Background(), st.Queries(), deviceID))
+		status, total, passing := deviceStatus(t, st, deviceID)
+		assert.Equal(t, compliance.StatusCompliant, status)
+		assert.Equal(t, int32(2), total)
+		assert.Equal(t, int32(2), passing)
+	})
+
+	t.Run("an UNKNOWN rule keeps the device out of COMPLIANT", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		deviceID := testutil.CreateTestDevice(t, st, "rollup-unknown")
+		pol := testutil.NewID()
+		aOK, aNoResult := testutil.NewID(), testutil.NewID()
+		seedRule(t, st, deviceID, pol, aOK, 0)
+		seedRule(t, st, deviceID, pol, aNoResult, 0) // no result seeded -> UNKNOWN
+		seedResult(t, st, deviceID, aOK, true, now)
+
+		e := compliance.New(slog.Default())
+		e.SetClock(func() time.Time { return now })
+		require.NoError(t, e.EvaluateInTx(context.Background(), st.Queries(), deviceID))
+		status, _, _ := deviceStatus(t, st, deviceID)
+		assert.NotEqual(t, compliance.StatusCompliant, status, "an unevaluated rule must keep the device out of COMPLIANT")
+	})
+}
+
+// TestEvaluator_RecalculateOnlyWhenNoPolicies pins the no-rules fallback that
+// counts compliance_results directly: total==0 -> UNKNOWN, passing==total ->
+// COMPLIANT, else NON_COMPLIANT.
+func TestEvaluator_RecalculateOnlyWhenNoPolicies(t *testing.T) {
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+
+	t.Run("no results -> UNKNOWN", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		deviceID := testutil.CreateTestDevice(t, st, "recalc-unknown")
+		e := compliance.New(slog.Default())
+		e.SetClock(func() time.Time { return now })
+		require.NoError(t, e.EvaluateInTx(context.Background(), st.Queries(), deviceID))
+		status, _, _ := deviceStatus(t, st, deviceID)
+		assert.Equal(t, compliance.StatusUnknown, status)
+	})
+
+	t.Run("all results passing -> COMPLIANT", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		deviceID := testutil.CreateTestDevice(t, st, "recalc-ok")
+		seedResult(t, st, deviceID, testutil.NewID(), true, now)
+		seedResult(t, st, deviceID, testutil.NewID(), true, now)
+		e := compliance.New(slog.Default())
+		e.SetClock(func() time.Time { return now })
+		require.NoError(t, e.EvaluateInTx(context.Background(), st.Queries(), deviceID))
+		status, _, _ := deviceStatus(t, st, deviceID)
+		assert.Equal(t, compliance.StatusCompliant, status)
+	})
+
+	t.Run("a failing result -> NON_COMPLIANT", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		deviceID := testutil.CreateTestDevice(t, st, "recalc-bad")
+		seedResult(t, st, deviceID, testutil.NewID(), true, now)
+		seedResult(t, st, deviceID, testutil.NewID(), false, now)
+		e := compliance.New(slog.Default())
+		e.SetClock(func() time.Time { return now })
+		require.NoError(t, e.EvaluateInTx(context.Background(), st.Queries(), deviceID))
+		status, _, _ := deviceStatus(t, st, deviceID)
+		assert.Equal(t, compliance.StatusNonCompliant, status)
+	})
+}

--- a/internal/dynamicquery/eval_test.go
+++ b/internal/dynamicquery/eval_test.go
@@ -15,6 +15,58 @@ func mustParse(t *testing.T, q string) dynamicquery.Expr {
 	return expr
 }
 
+// in/notIn split the value on commas (splitTrimLower), so a value carrying a
+// comma, empty list elements, and keyword/quote characters all have specific,
+// non-obvious outcomes that the simple-value cases in TestEvaluateDevice_LabelOps
+// never exercise. The expected outcomes here are sourced from the split SEMANTICS
+// (comma is the separator, empties are kept, equals does NOT split), not from the
+// implementation — so an under-specified split rule is caught.
+func TestEvaluateDevice_InSplitMetacharacters(t *testing.T) {
+	ctx := dynamicquery.DeviceContext{
+		Labels: map[string]string{
+			"role":  "web",
+			"csv":   "a,b",   // a label VALUE that itself contains the separator
+			"empty": "",      // an explicitly empty label value
+			"kw":    "in",    // a value equal to an operator keyword
+			"quote": `pr"od`, // a value containing a double quote
+		},
+	}
+	cases := []struct {
+		query string
+		want  bool
+	}{
+		// equals does NOT split — a comma-bearing value matches itself.
+		{`labels.csv equals "a,b"`, true},
+		// in() DOES split on comma, so the comma-bearing value matches neither
+		// element of the list it looks identical to.
+		{`labels.csv in "a,b"`, false},
+		{`labels.csv notIn "a,b"`, true},
+		// A normal member still matches across the split.
+		{`labels.role in "web,db,cache"`, true},
+		// Empty list elements ("web,,db" -> ["web","","db"]) don't break a real match.
+		{`labels.role in "web,,db"`, true},
+		// Footgun pinned: an EMPTY field value matches the empty element produced
+		// by a stray comma. Documenting it so a future "skip empties" change is a
+		// deliberate, test-visible decision.
+		{`labels.empty in "a,,b"`, true},
+		{`labels.empty in "a,b"`, false},
+		// A keyword as a list element is just a string element.
+		{`labels.kw in "equals,in,contains"`, true},
+		// A quote inside the value is matched literally by equals; in() splits on
+		// comma only, so the quoted value (no comma) is a single element.
+		{`labels.quote equals "pr\"od"`, true},
+		{`labels.quote in "pr\"od,other"`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			got := dynamicquery.EvaluateDevice(mustParse(t, tc.query), ctx)
+			if got != tc.want {
+				t.Fatalf("EvaluateDevice(%q) = %v; want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestEvaluateDevice_LabelOps(t *testing.T) {
 	ctx := dynamicquery.DeviceContext{
 		Labels: map[string]string{

--- a/internal/dyngroupeval/evaluator_test.go
+++ b/internal/dyngroupeval/evaluator_test.go
@@ -3,6 +3,7 @@ package dyngroupeval_test
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"sync"
 	"testing"
 
@@ -107,4 +108,142 @@ func TestDrainUserGroupQueue_DrainsUnderLock(t *testing.T) {
 	has, err := st.Queries().HasDynamicUserGroupQueueEntries(context.Background())
 	require.NoError(t, err)
 	assert.False(t, has, "queue row must be consumed")
+}
+
+// ---------------------------------------------------------------------------
+// Membership reconciliation (#12) — the drain tests above only proved the queue
+// lifecycle; these pin the actual add/remove of members and the short-circuits.
+// ---------------------------------------------------------------------------
+
+func execSQL(t *testing.T, st *store.Store, sql string, args ...any) {
+	t.Helper()
+	_, err := st.TestingPool().Exec(context.Background(), sql, args...)
+	require.NoError(t, err)
+}
+
+func deviceMembers(t *testing.T, st *store.Store, groupID string) []string {
+	t.Helper()
+	rows, err := st.TestingPool().Query(context.Background(),
+		`SELECT device_id FROM device_group_members_projection WHERE group_id = $1`, groupID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		out = append(out, id)
+	}
+	require.NoError(t, rows.Err())
+	sort.Strings(out)
+	return out
+}
+
+func deviceQueueCount(t *testing.T, st *store.Store, groupID string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, st.TestingPool().QueryRow(context.Background(),
+		`SELECT count(*) FROM dynamic_group_evaluation_queue WHERE group_id = $1`, groupID).Scan(&n))
+	return n
+}
+
+// TestEvaluateDeviceGroup_AddsAndRemovesMembers pins reconciliation in BOTH
+// directions in a single evaluation: a now-matching device is inserted and a
+// stale member that no longer matches is deleted.
+func TestEvaluateDeviceGroup_AddsAndRemovesMembers(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	dMatch := testutil.CreateTestDevice(t, st, "prod-host")
+	dStale := testutil.CreateTestDevice(t, st, "dev-host")
+	execSQL(t, st, `INSERT INTO device_labels (device_id, key, value) VALUES ($1, 'env', 'prod')`, dMatch)
+	execSQL(t, st, `INSERT INTO device_labels (device_id, key, value) VALUES ($1, 'env', 'dev')`, dStale)
+
+	groupID := testutil.NewID()
+	execSQL(t, st, `INSERT INTO device_groups_projection (id, name, is_dynamic, dynamic_query) VALUES ($1, 'dyn', TRUE, $2)`,
+		groupID, `labels.env equals "prod"`)
+	// dStale is a leftover member that no longer matches.
+	execSQL(t, st, `INSERT INTO device_group_members_projection (group_id, device_id) VALUES ($1, $2)`, groupID, dStale)
+	enqueueDeviceGroup(t, st, groupID)
+
+	require.NoError(t, dyngroupeval.New(st, slog.Default()).EvaluateDeviceGroup(ctx, groupID))
+	assert.Equal(t, []string{dMatch}, deviceMembers(t, st, groupID),
+		"matching device added, stale non-matching device removed")
+}
+
+// TestEvaluateUserGroup_AddsAndRemovesMembers — same reconciliation for user
+// groups, matching on user.email.
+func TestEvaluateUserGroup_AddsAndRemovesMembers(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	uMatch := testutil.CreateTestUser(t, st, "alice@prod.example", "pw", "user")
+	uStale := testutil.CreateTestUser(t, st, "bob@dev.example", "pw", "user")
+
+	groupID := testutil.NewID()
+	execSQL(t, st, `INSERT INTO user_groups_projection (id, name, is_dynamic, dynamic_query) VALUES ($1, 'dyn', TRUE, $2)`,
+		groupID, `user.email endsWith "@prod.example"`)
+	execSQL(t, st, `INSERT INTO user_group_members_projection (group_id, user_id) VALUES ($1, $2)`, groupID, uStale)
+	reason := "test"
+	require.NoError(t, st.Queries().EnqueueDynamicUserGroupEvaluation(ctx,
+		db.EnqueueDynamicUserGroupEvaluationParams{GroupID: groupID, Reason: &reason}))
+
+	require.NoError(t, dyngroupeval.New(st, slog.Default()).EvaluateUserGroup(ctx, groupID))
+
+	rows, err := st.TestingPool().Query(ctx, `SELECT user_id FROM user_group_members_projection WHERE group_id = $1`, groupID)
+	require.NoError(t, err)
+	defer rows.Close()
+	var members []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		members = append(members, id)
+	}
+	require.NoError(t, rows.Err())
+	assert.Equal(t, []string{uMatch}, members, "matching user added, stale non-matching user removed")
+}
+
+// TestEvaluateDeviceGroup_NonDynamicOrMissingClearsQueueNoOp pins the two
+// short-circuits: a non-dynamic group and a missing group each clear their queue
+// row and write no membership.
+func TestEvaluateDeviceGroup_NonDynamicOrMissingClearsQueueNoOp(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("non-dynamic group clears queue, no membership", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.co", "pw", "admin")
+		groupID := testutil.CreateTestDeviceGroup(t, st, actor, "static")
+		enqueueDeviceGroup(t, st, groupID)
+
+		require.NoError(t, dyngroupeval.New(st, slog.Default()).EvaluateDeviceGroup(ctx, groupID))
+		assert.Equal(t, 0, deviceQueueCount(t, st, groupID), "queue row cleared for a non-dynamic group")
+		assert.Empty(t, deviceMembers(t, st, groupID), "no membership written for a non-dynamic group")
+	})
+
+	t.Run("missing group clears queue", func(t *testing.T) {
+		st := testutil.SetupPostgres(t)
+		groupID := testutil.NewID() // never created
+		enqueueDeviceGroup(t, st, groupID)
+
+		require.NoError(t, dyngroupeval.New(st, slog.Default()).EvaluateDeviceGroup(ctx, groupID))
+		assert.Equal(t, 0, deviceQueueCount(t, st, groupID), "queue row cleared for a missing group")
+	})
+}
+
+// TestEvaluateDeviceGroup_ParseErrorLeavesQueueIntact pins the fail-safe: an
+// unparseable dynamic_query returns an error, writes no membership, and leaves
+// the queue row intact so a fixed query re-queues and re-evaluates.
+func TestEvaluateDeviceGroup_ParseErrorLeavesQueueIntact(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	device := testutil.CreateTestDevice(t, st, "host")
+	execSQL(t, st, `INSERT INTO device_labels (device_id, key, value) VALUES ($1, 'env', 'prod')`, device)
+
+	groupID := testutil.NewID()
+	// "equalz" is not a valid operator — the parser rejects it.
+	execSQL(t, st, `INSERT INTO device_groups_projection (id, name, is_dynamic, dynamic_query) VALUES ($1, 'dyn', TRUE, $2)`,
+		groupID, `labels.env equalz "prod"`)
+	enqueueDeviceGroup(t, st, groupID)
+
+	err := dyngroupeval.New(st, slog.Default()).EvaluateDeviceGroup(ctx, groupID)
+	require.Error(t, err, "an unparseable dynamic_query must surface an error")
+	assert.Equal(t, 1, deviceQueueCount(t, st, groupID), "the queue row must survive a parse error so a fix re-queues")
+	assert.Empty(t, deviceMembers(t, st, groupID), "no membership written on a parse error")
 }

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -841,10 +841,37 @@ func (h *AgentHandler) handleLogQueryResult(deviceID string, result *pm.LogQuery
 	})
 }
 
+// assertDeviceMatchesCert enforces that the mTLS client-certificate identity
+// matches the device_id a device-scoped RPC claims to act on. It must run
+// before any work so a compromised agent presenting device A's certificate
+// cannot drive an operation against device B. When mTLS is not required
+// (dev/test without a terminating gateway) it is a no-op. Shared by every
+// device-scoped agent RPC so the binding cannot drift between them.
+func (h *AgentHandler) assertDeviceMatchesCert(ctx context.Context, deviceID string) error {
+	if !h.requireTLS {
+		return nil
+	}
+	certDeviceID, ok := DeviceIDFromContext(ctx)
+	if !ok {
+		return connect.NewError(connect.CodeUnauthenticated, errors.New("mTLS authentication required"))
+	}
+	if certDeviceID != deviceID {
+		h.logger.Warn("agent RPC device ID mismatch", "cert_device_id", certDeviceID, "requested_device_id", deviceID)
+		return connect.NewError(connect.CodePermissionDenied, errors.New("device ID does not match certificate"))
+	}
+	return nil
+}
+
 // ValidateLuksToken validates and consumes a one-time LUKS token via the control server.
 func (h *AgentHandler) ValidateLuksToken(ctx context.Context, req *connect.Request[pm.ValidateLuksTokenRequest]) (*connect.Response[pm.ValidateLuksTokenResponse], error) {
 	if req.Msg.DeviceId == "" || req.Msg.Token == "" {
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("device_id and token are required"))
+	}
+
+	// Bind to the mTLS cert exactly as SyncActions does — without this a
+	// compromised agent could redeem a LUKS token issued for another device.
+	if err := h.assertDeviceMatchesCert(ctx, req.Msg.DeviceId); err != nil {
+		return nil, err
 	}
 
 	resp, err := h.controlProxy.ValidateLuksToken(ctx, req.Msg.DeviceId, req.Msg.Token)
@@ -863,16 +890,9 @@ func (h *AgentHandler) SyncActions(ctx context.Context, req *connect.Request[pm.
 		return nil, connect.NewError(connect.CodeInvalidArgument, errors.New("device_id is required"))
 	}
 
-	// Verify mTLS certificate matches requested device ID
-	if h.requireTLS {
-		certDeviceID, ok := DeviceIDFromContext(ctx)
-		if !ok {
-			return nil, connect.NewError(connect.CodeUnauthenticated, errors.New("mTLS authentication required"))
-		}
-		if certDeviceID != deviceID {
-			h.logger.Warn("SyncActions device ID mismatch", "cert_device_id", certDeviceID, "requested_device_id", deviceID)
-			return nil, connect.NewError(connect.CodePermissionDenied, errors.New("device ID does not match certificate"))
-		}
+	// Verify mTLS certificate matches requested device ID.
+	if err := h.assertDeviceMatchesCert(ctx, deviceID); err != nil {
+		return nil, err
 	}
 
 	h.logger.Info("agent syncing actions", "device_id", deviceID)

--- a/internal/handler/agent_rpc_test.go
+++ b/internal/handler/agent_rpc_test.go
@@ -139,6 +139,52 @@ func TestValidateLuksToken_ProxyError_MappedToNotFound(t *testing.T) {
 		"proxy error MUST be re-mapped to CodeNotFound — leaking the upstream code would enable timing-side-channel probes against the control plane")
 }
 
+func TestValidateLuksToken_TLS_DeviceIDMismatch_PermissionDenied(t *testing.T) {
+	// requireTLS=true: the cert's device-ID context MUST match the request's
+	// device_id, exactly as SyncActions enforces. A mismatch lets a compromised
+	// agent redeem a one-time LUKS token issued for a DIFFERENT device — the
+	// token unlocks that other device's encrypted volume. The guard must run
+	// BEFORE the proxy is touched.
+	h, stub := setupAgentForRPCTest(t)
+	h.requireTLS = true
+	ctx := contextWithDeviceID(context.Background(), "cert-dev-1")
+	_, err := h.ValidateLuksToken(ctx, connect.NewRequest(&pm.ValidateLuksTokenRequest{
+		DeviceId: "different-dev-2",
+		Token:    "the-token",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err),
+		"cert/request device-ID mismatch MUST be CodePermissionDenied — anything else lets a device redeem another's LUKS token")
+	assert.Empty(t, stub.lastValidateLuksToken,
+		"the control proxy MUST NOT be called on a cert mismatch — the guard runs before the work")
+}
+
+func TestValidateLuksToken_TLS_NoDeviceIDInContext_Unauthenticated(t *testing.T) {
+	h, stub := setupAgentForRPCTest(t)
+	h.requireTLS = true
+	_, err := h.ValidateLuksToken(context.Background(), connect.NewRequest(&pm.ValidateLuksTokenRequest{
+		DeviceId: "dev-1",
+		Token:    "tok",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	assert.Empty(t, stub.lastValidateLuksToken, "no proxy call without an authenticated cert identity")
+}
+
+func TestValidateLuksToken_TLS_MatchingDeviceID_PropagatesToProxy(t *testing.T) {
+	h, stub := setupAgentForRPCTest(t)
+	h.requireTLS = true
+	stub.validateLuksResp = &pm.ValidateLuksTokenResponse{ActionId: "act-1"}
+	ctx := contextWithDeviceID(context.Background(), "dev-1")
+	resp, err := h.ValidateLuksToken(ctx, connect.NewRequest(&pm.ValidateLuksTokenRequest{
+		DeviceId: "dev-1",
+		Token:    "the-token",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "act-1", resp.Msg.ActionId)
+	assert.Equal(t, "the-token", stub.lastValidateLuksToken, "a matching cert identity proceeds to the proxy")
+}
+
 // =============================================================================
 // SyncActions
 // =============================================================================

--- a/internal/handler/agent_stream_test.go
+++ b/internal/handler/agent_stream_test.go
@@ -92,6 +92,14 @@ type streamFixture struct {
 }
 
 func newStreamFixture(t *testing.T, requireTLS bool) *streamFixture {
+	return newStreamFixtureWithCert(t, requireTLS, "")
+}
+
+// newStreamFixtureWithCert is newStreamFixture plus an mTLS-cert-derived device
+// id stamped into the server-side request context (mimicking MTLSMiddleware), so
+// the cert/Hello device-id mismatch gate can be driven. certDeviceID == ""
+// injects nothing — the requireTLS path then sees no cert identity.
+func newStreamFixtureWithCert(t *testing.T, requireTLS bool, certDeviceID string) *streamFixture {
 	t.Helper()
 
 	// 1) httptest InternalService stub for ControlProxy.VerifyDevice.
@@ -129,7 +137,14 @@ func newStreamFixture(t *testing.T, requireTLS bool) *streamFixture {
 	mux := http.NewServeMux()
 	path, hh := pmv1connect.NewAgentServiceHandler(h)
 	mux.Handle(path, hh)
-	srv := httptest.NewUnstartedServer(mux)
+	var agentHandler http.Handler = mux
+	if certDeviceID != "" {
+		agentHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := context.WithValue(r.Context(), DeviceIDContextKey, certDeviceID)
+			mux.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+	srv := httptest.NewUnstartedServer(agentHandler)
 	protocols := new(http.Protocols)
 	protocols.SetUnencryptedHTTP2(true)
 	srv.Config.Protocols = protocols
@@ -224,6 +239,59 @@ func TestStream_HelloWithEmptyDeviceIDIsRejected(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
 		"Hello with empty device_id MUST be rejected — the empty key would collide across agents")
+}
+
+func TestStream_NoCertDeviceIDWhenTLSRequiredIsUnauthenticated(t *testing.T) {
+	// requireTLS=true but no mTLS-derived device id in context (the gateway
+	// terminating mTLS should always set it; if it ever doesn't, the handler
+	// must fail closed rather than stream unauthenticated).
+	f := newStreamFixture(t, true)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream := f.client.Stream(ctx)
+	require.NoError(t, stream.Send(&pm.AgentMessage{
+		Payload: &pm.AgentMessage_Hello{Hello: &pm.Hello{
+			DeviceId: &pm.DeviceId{Value: "01HZX9ABCD0000000000000000"},
+			Hostname: "h", AgentVersion: "v",
+		}},
+	}))
+	require.NoError(t, stream.CloseRequest())
+
+	err := recvErr(stream)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	assert.Empty(t, f.control.lastVerifyDevice, "VerifyDevice must not run without a cert identity")
+	started, _ := f.worker.snapshot()
+	assert.Empty(t, started, "no worker started")
+}
+
+func TestStream_CertHelloDeviceIDMismatchRejected(t *testing.T) {
+	// The cert identifies deviceA; the Hello claims deviceB. A compromised agent
+	// presenting another device's certificate must not register or stream as
+	// that other device — the gate must reject before VerifyDevice/StartWorker.
+	const certID = "01HZX9ABCD000000000000000A"
+	const helloID = "01HZX9ABCD000000000000000B"
+	f := newStreamFixtureWithCert(t, true, certID)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream := f.client.Stream(ctx)
+	require.NoError(t, stream.Send(&pm.AgentMessage{
+		Payload: &pm.AgentMessage_Hello{Hello: &pm.Hello{
+			DeviceId: &pm.DeviceId{Value: helloID},
+			Hostname: "h", AgentVersion: "v",
+		}},
+	}))
+	require.NoError(t, stream.CloseRequest())
+
+	err := recvErr(stream)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err),
+		"cert/Hello device-ID mismatch MUST be CodePermissionDenied")
+	assert.Empty(t, f.control.lastVerifyDevice, "VerifyDevice must not run on a cert/Hello mismatch")
+	started, _ := f.worker.snapshot()
+	assert.Empty(t, started, "no worker started on a mismatch")
 }
 
 func TestStream_VerifyDeviceFailureRejectsConnection(t *testing.T) {

--- a/internal/projectors/user_role_test.go
+++ b/internal/projectors/user_role_test.go
@@ -209,26 +209,46 @@ func TestUserRoleListener_AssignReplayIsIdempotent(t *testing.T) {
 	assert.Equal(t, 1, count, "ON CONFLICT DO NOTHING keeps assignment row unique despite replays")
 }
 
-// TestUserRoleListener_RevokeWhenAbsentIsNoop — defensive: a Revoke
-// event with no matching row must not error. The PL/pgSQL projector
-// used a plain DELETE which silently affects zero rows on a miss;
-// the Go listener must preserve that.
+// TestUserRoleListener_RevokeWhenAbsentIsNoop — a Revoke event with no matching
+// row must not error AND must not disturb any OTHER grant. The PL/pgSQL
+// projector used a plain DELETE (scoped to the event's user_id+role_id); the Go
+// listener must preserve that exact scoping. This feeds the JWT `sgrants` claim,
+// so an over-broad revoke would silently strip a user's roles. Plant a real,
+// unrelated grant first and prove it survives the absent revoke.
 func TestUserRoleListener_RevokeWhenAbsentIsNoop(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	ctx := context.Background()
 
+	roleID := testutil.NewID()
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pw", "user")
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "role", StreamID: roleID, EventType: "RoleCreated",
+		Data:      map[string]any{"name": "tmp", "permissions": []string{"x"}},
+		ActorType: "user", ActorID: "u",
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user_role", StreamID: userID + ":" + roleID, EventType: "UserRoleAssigned",
+		Data:      map[string]any{"user_id": userID, "role_id": roleID},
+		ActorType: "user", ActorID: "u",
+	}))
+
+	// Revoke a grant that does NOT exist (different user AND role).
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "user_role",
 		StreamID:   "ghost:role",
 		EventType:  "UserRoleRevoked",
-		Data: map[string]any{
-			"user_id": "ghost-user",
-			"role_id": "ghost-role",
-		},
-		ActorType: "user", ActorID: "u",
+		Data:       map[string]any{"user_id": "ghost-user", "role_id": "ghost-role"},
+		ActorType:  "user", ActorID: "u",
 	}))
-	// No assertion needed — the test passes as long as AppendEvent
-	// returns without error.
+
+	// The planted, unrelated grant must be untouched — the absent revoke
+	// deleted nothing else.
+	count := -1
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		"SELECT count(*) FROM user_roles_projection WHERE user_id=$1 AND role_id=$2",
+		userID, roleID,
+	).Scan(&count))
+	assert.Equal(t, 1, count, "a revoke of an absent (user,role) must not delete an unrelated grant")
 }
 
 // TestUserRoleListener_IgnoresWrongStreamType — defensive.

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -716,9 +716,11 @@ func (idx *Index) warmDevices(ctx context.Context) (int, error) {
 		for _, d := range devices {
 			labels := FlattenLabels(d.Labels)
 			fields := map[string]any{
-				"hostname":          d.Hostname,
-				"agent_version":     d.AgentVersion,
-				"labels":            labels,
+				// hostname / labels / agent_version are agent-reported — bound and
+				// strip them before indexing (see sanitizeSearchField).
+				"hostname":          sanitizeSearchField(d.Hostname, maxHostnameField),
+				"agent_version":     sanitizeSearchField(d.AgentVersion, maxOSField),
+				"labels":            sanitizeSearchField(labels, maxLabelsField),
 				"compliance_status": strconv.Itoa(int(d.ComplianceStatus)),
 			}
 			if d.RegisteredAt != nil {
@@ -733,17 +735,18 @@ func (idx *Index) warmDevices(ctx context.Context) (int, error) {
 			if err == nil {
 				for _, t := range inv {
 					osName, osVer, osArch, kernel := extractInventoryFields(t.TableName, t.Rows)
+					// os_* / kernel come from agent-reported osquery rows — sanitize.
 					if osName != "" {
-						fields["os_name"] = osName
+						fields["os_name"] = sanitizeSearchField(osName, maxOSField)
 					}
 					if osVer != "" {
-						fields["os_version"] = osVer
+						fields["os_version"] = sanitizeSearchField(osVer, maxOSField)
 					}
 					if osArch != "" {
-						fields["os_arch"] = osArch
+						fields["os_arch"] = sanitizeSearchField(osArch, maxOSField)
 					}
 					if kernel != "" {
-						fields["kernel"] = kernel
+						fields["kernel"] = sanitizeSearchField(kernel, maxOSField)
 					}
 				}
 			}

--- a/internal/search/sanitize.go
+++ b/internal/search/sanitize.go
@@ -1,0 +1,45 @@
+package search
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// Length caps for agent-controlled values written to the search index.
+const (
+	maxHostnameField = 253  // DNS hostname ceiling
+	maxLabelsField   = 4096 // flattened "k=v k=v …" label blob
+	maxOSField       = 256  // os_name / os_version / os_arch / kernel / agent_version
+)
+
+// sanitizeSearchField bounds an AGENT-CONTROLLED string before it is written
+// into the Valkey search index. Agents self-report hostname / labels / os_* /
+// kernel / agent_version; a malicious or buggy agent could report a multi-KB
+// value (index bloat / memory pressure) or one embedding ASCII control
+// characters or <markup> (which a UI rendering raw search-result fields could
+// then execute). The helper drops control characters (incl. NUL and newlines),
+// angle brackets, and invalid UTF-8, then caps the result to maxRunes.
+//
+// Operator-set fields (linux_username, actor_id) are trusted-by-policy and are
+// deliberately NOT routed through this — they never originate from an agent.
+func sanitizeSearchField(s string, maxRunes int) string {
+	if s == "" {
+		return s
+	}
+	var b strings.Builder
+	runes := 0
+	for _, r := range s {
+		if runes >= maxRunes {
+			break
+		}
+		if r == '<' || r == '>' {
+			continue
+		}
+		if r < 0x20 || r == 0x7f || r == utf8.RuneError {
+			continue
+		}
+		b.WriteRune(r)
+		runes++
+	}
+	return b.String()
+}

--- a/internal/search/sanitize_test.go
+++ b/internal/search/sanitize_test.go
@@ -1,0 +1,86 @@
+package search
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/manchtools/power-manage/server/internal/taskqueue"
+)
+
+// sanitizeSearchField must drop ASCII control characters and angle brackets and
+// cap length, so an agent-reported value cannot bloat the index or smuggle
+// markup into a UI that renders raw search fields. The hostile inputs are
+// sourced from intent (NUL/newline/escape control bytes, <script> markup,
+// over-long strings), not from the stripping rule itself.
+func TestSanitizeSearchField(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		max  int
+		want string
+	}{
+		{"empty stays empty", "", 253, ""},
+		{"plain hostname passes through", "web-01.example.com", 253, "web-01.example.com"},
+		{"strips NUL/newline/tab/escape", "host\x00\n\t\x1bname", 253, "hostname"},
+		{"strips DEL", "ab\x7fcd", 253, "abcd"},
+		{"strips angle brackets (markup)", "<script>alert(1)</script>x", 253, "scriptalert(1)/scriptx"},
+		{"preserves multibyte", "café-böx", 253, "café-böx"},
+		{"caps length to maxRunes", strings.Repeat("a", 300), 10, strings.Repeat("a", 10)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeSearchField(tc.in, tc.max)
+			if got != tc.want {
+				t.Errorf("sanitizeSearchField(%q, %d) = %q, want %q", tc.in, tc.max, got, tc.want)
+			}
+			if strings.ContainsAny(got, "<>") {
+				t.Errorf("result %q still contains angle brackets", got)
+			}
+			for _, r := range got {
+				if r < 0x20 || r == 0x7f {
+					t.Errorf("result %q still contains a control char %#x", got, r)
+				}
+			}
+		})
+	}
+}
+
+// entityFields is the LIVE index-update path; it must sanitize every
+// agent-reported device field exactly as Index.warmDevices does on the warm
+// path (both call sanitizeSearchField). Pin that a hostile device record is
+// bounded/stripped before it becomes the HSET payload.
+func TestEntityFields_Device_SanitizesAgentControlledFields(t *testing.T) {
+	data := &taskqueue.SearchEntityData{
+		Hostname:     "<b>evil</b>\x00host\n",
+		AgentVersion: "2026.2.0\x07",
+		Labels:       "env=prod\x1b<x>",
+		OSName:       "Ubuntu<script>",
+		OSVersion:    "24.04\n",
+		OSArch:       "x86_64\x00",
+		Kernel:       strings.Repeat("k", maxOSField+50),
+	}
+	fields := entityFields(ScopeDevice, data)
+
+	for _, key := range []string{"hostname", "agent_version", "labels", "os_name", "os_version", "os_arch", "kernel"} {
+		v, ok := fields[key].(string)
+		if !ok {
+			t.Fatalf("field %q missing or not a string: %v", key, fields[key])
+		}
+		if strings.ContainsAny(v, "<>") {
+			t.Errorf("field %q = %q still contains angle brackets", key, v)
+		}
+		for _, r := range v {
+			if r < 0x20 || r == 0x7f {
+				t.Errorf("field %q = %q still contains a control char %#x", key, v, r)
+			}
+		}
+	}
+	// Only the angle brackets and control chars are removed — the surrounding
+	// text survives (we neutralize markup, we don't drop arbitrary letters).
+	if got := fields["hostname"].(string); !strings.Contains(got, "evil") || !strings.Contains(got, "host") {
+		t.Errorf("hostname = %q, want the non-markup text preserved", got)
+	}
+	if got := len([]rune(fields["kernel"].(string))); got > maxOSField {
+		t.Errorf("kernel rune length = %d, want <= %d", got, maxOSField)
+	}
+}

--- a/internal/search/worker.go
+++ b/internal/search/worker.go
@@ -353,15 +353,17 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 		}
 		return fields
 	case ScopeDevice:
+		// Every field here is agent-reported — bound and strip them before the
+		// live HSET, mirroring the warm path (Index.warmDevices) exactly.
 		fields := map[string]any{
-			"hostname":          data.Hostname,
-			"agent_version":     data.AgentVersion,
-			"labels":            data.Labels,
+			"hostname":          sanitizeSearchField(data.Hostname, maxHostnameField),
+			"agent_version":     sanitizeSearchField(data.AgentVersion, maxOSField),
+			"labels":            sanitizeSearchField(data.Labels, maxLabelsField),
 			"compliance_status": strconv.Itoa(int(data.ComplianceStatus)),
-			"os_name":           data.OSName,
-			"os_version":        data.OSVersion,
-			"os_arch":           data.OSArch,
-			"kernel":            data.Kernel,
+			"os_name":           sanitizeSearchField(data.OSName, maxOSField),
+			"os_version":        sanitizeSearchField(data.OSVersion, maxOSField),
+			"os_arch":           sanitizeSearchField(data.OSArch, maxOSField),
+			"kernel":            sanitizeSearchField(data.Kernel, maxOSField),
 		}
 		if data.RegisteredAt != 0 {
 			fields["registered_at"] = strconv.FormatInt(data.RegisteredAt, 10)

--- a/internal/search/worker.go
+++ b/internal/search/worker.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strconv"
@@ -39,6 +40,22 @@ func (w *Worker) RegisterHandlers(mux *asynq.ServeMux) {
 	mux.HandleFunc(taskqueue.TypeSearchReindex, w.handleReindex)
 	mux.HandleFunc(taskqueue.TypeSearchMemberChange, w.handleMemberChange)
 	mux.HandleFunc(taskqueue.TypeSearchRemove, w.handleRemove)
+}
+
+// BuildSearchWorkerMux assembles the search worker's Asynq mux with the F-02
+// HMAC verify-middleware mounted AHEAD of every handler. It returns an error
+// when signer is nil so a missing PM_TASK_SIGNING_KEY is a fatal startup
+// failure rather than an unsigned mux — an unsigned mux would let a compromised
+// Valkey relay (actor-4) inject forged or unsigned search:* tasks. Extracted
+// from cmd/indexer so the verify-first wiring is testable without booting the
+// binary.
+func BuildSearchWorkerMux(rdb *redis.Client, signer *taskqueue.Signer, logger *slog.Logger) (*asynq.ServeMux, error) {
+	if signer == nil {
+		return nil, errors.New("search worker mux requires a task signer: PM_TASK_SIGNING_KEY must be set (audit F-02 — task verification is mandatory)")
+	}
+	mux := asynq.NewServeMux()
+	NewWorker(rdb, signer, logger).RegisterHandlers(mux)
+	return mux, nil
 }
 
 func (w *Worker) handleReindex(ctx context.Context, t *asynq.Task) error {

--- a/internal/search/worker_test.go
+++ b/internal/search/worker_test.go
@@ -3,6 +3,7 @@ package search
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
 	"testing"
@@ -115,4 +116,88 @@ func TestWorker_UnsignedTaskIsRejected(t *testing.T) {
 	err = f.mux.ProcessTask(f.ctx, asynq.NewTask(taskqueue.TypeSearchReindex, data))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "task signature")
+}
+
+// A task signed with a DIFFERENT key (forged, not merely absent) must be
+// rejected with asynq.SkipRetry (so it dead-letters rather than retry-loops)
+// and must NOT mutate the index — the F-02 HMAC is the sole authenticator for
+// search:* tasks against a compromised Valkey relay (actor-4). Driven through
+// the real mux for all three task types.
+func TestWorker_ForgedKeyTaskRejectedAndNoHSET(t *testing.T) {
+	const forgedKeyHex = "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+	forged, err := taskqueue.NewSigner(forgedKeyHex)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		taskType string
+		payload  any
+		hashKey  string
+	}{
+		{"reindex", taskqueue.TypeSearchReindex,
+			taskqueue.SearchReindexPayload{Scope: ScopeAction, ID: "act-1", Data: &taskqueue.SearchEntityData{Name: "forged"}},
+			prefixAction + "act-1"},
+		{"member change", taskqueue.TypeSearchMemberChange,
+			taskqueue.SearchMemberChangePayload{ParentScope: ScopeActionSet, ParentID: "set-1", ChildScope: ScopeAction, ChildID: "act-1", Action: "add"},
+			prefixActionSet + "set-1"},
+		{"remove", taskqueue.TypeSearchRemove,
+			taskqueue.SearchRemovePayload{Scope: ScopeAction, ID: "act-1"},
+			prefixAction + "act-1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newWorkerFixture(t)
+			data, err := json.Marshal(tc.payload)
+			require.NoError(t, err)
+			// Signed with the WRONG key.
+			task := asynq.NewTask(tc.taskType, forged.Wrap(data), asynq.Queue(taskqueue.SearchQueue))
+
+			err = f.mux.ProcessTask(f.ctx, task)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, asynq.SkipRetry),
+				"a forged-key task must dead-letter (SkipRetry), not retry-loop; got %v", err)
+
+			exists, err := f.rdb.Exists(f.ctx, tc.hashKey).Result()
+			require.NoError(t, err)
+			assert.Equal(t, int64(0), exists, "a forged task must not create/mutate the %s hash", tc.hashKey)
+		})
+	}
+}
+
+func TestBuildSearchWorkerMux_NilSignerIsFatal(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, rdb.Close()) })
+
+	mux, err := BuildSearchWorkerMux(rdb, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.Error(t, err, "a nil signer (empty PM_TASK_SIGNING_KEY) must be fatal")
+	assert.Nil(t, mux)
+	assert.Contains(t, err.Error(), "PM_TASK_SIGNING_KEY")
+}
+
+// BuildSearchWorkerMux must mount VerifyMiddleware AHEAD of the handlers, so an
+// unsigned or forged task is rejected before any HSET. Drive both through the
+// assembled mux and assert SkipRetry + no index mutation.
+func TestBuildSearchWorkerMux_VerifiesBeforeHandlers(t *testing.T) {
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, rdb.Close()) })
+
+	signer, err := taskqueue.NewSigner(workerTestKeyHex)
+	require.NoError(t, err)
+	mux, err := BuildSearchWorkerMux(rdb, signer, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	require.NoError(t, err)
+
+	payload := taskqueue.SearchReindexPayload{Scope: ScopeAction, ID: "act-1", Data: &taskqueue.SearchEntityData{Name: "x"}}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+
+	// Unsigned.
+	err = mux.ProcessTask(context.Background(), asynq.NewTask(taskqueue.TypeSearchReindex, data, asynq.Queue(taskqueue.SearchQueue)))
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, asynq.SkipRetry), "unsigned task rejected before the handler; got %v", err)
+
+	exists, err := rdb.Exists(context.Background(), prefixAction+"act-1").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists, "verify-middleware must run before any HSET")
 }

--- a/internal/store/migrations/014_reconciler_owned_role_permissions.sql
+++ b/internal/store/migrations/014_reconciler_owned_role_permissions.sql
@@ -1,0 +1,26 @@
+-- 014_reconciler_owned_role_permissions.sql
+--
+-- WS17b #18: the Admin/User system-role permission arrays were seeded as SQL
+-- literals (008_seeds.sql) and patched by later migrations (009, 010). Each
+-- frozen snapshot drifts from the Go source of truth (auth.AdminPermissions /
+-- auth.DefaultUserPermissions) as permissions are added/renamed — the Admin
+-- literal had already drifted 18 added + 6 renamed permissions behind by the
+-- time this landed.
+--
+-- auth.ReconcileSystemRoles runs on every control-server boot (after
+-- migrations) and OVERWRITES these arrays from the Go sets, so the literals are
+-- runtime-irrelevant — only misleading, and a drift surface that no test could
+-- guard while the literal was the seed. Blank them here so the permission set
+-- is reconciler-owned (single source of truth = Go) with no SQL literal left to
+-- drift. The reconciler refills them on the same boot.
+
+-- +goose Up
+UPDATE public.roles_projection
+SET permissions = '{}'
+WHERE id IN ('00000000000000000000000001', '00000000000000000000000002')
+  AND is_system = TRUE;
+
+-- +goose Down
+-- No-op: the Go reconciler repopulates these on every boot regardless, so there
+-- is nothing meaningful to restore.
+SELECT 1;

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -126,6 +126,23 @@ func TestRebuildAll_NoArgsRebuildsEverything(t *testing.T) {
 	}
 }
 
+// TestAllRebuildTargetsHaveRegisteredApplier is the self-discovering parity
+// guard for #125's silent-no-op failure mode: every entry in AllRebuildTargets
+// MUST have a Go applier wired by projectors.WireAll. A target without one makes
+// RebuildAll TRUNCATE the projection and then "succeed" without re-applying any
+// event — a destructive no-op during emergency replay. Adding a target here
+// without the matching WireAll registration trips this test. (Matches-zero
+// guarded so an empty target list can't pass vacuously.)
+func TestAllRebuildTargetsHaveRegisteredApplier(t *testing.T) {
+	require.NotEmpty(t, store.AllRebuildTargets, "AllRebuildTargets is empty — the parity guard would pass vacuously")
+
+	st := testutil.SetupPostgres(t) // SetupPostgres runs projectors.WireAll
+	for _, target := range store.AllRebuildTargets {
+		assert.Truef(t, st.HasRebuildApply(target.Name),
+			"rebuild target %q has no Go applier registered — projectors.WireAll must RegisterRebuildApply it, or RebuildAll silently no-ops the projection", target.Name)
+	}
+}
+
 // TestRebuildAll_UnknownTargetIsRejected — operators mistyping a
 // target name must get a clean error rather than a silent no-op.
 // Bug-class avoidance: a typo'd `RebuildAll(ctx, "user")` (singular)

--- a/internal/store/seed_parity_test.go
+++ b/internal/store/seed_parity_test.go
@@ -45,20 +45,27 @@ func TestSystemRolePermissionsAreReconcilerOwned(t *testing.T) {
 	for _, f := range files {
 		raw, err := os.ReadFile(f)
 		require.NoError(t, err)
-		body := string(raw)
-		for _, roleID := range roleIDs {
-			if !strings.Contains(body, roleID) {
-				continue
+		// Scope the check to individual statements so a migration that mentions
+		// a role ID in one statement and sets unrelated permissions in another
+		// cannot produce a false classification. Splitting on ';' is sufficient
+		// for these literal-only seed/update statements.
+		for _, stmt := range strings.Split(string(raw), ";") {
+			for _, roleID := range roleIDs {
+				if !strings.Contains(stmt, roleID) {
+					continue
+				}
+				// Only consider statements that actually set a permissions value.
+				if !strings.Contains(stmt, "permissions") {
+					continue
+				}
+				sawSeed = true
+				// A non-empty literal here means this statement seeded a frozen
+				// list; an empty '{}' (no match of the non-empty RE) means
+				// reconciler-owned. Statements are visited in file order, so the
+				// last one to set the role wins.
+				lastFinalEmpty[roleID] = !nonEmptyPermArrayRE.MatchString(stmt)
+				lastFile[roleID] = f
 			}
-			// Only consider migrations that actually set a permissions value.
-			if !strings.Contains(body, "permissions") {
-				continue
-			}
-			sawSeed = true
-			// A non-empty literal here means this migration seeded a frozen list;
-			// an empty '{}' (no match of the non-empty RE) means reconciler-owned.
-			lastFinalEmpty[roleID] = !nonEmptyPermArrayRE.MatchString(body)
-			lastFile[roleID] = f
 		}
 	}
 

--- a/internal/store/seed_parity_test.go
+++ b/internal/store/seed_parity_test.go
@@ -1,0 +1,73 @@
+package store_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+)
+
+// nonEmptyPermArrayRE matches a non-empty `'{Permission,…}'` literal in either
+// INSERT (`…, '{GetUser,…}', …`) or UPDATE (`permissions = '{GetUser,…}'`)
+// form — permission names start with a letter, so `'{` followed by a letter is
+// a seeded list; the reconciler-owned empty array `'{}'` does not match. This
+// is the drift-prone pattern WS17b #18 retires.
+var nonEmptyPermArrayRE = regexp.MustCompile(`'\{[A-Za-z]`)
+
+// TestSystemRolePermissionsAreReconcilerOwned pins that no migration leaves the
+// Admin/User system roles seeded with a frozen SQL permission literal. Those
+// literals duplicated the Go source of truth (auth.AdminPermissions /
+// auth.DefaultUserPermissions, applied by auth.ReconcileSystemRoles on every
+// boot) and silently drifted as permissions were added/renamed. Migration 014
+// blanks them so the reconciler is the single source of truth; this test fails
+// if a later migration re-introduces a non-empty literal for a system role.
+func TestSystemRolePermissionsAreReconcilerOwned(t *testing.T) {
+	files, err := filepath.Glob("migrations/*.sql")
+	require.NoError(t, err)
+	require.NotEmpty(t, files, "no migration files found")
+	sort.Strings(files) // numeric prefixes → lexical order == apply order
+
+	roleIDs := []string{auth.AdminRoleID, auth.UserRoleID}
+
+	// Track, per role, the LAST migration that sets its permissions and whether
+	// that final assignment is the reconciler-owned empty literal.
+	lastFinalEmpty := map[string]bool{}
+	lastFile := map[string]string{}
+	sawSeed := false
+
+	for _, f := range files {
+		raw, err := os.ReadFile(f)
+		require.NoError(t, err)
+		body := string(raw)
+		for _, roleID := range roleIDs {
+			if !strings.Contains(body, roleID) {
+				continue
+			}
+			// Only consider migrations that actually set a permissions value.
+			if !strings.Contains(body, "permissions") {
+				continue
+			}
+			sawSeed = true
+			// A non-empty literal here means this migration seeded a frozen list;
+			// an empty '{}' (no match of the non-empty RE) means reconciler-owned.
+			lastFinalEmpty[roleID] = !nonEmptyPermArrayRE.MatchString(body)
+			lastFile[roleID] = f
+		}
+	}
+
+	require.True(t, sawSeed, "expected at least one migration referencing the system role IDs")
+	for _, roleID := range roleIDs {
+		require.Contains(t, lastFile, roleID, "no migration sets permissions for system role %s", roleID)
+		assert.Truef(t, lastFinalEmpty[roleID],
+			"the last migration to set system role %s permissions (%s) seeds a frozen literal — "+
+				"system-role permissions must be reconciler-owned (set to '{}') so they cannot drift from auth.AdminPermissions/DefaultUserPermissions",
+			roleID, lastFile[roleID])
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -198,6 +198,17 @@ func (s *Store) rebuildApplyFor(name string) RebuildApply {
 	return s.rebuildAppliers[name]
 }
 
+// HasRebuildApply reports whether a Go applier is registered for the named
+// rebuild target. Exposed so a parity test can assert every AllRebuildTargets
+// entry is wired (a missing applier makes RebuildAll silently no-op the
+// projection — the failure mode #125 fixed).
+func (s *Store) HasRebuildApply(name string) bool {
+	s.listenersMu.RLock()
+	defer s.listenersMu.RUnlock()
+	_, ok := s.rebuildAppliers[name]
+	return ok
+}
+
 // fireListeners invokes both the legacy OnEventAppended callback (if
 // set) and every RegisterEventListener entry. Centralised so the two
 // AppendEvent variants stay in sync.


### PR DESCRIPTION
WS17b server arm — all 23 findings. Depends on (and bumps the pin to) the merged sdk PR #121.

## Code changes (each RED-first where it flipped behaviour)
- **#7** `ValidateLuksToken` now enforces the mTLS cert-CN binding via a shared `assertDeviceMatchesCert` (the only two device-scoped agent RPCs, +SyncActions, call it). A compromised agent could otherwise redeem another device's one-time LUKS token.
- **#17** `sanitizeSearchField` (drop control chars/angle-brackets/invalid-UTF-8 + length cap) applied to agent-reported hostname/labels/os_*/kernel on BOTH the warm (`warmDevices`) and live (`entityFields`) paths.
- **#18** system-role permission seed made reconciler-owned (migration 014 blanks the drifted SQL literals; the Go reconciler is the single source of truth). Self-discovering test + DB-level assertion.
- **#15** `BuildSearchWorkerMux` extracted, fail-closed on a nil signer, `VerifyMiddleware` mounted first.
- **#6 — REAL BUG, found by writing the coverage.** The compliance evaluator resolved "no result yet → UNKNOWN" and "first-ever non-compliant → seed first_failed_at" with `errors.Is(err, store.ErrNotFound)`, but the generated queries return the backend's `pgx.ErrNoRows` (a different sentinel), so those branches **never fired** — a rule with no result yet, or failing the first time, errored and aborted the device evaluation. Fixed to the mandated `store.IsNotFound`. Sibling sweep: no other caller had the pattern.

## Self-discovering guards
- **#8** validate-before-work sweep over **every** ControlService RPC via reflection (zero request → CodeInvalidArgument before the handler), exempt list rot-guarded.
- **#1** system-actor canary re-keyed to enclosing-function (stable) + fail-closed + matches-zero.
- **#14** every `AllRebuildTargets` has a registered Go applier (`HasRebuildApply`).
- **#19** matches-zero guards on the RPC/permission parity tests.

## Rejection / coverage tests
#2 registration cert-CN binding + SAN rejection · #3 CA identity-from-server (non-circular) · #5 stream cert/Hello mismatch + no-cert-unauthenticated · #9 Register pre-auth field bounds · #11/#16 forged-key search tasks (SkipRetry + no HSET) · #12 dyngroupeval membership add/remove + short-circuits + parse-error fail-safe · #13 dynamicquery in-split metacharacters · #21 user_role revoke-absent scoping invariant.

#22/#23 (idp/scim coverage tail) are covered by their feature streams — cross-referenced, not duplicated.

## Verification
`gofmt` clean · `go vet ./...` clean · full `go test ./...` green (incl. the new compliance + dyngroupeval testcontainer suites) · local CodeRabbit review: **No findings**. ADR 0022 records the boundary-hardening + the compliance fix.

Closes #439

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compliance evaluator to correctly handle missing evaluation results without treating them as errors.

* **Security Enhancements**
  * Enforced mTLS certificate device-ID binding for device-scoped operations.
  * Sanitized agent-supplied fields before indexing in search to prevent injection issues.
  * Made task signing verification mandatory; unsigned or forged tasks are now rejected before processing.
  * Made system-role permissions reconciler-owned to prevent permission drift.

* **Documentation**
  * Added architecture decision record detailing WS17b boundary-hardening changes.

* **Tests**
  * Expanded test coverage for boundary validation, compliance evaluation, and search field sanitization.

* **Chores**
  * Updated SDK dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->