### PR TITLE
test(archtest): WS0 fitness functions — signing-invariant, unframed-hash, InternalService classification

### DIFF
--- a/docs/adr/0002-architectural-fitness-functions.md
+++ b/docs/adr/0002-architectural-fitness-functions.md
@@ -45,12 +45,39 @@ Ground rules for every guard:
 | `TestSecretComparesAreConstantTime` | ✅ | ✅ | ✅ | Secret/MAC/token/signature/fingerprint/digest compares use `subtle.ConstantTimeCompare`/`hmac.Equal`, never `==`/`bytes.Equal`. Presence (`== nil`/`== ""`) and metadata fields excluded. |
 | `TestProjectionTablesWrittenOnlyByProjectors` | ✅ | — | — | Request handlers never write `*_projection` directly — they append events; projectors and computed-read-model engines write projections (see below). |
 | `TestNoUnabstractedTimeNow` | ✅ | — | ✅ | No direct `time.Now()` calls in runtime code (see clock seam below). |
+| `TestNoStdlibJSONOfProtoMessage` | ✅ | — | ✅ | Proto messages are (de)serialised with `protojson`, never stdlib `encoding/json` (WS1b#5). |
+| `TestNoUnframedHashPreimage` | ✅ | — | — | Hash/MAC preimages must be length-prefixed / domain-separated, never built by `+`-concatenation or `fmt.Sprintf` of multiple fields (the pre-image-ambiguity class behind WS1 / WS1b#3). |
+| `TestSignatureIsOverDeterministicProtoAndSingleRepresentation` | ✅ | — | — | No proto field named `*_canonical` (one representation, no divergent twin); the action signer's `Sign()` is called only from the single canonicalization seam `actionparams.BuildAndSignEnvelope` (ADR 0003). |
 
-RPC classification (every `ControlService` RPC is in exactly one of
-{public allow-list, permission, procedure-alternative}, both directions,
-matches-zero-guarded) is already enforced by
-`server/internal/auth/permissions_parity_test.go` and is **not** duplicated in
-`archtest`.
+### RPC classification (lives next to the handlers, not in `archtest`)
+
+Every RPC is consciously classified, by a self-discovering, matches-zero-guarded
+test anchored to the live proto/connect registry — kept beside the code it
+guards rather than duplicated in `archtest`:
+
+- **`ControlService`** — every RPC is in exactly one of {public allow-list,
+  permission, procedure-alternative}, both directions:
+  `server/internal/auth/permissions_parity_test.go`.
+- **`InternalService`** — every RPC is either device-origin-bound (request
+  carries `device_id`, covered by the gateway-binding completeness guard
+  `TestInternalHandlers_GatewayBindingIsSelfDiscovering`) or explicitly listed
+  non-device-scoped (gated by the peer-class mTLS listener + session ownership):
+  `server/internal/api/internal_service_classification_test.go`. A new
+  unclassified InternalService RPC fails the build.
+
+### Other self-discovering guards (in their owning packages)
+
+- **`TestEveryActionTypeHandledInEveryParamsSwitch`**
+  (`internal/actionparams/registry_test.go`) — every `ActionType` is handled by
+  the single proto-reflection params registry (WS1b#1).
+- **`TestExecutionCreatedEmittedTyped`** (`internal/api`) — dispatch emits typed
+  `payloads.ExecutionCreated`, never an ad-hoc `map[string]any` (WS1b#2).
+- **`TestGeneratedCodeIsRegenerated`** — enforced as CI jobs (sqlc drift in
+  `sqlc.yml`; proto regen drift in the sdk repo), not a Go test.
+
+A `dupl`-style cross-file duplication CI backstop was **considered and
+deferred** in favour of single-source helpers + completeness tests — see ADR
+0021.
 
 ### The clock seam (`TestNoUnabstractedTimeNow`)
 

--- a/internal/api/internal_service_classification_test.go
+++ b/internal/api/internal_service_classification_test.go
@@ -1,0 +1,67 @@
+package api_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// nonDeviceScopedInternalRPCs lists the InternalService methods whose requests
+// do NOT carry a device_id and so are intentionally not device-origin-bound.
+// They are gated by the InternalService mTLS peer-class listener plus their own
+// session-ownership/scope checks rather than by the device→gateway registry.
+// Each entry is justified; the test below fails the build if an entry no longer
+// resolves to a real method (stale), or if a new InternalService method appears
+// that is neither device-bound nor listed here.
+var nonDeviceScopedInternalRPCs = map[string]string{
+	"ProxyValidateTerminalToken": "keyed by session_id+token and validated against the session, not a device origin",
+}
+
+// TestEveryInternalServiceRPCIsClassified pins that EVERY InternalService RPC is
+// consciously classified into exactly one of:
+//
+//   - device-origin-bound: its request carries device_id and so is covered by
+//     the gateway-binding completeness guard
+//     (TestInternalHandlers_GatewayBindingIsSelfDiscovering); or
+//   - non-device-scoped: explicitly listed in nonDeviceScopedInternalRPCs with a
+//     justification (gated by the peer-class mTLS listener + session ownership).
+//
+// A newly-added InternalService RPC that is neither device-bound nor listed
+// fails here, forcing the author to decide its gating rather than silently
+// shipping an unclassified credential-bearing endpoint. This is the
+// InternalService counterpart to the ControlService classification enforced by
+// internal/auth/permissions_parity_test.go (WS0 / WS2), closing the gap that the
+// ControlService parity test did not cover the InternalService surface.
+func TestEveryInternalServiceRPCIsClassified(t *testing.T) {
+	svc := pm.File_pm_v1_internal_proto.Services().ByName("InternalService")
+	require.NotNil(t, svc, "InternalService descriptor must resolve")
+	methods := svc.Methods()
+	require.NotZero(t, methods.Len(), "matches-zero guard: no InternalService methods discovered — the descriptor walk is dead")
+
+	seenNonDevice := map[string]bool{}
+	for i := 0; i < methods.Len(); i++ {
+		m := methods.Get(i)
+		name := string(m.Name())
+		deviceBound := m.Input().Fields().ByName("device_id") != nil
+		_, listedNonDevice := nonDeviceScopedInternalRPCs[name]
+
+		switch {
+		case deviceBound && listedNonDevice:
+			t.Errorf("InternalService.%s is both device-bound (request carries device_id) and listed in nonDeviceScopedInternalRPCs — remove the allowlist entry", name)
+		case !deviceBound && !listedNonDevice:
+			t.Errorf("InternalService.%s is UNCLASSIFIED: its request has no device_id (so the device-origin binding guard cannot cover it) and it is not in nonDeviceScopedInternalRPCs.\n  Either add a device_id binding + a case in TestInternalHandlers_GatewayBindingIsSelfDiscovering, or add a justified entry to nonDeviceScopedInternalRPCs.", name)
+		case listedNonDevice:
+			seenNonDevice[name] = true
+		}
+	}
+
+	// No-stale-entry guard: every allowlisted non-device-scoped RPC must still
+	// resolve to a real method, or the allowlist has rotted open.
+	for name := range nonDeviceScopedInternalRPCs {
+		if !seenNonDevice[name] {
+			t.Errorf("stale nonDeviceScopedInternalRPCs entry %q no longer resolves to an InternalService method (remove it)", name)
+		}
+	}
+}

--- a/internal/archtest/archtest.go
+++ b/internal/archtest/archtest.go
@@ -35,13 +35,16 @@
 //   - TestProjectionTablesWrittenOnlyByProjectors ... projection_writes_test.go
 //   - TestNoUnabstractedTimeNow ........... time_now_test.go
 //   - TestNoStdlibJSONOfProtoMessage ...... proto_json_test.go
+//   - TestNoUnframedHashPreimage .......... hash_preimage_test.go
+//   - TestSignatureIsOverDeterministicProtoAndSingleRepresentation ... signing_test.go
 //
 // RPC classification (every ControlService RPC is in exactly one of
 // {public allow-list, permission, procedure-alternative}, both
 // directions, matches-zero-guarded) is ALREADY enforced by
 // internal/auth/permissions_parity_test.go — it is not duplicated here.
-// InternalService classification belongs to the gateway↔control trust
-// stream, not to these module-wide guards.
+// InternalService classification (every RPC is device-origin-bound or an
+// explicitly-justified non-device-scoped exception) lives beside its
+// handlers in internal/api/internal_service_classification_test.go.
 //
 // The unabstracted-clock guard (TestNoUnabstractedTimeNow) landed with
 // the module-wide clock-seam refactor (WS0): every time.Now() call site

--- a/internal/archtest/hash_preimage_test.go
+++ b/internal/archtest/hash_preimage_test.go
@@ -1,0 +1,126 @@
+package archtest
+
+import (
+	"go/ast"
+	"go/token"
+	"regexp"
+	"testing"
+)
+
+// hashPreimageAllowlist exempts hashing call sites whose multi-field preimage is
+// nonetheless unambiguous (e.g. a fixed-width, self-delimiting layout). Empty
+// today: every hashing site in the module either hashes a single value or builds
+// a length-prefixed/domain-separated preimage (stableExecutionID's writeFramed,
+// the signing canonicalDigest). Keyed by "<module-rel path> :: <rendered call>".
+var hashPreimageAllowlist = map[string]string{}
+
+// hashReceiverRe matches identifiers that conventionally name a hash/MAC writer,
+// so `<recv>.Write(preimage)` is treated as a hashing sink. Documented heuristic
+// per the archtest design constraints.
+var hashReceiverRe = regexp.MustCompile(`(?i)^(h|hash|hasher|mac|hmac|digest|sum|sha\d*)$`)
+
+// hashSumFuncs are the package-qualified one-shot hashing constructors whose
+// FIRST argument is the preimage (crypto/sha256, sha512, sha1, md5).
+var hashSumFuncs = map[string]map[string]bool{
+	"sha256": {"Sum256": true, "Sum224": true},
+	"sha512": {"Sum512": true, "Sum384": true, "Sum512_256": true, "Sum512_224": true},
+	"sha1":   {"Sum": true},
+	"md5":    {"Sum": true},
+}
+
+// TestNoUnframedHashPreimage forbids feeding a hash/MAC a preimage built by
+// +-concatenation or fmt.Sprintf of multiple fields. Such a preimage is
+// ambiguous: ("a","bc") and ("ab","c") hash identically, so a value that can
+// contain the (implicit) separator lets one input forge another's digest — the
+// same pre-image-ambiguity class as the action-signing bug (WS1) and the dedup
+// execution-id bug (WS1b#3). Preimages must be length-prefixed / domain-separated
+// (e.g. the writeFramed helper) or a single value.
+//
+// Detected sinks: sha{256,512,1}/md5 one-shot Sum* calls (first arg), and
+// `<recv>.Write(arg)` where recv looks like a hash writer (hashReceiverRe).
+// A site is a violation when the preimage arg is a `+` BinaryExpr or a
+// fmt.Sprintf(...) call. Genuinely-unambiguous multi-field layouts go in the
+// guarded hashPreimageAllowlist.
+func TestNoUnframedHashPreimage(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(string) bool { return true })
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero production Go files")
+	}
+	allow := newAllowlist(hashPreimageAllowlist)
+	sawSink := false
+
+	for _, gf := range files {
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			preimage, isSink := hashSinkPreimage(call)
+			if !isSink {
+				return true
+			}
+			sawSink = true
+			if !isUnframedPreimage(preimage) {
+				return true
+			}
+			key := gf.rel + " :: " + render(gf.fset, call)
+			if allow.exempt(key) {
+				return true
+			}
+			t.Errorf("hash preimage built by concatenation/Sprintf at %s:%d — %s\n  a +-joined or fmt.Sprintf preimage is field-boundary ambiguous; length-prefix/domain-separate it (see writeFramed / canonicalDigest). If the layout is genuinely unambiguous, justify it in hashPreimageAllowlist.",
+				gf.rel, gf.line(call), render(gf.fset, call))
+			return true
+		})
+	}
+
+	if !sawSink {
+		t.Fatal("matches-zero guard: detected no hashing sinks in the module — the detector is dead, the guard would pass vacuously")
+	}
+	allow.assertNoStale(t)
+}
+
+// hashSinkPreimage reports whether call is a hashing sink and returns the
+// expression that becomes the hash preimage.
+func hashSinkPreimage(call *ast.CallExpr) (ast.Expr, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return nil, false
+	}
+	// pkg.Sum256(preimage) one-shot forms.
+	if pkg, ok := sel.X.(*ast.Ident); ok {
+		if funcs, ok := hashSumFuncs[pkg.Name]; ok && funcs[sel.Sel.Name] && len(call.Args) >= 1 {
+			return call.Args[0], true
+		}
+	}
+	// <recv>.Write(preimage) where recv looks like a hash writer.
+	if sel.Sel.Name == "Write" && len(call.Args) == 1 {
+		if recv, ok := sel.X.(*ast.Ident); ok && hashReceiverRe.MatchString(recv.Name) {
+			return call.Args[0], true
+		}
+	}
+	return nil, false
+}
+
+// isUnframedPreimage reports whether e is a multi-field concatenation (`a + b`)
+// or a fmt.Sprintf(...) call — the ambiguous shapes this guard forbids.
+func isUnframedPreimage(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.BinaryExpr:
+		return x.Op == token.ADD
+	case *ast.CallExpr:
+		// fmt.Sprintf(...) (or any *.Sprintf) used to build the preimage.
+		if sel, ok := x.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "Sprintf" {
+			return true
+		}
+		// A conversion like []byte(a + b) — unwrap a single-arg conversion.
+		if len(x.Args) == 1 {
+			if _, isArr := x.Fun.(*ast.ArrayType); isArr {
+				return isUnframedPreimage(x.Args[0])
+			}
+		}
+	case *ast.ParenExpr:
+		return isUnframedPreimage(x.X)
+	}
+	return false
+}

--- a/internal/archtest/signing_test.go
+++ b/internal/archtest/signing_test.go
@@ -1,0 +1,112 @@
+package archtest
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+
+	// Imported for its init() side effect: registers every pm.v1 file
+	// descriptor in protoregistry.GlobalFiles so the proto-reflection arm below
+	// can walk them.
+	_ "github.com/manchtools/power-manage/sdk/gen/go/pm/v1"
+)
+
+// signCallAllowlist enumerates the application-level call sites of the action
+// signer's Sign method. The action-signing design (ADR 0003) requires the CA
+// signature to be minted from exactly ONE canonicalization seam
+// (actionparams.BuildAndSignEnvelope), so the bytes that are signed are exactly
+// the deterministic SignedActionEnvelope wire bytes that get transported and
+// executed. A second Sign call site would reintroduce the divergent-representation
+// risk WS1 removed. Keyed by "<module-rel path> :: <rendered call expression>".
+var signCallAllowlist = map[string]string{
+	"internal/actionparams/sign_envelope.go :: signer.Sign(envelopeBytes)": "the single canonicalization seam: signs verify.MarshalEnvelope(env) deterministic bytes (ADR 0003)",
+}
+
+const protoPackageName = "pm.v1"
+
+// TestSignatureIsOverDeterministicProtoAndSingleRepresentation pins the two
+// structural invariants behind the action-signing design (ADR 0003 / WS1):
+//
+//	(a) proto reflection — NO message field is named "*_canonical". The clean
+//	    break removed Action.params_canonical and the params_canonical/typed-params
+//	    split; a re-introduced "*_canonical" field is the smell returning (two
+//	    representations of the same data that can diverge under signing).
+//	(b) AST — the action signer's Sign method is invoked from exactly one
+//	    canonicalization seam (actionparams.BuildAndSignEnvelope). Every Sign
+//	    call site must be in signCallAllowlist; a new one fails the build.
+//
+// Together they pin "one deterministic representation, signed once" so a future
+// change cannot silently reintroduce a second, divergent canonical form.
+func TestSignatureIsOverDeterministicProtoAndSingleRepresentation(t *testing.T) {
+	t.Run("no _canonical proto fields", func(t *testing.T) {
+		messages := 0
+		violations := 0
+		protoregistry.GlobalFiles.RangeFiles(func(fd protoreflect.FileDescriptor) bool {
+			if string(fd.Package()) != protoPackageName {
+				return true
+			}
+			walkMessages(fd.Messages(), func(md protoreflect.MessageDescriptor) {
+				messages++
+				fields := md.Fields()
+				for i := 0; i < fields.Len(); i++ {
+					name := string(fields.Get(i).Name())
+					if strings.HasSuffix(name, "_canonical") {
+						violations++
+						t.Errorf("proto field %s.%s ends in _canonical — a *_canonical field paired with a typed twin is the divergent-representation smell WS1 removed; carry the single typed/deterministic form instead", md.FullName(), name)
+					}
+				}
+			})
+			return true
+		})
+		if messages == 0 {
+			t.Fatal("matches-zero guard: walked zero pm.v1 proto messages — the proto package is not registered, the check would pass vacuously")
+		}
+	})
+
+	t.Run("Sign called only from the canonicalization seam", func(t *testing.T) {
+		root := moduleRoot(t)
+		files := walkGoFiles(t, root, func(string) bool { return true })
+		if len(files) == 0 {
+			t.Fatal("matches-zero guard: walked zero production Go files")
+		}
+		allow := newAllowlist(signCallAllowlist)
+		sawSignCall := false
+		for _, gf := range files {
+			ast.Inspect(gf.ast, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || sel.Sel.Name != "Sign" {
+					return true
+				}
+				sawSignCall = true
+				key := gf.rel + " :: " + render(gf.fset, call)
+				if allow.exempt(key) {
+					return true
+				}
+				t.Errorf("action-signer Sign() called outside the single canonicalization seam at %s:%d — %s\n  all action signing must route through actionparams.BuildAndSignEnvelope so the signed bytes are the deterministic SignedActionEnvelope wire bytes (ADR 0003). If this is a legitimate new seam, justify it in signCallAllowlist.",
+					gf.rel, gf.line(call), render(gf.fset, call))
+				return true
+			})
+		}
+		if !sawSignCall {
+			t.Fatal("matches-zero guard: detected no .Sign(...) calls in the module — the detector is dead, the guard would pass vacuously")
+		}
+		allow.assertNoStale(t)
+	})
+}
+
+// walkMessages invokes fn for every message descriptor in mds, recursing into
+// nested message types so a *_canonical field cannot hide inside a nested message.
+func walkMessages(mds protoreflect.MessageDescriptors, fn func(protoreflect.MessageDescriptor)) {
+	for i := 0; i < mds.Len(); i++ {
+		md := mds.Get(i)
+		fn(md)
+		walkMessages(md.Messages(), fn)
+	}
+}


### PR DESCRIPTION
Closes #445.

Installs the WS0 guardrails the audit found missing (production code is already correct; these lock the invariants against regression):

- **TestSignatureIsOverDeterministicProtoAndSingleRepresentation** — proto reflection asserts no `*_canonical` field (one representation), and the action signer's `Sign()` is called only from the single canonicalization seam `actionparams.BuildAndSignEnvelope` (ADR 0003).
- **TestNoUnframedHashPreimage** — forbids hash/MAC preimages built by `+`-concat or `fmt.Sprintf`; preimages must be length-prefixed/domain-separated.
- **TestEveryInternalServiceRPCIsClassified** — every InternalService RPC is device-origin-bound or a justified non-device-scoped exception (the ControlService parity test left InternalService unclassified).

Self-discovering, matches-zero + no-stale-allowlist guards; both flag paths red-checked. ADR 0002 updated to list every guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural decision records with guidance on hash/MAC preimage patterns, signature canonicalization requirements, and RPC classification standards.

* **Tests**
  * Added architectural compliance tests to enforce proper RPC method classification, validate hash/MAC preimage patterns, and ensure signature canonicalization requirements are met across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->