### PR TITLE
test(api): pin LUKS cross-device scoping (WS2 #9) + login timing-oracle control (WS5)

### DIFF
--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -37,6 +37,14 @@ type AuthHandler struct {
 	// (keyed by normalised email), closing the IP-rotation bypass on the
 	// interceptor's per-IP login limiter.
 	loginAccountLimiter *auth.RateLimiter
+	// dummyVerify is a PER-INSTANCE seam over the timing-equalisation dummy
+	// bcrypt that runs on the no-user / disabled / SSO-only / provider-disabled
+	// login paths. It wraps ONLY the discarded dummy comparison — the real
+	// password check uses auth.VerifyPassword directly, so no swappable hook
+	// sits on the authentication path. Defaulted in NewAuthHandler; tests set it
+	// per handler instance (no shared global → no data race) to confirm the
+	// control actually fires.
+	dummyVerify func(password, hash string) bool
 }
 
 // NewAuthHandler creates a new auth handler. The passwordAuthEnabled flag
@@ -52,6 +60,7 @@ func NewAuthHandler(st *store.Store, logger *slog.Logger, jwtManager *auth.JWTMa
 		jwtManager:          jwtManager,
 		passwordAuthEnabled: passwordAuthEnabled,
 		loginAccountLimiter: auth.NewRateLimiter(loginAccountFailLimit, loginAccountFailWindow),
+		dummyVerify:         auth.VerifyPassword,
 	}
 }
 
@@ -65,7 +74,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 	// burned bcrypt cycle doesn't leak account existence via timing when
 	// the operator has disabled password login entirely.
 	if !h.passwordAuthEnabled {
-		auth.VerifyPassword(req.Msg.Password, auth.DummyHash)
+		h.dummyVerify(req.Msg.Password, auth.DummyHash)
 		return nil, apiErrorCtx(ctx, ErrPasswordLoginDisabled, connect.CodeUnauthenticated, "password login is disabled on this server")
 	}
 
@@ -84,7 +93,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 	if err != nil {
 		if store.IsNotFound(err) {
 			// Perform a dummy bcrypt comparison to prevent timing-based user enumeration
-			auth.VerifyPassword(req.Msg.Password, auth.DummyHash)
+			h.dummyVerify(req.Msg.Password, auth.DummyHash)
 			// Count the failure for the per-account ceiling. Recording for a
 			// non-existent email too keeps the behaviour identical to a real
 			// account (no enumeration), and an attacker spraying one address is
@@ -103,7 +112,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 	// (audit). The login UI learns the right method from the (now rate-limited)
 	// ListAuthMethods, not from this error.
 	if !user.HasPassword {
-		auth.VerifyPassword(req.Msg.Password, auth.DummyHash)
+		h.dummyVerify(req.Msg.Password, auth.DummyHash)
 		h.loginAccountLimiter.Allow(acctKey)
 		return nil, apiErrorCtx(ctx, ErrInvalidCredentials, connect.CodeUnauthenticated, "invalid credentials")
 	}
@@ -119,7 +128,7 @@ func (h *AuthHandler) Login(ctx context.Context, req *connect.Request[pm.LoginRe
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to verify login eligibility")
 	}
 	if len(disablingProviders) > 0 {
-		auth.VerifyPassword(req.Msg.Password, auth.DummyHash)
+		h.dummyVerify(req.Msg.Password, auth.DummyHash)
 		h.loginAccountLimiter.Allow(acctKey)
 		return nil, apiErrorCtx(ctx, ErrInvalidCredentials, connect.CodeUnauthenticated, "invalid credentials")
 	}

--- a/internal/api/auth_handler_test.go
+++ b/internal/api/auth_handler_test.go
@@ -469,6 +469,33 @@ func TestLogin_SSOOnlyUserNoPassword(t *testing.T) {
 // with a wrong password apart: all three return the IDENTICAL Unauthenticated
 // "invalid credentials" error (audit user-enumeration fix). Timing parity comes
 // from the dummy bcrypt each path runs.
+// TestLogin_TimingEqualization_RunsDummyBcryptOnMiss pins WS5's timing-oracle
+// control: a no-such-user login MUST still perform a bcrypt comparison against
+// auth.DummyHash, so a wrong-email attempt costs the same as a wrong-password
+// one (no user-enumeration timing oracle). The existing enumeration tests assert
+// identical *responses* but would still pass if the dummy bcrypt were deleted;
+// this asserts the control itself fires, via the VerifyPassword seam.
+func TestLogin_TimingEqualization_RunsDummyBcryptOnMiss(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	h := api.NewAuthHandler(st, slog.Default(), jwtMgr, true)
+
+	var hashes []string
+	h.SetDummyVerifyForTest(func(_, hash string) bool {
+		hashes = append(hashes, hash)
+		return false // the dummy comparison's result is discarded by the handler
+	})
+
+	_, err := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email:    testutil.NewID() + "@nonexistent.test",
+		Password: "whatever",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnauthenticated, connect.CodeOf(err))
+	assert.Contains(t, hashes, auth.DummyHash,
+		"a no-such-user login must run a dummy bcrypt against auth.DummyHash to equalise timing (WS5 timing-oracle control)")
+}
+
 func TestLogin_EnumerationSafe_IdenticalErrors(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	jwtMgr := testutil.NewJWTManager()

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -18,3 +18,12 @@ func (h *TerminalHandler) ScopedSessionsForTest(ctx context.Context, sessions []
 // concurrency regression test widen the read→append window. Compiled only into
 // test binaries. Pass nil to clear.
 func SetRenewCertTestHook(fn func()) { renewCertTestHook = fn }
+
+// SetDummyVerifyForTest overrides this handler's per-instance dummy-bcrypt seam
+// (the discarded timing-equalisation comparison on the Login miss paths) so a
+// test can confirm the control runs. Per-instance: no shared global, so it is
+// race-free even across parallel tests. Compiled only into test binaries; the
+// real password check (auth.VerifyPassword) is unaffected.
+func (h *AuthHandler) SetDummyVerifyForTest(fn func(password, hash string) bool) {
+	h.dummyVerify = fn
+}

--- a/internal/api/internal_handler_gateway_binding_test.go
+++ b/internal/api/internal_handler_gateway_binding_test.go
@@ -182,6 +182,44 @@ func TestProxyGetLuksKey_GatewayBinding(t *testing.T) {
 	})
 }
 
+// TestProxyGetLuksKey_DeviceScopingAcrossDevices pins WS2 #9 (explicitly
+// requested by the work plan): a LUKS key stored for device A must NEVER be
+// returned to device B, even when B presents a perfectly valid gateway binding
+// of its own. This guards the WHERE device_id scoping in the GetLuksKey query
+// independently of the gateway-origin binding — a regression that scoped only by
+// action_id would leak A's passphrase to B.
+func TestProxyGetLuksKey_DeviceScopingAcrossDevices(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	deviceA := testutil.CreateTestDevice(t, st, "luks-scope-a")
+	deviceB := testutil.CreateTestDevice(t, st, "luks-scope-b")
+	const gwA, gwB = "gw-A", "gw-B"
+	h, reg := wiredHandler(t, st, deviceA, gwA)
+	require.NoError(t, reg.AttachDevice(context.Background(), deviceB, gwB, registry.DefaultDeviceTTL))
+	ctx := context.Background()
+	actionID := newULID()
+
+	// Seed a secret for device A via its correctly-bound gateway.
+	_, err := h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+		DeviceId: deviceA, ActionId: actionID, DevicePath: "/dev/sda1", Passphrase: "A-secret",
+		RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL, GatewayId: gwA,
+	}))
+	require.NoError(t, err)
+
+	// Device B — correctly bound to ITS OWN gateway — asks for the SAME action
+	// id. It must not receive device A's passphrase: either a not-found error, or
+	// (defensively) a response that is anything but A's secret.
+	resp, err := h.ProxyGetLuksKey(ctx, connect.NewRequest(&pm.InternalGetLuksKeyRequest{
+		DeviceId: deviceB, ActionId: actionID, GatewayId: gwB,
+	}))
+	if err != nil {
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err),
+			"device B has no key for this action id and must be told not-found, not handed another device's key")
+	} else {
+		assert.NotEqual(t, "A-secret", resp.Msg.Passphrase,
+			"device B must NEVER receive device A's LUKS passphrase")
+	}
+}
+
 // TestProxyStoreLuksKey_NoEventOnGatewayMismatch proves the device-attributed
 // LuksKeyRotated event is NEVER appended on a binding mismatch — the forge path.
 func TestProxyStoreLuksKey_NoEventOnGatewayMismatch(t *testing.T) {

--- a/internal/auth/password.go
+++ b/internal/auth/password.go
@@ -24,7 +24,9 @@ func HashPassword(password string) (string, error) {
 	return string(hash), nil
 }
 
-// VerifyPassword checks if a password matches a hash.
+// VerifyPassword checks if a password matches a hash. Intentionally a plain
+// func (not a reassignable var): this is the authentication primitive in
+// security-critical code, so it must not be a runtime-swappable bypass vector.
 func VerifyPassword(password, hash string) bool {
 	err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(password))
 	return err == nil


### PR DESCRIPTION
Closes #447.

- **WS2 #9** (explicitly requested): `TestProxyGetLuksKey_DeviceScopingAcrossDevices` proves a LUKS key stored for device A is never returned to device B even with a valid B gateway binding — guarding the WHERE device_id query scoping independently of the origin binding.
- **WS5**: pin that the login timing-equalisation dummy bcrypt actually runs on the no-such-user path (the existing enumeration tests only assert identical responses and would stay green if the control were deleted). The seam is a **per-instance `AuthHandler` field** wrapping only the discarded dummy comparison — `auth.VerifyPassword` stays a plain func (no swappable var on the real auth path), per-instance so race-free. Red-checked + `-race` clean.