### PR TITLE
test(ca,api): forged-CSR rejection + LUKS validate-by-hash coverage (WS10)

### DIFF
--- a/internal/api/internal_handler_gateway_binding_test.go
+++ b/internal/api/internal_handler_gateway_binding_test.go
@@ -220,6 +220,58 @@ func TestProxyGetLuksKey_DeviceScopingAcrossDevices(t *testing.T) {
 	}
 }
 
+// TestProxyValidateLuksToken_ConsumesByHash pins the validate-side at-rest-hash
+// contract (WS10): a minted plaintext token validates once (the server hashes it
+// before lookup), is single-use (replay → not-found), and a tampered token never
+// matches. Create-side hashing is covered elsewhere; this covers the proxy
+// validate path, which was previously only tested for missing fields.
+func TestProxyValidateLuksToken_ConsumesByHash(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	dh := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "luks-validate-host")
+	actionID := testutil.CreateTestAction(t, st, userID, "Encrypt Disk", int(pm.ActionType_ACTION_TYPE_ENCRYPTION))
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
+	const gw = "gw-A"
+	ih, _ := wiredHandler(t, st, deviceID, gw)
+	ctx := context.Background()
+
+	mint := func() string {
+		resp, err := dh.CreateLuksToken(testutil.UserContext(userID), connect.NewRequest(&pm.CreateLuksTokenRequest{
+			DeviceId: deviceID, ActionId: actionID,
+		}))
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Msg.Token)
+		return resp.Msg.Token
+	}
+
+	// Happy: the plaintext validates (server hashes before lookup) and returns
+	// the bound action.
+	plaintext := mint()
+	resp, err := ih.ProxyValidateLuksToken(ctx, connect.NewRequest(&pm.InternalValidateLuksTokenRequest{
+		DeviceId: deviceID, Token: plaintext, GatewayId: gw,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, actionID, resp.Msg.ActionId)
+
+	// Replay: a consumed one-time token is rejected.
+	_, err = ih.ProxyValidateLuksToken(ctx, connect.NewRequest(&pm.InternalValidateLuksTokenRequest{
+		DeviceId: deviceID, Token: plaintext, GatewayId: gw,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err), "a consumed token must not be replayable")
+
+	// Tampered: a different token never matches the stored hash (mint a fresh
+	// valid one first so the rejection is hash-mismatch, not an empty store).
+	tampered := mint() + "tampered"
+	_, err = ih.ProxyValidateLuksToken(ctx, connect.NewRequest(&pm.InternalValidateLuksTokenRequest{
+		DeviceId: deviceID, Token: tampered, GatewayId: gw,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err), "a tampered token must not match the at-rest hash")
+}
+
 // TestProxyStoreLuksKey_NoEventOnGatewayMismatch proves the device-attributed
 // LuksKeyRotated event is NEVER appended on a binding mismatch — the forge path.
 func TestProxyStoreLuksKey_NoEventOnGatewayMismatch(t *testing.T) {

--- a/internal/ca/ca_test.go
+++ b/internal/ca/ca_test.go
@@ -315,6 +315,37 @@ func TestIssueCertificateFromCSR_InvalidCSR(t *testing.T) {
 	assert.Contains(t, err.Error(), "decode CSR PEM")
 }
 
+// TestIssueCertificateFromCSR_ForgedSignatureRejected pins the csr.CheckSignature
+// gate: a CSR whose ASN.1 structure is valid but whose signature does NOT verify
+// (tampered in transit, or minted by someone who does not hold the private key)
+// must be refused. The InvalidCSR test above only feeds garbage PEM; this covers
+// the structurally-valid-but-forged-signature branch — an uncovered edge that
+// guards proof-of-possession at issuance.
+func TestIssueCertificateFromCSR_ForgedSignatureRejected(t *testing.T) {
+	certPEM, keyPEM := generateTestCA(t)
+	c, err := ca.NewFromPEM(certPEM, keyPEM, 24*time.Hour)
+	require.NoError(t, err)
+
+	// A structurally valid CSR, then corrupt its signature: the last byte of the
+	// DER lies in the signatureValue, so ParseCertificateRequest still succeeds
+	// while CheckSignature must fail.
+	csrPEM, _ := generateCSR(t, "device-001")
+	block, _ := pem.Decode(csrPEM)
+	require.NotNil(t, block)
+	der := append([]byte(nil), block.Bytes...)
+	der[len(der)-1] ^= 0xFF
+	forged := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
+
+	// Sanity: the forged CSR still parses, so we are exercising CheckSignature,
+	// not the parse path the InvalidCSR test already covers.
+	_, perr := x509.ParseCertificateRequest(der)
+	require.NoError(t, perr, "forged CSR must remain structurally parseable")
+
+	_, err = c.IssueCertificateFromCSR("device-001", forged)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid CSR signature")
+}
+
 func TestVerifyCertificate_Success(t *testing.T) {
 	certPEM, keyPEM := generateTestCA(t)
 	c, err := ca.NewFromPEM(certPEM, keyPEM, 24*time.Hour)


### PR DESCRIPTION
Two previously-uncovered edge paths over already-correct code:
- `TestIssueCertificateFromCSR_ForgedSignatureRejected` drives the `csr.CheckSignature` gate with a structurally-valid CSR whose signature is corrupted (the existing InvalidCSR test only fed garbage PEM).
- `TestProxyValidateLuksToken_ConsumesByHash` pins the validate-side at-rest-hash contract: a minted plaintext validates once, is single-use (replay → not-found), and a tampered token never matches.

Closes #449.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for token validation to verify one-time consumption behavior and hash-based matching.
  * Added test coverage for certificate signature verification to ensure invalid signatures are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->