### PR TITLE
chore(deps): bump SDK to v0.5.0; fix stale proto-path fitness function

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       # in the right list. eventtypes/... is pure-Go (no DB, no network)
       # so it lives here.
       - name: Run unit tests
-        run: go test -count=1 ./internal/auth/... ./internal/connection/... ./internal/middleware/... ./internal/taskqueue/... ./internal/config/... ./internal/mtls/... ./internal/crypto/... ./internal/eventtypes/...
+        run: go test -count=1 ./internal/archtest/... ./internal/auth/... ./internal/connection/... ./internal/middleware/... ./internal/taskqueue/... ./internal/config/... ./internal/mtls/... ./internal/crypto/... ./internal/eventtypes/...
 
   # Integration tests are sharded across parallel runners so wall-clock is
   # the slowest shard rather than the sum of all packages (#338). Each shard

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.0
-	github.com/manchtools/power-manage-sdk v0.4.1-0.20260619054456-9f9e35b04d92
+	github.com/manchtools/power-manage-sdk v0.5.0
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260619054456-9f9e35b04d92 h1:W//czJKqyGNBtUVHga9ozi1ymz+5K41ZajPZs7laXRg=
-github.com/manchtools/power-manage-sdk v0.4.1-0.20260619054456-9f9e35b04d92/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
+github.com/manchtools/power-manage-sdk v0.5.0 h1:DackmRN4rbjeuKNmpz3FVRWyuOnUA6KUqCfxtn+PstU=
+github.com/manchtools/power-manage-sdk v0.5.0/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/archtest/proto_json_test.go
+++ b/internal/archtest/proto_json_test.go
@@ -16,8 +16,11 @@ import (
 var protoJSONAllowlist = map[string]string{}
 
 // protoPkgPathSuffix identifies the generated protobuf package regardless of
-// the import alias a file chooses (conventionally "pm").
-const protoPkgPathSuffix = "/sdk/gen/go/pm/v1"
+// the import alias a file chooses (conventionally "pm"). It anchors on the
+// generated-code path segment, NOT the module name, so a module rename (e.g.
+// power-manage/sdk → power-manage-sdk) can't silently turn the guard vacuous.
+// HasSuffix excludes the sibling connect package (…/gen/go/pm/v1/pmv1connect).
+const protoPkgPathSuffix = "/gen/go/pm/v1"
 
 // TestNoStdlibJSONOfProtoMessage forbids passing a generated protobuf type to
 // the standard library encoding/json (Marshal / MarshalIndent / Unmarshal, and
@@ -97,7 +100,7 @@ func TestNoStdlibJSONOfProtoMessage(t *testing.T) {
 }
 
 // protoImportAliases returns the set of local names by which f imports the
-// generated protobuf package (path suffix /sdk/gen/go/pm/v1). Self-discovered
+// generated protobuf package (path suffix /gen/go/pm/v1). Self-discovered
 // from the import block so the guard is not tied to the conventional "pm".
 func protoImportAliases(f *ast.File) map[string]bool {
 	out := map[string]bool{}


### PR DESCRIPTION
## What

- Bump the SDK pin from the untagged `#185` pseudo-version to the tagged **v0.5.0** release.
- Fix a pre-existing breakage this surfaced, and gate it so it can't recur.

## Why the bump is safe (zero code changes)

The server only consumes **stable** SDK surface — `gen/go/pm/v1` proto types, `verify`, `maintenance`, `validate`, `logging`, `sys/terminal` — none of the reworked packages (`sys/fs`, `pkg`, `sys/desktop`, `crypto`, `sys/remote`) that v0.5.0 changed. Diff is `go.mod`/`go.sum` only for the bump; build/vet/staticcheck/gofmt and the full test suite are green.

## The surfaced bug

Running the full suite flagged `archtest.TestNoStdlibJSONOfProtoMessage` tripping its own matches-zero guard: its `protoPkgPathSuffix` still pointed at the old `/sdk/gen/go/pm/v1` import path. The #185 module rename (`power-manage/sdk` → `power-manage-sdk`) made it match nothing, so the proto-type detector was dead. It went unnoticed because **`internal/archtest` is in no CI shard** — the architecture fitness functions weren't gating.

Fixes:
- Re-anchor the suffix on the generated-code segment `/gen/go/pm/v1` (rename-robust; `HasSuffix` still excludes the sibling `pmv1connect` package).
- Add `./internal/archtest/...` to the unit-test job so all 7 fitness functions gate from now on.

## Test
- `go test ./...` green (was red only on the stale archtest guard).
- archtest now runs in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Dependencies**
  * Updated a direct dependency to version 0.5.0.

* **Tests**
  * Extended test coverage to include additional package tests in the CI/CD pipeline.

* **Chores**
  * Internal adjustments to import-path validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->