### PR TITLE
feat(search): list-page sort via valkey-search SORTBY (server#325)

### DIFF
--- a/cmd/indexer/rebuild_gate.go
+++ b/cmd/indexer/rebuild_gate.go
@@ -29,6 +29,7 @@ const (
 // so the gate logic is unit-testable without a real RediSearch backend.
 type searchGate interface {
 	IndexesPresent(ctx context.Context) (bool, error)
+	SchemaCurrent(ctx context.Context) (bool, error)
 	Warm(ctx context.Context) error
 	Rebuild(ctx context.Context) error
 }
@@ -55,8 +56,18 @@ func startupSearchSync(ctx context.Context, gate searchGate, locker rebuildLocke
 		return fmt.Errorf("check search indexes present: %w", err)
 	}
 	if present {
-		logger.Info("search indexes already present; warming without destructive flush")
-		return gate.Warm(ctx)
+		// Present is not enough — a schema change (new field / SORTABLE) needs a
+		// drop+rebuild because FT.CREATE no-ops on an existing index. Warm only
+		// when the schema also matches the last rebuild's fingerprint.
+		current, err := gate.SchemaCurrent(ctx)
+		if err != nil {
+			return fmt.Errorf("check search schema fingerprint: %w", err)
+		}
+		if current {
+			logger.Info("search indexes present and schema current; warming without destructive flush")
+			return gate.Warm(ctx)
+		}
+		logger.Info("search index schema changed since last rebuild; rebuild required")
 	}
 
 	acquired, release, err := locker.TryLock(ctx)

--- a/cmd/indexer/rebuild_gate_test.go
+++ b/cmd/indexer/rebuild_gate_test.go
@@ -16,13 +16,16 @@ import (
 func gateTestLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
 
 type fakeGate struct {
-	present      bool
-	presentErr   error
-	warmCalls    int
-	rebuildCalls int
+	present       bool
+	presentErr    error
+	schemaCurrent bool
+	schemaErr     error
+	warmCalls     int
+	rebuildCalls  int
 }
 
 func (f *fakeGate) IndexesPresent(context.Context) (bool, error) { return f.present, f.presentErr }
+func (f *fakeGate) SchemaCurrent(context.Context) (bool, error)  { return f.schemaCurrent, f.schemaErr }
 func (f *fakeGate) Warm(context.Context) error                   { f.warmCalls++; return nil }
 func (f *fakeGate) Rebuild(context.Context) error                { f.rebuildCalls++; return nil }
 
@@ -43,12 +46,29 @@ func (f *fakeLocker) TryLock(context.Context) (bool, func(), error) {
 func TestStartupSearchSync_GatesDestructiveRebuild(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("indexes present → warm only, never rebuild", func(t *testing.T) {
-		g := &fakeGate{present: true}
+	t.Run("indexes present + schema current → warm only, never rebuild", func(t *testing.T) {
+		g := &fakeGate{present: true, schemaCurrent: true}
 		l := &fakeLocker{acquired: true} // would acquire, but must not be consulted
 		require.NoError(t, startupSearchSync(ctx, g, l, gateTestLogger()))
 		assert.Equal(t, 1, g.warmCalls, "present indexes must be warmed")
-		assert.Equal(t, 0, g.rebuildCalls, "present indexes must NOT be destructively rebuilt")
+		assert.Equal(t, 0, g.rebuildCalls, "present+current indexes must NOT be destructively rebuilt")
+	})
+
+	t.Run("indexes present but schema changed → rebuild under lock (#325)", func(t *testing.T) {
+		g := &fakeGate{present: true, schemaCurrent: false}
+		l := &fakeLocker{acquired: true}
+		require.NoError(t, startupSearchSync(ctx, g, l, gateTestLogger()))
+		assert.Equal(t, 1, g.rebuildCalls, "a schema change must trigger a drop+rebuild even when indexes exist")
+		assert.Equal(t, 0, g.warmCalls)
+		assert.Equal(t, 1, l.released)
+	})
+
+	t.Run("schema-check error fails closed (no flush)", func(t *testing.T) {
+		g := &fakeGate{present: true, schemaErr: errors.New("backend down")}
+		l := &fakeLocker{acquired: true}
+		require.Error(t, startupSearchSync(ctx, g, l, gateTestLogger()))
+		assert.Equal(t, 0, g.rebuildCalls)
+		assert.Equal(t, 0, g.warmCalls)
 	})
 
 	t.Run("indexes missing + lock won → rebuild under lock", func(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.0
-	github.com/manchtools/power-manage-sdk v0.5.0
+	github.com/manchtools/power-manage-sdk v0.5.1
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.5.0 h1:DackmRN4rbjeuKNmpz3FVRWyuOnUA6KUqCfxtn+PstU=
-github.com/manchtools/power-manage-sdk v0.5.0/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
+github.com/manchtools/power-manage-sdk v0.5.1 h1:SFNBq+zaMCR6/ElvMEo0ia37OK40rQaWOLN3/YMtwU0=
+github.com/manchtools/power-manage-sdk v0.5.1/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -26,6 +26,70 @@ func NewSearchHandler(logger *slog.Logger) *SearchHandler {
 	}
 }
 
+// sortFieldNames maps the wire SortField enum to the RediSearch index field it
+// sorts by. The enum is shared across scopes (#325); resolveSort enforces that
+// the field is actually SORTABLE on the requested scope via scopeSortableFields.
+var sortFieldNames = map[pm.SortField]string{
+	pm.SortField_SORT_FIELD_NAME:              "name",
+	pm.SortField_SORT_FIELD_TYPE:              "type",
+	pm.SortField_SORT_FIELD_HOSTNAME:          "hostname",
+	pm.SortField_SORT_FIELD_COMPLIANCE_STATUS: "compliance_status",
+	pm.SortField_SORT_FIELD_EMAIL:             "email",
+	pm.SortField_SORT_FIELD_DISPLAY_NAME:      "display_name",
+	pm.SortField_SORT_FIELD_DISABLED:          "disabled",
+	pm.SortField_SORT_FIELD_MEMBER_COUNT:      "member_count",
+	pm.SortField_SORT_FIELD_STATUS:            "status",
+	pm.SortField_SORT_FIELD_ACTION_TYPE:       "action_type",
+	pm.SortField_SORT_FIELD_DEVICE_HOSTNAME:   "device_hostname",
+	pm.SortField_SORT_FIELD_ACTOR_TYPE:        "actor_type",
+	pm.SortField_SORT_FIELD_STREAM_TYPE:       "stream_type",
+	pm.SortField_SORT_FIELD_EVENT_TYPE:        "event_type",
+	pm.SortField_SORT_FIELD_CREATED_AT:        "created_at",
+	pm.SortField_SORT_FIELD_UPDATED_AT:        "updated_at",
+	pm.SortField_SORT_FIELD_LAST_SEEN_AT:      "last_seen_at",
+	pm.SortField_SORT_FIELD_REGISTERED_AT:     "registered_at",
+	pm.SortField_SORT_FIELD_OCCURRED_AT:       "occurred_at",
+	// RULE_COUNT and LAST_LOGIN_AT are reserved for a follow-up (their index
+	// fields aren't populated yet) — intentionally absent so resolveSort rejects.
+}
+
+// scopeSortableFields lists the SORTABLE index fields per scope. Mirrors the
+// SORTABLE attributes in internal/search/index.go; a field is only here if its
+// scope's FT.CREATE schema declares it SORTABLE. Kept in lockstep with the index
+// by TestSearchSortableFieldsMatchIndex (self-discovering, matches-zero guard).
+var scopeSortableFields = map[string]map[string]bool{
+	"actions":             {"name": true, "type": true, "created_at": true, "updated_at": true},
+	"action_sets":         {"name": true, "member_count": true, "created_at": true, "updated_at": true},
+	"definitions":         {"name": true, "member_count": true, "created_at": true, "updated_at": true},
+	"compliance_policies": {"name": true},
+	"devices":             {"hostname": true, "compliance_status": true, "registered_at": true, "last_seen_at": true},
+	"users":               {"email": true, "display_name": true, "disabled": true, "created_at": true},
+	"device_groups":       {"name": true, "member_count": true, "created_at": true},
+	"user_groups":         {"name": true, "member_count": true, "created_at": true},
+	"executions":          {"device_hostname": true, "status": true, "action_type": true, "created_at": true},
+	"audit_events":        {"event_type": true, "stream_type": true, "actor_type": true, "occurred_at": true},
+}
+
+// resolveSort returns the (field, direction) for FT.SEARCH SORTBY. An unset
+// sort_field falls back to the scope's default (DESC); a set field is validated
+// against scopeSortableFields and rejected with InvalidArgument if it isn't
+// sortable on the requested scope.
+func resolveSort(ctx context.Context, scope string, sf pm.SortField, sd pm.SortDirection) (string, string, error) {
+	if sf == pm.SortField_SORT_FIELD_UNSPECIFIED {
+		return scopeSortField(scope), "DESC", nil
+	}
+	field, ok := sortFieldNames[sf]
+	if !ok || !scopeSortableFields[scope][field] {
+		return "", "", apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument,
+			fmt.Sprintf("sort field is not sortable on scope=%s", scope))
+	}
+	dir := "DESC"
+	if sd == pm.SortDirection_SORT_DIRECTION_ASC {
+		dir = "ASC"
+	}
+	return field, dir, nil
+}
+
 // scopeSortField returns the default sort field for a scope, or empty if none.
 func scopeSortField(scope string) string {
 	switch scope {
@@ -185,9 +249,14 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 
 		args := []any{"FT.SEARCH", idxName, ftQuery}
 
-		// Add SORTBY for scopes that have a timestamp field.
-		if sortField := scopeSortField(scope); sortField != "" {
-			args = append(args, "SORTBY", sortField, "DESC")
+		// SORTBY: the request's sort_field/direction validated against the scope,
+		// falling back to the scope default when unset (#325).
+		sortField, sortDir, err := resolveSort(ctx, scope, req.Msg.SortField, req.Msg.SortDirection)
+		if err != nil {
+			return nil, err
+		}
+		if sortField != "" {
+			args = append(args, "SORTBY", sortField, sortDir)
 		}
 
 		args = append(args, "LIMIT", offset, pageSize)

--- a/internal/api/search_sort_test.go
+++ b/internal/api/search_sort_test.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/search"
+)
+
+// TestScopeSortableFields_MirrorIndexSchemas is a self-discovering guard that
+// scopeSortableFields stays in lockstep with the SORTABLE attributes in
+// search.IndexSchemas. A SORTBY on a field the index didn't declare SORTABLE is
+// rejected by RediSearch; a SORTABLE field missing here is silently unsortable.
+// Both sides derive from their sources, so the test fails on any drift.
+func TestScopeSortableFields_MirrorIndexSchemas(t *testing.T) {
+	require.NotEmpty(t, search.IndexSchemas, "no index schemas discovered — parity check would vacuously pass")
+
+	sawSortable := false
+	for _, ix := range search.IndexSchemas {
+		scope := ix.Scope()
+		want := ix.SortableFields()
+		got := scopeSortableFields[scope] // may be nil if the scope has no sortable fields
+
+		for field := range want {
+			sawSortable = true
+			assert.Truef(t, got[field],
+				"scope %q: index %q declares SORTABLE field %q but scopeSortableFields omits it", scope, ix.Name, field)
+		}
+		for field := range got {
+			assert.Truef(t, want[field],
+				"scope %q: scopeSortableFields lists %q but index %q does not declare it SORTABLE", scope, field, ix.Name)
+		}
+	}
+	require.True(t, sawSortable, "no SORTABLE fields discovered across any index — detector is dead")
+
+	indexed := map[string]bool{}
+	for _, ix := range search.IndexSchemas {
+		indexed[ix.Scope()] = true
+	}
+	for scope := range scopeSortableFields {
+		assert.Truef(t, indexed[scope], "scopeSortableFields advertises scope %q with no matching index", scope)
+	}
+}
+
+func TestResolveSort_UnspecifiedFallsBackToScopeDefault(t *testing.T) {
+	field, dir, err := resolveSort(context.Background(), "devices",
+		pm.SortField_SORT_FIELD_UNSPECIFIED, pm.SortDirection_SORT_DIRECTION_UNSPECIFIED)
+	require.NoError(t, err)
+	assert.Equal(t, "last_seen_at", field, "devices default sort is last_seen_at")
+	assert.Equal(t, "DESC", dir)
+}
+
+func TestResolveSort_ValidFieldAndDirection(t *testing.T) {
+	field, dir, err := resolveSort(context.Background(), "actions",
+		pm.SortField_SORT_FIELD_NAME, pm.SortDirection_SORT_DIRECTION_ASC)
+	require.NoError(t, err)
+	assert.Equal(t, "name", field)
+	assert.Equal(t, "ASC", dir)
+}
+
+func TestResolveSort_FieldNotSortableOnScope_InvalidArgument(t *testing.T) {
+	// hostname is sortable on devices, NOT on actions.
+	_, _, err := resolveSort(context.Background(), "actions",
+		pm.SortField_SORT_FIELD_HOSTNAME, pm.SortDirection_SORT_DIRECTION_DESC)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestResolveSort_ReservedFieldNotYetWired_InvalidArgument(t *testing.T) {
+	// rule_count's index field isn't populated yet — must be rejected, not sent.
+	_, _, err := resolveSort(context.Background(), "compliance_policies",
+		pm.SortField_SORT_FIELD_RULE_COUNT, pm.SortDirection_SORT_DIRECTION_DESC)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -322,9 +322,9 @@ const schemaFingerprintKey = "pm:indexer:schema:fingerprint"
 func SchemaFingerprint() string {
 	h := sha256.New()
 	for _, ix := range IndexSchemas {
-		fmt.Fprintf(h, "%s\x00%s\x00", ix.Name, ix.Prefix)
+		_, _ = fmt.Fprintf(h, "%s\x00%s\x00", ix.Name, ix.Prefix)
 		for _, f := range ix.Schema {
-			fmt.Fprintf(h, "%v\x00", f)
+			_, _ = fmt.Fprintf(h, "%v\x00", f)
 		}
 		_, _ = h.Write([]byte{'\n'})
 	}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -5,6 +5,8 @@ package search
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -169,15 +171,32 @@ func (s IndexSchema) FilterableFields() map[string]bool {
 	return out
 }
 
+// SortableFields returns the field names declared SORTABLE — the only fields an
+// FT.SEARCH SORTBY can target. In every schema here SORTABLE immediately follows
+// the field's type (field, TYPE, SORTABLE), so the field is two tokens back; we
+// don't stack other modifiers before SORTABLE.
+func (s IndexSchema) SortableFields() map[string]bool {
+	out := map[string]bool{}
+	for i := 2; i < len(s.Schema); i++ {
+		if tok, _ := s.Schema[i].(string); tok != "SORTABLE" {
+			continue
+		}
+		if field, ok := s.Schema[i-2].(string); ok {
+			out[field] = true
+		}
+	}
+	return out
+}
+
 // IndexSchemas is the canonical set of RediSearch indexes EnsureIndexes creates.
 var IndexSchemas = []IndexSchema{
 	{
 		Name:   idxActions,
 		Prefix: prefixAction,
 		Schema: []any{
-			"name", "TEXT",
+			"name", "TEXT", "SORTABLE",
 			"description", "TEXT",
-			"type", "TAG",
+			"type", "TAG", "SORTABLE",
 			"is_compliance", "TAG",
 			"created_at", "NUMERIC", "SORTABLE",
 			"updated_at", "NUMERIC", "SORTABLE",
@@ -187,9 +206,9 @@ var IndexSchemas = []IndexSchema{
 		Name:   idxActionSets,
 		Prefix: prefixActionSet,
 		Schema: []any{
-			"name", "TEXT",
+			"name", "TEXT", "SORTABLE",
 			"description", "TEXT",
-			"member_count", "NUMERIC",
+			"member_count", "NUMERIC", "SORTABLE",
 			"action_names", "TEXT",
 			"created_at", "NUMERIC", "SORTABLE",
 			"updated_at", "NUMERIC", "SORTABLE",
@@ -199,9 +218,9 @@ var IndexSchemas = []IndexSchema{
 		Name:   idxDefinitions,
 		Prefix: prefixDefinition,
 		Schema: []any{
-			"name", "TEXT",
+			"name", "TEXT", "SORTABLE",
 			"description", "TEXT",
-			"member_count", "NUMERIC",
+			"member_count", "NUMERIC", "SORTABLE",
 			"set_names", "TEXT",
 			"action_names", "TEXT",
 			"created_at", "NUMERIC", "SORTABLE",
@@ -212,7 +231,7 @@ var IndexSchemas = []IndexSchema{
 		Name:   idxCompliancePolicies,
 		Prefix: prefixCompliancePolicy,
 		Schema: []any{
-			"name", "TEXT",
+			"name", "TEXT", "SORTABLE",
 			"description", "TEXT",
 			"action_names", "TEXT",
 		},
@@ -221,14 +240,14 @@ var IndexSchemas = []IndexSchema{
 		Name:   idxDevices,
 		Prefix: prefixDevice,
 		Schema: []any{
-			"hostname", "TEXT",
+			"hostname", "TEXT", "SORTABLE",
 			"agent_version", "TAG",
 			"labels", "TEXT",
 			"os_name", "TEXT",
 			"os_version", "TEXT",
 			"os_arch", "TAG",
 			"kernel", "TEXT",
-			"compliance_status", "TAG",
+			"compliance_status", "TAG", "SORTABLE",
 			"registered_at", "NUMERIC", "SORTABLE",
 			"last_seen_at", "NUMERIC", "SORTABLE",
 		},
@@ -237,10 +256,10 @@ var IndexSchemas = []IndexSchema{
 		Name:   idxUsers,
 		Prefix: prefixUser,
 		Schema: []any{
-			"email", "TEXT",
-			"display_name", "TEXT",
+			"email", "TEXT", "SORTABLE",
+			"display_name", "TEXT", "SORTABLE",
 			"linux_username", "TEXT",
-			"disabled", "TAG",
+			"disabled", "TAG", "SORTABLE",
 			"created_at", "NUMERIC", "SORTABLE",
 		},
 	},
@@ -248,10 +267,10 @@ var IndexSchemas = []IndexSchema{
 		Name:   idxDeviceGroups,
 		Prefix: prefixDeviceGroup,
 		Schema: []any{
-			"name", "TEXT",
+			"name", "TEXT", "SORTABLE",
 			"description", "TEXT",
 			"is_dynamic", "TAG",
-			"member_count", "NUMERIC",
+			"member_count", "NUMERIC", "SORTABLE",
 			"created_at", "NUMERIC", "SORTABLE",
 		},
 	},
@@ -259,10 +278,10 @@ var IndexSchemas = []IndexSchema{
 		Name:   idxUserGroups,
 		Prefix: prefixUserGroup,
 		Schema: []any{
-			"name", "TEXT",
+			"name", "TEXT", "SORTABLE",
 			"description", "TEXT",
 			"is_dynamic", "TAG",
-			"member_count", "NUMERIC",
+			"member_count", "NUMERIC", "SORTABLE",
 			"created_at", "NUMERIC", "SORTABLE",
 		},
 	},
@@ -271,9 +290,9 @@ var IndexSchemas = []IndexSchema{
 		Prefix: prefixExecution,
 		Schema: []any{
 			"action_name", "TEXT",
-			"device_hostname", "TEXT",
-			"status", "TAG",
-			"action_type", "TAG",
+			"device_hostname", "TEXT", "SORTABLE",
+			"status", "TAG", "SORTABLE",
+			"action_type", "TAG", "SORTABLE",
 			"device_id", "TAG",
 			"created_at", "NUMERIC", "SORTABLE",
 		},
@@ -282,13 +301,49 @@ var IndexSchemas = []IndexSchema{
 		Name:   idxAuditEvents,
 		Prefix: prefixAuditEvent,
 		Schema: []any{
-			"event_type", "TEXT",
-			"stream_type", "TAG",
-			"actor_type", "TAG",
+			"event_type", "TEXT", "SORTABLE",
+			"stream_type", "TAG", "SORTABLE",
+			"actor_type", "TAG", "SORTABLE",
 			"actor_id", "TAG",
 			"occurred_at", "NUMERIC", "SORTABLE",
 		},
 	},
+}
+
+// schemaFingerprintKey stores the hash of IndexSchemas from the last Rebuild.
+const schemaFingerprintKey = "pm:indexer:schema:fingerprint"
+
+// SchemaFingerprint is a stable hash of IndexSchemas. The indexer stamps it on
+// every successful Rebuild and compares it at boot; a mismatch means the schema
+// changed (a field added or promoted to SORTABLE/TAG) and the indexes must be
+// dropped+recreated to apply it — FT.CREATE is a no-op on an existing index.
+// Self-maintaining: editing IndexSchemas changes the fingerprint, so there is no
+// version constant to forget to bump (ponytail: the schema IS the version).
+func SchemaFingerprint() string {
+	h := sha256.New()
+	for _, ix := range IndexSchemas {
+		fmt.Fprintf(h, "%s\x00%s\x00", ix.Name, ix.Prefix)
+		for _, f := range ix.Schema {
+			fmt.Fprintf(h, "%v\x00", f)
+		}
+		_, _ = h.Write([]byte{'\n'})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// SchemaCurrent reports whether the fingerprint stored at the last Rebuild
+// matches the current IndexSchemas. A missing stored value (never rebuilt, or a
+// pre-fingerprint deploy) counts as NOT current so the new schema is applied.
+// Backend read errors are surfaced (fail closed) rather than guessed.
+func (idx *Index) SchemaCurrent(ctx context.Context) (bool, error) {
+	stored, err := idx.rdb.Get(ctx, schemaFingerprintKey).Result()
+	if err == redis.Nil {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("read schema fingerprint: %w", err)
+	}
+	return stored == SchemaFingerprint(), nil
 }
 
 // EnsureIndexes creates the FT search indexes if they do not already exist.
@@ -1098,6 +1153,12 @@ func (idx *Index) Rebuild(ctx context.Context) error {
 	}
 	if err := idx.Warm(ctx); err != nil {
 		return fmt.Errorf("warm: %w", err)
+	}
+	// Stamp the schema fingerprint so the next boot warms instead of rebuilding
+	// (until the schema changes again). Last step: only a fully-rebuilt index
+	// should claim to be current.
+	if err := idx.rdb.Set(ctx, schemaFingerprintKey, SchemaFingerprint(), 0).Err(); err != nil {
+		return fmt.Errorf("stamp schema fingerprint: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
First slice of #325: **sorting** on every list page (the ~43 disabled sort buttons), routed through the scoped `Search` RPC's new `sort_field`/`sort_direction` (SDK v0.5.1).

## What
- Promote per-scope sortable columns to `SORTABLE` across all 10 FT.CREATE schemas.
- `resolveSort` validates the requested `SortField` against `scopeSortableFields` (plain `InvalidArgument` if not sortable on the scope) and falls back to the scope default; wired into `Search`'s `SORTBY`.
- **Self-maintaining schema fingerprint**: the indexer rebuilds when `IndexSchemas` changes (FT.CREATE no-ops on an existing index), so the new `SORTABLE` attributes take effect on deploy — no manual version constant to bump.
- Self-discovering parity test keeps `scopeSortableFields` ↔ index `SORTABLE` in lockstep.

## Scope
Sort only. The new-field **filters** (assigned, rule_count, os_name, role, last_login, device online/offline) are a deliberate follow-up — each needs population in both the bulk `warm*` and incremental `entityFields` paths (and assigned needs assignment-event wiring). Splitting keeps this PR low-risk and reviewable.

## Tests
- Unit: `resolveSort` (default/valid/ASC/invalid→InvalidArgument), self-discovering parity guard, rebuild-gate schema-change→rebuild.
- Integration: full `internal/search` suite green against valkey-search with the new schema + fingerprint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for client-driven sorting in search results, with validation ensuring requested fields are sortable for the target scope.

* **Improvements**
  * Optimized startup performance with schema fingerprinting; unchanged schemas now trigger non-destructive warm instead of full rebuild.

* **Dependencies**
  * Updated power-manage-sdk to v0.5.1.

* **Tests**
  * Expanded test coverage for search sorting validation and schema detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->