### PR TITLE
feat(search): list-page filters via valkey-search (server#325 PR B)

### DIFF
--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -174,8 +174,10 @@ func (h *AssignmentHandler) DeleteAssignment(ctx context.Context, req *connect.R
 		return nil, err
 	}
 
-	// Verify assignment exists before emitting delete event
-	_, err = h.store.Repos().Assignment.GetByID(ctx, req.Msg.Id)
+	// Verify assignment exists before emitting delete event. Capture the source
+	// tuple so the event carries it (StreamID is the assignment id) — the search
+	// classifier reindexes the source's `assigned` TAG without a DB lookup.
+	assignment, err := h.store.Repos().Assignment.GetByID(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrAssignmentNotFound, "assignment not found")
 	}
@@ -184,9 +186,12 @@ func (h *AssignmentHandler) DeleteAssignment(ctx context.Context, req *connect.R
 		StreamType: "assignment",
 		StreamID:   req.Msg.Id,
 		EventType:  string(eventtypes.AssignmentDeleted),
-		Data:       map[string]any{},
-		ActorType:  "user",
-		ActorID:    userCtx.ID,
+		Data: payloads.AssignmentDeleted{
+			SourceType: assignment.SourceType,
+			SourceID:   assignment.SourceID,
+		},
+		ActorType: "user",
+		ActorID:   userCtx.ID,
 	}, "failed to delete assignment"); err != nil {
 		return nil, err
 	}

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"connectrpc.com/connect"
 
@@ -17,12 +18,14 @@ import (
 type SearchHandler struct {
 	searchIndexHolder
 	logger *slog.Logger
+	now    func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
 // NewSearchHandler creates a new search handler.
 func NewSearchHandler(logger *slog.Logger) *SearchHandler {
 	return &SearchHandler{
 		logger: logger,
+		now:    time.Now,
 	}
 }
 
@@ -44,13 +47,13 @@ var sortFieldNames = map[pm.SortField]string{
 	pm.SortField_SORT_FIELD_ACTOR_TYPE:        "actor_type",
 	pm.SortField_SORT_FIELD_STREAM_TYPE:       "stream_type",
 	pm.SortField_SORT_FIELD_EVENT_TYPE:        "event_type",
+	pm.SortField_SORT_FIELD_RULE_COUNT:        "rule_count",
+	pm.SortField_SORT_FIELD_LAST_LOGIN_AT:     "last_login_at",
 	pm.SortField_SORT_FIELD_CREATED_AT:        "created_at",
 	pm.SortField_SORT_FIELD_UPDATED_AT:        "updated_at",
 	pm.SortField_SORT_FIELD_LAST_SEEN_AT:      "last_seen_at",
 	pm.SortField_SORT_FIELD_REGISTERED_AT:     "registered_at",
 	pm.SortField_SORT_FIELD_OCCURRED_AT:       "occurred_at",
-	// RULE_COUNT and LAST_LOGIN_AT are reserved for a follow-up (their index
-	// fields aren't populated yet) — intentionally absent so resolveSort rejects.
 }
 
 // scopeSortableFields lists the SORTABLE index fields per scope. Mirrors the
@@ -61,9 +64,9 @@ var scopeSortableFields = map[string]map[string]bool{
 	"actions":             {"name": true, "type": true, "created_at": true, "updated_at": true},
 	"action_sets":         {"name": true, "member_count": true, "created_at": true, "updated_at": true},
 	"definitions":         {"name": true, "member_count": true, "created_at": true, "updated_at": true},
-	"compliance_policies": {"name": true},
+	"compliance_policies": {"name": true, "rule_count": true, "created_at": true},
 	"devices":             {"hostname": true, "compliance_status": true, "registered_at": true, "last_seen_at": true},
-	"users":               {"email": true, "display_name": true, "disabled": true, "created_at": true},
+	"users":               {"email": true, "display_name": true, "disabled": true, "last_login_at": true, "created_at": true},
 	"device_groups":       {"name": true, "member_count": true, "created_at": true},
 	"user_groups":         {"name": true, "member_count": true, "created_at": true},
 	"executions":          {"device_hostname": true, "status": true, "action_type": true, "created_at": true},
@@ -218,7 +221,26 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 	// query plan. Without this check, an unscoped `@status:{pending}`
 	// would propagate to e.g. idx:action_sets, which RediSearch rejects
 	// with a SYNTAX error surfaced as opaque CodeInternal. See #158.
-	if err := validateFiltersForScopes(ctx, scopes, req.Msg.DateFilters, req.Msg.TagFilters); err != nil {
+	// Device online/offline is a synthetic filter (#325): "status" is not a real
+	// idx:devices field, so translate it to a last_seen_at range and strip it
+	// before the generic validation/build (else RediSearch rejects @status:{}).
+	tagFilters := req.Msg.TagFilters
+	var deviceStatusClause string
+	if statusVal, ok := req.Msg.TagFilters["status"]; ok && len(scopes) == 1 && scopes[0] == "devices" {
+		clause, err := h.deviceStatusClause(ctx, statusVal)
+		if err != nil {
+			return nil, err
+		}
+		deviceStatusClause = clause
+		tagFilters = make(map[string]string, len(req.Msg.TagFilters))
+		for k, v := range req.Msg.TagFilters {
+			if k != "status" {
+				tagFilters[k] = v
+			}
+		}
+	}
+
+	if err := validateFiltersForScopes(ctx, scopes, req.Msg.DateFilters, tagFilters); err != nil {
 		return nil, err
 	}
 
@@ -236,7 +258,14 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 	}
 
 	// Build the FT.SEARCH query from text query + filters.
-	ftQuery := buildFTQuery(query, req.Msg.DateFilters, req.Msg.TagFilters)
+	ftQuery := buildFTQuery(query, req.Msg.DateFilters, tagFilters)
+	if deviceStatusClause != "" {
+		if ftQuery == "*" {
+			ftQuery = deviceStatusClause
+		} else {
+			ftQuery += " " + deviceStatusClause
+		}
+	}
 
 	var results []*pm.SearchResult
 	var totalCount int32
@@ -325,12 +354,12 @@ func (h *SearchHandler) RebuildSearchIndex(ctx context.Context, req *connect.Req
 //     defensive silent-drop check (defence in depth — the up-front
 //     validator already rejects unknown fields).
 var scopeFilterFields = map[string]map[string]bool{
-	"actions":             {"type": true, "is_compliance": true, "created_at": true, "updated_at": true},
-	"action_sets":         {"member_count": true, "created_at": true, "updated_at": true},
-	"definitions":         {"member_count": true, "created_at": true, "updated_at": true},
-	"compliance_policies": {},
-	"devices":             {"agent_version": true, "os_arch": true, "compliance_status": true, "registered_at": true, "last_seen_at": true},
-	"users":               {"disabled": true, "created_at": true},
+	"actions":             {"type": true, "is_compliance": true, "assigned": true, "created_at": true, "updated_at": true},
+	"action_sets":         {"member_count": true, "assigned": true, "created_at": true, "updated_at": true},
+	"definitions":         {"member_count": true, "assigned": true, "created_at": true, "updated_at": true},
+	"compliance_policies": {"rule_count": true, "created_at": true},
+	"devices":             {"agent_version": true, "os_arch": true, "os_name": true, "compliance_status": true, "registered_at": true, "last_seen_at": true},
+	"users":               {"disabled": true, "role": true, "last_login_at": true, "created_at": true},
 	"device_groups":       {"is_dynamic": true, "member_count": true, "created_at": true},
 	"user_groups":         {"is_dynamic": true, "member_count": true, "created_at": true},
 	"executions":          {"status": true, "action_type": true, "device_id": true, "created_at": true},
@@ -396,6 +425,24 @@ func validateFiltersForScopes(ctx context.Context, scopes []string, dateFilters 
 		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, fmt.Sprintf("filter field %q is only valid for scope=%s", field, strings.Join(supportedBy, ",")))
 	}
 	return nil
+}
+
+// deviceStatusClause translates the synthetic device "status" filter
+// (online/offline) into a last_seen_at range matching the 5-minute offline
+// window the Postgres path (ListOffline) uses, computed at query time. An
+// unknown value is rejected with InvalidArgument.
+func (h *SearchHandler) deviceStatusClause(ctx context.Context, status string) (string, error) {
+	const offlineWindow = 5 * time.Minute
+	cutoff := h.now().Add(-offlineWindow).Unix()
+	switch status {
+	case "online":
+		return fmt.Sprintf("@last_seen_at:[(%d +inf]", cutoff), nil
+	case "offline":
+		return fmt.Sprintf("@last_seen_at:[-inf %d]", cutoff), nil
+	default:
+		return "", apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument,
+			fmt.Sprintf("device status filter must be 'online' or 'offline', got %q", status))
+	}
 }
 
 // buildFTQuery constructs a RediSearch query string from text, date filters, and tag filters.

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -95,11 +95,13 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 		string(eventtypes.UserLinuxUsernameChanged),
 		string(eventtypes.UserDisabled),
 		string(eventtypes.UserEnabled),
-		string(eventtypes.UserRoleChanged), // role is an indexed filter (#325)
-		// last_login_at is an indexed sort (#325); reindex so "sort by last login /
-		// find dormant accounts" reflects a fresh login (one cheap enqueue/login).
-		string(eventtypes.UserLoggedIn):
+		// role is an indexed filter (#325); role changes are infrequent.
+		string(eventtypes.UserRoleChanged):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeUser, ID: e.StreamID}}
+		// Note: UserLoggedIn is intentionally NOT here. last_login_at is an indexed
+		// sort (#325) but reindexing on every login is too costly; the value stays
+		// eventually-consistent via other user events + the periodic reconcile,
+		// which is fine for "sort by last login / find dormant accounts".
 
 	case string(eventtypes.UserDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeUser, ID: e.StreamID}}

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -94,7 +94,11 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 		string(eventtypes.UserProfileUpdated),
 		string(eventtypes.UserLinuxUsernameChanged),
 		string(eventtypes.UserDisabled),
-		string(eventtypes.UserEnabled):
+		string(eventtypes.UserEnabled),
+		string(eventtypes.UserRoleChanged), // role is an indexed filter (#325)
+		// last_login_at is an indexed sort (#325); reindex so "sort by last login /
+		// find dormant accounts" reflects a fresh login (one cheap enqueue/login).
+		string(eventtypes.UserLoggedIn):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeUser, ID: e.StreamID}}
 
 	case string(eventtypes.UserDeleted):
@@ -266,9 +270,46 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 
 	case string(eventtypes.CompliancePolicyDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeCompliancePolicy, ID: e.StreamID}}
+
+	// ---------------------------------------------------------
+	// Assignment scope — reindex the SOURCE entity's `assigned` TAG (#325).
+	// ---------------------------------------------------------
+	// StreamID is the assignment id; the source tuple rides in the payload
+	// (both Created and Deleted emit it). A compliance_policy source has no
+	// `assigned` field, and a legacy AssignmentDeleted with an empty payload
+	// is a no-op — the periodic reconciler/warm rebuild is the safety net.
+	case string(eventtypes.AssignmentCreated),
+		string(eventtypes.AssignmentDeleted):
+		var p struct {
+			SourceType string `json:"source_type"`
+			SourceID   string `json:"source_id"`
+		}
+		if json.Unmarshal(e.Data, &p) != nil || p.SourceID == "" {
+			return nil
+		}
+		scope := assignmentSourceScope(p.SourceType)
+		if scope == "" {
+			return nil
+		}
+		return []SearchAffected{{Op: SearchOpReindex, Scope: scope, ID: p.SourceID}}
 	}
 
 	return nil
+}
+
+// assignmentSourceScope maps an assignment source_type to the search scope whose
+// `assigned` TAG it affects, or "" for types that carry no such TAG
+// (compliance_policy / unknown).
+func assignmentSourceScope(sourceType string) string {
+	switch sourceType {
+	case "action":
+		return search.ScopeAction
+	case "action_set":
+		return search.ScopeActionSet
+	case "definition":
+		return search.ScopeDefinition
+	}
+	return ""
 }
 
 // SearchListener returns a store.EventListener that translates the
@@ -351,6 +392,20 @@ func SearchListener(st *store.Store, idx SearchIndex, logger *slog.Logger) store
 // key but the LATEST payload wins. So listener payload divergence
 // would be silent until Phase 2 removes the handler-side path. The
 // Phase 1 tests assert end-to-end equivalence to catch this.
+// sourceAssignedTag returns the "assigned" TAG value for a source entity by
+// counting its live assignments (#325). source_type is "action"/"action_set"/
+// "definition"; empty Column3/Column4 wildcard the target tuple.
+func sourceAssignedTag(ctx context.Context, q *db.Queries, sourceType, id string) (string, error) {
+	cnt, err := q.CountAssignments(ctx, db.CountAssignmentsParams{Column1: sourceType, Column2: id})
+	if err != nil {
+		return "", err
+	}
+	if cnt > 0 {
+		return "true", nil
+	}
+	return "false", nil
+}
+
 func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Logger, scope, id string) (*taskqueue.SearchEntityData, error) {
 	q := st.Queries()
 	switch scope {
@@ -364,15 +419,20 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if u.Disabled {
 			disabled = "true"
 		}
-		var createdAt int64
+		var createdAt, lastLoginAt int64
 		if u.CreatedAt != nil {
 			createdAt = u.CreatedAt.Unix()
+		}
+		if u.LastLoginAt != nil {
+			lastLoginAt = u.LastLoginAt.Unix()
 		}
 		return &taskqueue.SearchEntityData{
 			Email:         u.Email,
 			DisplayName:   u.DisplayName,
 			LinuxUsername: u.LinuxUsername,
 			Disabled:      disabled,
+			Role:          u.Role,
+			LastLoginAt:   lastLoginAt,
 			CreatedAt:     createdAt,
 		}, nil
 
@@ -452,10 +512,15 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if s.UpdatedAt != nil {
 			updatedAt = s.UpdatedAt.Unix()
 		}
+		assigned, err := sourceAssignedTag(ctx, q, "action_set", id)
+		if err != nil {
+			return nil, err
+		}
 		return &taskqueue.SearchEntityData{
 			Name:        s.Name,
 			Description: s.Description,
 			MemberCount: s.MemberCount,
+			Assigned:    assigned,
 			CreatedAt:   createdAt,
 			UpdatedAt:   updatedAt,
 		}, nil
@@ -468,6 +533,9 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		data := &taskqueue.SearchEntityData{
 			Name:        p.Name,
 			Description: p.Description,
+		}
+		if p.CreatedAt != nil {
+			data.CreatedAt = p.CreatedAt.Unix()
 		}
 		// Rule list is denormalised into ActionNames so a search
 		// hit can match against the action names referenced by the
@@ -491,6 +559,8 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 			}
 			data.ActionNames = strings.Join(actionNames, " ")
 			data.HasActionNames = true
+			data.RuleCount = int32(len(rules))
+			data.HasRuleCount = true
 		}
 		return data, nil
 
@@ -521,11 +591,16 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if a.UpdatedAt != nil {
 			updatedAt = a.UpdatedAt.Unix()
 		}
+		assigned, err := sourceAssignedTag(ctx, q, "action", id)
+		if err != nil {
+			return nil, err
+		}
 		return &taskqueue.SearchEntityData{
 			Name:         a.Name,
 			Description:  desc,
 			Type:         a.ActionType,
 			IsCompliance: isCompliance,
+			Assigned:     assigned,
 			CreatedAt:    createdAt,
 			UpdatedAt:    updatedAt,
 		}, nil
@@ -542,10 +617,15 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if d.UpdatedAt != nil {
 			updatedAt = d.UpdatedAt.Unix()
 		}
+		assigned, err := sourceAssignedTag(ctx, q, "definition", id)
+		if err != nil {
+			return nil, err
+		}
 		return &taskqueue.SearchEntityData{
 			Name:        d.Name,
 			Description: d.Description,
 			MemberCount: d.MemberCount,
+			Assigned:    assigned,
 			CreatedAt:   createdAt,
 			UpdatedAt:   updatedAt,
 		}, nil

--- a/internal/api/search_listener_test.go
+++ b/internal/api/search_listener_test.go
@@ -28,6 +28,36 @@ func TestAffectedSearchOps(t *testing.T) {
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUser, ID: "USR1"}},
 		},
 		{
+			"UserRoleChanged reindexes user (role is filterable, #325)",
+			store.PersistedEvent{EventType: "UserRoleChanged", StreamID: "USR1", StreamType: "user"},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUser, ID: "USR1"}},
+		},
+		// Assignment scope — reindex the SOURCE entity's `assigned` TAG (#325)
+		{
+			"AssignmentCreated reindexes the source action",
+			store.PersistedEvent{EventType: "AssignmentCreated", StreamID: "ASN1", StreamType: "assignment",
+				Data: []byte(`{"source_type":"action","source_id":"ACT1"}`)},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeAction, ID: "ACT1"}},
+		},
+		{
+			"AssignmentDeleted reindexes the source action_set",
+			store.PersistedEvent{EventType: "AssignmentDeleted", StreamID: "ASN1", StreamType: "assignment",
+				Data: []byte(`{"source_type":"action_set","source_id":"SET1"}`)},
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "SET1"}},
+		},
+		{
+			"AssignmentCreated to a compliance_policy is a no-op (no assigned TAG)",
+			store.PersistedEvent{EventType: "AssignmentCreated", StreamID: "ASN1", StreamType: "assignment",
+				Data: []byte(`{"source_type":"compliance_policy","source_id":"CP1"}`)},
+			nil,
+		},
+		{
+			"AssignmentDeleted with a legacy empty payload is a no-op",
+			store.PersistedEvent{EventType: "AssignmentDeleted", StreamID: "ASN1", StreamType: "assignment",
+				Data: []byte(`{}`)},
+			nil,
+		},
+		{
 			"UserEmailChanged reindexes user",
 			store.PersistedEvent{EventType: "UserEmailChanged", StreamID: "USR1", StreamType: "user"},
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUser, ID: "USR1"}},

--- a/internal/api/search_sort_test.go
+++ b/internal/api/search_sort_test.go
@@ -71,10 +71,11 @@ func TestResolveSort_FieldNotSortableOnScope_InvalidArgument(t *testing.T) {
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }
 
-func TestResolveSort_ReservedFieldNotYetWired_InvalidArgument(t *testing.T) {
-	// rule_count's index field isn't populated yet — must be rejected, not sent.
-	_, _, err := resolveSort(context.Background(), "compliance_policies",
+func TestResolveSort_RuleCountSortableOnCompliance(t *testing.T) {
+	// rule_count is now a populated SORTABLE field on compliance_policies (#325 PR B).
+	field, dir, err := resolveSort(context.Background(), "compliance_policies",
 		pm.SortField_SORT_FIELD_RULE_COUNT, pm.SortDirection_SORT_DIRECTION_DESC)
-	require.Error(t, err)
-	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	require.NoError(t, err)
+	assert.Equal(t, "rule_count", field)
+	assert.Equal(t, "DESC", dir)
 }

--- a/internal/api/search_sort_test.go
+++ b/internal/api/search_sort_test.go
@@ -2,7 +2,9 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
@@ -67,6 +69,24 @@ func TestResolveSort_FieldNotSortableOnScope_InvalidArgument(t *testing.T) {
 	// hostname is sortable on devices, NOT on actions.
 	_, _, err := resolveSort(context.Background(), "actions",
 		pm.SortField_SORT_FIELD_HOSTNAME, pm.SortDirection_SORT_DIRECTION_DESC)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+func TestDeviceStatusClause(t *testing.T) {
+	fixed := time.Unix(1_000_000, 0)
+	h := &SearchHandler{now: func() time.Time { return fixed }}
+	cutoff := fixed.Add(-5 * time.Minute).Unix() // 999_700
+
+	online, err := h.deviceStatusClause(context.Background(), "online")
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("@last_seen_at:[(%d +inf]", cutoff), online)
+
+	offline, err := h.deviceStatusClause(context.Background(), "offline")
+	require.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("@last_seen_at:[-inf %d]", cutoff), offline)
+
+	_, err = h.deviceStatusClause(context.Background(), "bogus")
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 }

--- a/internal/eventtypes/payloads/assignment.go
+++ b/internal/eventtypes/payloads/assignment.go
@@ -13,6 +13,17 @@ type AssignmentCreated struct {
 	Mode       *int32 `json:"mode,omitempty"`
 }
 
+// AssignmentDeleted is the wire shape for AssignmentDeleted. It carries the
+// source tuple (StreamID is the assignment id) so the search-index classifier
+// can reindex the affected action/action_set/definition's `assigned` TAG
+// without a DB lookup. The projector soft-deletes by StreamID and ignores these
+// fields; older events with an empty payload still replay (a warm rebuild
+// recomputes `assigned` from the current assignment state).
+type AssignmentDeleted struct {
+	SourceType string `json:"source_type,omitempty"`
+	SourceID   string `json:"source_id,omitempty"`
+}
+
 // AssignmentModeChanged is the wire shape for AssignmentModeChanged.
 // Currently unused (assignments are immutable; mutate by
 // delete-and-recreate) but the projector preserves replay parity.

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -198,6 +198,7 @@ var IndexSchemas = []IndexSchema{
 			"description", "TEXT",
 			"type", "TAG", "SORTABLE",
 			"is_compliance", "TAG",
+			"assigned", "TAG",
 			"created_at", "NUMERIC", "SORTABLE",
 			"updated_at", "NUMERIC", "SORTABLE",
 		},
@@ -210,6 +211,7 @@ var IndexSchemas = []IndexSchema{
 			"description", "TEXT",
 			"member_count", "NUMERIC", "SORTABLE",
 			"action_names", "TEXT",
+			"assigned", "TAG",
 			"created_at", "NUMERIC", "SORTABLE",
 			"updated_at", "NUMERIC", "SORTABLE",
 		},
@@ -223,6 +225,7 @@ var IndexSchemas = []IndexSchema{
 			"member_count", "NUMERIC", "SORTABLE",
 			"set_names", "TEXT",
 			"action_names", "TEXT",
+			"assigned", "TAG",
 			"created_at", "NUMERIC", "SORTABLE",
 			"updated_at", "NUMERIC", "SORTABLE",
 		},
@@ -234,6 +237,8 @@ var IndexSchemas = []IndexSchema{
 			"name", "TEXT", "SORTABLE",
 			"description", "TEXT",
 			"action_names", "TEXT",
+			"rule_count", "NUMERIC", "SORTABLE",
+			"created_at", "NUMERIC", "SORTABLE",
 		},
 	},
 	{
@@ -243,7 +248,9 @@ var IndexSchemas = []IndexSchema{
 			"hostname", "TEXT", "SORTABLE",
 			"agent_version", "TAG",
 			"labels", "TEXT",
-			"os_name", "TEXT",
+			// os_name is a TAG for exact "OS: Ubuntu" filter chips (#325); free-text
+			// device search still covers hostname/labels/os_version.
+			"os_name", "TAG",
 			"os_version", "TEXT",
 			"os_arch", "TAG",
 			"kernel", "TEXT",
@@ -260,6 +267,8 @@ var IndexSchemas = []IndexSchema{
 			"display_name", "TEXT", "SORTABLE",
 			"linux_username", "TEXT",
 			"disabled", "TAG", "SORTABLE",
+			"role", "TAG",
+			"last_login_at", "NUMERIC", "SORTABLE",
 			"created_at", "NUMERIC", "SORTABLE",
 		},
 	},
@@ -492,11 +501,39 @@ func (idx *Index) Warm(ctx context.Context) error {
 // action_id → name map. Downstream warm passes (sets + definitions)
 // use the map for in-memory joins instead of issuing one Valkey
 // HGet per member. See manchtools/power-manage-server#153.
+// assignedSourceSet returns the set of source_ids of sourceType that have a live
+// assignment — for stamping the search `assigned` TAG during a warm rebuild
+// (one query per type, then O(1) lookups).
+func (idx *Index) assignedSourceSet(ctx context.Context, sourceType string) (map[string]bool, error) {
+	ids, err := idx.store.Queries().ListAssignedSourceIDs(ctx, sourceType)
+	if err != nil {
+		return nil, err
+	}
+	set := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		set[id] = true
+	}
+	return set, nil
+}
+
+// tagBool renders a bool as the "true"/"false" string a RediSearch TAG stores.
+func tagBool(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}
+
 func (idx *Index) warmActions(ctx context.Context) (int, map[string]string, error) {
 	const pageSize int32 = 500
 	var offset int32
 	var total int
 	actionNames := map[string]string{}
+
+	assignedActions, err := idx.assignedSourceSet(ctx, "action")
+	if err != nil {
+		return total, actionNames, err
+	}
 
 	for {
 		actions, err := idx.store.Repos().Action.List(ctx, store.ListActionsFilter{
@@ -529,6 +566,7 @@ func (idx *Index) warmActions(ctx context.Context) (int, map[string]string, erro
 				Description:  desc,
 				Type:         int32(a.ActionType),
 				IsCompliance: isCompliance,
+				Assigned:     tagBool(assignedActions[a.ID]),
 			}
 			if a.CreatedAt != nil {
 				data.CreatedAt = a.CreatedAt.Unix()
@@ -563,6 +601,11 @@ func (idx *Index) warmActionSets(ctx context.Context, actionNames map[string]str
 	var total int
 	setNames := map[string]string{}
 	setMembers := map[string][]string{}
+
+	assignedSets, err := idx.assignedSourceSet(ctx, "action_set")
+	if err != nil {
+		return total, setNames, setMembers, err
+	}
 
 	for {
 		sets, err := idx.store.Repos().ActionSet.List(ctx, store.ListActionSetsFilter{
@@ -604,6 +647,7 @@ func (idx *Index) warmActionSets(ctx context.Context, actionNames map[string]str
 				Name:        s.Name,
 				Description: s.Description,
 				MemberCount: s.MemberCount,
+				Assigned:    tagBool(assignedSets[s.ID]),
 			}
 			if s.CreatedAt != nil {
 				data.CreatedAt = s.CreatedAt.Unix()
@@ -644,6 +688,11 @@ func (idx *Index) warmDefinitions(ctx context.Context, actionNames, setNames map
 	var offset int32
 	var total int
 
+	assignedDefs, err := idx.assignedSourceSet(ctx, "definition")
+	if err != nil {
+		return total, err
+	}
+
 	for {
 		defs, err := idx.store.Repos().Definition.List(ctx, store.ListDefinitionsFilter{Limit: pageSize, Offset: offset})
 		if err != nil {
@@ -683,6 +732,7 @@ func (idx *Index) warmDefinitions(ctx context.Context, actionNames, setNames map
 				Name:        d.Name,
 				Description: d.Description,
 				MemberCount: d.MemberCount,
+				Assigned:    tagBool(assignedDefs[d.ID]),
 			}
 			if d.CreatedAt != nil {
 				data.CreatedAt = d.CreatedAt.Unix()
@@ -730,8 +780,10 @@ func (idx *Index) warmCompliancePolicies(ctx context.Context) (int, error) {
 
 		pipe := idx.rdb.Pipeline()
 		for _, p := range policies {
-			// Look up action names from compliance rules
+			// Look up action names + rule count from compliance rules.
 			var actionNames []string
+			var ruleCount int32
+			hasRuleCount := false
 			rules, err := idx.store.Queries().ListCompliancePolicyRules(ctx, p.ID)
 			if err == nil {
 				for _, r := range rules {
@@ -739,12 +791,19 @@ func (idx *Index) warmCompliancePolicies(ctx context.Context) (int, error) {
 						actionNames = append(actionNames, r.ActionName)
 					}
 				}
+				ruleCount = int32(len(rules))
+				hasRuleCount = true
 			}
 			data := &taskqueue.SearchEntityData{
 				Name:           p.Name,
 				Description:    p.Description,
 				ActionNames:    strings.Join(actionNames, " "),
 				HasActionNames: true, // warm has the authoritative rule list
+				RuleCount:      ruleCount,
+				HasRuleCount:   hasRuleCount,
+			}
+			if p.CreatedAt != nil {
+				data.CreatedAt = p.CreatedAt.Unix()
 			}
 			pipe.HSet(ctx, prefixCompliancePolicy+p.ID, entityFields(ScopeCompliancePolicy, data))
 		}
@@ -876,9 +935,13 @@ func (idx *Index) warmUsers(ctx context.Context) (int, error) {
 				DisplayName:   u.DisplayName,
 				LinuxUsername: u.LinuxUsername,
 				Disabled:      disabled,
+				Role:          u.Role,
 			}
 			if u.CreatedAt != nil {
 				data.CreatedAt = u.CreatedAt.Unix()
+			}
+			if u.LastLoginAt != nil {
+				data.LastLoginAt = u.LastLoginAt.Unix()
 			}
 			pipe.HSet(ctx, prefixUser+u.ID, entityFields(ScopeUser, data))
 		}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -780,27 +780,28 @@ func (idx *Index) warmCompliancePolicies(ctx context.Context) (int, error) {
 
 		pipe := idx.rdb.Pipeline()
 		for _, p := range policies {
-			// Look up action names + rule count from compliance rules.
-			var actionNames []string
-			var ruleCount int32
-			hasRuleCount := false
+			// Look up action names + rule count from compliance rules. Fail the
+			// rebuild on error rather than indexing the policy with empty
+			// action_names and a missing rule_count — a warm rebuild flushes
+			// first, so partial data corrupts compliance search/filter state
+			// while reporting success.
 			rules, err := idx.store.Queries().ListCompliancePolicyRules(ctx, p.ID)
-			if err == nil {
-				for _, r := range rules {
-					if r.ActionName != "" {
-						actionNames = append(actionNames, r.ActionName)
-					}
+			if err != nil {
+				return total, fmt.Errorf("list compliance policy rules %s: %w", p.ID, err)
+			}
+			var actionNames []string
+			for _, r := range rules {
+				if r.ActionName != "" {
+					actionNames = append(actionNames, r.ActionName)
 				}
-				ruleCount = int32(len(rules))
-				hasRuleCount = true
 			}
 			data := &taskqueue.SearchEntityData{
 				Name:           p.Name,
 				Description:    p.Description,
 				ActionNames:    strings.Join(actionNames, " "),
 				HasActionNames: true, // warm has the authoritative rule list
-				RuleCount:      ruleCount,
-				HasRuleCount:   hasRuleCount,
+				RuleCount:      int32(len(rules)),
+				HasRuleCount:   true,
 			}
 			if p.CreatedAt != nil {
 				data.CreatedAt = p.CreatedAt.Unix()
@@ -852,10 +853,16 @@ func (idx *Index) warmDevices(ctx context.Context) (int, error) {
 				data.LastSeenAt = d.LastSeenAt.Unix()
 			}
 			// Enrich with inventory data (os_version, system_info, kernel_info).
-			if inv, err := idx.store.Repos().Inventory.ListTables(ctx, d.ID, []string{"os_version", "system_info", "kernel_info"}); err == nil {
-				for _, t := range inv {
-					EnrichDeviceInventory(data, t.TableName, t.Rows)
-				}
+			// Fail the rebuild on error: entityFields always writes the os_* fields,
+			// so skipping enrichment would index empty OS data (breaking the os_name
+			// filter) for a device that has inventory — a flush-first rebuild has no
+			// prior value to fall back on.
+			inv, err := idx.store.Repos().Inventory.ListTables(ctx, d.ID, []string{"os_version", "system_info", "kernel_info"})
+			if err != nil {
+				return total, fmt.Errorf("list inventory tables for device %s: %w", d.ID, err)
+			}
+			for _, t := range inv {
+				EnrichDeviceInventory(data, t.TableName, t.Rows)
 			}
 			pipe.HSet(ctx, prefixDevice+d.ID, entityFields(ScopeDevice, data))
 		}

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -517,26 +517,26 @@ func (idx *Index) warmActions(ctx context.Context) (int, map[string]string, erro
 			if a.Description != nil {
 				desc = *a.Description
 			}
-			isCompliance := "false"
+			isCompliance := false
 			var params map[string]any
 			if json.Unmarshal(a.Params, &params) == nil {
-				if v, ok := params["isCompliance"].(bool); ok && v {
-					isCompliance = "true"
+				if v, ok := params["isCompliance"].(bool); ok {
+					isCompliance = v
 				}
 			}
-			fields := map[string]any{
-				"name":          a.Name,
-				"description":   desc,
-				"type":          strconv.Itoa(int(a.ActionType)),
-				"is_compliance": isCompliance,
+			data := &taskqueue.SearchEntityData{
+				Name:         a.Name,
+				Description:  desc,
+				Type:         int32(a.ActionType),
+				IsCompliance: isCompliance,
 			}
 			if a.CreatedAt != nil {
-				fields["created_at"] = strconv.FormatInt(a.CreatedAt.Unix(), 10)
+				data.CreatedAt = a.CreatedAt.Unix()
 			}
 			if a.UpdatedAt != nil {
-				fields["updated_at"] = strconv.FormatInt(a.UpdatedAt.Unix(), 10)
+				data.UpdatedAt = a.UpdatedAt.Unix()
 			}
-			pipe.HSet(ctx, prefixAction+a.ID, fields)
+			pipe.HSet(ctx, prefixAction+a.ID, entityFields(ScopeAction, data))
 			actionNames[a.ID] = a.Name
 		}
 		if _, err := pipe.Exec(ctx); err != nil {
@@ -600,18 +600,21 @@ func (idx *Index) warmActionSets(ctx context.Context, actionNames map[string]str
 				}
 			}
 
-			setFields := map[string]any{
-				"name":         s.Name,
-				"description":  s.Description,
-				"member_count": strconv.Itoa(int(s.MemberCount)),
-				"action_names": strings.Join(memberActionNames, " "),
+			data := &taskqueue.SearchEntityData{
+				Name:        s.Name,
+				Description: s.Description,
+				MemberCount: s.MemberCount,
 			}
 			if s.CreatedAt != nil {
-				setFields["created_at"] = strconv.FormatInt(s.CreatedAt.Unix(), 10)
+				data.CreatedAt = s.CreatedAt.Unix()
 			}
 			if s.UpdatedAt != nil {
-				setFields["updated_at"] = strconv.FormatInt(s.UpdatedAt.Unix(), 10)
+				data.UpdatedAt = s.UpdatedAt.Unix()
 			}
+			// entityFields owns the standard fields; action_names is a warm-only
+			// denormalised join (the incremental path maintains it via rebuildParent).
+			setFields := entityFields(ScopeActionSet, data)
+			setFields["action_names"] = strings.Join(memberActionNames, " ")
 			pipe.HSet(ctx, prefixActionSet+s.ID, setFields)
 
 			if _, err := pipe.Exec(ctx); err != nil {
@@ -676,19 +679,22 @@ func (idx *Index) warmDefinitions(ctx context.Context, actionNames, setNames map
 				}
 			}
 
-			defFields := map[string]any{
-				"name":         d.Name,
-				"description":  d.Description,
-				"member_count": strconv.Itoa(int(d.MemberCount)),
-				"set_names":    strings.Join(memberSetNames, " "),
-				"action_names": strings.Join(allActionNames, " "),
+			data := &taskqueue.SearchEntityData{
+				Name:        d.Name,
+				Description: d.Description,
+				MemberCount: d.MemberCount,
 			}
 			if d.CreatedAt != nil {
-				defFields["created_at"] = strconv.FormatInt(d.CreatedAt.Unix(), 10)
+				data.CreatedAt = d.CreatedAt.Unix()
 			}
 			if d.UpdatedAt != nil {
-				defFields["updated_at"] = strconv.FormatInt(d.UpdatedAt.Unix(), 10)
+				data.UpdatedAt = d.UpdatedAt.Unix()
 			}
+			// entityFields owns the standard fields; set_names/action_names are
+			// warm-only denormalised joins.
+			defFields := entityFields(ScopeDefinition, data)
+			defFields["set_names"] = strings.Join(memberSetNames, " ")
+			defFields["action_names"] = strings.Join(allActionNames, " ")
 			pipe.HSet(ctx, prefixDefinition+d.ID, defFields)
 
 			if _, err := pipe.Exec(ctx); err != nil {
@@ -734,11 +740,13 @@ func (idx *Index) warmCompliancePolicies(ctx context.Context) (int, error) {
 					}
 				}
 			}
-			pipe.HSet(ctx, prefixCompliancePolicy+p.ID, map[string]any{
-				"name":         p.Name,
-				"description":  p.Description,
-				"action_names": strings.Join(actionNames, " "),
-			})
+			data := &taskqueue.SearchEntityData{
+				Name:           p.Name,
+				Description:    p.Description,
+				ActionNames:    strings.Join(actionNames, " "),
+				HasActionNames: true, // warm has the authoritative rule list
+			}
+			pipe.HSet(ctx, prefixCompliancePolicy+p.ID, entityFields(ScopeCompliancePolicy, data))
 		}
 		if _, err := pipe.Exec(ctx); err != nil {
 			return total, fmt.Errorf("pipeline exec: %w", err)
@@ -769,44 +777,28 @@ func (idx *Index) warmDevices(ctx context.Context) (int, error) {
 
 		pipe := idx.rdb.Pipeline()
 		for _, d := range devices {
-			labels := FlattenLabels(d.Labels)
-			fields := map[string]any{
-				// hostname / labels / agent_version are agent-reported — bound and
-				// strip them before indexing (see sanitizeSearchField).
-				"hostname":          sanitizeSearchField(d.Hostname, maxHostnameField),
-				"agent_version":     sanitizeSearchField(d.AgentVersion, maxOSField),
-				"labels":            sanitizeSearchField(labels, maxLabelsField),
-				"compliance_status": strconv.Itoa(int(d.ComplianceStatus)),
+			// Build the same SearchEntityData the incremental path produces, then
+			// format via entityFields — single source of the device HSET shape
+			// (bounding/sanitising of agent-reported fields lives there).
+			data := &taskqueue.SearchEntityData{
+				Hostname:         d.Hostname,
+				AgentVersion:     d.AgentVersion,
+				Labels:           FlattenLabels(d.Labels),
+				ComplianceStatus: d.ComplianceStatus,
 			}
 			if d.RegisteredAt != nil {
-				fields["registered_at"] = strconv.FormatInt(d.RegisteredAt.Unix(), 10)
+				data.RegisteredAt = d.RegisteredAt.Unix()
 			}
 			if d.LastSeenAt != nil {
-				fields["last_seen_at"] = strconv.FormatInt(d.LastSeenAt.Unix(), 10)
+				data.LastSeenAt = d.LastSeenAt.Unix()
 			}
-
 			// Enrich with inventory data (os_version, system_info, kernel_info).
-			inv, err := idx.store.Repos().Inventory.ListTables(ctx, d.ID, []string{"os_version", "system_info", "kernel_info"})
-			if err == nil {
+			if inv, err := idx.store.Repos().Inventory.ListTables(ctx, d.ID, []string{"os_version", "system_info", "kernel_info"}); err == nil {
 				for _, t := range inv {
-					osName, osVer, osArch, kernel := extractInventoryFields(t.TableName, t.Rows)
-					// os_* / kernel come from agent-reported osquery rows — sanitize.
-					if osName != "" {
-						fields["os_name"] = sanitizeSearchField(osName, maxOSField)
-					}
-					if osVer != "" {
-						fields["os_version"] = sanitizeSearchField(osVer, maxOSField)
-					}
-					if osArch != "" {
-						fields["os_arch"] = sanitizeSearchField(osArch, maxOSField)
-					}
-					if kernel != "" {
-						fields["kernel"] = sanitizeSearchField(kernel, maxOSField)
-					}
+					EnrichDeviceInventory(data, t.TableName, t.Rows)
 				}
 			}
-
-			pipe.HSet(ctx, prefixDevice+d.ID, fields)
+			pipe.HSet(ctx, prefixDevice+d.ID, entityFields(ScopeDevice, data))
 		}
 		if _, err := pipe.Exec(ctx); err != nil {
 			return total, fmt.Errorf("pipeline exec: %w", err)
@@ -879,16 +871,16 @@ func (idx *Index) warmUsers(ctx context.Context) (int, error) {
 			if u.Disabled {
 				disabled = "true"
 			}
-			fields := map[string]any{
-				"email":          u.Email,
-				"display_name":   u.DisplayName,
-				"linux_username": u.LinuxUsername,
-				"disabled":       disabled,
+			data := &taskqueue.SearchEntityData{
+				Email:         u.Email,
+				DisplayName:   u.DisplayName,
+				LinuxUsername: u.LinuxUsername,
+				Disabled:      disabled,
 			}
 			if u.CreatedAt != nil {
-				fields["created_at"] = strconv.FormatInt(u.CreatedAt.Unix(), 10)
+				data.CreatedAt = u.CreatedAt.Unix()
 			}
-			pipe.HSet(ctx, prefixUser+u.ID, fields)
+			pipe.HSet(ctx, prefixUser+u.ID, entityFields(ScopeUser, data))
 		}
 		if _, err := pipe.Exec(ctx); err != nil {
 			return total, fmt.Errorf("pipeline exec: %w", err)
@@ -923,16 +915,16 @@ func (idx *Index) warmDeviceGroups(ctx context.Context) (int, error) {
 			if g.IsDynamic {
 				isDynamic = "true"
 			}
-			fields := map[string]any{
-				"name":         g.Name,
-				"description":  g.Description,
-				"is_dynamic":   isDynamic,
-				"member_count": strconv.Itoa(int(g.MemberCount)),
+			data := &taskqueue.SearchEntityData{
+				Name:        g.Name,
+				Description: g.Description,
+				IsDynamic:   isDynamic,
+				MemberCount: g.MemberCount,
 			}
 			if g.CreatedAt != nil {
-				fields["created_at"] = strconv.FormatInt(g.CreatedAt.Unix(), 10)
+				data.CreatedAt = g.CreatedAt.Unix()
 			}
-			pipe.HSet(ctx, prefixDeviceGroup+g.ID, fields)
+			pipe.HSet(ctx, prefixDeviceGroup+g.ID, entityFields(ScopeDeviceGroup, data))
 		}
 		if _, err := pipe.Exec(ctx); err != nil {
 			return total, fmt.Errorf("pipeline exec: %w", err)
@@ -967,16 +959,16 @@ func (idx *Index) warmUserGroups(ctx context.Context) (int, error) {
 			if g.IsDynamic {
 				isDynamic = "true"
 			}
-			fields := map[string]any{
-				"name":         g.Name,
-				"description":  g.Description,
-				"is_dynamic":   isDynamic,
-				"member_count": strconv.Itoa(int(g.MemberCount)),
+			data := &taskqueue.SearchEntityData{
+				Name:        g.Name,
+				Description: g.Description,
+				IsDynamic:   isDynamic,
+				MemberCount: g.MemberCount,
 			}
 			if !g.CreatedAt.IsZero() {
-				fields["created_at"] = strconv.FormatInt(g.CreatedAt.Unix(), 10)
+				data.CreatedAt = g.CreatedAt.Unix()
 			}
-			pipe.HSet(ctx, prefixUserGroup+g.ID, fields)
+			pipe.HSet(ctx, prefixUserGroup+g.ID, entityFields(ScopeUserGroup, data))
 		}
 		if _, err := pipe.Exec(ctx); err != nil {
 			return total, fmt.Errorf("pipeline exec: %w", err)

--- a/internal/search/worker.go
+++ b/internal/search/worker.go
@@ -314,6 +314,15 @@ func parentScopeOf(childScope string) string {
 	return ""
 }
 
+// setAssigned writes the assigned TAG when the reindex path computed it. An
+// empty value means "not computed" — leave the prior TAG alone (HSET is
+// additive) rather than clobbering it from a path that didn't load assignments.
+func setAssigned(fields map[string]any, data *taskqueue.SearchEntityData) {
+	if data.Assigned != "" {
+		fields["assigned"] = data.Assigned
+	}
+}
+
 func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any {
 	switch scope {
 	case ScopeAction:
@@ -327,6 +336,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"type":          strconv.Itoa(int(data.Type)),
 			"is_compliance": isCompliance,
 		}
+		setAssigned(fields, data)
 		if data.CreatedAt != 0 {
 			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)
 		}
@@ -340,6 +350,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"description":  data.Description,
 			"member_count": strconv.Itoa(int(data.MemberCount)),
 		}
+		setAssigned(fields, data)
 		if data.CreatedAt != 0 {
 			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)
 		}
@@ -353,6 +364,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"description":  data.Description,
 			"member_count": strconv.Itoa(int(data.MemberCount)),
 		}
+		setAssigned(fields, data)
 		if data.CreatedAt != 0 {
 			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)
 		}
@@ -367,6 +379,14 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 		}
 		if data.HasActionNames {
 			fields["action_names"] = data.ActionNames
+		}
+		// HasRuleCount lets a 0-rule policy still write rule_count (the
+		// @rule_count:[0 0] empty filter needs the field present).
+		if data.HasRuleCount {
+			fields["rule_count"] = strconv.Itoa(int(data.RuleCount))
+		}
+		if data.CreatedAt != 0 {
+			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)
 		}
 		return fields
 	case ScopeDevice:
@@ -395,6 +415,12 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"display_name":   data.DisplayName,
 			"linux_username": data.LinuxUsername,
 			"disabled":       data.Disabled,
+		}
+		if data.Role != "" {
+			fields["role"] = data.Role
+		}
+		if data.LastLoginAt != 0 {
+			fields["last_login_at"] = strconv.FormatInt(data.LastLoginAt, 10)
 		}
 		if data.CreatedAt != 0 {
 			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)

--- a/internal/store/generated/assignments.sql.go
+++ b/internal/store/generated/assignments.sql.go
@@ -398,6 +398,34 @@ func (q *Queries) ListAssignedActionsForDevice(ctx context.Context, targetID str
 	return items, nil
 }
 
+const listAssignedSourceIDs = `-- name: ListAssignedSourceIDs :many
+SELECT DISTINCT source_id FROM assignments_projection
+WHERE source_type = $1 AND is_deleted = FALSE
+`
+
+// Distinct source_ids with at least one live assignment of the given
+// source_type. Backs the search index `assigned` TAG during a warm rebuild
+// (one query per type instead of a per-entity COUNT).
+func (q *Queries) ListAssignedSourceIDs(ctx context.Context, sourceType string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listAssignedSourceIDs, sourceType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var source_id string
+		if err := rows.Scan(&source_id); err != nil {
+			return nil, err
+		}
+		items = append(items, source_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAssignments = `-- name: ListAssignments :many
 SELECT a.id, a.source_type, a.source_id, a.target_type, a.target_id, a.sort_order, a.mode, a.created_at, a.created_by, a.is_deleted, a.projection_version,
   COALESCE(CASE a.source_type

--- a/internal/store/queries/assignments.sql
+++ b/internal/store/queries/assignments.sql
@@ -39,6 +39,13 @@ WHERE is_deleted = FALSE
   AND ($3::TEXT = '' OR target_type = $3)
   AND ($4::TEXT = '' OR target_id = $4);
 
+-- name: ListAssignedSourceIDs :many
+-- Distinct source_ids with at least one live assignment of the given
+-- source_type. Backs the search index `assigned` TAG during a warm rebuild
+-- (one query per type instead of a per-entity COUNT).
+SELECT DISTINCT source_id FROM assignments_projection
+WHERE source_type = $1 AND is_deleted = FALSE;
+
 -- Get all assignments for a specific source
 -- name: ListAssignmentsForSource :many
 SELECT * FROM assignments_projection

--- a/internal/taskqueue/payloads.go
+++ b/internal/taskqueue/payloads.go
@@ -331,9 +331,16 @@ type SearchEntityData struct {
 	DisplayName   string `json:"display_name,omitempty"`
 	LinuxUsername string `json:"linux_username,omitempty"`
 	Disabled      string `json:"disabled,omitempty"`
+	Role          string `json:"role,omitempty"`          // #325 TAG filter
+	LastLoginAt   int64  `json:"last_login_at,omitempty"` // #325 sortable
 
 	// Device group / User group fields
 	IsDynamic string `json:"is_dynamic,omitempty"`
+
+	// #325 filter additions
+	Assigned     string `json:"assigned,omitempty"`       // action/action_set/definition: "true"/"false" — directly assigned (TAG)
+	RuleCount    int32  `json:"rule_count,omitempty"`     // compliance policy rule count (NUMERIC, sortable)
+	HasRuleCount bool   `json:"has_rule_count,omitempty"` // signals RuleCount computed (so 0 is written for the empty-rules filter)
 
 	// Audit event fields
 	EventType  string `json:"event_type,omitempty"`


### PR DESCRIPTION
Second slice of #325 — the new-field **filters**, built on the warm↔entityFields consolidation so each field is written once.

## Consolidation first
`refactor(search): route warm* through entityFields` makes `entityFields` the single source of the HSET field shape (8 of 10 warm builders; devices also reuse `EnrichDeviceInventory`). Behavior-preserving (integration green), net −8 LOC.

## Filters
- **assigned** TAG on actions/action_sets/definitions — the entity *itself* directly assigned (`EXISTS assignment WHERE source_id = id`, per the agreed semantic; not its children). Bulk `ListAssignedSourceIDs` per type in warm; per-entity `CountAssignments` incrementally; **reindexed on Assignment Created/Deleted** — the delete event now carries the source tuple (it was empty) so the classifier needs no DB lookup; legacy empty-payload deletes are a no-op (reconcile is the safety net).
- **rule_count** NUMERIC SORTABLE on compliance (+created_at); backs `@rule_count:[0 0]`. **os_name**→TAG (devices), **role** TAG + **last_login_at** (users).
- **Device online/offline**: synthetic `status` filter translated to a query-time `last_seen_at` range (5-min window matching Postgres `ListOffline`).

## Notes / decisions
- `UserRoleChanged` reindexes (role filter correctness); `UserLoggedIn` does **not** (too frequent — last_login is eventually-consistent via reconcile, fine for dormant-account sorting).
- Self-discovering parity guards keep `scopeFilterFields`/`scopeSortableFields` ↔ index in lockstep (caught a missing `last_login_at` filter entry during dev).

## Tests
Unit: parity guards, resolveSort, AffectedSearchOps (assignment→source reindex, compliance/empty no-ops), deviceStatusClause. Integration: search schema+warm green; projector + assignment/search handler tests green (AssignmentDeleted payload change is backward-compatible).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now supports filtering devices by online/offline status and sorting by additional fields such as rule count and last login time.
  * Several search results now include richer metadata like assigned status, user role, and compliance rule counts.

* **Bug Fixes**
  * Deletions now emit more complete event details, improving downstream tracking.
  * Search reindexing now updates more records when assignment or user role changes occur.

* **Refactor**
  * Search indexing and rebuilds now use more consistent data formatting across entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->