### PR TITLE
fix(search): NUMERIC empty-relation filters (server#325)

### DIFF
--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -440,6 +440,19 @@ func validateFiltersForScopes(ctx context.Context, scopes []string, dateFilters 
 		}
 		return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, fmt.Sprintf("filter field %q is only valid for scope=%s", field, strings.Join(supportedBy, ",")))
 	}
+	// A NUMERIC field is emitted as a range (@field:[v v]); a non-integer value
+	// can't be expressed and would silently widen the query (fail-open). Reject
+	// it at the boundary rather than dropping it.
+	for field, value := range tagFilters {
+		if field == "" || value == "" || !numericSearchFields[field] {
+			continue
+		}
+		for _, v := range strings.Split(value, "|") {
+			if _, err := strconv.Atoi(strings.TrimSpace(v)); err != nil {
+				return apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, fmt.Sprintf("filter field %q requires integer values, got %q", field, v))
+			}
+		}
+	}
 	return nil
 }
 

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -12,6 +12,7 @@ import (
 	"connectrpc.com/connect"
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/search"
 )
 
 // SearchHandler handles search and search index management RPCs.
@@ -380,6 +381,21 @@ var allowedSearchFields = func() map[string]bool {
 	return out
 }()
 
+// numericSearchFields is the union of NUMERIC-declared fields across every index
+// schema. A tag filter on one must be emitted as a range (@field:[v v]) — the
+// TAG @field:{v} syntax is a RediSearch SYNTAX error on a NUMERIC field. This
+// backs the empty-relation filters (member_count/rule_count = 0). Derived from
+// the index schemas so it can't drift from what's actually declared.
+var numericSearchFields = func() map[string]bool {
+	out := map[string]bool{}
+	for _, ix := range search.IndexSchemas {
+		for f := range ix.NumericFields() {
+			out[f] = true
+		}
+	}
+	return out
+}()
+
 // validateFiltersForScopes returns InvalidArgument when the request's
 // filter fields reference attributes that aren't declared by every
 // index in the query plan. The error message names the scopes that
@@ -479,8 +495,32 @@ func buildFTQuery(textQuery string, dateFilters []*pm.SearchDateFilter, tagFilte
 		if field == "" || value == "" || !allowedSearchFields[field] {
 			continue
 		}
-		// Values may be pipe-separated for OR. Escape each value.
+		// Values may be pipe-separated for OR.
 		vals := strings.Split(value, "|")
+		if numericSearchFields[field] {
+			// NUMERIC fields take a range, not TAG syntax. Each value V → an
+			// exact match [V V] (this backs the empty-relation filters, e.g.
+			// member_count=0 / rule_count=0). Non-integer values are dropped
+			// defensively so nothing unvalidated reaches the query string.
+			var ranges []string
+			for _, v := range vals {
+				v = strings.TrimSpace(v)
+				if _, err := strconv.Atoi(v); err != nil {
+					continue
+				}
+				ranges = append(ranges, fmt.Sprintf("@%s:[%s %s]", field, v, v))
+			}
+			switch len(ranges) {
+			case 0:
+				// nothing valid
+			case 1:
+				parts = append(parts, ranges[0])
+			default:
+				parts = append(parts, "("+strings.Join(ranges, "|")+")")
+			}
+			continue
+		}
+		// TAG fields.
 		var escaped []string
 		for _, v := range vals {
 			escaped = append(escaped, escapeRediSearchTagValue(v))

--- a/internal/api/search_handler_test.go
+++ b/internal/api/search_handler_test.go
@@ -430,6 +430,30 @@ func TestValidateFiltersForScopes_UnknownField_RejectsAsUnsupported(t *testing.T
 	assert.Contains(t, connectErr.Message(), "not supported by any search scope")
 }
 
+func TestValidateFiltersForScopes_NumericFieldNonInteger_Rejected(t *testing.T) {
+	// member_count is a NUMERIC index field; a non-integer value must be
+	// rejected with InvalidArgument, not silently widened to no clause.
+	tagFilters := map[string]string{"member_count": "abc"}
+	err := validateFiltersForScopes(context.Background(), []string{"action_sets"}, nil, tagFilters)
+	require.Error(t, err)
+
+	connectErr := new(connect.Error)
+	require.ErrorAs(t, err, &connectErr)
+	assert.Equal(t, connect.CodeInvalidArgument, connectErr.Code())
+	assert.Contains(t, connectErr.Message(), "member_count")
+}
+
+func TestValidateFiltersForScopes_NumericFieldInteger_OK(t *testing.T) {
+	tagFilters := map[string]string{"member_count": "0"}
+	require.NoError(t, validateFiltersForScopes(context.Background(), []string{"action_sets"}, nil, tagFilters))
+}
+
+func TestValidateFiltersForScopes_NumericFieldMultiInteger_OK(t *testing.T) {
+	// Pipe-separated OR of integers is valid.
+	tagFilters := map[string]string{"member_count": "0|5"}
+	require.NoError(t, validateFiltersForScopes(context.Background(), []string{"action_sets"}, nil, tagFilters))
+}
+
 func TestValidateFiltersForScopes_EmptyFieldOrValue_Skipped(t *testing.T) {
 	// Empty field names + empty values must NOT trip validation —
 	// they're silently dropped further down in buildFTQuery.

--- a/internal/api/search_handler_test.go
+++ b/internal/api/search_handler_test.go
@@ -101,6 +101,33 @@ func TestBuildFTQuery_TagFilterEmptyValue(t *testing.T) {
 	assert.Equal(t, "*", q, "empty tag value should be skipped")
 }
 
+// NUMERIC fields (member_count, rule_count) must be emitted as a range — the
+// TAG @field:{v} syntax is a RediSearch error on a NUMERIC field. This backs
+// the empty-relation filters (e.g. action-sets with no actions → member_count=0).
+func TestBuildFTQuery_NumericFieldEmptyRelation(t *testing.T) {
+	tags := map[string]string{"member_count": "0"}
+	q := buildFTQuery("", nil, tags)
+	assert.Equal(t, "@member_count:[0 0]", q)
+}
+
+func TestBuildFTQuery_NumericFieldRuleCount(t *testing.T) {
+	tags := map[string]string{"rule_count": "0"}
+	q := buildFTQuery("", nil, tags)
+	assert.Equal(t, "@rule_count:[0 0]", q)
+}
+
+func TestBuildFTQuery_NumericFieldMultipleValues(t *testing.T) {
+	tags := map[string]string{"member_count": "0|5"}
+	q := buildFTQuery("", nil, tags)
+	assert.Equal(t, "(@member_count:[0 0]|@member_count:[5 5])", q)
+}
+
+func TestBuildFTQuery_NumericFieldNonIntegerDropped(t *testing.T) {
+	tags := map[string]string{"member_count": "abc"}
+	q := buildFTQuery("", nil, tags)
+	assert.Equal(t, "*", q, "non-integer numeric value must not reach the query")
+}
+
 func TestBuildFTQuery_Combined(t *testing.T) {
 	dateFilters := []*pm.SearchDateFilter{
 		{Field: "created_at", Start: 1000, End: 2000},

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -171,6 +171,23 @@ func (s IndexSchema) FilterableFields() map[string]bool {
 	return out
 }
 
+// NumericFields returns the field names declared NUMERIC. A structured filter on
+// a NUMERIC field must use a range (@field:[min max]); the TAG @field:{value}
+// syntax is a RediSearch error on a NUMERIC field. Derived by pairing each type
+// token with its preceding field name.
+func (s IndexSchema) NumericFields() map[string]bool {
+	out := map[string]bool{}
+	for i := 1; i < len(s.Schema); i++ {
+		if t, _ := s.Schema[i].(string); t != "NUMERIC" {
+			continue
+		}
+		if field, ok := s.Schema[i-1].(string); ok {
+			out[field] = true
+		}
+	}
+	return out
+}
+
 // SortableFields returns the field names declared SORTABLE — the only fields an
 // FT.SEARCH SORTBY can target. In every schema here SORTABLE immediately follows
 // the field's type (field, TYPE, SORTABLE), so the field is two tokens back; we


### PR DESCRIPTION
## What

`buildFTQuery` emitted every structured tag filter with TAG syntax (`@field:{v}`), which is a **RediSearch SYNTAX error on a NUMERIC field**. `member_count` and `rule_count` are indexed NUMERIC, so the empty-relation filters could never resolve:

- action-sets with **no actions** (`member_count = 0`)
- definitions with **no sets** (`member_count = 0`)
- compliance policies with **no rules** (`rule_count = 0`)

## Fix

- `IndexSchema.NumericFields()` — derive the NUMERIC-declared fields from the schema (self-discovering, can't drift).
- `numericSearchFields` in the handler — union across all index schemas.
- `buildFTQuery` emits `@field:[v v]` ranges for NUMERIC fields; pipe-separated values OR into `(a|b)`. Non-integer values are dropped before reaching the query string.

## Tests

`TestBuildFTQuery_NumericFieldEmptyRelation`, `_RuleCount`, `_MultipleValues`, `_NonIntegerDropped`. The numeric path is also the live check on `NumericFields()` — if it returned empty, these would fall through to TAG syntax and fail.

Companion web change re-adds the three filter controls these unblock.

Closes the empty-relation gap left open by #460.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search filtering so numeric fields now use valid numeric match syntax instead of tag filters.
  * Non-integer values in numeric filters are ignored, and multiple numeric values are combined correctly.
* **Tests**
  * Added coverage for numeric filter handling, including single values, multiple values, and invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->