### PR TITLE
Scoped access (#7): object visibility + device/user Search scope + event-driven dynamic membership

### DIFF
--- a/docs/adr/0024-scoped-object-visibility.md
+++ b/docs/adr/0024-scoped-object-visibility.md
@@ -92,12 +92,40 @@ build.
 - **Known boundary (documented, fail-closed):** transitive-only and
   individual-device/user-assigned objects under-show in `Search` for scoped
   callers; they remain reachable via `Get`.
-- **Out of scope of this ADR — a related, broader leak:** the `Search` RPC also
-  applies *no* device/user scope today, so the device/user **list pages** (which
-  use `Search`, not the scoped `ListDevices`/`ListUsers` RPCs) leak the whole org
-  to a scoped admin. Closing it needs the same `scope_group_ids` mechanism on the
-  device/user indexes plus a membership-change reindex cascade — and, for
-  *dynamic* groups (whose re-evaluation emits a **bulk** `*MembersRebuilt` event,
-  not per-member), an explicit eventual-consistency tradeoff on an access-control
-  filter. That design decision is deferred to a follow-up rather than shipped
-  implicitly here.
+
+## Device/user Search scope + event-driven dynamic membership (follow-up, shipped)
+
+The `Search` RPC applied *no* device/user scope, and the device/user **list
+pages use `Search`** (not the scoped `ListDevices`/`ListUsers` RPCs) — so a scoped
+admin's Device/User lists leaked the whole org. Closed with the same mechanism:
+
+- `scope_group_ids` TAG on `idx:devices` / `idx:users` = the entity's device-/
+  user-group memberships (same `is_deleted`-excluded source the auth
+  `ScopeResolver` uses, so Search confinement matches handler enforcement).
+  `scopeGroupClause` keys devices off `DeviceScopeListFilter("ListDevices")` and
+  users off `UserScopeListFilter("ListUsers")` — the JWT scope, no round-trip.
+- Freshness: the search listener reindexes the affected device/user on every
+  membership event — static admin add/remove (`*GroupMemberAdded/Removed`) and
+  the new dynamic-evaluation events below.
+
+**Event-driven dynamic membership (no audit drift, no ticker).** The dynamic-group
+evaluator previously wrote `*_group_members_projection` **directly, emitting no
+events** — so membership changes were absent from the event log and search could
+only catch up via the periodic reconcile. Reworked to be event-sourced:
+
+- The evaluator computes the membership delta and **emits a
+  `DeviceGroupMembersReevaluated` / `UserGroupMembersReevaluated` event** (group
+  id + added/removed ids, actor `system`); it no longer writes the projection
+  directly.
+- A **projector applies the delta** (`ClaimDynamic*GroupForMembership` version+
+  dynamic guard → insert added / delete removed → recount). The event is the
+  **source of truth**: a projection rebuild reconstructs dynamic membership by
+  replaying these events, exactly like static membership — so the audit log can
+  never drift from the materialized members.
+- The search listener reacts to the same event to reindex every affected
+  device/user — freshness is driven by the evaluator emitting on each run, not a
+  ticker (the periodic reconcile remains only a failure backstop).
+- The `Claim*` guard is the **dynamic** sibling of the static
+  `Claim*GroupForMembership` (`is_dynamic = TRUE`): static member events apply
+  only to static groups, reevaluation deltas only to dynamic groups; a stale
+  replay can't resurrect removed members or wipe live ones.

--- a/docs/adr/0024-scoped-object-visibility.md
+++ b/docs/adr/0024-scoped-object-visibility.md
@@ -1,0 +1,103 @@
+# 0024 — Scoped object visibility (assignment-keyed RBAC for actions/sets/definitions/policies)
+
+- Status: accepted
+- Date: 2026-06-25
+- Related: server#7 (Scoped Access); spec `docs/content/06-specs/14-scoped-object-visibility.md`;
+  ADR 0006 (handler-level, uniform scope enforcement); spec 13 / #325 (search index).
+
+## Context
+
+Scope enforcement (#7 / ADR 0006) confines a scoped admin to their device/user
+groups for ~61 permissions — devices, users, groups, dispatch, terminal, lists.
+But every action / action-set / definition / compliance-policy permission was
+`TargetUnspecified` (not scopable), so a device-group-scoped operator could
+`Search`, `Get`, and **mutate** the entire org catalog: every action's
+`ShellParams` script and `FileParams` contents, every definition, every
+compliance policy (the org's complete security posture). That is information
+disclosure — and unauthorized mutation — past the operator's scope: a V1 security
+gap, not a V2 nicety.
+
+The shared objects have no per-user owner; they are reached by **assignment** to
+device/user groups (or individual devices/users). So the natural confinement is:
+*a scoped admin sees and manages only objects assigned within their scope.*
+
+## Decision
+
+### Confinement model
+
+- **Caller scope = the union of the device-group and user-group ids the caller's
+  JWT scoped grants confine them to.** Object permissions are not independently
+  scopable; the confinement reuses the device-/user-group scope the caller
+  already holds (`auth.ObjectScopeListFilter`, JWT-only — no DB round-trip). A
+  caller with no scoped grant is a global admin (unrestricted, as today).
+
+- **Read uses EFFECTIVE scope, write uses DIRECT scope.**
+  - *Effective* = the object's own assignment groups **plus** its containers'
+    (action → sets/definitions; set → definitions). An action that runs on your
+    fleet via an assigned definition is *visible*.
+  - *Direct* = the object's own assignment groups only. Editing a set never
+    implies editing its member actions; a transitively-visible object is not
+    writable.
+
+- **Out-of-scope `Get` → `NotFound`** (never `PermissionDenied` — no existence
+  leak), with the true reason logged at WARN so denials are observable.
+  **Out-of-scope mutation → `PermissionDenied`.**
+
+### Why the index carries DIRECT group targets, not effective groups
+
+The search index field `scope_group_ids` (multi-value TAG on the four object
+indexes) holds only the object's **direct device-/user-group target** assignment
+ids — *not* effective groups, and *not* device/user targets resolved to groups.
+Rationale:
+
+- **Full freshness with no new cascade.** A direct group-target edge changes only
+  on the object's *own* `AssignmentCreated/Deleted`, which already reindexes the
+  object. There is no projection table, no container cascade, and no
+  membership-change cascade to keep correct — the field can never go stale-high
+  (the failure mode that would *leak*).
+- **Transitivity and device/user→group resolution are resolved live in the
+  handler** (`Get` effective walk; both `Get` and mutation resolve device/user
+  targets through membership). These are single-object lookups, always fresh.
+
+The cost is that a scope-restricted **Search** under-shows objects that are only
+*transitively* in scope, or assigned to an individual device/user rather than a
+group — they don't appear in the list, but remain readable via `Get`. This is
+**fail-closed** (a scoped admin sees *less*, never more) and the dominant case —
+objects assigned to a *group* — is exact. Full effective-search is a deferred
+refinement, not a leak.
+
+### No proto change
+
+Scope is derived server-side from the caller's JWT grants; no request field is
+added, so a client cannot widen its own scope. `scope_group_ids` is a
+**server-only** index field (`search.ServerScopeFields`) — populated and filtered
+by the server, never exposed as a client filter (the `scopeFilterFields` parity
+guard skips it).
+
+### Self-discovering parity
+
+`TestObjectScope_EnforcementMatchesIndexFiltering` AST-scans the package for
+`enforceObjectReadScope` / `enforceObjectWriteScope` calls and requires the set of
+handler-enforced object types to equal the set of search scopes declaring
+`scope_group_ids` (both ways, with a matches-zero guard). Index-filtering without
+handler enforcement (a `Get` leak) or vice-versa (a `Search` leak) fails the
+build.
+
+## Consequences
+
+- A scoped admin's object lists/reads/mutations are confined to their scope;
+  unassigned objects are invisible to them (managed only by global admins).
+- Global admins are entirely unaffected (the restricted-gate short-circuits
+  before any extra DB work).
+- **Known boundary (documented, fail-closed):** transitive-only and
+  individual-device/user-assigned objects under-show in `Search` for scoped
+  callers; they remain reachable via `Get`.
+- **Out of scope of this ADR — a related, broader leak:** the `Search` RPC also
+  applies *no* device/user scope today, so the device/user **list pages** (which
+  use `Search`, not the scoped `ListDevices`/`ListUsers` RPCs) leak the whole org
+  to a scoped admin. Closing it needs the same `scope_group_ids` mechanism on the
+  device/user indexes plus a membership-change reindex cascade — and, for
+  *dynamic* groups (whose re-evaluation emits a **bulk** `*MembersRebuilt` event,
+  not per-member), an explicit eventual-consistency tradeoff on an access-control
+  filter. That design decision is deferred to a follow-up rather than shipped
+  implicitly here.

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
-	github.com/jackc/pgx/v5 v5.9.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/manchtools/power-manage-sdk v0.5.1
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.9.0 h1:T/dI+2TvmI2H8s/KH1/lXIbz1CUFk3gn5oTjr0/mBsE=
-github.com/jackc/pgx/v5 v5.9.0/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/klauspost/compress v1.18.2 h1:iiPHWW0YrcFgpBYhsA6D1+fqHssJscY/Tm/y2Uqnapk=

--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -125,6 +125,10 @@ func (h *ActionHandler) GetAction(ctx context.Context, req *connect.Request[pm.G
 		return nil, err
 	}
 
+	if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "action", req.Msg.Id, ErrActionNotFound, "action not found"); err != nil {
+		return nil, err
+	}
+
 	action, err := h.store.Repos().Action.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
@@ -183,6 +187,10 @@ func (h *ActionHandler) RenameAction(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	// Verify action exists before appending event
 	if _, err := h.store.Repos().Action.Get(ctx, req.Msg.Id); err != nil {
 		if store.IsNotFound(err) {
@@ -222,6 +230,10 @@ func (h *ActionHandler) UpdateActionDescription(ctx context.Context, req *connec
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -268,6 +280,10 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -438,6 +454,10 @@ func (h *ActionHandler) DeleteAction(ctx context.Context, req *connect.Request[p
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action", req.Msg.Id); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -335,6 +335,13 @@ func (h *ActionSetHandler) AddActionToSet(ctx context.Context, req *connect.Requ
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
 	}
 
+	// The referenced action must be readable in the caller's scope (#7 spec 14):
+	// otherwise a scoped admin could pull an out-of-scope action into their
+	// in-scope set, making it deployable + transitively readable through the set.
+	if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "action", req.Msg.ActionId, ErrActionNotFound, "action not found"); err != nil {
+		return nil, err
+	}
+
 	// Verify action exists
 	action, err := h.store.Repos().Action.Get(ctx, req.Msg.ActionId)
 	if err != nil {

--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -89,6 +89,10 @@ func (h *ActionSetHandler) GetActionSet(ctx context.Context, req *connect.Reques
 		return nil, err
 	}
 
+	if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "action_set", req.Msg.Id, ErrActionSetNotFound, "action set not found"); err != nil {
+		return nil, err
+	}
+
 	set, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionSetNotFound, "action set not found")
@@ -161,6 +165,10 @@ func (h *ActionSetHandler) RenameActionSet(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action_set", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.Id,
@@ -194,6 +202,10 @@ func (h *ActionSetHandler) UpdateActionSetSchedule(ctx context.Context, req *con
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action_set", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -241,6 +253,10 @@ func (h *ActionSetHandler) UpdateActionSetDescription(ctx context.Context, req *
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action_set", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.Id,
@@ -275,6 +291,10 @@ func (h *ActionSetHandler) DeleteActionSet(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action_set", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.Id,
@@ -302,6 +322,10 @@ func (h *ActionSetHandler) AddActionToSet(ctx context.Context, req *connect.Requ
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action_set", req.Msg.SetId); err != nil {
 		return nil, err
 	}
 
@@ -358,6 +382,10 @@ func (h *ActionSetHandler) RemoveActionFromSet(ctx context.Context, req *connect
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action_set", req.Msg.SetId); err != nil {
+		return nil, err
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.SetId,
@@ -395,6 +423,10 @@ func (h *ActionSetHandler) ReorderActionInSet(ctx context.Context, req *connect.
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action_set", req.Msg.SetId); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -75,6 +75,10 @@ func (h *CompliancePolicyHandler) GetCompliancePolicy(ctx context.Context, req *
 		return nil, err
 	}
 
+	if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "compliance_policy", req.Msg.Id, ErrCompliancePolicyNotFound, "compliance policy not found"); err != nil {
+		return nil, err
+	}
+
 	policy, err := h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrCompliancePolicyNotFound, "compliance policy not found")
@@ -139,6 +143,10 @@ func (h *CompliancePolicyHandler) RenameCompliancePolicy(ctx context.Context, re
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "compliance_policy", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	// Verify policy exists before emitting event
 	_, err = h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.Id)
 	if err != nil {
@@ -176,6 +184,10 @@ func (h *CompliancePolicyHandler) UpdateCompliancePolicyDescription(ctx context.
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "compliance_policy", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -219,6 +231,10 @@ func (h *CompliancePolicyHandler) DeleteCompliancePolicy(ctx context.Context, re
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "compliance_policy", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	// Verify policy exists before emitting delete event
 	_, err = h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.Id)
 	if err != nil {
@@ -250,6 +266,10 @@ func (h *CompliancePolicyHandler) AddCompliancePolicyRule(ctx context.Context, r
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "compliance_policy", req.Msg.PolicyId); err != nil {
 		return nil, err
 	}
 
@@ -321,6 +341,10 @@ func (h *CompliancePolicyHandler) RemoveCompliancePolicyRule(ctx context.Context
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "compliance_policy", req.Msg.PolicyId); err != nil {
+		return nil, err
+	}
+
 	// Verify policy exists before emitting event
 	_, err = h.store.Repos().Compliance.GetPolicy(ctx, req.Msg.PolicyId)
 	if err != nil {
@@ -363,6 +387,10 @@ func (h *CompliancePolicyHandler) UpdateCompliancePolicyRule(ctx context.Context
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "compliance_policy", req.Msg.PolicyId); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -279,6 +279,13 @@ func (h *CompliancePolicyHandler) AddCompliancePolicyRule(ctx context.Context, r
 		return nil, handleGetError(ctx, err, ErrCompliancePolicyNotFound, "compliance policy not found")
 	}
 
+	// The referenced action must be readable in the caller's scope (#7 spec 14):
+	// otherwise a scoped admin could reference an out-of-scope action in their
+	// in-scope policy, applying unseen org-wide content to their fleet.
+	if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "action", req.Msg.ActionId, ErrActionNotFound, "action not found"); err != nil {
+		return nil, err
+	}
+
 	// Verify action exists and is a compliance action
 	action, err := h.store.Repos().Action.Get(ctx, req.Msg.ActionId)
 	if err != nil {

--- a/internal/api/definition_handler.go
+++ b/internal/api/definition_handler.go
@@ -88,6 +88,10 @@ func (h *DefinitionHandler) GetDefinition(ctx context.Context, req *connect.Requ
 		return nil, err
 	}
 
+	if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "definition", req.Msg.Id, ErrDefinitionNotFound, "definition not found"); err != nil {
+		return nil, err
+	}
+
 	def, err := h.store.Repos().Definition.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
@@ -159,6 +163,10 @@ func (h *DefinitionHandler) RenameDefinition(ctx context.Context, req *connect.R
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "definition", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.Id,
@@ -193,6 +201,10 @@ func (h *DefinitionHandler) UpdateDefinitionSchedule(ctx context.Context, req *c
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "definition", req.Msg.Id); err != nil {
 		return nil, err
 	}
 
@@ -240,6 +252,10 @@ func (h *DefinitionHandler) UpdateDefinitionDescription(ctx context.Context, req
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "definition", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.Id,
@@ -274,6 +290,10 @@ func (h *DefinitionHandler) DeleteDefinition(ctx context.Context, req *connect.R
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "definition", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.Id,
@@ -301,6 +321,10 @@ func (h *DefinitionHandler) AddActionSetToDefinition(ctx context.Context, req *c
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "definition", req.Msg.DefinitionId); err != nil {
 		return nil, err
 	}
 
@@ -357,6 +381,10 @@ func (h *DefinitionHandler) RemoveActionSetFromDefinition(ctx context.Context, r
 		return nil, err
 	}
 
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "definition", req.Msg.DefinitionId); err != nil {
+		return nil, err
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "definition",
 		StreamID:   req.Msg.DefinitionId,
@@ -394,6 +422,10 @@ func (h *DefinitionHandler) ReorderActionSetInDefinition(ctx context.Context, re
 
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "definition", req.Msg.DefinitionId); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/definition_handler.go
+++ b/internal/api/definition_handler.go
@@ -334,6 +334,13 @@ func (h *DefinitionHandler) AddActionSetToDefinition(ctx context.Context, req *c
 		return nil, handleGetError(ctx, err, ErrDefinitionNotFound, "definition not found")
 	}
 
+	// The referenced action set must be readable in the caller's scope (#7 spec
+	// 14): otherwise a scoped admin could attach an out-of-scope set to their
+	// in-scope definition, making it deployable + readable through the definition.
+	if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "action_set", req.Msg.ActionSetId, ErrActionSetNotFound, "action set not found"); err != nil {
+		return nil, err
+	}
+
 	// Verify action set exists
 	actionSet, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.ActionSetId)
 	if err != nil {

--- a/internal/api/object_scope.go
+++ b/internal/api/object_scope.go
@@ -1,0 +1,195 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+
+	"connectrpc.com/connect"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// Object-visibility scope enforcement (#7 spec 14). The four shared object types
+// (action, action_set, definition, compliance_policy) are confined to a scoped
+// admin by ASSIGNMENT: a caller scoped to device/user groups sees and manages
+// only objects assigned within those groups. Caller scope comes from the JWT
+// (auth.ObjectScopeListFilter — no DB round-trip); the object's groups are
+// resolved live here.
+//
+//   - READ  uses EFFECTIVE groups (the object's own assignments PLUS its
+//     containers' — an action that runs on your fleet via an assigned set/
+//     definition is visible). Out of scope → NotFound (never PermissionDenied —
+//     no existence leak), and the real reason is logged at WARN.
+//   - WRITE uses DIRECT groups only (a transitively-visible object is not
+//     editable). Out of scope → PermissionDenied.
+
+// objectScopeGroups resolves an object's scope groups. Behind an interface so the
+// enforcement decision logic (restricted-gate, intersection, error mapping) is
+// unit-testable without a database.
+type objectScopeGroups interface {
+	// effective returns the object's own assignment groups plus its containers'.
+	effective(ctx context.Context, objectType, id string) ([]string, error)
+	// direct returns only the object's own assignment groups.
+	direct(ctx context.Context, objectType, id string) ([]string, error)
+}
+
+// storeObjectScopeGroups resolves object scope groups from the projections.
+type storeObjectScopeGroups struct {
+	q        *db.Queries
+	resolver auth.ScopeResolver
+}
+
+// objScope builds the store-backed resolver for a handler's store.
+func objScope(st *store.Store) objectScopeGroups {
+	return storeObjectScopeGroups{q: st.Queries(), resolver: newScopeResolver(st)}
+}
+
+// resolveAssignmentGroups returns the device-/user-group ids an object is
+// directly assigned to: device_group/user_group targets contribute their id;
+// device/user targets are resolved through group membership (spec 14, criterion
+// 8). Shared by direct() and the container walk in effective().
+func (s storeObjectScopeGroups) resolveAssignmentGroups(ctx context.Context, objectType, id string) ([]string, error) {
+	assigns, err := s.q.ListAssignmentsForSource(ctx, db.ListAssignmentsForSourceParams{SourceType: objectType, SourceID: id})
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, a := range assigns {
+		switch a.TargetType {
+		case "device_group", "user_group":
+			out = append(out, a.TargetID)
+		case "device":
+			gs, err := s.resolver.DeviceGroupsForDevice(ctx, a.TargetID)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, gs...)
+		case "user":
+			gs, err := s.resolver.UserGroupsForUser(ctx, a.TargetID)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, gs...)
+		}
+	}
+	return out, nil
+}
+
+func (s storeObjectScopeGroups) direct(ctx context.Context, objectType, id string) ([]string, error) {
+	return s.resolveAssignmentGroups(ctx, objectType, id)
+}
+
+func (s storeObjectScopeGroups) effective(ctx context.Context, objectType, id string) ([]string, error) {
+	groups, err := s.resolveAssignmentGroups(ctx, objectType, id)
+	if err != nil {
+		return nil, err
+	}
+	switch objectType {
+	case "action":
+		// Containers: every set holding the action, and every definition holding
+		// one of those sets. (Definitions hold sets, not actions directly.)
+		setIDs, err := s.q.ListActionSetIDsContainingAction(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		defIDs := map[string]struct{}{}
+		for _, sid := range setIDs {
+			g, err := s.resolveAssignmentGroups(ctx, "action_set", sid)
+			if err != nil {
+				return nil, err
+			}
+			groups = append(groups, g...)
+			dids, err := s.q.ListDefinitionIDsContainingActionSet(ctx, sid)
+			if err != nil {
+				return nil, err
+			}
+			for _, did := range dids {
+				defIDs[did] = struct{}{}
+			}
+		}
+		for did := range defIDs {
+			g, err := s.resolveAssignmentGroups(ctx, "definition", did)
+			if err != nil {
+				return nil, err
+			}
+			groups = append(groups, g...)
+		}
+	case "action_set":
+		defIDs, err := s.q.ListDefinitionIDsContainingActionSet(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		for _, did := range defIDs {
+			g, err := s.resolveAssignmentGroups(ctx, "definition", did)
+			if err != nil {
+				return nil, err
+			}
+			groups = append(groups, g...)
+		}
+	}
+	// definition / compliance_policy are top-level — no containers.
+	return groups, nil
+}
+
+// enforceObjectReadScope confines a Get to the caller's scope. A scope-restricted
+// caller whose scope groups don't intersect the object's EFFECTIVE groups gets
+// notFoundErr (CodeNotFound) — never PermissionDenied, so existence isn't leaked
+// — while the true reason is logged at WARN so operators can see the denial
+// (spec 14, criterion 5). Unrestricted callers (global admins) are unaffected.
+func enforceObjectReadScope(ctx context.Context, groups objectScopeGroups, logger *slog.Logger, objectType, id, notFoundErr, notFoundMsg string) error {
+	callerGroups, restricted := auth.ObjectScopeListFilter(ctx)
+	if !restricted {
+		return nil
+	}
+	objGroups, err := groups.effective(ctx, objectType, id)
+	if err != nil {
+		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "scope resolution failed")
+	}
+	if groupsIntersect(callerGroups, objGroups) {
+		return nil
+	}
+	logger.Warn("out-of-scope object access denied (returning NotFound)",
+		"object_type", objectType, "object_id", id, "caller_scope_group_ids", callerGroups)
+	return apiErrorCtx(ctx, notFoundErr, connect.CodeNotFound, notFoundMsg)
+}
+
+// enforceObjectWriteScope confines a mutation to the caller's scope. A
+// scope-restricted caller whose scope groups don't intersect the object's DIRECT
+// groups gets PermissionDenied — including when the object is only transitively
+// visible (visible via a container, but not directly assigned to the caller).
+// Unrestricted callers are unaffected.
+func enforceObjectWriteScope(ctx context.Context, groups objectScopeGroups, logger *slog.Logger, objectType, id string) error {
+	callerGroups, restricted := auth.ObjectScopeListFilter(ctx)
+	if !restricted {
+		return nil
+	}
+	objGroups, err := groups.direct(ctx, objectType, id)
+	if err != nil {
+		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "scope resolution failed")
+	}
+	if groupsIntersect(callerGroups, objGroups) {
+		return nil
+	}
+	logger.Warn("out-of-scope object mutation denied",
+		"object_type", objectType, "object_id", id, "caller_scope_group_ids", callerGroups)
+	return apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "permission denied")
+}
+
+// groupsIntersect reports whether a and b share any element.
+func groupsIntersect(a, b []string) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return false
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, x := range a {
+		set[x] = struct{}{}
+	}
+	for _, y := range b {
+		if _, ok := set[y]; ok {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/object_scope_integration_test.go
+++ b/internal/api/object_scope_integration_test.go
@@ -134,3 +134,35 @@ func TestObjectScope_TransitiveRead_GetAllowed_WriteDenied(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err), "transitive visibility must not grant write")
 }
+
+// CR (Critical): a scoped admin who owns an in-scope set must not be able to add
+// an OUT-OF-SCOPE action to it — that would pull hidden org content into their
+// fleet and make it transitively readable. The referenced action gets a
+// read-scope check → NotFound (no existence leak).
+func TestObjectScope_AddActionToSet_OutOfScopeActionRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionSetHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet A")
+	dgOther := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet B")
+
+	setID := testutil.CreateTestActionSet(t, st, adminID, "My Set")
+	testutil.CreateTestAssignment(t, st, adminID, "action_set", setID, "device_group", dg, 0) // set in caller's scope
+
+	outOfScope := testutil.CreateTestAction(t, st, adminID, "Secret Action", 1)
+	testutil.CreateTestAssignment(t, st, adminID, "action", outOfScope, "device_group", dgOther, 0) // action out of scope
+
+	id, grants := scopedToGroup("scoped-admin", dg, "AddActionToSet", "GetAction")
+	ctx := testutil.AuthContextScoped(id, "s@test.com", []string{"AddActionToSet", "GetAction"}, grants)
+
+	_, err := h.AddActionToSet(ctx, connect.NewRequest(&pm.AddActionToSetRequest{SetId: setID, ActionId: outOfScope}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err), "out-of-scope referenced action must be rejected (NotFound)")
+
+	// Sanity: an in-scope action CAN be added to the set.
+	inScope := testutil.CreateTestAction(t, st, adminID, "Own Action", 1)
+	testutil.CreateTestAssignment(t, st, adminID, "action", inScope, "device_group", dg, 0)
+	_, err = h.AddActionToSet(ctx, connect.NewRequest(&pm.AddActionToSetRequest{SetId: setID, ActionId: inScope}))
+	require.NoError(t, err)
+}

--- a/internal/api/object_scope_integration_test.go
+++ b/internal/api/object_scope_integration_test.go
@@ -1,0 +1,136 @@
+package api_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// scopedToGroup builds a caller confined to a single device group (#7 spec 14).
+// The permission strings are irrelevant to ObjectScopeListFilter (it keys off the
+// grant's scope kind/id), but we include the object permission so the context is
+// realistic.
+func scopedToGroup(id, groupID string, perms ...string) (string, []auth.ScopedGrant) {
+	grants := make([]auth.ScopedGrant, 0, len(perms))
+	for _, p := range perms {
+		grants = append(grants, auth.ScopedGrant{Permission: p, ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: groupID})
+	}
+	return id, grants
+}
+
+func TestObjectScope_GetActionSet_InScope_Allowed(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionSetHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet A")
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Set A")
+	testutil.CreateTestAssignment(t, st, adminID, "action_set", setID, "device_group", dg, 0)
+
+	id, grants := scopedToGroup("scoped-admin", dg, "GetActionSet")
+	ctx := testutil.AuthContextScoped(id, "s@test.com", []string{"GetActionSet"}, grants)
+
+	resp, err := h.GetActionSet(ctx, connect.NewRequest(&pm.GetActionSetRequest{Id: setID}))
+	require.NoError(t, err)
+	assert.Equal(t, setID, resp.Msg.Set.Id)
+}
+
+func TestObjectScope_GetActionSet_OutOfScope_NotFound(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionSetHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	dgA := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet A")
+	dgB := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet B")
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Set A")
+	testutil.CreateTestAssignment(t, st, adminID, "action_set", setID, "device_group", dgA, 0)
+
+	// Caller scoped to a DIFFERENT group than the set is assigned to.
+	id, grants := scopedToGroup("scoped-admin", dgB, "GetActionSet")
+	ctx := testutil.AuthContextScoped(id, "s@test.com", []string{"GetActionSet"}, grants)
+
+	_, err := h.GetActionSet(ctx, connect.NewRequest(&pm.GetActionSetRequest{Id: setID}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err), "out-of-scope must be NotFound, never PermissionDenied")
+}
+
+func TestObjectScope_GetActionSet_Unassigned_NotFound(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionSetHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet A")
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Orphan Set") // never assigned
+
+	id, grants := scopedToGroup("scoped-admin", dg, "GetActionSet")
+	ctx := testutil.AuthContextScoped(id, "s@test.com", []string{"GetActionSet"}, grants)
+
+	_, err := h.GetActionSet(ctx, connect.NewRequest(&pm.GetActionSetRequest{Id: setID}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err), "unassigned object is invisible to a scoped admin (fail closed)")
+}
+
+func TestObjectScope_RenameActionSet_OutOfScope_PermissionDenied(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionSetHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	dgA := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet A")
+	dgB := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet B")
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Set A")
+	testutil.CreateTestAssignment(t, st, adminID, "action_set", setID, "device_group", dgA, 0)
+
+	id, grants := scopedToGroup("scoped-admin", dgB, "RenameActionSet")
+	ctx := testutil.AuthContextScoped(id, "s@test.com", []string{"RenameActionSet"}, grants)
+
+	_, err := h.RenameActionSet(ctx, connect.NewRequest(&pm.RenameActionSetRequest{Id: setID, Name: "Hijack"}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	// Sanity: an in-scope caller CAN rename it.
+	idOK, grantsOK := scopedToGroup("scoped-ok", dgA, "RenameActionSet")
+	ctxOK := testutil.AuthContextScoped(idOK, "ok@test.com", []string{"RenameActionSet"}, grantsOK)
+	_, err = h.RenameActionSet(ctxOK, connect.NewRequest(&pm.RenameActionSetRequest{Id: setID, Name: "Renamed"}))
+	require.NoError(t, err)
+}
+
+// TransitiveRead: an action is only a MEMBER of an assigned set (not directly
+// assigned). A scoped admin can READ it (effective scope, criterion 4) but cannot
+// WRITE it (direct scope, criterion 6).
+func TestObjectScope_TransitiveRead_GetAllowed_WriteDenied(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	setH := api.NewActionSetHandler(st, slog.Default())
+	actH := api.NewActionHandler(st, slog.Default(), nil)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	adminCtx := testutil.AdminContext(adminID)
+	dg := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet A")
+
+	actionID := testutil.CreateTestAction(t, st, adminID, "Member Action", 1)
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Container Set")
+	_, err := setH.AddActionToSet(adminCtx, connect.NewRequest(&pm.AddActionToSetRequest{SetId: setID, ActionId: actionID}))
+	require.NoError(t, err)
+	// Only the SET is assigned to the group; the action is in-scope only transitively.
+	testutil.CreateTestAssignment(t, st, adminID, "action_set", setID, "device_group", dg, 0)
+
+	id, grants := scopedToGroup("scoped-admin", dg, "GetAction", "RenameAction")
+	ctx := testutil.AuthContextScoped(id, "s@test.com", []string{"GetAction", "RenameAction"}, grants)
+
+	// Read: allowed via the container (effective scope).
+	getResp, err := actH.GetAction(ctx, connect.NewRequest(&pm.GetActionRequest{Id: actionID}))
+	require.NoError(t, err, "transitively in-scope action must be readable")
+	assert.Equal(t, actionID, getResp.Msg.Action.Id)
+
+	// Write: denied — the action is not DIRECTLY assigned to the caller's group.
+	_, err = actH.RenameAction(ctx, connect.NewRequest(&pm.RenameActionRequest{Id: actionID, Name: "Hijack"}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err), "transitive visibility must not grant write")
+}

--- a/internal/api/object_scope_parity_test.go
+++ b/internal/api/object_scope_parity_test.go
@@ -114,7 +114,22 @@ func TestObjectScope_EnforcementMatchesIndexFiltering(t *testing.T) {
 	require.Emptyf(t, missingWrite, "object types with no mutation/write scope enforcement: %s", strings.Join(missingWrite, ", "))
 
 	for scope := range scopesWithScopeGroupField {
+		if searchScopedNonObjectScopes[scope] {
+			continue
+		}
 		_, ok := scopeToType[scope]
 		require.Truef(t, ok, "index scope %q declares scope_group_ids but no object type / handler enforcement maps to it — Get would leak", scope)
 	}
+}
+
+// searchScopedNonObjectScopes are the non-object search scopes that also carry the
+// scope_group_ids TAG (#7 spec 14). They are NOT confined by enforceObjectReadScope
+// / enforceObjectWriteScope; their Search is filtered in scopeGroupClause via the
+// dedicated device-/user-group list filters (DeviceScopeListFilter("ListDevices") /
+// UserScopeListFilter("ListUsers")), and their per-object Get is already confined by
+// the existing device/user handler scope (covered by scope_enforcement_*_test.go and
+// TestScopablePermissions_AllEnforced). So the object-parity reverse check skips them.
+var searchScopedNonObjectScopes = map[string]bool{
+	"devices": true,
+	"users":   true,
 }

--- a/internal/api/object_scope_parity_test.go
+++ b/internal/api/object_scope_parity_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// objectTypeToIndexScope bridges the singular assignment/object type used by the
+// handler scope enforcement ("action_set") to the plural search index scope used
+// by the FT index ("action_sets"). It is the canonical set of scopable object
+// types (#7 spec 14). A new object type forces an entry here, which forces the
+// index-field + read/write-enforcement assertions below.
+var objectTypeToIndexScope = map[string]string{
+	"action":            "actions",
+	"action_set":        "action_sets",
+	"definition":        "definitions",
+	"compliance_policy": "compliance_policies",
+}
+
+// TestObjectScope_EnforcementMatchesIndexFiltering is the self-discovering guard
+// for #7 spec 14: the object types enforced at the handler boundary
+// (enforceObjectReadScope / enforceObjectWriteScope) MUST be exactly the search
+// scopes whose index declares the scope_group_ids TAG (scopesWithScopeGroupField,
+// itself derived from the schemas). If they diverge, scope leaks:
+//
+//   - an index field with no handler enforcement → Get/mutation leaks the object;
+//   - handler enforcement with no index field → Search leaks the whole catalog.
+//
+// The enforced set is DISCOVERED by AST-scanning this package for the two
+// enforcement calls and collecting their object-type literal — not a hardcoded
+// list — so forgetting to wire a new object type fails the build.
+func TestObjectScope_EnforcementMatchesIndexFiltering(t *testing.T) {
+	readEnforced := map[string]bool{}
+	writeEnforced := map[string]bool{}
+
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	sawFile := false
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		sawFile = true
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		require.NoErrorf(t, err, "parse %s", name)
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			fn := calleeName(call.Fun)
+			var sink map[string]bool
+			switch fn {
+			case "enforceObjectReadScope":
+				sink = readEnforced
+			case "enforceObjectWriteScope":
+				sink = writeEnforced
+			default:
+				return true
+			}
+			// The object type is the first string-literal argument.
+			for _, arg := range call.Args {
+				if s, ok := stringLit(arg); ok {
+					sink[s] = true
+					break
+				}
+			}
+			return true
+		})
+	}
+	require.True(t, sawFile, "scanned zero source files — discovery is broken")
+	require.NotEmpty(t, readEnforced, "no enforceObjectReadScope calls discovered — the guard would vacuously pass")
+	require.NotEmpty(t, writeEnforced, "no enforceObjectWriteScope calls discovered — the guard would vacuously pass")
+
+	// Every discovered object type must be a known scopable type with an index
+	// scope, and must carry the scope_group_ids field on that index.
+	for _, sink := range []map[string]bool{readEnforced, writeEnforced} {
+		for objType := range sink {
+			scope, ok := objectTypeToIndexScope[objType]
+			require.Truef(t, ok, "object type %q is scope-enforced but has no objectTypeToIndexScope mapping", objType)
+			require.Truef(t, scopesWithScopeGroupField[scope],
+				"object type %q (index scope %q) is handler-enforced but its index does not declare scope_group_ids — Search would leak the whole catalog", objType, scope)
+		}
+	}
+
+	// Every object type must have BOTH read and write enforcement, and every
+	// scope_group_ids index scope must correspond to an enforced object type
+	// (no index field without handler enforcement → Get leak).
+	var missingRead, missingWrite []string
+	scopeToType := map[string]string{}
+	for objType, scope := range objectTypeToIndexScope {
+		scopeToType[scope] = objType
+		if !readEnforced[objType] {
+			missingRead = append(missingRead, objType)
+		}
+		if !writeEnforced[objType] {
+			missingWrite = append(missingWrite, objType)
+		}
+	}
+	sort.Strings(missingRead)
+	sort.Strings(missingWrite)
+	require.Emptyf(t, missingRead, "object types with no Get/read scope enforcement: %s", strings.Join(missingRead, ", "))
+	require.Emptyf(t, missingWrite, "object types with no mutation/write scope enforcement: %s", strings.Join(missingWrite, ", "))
+
+	for scope := range scopesWithScopeGroupField {
+		_, ok := scopeToType[scope]
+		require.Truef(t, ok, "index scope %q declares scope_group_ids but no object type / handler enforcement maps to it — Get would leak", scope)
+	}
+}

--- a/internal/api/object_scope_test.go
+++ b/internal/api/object_scope_test.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+)
+
+// fakeObjectScopeGroups returns canned effective/direct groups (or an error) so
+// the scope-enforcement DECISION logic is testable without a database.
+type fakeObjectScopeGroups struct {
+	eff, dir []string
+	err      error
+}
+
+func (f fakeObjectScopeGroups) effective(context.Context, string, string) ([]string, error) {
+	return f.eff, f.err
+}
+func (f fakeObjectScopeGroups) direct(context.Context, string, string) ([]string, error) {
+	return f.dir, f.err
+}
+
+func ctxScoped(groupIDs ...string) context.Context {
+	var grants []auth.ScopedGrant
+	for _, id := range groupIDs {
+		grants = append(grants, auth.ScopedGrant{Permission: "ListDevices", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: id})
+	}
+	return auth.WithUser(context.Background(), &auth.UserContext{ID: "caller", ScopedGrants: grants})
+}
+
+func ctxUnrestricted() context.Context {
+	return auth.WithUser(context.Background(), &auth.UserContext{ID: "admin"})
+}
+
+func discardLogger() *slog.Logger { return slog.New(slog.NewTextHandler(io.Discard, nil)) }
+
+func TestEnforceObjectReadScope(t *testing.T) {
+	log := discardLogger()
+
+	t.Run("unrestricted caller is always allowed, even out of scope", func(t *testing.T) {
+		err := enforceObjectReadScope(ctxUnrestricted(), fakeObjectScopeGroups{eff: nil}, log,
+			"action_set", "as1", ErrActionSetNotFound, "action set not found")
+		assert.NoError(t, err)
+	})
+
+	t.Run("scoped caller in effective scope is allowed", func(t *testing.T) {
+		err := enforceObjectReadScope(ctxScoped("dg1"), fakeObjectScopeGroups{eff: []string{"dg9", "dg1"}}, log,
+			"action_set", "as1", ErrActionSetNotFound, "action set not found")
+		assert.NoError(t, err)
+	})
+
+	t.Run("scoped caller out of effective scope gets NotFound (no existence leak)", func(t *testing.T) {
+		err := enforceObjectReadScope(ctxScoped("dg1"), fakeObjectScopeGroups{eff: []string{"dg9"}}, log,
+			"action_set", "as1", ErrActionSetNotFound, "action set not found")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err), "must be NotFound, never PermissionDenied")
+	})
+
+	t.Run("scoped caller, unassigned object (no groups) gets NotFound", func(t *testing.T) {
+		err := enforceObjectReadScope(ctxScoped("dg1"), fakeObjectScopeGroups{eff: nil}, log,
+			"definition", "d1", ErrDefinitionNotFound, "definition not found")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	})
+
+	t.Run("resolution error maps to Internal, not a silent allow", func(t *testing.T) {
+		err := enforceObjectReadScope(ctxScoped("dg1"), fakeObjectScopeGroups{err: errors.New("db down")}, log,
+			"action", "a1", ErrActionNotFound, "action not found")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+	})
+}
+
+func TestEnforceObjectWriteScope(t *testing.T) {
+	log := discardLogger()
+
+	t.Run("unrestricted caller is always allowed", func(t *testing.T) {
+		err := enforceObjectWriteScope(ctxUnrestricted(), fakeObjectScopeGroups{dir: nil}, log, "action_set", "as1")
+		assert.NoError(t, err)
+	})
+
+	t.Run("scoped caller directly in scope is allowed", func(t *testing.T) {
+		err := enforceObjectWriteScope(ctxScoped("dg1"), fakeObjectScopeGroups{dir: []string{"dg1"}}, log, "action_set", "as1")
+		assert.NoError(t, err)
+	})
+
+	t.Run("scoped caller out of DIRECT scope gets PermissionDenied", func(t *testing.T) {
+		err := enforceObjectWriteScope(ctxScoped("dg1"), fakeObjectScopeGroups{dir: []string{"dg9"}}, log, "action_set", "as1")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("transitive-only object (effective in scope, direct not) is NOT writable", func(t *testing.T) {
+		// Direct groups are out of scope even though effective (a container) would
+		// be in scope — write must key off DIRECT only.
+		err := enforceObjectWriteScope(ctxScoped("dg1"), fakeObjectScopeGroups{dir: []string{"dg9"}, eff: []string{"dg1"}}, log, "action", "a1")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	})
+
+	t.Run("resolution error maps to Internal", func(t *testing.T) {
+		err := enforceObjectWriteScope(ctxScoped("dg1"), fakeObjectScopeGroups{err: errors.New("db down")}, log, "action", "a1")
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+	})
+}

--- a/internal/api/scope_group_clause_test.go
+++ b/internal/api/scope_group_clause_test.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+)
+
+// scopeGroupClause (#7 spec 14) confines a scope-restricted caller's Search.
+// Devices key off the caller's ListDevices device-group scope, users off the
+// ListUsers user-group scope, and the four object scopes off the union
+// ObjectScopeListFilter — all read from the JWT-backed context, no DB.
+func TestScopeGroupClause(t *testing.T) {
+	deviceScoped := auth.WithUser(context.Background(), &auth.UserContext{
+		ID:           "c",
+		Permissions:  []string{"ListDevices"},
+		ScopedGrants: []auth.ScopedGrant{{Permission: "ListDevices", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: "dg1"}},
+	})
+	userScoped := auth.WithUser(context.Background(), &auth.UserContext{
+		ID:           "c",
+		Permissions:  []string{"ListUsers"},
+		ScopedGrants: []auth.ScopedGrant{{Permission: "ListUsers", ScopeKind: auth.ScopeKindUserGroup, ScopeID: "ug1"}},
+	})
+	objectScoped := auth.WithUser(context.Background(), &auth.UserContext{
+		ID:           "c",
+		ScopedGrants: []auth.ScopedGrant{{Permission: "ListDevices", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: "dg9"}},
+	})
+	unrestricted := auth.WithUser(context.Background(), &auth.UserContext{ID: "admin"})
+
+	t.Run("devices use the caller's device-group scope", func(t *testing.T) {
+		assert.Equal(t, "@scope_group_ids:{dg1}", scopeGroupClause(deviceScoped, "devices"))
+	})
+	t.Run("users use the caller's user-group scope", func(t *testing.T) {
+		assert.Equal(t, "@scope_group_ids:{ug1}", scopeGroupClause(userScoped, "users"))
+	})
+	t.Run("object scopes use the union object filter", func(t *testing.T) {
+		assert.Equal(t, "@scope_group_ids:{dg9}", scopeGroupClause(objectScoped, "actions"))
+	})
+	t.Run("a device-scoped caller is unrestricted on the USERS scope", func(t *testing.T) {
+		// Wrong-axis: device-group scope must not confine user Search.
+		assert.Equal(t, "", scopeGroupClause(deviceScoped, "users"))
+	})
+	t.Run("unrestricted caller gets no clause", func(t *testing.T) {
+		assert.Equal(t, "", scopeGroupClause(unrestricted, "devices"))
+		assert.Equal(t, "", scopeGroupClause(unrestricted, "actions"))
+	})
+	t.Run("non-scope-filtered scope gets no clause", func(t *testing.T) {
+		assert.Equal(t, "", scopeGroupClause(deviceScoped, "executions"))
+		assert.Equal(t, "", scopeGroupClause(deviceScoped, "device_groups"))
+	})
+}

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -12,8 +12,53 @@ import (
 	"connectrpc.com/connect"
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/search"
 )
+
+// scopesWithScopeGroupField are the search scopes whose index declares the
+// server-only scope_group_ids TAG (#7 spec 14 — scoped object visibility).
+// Derived from the index schemas so it can never drift from what's declared. A
+// scope-restricted caller's Search on these scopes is confined to objects whose
+// assignment groups intersect the caller's scope groups.
+var scopesWithScopeGroupField = func() map[string]bool {
+	out := map[string]bool{}
+	for _, ix := range search.IndexSchemas {
+		if ix.FilterableFields()[search.ScopeGroupField] {
+			out[ix.Scope()] = true
+		}
+	}
+	return out
+}()
+
+// noScopeSentinel is a TAG value no real object carries. A scope-restricted
+// caller with no resolvable scope groups (only possible with no authenticated
+// caller, behind the interceptor) gets a clause matching it, so the result is
+// empty — fail closed, never fail open to the whole catalog.
+const noScopeSentinel = "__pm_no_scope__"
+
+// scopeGroupClause returns the RediSearch clause confining a scope-restricted
+// caller to objects assigned within their scope groups (#7 spec 14), or "" when
+// the scope carries no scope_group_ids field or the caller is unrestricted
+// (global admin). Caller scope is read from the JWT — no DB round-trip (spec 14,
+// criterion 13).
+func scopeGroupClause(ctx context.Context, scope string) string {
+	if !scopesWithScopeGroupField[scope] {
+		return ""
+	}
+	groupIDs, restricted := auth.ObjectScopeListFilter(ctx)
+	if !restricted {
+		return ""
+	}
+	if len(groupIDs) == 0 {
+		return fmt.Sprintf("@%s:{%s}", search.ScopeGroupField, noScopeSentinel)
+	}
+	escaped := make([]string, len(groupIDs))
+	for i, id := range groupIDs {
+		escaped[i] = escapeRediSearchTagValue(id)
+	}
+	return fmt.Sprintf("@%s:{%s}", search.ScopeGroupField, strings.Join(escaped, "|"))
+}
 
 // SearchHandler handles search and search index management RPCs.
 type SearchHandler struct {
@@ -277,7 +322,20 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 			continue
 		}
 
-		args := []any{"FT.SEARCH", idxName, ftQuery}
+		// #7 spec 14: confine a scope-restricted caller to objects assigned within
+		// their scope groups. Per-scope (only object indexes carry the field) and
+		// derived from the caller's JWT — no DB round-trip. Mirrors the
+		// deviceStatusClause "*"-vs-append handling.
+		scopedQuery := ftQuery
+		if clause := scopeGroupClause(ctx, scope); clause != "" {
+			if scopedQuery == "*" {
+				scopedQuery = clause
+			} else {
+				scopedQuery += " " + clause
+			}
+		}
+
+		args := []any{"FT.SEARCH", idxName, scopedQuery}
 
 		// SORTBY: the request's sort_field/direction validated against the scope,
 		// falling back to the scope default when unset (#325).

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -46,7 +46,19 @@ func scopeGroupClause(ctx context.Context, scope string) string {
 	if !scopesWithScopeGroupField[scope] {
 		return ""
 	}
-	groupIDs, restricted := auth.ObjectScopeListFilter(ctx)
+	var groupIDs []string
+	var restricted bool
+	switch scope {
+	case "devices":
+		// Device Search mirrors the dedicated ListDevices scope: confine to the
+		// caller's device-group scope.
+		groupIDs, restricted = auth.DeviceScopeListFilter(ctx, "ListDevices")
+	case "users":
+		groupIDs, restricted = auth.UserScopeListFilter(ctx, "ListUsers")
+	default:
+		// The four object scopes share the caller's union device-/user-group scope.
+		groupIDs, restricted = auth.ObjectScopeListFilter(ctx)
+	}
 	if !restricted {
 		return ""
 	}

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -135,19 +135,44 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 		string(eventtypes.DeviceGroupDescriptionUpdated),
 		string(eventtypes.DeviceGroupQueryUpdated),
 		string(eventtypes.DeviceGroupSyncIntervalSet),
-		string(eventtypes.DeviceGroupMaintenanceWindowSet),
-		string(eventtypes.DeviceGroupMemberAdded),
-		string(eventtypes.DeviceGroupMemberRemoved):
+		string(eventtypes.DeviceGroupMaintenanceWindowSet):
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeDeviceGroup, ID: e.StreamID}}
+
+	// Membership change (static admin add/remove, or legacy aliases): reindex the
+	// GROUP (member_count) AND the affected DEVICE (its scope_group_ids changed,
+	// #7 spec 14). device_id rides in the payload; StreamID is the group id.
+	case string(eventtypes.DeviceGroupMemberAdded),
+		string(eventtypes.DeviceGroupMemberRemoved),
+		string(eventtypes.DeviceAddedToGroup),
+		string(eventtypes.DeviceRemovedFromGroup):
+		ops := []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeDeviceGroup, ID: e.StreamID}}
+		var p struct {
+			DeviceID string `json:"device_id"`
+		}
+		if json.Unmarshal(e.Data, &p) == nil && p.DeviceID != "" {
+			ops = append(ops, SearchAffected{Op: SearchOpReindex, Scope: search.ScopeDevice, ID: p.DeviceID})
+		}
+		return ops
+
+	// Dynamic re-evaluation delta (#7 spec 14): reindex the group + every device
+	// whose membership changed this evaluation.
+	case string(eventtypes.DeviceGroupMembersReevaluated):
+		ops := []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeDeviceGroup, ID: e.StreamID}}
+		var p struct {
+			Added   []string `json:"added_device_ids"`
+			Removed []string `json:"removed_device_ids"`
+		}
+		if json.Unmarshal(e.Data, &p) == nil {
+			for _, id := range append(p.Added, p.Removed...) {
+				if id != "" {
+					ops = append(ops, SearchAffected{Op: SearchOpReindex, Scope: search.ScopeDevice, ID: id})
+				}
+			}
+		}
+		return ops
 
 	case string(eventtypes.DeviceGroupDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeDeviceGroup, ID: e.StreamID}}
-
-	// DeviceAddedToGroup / DeviceRemovedFromGroup / DeviceGroupAssigned
-	// / DeviceGroupUnassigned do not change device_groups_projection
-	// fields directly — they live on different relationship tables.
-	// The DeviceGroupMemberAdded/Removed cases above already cover
-	// the membership-count refresh.
 
 	// ---------------------------------------------------------
 	// UserGroup scope
@@ -172,15 +197,45 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// listener (#77) — the user_id / role_id suffixes are irrelevant
 	// to the search payload (member_count + role list are already
 	// denormalised on the projection row by the projector).
+	// Member events: composite StreamID "<group_id>:<user_id>" — reindex the group
+	// (member_count) AND the affected user (its scope_group_ids changed, #7 spec 14).
 	case string(eventtypes.UserGroupMemberAdded),
-		string(eventtypes.UserGroupMemberRemoved),
-		string(eventtypes.UserGroupRoleAssigned),
+		string(eventtypes.UserGroupMemberRemoved):
+		groupID, userID, _ := strings.Cut(e.StreamID, ":")
+		if groupID == "" {
+			return nil
+		}
+		ops := []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeUserGroup, ID: groupID}}
+		if userID != "" {
+			ops = append(ops, SearchAffected{Op: SearchOpReindex, Scope: search.ScopeUser, ID: userID})
+		}
+		return ops
+
+	// Role events: composite StreamID "<group_id>:role:<role_id>" — group only.
+	case string(eventtypes.UserGroupRoleAssigned),
 		string(eventtypes.UserGroupRoleRevoked):
 		groupID, _, _ := strings.Cut(e.StreamID, ":")
 		if groupID == "" {
 			return nil
 		}
 		return []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeUserGroup, ID: groupID}}
+
+	// Dynamic re-evaluation delta (#7 spec 14): reindex the group + every user
+	// whose membership changed. StreamID is the group id (not composite).
+	case string(eventtypes.UserGroupMembersReevaluated):
+		ops := []SearchAffected{{Op: SearchOpReindex, Scope: search.ScopeUserGroup, ID: e.StreamID}}
+		var p struct {
+			Added   []string `json:"added_user_ids"`
+			Removed []string `json:"removed_user_ids"`
+		}
+		if json.Unmarshal(e.Data, &p) == nil {
+			for _, id := range append(p.Added, p.Removed...) {
+				if id != "" {
+					ops = append(ops, SearchAffected{Op: SearchOpReindex, Scope: search.ScopeUser, ID: id})
+				}
+			}
+		}
+		return ops
 
 	// ---------------------------------------------------------
 	// Execution scope
@@ -428,6 +483,28 @@ func loadScopeGroupIDs(ctx context.Context, q *db.Queries, sourceType, id string
 	return strings.Join(ids, ","), nil
 }
 
+// loadDeviceScopeGroupIDs / loadUserScopeGroupIDs return the comma-joined sorted
+// group ids a device/user belongs to, for the device/user search `scope_group_ids`
+// TAG (#7 spec 14). Same source as the auth ScopeResolver, so search confinement
+// matches handler enforcement.
+func loadDeviceScopeGroupIDs(ctx context.Context, q *db.Queries, deviceID string) (string, error) {
+	ids, err := q.ListDeviceGroupIDsForDevice(ctx, deviceID)
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ","), nil
+}
+
+func loadUserScopeGroupIDs(ctx context.Context, q *db.Queries, userID string) (string, error) {
+	ids, err := q.ListUserGroupIDsForUser(ctx, userID)
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ","), nil
+}
+
 func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Logger, scope, id string) (*taskqueue.SearchEntityData, error) {
 	q := st.Queries()
 	switch scope {
@@ -448,14 +525,20 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if u.LastLoginAt != nil {
 			lastLoginAt = u.LastLoginAt.Unix()
 		}
+		scopeGroups, err := loadUserScopeGroupIDs(ctx, q, id)
+		if err != nil {
+			return nil, err
+		}
 		return &taskqueue.SearchEntityData{
-			Email:         u.Email,
-			DisplayName:   u.DisplayName,
-			LinuxUsername: u.LinuxUsername,
-			Disabled:      disabled,
-			Role:          u.Role,
-			LastLoginAt:   lastLoginAt,
-			CreatedAt:     createdAt,
+			Email:            u.Email,
+			DisplayName:      u.DisplayName,
+			LinuxUsername:    u.LinuxUsername,
+			Disabled:         disabled,
+			Role:             u.Role,
+			LastLoginAt:      lastLoginAt,
+			CreatedAt:        createdAt,
+			ScopeGroupIDs:    scopeGroups,
+			HasScopeGroupIDs: true,
 		}, nil
 
 	case search.ScopeDevice:
@@ -479,6 +562,10 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if d.LastSeenAt != nil {
 			lastSeenAt = d.LastSeenAt.Unix()
 		}
+		scopeGroups, err := loadDeviceScopeGroupIDs(ctx, q, id)
+		if err != nil {
+			return nil, err
+		}
 		data := &taskqueue.SearchEntityData{
 			Hostname:         d.Hostname,
 			AgentVersion:     d.AgentVersion,
@@ -486,6 +573,8 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 			ComplianceStatus: d.ComplianceStatus,
 			RegisteredAt:     registeredAt,
 			LastSeenAt:       lastSeenAt,
+			ScopeGroupIDs:    scopeGroups,
+			HasScopeGroupIDs: true,
 		}
 		// Inventory enrichment is best-effort — matches the
 		// handler-side helper in device_handler.go. A missing

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -277,9 +278,10 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 	// Assignment scope — reindex the SOURCE entity's `assigned` TAG (#325).
 	// ---------------------------------------------------------
 	// StreamID is the assignment id; the source tuple rides in the payload
-	// (both Created and Deleted emit it). A compliance_policy source has no
-	// `assigned` field, and a legacy AssignmentDeleted with an empty payload
-	// is a no-op — the periodic reconciler/warm rebuild is the safety net.
+	// (both Created and Deleted emit it). All four object source types carry
+	// `scope_group_ids` (#7 spec 14), so every assignment change reindexes its
+	// source. A legacy AssignmentDeleted with an empty payload is a no-op — the
+	// periodic reconciler/warm rebuild is the safety net.
 	case string(eventtypes.AssignmentCreated),
 		string(eventtypes.AssignmentDeleted):
 		var p struct {
@@ -300,8 +302,10 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 }
 
 // assignmentSourceScope maps an assignment source_type to the search scope whose
-// `assigned` TAG it affects, or "" for types that carry no such TAG
-// (compliance_policy / unknown).
+// `assigned` / `scope_group_ids` TAG it affects, or "" for an unknown type. All
+// four object types carry `scope_group_ids` (#7 spec 14), so compliance_policy —
+// which has no `assigned` TAG but IS scope-filtered — must reindex on assignment
+// too.
 func assignmentSourceScope(sourceType string) string {
 	switch sourceType {
 	case "action":
@@ -310,6 +314,8 @@ func assignmentSourceScope(sourceType string) string {
 		return search.ScopeActionSet
 	case "definition":
 		return search.ScopeDefinition
+	case "compliance_policy":
+		return search.ScopeCompliancePolicy
 	}
 	return ""
 }
@@ -406,6 +412,20 @@ func sourceAssignedTag(ctx context.Context, q *db.Queries, sourceType, id string
 		return "true", nil
 	}
 	return "false", nil
+}
+
+// loadScopeGroupIDs returns the comma-joined, sorted device-/user-group ids the
+// object is DIRECTLY assigned to, for the search index `scope_group_ids` TAG (#7
+// spec 14). Sorted so the indexed value is deterministic (stable tests; stable
+// HSET). An unassigned object returns "" — written as an empty TAG so it matches
+// no scoped query and stays invisible to scoped admins.
+func loadScopeGroupIDs(ctx context.Context, q *db.Queries, sourceType, id string) (string, error) {
+	ids, err := q.ListScopeGroupIDsForSource(ctx, db.ListScopeGroupIDsForSourceParams{SourceType: sourceType, SourceID: id})
+	if err != nil {
+		return "", err
+	}
+	sort.Strings(ids)
+	return strings.Join(ids, ","), nil
 }
 
 func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Logger, scope, id string) (*taskqueue.SearchEntityData, error) {
@@ -518,13 +538,19 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if err != nil {
 			return nil, err
 		}
+		scopeGroups, err := loadScopeGroupIDs(ctx, q, "action_set", id)
+		if err != nil {
+			return nil, err
+		}
 		return &taskqueue.SearchEntityData{
-			Name:        s.Name,
-			Description: s.Description,
-			MemberCount: s.MemberCount,
-			Assigned:    assigned,
-			CreatedAt:   createdAt,
-			UpdatedAt:   updatedAt,
+			Name:             s.Name,
+			Description:      s.Description,
+			MemberCount:      s.MemberCount,
+			Assigned:         assigned,
+			ScopeGroupIDs:    scopeGroups,
+			HasScopeGroupIDs: true,
+			CreatedAt:        createdAt,
+			UpdatedAt:        updatedAt,
 		}, nil
 
 	case search.ScopeCompliancePolicy:
@@ -532,9 +558,15 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if err != nil {
 			return nil, err
 		}
+		scopeGroups, err := loadScopeGroupIDs(ctx, q, "compliance_policy", id)
+		if err != nil {
+			return nil, err
+		}
 		data := &taskqueue.SearchEntityData{
-			Name:        p.Name,
-			Description: p.Description,
+			Name:             p.Name,
+			Description:      p.Description,
+			ScopeGroupIDs:    scopeGroups,
+			HasScopeGroupIDs: true,
 		}
 		if p.CreatedAt != nil {
 			data.CreatedAt = p.CreatedAt.Unix()
@@ -597,14 +629,20 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if err != nil {
 			return nil, err
 		}
+		scopeGroups, err := loadScopeGroupIDs(ctx, q, "action", id)
+		if err != nil {
+			return nil, err
+		}
 		return &taskqueue.SearchEntityData{
-			Name:         a.Name,
-			Description:  desc,
-			Type:         a.ActionType,
-			IsCompliance: isCompliance,
-			Assigned:     assigned,
-			CreatedAt:    createdAt,
-			UpdatedAt:    updatedAt,
+			Name:             a.Name,
+			Description:      desc,
+			Type:             a.ActionType,
+			IsCompliance:     isCompliance,
+			Assigned:         assigned,
+			ScopeGroupIDs:    scopeGroups,
+			HasScopeGroupIDs: true,
+			CreatedAt:        createdAt,
+			UpdatedAt:        updatedAt,
 		}, nil
 
 	case search.ScopeDefinition:
@@ -623,13 +661,19 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if err != nil {
 			return nil, err
 		}
+		scopeGroups, err := loadScopeGroupIDs(ctx, q, "definition", id)
+		if err != nil {
+			return nil, err
+		}
 		return &taskqueue.SearchEntityData{
-			Name:        d.Name,
-			Description: d.Description,
-			MemberCount: d.MemberCount,
-			Assigned:    assigned,
-			CreatedAt:   createdAt,
-			UpdatedAt:   updatedAt,
+			Name:             d.Name,
+			Description:      d.Description,
+			MemberCount:      d.MemberCount,
+			Assigned:         assigned,
+			ScopeGroupIDs:    scopeGroups,
+			HasScopeGroupIDs: true,
+			CreatedAt:        createdAt,
+			UpdatedAt:        updatedAt,
 		}, nil
 
 	case search.ScopeUserGroup:

--- a/internal/api/search_listener_e2e_test.go
+++ b/internal/api/search_listener_e2e_test.go
@@ -124,11 +124,19 @@ func (f *fakeSearchIndex) lastRemove(t *testing.T) removeCall {
 	return f.removed[len(f.removed)-1]
 }
 
-// reindexedScope reports whether (scope, id) was reindexed at least once.
-func (f *fakeSearchIndex) reindexedScope(scope, id string) bool {
+// reindexedScopeSince reports whether (scope, id) was reindexed at least once at
+// or after index `start` — so a membership-change assertion isn't satisfied by an
+// earlier entity-creation reindex (CR).
+func (f *fakeSearchIndex) reindexedScopeSince(start int, scope, id string) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	for _, c := range f.reindexed {
+	if start < 0 {
+		start = 0
+	}
+	if start > len(f.reindexed) {
+		start = len(f.reindexed)
+	}
+	for _, c := range f.reindexed[start:] {
 		if c.Scope == scope && c.ID == id {
 			return true
 		}
@@ -210,8 +218,8 @@ func TestSearchListener_DeviceGroupMemberAdded_ReindexesGroup(t *testing.T) {
 	// A DeviceGroupMemberAdded event reindexes the GROUP (member_count) AND the
 	// affected DEVICE (its scope_group_ids changed, #7 spec 14).
 	require.Greater(t, fake.reindexCount(), before, "membership change must trigger reindexes")
-	assert.True(t, fake.reindexedScope(search.ScopeDeviceGroup, groupID), "group must be reindexed (member_count)")
-	assert.True(t, fake.reindexedScope(search.ScopeDevice, deviceID), "affected device must be reindexed (scope_group_ids)")
+	assert.True(t, fake.reindexedScopeSince(before, search.ScopeDeviceGroup, groupID), "group must be reindexed (member_count)")
+	assert.True(t, fake.reindexedScopeSince(before, search.ScopeDevice, deviceID), "affected device must be reindexed (scope_group_ids)")
 }
 
 // =============================================================================
@@ -230,8 +238,8 @@ func TestSearchListener_UserGroupMemberAdded_ReindexesGroupViaPrefixSplit(t *tes
 	// splits on ':' to reindex the GROUP (member_count) AND the affected USER (its
 	// scope_group_ids changed, #7 spec 14).
 	require.Greater(t, fake.reindexCount(), before)
-	assert.True(t, fake.reindexedScope(search.ScopeUserGroup, groupID), "group must be reindexed")
-	assert.True(t, fake.reindexedScope(search.ScopeUser, userID), "affected user must be reindexed")
+	assert.True(t, fake.reindexedScopeSince(before, search.ScopeUserGroup, groupID), "group must be reindexed")
+	assert.True(t, fake.reindexedScopeSince(before, search.ScopeUser, userID), "affected user must be reindexed")
 }
 
 // =============================================================================

--- a/internal/api/search_listener_e2e_test.go
+++ b/internal/api/search_listener_e2e_test.go
@@ -124,6 +124,18 @@ func (f *fakeSearchIndex) lastRemove(t *testing.T) removeCall {
 	return f.removed[len(f.removed)-1]
 }
 
+// reindexedScope reports whether (scope, id) was reindexed at least once.
+func (f *fakeSearchIndex) reindexedScope(scope, id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.reindexed {
+		if c.Scope == scope && c.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
 func (f *fakeSearchIndex) reindexCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -195,13 +207,11 @@ func TestSearchListener_DeviceGroupMemberAdded_ReindexesGroup(t *testing.T) {
 	before := fake.reindexCount()
 	testutil.AddDeviceToTestGroup(t, st, "u", groupID, deviceID)
 
-	// AddDeviceToTestGroup fires a DeviceGroupMemberAdded event whose
-	// StreamID is the group ID directly (not composite). The listener
-	// reindexes the group so member_count refreshes.
-	require.Greater(t, fake.reindexCount(), before, "membership change must trigger a group reindex")
-	last := fake.lastReindex(t)
-	assert.Equal(t, search.ScopeDeviceGroup, last.Scope)
-	assert.Equal(t, groupID, last.ID)
+	// A DeviceGroupMemberAdded event reindexes the GROUP (member_count) AND the
+	// affected DEVICE (its scope_group_ids changed, #7 spec 14).
+	require.Greater(t, fake.reindexCount(), before, "membership change must trigger reindexes")
+	assert.True(t, fake.reindexedScope(search.ScopeDeviceGroup, groupID), "group must be reindexed (member_count)")
+	assert.True(t, fake.reindexedScope(search.ScopeDevice, deviceID), "affected device must be reindexed (scope_group_ids)")
 }
 
 // =============================================================================
@@ -216,12 +226,12 @@ func TestSearchListener_UserGroupMemberAdded_ReindexesGroupViaPrefixSplit(t *tes
 	before := fake.reindexCount()
 	testutil.AddUserToTestGroup(t, st, "u", groupID, userID)
 
-	// AddUserToTestGroup uses a composite stream id "<group>:<user>".
-	// The listener must split on ':' and reindex the group only.
+	// AddUserToTestGroup uses a composite stream id "<group>:<user>". The listener
+	// splits on ':' to reindex the GROUP (member_count) AND the affected USER (its
+	// scope_group_ids changed, #7 spec 14).
 	require.Greater(t, fake.reindexCount(), before)
-	last := fake.lastReindex(t)
-	assert.Equal(t, search.ScopeUserGroup, last.Scope)
-	assert.Equal(t, groupID, last.ID, "listener must drop the user_id suffix from the composite stream id")
+	assert.True(t, fake.reindexedScope(search.ScopeUserGroup, groupID), "group must be reindexed")
+	assert.True(t, fake.reindexedScope(search.ScopeUser, userID), "affected user must be reindexed")
 }
 
 // =============================================================================

--- a/internal/api/search_listener_test.go
+++ b/internal/api/search_listener_test.go
@@ -46,10 +46,12 @@ func TestAffectedSearchOps(t *testing.T) {
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeActionSet, ID: "SET1"}},
 		},
 		{
-			"AssignmentCreated to a compliance_policy is a no-op (no assigned TAG)",
+			// #7 spec 14: compliance policies carry scope_group_ids, so an
+			// assignment change now reindexes the policy (was a no-op pre-spec-14).
+			"AssignmentCreated to a compliance_policy reindexes the policy (scope_group_ids)",
 			store.PersistedEvent{EventType: "AssignmentCreated", StreamID: "ASN1", StreamType: "assignment",
 				Data: []byte(`{"source_type":"compliance_policy","source_id":"CP1"}`)},
-			nil,
+			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeCompliancePolicy, ID: "CP1"}},
 		},
 		{
 			"AssignmentDeleted with a legacy empty payload is a no-op",

--- a/internal/api/search_listener_test.go
+++ b/internal/api/search_listener_test.go
@@ -159,6 +159,17 @@ func TestAffectedSearchOps(t *testing.T) {
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDeviceGroup, ID: "DGRP1"}},
 		},
 		{
+			// #7 spec 14: dynamic re-eval delta reindexes the group + each affected device.
+			"DeviceGroupMembersReevaluated reindexes group + each affected device",
+			store.PersistedEvent{EventType: "DeviceGroupMembersReevaluated", StreamID: "DGRP1", StreamType: "device_group",
+				Data: []byte(`{"added_device_ids":["DEV1"],"removed_device_ids":["DEV2"]}`)},
+			[]api.SearchAffected{
+				{Op: api.SearchOpReindex, Scope: search.ScopeDeviceGroup, ID: "DGRP1"},
+				{Op: api.SearchOpReindex, Scope: search.ScopeDevice, ID: "DEV1"},
+				{Op: api.SearchOpReindex, Scope: search.ScopeDevice, ID: "DEV2"},
+			},
+		},
+		{
 			"DeviceGroupMaintenanceWindowSet reindexes device group",
 			store.PersistedEvent{EventType: "DeviceGroupMaintenanceWindowSet", StreamID: "DGRP1", StreamType: "device_group"},
 			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeDeviceGroup, ID: "DGRP1"}},
@@ -258,14 +269,32 @@ func TestAffectedSearchOps(t *testing.T) {
 		// make loadSearchEntityData fail to find the row and the
 		// reindex would silently drop. CodeRabbit catch on PR #112.
 		{
-			"UserGroupMemberAdded extracts group_id from composite StreamID",
+			// Member event: reindex the group (member_count) AND the affected user
+			// (scope_group_ids, #7 spec 14), from the "<group>:<user>" composite.
+			"UserGroupMemberAdded reindexes group + affected user",
 			store.PersistedEvent{EventType: "UserGroupMemberAdded", StreamID: "UGRP1:USR42", StreamType: "user_group"},
-			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+			[]api.SearchAffected{
+				{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"},
+				{Op: api.SearchOpReindex, Scope: search.ScopeUser, ID: "USR42"},
+			},
 		},
 		{
-			"UserGroupMemberRemoved extracts group_id",
+			"UserGroupMemberRemoved reindexes group + affected user",
 			store.PersistedEvent{EventType: "UserGroupMemberRemoved", StreamID: "UGRP1:USR42", StreamType: "user_group"},
-			[]api.SearchAffected{{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"}},
+			[]api.SearchAffected{
+				{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"},
+				{Op: api.SearchOpReindex, Scope: search.ScopeUser, ID: "USR42"},
+			},
+		},
+		{
+			"UserGroupMembersReevaluated reindexes group + each affected user",
+			store.PersistedEvent{EventType: "UserGroupMembersReevaluated", StreamID: "UGRP1", StreamType: "user_group",
+				Data: []byte(`{"added_user_ids":["USR1"],"removed_user_ids":["USR2"]}`)},
+			[]api.SearchAffected{
+				{Op: api.SearchOpReindex, Scope: search.ScopeUserGroup, ID: "UGRP1"},
+				{Op: api.SearchOpReindex, Scope: search.ScopeUser, ID: "USR1"},
+				{Op: api.SearchOpReindex, Scope: search.ScopeUser, ID: "USR2"},
+			},
 		},
 		{
 			"UserGroupRoleAssigned extracts group_id from <group>:role:<role> composite",

--- a/internal/api/search_scope_parity_test.go
+++ b/internal/api/search_scope_parity_test.go
@@ -32,8 +32,15 @@ func TestScopeFilterFields_MirrorIndexSchemas(t *testing.T) {
 		want := ix.FilterableFields() // TAG/NUMERIC fields the index actually declares
 
 		// Every declared filterable field must be advertised, else operators
-		// can't filter on it.
+		// can't filter on it — EXCEPT server-only scope fields (scope_group_ids),
+		// which the server populates and filters on internally for RBAC scope and
+		// intentionally never exposes as a client filter (#7 spec 14).
 		for field := range want {
+			if search.ServerScopeFields[field] {
+				assert.Falsef(t, got[field],
+					"scope %q: %q is a server-only scope field and must NOT be in scopeFilterFields (it would become a client filter)", scope, field)
+				continue
+			}
 			assert.Truef(t, got[field],
 				"scope %q: index %q declares filterable field %q (TAG/NUMERIC) but scopeFilterFields omits it", scope, ix.Name, field)
 		}

--- a/internal/archtest/projection_writes_test.go
+++ b/internal/archtest/projection_writes_test.go
@@ -33,14 +33,13 @@ var projectionMutationRe = regexp.MustCompile(`(?i)(INSERT\s+INTO|UPDATE|DELETE\
 var projectionWriteAllowlist = map[string]string{
 	"internal/compliance :: UpdateDeviceComplianceSummary": "Computed read-model: the compliance evaluator computes per-device compliance and writes the summary columns on device_projection. Evaluation results are derived state, not event-sourced.",
 	"internal/compliance :: UpsertComplianceEvaluation":    "Computed read-model: per-policy evaluation results written by the compliance evaluator. Derived state, not event-sourced.",
-	"internal/dyngroupeval :: InsertDeviceGroupMember":     "Computed read-model: DYNAMIC device-group membership is materialized by evaluating the group query (static membership is event-sourced via projectors).",
-	"internal/dyngroupeval :: DeleteDeviceGroupMember":     "Computed read-model: dynamic device-group membership reconciliation removes stale members.",
-	"internal/dyngroupeval :: RecountDeviceGroupMembers":   "Computed read-model: recomputes the dynamic device-group member count after materialization.",
-	"internal/dyngroupeval :: InsertUserGroupMember":       "Computed read-model: DYNAMIC user-group membership materialized from the group query.",
-	"internal/dyngroupeval :: DeleteUserGroupMember":       "Computed read-model: dynamic user-group membership reconciliation removes stale members.",
-	"internal/dyngroupeval :: RecountUserGroupMembers":     "Computed read-model: recomputes the dynamic user-group member count after materialization.",
-	"internal/auth :: UpdateSystemRolePermissions":         "Bootstrap reconcile: ReconcileSystemRoles syncs the Admin/User system-role permissions to the code-defined sets at startup so new permissions land without a manual toggle. System-role permission sets are code-owned, not user-event-sourced.",
-	"internal/store/postgres :: UpdateActionSignature":     "Store adapter: writes the server-computed CA signature back onto action_projection after signing. Tied to the WS1 action-signing rework — revisit when SignedActionEnvelope lands.",
+	// NOTE: dyngroupeval no longer appears here. #7 spec 14 made dynamic group
+	// membership event-driven — the evaluator emits *GroupMembersReevaluated delta
+	// events and a projector applies them (insert/delete/recount). The forcing
+	// function above is satisfied: removing these entries keeps this test red if
+	// the evaluator ever writes membership projections directly again.
+	"internal/auth :: UpdateSystemRolePermissions":     "Bootstrap reconcile: ReconcileSystemRoles syncs the Admin/User system-role permissions to the code-defined sets at startup so new permissions land without a manual toggle. System-role permission sets are code-owned, not user-event-sourced.",
+	"internal/store/postgres :: UpdateActionSignature": "Store adapter: writes the server-computed CA signature back onto action_projection after signing. Tied to the WS1 action-signing rework — revisit when SignedActionEnvelope lands.",
 }
 
 // TestProjectionTablesWrittenOnlyByProjectors enforces the CQRS write

--- a/internal/auth/object_scope_test.go
+++ b/internal/auth/object_scope_test.go
@@ -1,0 +1,75 @@
+package auth
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ObjectScopeListFilter reduces the caller's JWT scoped grants to the union of
+// device-group + user-group ids that confine their object access (#7 spec 14).
+// It must read ONLY the JWT-backed context (UserContext.ScopedGrants) — never a
+// DB lookup — so a scoped Search slices objects with zero round-trips.
+func TestObjectScopeListFilter(t *testing.T) {
+	t.Run("no caller in context fails closed (restricted, empty)", func(t *testing.T) {
+		ids, restricted := ObjectScopeListFilter(context.Background())
+		assert.True(t, restricted, "missing caller must restrict, never fail open")
+		assert.Empty(t, ids)
+	})
+
+	t.Run("no scoped grants is unrestricted (global admin)", func(t *testing.T) {
+		ctx := ctxWithGrants(
+			ScopedGrant{Permission: "ListActionSets"},
+			ScopedGrant{Permission: "GetAction"},
+		)
+		ids, restricted := ObjectScopeListFilter(ctx)
+		assert.False(t, restricted, "an operator with only unscoped grants sees everything")
+		assert.Empty(t, ids)
+	})
+
+	t.Run("device-group scope confines to that group", func(t *testing.T) {
+		ctx := ctxWithGrants(
+			ScopedGrant{Permission: "ListDevices", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"},
+		)
+		ids, restricted := ObjectScopeListFilter(ctx)
+		assert.True(t, restricted)
+		assert.Equal(t, []string{"dg1"}, ids)
+	})
+
+	t.Run("union of device- and user-group scope ids across grants", func(t *testing.T) {
+		ctx := ctxWithGrants(
+			ScopedGrant{Permission: "ListDevices", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"},
+			ScopedGrant{Permission: "GetDevice", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg2"},
+			ScopedGrant{Permission: "ListUsers", ScopeKind: ScopeKindUserGroup, ScopeID: "ug1"},
+			ScopedGrant{Permission: "Whatever"}, // unscoped grant contributes nothing
+		)
+		ids, restricted := ObjectScopeListFilter(ctx)
+		assert.True(t, restricted)
+		sort.Strings(ids)
+		assert.Equal(t, []string{"dg1", "dg2", "ug1"}, ids)
+	})
+
+	t.Run("duplicate scope ids are de-duplicated", func(t *testing.T) {
+		ctx := ctxWithGrants(
+			ScopedGrant{Permission: "ListDevices", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"},
+			ScopedGrant{Permission: "GetDevice", ScopeKind: ScopeKindDeviceGroup, ScopeID: "dg1"},
+		)
+		ids, restricted := ObjectScopeListFilter(ctx)
+		assert.True(t, restricted)
+		assert.Equal(t, []string{"dg1"}, ids)
+	})
+
+	t.Run("a scoped grant with an empty id is ignored, leaving the caller unrestricted", func(t *testing.T) {
+		// Defensive: a malformed grant (kind set, id empty) must not silently
+		// confine the caller to an empty set (which would hide everything) nor
+		// count as a scope. With no other scoped grant the caller is global.
+		ctx := ctxWithGrants(
+			ScopedGrant{Permission: "ListDevices", ScopeKind: ScopeKindDeviceGroup, ScopeID: ""},
+		)
+		ids, restricted := ObjectScopeListFilter(ctx)
+		assert.False(t, restricted)
+		assert.Empty(t, ids)
+	})
+}

--- a/internal/auth/object_scope_test.go
+++ b/internal/auth/object_scope_test.go
@@ -61,15 +61,15 @@ func TestObjectScopeListFilter(t *testing.T) {
 		assert.Equal(t, []string{"dg1"}, ids)
 	})
 
-	t.Run("a scoped grant with an empty id is ignored, leaving the caller unrestricted", func(t *testing.T) {
-		// Defensive: a malformed grant (kind set, id empty) must not silently
-		// confine the caller to an empty set (which would hide everything) nor
-		// count as a scope. With no other scoped grant the caller is global.
+	t.Run("a malformed scoped grant (kind set, id empty) fails CLOSED, never open", func(t *testing.T) {
+		// A group-kind scoped grant with an empty id must NOT fall through to
+		// unrestricted (org-wide) access — that would turn a malformed JWT into a
+		// scope escalation (CR finding). The caller IS scoped, just to nothing.
 		ctx := ctxWithGrants(
 			ScopedGrant{Permission: "ListDevices", ScopeKind: ScopeKindDeviceGroup, ScopeID: ""},
 		)
 		ids, restricted := ObjectScopeListFilter(ctx)
-		assert.False(t, restricted)
+		assert.True(t, restricted, "malformed scoped grant must restrict (fail closed), not grant global access")
 		assert.Empty(t, ids)
 	})
 }

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -402,12 +402,17 @@ func ObjectScopeListFilter(ctx context.Context) (groupIDs []string, restricted b
 		return nil, true
 	}
 	seen := make(map[string]struct{}, len(user.ScopedGrants))
+	sawScopedGrant := false
 	for _, g := range user.ScopedGrants {
 		if g.ScopeKind != ScopeKindDeviceGroup && g.ScopeKind != ScopeKindUserGroup {
 			continue // unscoped grant (global for its permission) — no confinement
 		}
+		// A group-kind scoped grant means the caller IS scoped, even if the id is
+		// malformed (empty). Record that BEFORE the empty-id check so a malformed
+		// grant fails CLOSED below instead of falling through to global access.
+		sawScopedGrant = true
 		if g.ScopeID == "" {
-			continue // malformed grant — ignore rather than confine to nothing
+			continue // malformed grant — confines to nothing (handled by fail-closed return)
 		}
 		if _, dup := seen[g.ScopeID]; dup {
 			continue
@@ -416,7 +421,11 @@ func ObjectScopeListFilter(ctx context.Context) (groupIDs []string, restricted b
 		groupIDs = append(groupIDs, g.ScopeID)
 	}
 	if len(groupIDs) == 0 {
-		return nil, false // no scoped grant ⇒ unrestricted (global admin)
+		// No groups resolved. If the caller held ANY group-kind scoped grant, they
+		// are scoped — to nothing — so fail CLOSED (restricted, sees nothing); a
+		// malformed scoped JWT must never escalate to org-wide access. Only a
+		// COMPLETE absence of scoped grants is unrestricted (a global admin).
+		return nil, sawScopedGrant
 	}
 	return groupIDs, true
 }

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -376,6 +376,51 @@ func UserScopeListFilter(ctx context.Context, permission string) (groupIDs []str
 	return scopeListFilter(ctx, permission, UserScopeFilterFor)
 }
 
+// ObjectScopeListFilter reduces the caller's scoped grants to the union of every
+// device-group and user-group id they are confined to, for scoping the shared
+// object types (actions, action-sets, definitions, compliance policies) by
+// assignment (#7 spec 14). Unlike the per-permission device/user filters, object
+// permissions are not independently scopable (they are TargetUnspecified), so an
+// object's visibility reuses the device-/user-group scope the caller already
+// holds from their grants: a caller scoped to device group X is confined to X's
+// objects too.
+//
+//   - restricted=false ⇒ the caller holds NO scoped grant at all (a global/org
+//     admin) — apply no object filter (sees everything, as today).
+//   - restricted=true  ⇒ confine to objects whose assignment groups intersect
+//     groupIDs. groupIDs may be empty only when there is no authenticated caller
+//     (fail closed — restrict to nothing); a real scoped grant always yields ≥1
+//     id.
+//
+// Read ONLY from the JWT-backed UserContext.ScopedGrants — never a DB lookup — so
+// a scoped Search slices results with zero round-trips (spec 14, criterion 13).
+func ObjectScopeListFilter(ctx context.Context) (groupIDs []string, restricted bool) {
+	user, ok := UserFromContext(ctx)
+	if !ok {
+		// No caller to resolve — fail closed (restrict to nothing), never open.
+		// Object handlers run behind the auth interceptor, so this is defensive.
+		return nil, true
+	}
+	seen := make(map[string]struct{}, len(user.ScopedGrants))
+	for _, g := range user.ScopedGrants {
+		if g.ScopeKind != ScopeKindDeviceGroup && g.ScopeKind != ScopeKindUserGroup {
+			continue // unscoped grant (global for its permission) — no confinement
+		}
+		if g.ScopeID == "" {
+			continue // malformed grant — ignore rather than confine to nothing
+		}
+		if _, dup := seen[g.ScopeID]; dup {
+			continue
+		}
+		seen[g.ScopeID] = struct{}{}
+		groupIDs = append(groupIDs, g.ScopeID)
+	}
+	if len(groupIDs) == 0 {
+		return nil, false // no scoped grant ⇒ unrestricted (global admin)
+	}
+	return groupIDs, true
+}
+
 // scopeListFilter is the shared body for the device/user list filters. filterFor
 // selects the relevant scope kind (DeviceScopeFilterFor / UserScopeFilterFor).
 func scopeListFilter(ctx context.Context, permission string, filterFor func(context.Context, string) ScopeFilter) (groupIDs []string, restricted bool) {

--- a/internal/dyngroupeval/evaluator.go
+++ b/internal/dyngroupeval/evaluator.go
@@ -24,10 +24,13 @@ import (
 	"fmt"
 	"hash/fnv"
 	"log/slog"
+	"sort"
 	"strings"
 	"time"
 
 	"github.com/manchtools/power-manage/server/internal/dynamicquery"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -125,32 +128,28 @@ func (e *Evaluator) EvaluateDeviceGroup(ctx context.Context, groupID string) err
 		}
 	}
 
+	// Membership is event-driven (#7 spec 14): the evaluator computes the delta
+	// and EMITS it; the device_group projector applies it (insert/delete +
+	// recount). The event — not a direct projection write — is the source of
+	// truth, so the audit log can never drift from membership and a projection
+	// rebuild reconstructs dynamic membership by replaying these events.
+	var added, removed []string
 	for id := range newSet {
 		if !currentSet[id] {
-			added := evalStart
-			if err := q.InsertDeviceGroupMember(ctx, db.InsertDeviceGroupMemberParams{
-				GroupID:           groupID,
-				DeviceID:          id,
-				AddedAt:           &added,
-				ProjectionVersion: 0,
-			}); err != nil {
-				return fmt.Errorf("dyngroupeval: add device %s to group %s: %w", id, groupID, err)
-			}
+			added = append(added, id)
 		}
 	}
 	for id := range currentSet {
 		if !newSet[id] {
-			if err := q.DeleteDeviceGroupMember(ctx, db.DeleteDeviceGroupMemberParams{
-				GroupID:  groupID,
-				DeviceID: id,
-			}); err != nil {
-				return fmt.Errorf("dyngroupeval: remove device %s from group %s: %w", id, groupID, err)
-			}
+			removed = append(removed, id)
 		}
 	}
 
-	if err := q.RecountDeviceGroupMembers(ctx, groupID); err != nil {
-		return fmt.Errorf("dyngroupeval: recount %s: %w", groupID, err)
+	if err := e.emitMembersReevaluated(ctx, "device_group", groupID,
+		string(eventtypes.DeviceGroupMembersReevaluated),
+		payloads.DeviceGroupMembersReevaluated{AddedDeviceIDs: sortedCopy(added), RemovedDeviceIDs: sortedCopy(removed)},
+		len(added)+len(removed)); err != nil {
+		return err
 	}
 
 	return q.DeleteDynamicDeviceGroupQueueBefore(ctx, db.DeleteDynamicDeviceGroupQueueBeforeParams{
@@ -208,38 +207,65 @@ func (e *Evaluator) EvaluateUserGroup(ctx context.Context, groupID string) error
 		}
 	}
 
+	// Event-driven membership (#7 spec 14): emit the delta; the user_group
+	// projector applies it. Source of truth = the event, so no audit/state drift.
+	var added, removed []string
 	for id := range newSet {
 		if !currentSet[id] {
-			if err := q.InsertUserGroupMember(ctx, db.InsertUserGroupMemberParams{
-				GroupID:           groupID,
-				UserID:            id,
-				AddedAt:           evalStart,
-				AddedBy:           "system",
-				ProjectionVersion: 0,
-			}); err != nil {
-				return fmt.Errorf("dyngroupeval: add user %s to group %s: %w", id, groupID, err)
-			}
+			added = append(added, id)
 		}
 	}
 	for id := range currentSet {
 		if !newSet[id] {
-			if err := q.DeleteUserGroupMember(ctx, db.DeleteUserGroupMemberParams{
-				GroupID: groupID,
-				UserID:  id,
-			}); err != nil {
-				return fmt.Errorf("dyngroupeval: remove user %s from group %s: %w", id, groupID, err)
-			}
+			removed = append(removed, id)
 		}
 	}
 
-	if err := q.RecountUserGroupMembers(ctx, groupID); err != nil {
-		return fmt.Errorf("dyngroupeval: recount user group %s: %w", groupID, err)
+	if err := e.emitMembersReevaluated(ctx, "user_group", groupID,
+		string(eventtypes.UserGroupMembersReevaluated),
+		payloads.UserGroupMembersReevaluated{AddedUserIDs: sortedCopy(added), RemovedUserIDs: sortedCopy(removed)},
+		len(added)+len(removed)); err != nil {
+		return err
 	}
 
 	return q.DeleteDynamicUserGroupQueueBefore(ctx, db.DeleteDynamicUserGroupQueueBeforeParams{
 		GroupID:  groupID,
 		BeforeTs: evalStart,
 	})
+}
+
+// emitMembersReevaluated appends a dynamic-group membership delta event (#7 spec
+// 14). The projector applies it (membership is event-driven — the event is the
+// source of truth, so no audit/state drift), and the search index reindexes the
+// affected devices/users. No-op when nothing changed. A failed append is returned
+// so the evaluation fails and the group stays queued for retry — membership is
+// NOT applied any other way, so the emit must not be silently dropped.
+func (e *Evaluator) emitMembersReevaluated(ctx context.Context, streamType, groupID, eventType string, data any, changed int) error {
+	if changed == 0 {
+		return nil
+	}
+	if err := e.store.AppendEvent(ctx, store.Event{
+		StreamType: streamType,
+		StreamID:   groupID,
+		EventType:  eventType,
+		Data:       data,
+		ActorType:  "system",
+		ActorID:    "system",
+	}); err != nil {
+		return fmt.Errorf("dyngroupeval: emit %s for %s: %w", eventType, groupID, err)
+	}
+	return nil
+}
+
+// sortedCopy returns a sorted copy of ids (deterministic event payload + stable
+// tests) without mutating the caller's slice.
+func sortedCopy(ids []string) []string {
+	if len(ids) == 0 {
+		return nil
+	}
+	out := append([]string(nil), ids...)
+	sort.Strings(out)
+	return out
 }
 
 // DrainResult is the per-batch summary the drain loop returns. Count

--- a/internal/dyngroupeval/reevaluated_event_test.go
+++ b/internal/dyngroupeval/reevaluated_event_test.go
@@ -1,0 +1,96 @@
+package dyngroupeval_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/dyngroupeval"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// #7 spec 14: dynamic membership is event-driven. The evaluator emits a
+// DeviceGroupMembersReevaluated event carrying the delta; the projector applies
+// it (proven by the membership-correctness tests). This test pins the OTHER half:
+// the event is in the log (auditability) with the correct delta, so the audit
+// trail can never drift from membership.
+func TestEvaluateDeviceGroup_EmitsReevaluatedEventWithDelta(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	dMatch := testutil.CreateTestDevice(t, st, "prod-host")
+	dStale := testutil.CreateTestDevice(t, st, "dev-host")
+	execSQL(t, st, `INSERT INTO device_labels (device_id, key, value) VALUES ($1, 'env', 'prod')`, dMatch)
+
+	groupID := testutil.NewID()
+	execSQL(t, st, `INSERT INTO device_groups_projection (id, name, is_dynamic, dynamic_query) VALUES ($1, 'dyn', TRUE, $2)`,
+		groupID, `labels.env equals "prod"`)
+	execSQL(t, st, `INSERT INTO device_group_members_projection (group_id, device_id) VALUES ($1, $2)`, groupID, dStale)
+	enqueueDeviceGroup(t, st, groupID)
+
+	require.NoError(t, dyngroupeval.New(st, slog.Default()).EvaluateDeviceGroup(ctx, groupID))
+
+	// Membership applied via the projector (the event is the source of truth).
+	assert.Equal(t, []string{dMatch}, deviceMembers(t, st, groupID))
+
+	// AND the delta is recorded as an event for the audit trail.
+	p := findReevaluatedDelta(t, st, "device_group", groupID, string(eventtypes.DeviceGroupMembersReevaluated))
+	assert.Equal(t, []string{dMatch}, p.AddedDeviceIDs, "added device recorded in the event")
+	assert.Equal(t, []string{dStale}, p.RemovedDeviceIDs, "removed device recorded in the event")
+}
+
+// No membership change → no event (don't pollute the log / trigger empty reindexes).
+func TestEvaluateDeviceGroup_NoDeltaEmitsNoEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	groupID := testutil.NewID()
+	execSQL(t, st, `INSERT INTO device_groups_projection (id, name, is_dynamic, dynamic_query) VALUES ($1, 'dyn', TRUE, $2)`,
+		groupID, `labels.env equals "prod"`) // matches nothing; no current members
+	enqueueDeviceGroup(t, st, groupID)
+
+	require.NoError(t, dyngroupeval.New(st, slog.Default()).EvaluateDeviceGroup(ctx, groupID))
+
+	assert.Equal(t, 0, countReevaluatedEvents(t, st, "device_group", groupID, string(eventtypes.DeviceGroupMembersReevaluated)),
+		"an evaluation that changes nothing must not emit a reevaluated event")
+}
+
+func findReevaluatedDelta(t *testing.T, st *store.Store, streamType, groupID, eventType string) payloads.DeviceGroupMembersReevaluated {
+	t.Helper()
+	events, err := st.Queries().LoadEventsByStreamType(context.Background(), db.LoadEventsByStreamTypeParams{
+		StreamType: streamType, Limit: 1000, Offset: 0,
+	})
+	require.NoError(t, err)
+	for _, e := range events {
+		if e.EventType == eventType && e.StreamID == groupID {
+			var p payloads.DeviceGroupMembersReevaluated
+			require.NoError(t, json.Unmarshal(e.Data, &p))
+			return p
+		}
+	}
+	t.Fatalf("no %s event found for group %s", eventType, groupID)
+	return payloads.DeviceGroupMembersReevaluated{}
+}
+
+func countReevaluatedEvents(t *testing.T, st *store.Store, streamType, groupID, eventType string) int {
+	t.Helper()
+	events, err := st.Queries().LoadEventsByStreamType(context.Background(), db.LoadEventsByStreamTypeParams{
+		StreamType: streamType, Limit: 1000, Offset: 0,
+	})
+	require.NoError(t, err)
+	n := 0
+	for _, e := range events {
+		if e.EventType == eventType && e.StreamID == groupID {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/eventtypes/payloads/device_group.go
+++ b/internal/eventtypes/payloads/device_group.go
@@ -33,6 +33,15 @@ type DeviceGroupMemberRemoved struct {
 	DeviceID string `json:"device_id"`
 }
 
+// DeviceGroupMembersReevaluated is the wire shape for the dynamic-group
+// membership delta the evaluator emits (#7 spec 14). StreamID carries the group
+// id; the payload carries the device ids added and removed by this evaluation.
+// Audited + consumed by api/SearchListener to reindex the affected devices.
+type DeviceGroupMembersReevaluated struct {
+	AddedDeviceIDs   []string `json:"added_device_ids,omitempty"`
+	RemovedDeviceIDs []string `json:"removed_device_ids,omitempty"`
+}
+
 // DeviceGroupQueryUpdated toggles a static group to dynamic (or back).
 type DeviceGroupQueryUpdated struct {
 	IsDynamic    bool   `json:"is_dynamic"`

--- a/internal/eventtypes/payloads/user_group.go
+++ b/internal/eventtypes/payloads/user_group.go
@@ -43,6 +43,15 @@ type UserGroupMemberRemoved struct {
 	UserID  string `json:"user_id"`
 }
 
+// UserGroupMembersReevaluated is the user-group dynamic membership delta the
+// evaluator emits (#7 spec 14). StreamID carries the group id; the payload
+// carries the user ids added and removed. Audited + drives the search reindex of
+// the affected users.
+type UserGroupMembersReevaluated struct {
+	AddedUserIDs   []string `json:"added_user_ids,omitempty"`
+	RemovedUserIDs []string `json:"removed_user_ids,omitempty"`
+}
+
 // UserGroupRoleAssigned / UserGroupRoleRevoked share the same
 // (group_id, role_id) composite-key shape plus the optional scope
 // tuple added in server #7 S2 / S5 (paired-or-neither, both nil =

--- a/internal/eventtypes/types.go
+++ b/internal/eventtypes/types.go
@@ -91,7 +91,13 @@ const (
 	DeviceGroupMaintenanceWindowSet EventType = "DeviceGroupMaintenanceWindowSet"
 	DeviceGroupMemberAdded          EventType = "DeviceGroupMemberAdded"
 	DeviceGroupMemberRemoved        EventType = "DeviceGroupMemberRemoved"
-	DeviceGroupDeleted              EventType = "DeviceGroupDeleted"
+	// DeviceGroupMembersReevaluated records a DYNAMIC group's membership delta
+	// produced by the in-process evaluator (#7 spec 14). The evaluator materializes
+	// dynamic membership imperatively (and a rebuild re-evaluates), so this is not a
+	// projected source — it exists for the audit trail and to drive the search
+	// index reindex of the affected devices via api/SearchListener.
+	DeviceGroupMembersReevaluated EventType = "DeviceGroupMembersReevaluated"
+	DeviceGroupDeleted            EventType = "DeviceGroupDeleted"
 	// Legacy device-group membership aliases — emitted by older versions
 	// before the *MemberAdded / *MemberRemoved naming. The device_group
 	// listener still recognises them so historical events replay
@@ -213,6 +219,11 @@ const (
 	UserGroupRoleAssigned         EventType = "UserGroupRoleAssigned"
 	UserGroupRoleRevoked          EventType = "UserGroupRoleRevoked"
 	UserGroupMembersRebuilt       EventType = "UserGroupMembersRebuilt"
+	// UserGroupMembersReevaluated is the user-group sibling of
+	// DeviceGroupMembersReevaluated — a dynamic user-group membership delta from
+	// the evaluator (#7 spec 14), audited + drives the search reindex of affected
+	// users; not a projected source.
+	UserGroupMembersReevaluated EventType = "UserGroupMembersReevaluated"
 
 	// user_selection stream
 	UserSelectionChanged EventType = "UserSelectionChanged"
@@ -237,7 +248,7 @@ func All() []EventType {
 		DeviceGroupAssigned, DeviceGroupUnassigned, DeviceSyncIntervalSet,
 		DeviceGroupCreated, DeviceGroupRenamed, DeviceGroupDescriptionUpdated, DeviceGroupQueryUpdated,
 		DeviceGroupSyncIntervalSet, DeviceGroupMaintenanceWindowSet, DeviceGroupMemberAdded,
-		DeviceGroupMemberRemoved, DeviceGroupDeleted, DeviceAddedToGroup, DeviceRemovedFromGroup,
+		DeviceGroupMemberRemoved, DeviceGroupMembersReevaluated, DeviceGroupDeleted, DeviceAddedToGroup, DeviceRemovedFromGroup,
 		ExecutionCreated, ExecutionScheduled, ExecutionDispatched, ExecutionStarted, ExecutionCompleted,
 		ExecutionFailed, ExecutionTimedOut, ExecutionSkipped, ExecutionCancelled, OutputChunk,
 		IdentityProviderCreated, IdentityProviderUpdated, IdentityProviderDeleted, IdentityProviderSCIMEnabled,
@@ -261,7 +272,7 @@ func All() []EventType {
 		UserRoleAssigned, UserRoleRevoked,
 		UserGroupCreated, UserGroupUpdated, UserGroupQueryUpdated, UserGroupMaintenanceWindowSet,
 		UserGroupDeleted, UserGroupMemberAdded, UserGroupMemberRemoved, UserGroupRoleAssigned,
-		UserGroupRoleRevoked, UserGroupMembersRebuilt,
+		UserGroupRoleRevoked, UserGroupMembersRebuilt, UserGroupMembersReevaluated,
 		UserSelectionChanged,
 	}
 }

--- a/internal/projectors/device_group_listener.go
+++ b/internal/projectors/device_group_listener.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -79,7 +80,8 @@ func DeviceGroupListener(st *store.Store, logger *slog.Logger) store.EventListen
 			string(eventtypes.DeviceGroupMemberAdded),
 			string(eventtypes.DeviceAddedToGroup),
 			string(eventtypes.DeviceGroupMemberRemoved),
-			string(eventtypes.DeviceRemovedFromGroup):
+			string(eventtypes.DeviceRemovedFromGroup),
+			string(eventtypes.DeviceGroupMembersReevaluated):
 			if err := st.WithTx(ctx, func(q *store.Queries) error {
 				return ApplyDeviceGroup(ctx, q, e)
 			}); err != nil {
@@ -128,10 +130,65 @@ func ApplyDeviceGroup(ctx context.Context, q *store.Queries, e store.PersistedEv
 		return applyDeviceGroupMemberAdded(ctx, q, e)
 	case string(eventtypes.DeviceGroupMemberRemoved), string(eventtypes.DeviceRemovedFromGroup):
 		return applyDeviceGroupMemberRemoved(ctx, q, e)
+	case string(eventtypes.DeviceGroupMembersReevaluated):
+		return applyDeviceGroupMembersReevaluated(ctx, q, e)
 	case string(eventtypes.DeviceGroupDeleted):
 		return applyDeviceGroupDeleted(ctx, q, e)
 	}
 	return nil
+}
+
+// applyDeviceGroupMembersReevaluated projects the dynamic-group membership delta
+// the evaluator emits (#7 spec 14). The event is the SOURCE OF TRUTH for dynamic
+// membership (the evaluator no longer writes the projection directly), so a
+// rebuild reconstructs membership by replaying these events. Asymmetric-guard
+// discipline: the version+dynamic guard runs FIRST; on n==0 (stale replay,
+// flipped-to-static, or deleted) the delta is skipped so it can't resurrect
+// removed members or wipe live ones.
+func applyDeviceGroupMembersReevaluated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	p, err := decodePayload[payloads.DeviceGroupMembersReevaluated](e, "device_group", eventtypes.DeviceGroupMembersReevaluated)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	n, err := q.ClaimDynamicDeviceGroupForMembership(ctx, db.ClaimDynamicDeviceGroupForMembershipParams{
+		ID:                e.StreamID,
+		ProjectionVersion: e.SequenceNum,
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	addedAt := e.OccurredAt
+	for _, id := range p.AddedDeviceIDs {
+		if id == "" {
+			continue
+		}
+		if err := q.InsertDeviceGroupMember(ctx, db.InsertDeviceGroupMemberParams{
+			GroupID:           e.StreamID,
+			DeviceID:          id,
+			AddedAt:           &addedAt,
+			ProjectionVersion: e.SequenceNum,
+		}); err != nil {
+			return err
+		}
+	}
+	for _, id := range p.RemovedDeviceIDs {
+		if id == "" {
+			continue
+		}
+		if err := q.DeleteDeviceGroupMember(ctx, db.DeleteDeviceGroupMemberParams{
+			GroupID:  e.StreamID,
+			DeviceID: id,
+		}); err != nil {
+			return err
+		}
+	}
+	return q.RecountDeviceGroupMembers(ctx, e.StreamID)
 }
 
 func applyDeviceGroupCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {

--- a/internal/projectors/user_group_listener.go
+++ b/internal/projectors/user_group_listener.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -80,6 +81,7 @@ func UserGroupListener(st *store.Store, logger *slog.Logger) store.EventListener
 			string(eventtypes.UserGroupMemberAdded),
 			string(eventtypes.UserGroupMemberRemoved),
 			string(eventtypes.UserGroupMembersRebuilt),
+			string(eventtypes.UserGroupMembersReevaluated),
 			string(eventtypes.UserGroupRoleAssigned),
 			string(eventtypes.UserGroupRoleRevoked):
 			if err := st.WithTx(ctx, func(q *store.Queries) error {
@@ -135,8 +137,61 @@ func ApplyUserGroup(ctx context.Context, q *store.Queries, e store.PersistedEven
 		return applyUserGroupRoleRevoked(ctx, q, e)
 	case string(eventtypes.UserGroupMembersRebuilt):
 		return applyUserGroupMembersRebuilt(ctx, q, e)
+	case string(eventtypes.UserGroupMembersReevaluated):
+		return applyUserGroupMembersReevaluated(ctx, q, e)
 	}
 	return nil
+}
+
+// applyUserGroupMembersReevaluated projects the dynamic user-group membership
+// delta the evaluator emits (#7 spec 14) — the source of truth for dynamic
+// membership (no direct projection write), so a rebuild replays it. Dynamic
+// sibling of applyUserGroupMemberAdded/Removed; version+dynamic guard first.
+func applyUserGroupMembersReevaluated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	p, err := decodePayload[payloads.UserGroupMembersReevaluated](e, "user_group", eventtypes.UserGroupMembersReevaluated)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	n, err := q.ClaimDynamicUserGroupForMembership(ctx, db.ClaimDynamicUserGroupForMembershipParams{
+		ID:                e.StreamID,
+		UpdatedAt:         e.OccurredAt,
+		ProjectionVersion: e.SequenceNum,
+	})
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return nil
+	}
+	for _, id := range p.AddedUserIDs {
+		if id == "" {
+			continue
+		}
+		if err := q.InsertUserGroupMember(ctx, db.InsertUserGroupMemberParams{
+			GroupID:           e.StreamID,
+			UserID:            id,
+			AddedAt:           e.OccurredAt,
+			AddedBy:           e.ActorID,
+			ProjectionVersion: e.SequenceNum,
+		}); err != nil {
+			return err
+		}
+	}
+	for _, id := range p.RemovedUserIDs {
+		if id == "" {
+			continue
+		}
+		if err := q.DeleteUserGroupMember(ctx, db.DeleteUserGroupMemberParams{
+			GroupID: e.StreamID,
+			UserID:  id,
+		}); err != nil {
+			return err
+		}
+	}
+	return q.RecountUserGroupMembers(ctx, e.StreamID)
 }
 
 func applyUserGroupCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -281,6 +281,11 @@ var IndexSchemas = []IndexSchema{
 			"os_arch", "TAG",
 			"kernel", "TEXT",
 			"compliance_status", "TAG", "SORTABLE",
+			// scope_group_ids: the device-group ids this device belongs to (#7
+			// spec 14). Confines a scope-restricted admin's device Search to their
+			// device groups — the Search counterpart of the dedicated ListDevices
+			// scope filter. Server-only TAG (kept out of client filters).
+			"scope_group_ids", "TAG",
 			"registered_at", "NUMERIC", "SORTABLE",
 			"last_seen_at", "NUMERIC", "SORTABLE",
 		},
@@ -294,6 +299,8 @@ var IndexSchemas = []IndexSchema{
 			"linux_username", "TEXT",
 			"disabled", "TAG", "SORTABLE",
 			"role", "TAG",
+			// scope_group_ids: the user-group ids this user belongs to (#7 spec 14).
+			"scope_group_ids", "TAG",
 			"last_login_at", "NUMERIC", "SORTABLE",
 			"created_at", "NUMERIC", "SORTABLE",
 		},
@@ -576,12 +583,46 @@ func (idx *Index) scopeGroupSet(ctx context.Context, sourceType string) (map[str
 	for _, r := range rows {
 		tmp[r.SourceID] = append(tmp[r.SourceID], r.TargetID)
 	}
-	out := make(map[string]string, len(tmp))
-	for id, ids := range tmp {
+	return joinSortedGroups(tmp), nil
+}
+
+// deviceGroupSet / userGroupSet return entity_id → comma-joined sorted group ids
+// for the device/user search `scope_group_ids` TAG during a warm rebuild (#7 spec
+// 14). One query each (the same is_deleted-excluded membership the auth resolver
+// uses), then O(1) lookups.
+func (idx *Index) deviceGroupSet(ctx context.Context) (map[string]string, error) {
+	rows, err := idx.store.Queries().ListAllDeviceGroupMemberships(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tmp := map[string][]string{}
+	for _, r := range rows {
+		tmp[r.DeviceID] = append(tmp[r.DeviceID], r.GroupID)
+	}
+	return joinSortedGroups(tmp), nil
+}
+
+func (idx *Index) userGroupSet(ctx context.Context) (map[string]string, error) {
+	rows, err := idx.store.Queries().ListAllUserGroupMemberships(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tmp := map[string][]string{}
+	for _, r := range rows {
+		tmp[r.UserID] = append(tmp[r.UserID], r.GroupID)
+	}
+	return joinSortedGroups(tmp), nil
+}
+
+// joinSortedGroups renders id→[group ids] as id→"g1,g2" (sorted, comma-joined) —
+// the multi-value TAG form scope_group_ids stores.
+func joinSortedGroups(m map[string][]string) map[string]string {
+	out := make(map[string]string, len(m))
+	for id, ids := range m {
 		sort.Strings(ids)
 		out[id] = strings.Join(ids, ",")
 	}
-	return out, nil
+	return out
 }
 
 func (idx *Index) warmActions(ctx context.Context) (int, map[string]string, error) {
@@ -911,6 +952,11 @@ func (idx *Index) warmDevices(ctx context.Context) (int, error) {
 	var offset int32
 	var total int
 
+	scopeGroups, err := idx.deviceGroupSet(ctx)
+	if err != nil {
+		return total, err
+	}
+
 	for {
 		devices, err := idx.store.Repos().Device.List(ctx, store.ListDevicesFilter{Limit: pageSize, Offset: offset, OwnerScope: nil})
 		if err != nil {
@@ -930,6 +976,8 @@ func (idx *Index) warmDevices(ctx context.Context) (int, error) {
 				AgentVersion:     d.AgentVersion,
 				Labels:           FlattenLabels(d.Labels),
 				ComplianceStatus: d.ComplianceStatus,
+				ScopeGroupIDs:    scopeGroups[d.ID],
+				HasScopeGroupIDs: true,
 			}
 			if d.RegisteredAt != nil {
 				data.RegisteredAt = d.RegisteredAt.Unix()
@@ -1004,6 +1052,11 @@ func (idx *Index) warmUsers(ctx context.Context) (int, error) {
 	var offset int32
 	var total int
 
+	scopeGroups, err := idx.userGroupSet(ctx)
+	if err != nil {
+		return total, err
+	}
+
 	for {
 		users, err := idx.store.Queries().ListAllUsers(ctx, db.ListAllUsersParams{
 			Limit:  pageSize,
@@ -1023,11 +1076,13 @@ func (idx *Index) warmUsers(ctx context.Context) (int, error) {
 				disabled = "true"
 			}
 			data := &taskqueue.SearchEntityData{
-				Email:         u.Email,
-				DisplayName:   u.DisplayName,
-				LinuxUsername: u.LinuxUsername,
-				Disabled:      disabled,
-				Role:          u.Role,
+				Email:            u.Email,
+				DisplayName:      u.DisplayName,
+				LinuxUsername:    u.LinuxUsername,
+				Disabled:         disabled,
+				Role:             u.Role,
+				ScopeGroupIDs:    scopeGroups[u.ID],
+				HasScopeGroupIDs: true,
 			}
 			if u.CreatedAt != nil {
 				data.CreatedAt = u.CreatedAt.Unix()

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -216,6 +217,11 @@ var IndexSchemas = []IndexSchema{
 			"type", "TAG", "SORTABLE",
 			"is_compliance", "TAG",
 			"assigned", "TAG",
+			// scope_group_ids: multi-value TAG of the device-/user-group ids this
+			// object is DIRECTLY assigned to (#7 spec 14). Scoped admins are
+			// confined to objects whose groups intersect their scope. Default ","
+			// separator — ULIDs contain no comma.
+			"scope_group_ids", "TAG",
 			"created_at", "NUMERIC", "SORTABLE",
 			"updated_at", "NUMERIC", "SORTABLE",
 		},
@@ -229,6 +235,7 @@ var IndexSchemas = []IndexSchema{
 			"member_count", "NUMERIC", "SORTABLE",
 			"action_names", "TEXT",
 			"assigned", "TAG",
+			"scope_group_ids", "TAG",
 			"created_at", "NUMERIC", "SORTABLE",
 			"updated_at", "NUMERIC", "SORTABLE",
 		},
@@ -243,6 +250,7 @@ var IndexSchemas = []IndexSchema{
 			"set_names", "TEXT",
 			"action_names", "TEXT",
 			"assigned", "TAG",
+			"scope_group_ids", "TAG",
 			"created_at", "NUMERIC", "SORTABLE",
 			"updated_at", "NUMERIC", "SORTABLE",
 		},
@@ -255,6 +263,7 @@ var IndexSchemas = []IndexSchema{
 			"description", "TEXT",
 			"action_names", "TEXT",
 			"rule_count", "NUMERIC", "SORTABLE",
+			"scope_group_ids", "TAG",
 			"created_at", "NUMERIC", "SORTABLE",
 		},
 	},
@@ -335,6 +344,18 @@ var IndexSchemas = []IndexSchema{
 		},
 	},
 }
+
+// ScopeGroupField is the multi-value TAG that holds the device-/user-group ids an
+// object is directly assigned to, used to confine scoped admins to their own
+// objects (#7 spec 14). The server both populates it (indexer) and filters on it
+// (search handler); it is NOT a client-facing filter, so ServerScopeFields keeps
+// it out of the api scopeFilterFields allow-list and the parity guard skips it.
+const ScopeGroupField = "scope_group_ids"
+
+// ServerScopeFields are index TAG fields the server populates and filters on for
+// RBAC scope confinement — never client-filterable. Self-discovering consumers
+// (scopeFilterFields parity, query builders) skip these.
+var ServerScopeFields = map[string]bool{ScopeGroupField: true}
 
 // schemaFingerprintKey stores the hash of IndexSchemas from the last Rebuild.
 const schemaFingerprintKey = "pm:indexer:schema:fingerprint"
@@ -541,6 +562,28 @@ func tagBool(b bool) string {
 	return "false"
 }
 
+// scopeGroupSet returns source_id → comma-joined sorted device-/user-group ids
+// for stamping the search `scope_group_ids` TAG during a warm rebuild (#7 spec
+// 14). One query per type, then O(1) lookups. A source absent from the map has
+// no group assignments → "" → invisible to scoped admins. Sorted for a stable
+// indexed value.
+func (idx *Index) scopeGroupSet(ctx context.Context, sourceType string) (map[string]string, error) {
+	rows, err := idx.store.Queries().ListScopeGroupAssignmentsBySourceType(ctx, sourceType)
+	if err != nil {
+		return nil, err
+	}
+	tmp := map[string][]string{}
+	for _, r := range rows {
+		tmp[r.SourceID] = append(tmp[r.SourceID], r.TargetID)
+	}
+	out := make(map[string]string, len(tmp))
+	for id, ids := range tmp {
+		sort.Strings(ids)
+		out[id] = strings.Join(ids, ",")
+	}
+	return out, nil
+}
+
 func (idx *Index) warmActions(ctx context.Context) (int, map[string]string, error) {
 	const pageSize int32 = 500
 	var offset int32
@@ -548,6 +591,10 @@ func (idx *Index) warmActions(ctx context.Context) (int, map[string]string, erro
 	actionNames := map[string]string{}
 
 	assignedActions, err := idx.assignedSourceSet(ctx, "action")
+	if err != nil {
+		return total, actionNames, err
+	}
+	scopeGroups, err := idx.scopeGroupSet(ctx, "action")
 	if err != nil {
 		return total, actionNames, err
 	}
@@ -579,11 +626,13 @@ func (idx *Index) warmActions(ctx context.Context) (int, map[string]string, erro
 				}
 			}
 			data := &taskqueue.SearchEntityData{
-				Name:         a.Name,
-				Description:  desc,
-				Type:         int32(a.ActionType),
-				IsCompliance: isCompliance,
-				Assigned:     tagBool(assignedActions[a.ID]),
+				Name:             a.Name,
+				Description:      desc,
+				Type:             int32(a.ActionType),
+				IsCompliance:     isCompliance,
+				Assigned:         tagBool(assignedActions[a.ID]),
+				ScopeGroupIDs:    scopeGroups[a.ID],
+				HasScopeGroupIDs: true,
 			}
 			if a.CreatedAt != nil {
 				data.CreatedAt = a.CreatedAt.Unix()
@@ -620,6 +669,10 @@ func (idx *Index) warmActionSets(ctx context.Context, actionNames map[string]str
 	setMembers := map[string][]string{}
 
 	assignedSets, err := idx.assignedSourceSet(ctx, "action_set")
+	if err != nil {
+		return total, setNames, setMembers, err
+	}
+	scopeGroups, err := idx.scopeGroupSet(ctx, "action_set")
 	if err != nil {
 		return total, setNames, setMembers, err
 	}
@@ -661,10 +714,12 @@ func (idx *Index) warmActionSets(ctx context.Context, actionNames map[string]str
 			}
 
 			data := &taskqueue.SearchEntityData{
-				Name:        s.Name,
-				Description: s.Description,
-				MemberCount: s.MemberCount,
-				Assigned:    tagBool(assignedSets[s.ID]),
+				Name:             s.Name,
+				Description:      s.Description,
+				MemberCount:      s.MemberCount,
+				Assigned:         tagBool(assignedSets[s.ID]),
+				ScopeGroupIDs:    scopeGroups[s.ID],
+				HasScopeGroupIDs: true,
 			}
 			if s.CreatedAt != nil {
 				data.CreatedAt = s.CreatedAt.Unix()
@@ -709,6 +764,10 @@ func (idx *Index) warmDefinitions(ctx context.Context, actionNames, setNames map
 	if err != nil {
 		return total, err
 	}
+	scopeGroups, err := idx.scopeGroupSet(ctx, "definition")
+	if err != nil {
+		return total, err
+	}
 
 	for {
 		defs, err := idx.store.Repos().Definition.List(ctx, store.ListDefinitionsFilter{Limit: pageSize, Offset: offset})
@@ -746,10 +805,12 @@ func (idx *Index) warmDefinitions(ctx context.Context, actionNames, setNames map
 			}
 
 			data := &taskqueue.SearchEntityData{
-				Name:        d.Name,
-				Description: d.Description,
-				MemberCount: d.MemberCount,
-				Assigned:    tagBool(assignedDefs[d.ID]),
+				Name:             d.Name,
+				Description:      d.Description,
+				MemberCount:      d.MemberCount,
+				Assigned:         tagBool(assignedDefs[d.ID]),
+				ScopeGroupIDs:    scopeGroups[d.ID],
+				HasScopeGroupIDs: true,
 			}
 			if d.CreatedAt != nil {
 				data.CreatedAt = d.CreatedAt.Unix()
@@ -783,6 +844,11 @@ func (idx *Index) warmCompliancePolicies(ctx context.Context) (int, error) {
 	var offset int32
 	var total int
 
+	scopeGroups, err := idx.scopeGroupSet(ctx, "compliance_policy")
+	if err != nil {
+		return total, err
+	}
+
 	for {
 		policies, err := idx.store.Queries().ListCompliancePolicies(ctx, db.ListCompliancePoliciesParams{
 			Limit:  pageSize,
@@ -813,12 +879,14 @@ func (idx *Index) warmCompliancePolicies(ctx context.Context) (int, error) {
 				}
 			}
 			data := &taskqueue.SearchEntityData{
-				Name:           p.Name,
-				Description:    p.Description,
-				ActionNames:    strings.Join(actionNames, " "),
-				HasActionNames: true, // warm has the authoritative rule list
-				RuleCount:      int32(len(rules)),
-				HasRuleCount:   true,
+				Name:             p.Name,
+				Description:      p.Description,
+				ActionNames:      strings.Join(actionNames, " "),
+				HasActionNames:   true, // warm has the authoritative rule list
+				RuleCount:        int32(len(rules)),
+				HasRuleCount:     true,
+				ScopeGroupIDs:    scopeGroups[p.ID],
+				HasScopeGroupIDs: true,
 			}
 			if p.CreatedAt != nil {
 				data.CreatedAt = p.CreatedAt.Unix()

--- a/internal/search/worker.go
+++ b/internal/search/worker.go
@@ -418,6 +418,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"os_arch":           sanitizeSearchField(data.OSArch, maxOSField),
 			"kernel":            sanitizeSearchField(data.Kernel, maxOSField),
 		}
+		setScopeGroupIDs(fields, data)
 		if data.RegisteredAt != 0 {
 			fields["registered_at"] = strconv.FormatInt(data.RegisteredAt, 10)
 		}
@@ -432,6 +433,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"linux_username": data.LinuxUsername,
 			"disabled":       data.Disabled,
 		}
+		setScopeGroupIDs(fields, data)
 		if data.Role != "" {
 			fields["role"] = data.Role
 		}

--- a/internal/search/worker.go
+++ b/internal/search/worker.go
@@ -323,6 +323,18 @@ func setAssigned(fields map[string]any, data *taskqueue.SearchEntityData) {
 	}
 }
 
+// setScopeGroupIDs writes the scope_group_ids TAG (#7 spec 14). Unlike
+// setAssigned, it keys off the HasScopeGroupIDs flag, not a non-empty value: an
+// UNASSIGNED object must write an EMPTY TAG (so it matches no scoped query and is
+// invisible to scoped admins), which an "" == not-computed rule would wrongly
+// skip. A path that didn't compute scope groups (Has == false) leaves the prior
+// value alone (HSET additive).
+func setScopeGroupIDs(fields map[string]any, data *taskqueue.SearchEntityData) {
+	if data.HasScopeGroupIDs {
+		fields[ScopeGroupField] = data.ScopeGroupIDs
+	}
+}
+
 func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any {
 	switch scope {
 	case ScopeAction:
@@ -337,6 +349,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"is_compliance": isCompliance,
 		}
 		setAssigned(fields, data)
+		setScopeGroupIDs(fields, data)
 		if data.CreatedAt != 0 {
 			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)
 		}
@@ -351,6 +364,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"member_count": strconv.Itoa(int(data.MemberCount)),
 		}
 		setAssigned(fields, data)
+		setScopeGroupIDs(fields, data)
 		if data.CreatedAt != 0 {
 			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)
 		}
@@ -365,6 +379,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"member_count": strconv.Itoa(int(data.MemberCount)),
 		}
 		setAssigned(fields, data)
+		setScopeGroupIDs(fields, data)
 		if data.CreatedAt != 0 {
 			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)
 		}
@@ -385,6 +400,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 		if data.HasRuleCount {
 			fields["rule_count"] = strconv.Itoa(int(data.RuleCount))
 		}
+		setScopeGroupIDs(fields, data)
 		if data.CreatedAt != 0 {
 			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)
 		}

--- a/internal/store/generated/assignments.sql.go
+++ b/internal/store/generated/assignments.sql.go
@@ -201,6 +201,32 @@ func (q *Queries) InsertAssignmentProjection(ctx context.Context, arg InsertAssi
 	return result.RowsAffected(), nil
 }
 
+const listActionSetIDsContainingAction = `-- name: ListActionSetIDsContainingAction :many
+SELECT set_id FROM action_set_members_projection WHERE action_id = $1
+`
+
+// Reverse container edge: the action-set ids that contain an action. Used by the
+// handler's EFFECTIVE (transitive read) scope walk (#7 spec 14).
+func (q *Queries) ListActionSetIDsContainingAction(ctx context.Context, actionID string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listActionSetIDsContainingAction, actionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var set_id string
+		if err := rows.Scan(&set_id); err != nil {
+			return nil, err
+		}
+		items = append(items, set_id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listAssignedActionsForDevice = `-- name: ListAssignedActionsForDevice :many
 WITH assigned_actions AS (
   -- Direct action assignments (no hierarchy, use assignment sort_order only)
@@ -641,6 +667,31 @@ func (q *Queries) ListAssignmentsForUser(ctx context.Context, targetID string) (
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listDefinitionIDsContainingActionSet = `-- name: ListDefinitionIDsContainingActionSet :many
+SELECT definition_id FROM definition_members_projection WHERE action_set_id = $1
+`
+
+// Reverse container edge: the definition ids that contain an action-set.
+func (q *Queries) ListDefinitionIDsContainingActionSet(ctx context.Context, actionSetID string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listDefinitionIDsContainingActionSet, actionSetID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var definition_id string
+		if err := rows.Scan(&definition_id); err != nil {
+			return nil, err
+		}
+		items = append(items, definition_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
@@ -1165,6 +1216,79 @@ func (q *Queries) ListResolvedActionsForDevice(ctx context.Context, targetID str
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listScopeGroupAssignmentsBySourceType = `-- name: ListScopeGroupAssignmentsBySourceType :many
+SELECT source_id, target_id FROM assignments_projection
+WHERE source_type = $1
+  AND target_type IN ('device_group', 'user_group')
+  AND is_deleted = FALSE
+`
+
+type ListScopeGroupAssignmentsBySourceTypeRow struct {
+	SourceID string `json:"source_id"`
+	TargetID string `json:"target_id"`
+}
+
+// (source_id, group_id) pairs for every object of a type that is directly
+// assigned to a device-/user-group. One query per type drives the search warm
+// rebuild of `scope_group_ids` (mirrors ListAssignedSourceIDs).
+func (q *Queries) ListScopeGroupAssignmentsBySourceType(ctx context.Context, sourceType string) ([]ListScopeGroupAssignmentsBySourceTypeRow, error) {
+	rows, err := q.db.Query(ctx, listScopeGroupAssignmentsBySourceType, sourceType)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListScopeGroupAssignmentsBySourceTypeRow{}
+	for rows.Next() {
+		var i ListScopeGroupAssignmentsBySourceTypeRow
+		if err := rows.Scan(&i.SourceID, &i.TargetID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listScopeGroupIDsForSource = `-- name: ListScopeGroupIDsForSource :many
+
+SELECT target_id FROM assignments_projection
+WHERE source_type = $1 AND source_id = $2
+  AND target_type IN ('device_group', 'user_group')
+  AND is_deleted = FALSE
+`
+
+type ListScopeGroupIDsForSourceParams struct {
+	SourceType string `json:"source_type"`
+	SourceID   string `json:"source_id"`
+}
+
+// #7 spec 14 — scoped object visibility. The following queries back the
+// search index `scope_group_ids` TAG (direct device-/user-group assignment ids
+// per object) and the live effective/direct scope walk in the object handlers.
+// Device-/user-group ids one object is DIRECTLY assigned to. Backs the search
+// index `scope_group_ids` for an incremental object reindex (#7 spec 14).
+func (q *Queries) ListScopeGroupIDsForSource(ctx context.Context, arg ListScopeGroupIDsForSourceParams) ([]string, error) {
+	rows, err := q.db.Query(ctx, listScopeGroupIDsForSource, arg.SourceType, arg.SourceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var target_id string
+		if err := rows.Scan(&target_id); err != nil {
+			return nil, err
+		}
+		items = append(items, target_id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/store/generated/device_groups.sql.go
+++ b/internal/store/generated/device_groups.sql.go
@@ -53,6 +53,34 @@ func (q *Queries) ClaimDeviceGroupForMembership(ctx context.Context, arg ClaimDe
 	return result.RowsAffected(), nil
 }
 
+const claimDynamicDeviceGroupForMembership = `-- name: ClaimDynamicDeviceGroupForMembership :execrows
+UPDATE device_groups_projection
+SET projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+  AND is_deleted = FALSE
+  AND is_dynamic = TRUE
+`
+
+type ClaimDynamicDeviceGroupForMembershipParams struct {
+	ID                string `json:"id"`
+	ProjectionVersion int64  `json:"projection_version"`
+}
+
+// Atomic guard for DeviceGroupMembersReevaluated (#7 spec 14). The DYNAMIC
+// sibling of ClaimDeviceGroupForMembership: bumps projection_version only when
+// the group exists, is alive, is DYNAMIC (the evaluator owns its member set),
+// and the event is newer. n=0 → skip (stale replay / non-dynamic / deleted),
+// so a stale reevaluation delta can't recreate removed members or wipe live
+// ones on replay.
+func (q *Queries) ClaimDynamicDeviceGroupForMembership(ctx context.Context, arg ClaimDynamicDeviceGroupForMembershipParams) (int64, error) {
+	result, err := q.db.Exec(ctx, claimDynamicDeviceGroupForMembership, arg.ID, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const countDeviceGroups = `-- name: CountDeviceGroups :one
 SELECT COUNT(*) FROM device_groups_projection
 WHERE is_deleted = FALSE
@@ -409,6 +437,67 @@ func (q *Queries) InsertDeviceGroupProjection(ctx context.Context, arg InsertDev
 		arg.ProjectionVersion,
 	)
 	return err
+}
+
+const listAllDeviceGroupMemberships = `-- name: ListAllDeviceGroupMemberships :many
+SELECT m.device_id, m.group_id FROM device_group_members_projection m
+JOIN device_groups_projection g ON g.id = m.group_id
+WHERE g.is_deleted = FALSE
+`
+
+type ListAllDeviceGroupMembershipsRow struct {
+	DeviceID string `json:"device_id"`
+	GroupID  string `json:"group_id"`
+}
+
+func (q *Queries) ListAllDeviceGroupMemberships(ctx context.Context) ([]ListAllDeviceGroupMembershipsRow, error) {
+	rows, err := q.db.Query(ctx, listAllDeviceGroupMemberships)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAllDeviceGroupMembershipsRow{}
+	for rows.Next() {
+		var i ListAllDeviceGroupMembershipsRow
+		if err := rows.Scan(&i.DeviceID, &i.GroupID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listDeviceGroupIDsForDevice = `-- name: ListDeviceGroupIDsForDevice :many
+
+SELECT g.id FROM device_groups_projection g
+JOIN device_group_members_projection m ON m.group_id = g.id
+WHERE m.device_id = $1 AND g.is_deleted = FALSE
+`
+
+// #7 spec 14 — device search scope. Group ids a device belongs to (static +
+// dynamic-materialized), excluding soft-deleted groups — matches the auth
+// ScopeResolver (ListGroupsForDevice). Backs the search `scope_group_ids` TAG.
+func (q *Queries) ListDeviceGroupIDsForDevice(ctx context.Context, deviceID string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listDeviceGroupIDsForDevice, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const listDeviceGroupMemberIDs = `-- name: ListDeviceGroupMemberIDs :many

--- a/internal/store/generated/user_groups.sql.go
+++ b/internal/store/generated/user_groups.sql.go
@@ -10,6 +10,32 @@ import (
 	"time"
 )
 
+const claimDynamicUserGroupForMembership = `-- name: ClaimDynamicUserGroupForMembership :execrows
+UPDATE user_groups_projection
+SET updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+  AND is_deleted = FALSE
+  AND is_dynamic = TRUE
+`
+
+type ClaimDynamicUserGroupForMembershipParams struct {
+	ID                string    `json:"id"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	ProjectionVersion int64     `json:"projection_version"`
+}
+
+// DYNAMIC sibling of ClaimUserGroupForMembership for UserGroupMembersReevaluated
+// (#7 spec 14).
+func (q *Queries) ClaimDynamicUserGroupForMembership(ctx context.Context, arg ClaimDynamicUserGroupForMembershipParams) (int64, error) {
+	result, err := q.db.Exec(ctx, claimDynamicUserGroupForMembership, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const claimUserGroupForMembership = `-- name: ClaimUserGroupForMembership :execrows
 UPDATE user_groups_projection
 SET updated_at         = $2,
@@ -560,6 +586,37 @@ func (q *Queries) IsUserInGroup(ctx context.Context, arg IsUserInGroupParams) (b
 	return is_member, err
 }
 
+const listAllUserGroupMemberships = `-- name: ListAllUserGroupMemberships :many
+SELECT ugm.user_id, ugm.group_id FROM user_group_members_projection ugm
+JOIN user_groups_projection ug ON ug.id = ugm.group_id
+WHERE ug.is_deleted = FALSE
+`
+
+type ListAllUserGroupMembershipsRow struct {
+	UserID  string `json:"user_id"`
+	GroupID string `json:"group_id"`
+}
+
+func (q *Queries) ListAllUserGroupMemberships(ctx context.Context) ([]ListAllUserGroupMembershipsRow, error) {
+	rows, err := q.db.Query(ctx, listAllUserGroupMemberships)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListAllUserGroupMembershipsRow{}
+	for rows.Next() {
+		var i ListAllUserGroupMembershipsRow
+		if err := rows.Scan(&i.UserID, &i.GroupID); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDynamicUserGroupQueueBatch = `-- name: ListDynamicUserGroupQueueBatch :many
 SELECT group_id FROM dynamic_user_group_evaluation_queue
 ORDER BY queued_at
@@ -633,6 +690,35 @@ func (q *Queries) ListInheritedRolesByUserIDs(ctx context.Context, dollar_1 []st
 			return nil, err
 		}
 		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listUserGroupIDsForUser = `-- name: ListUserGroupIDsForUser :many
+
+SELECT ug.id FROM user_groups_projection ug
+JOIN user_group_members_projection ugm ON ugm.group_id = ug.id
+WHERE ugm.user_id = $1 AND ug.is_deleted = FALSE
+`
+
+// #7 spec 14 — user search scope. Group ids a user belongs to, excluding
+// soft-deleted groups — matches the auth ScopeResolver (ListUserGroupsForUser).
+func (q *Queries) ListUserGroupIDsForUser(ctx context.Context, userID string) ([]string, error) {
+	rows, err := q.db.Query(ctx, listUserGroupIDsForUser, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		items = append(items, id)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/store/queries/assignments.sql
+++ b/internal/store/queries/assignments.sql
@@ -977,3 +977,33 @@ WHERE is_deleted = FALSE
        OR name LIKE 'system:terminal-admin-full:%')
   AND name NOT IN ('system:terminal-admin-limited:global',
                    'system:terminal-admin-full:global');
+
+-- #7 spec 14 — scoped object visibility. The following queries back the
+-- search index `scope_group_ids` TAG (direct device-/user-group assignment ids
+-- per object) and the live effective/direct scope walk in the object handlers.
+
+-- name: ListScopeGroupIDsForSource :many
+-- Device-/user-group ids one object is DIRECTLY assigned to. Backs the search
+-- index `scope_group_ids` for an incremental object reindex (#7 spec 14).
+SELECT target_id FROM assignments_projection
+WHERE source_type = $1 AND source_id = $2
+  AND target_type IN ('device_group', 'user_group')
+  AND is_deleted = FALSE;
+
+-- name: ListScopeGroupAssignmentsBySourceType :many
+-- (source_id, group_id) pairs for every object of a type that is directly
+-- assigned to a device-/user-group. One query per type drives the search warm
+-- rebuild of `scope_group_ids` (mirrors ListAssignedSourceIDs).
+SELECT source_id, target_id FROM assignments_projection
+WHERE source_type = $1
+  AND target_type IN ('device_group', 'user_group')
+  AND is_deleted = FALSE;
+
+-- name: ListActionSetIDsContainingAction :many
+-- Reverse container edge: the action-set ids that contain an action. Used by the
+-- handler's EFFECTIVE (transitive read) scope walk (#7 spec 14).
+SELECT set_id FROM action_set_members_projection WHERE action_id = $1;
+
+-- name: ListDefinitionIDsContainingActionSet :many
+-- Reverse container edge: the definition ids that contain an action-set.
+SELECT definition_id FROM definition_members_projection WHERE action_set_id = $1;

--- a/internal/store/queries/device_groups.sql
+++ b/internal/store/queries/device_groups.sql
@@ -352,3 +352,31 @@ WHERE group_id = $1
 UPDATE device_groups_projection
 SET member_count = (SELECT COUNT(*) FROM device_group_members_projection WHERE group_id = $1)
 WHERE id = $1;
+
+-- #7 spec 14 — device search scope. Group ids a device belongs to (static +
+-- dynamic-materialized), excluding soft-deleted groups — matches the auth
+-- ScopeResolver (ListGroupsForDevice). Backs the search `scope_group_ids` TAG.
+
+-- name: ListDeviceGroupIDsForDevice :many
+SELECT g.id FROM device_groups_projection g
+JOIN device_group_members_projection m ON m.group_id = g.id
+WHERE m.device_id = $1 AND g.is_deleted = FALSE;
+
+-- name: ListAllDeviceGroupMemberships :many
+SELECT m.device_id, m.group_id FROM device_group_members_projection m
+JOIN device_groups_projection g ON g.id = m.group_id
+WHERE g.is_deleted = FALSE;
+
+-- name: ClaimDynamicDeviceGroupForMembership :execrows
+-- Atomic guard for DeviceGroupMembersReevaluated (#7 spec 14). The DYNAMIC
+-- sibling of ClaimDeviceGroupForMembership: bumps projection_version only when
+-- the group exists, is alive, is DYNAMIC (the evaluator owns its member set),
+-- and the event is newer. n=0 → skip (stale replay / non-dynamic / deleted),
+-- so a stale reevaluation delta can't recreate removed members or wipe live
+-- ones on replay.
+UPDATE device_groups_projection
+SET projection_version = $2
+WHERE id = $1
+  AND projection_version < $2
+  AND is_deleted = FALSE
+  AND is_dynamic = TRUE;

--- a/internal/store/queries/user_groups.sql
+++ b/internal/store/queries/user_groups.sql
@@ -427,3 +427,27 @@ WHERE group_id = $1
   AND role_id = $2
   AND scope_kind IS NOT DISTINCT FROM sqlc.narg('scope_kind')::TEXT
   AND scope_id   IS NOT DISTINCT FROM sqlc.narg('scope_id')::TEXT;
+
+-- #7 spec 14 — user search scope. Group ids a user belongs to, excluding
+-- soft-deleted groups — matches the auth ScopeResolver (ListUserGroupsForUser).
+
+-- name: ListUserGroupIDsForUser :many
+SELECT ug.id FROM user_groups_projection ug
+JOIN user_group_members_projection ugm ON ugm.group_id = ug.id
+WHERE ugm.user_id = $1 AND ug.is_deleted = FALSE;
+
+-- name: ListAllUserGroupMemberships :many
+SELECT ugm.user_id, ugm.group_id FROM user_group_members_projection ugm
+JOIN user_groups_projection ug ON ug.id = ugm.group_id
+WHERE ug.is_deleted = FALSE;
+
+-- name: ClaimDynamicUserGroupForMembership :execrows
+-- DYNAMIC sibling of ClaimUserGroupForMembership for UserGroupMembersReevaluated
+-- (#7 spec 14).
+UPDATE user_groups_projection
+SET updated_at         = $2,
+    projection_version = $3
+WHERE id = $1
+  AND projection_version < $3
+  AND is_deleted = FALSE
+  AND is_dynamic = TRUE;

--- a/internal/taskqueue/payloads.go
+++ b/internal/taskqueue/payloads.go
@@ -342,6 +342,14 @@ type SearchEntityData struct {
 	RuleCount    int32  `json:"rule_count,omitempty"`     // compliance policy rule count (NUMERIC, sortable)
 	HasRuleCount bool   `json:"has_rule_count,omitempty"` // signals RuleCount computed (so 0 is written for the empty-rules filter)
 
+	// #7 spec 14 — scoped object visibility. Comma-joined device-/user-group
+	// ids the object is directly assigned to (multi-value TAG). HasScopeGroupIDs
+	// signals it was computed so the indexer writes the field even when empty
+	// (an unassigned object must have an empty TAG → matches no scoped query →
+	// invisible to scoped admins), rather than leaving a stale prior value.
+	ScopeGroupIDs    string `json:"scope_group_ids,omitempty"`
+	HasScopeGroupIDs bool   `json:"has_scope_group_ids,omitempty"`
+
 	// Audit event fields
 	EventType  string `json:"event_type,omitempty"`
 	StreamType string `json:"stream_type,omitempty"`


### PR DESCRIPTION
Closes the object-catalog and device/user Search leaks for scope-restricted admins (server#7). Two commits on this branch.

## 1. Scoped object visibility — actions / action-sets / definitions / compliance policies
All four object permissions were `TargetUnspecified`, so a device-group-scoped operator could `Search`, `Get`, and **mutate** the entire org catalog (every action's `ShellParams` script, every policy — the whole security posture).

- `auth.ObjectScopeListFilter` — caller scope = union of device-/user-group ids from the **JWT** grants (no DB round-trip).
- Server-only `scope_group_ids` TAG on the four object indexes = the object's direct group-target assignments; populated in warm + incremental reindex. Fully fresh (changes only on the object's own assignment events).
- Search appends `@scope_group_ids:{caller groups}` per object scope when restricted.
- 28 Get/mutation handlers: `Get` uses **effective** scope (object + containers, live) → `NotFound` + WARN log out-of-scope (no existence leak); mutations use **direct** scope → `PermissionDenied` (transitive visibility never grants write).
- Self-discovering parity test ties handler enforcement to index filtering both ways.

## 2. Device/user Search scope + event-driven dynamic group membership
The `Search` RPC applied no device/user scope, and the device/user list pages use `Search` (not the scoped `ListDevices`/`ListUsers`) → whole-org leak.

- `scope_group_ids` on `idx:devices` / `idx:users` = the entity's group memberships (same `is_deleted`-excluded source as the auth resolver). Search keys devices off `DeviceScopeListFilter("ListDevices")`, users off `UserScopeListFilter("ListUsers")`.
- **Event-driven dynamic membership (no audit/state drift, no ticker):** the dynamic-group evaluator wrote `*_group_members` directly with no events. It now emits a `*GroupMembersReevaluated` delta event and stops writing directly; a projector applies it (`ClaimDynamic*GroupForMembership` version+dynamic guard → insert/delete → recount). The event is the **source of truth** — a projection rebuild replays it, like static membership. The search listener reindexes the affected devices/users off the same event.

## Verification
`go vet`, `staticcheck`, and the `dyngroupeval` / `projectors` / `store` (rebuild) / `search` / full `api` suites all green. The existing evaluator membership-correctness tests run through the new event path unchanged (they are the integration test). ADR `0024-scoped-object-visibility.md`. No proto/SDK change.

Known fail-closed boundary: transitive-only / individual-device-assigned objects under-show in `Search` (readable via `Get`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now respects scoped visibility, so results are filtered to items the caller can access.
  * Read access can include container-derived visibility, while edit/delete access requires direct assignment.
  * Dynamic device and user group membership changes are now reflected more consistently in search results.

* **Bug Fixes**
  * Out-of-scope items now appear as not found when viewed, and unauthorized edits return permission denied.
  * Search now avoids leaking items outside the caller’s scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->