### PR TITLE
fix(deploy): correct the upgrade path (IMAGE_TAG, admin re-prompt, upgrade output) + docref-anchor doctor docs

### DIFF
--- a/.github/workflows/docref.yml
+++ b/.github/workflows/docref.yml
@@ -1,0 +1,23 @@
+name: docref
+
+# Keeps deploy/operator prose (deploy/QUICKSTART.md, SECURITY.md) honest against
+# the code it describes — the `control doctor` binary/subcommand name, the
+# doctor exit-code contract, the registered check set, and the CLI flags. A
+# claim or snippet that drifts from its anchored code fails this check. Runs on
+# every push/PR (no path filter) because drift can be introduced from EITHER
+# side — editing the prose OR editing the anchored Go / release workflow.
+on:
+  push:
+    branches: [main, 'v*']
+  pull_request:
+
+jobs:
+  docref-check:
+    name: docref (docs anchored to code)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Purpose-built docref CI image (docref + git on Alpine); nothing to build.
+      - name: docref check (docs match the code they describe)
+        run: docker run --rm -v "${{ github.workspace }}:/repo" ghcr.io/manchtools/open-docref:v0.1.0 check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,9 +168,11 @@ jobs:
           cat > Dockerfile.control <<'DEOF'
           FROM docker.io/library/alpine:3.21
           RUN apk add --no-cache ca-certificates
+          # docref: begin control-binary-name
           COPY dist/control-linux-* /usr/local/bin/control
           EXPOSE 8081
           ENTRYPOINT ["/usr/local/bin/control"]
+          # docref: end control-binary-name
           DEOF
           docker build --provenance=false -f Dockerfile.control -t ghcr.io/manchtools/power-manage-control:${{ steps.version.outputs.version }}-${{ matrix.arch }} .
           docker push ghcr.io/manchtools/power-manage-control:${{ steps.version.outputs.version }}-${{ matrix.arch }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -202,7 +202,7 @@ The threat model does **not** defend against:
   is not a defense against same-disk offline theft — full-disk encryption is that
   boundary.
 
-> Operators can run `power-manage-control doctor` to check that a live deployment
+> Operators can run `control doctor` to check that a live deployment
 > matches the transport/CA/secret expectations this document assumes.
 
 ## Accepted residuals

--- a/cmd/control/doctor.go
+++ b/cmd/control/doctor.go
@@ -12,7 +12,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/doctor"
 )
 
-// runDoctor implements `power-manage-control doctor [--json] [--env-file path]`:
+// runDoctor implements `control doctor [--json] [--env-file path]`:
 // a standalone, read-only health/security-posture pass. Returns the process exit
 // code (0 ok/info · 1 warning · 100 critical · 2 could-not-run — spec 15).
 func runDoctor(args []string) int {

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -76,12 +76,14 @@ type Config struct {
 }
 
 func main() {
-	// `power-manage-control doctor` is a standalone, read-only stack-health pass
+	// `control doctor` is a standalone, read-only stack-health pass
 	// (#322). It must run WITHOUT booting the server, so it intercepts before
 	// parseFlags (which would choke on the positional subcommand).
+	// docref: begin doctor-subcommand
 	if len(os.Args) > 1 && os.Args[1] == "doctor" {
 		os.Exit(runDoctor(os.Args[2:]))
 	}
+	// docref: end doctor-subcommand
 
 	cfg := parseFlags()
 

--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -1,6 +1,6 @@
 # Power Manage Server — Quickstart
 
-> Before exposing a deployment, read **[../SECURITY.md](../SECURITY.md)** — trust boundaries, what to protect (the Control host's CA keys), and the disclosure process. After install, `power-manage-control doctor` checks the live stack against those expectations.
+> Before exposing a deployment, read **[../SECURITY.md](../SECURITY.md)** — trust boundaries, what to protect (the Control host's CA keys), and the disclosure process. After install, `control doctor` checks the live stack against those expectations.
 
 One-line install on a fresh Linux host with Docker + the compose plugin already installed:
 
@@ -84,44 +84,52 @@ docker compose up -d
 
 ## Health & posture check: `doctor`
 
+<!-- docref: begin src=cmd/control/main.go#@doctor-subcommand:215d5a9d,.github/workflows/release.yml#@control-binary-name:6d502abb -->
 The Control binary ships a read-only `doctor` subcommand that checks the live
 stack and deployment configuration against the expectations in
 [../SECURITY.md](../SECURITY.md). It never mutates state, so it is safe to run
-against production. Run it inside the running Control container so it sees the
-same env and `.env`:
+against production. The in-container binary is `control` (run it inside the
+running Control container so it sees the same env and `.env`):
 
 ```bash
-docker compose exec control power-manage-control doctor          # human-readable
-docker compose exec control power-manage-control doctor --json   # machine-readable
+docker compose exec control control doctor          # human-readable
+docker compose exec control control doctor --json   # machine-readable
 ```
+<!-- docref: end -->
 
+<!-- docref: begin src=cmd/control/doctor.go#runDoctor:7091dc81 -->
 Flags:
 
 - `--json` — emit a JSON report (`{summary, findings, exec_errors, exit_code}`) for CI/monitoring.
 - `--env-file <path>` — also inspect this `.env` (default `.env`, silently skipped if absent). Values in the file take precedence over the process environment — it is the operator's stored config, the source of truth for what was configured.
+<!-- docref: end -->
 
+<!-- docref: begin src=internal/doctor/registry.go#DefaultChecks:401eacc2 -->
 It reports placeholder/weak secrets, mandatory at-rest encryption key, a
 credentialed CORS wildcard, an internal mTLS listener bound to all interfaces, a
 floating `IMAGE_TAG`, certificate file permissions and approaching expiry,
 Postgres/Valkey reachability, Asynq dead-letter depth, search-index presence
 and indexer liveness (reconcile heartbeat), and a bootstrap admin still on the
 default email.
+<!-- docref: end -->
 
 ### Exit codes
 
 The exit code is the worst outcome, so a single boolean gate works in CI:
 
+<!-- docref: begin src=internal/doctor/doctor.go#Report.ExitCode:91e925ce -->
 | Code | Meaning |
 |------|---------|
 | `0`  | all clear — only `ok`/`info` findings |
 | `1`  | at least one **warning** (worth fixing; not blocking) |
 | `100`| at least one **critical** finding (insecure/broken — do not ship) |
 | `2`  | a check could not run (exec error) — the report is incomplete; takes precedence over everything |
+<!-- docref: end -->
 
 Example gate (fail a deploy pipeline on any critical or could-not-run):
 
 ```bash
-docker compose exec -T control power-manage-control doctor
+docker compose exec -T control control doctor
 code=$?
 if [ "$code" -ge 100 ] || [ "$code" -eq 2 ]; then
   echo "doctor found critical issues (exit $code)"; exit 1

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -245,6 +245,22 @@ download_deploy_tree() {
 ###############################################################################
 # Step 3 — initialise .env if missing
 ###############################################################################
+
+# set_image_tag writes IMAGE_TAG=$1 into .env, replacing any existing line (or
+# appending if absent) and preserving the file's 0600 mode — it holds secrets.
+# Atomic same-directory mktemp + rename, mirroring setup.sh's write_env_var.
+set_image_tag() {
+    local value="$1" envfile="$INSTALL_DIR/.env" tmp
+    tmp="$(mktemp "${envfile}.XXXXXX")"
+    awk -v v="$value" '
+        /^IMAGE_TAG=/ { print "IMAGE_TAG=" v; found=1; next }
+        { print }
+        END { if (!found) print "IMAGE_TAG=" v }
+    ' "$envfile" > "$tmp"
+    chmod --reference="$envfile" "$tmp" 2>/dev/null || chmod 600 "$tmp"
+    mv "$tmp" "$envfile"
+}
+
 init_env() {
     cd "$INSTALL_DIR"
     if [[ ! -f .env ]]; then
@@ -252,6 +268,18 @@ init_env() {
         log_info "Created .env from .env.example — guided setup will fill it in."
     else
         log_info ".env already exists — guided setup will only prompt for missing values."
+    fi
+
+    # Pin IMAGE_TAG to the (already-resolved) release tag so the images actually
+    # match the deploy tree we just extracted. Without this, an upgrade re-run
+    # PRESERVES the operator's previous IMAGE_TAG and silently runs the OLD
+    # images against the NEW compose — the half-upgrade that left a 2026.06
+    # control talking to a 2026.07 valkey. Only version tags (vYYYY.MM[-rcN])
+    # map to published images; a branch deploy (e.g. main) has no matching image
+    # tag, so leave IMAGE_TAG untouched there.
+    if [[ "$RELEASE_TAG" == v* ]]; then
+        set_image_tag "$RELEASE_TAG"
+        log_info "  Pinned IMAGE_TAG=$RELEASE_TAG (matches the deployed release)."
     fi
 }
 
@@ -339,7 +367,11 @@ print_summary() {
     set -u
 
     echo ""
-    log_info "✓ Power Manage Server is up."
+    if [[ "${PM_EXISTING_INSTALL:-0}" -eq 1 ]]; then
+        log_info "✓ Power Manage Server upgraded to ${IMAGE_TAG:-<unset>}."
+    else
+        log_info "✓ Power Manage Server is up."
+    fi
     echo ""
     echo "  Control UI:    https://${CONTROL_DOMAIN:-<unset>}"
     echo "  Gateway mTLS:  https://${GATEWAY_DOMAIN:-<unset>}"
@@ -349,12 +381,24 @@ print_summary() {
     echo ""
     echo "  Admin login:   ${ADMIN_EMAIL:-<unset>}"
     echo "  Install dir:   $INSTALL_DIR"
+    echo "  Image tag:     ${IMAGE_TAG:-<unset>}"
     echo ""
-    echo "Next steps:"
-    echo "  1. Wait ~30s for Let's Encrypt to issue certs (first run only)."
-    echo "  2. Log in to the Control UI and create real user accounts."
-    echo "  3. Generate a registration token, then enroll an agent on a device:"
-    echo "       curl -fsSL https://github.com/MANCHTOOLS/power-manage-agent/releases/latest/download/install.sh | sudo bash -s -- -s https://${CONTROL_DOMAIN:-<DOMAIN>} -t <TOKEN>"
+    if [[ "${PM_EXISTING_INSTALL:-0}" -eq 1 ]]; then
+        echo "Next steps:"
+        echo "  1. Confirm control started on the new version and applied migrations:"
+        echo "       docker compose -f $INSTALL_DIR/compose.yml logs -f control"
+        echo "       (look for the version banner + any 'goose' migration lines)"
+        echo "  2. Verify health & security posture:"
+        echo "       docker compose -f $INSTALL_DIR/compose.yml exec control control doctor"
+        echo ""
+        echo "  Your admin account, enrolled agents, and data are unchanged."
+    else
+        echo "Next steps:"
+        echo "  1. Wait ~30s for Let's Encrypt to issue certs (first run only)."
+        echo "  2. Log in to the Control UI and create real user accounts."
+        echo "  3. Generate a registration token, then enroll an agent on a device:"
+        echo "       curl -fsSL https://github.com/MANCHTOOLS/power-manage-agent/releases/latest/download/install.sh | sudo bash -s -- -s https://${CONTROL_DOMAIN:-<DOMAIN>} -t <TOKEN>"
+    fi
     echo ""
     echo "  Logs:          docker compose -f $INSTALL_DIR/compose.yml logs -f"
     echo ""
@@ -363,6 +407,12 @@ print_summary() {
 main() {
     log_info "Power Manage Server installer (rc11)"
     echo ""
+
+    # Capture whether this is an upgrade BEFORE setup.sh (re)provisions certs:
+    # an existing CA is the canonical "already provisioned" marker, used to
+    # print upgrade-aware final instructions instead of fresh-install next-steps.
+    PM_EXISTING_INSTALL=0
+    [[ -f "$INSTALL_DIR/certs/ca.crt" ]] && PM_EXISTING_INSTALL=1
 
     preflight
     download_deploy_tree

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -279,6 +279,31 @@ generate_control_public_cert() {
 show_instructions() {
     echo ""
     echo "=========================================="
+    if [[ "${EXISTING_INSTALL:-0}" -eq 1 ]]; then
+        echo "  Power Manage Upgrade Prepared"
+        echo "=========================================="
+        echo ""
+        echo "Existing deployment — config and certificates refreshed in place."
+        echo "Your admin account, enrolled agents, DNS, and data are unchanged."
+        echo ""
+        echo "Next steps:"
+        echo ""
+        echo "1. Apply the new images / config:"
+        echo "   cd $SCRIPT_DIR && docker compose up -d"
+        echo ""
+        echo "2. Watch the control server start and apply any DB migrations:"
+        echo "   docker compose logs -f control     # look for the version + 'goose' lines"
+        echo ""
+        echo "3. Verify health & security posture:"
+        echo "   docker compose exec control control doctor"
+        echo ""
+        echo "If the indexer logs a Postgres auth failure (its DB role predates"
+        echo "INDEXER_POSTGRES_PASSWORD), set it once:"
+        echo "   docker exec -it pm-postgres psql -U powermanage -d powermanage \\"
+        echo "     -c \"ALTER ROLE pm_indexer PASSWORD '\$INDEXER_POSTGRES_PASSWORD'\""
+        echo ""
+        return
+    fi
     echo "  Power Manage Setup Complete"
     echo "=========================================="
     echo ""
@@ -297,11 +322,7 @@ show_instructions() {
     echo "3. Access the web UI at https://${CONTROL_DOMAIN}"
     echo "   Login with: ${ADMIN_EMAIL}"
     echo ""
-    echo "4. If upgrading an existing deployment, set the indexer DB password:"
-    echo "   docker exec -it pm-postgres psql -U powermanage -d powermanage \\"
-    echo "     -c \"ALTER ROLE pm_indexer PASSWORD '\$INDEXER_POSTGRES_PASSWORD'\""
-    echo ""
-    echo "5. Create a registration token, then install agents:"
+    echo "4. Create a registration token, then install agents:"
     echo "   curl -fsSL https://github.com/MANCHTOOLS/power-manage-agent/releases/latest/download/install.sh | sudo bash -s -- -s https://${CONTROL_DOMAIN} -t <TOKEN>"
     echo ""
 }
@@ -593,32 +614,42 @@ guided_setup() {
     write_env_var PM_TASK_SIGNING_KEY "$REPLY_VALUE"
 
     # --- Admin account ---
-    # admin@<parent-domain> if CONTROL_DOMAIN has a dot; admin@<full>
-    # for single-label cases (admin@localhost is a valid local-delivery
-    # address for those deployments).
-    local admin_parent
-    admin_parent="$(parent_domain "$CONTROL_DOMAIN")"
-    local default_email
-    if [[ -n "$admin_parent" ]]; then
-        default_email="admin@$admin_parent"
+    # The bootstrap admin is created ONCE, from these values, the first time the
+    # control server boots. On a re-run / upgrade — detected by an already
+    # generated CA, the canonical "this deployment is provisioned" marker — the
+    # admin already exists in the database. Re-prompting here is not just noise:
+    # a freshly entered password is written to .env, and if the original
+    # bootstrap admin had since been removed or renamed, the server's
+    # create-if-missing bootstrap would RESURRECT it on the next boot. So skip
+    # the admin prompts entirely once provisioned, leaving the operator's
+    # existing .env values untouched.
+    local admin_pass="" admin_pass_generated=0
+    if [[ "${EXISTING_INSTALL:-0}" -eq 1 ]]; then
+        log_info "  Upgrade mode — keeping the current admin; skipping bootstrap-admin prompts."
     else
-        default_email="admin@$CONTROL_DOMAIN"
-    fi
-    prompt_string "Bootstrap admin email (ADMIN_EMAIL)" "$default_email" "${ADMIN_EMAIL:-}"
-    write_env_var ADMIN_EMAIL "$REPLY_VALUE"
-    # Mirror the prompt result back into the shell var. The summary
-    # block below would otherwise echo the stale value sourced before
-    # the prompt loop ran (empty on a fresh install).
-    ADMIN_EMAIL="$REPLY_VALUE"
+        # admin@<parent-domain> if CONTROL_DOMAIN has a dot; admin@<full> for
+        # single-label cases (admin@localhost is a valid local-delivery address).
+        local admin_parent default_email
+        admin_parent="$(parent_domain "$CONTROL_DOMAIN")"
+        if [[ -n "$admin_parent" ]]; then
+            default_email="admin@$admin_parent"
+        else
+            default_email="admin@$CONTROL_DOMAIN"
+        fi
+        prompt_string "Bootstrap admin email (ADMIN_EMAIL)" "$default_email" "${ADMIN_EMAIL:-}"
+        write_env_var ADMIN_EMAIL "$REPLY_VALUE"
+        # Mirror back so the summary block echoes the chosen value, not the
+        # stale one sourced before the prompt loop (empty on a fresh install).
+        ADMIN_EMAIL="$REPLY_VALUE"
 
-    # Use hex (not base64) so the generated password is safe to paste
-    # into a web form. base64 emits '+' and '/' — '+' decodes as space
-    # under application/x-www-form-urlencoded so the bootstrap admin
-    # could not sign in through the UI without manual URL encoding.
-    prompt_secret "Bootstrap admin password (ADMIN_PASSWORD)" "openssl rand -hex 24" "${ADMIN_PASSWORD:-}"
-    write_env_var ADMIN_PASSWORD "$REPLY_VALUE"
-    local admin_pass="$REPLY_VALUE"
-    local admin_pass_generated="$REPLY_GENERATED"
+        # Use hex (not base64) so the generated password is safe to paste into a
+        # web form. base64 emits '+' which decodes as space under
+        # application/x-www-form-urlencoded, blocking UI sign-in.
+        prompt_secret "Bootstrap admin password (ADMIN_PASSWORD)" "openssl rand -hex 24" "${ADMIN_PASSWORD:-}"
+        write_env_var ADMIN_PASSWORD "$REPLY_VALUE"
+        admin_pass="$REPLY_VALUE"
+        admin_pass_generated="$REPLY_GENERATED"
+    fi
 
     echo ""
     log_info "Guided setup complete. .env updated."
@@ -674,6 +705,17 @@ EOF
 
 main() {
     log_info "Power Manage Server Setup"
+    echo ""
+
+    # Detect a re-run / upgrade BEFORE generate_ca creates the CA: an existing
+    # CA is the canonical "this deployment is already provisioned" marker. Used
+    # to skip the one-time bootstrap-admin prompts (guided_setup) and to print
+    # upgrade-aware instructions instead of fresh-install next-steps.
+    EXISTING_INSTALL=0
+    if [[ -f "$CERTS_DIR/ca.crt" ]]; then
+        EXISTING_INSTALL=1
+        log_info "Existing deployment detected — running in upgrade mode."
+    fi
     echo ""
 
     # Guided mode runs only on a TTY when --no-prompt wasn't passed.

--- a/docref.toml
+++ b/docref.toml
@@ -1,0 +1,9 @@
+# docref keeps deploy/operator prose honest against the code it describes.
+# `docref check` (run in CI) fails when an anchored snippet or claim drifts from
+# the symbol/region it points at — e.g. the `control doctor` binary/subcommand
+# name, the doctor exit-code contract, or the registered check set.
+[scan]
+include = ["deploy/QUICKSTART.md", "SECURITY.md"]
+
+[check]
+level = "strict"

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,6 +1,6 @@
 // Package doctor runs operator-facing stack-health and security-posture checks
 // for a Power Manage Control deployment (#322, spec 15). It is invoked as
-// `power-manage-control doctor` — a standalone, read-only pass that reports
+// `control doctor` — a standalone, read-only pass that reports
 // findings with a severity and an exit code, and never mutates state.
 package doctor
 


### PR DESCRIPTION
Found cutting **v2026.07-rc1** on a live v2026.06 server — three upgrade bugs, plus the `doctor` binary-name doc drift.

## Bugs fixed

### 1. `install.sh` never set `IMAGE_TAG` (the big one)
`RELEASE_TAG=v2026.07-rc1` swapped the `deploy/` tree but **not** `IMAGE_TAG`, so a re-run kept the operator's old tag and ran the **2026.06** images against the **2026.07** compose — a 2026.06 control talking to a valkey-bundle backend (broken search: `Invalid query string syntax`; migration never applied). `init_env` now pins `IMAGE_TAG` to the resolved release tag (version tags only; branch deploys left untouched), via an atomic 0600-preserving `.env` rewrite.

### 2. `setup.sh` re-prompted for admin creds on every upgrade
And a freshly entered password could **resurrect a since-removed bootstrap admin** on next boot. `guided_setup` now skips the admin prompts once provisioned (existing CA = the "already set up" marker), leaving `.env` untouched.

### 3. Post-run "next steps" assumed a fresh install
Both `setup.sh` (`show_instructions`) and `install.sh` (`print_summary`) now print **upgrade-aware** output (apply images → watch migrations → `control doctor`) instead of DNS / first-login / enroll-agent steps.

## Doc correctness + drift prevention
The in-container binary is **`control`** (the image `ENTRYPOINT`), not `power-manage-control` — corrected every reference (QUICKSTART, SECURITY.md, package docs). To stop this recurring, **docref** is bootstrapped in the server repo:
- `docref.toml` + a `docref.yml` CI job (mirrors the sdk's, runs on every push/PR).
- The QUICKSTART doctor section is anchored to code: binary/subcommand name (`main.go` dispatch region + the release-workflow `ENTRYPOINT` region), the exit-code contract (`Report.ExitCode`), the registered check set (`DefaultChecks`), and the CLI flags (`runDoctor`).
- `docref check`: **4 up-to-date, 0 broken**.

## Verification
- `bash -n` on both scripts; functional test of the `IMAGE_TAG` rewrite (replace + append, secrets preserved).
- YAML parses (release.yml heredoc still valid); `gofmt`/`vet`/`build` clean (Go changes are comments + one docref marker); `docref check` green.

Operators on the half-upgraded state can recover now with: set `IMAGE_TAG=v2026.07-rc1` in `.env`, `docker compose pull && up -d`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated documentation consistency checks in CI.
  * Improved install and setup flows to detect upgrades and show the right next steps.

* **Bug Fixes**
  * Prevented upgrades from reusing an outdated container image tag.
  * Preserved existing admin settings during upgrade runs.

* **Documentation**
  * Updated setup, security, and command references to use `control doctor`.
  * Added stricter documentation verification rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->