### PR TITLE
fix(deploy): pin IMAGE_TAG to the v-less image tag form (manifest unknown)

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -277,9 +277,14 @@ init_env() {
     # control talking to a 2026.07 valkey. Only version tags (vYYYY.MM[-rcN])
     # map to published images; a branch deploy (e.g. main) has no matching image
     # tag, so leave IMAGE_TAG untouched there.
+    #
+    # The published image tags STRIP the leading `v` (release.yml builds them
+    # from ${GITHUB_REF_NAME#v}, so tag v2026.07-rc2 → image 2026.07-rc2). Pin
+    # the v-less form or `docker compose pull` fails with `manifest unknown`.
     if [[ "$RELEASE_TAG" == v* ]]; then
-        set_image_tag "$RELEASE_TAG"
-        log_info "  Pinned IMAGE_TAG=$RELEASE_TAG (matches the deployed release)."
+        local image_tag="${RELEASE_TAG#v}"
+        set_image_tag "$image_tag"
+        log_info "  Pinned IMAGE_TAG=$image_tag (matches the deployed release)."
     fi
 }
 


### PR DESCRIPTION
Follow-up to #466. The IMAGE_TAG pin used the raw git tag (`v2026.07-rc2`), but the published images **strip the leading `v`** — `release.yml` builds them from `${GITHUB_REF_NAME#v}`, so git tag `v2026.07-rc2` → image tag `2026.07-rc2`. Result: `docker compose pull` → `manifest unknown` on an upgrade.

Fix: pin `${RELEASE_TAG#v}`.

Verified against the registry — `control/gateway/indexer:2026.07-rc2` exist, `:v2026.07-rc2` do not. `bash -n` + functional test (strip + `.env` write produces `IMAGE_TAG=2026.07-rc2`, no `v`).

Operator recovery in the meantime: set `IMAGE_TAG=2026.07-rc2` (no `v`) in `.env`, `docker compose pull && up -d`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Release image tags are now saved without the leading `v`, matching the deployed image tag format.
  - Environment setup now consistently pins the correct image tag value and logs the pinned tag for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->