### PR TITLE
fix(search): valkey-search-compatible match-all (empty/list-all queries) + bulk-warm timeout

### DIFF
--- a/cmd/control/valkey.go
+++ b/cmd/control/valkey.go
@@ -152,6 +152,10 @@ func newValkeySubsystem(ctx context.Context, cfg *Config, st *store.Store, svc *
 		Password: cfg.ValkeyPassword,
 		DB:       cfg.ValkeyDB,
 		Protocol: 2,
+		// 30s (vs the 3s default) so the admin-triggered RebuildSearchIndex —
+		// which bulk-warms every scope — tolerates valkey-search indexing
+		// latency on a modest host instead of failing with "i/o timeout".
+		ReadTimeout: 30 * time.Second,
 	})
 
 	searchIdx := search.New(v.rdb, st, v.aqClient, logger.With("component", "search"))

--- a/cmd/indexer/main.go
+++ b/cmd/indexer/main.go
@@ -79,6 +79,12 @@ func main() {
 		Password: cfg.ValkeyPassword,
 		DB:       cfg.ValkeyDB,
 		Protocol: 2,
+		// The default 3s read timeout is too tight for the bulk index rebuild:
+		// warming a scope pipelines hundreds of HSETs whose valkey-search
+		// indexing (SORTABLE/TEXT fields) can exceed 3s on a modest host, which
+		// then crash-loops the indexer ("warm …: i/o timeout"). 30s tolerates a
+		// slow host; WriteTimeout defaults to ReadTimeout when unset.
+		ReadTimeout: 30 * time.Second,
 	})
 	defer rdb.Close()
 

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -347,6 +347,15 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 			}
 		}
 
+		// `*` is our internal "no constraints" sentinel. valkey-search 1.2.0
+		// rejects a bare `*`, so translate it to the index's real match-all
+		// (`-@<tag>:{sentinel}`, derived from the schema) before querying.
+		if scopedQuery == "*" {
+			if all := search.MatchAllForIndex(idxName); all != "" {
+				scopedQuery = all
+			}
+		}
+
 		args := []any{"FT.SEARCH", idxName, scopedQuery}
 
 		// SORTBY: the request's sort_field/direction validated against the scope,

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -172,6 +172,53 @@ func (s IndexSchema) FilterableFields() map[string]bool {
 	return out
 }
 
+// matchAllSentinel is an impossible TAG value used to express "match every
+// document". valkey-search 1.2.0 (unlike RediSearch) rejects a bare `*`; the
+// list pages send `*` for an empty/no-filter query, which fails with "Invalid
+// query string syntax". Negating an impossible value — `-@field:{sentinel}` —
+// matches ALL docs, including those missing the field (a NUMERIC range
+// `[-inf +inf]` would silently drop docs without that field).
+const matchAllSentinel = "__pm_match_all__"
+
+// firstTAGField returns the first TAG field declared in the schema (schema order
+// is deterministic — Schema is a slice). Every index declares at least one TAG
+// field; a TAG negation is the cleanest match-all.
+func (s IndexSchema) firstTAGField() string {
+	for i := 1; i < len(s.Schema); i++ {
+		if t, _ := s.Schema[i].(string); t == "TAG" {
+			if field, ok := s.Schema[i-1].(string); ok {
+				return field
+			}
+		}
+	}
+	return ""
+}
+
+// MatchAllQuery returns a valkey-search query that matches every document in
+// this index. It is self-discovering: a new index automatically gets a valid
+// match-all from its own schema, so the empty/list-all path can never silently
+// regress to a bare `*` again. Returns "" only for the (impossible for current
+// indexes) case of a schema with no TAG field.
+func (s IndexSchema) MatchAllQuery() string {
+	field := s.firstTAGField()
+	if field == "" {
+		return ""
+	}
+	return fmt.Sprintf("-@%s:{%s}", field, matchAllSentinel)
+}
+
+// MatchAllForIndex returns the match-all query for the named index (e.g.
+// "idx:devices"), or "" if the index is unknown. Used by the search handler to
+// translate its internal `*` sentinel into a valkey-search-valid query.
+func MatchAllForIndex(name string) string {
+	for _, ix := range IndexSchemas {
+		if ix.Name == name {
+			return ix.MatchAllQuery()
+		}
+	}
+	return ""
+}
+
 // NumericFields returns the field names declared NUMERIC. A structured filter on
 // a NUMERIC field must use a range (@field:[min max]); the TAG @field:{value}
 // syntax is a RediSearch error on a NUMERIC field. Derived by pairing each type

--- a/internal/search/matchall_test.go
+++ b/internal/search/matchall_test.go
@@ -1,0 +1,81 @@
+package search_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/search"
+)
+
+// TestMatchAllQuery_EveryIndexHasValidMatchAll is the fast, container-free guard:
+// every registered index must yield a non-empty match-all that negates one of its
+// OWN declared filter fields. Self-discovering over IndexSchemas (matches-zero
+// guarded), so adding an index with no TAG field — which would have no valid
+// valkey-search match-all — fails the build here, before it can ship as a bare
+// `*` that the list pages send and valkey-search 1.2.0 rejects.
+func TestMatchAllQuery_EveryIndexHasValidMatchAll(t *testing.T) {
+	require.NotEmpty(t, search.IndexSchemas, "matches-zero guard: no index schemas")
+	for _, ix := range search.IndexSchemas {
+		q := ix.MatchAllQuery()
+		require.NotEmptyf(t, q, "index %s has no match-all query (no TAG field?)", ix.Name)
+		require.Truef(t, strings.HasPrefix(q, "-@"), "match-all for %s must be a negation, got %q", ix.Name, q)
+		colon := strings.IndexByte(q, ':')
+		require.Greaterf(t, colon, 2, "malformed match-all %q for %s", q, ix.Name)
+		field := q[2:colon]
+		assert.Truef(t, ix.FilterableFields()[field],
+			"match-all for %s negates %q which is not a declared filter field", ix.Name, field)
+	}
+}
+
+// TestMatchAllQuery_AcceptedByValkeySearch is the regression test for the bug the
+// list pages hit: valkey-search 1.2.0 rejects a bare `*`, so the empty/list-all
+// query failed with "Invalid query string syntax". For EVERY index it indexes a
+// probe doc and runs that index's match-all against the real valkey-search
+// backend, asserting the query is accepted and returns the doc. Self-discovering,
+// so no index can regress to an unsupported match-all unnoticed.
+func TestMatchAllQuery_AcceptedByValkeySearch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+	rdb := setupRedis(t)
+	idx := search.New(rdb, nil, nil, testLogger())
+	require.NoError(t, idx.EnsureIndexes(ctx))
+
+	for _, ix := range search.IndexSchemas {
+		ix := ix
+		t.Run(ix.Name, func(t *testing.T) {
+			// Index one probe doc under this index's prefix, populating its first
+			// declared field so it is a real, returnable document.
+			firstField, _ := ix.Schema[0].(string)
+			require.NotEmpty(t, firstField, "index %s has no fields", ix.Name)
+			key := ix.Prefix + "matchall-probe"
+			require.NoError(t, rdb.HSet(ctx, key, firstField, "probe-value").Err())
+			t.Cleanup(func() { rdb.Del(context.Background(), key) })
+
+			q := ix.MatchAllQuery()
+			res, err := rdb.Do(ctx, "FT.SEARCH", ix.Name, q, "LIMIT", 0, 10).Result()
+			require.NoErrorf(t, err, "valkey-search rejected match-all %q for %s", q, ix.Name)
+
+			arr, ok := res.([]any)
+			require.Truef(t, ok, "unexpected FT.SEARCH result shape for %s: %T", ix.Name, res)
+			require.NotEmpty(t, arr, "empty FT.SEARCH result for %s", ix.Name)
+			// FT.SEARCH (RESP2) returns [total, key, fields, ...]; total is first.
+			var total int64
+			switch v := arr[0].(type) {
+			case int64:
+				total = v
+			case string:
+				// some builds return the count as a string
+				require.NotEmpty(t, v)
+			}
+			if total != 0 {
+				assert.GreaterOrEqualf(t, total, int64(1), "match-all for %s matched no docs", ix.Name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two production-only bugs surfaced upgrading a live deployment to 2026.07 — both in paths CI never exercised (the redis-stack→valkey-search migration, #319).

## 1. Empty/list-all search broken (`Invalid query string syntax`)
valkey-search 1.2.0 (in `valkey-bundle:9.1.0`) **rejects a bare `*`**. The list pages send `*` for a no-filter query, so Devices/Actions/Device-Groups list pages fail. Every existing search test queries a *real term* (`Nginx*`, `@stream_type:{device}`), so the match-all path shipped untested across the whole 2026.07 line.

**Fix:** `IndexSchema.MatchAllQuery()` — self-discovering from each index's own schema, returns `-@<firstTAG>:{__pm_match_all__}` (negate an impossible value). Verified against real `valkey-bundle:9.1.0`: accepted, and returns docs **including those missing the field** (a `@ts:[-inf +inf]` numeric range silently drops them — 2/3 vs 3/3 in testing). The handler translates its internal `*` sentinel to this per-index query before `FT.SEARCH`; `buildFTQuery`'s `*` sentinel is unchanged.

## 2. Indexer crash-loop on a modest host (`warm …: i/o timeout`)
The bulk rebuild warm pipelines hundreds of HSETs whose valkey-search indexing (SORTABLE/TEXT) can exceed go-redis's **default 3s read timeout**, crash-looping the indexer. Bumped the indexer + control search clients to a 30s read timeout (CI's faster host never hit it).

## Regression tests (self-discovering over `IndexSchemas`)
- Unit: every index yields a valid match-all negating one of its own filter fields (fast, always runs — catches a new index with no usable match-all).
- Integration: every index's match-all is **accepted by real valkey-search 1.2.0** and returns an indexed probe doc. This is exactly the gate that was missing — it would have caught the `*` bug.

This is the prevention the incident called for: the empty-query path is now exercised against the real backend for every index, so it can't silently regress again.