### PR TITLE
feat(doctor): functional search-query probe (catch a present-but-unanswering index)

### DIFF
--- a/internal/doctor/check_live.go
+++ b/internal/doctor/check_live.go
@@ -116,17 +116,48 @@ func (c SearchCheck) Run(ctx context.Context, env *Env) ([]Finding, error) {
 	if skip, ok := cacheReady(ctx, c, env); !ok {
 		return skip, nil
 	}
-	missing, err := env.Cache.MissingIndexes(ctx, expectedIndexNames())
+	names := expectedIndexNames()
+	missing, err := env.Cache.MissingIndexes(ctx, names)
 	if err != nil {
 		// Reachable but FT.INFO failed (e.g. the RediSearch module is absent) —
 		// could-not-run, not a clean pass.
 		return nil, fmt.Errorf("query search indexes: %w", err)
 	}
 	var findings []Finding
+	missingSet := map[string]bool{}
 	for _, name := range missing {
+		missingSet[name] = true
 		findings = append(findings, crit(c.ID(),
 			fmt.Sprintf("search index %s is missing", name),
 			"run the indexer / RebuildSearchIndex to (re)create it"))
+	}
+
+	// Functional probe: a PRESENT index whose match-all query the engine REJECTS
+	// (e.g. a valkey-search version that doesn't accept the query syntax) breaks
+	// the list pages even though FT.INFO reports the index exists — a failure the
+	// presence/fingerprint/heartbeat checks all miss because none runs a query.
+	// Probe only the present indexes; a rejection is Critical (search can't answer).
+	present := make([]string, 0, len(names))
+	for _, n := range names {
+		if !missingSet[n] {
+			present = append(present, n)
+		}
+	}
+	rejected, err := env.Cache.SearchQueryRejections(ctx, present)
+	if err != nil {
+		return nil, fmt.Errorf("probe search queries: %w", err)
+	}
+	rejNames := make([]string, 0, len(rejected))
+	for n := range rejected {
+		rejNames = append(rejNames, n)
+	}
+	sort.Strings(rejNames)
+	for _, n := range rejNames {
+		f := crit(c.ID(),
+			fmt.Sprintf("search index %s is present but rejects queries — list pages will fail", n),
+			"the search engine does not accept the query syntax (e.g. a valkey-search version mismatch)")
+		f.Detail = rejected[n]
+		findings = append(findings, f)
 	}
 
 	// Indexer liveness: a heartbeat older than 2× the reconcile interval means
@@ -134,11 +165,11 @@ func (c SearchCheck) Run(ctx context.Context, env *Env) ([]Finding, error) {
 	// the fingerprint may still match. Absent heartbeat ⇒ never stamped (fresh
 	// deploy / pre-heartbeat indexer); not a "stale" signal, so no warning.
 	interval := reconcileInterval(env)
-	ts, present, err := env.Cache.LastReconcile(ctx)
+	ts, hbPresent, err := env.Cache.LastReconcile(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("read indexer reconcile heartbeat: %w", err)
 	}
-	if present {
+	if hbPresent {
 		if age := env.now().Sub(ts); age > 2*interval {
 			f := warn(c.ID(),
 				fmt.Sprintf("the search indexer has not reconciled in %s (> 2× the %s interval) — it may be dead or stuck", age.Round(time.Second), interval),
@@ -158,7 +189,7 @@ func (c SearchCheck) Run(ctx context.Context, env *Env) ([]Finding, error) {
 			"the indexer will rebuild on next boot; trigger a rebuild if it has not"))
 	}
 	if len(findings) == 0 {
-		return []Finding{ok(c.ID(), "all expected search indexes present, schema current, indexer reconciling")}, nil
+		return []Finding{ok(c.ID(), "all expected search indexes present and answering queries, schema current, indexer reconciling")}, nil
 	}
 	return findings, nil
 }

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -291,6 +291,24 @@ func TestSearchCheck(t *testing.T) {
 		env.Cache = fakeCache{reconcileErr: errors.New("bad heartbeat value")}
 		require.Error(t, runErr(t, SearchCheck{}, env))
 	})
+	t.Run("present index rejects queries → critical (functional probe)", func(t *testing.T) {
+		env := testEnv(nil)
+		env.Cache = fakeCache{
+			schemaCurrent: true,
+			reconcileOK:   true,
+			lastReconcile: env.now().Add(-1 * time.Minute),
+			// FT.INFO says the index is present, but it rejects the match-all
+			// query — the exact failure the list pages hit. State checks would
+			// pass; the functional probe catches it.
+			rejected: map[string]string{"idx:devices": "Invalid query string syntax"},
+		}
+		assert.Equal(t, SeverityCritical, worst(run1(t, SearchCheck{}, env)))
+	})
+	t.Run("query probe errors (reachable) → exec error", func(t *testing.T) {
+		env := testEnv(nil)
+		env.Cache = fakeCache{schemaCurrent: true, rejectErr: errors.New("probe boom")}
+		require.Error(t, runErr(t, SearchCheck{}, env))
+	})
 }
 
 func TestAdminCheck(t *testing.T) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -37,6 +37,8 @@ type fakeCache struct {
 	lastReconcile time.Time
 	reconcileOK   bool
 	reconcileErr  error
+	rejected      map[string]string
+	rejectErr     error
 }
 
 func (f fakeCache) Ping(context.Context) error { return f.pingErr }
@@ -49,6 +51,9 @@ func (f fakeCache) ArchivedByQueue(context.Context) (map[string]int, error) {
 }
 func (f fakeCache) LastReconcile(context.Context) (time.Time, bool, error) {
 	return f.lastReconcile, f.reconcileOK, f.reconcileErr
+}
+func (f fakeCache) SearchQueryRejections(context.Context, []string) (map[string]string, error) {
+	return f.rejected, f.rejectErr
 }
 
 func testEnv(vars map[string]string) *Env {

--- a/internal/doctor/env.go
+++ b/internal/doctor/env.go
@@ -158,4 +158,11 @@ type CacheProbe interface {
 	// whether that heartbeat is present (absent ⇒ never stamped / pre-heartbeat
 	// indexer). Used to detect a dead/stuck indexer.
 	LastReconcile(ctx context.Context) (time.Time, bool, error)
+	// SearchQueryRejections runs each named index's real match-all query and
+	// returns the indexes whose query the engine REJECTED, mapped to the error
+	// (e.g. a valkey-search version that doesn't accept the query syntax). This
+	// is the FUNCTIONAL probe — index-presence/freshness checks miss a search
+	// that is present but cannot answer. Missing indexes are skipped (covered by
+	// MissingIndexes).
+	SearchQueryRejections(ctx context.Context, indexNames []string) (map[string]string, error)
 }

--- a/internal/doctor/probe.go
+++ b/internal/doctor/probe.go
@@ -112,6 +112,28 @@ func (v *ValkeyProbe) ArchivedByQueue(_ context.Context) (map[string]int, error)
 	return out, nil
 }
 
+// SearchQueryRejections runs each index's real match-all query (the exact query
+// the list pages send for an empty/no-filter search) against the live engine and
+// records any the engine rejects. This catches a search that is PRESENT but
+// cannot answer — e.g. a valkey-search version that rejects the query syntax —
+// which the FT.INFO/fingerprint/heartbeat checks all miss. Read-only (LIMIT 0 0).
+func (v *ValkeyProbe) SearchQueryRejections(ctx context.Context, names []string) (map[string]string, error) {
+	rejected := map[string]string{}
+	for _, name := range names {
+		q := search.MatchAllForIndex(name)
+		if q == "" {
+			continue // unknown index — no match-all to probe
+		}
+		if err := v.rdb.Do(ctx, "FT.SEARCH", name, q, "LIMIT", 0, 0).Err(); err != nil {
+			if indexNotFound(err) {
+				continue // absent index is reported by MissingIndexes, not here
+			}
+			rejected[name] = err.Error()
+		}
+	}
+	return rejected, nil
+}
+
 // LastReconcile reads the indexer heartbeat (search.LastReconcileKey, RFC3339).
 func (v *ValkeyProbe) LastReconcile(ctx context.Context) (time.Time, bool, error) {
 	raw, err := v.rdb.Get(ctx, search.LastReconcileKey).Result()


### PR DESCRIPTION
Follow-up to the search match-all fix (#468). The doctor's `SearchCheck` only checked search **state** — indexes present (`FT.INFO`), schema fingerprint current, indexer heartbeat fresh. None of those runs a query, so a search that is *present but cannot answer* — exactly the `*` match-all bug, where valkey-search rejected the query syntax — was invisible to the doctor, and would have read as a **false green** once the index rebuilt.

This adds the missing **functional** dimension: for each present index, run its real match-all query (the exact query the list pages send) against the live engine and report any the engine **rejects** as `Critical` ("present but rejects queries — list pages will fail"). Read-only (`LIMIT 0 0`), self-discovering via `search.MatchAllForIndex` over the registered indexes.

This is the **runtime twin** of the CI regression test from #468: CI validates every index's match-all against real valkey-search; the doctor now catches the same failure on the live deployment, at upgrade time, even if a path ever slips past CI. The existing `TestValkeyProbe_Integration` already exercises it against a real valkey-search backend.

Tests are red-before-green: a rejected query → `Critical`; a reachable-but-failing probe → exec error (fail-closed, consistent with the other live checks).

No release tag — this lands on `main` for a future RC, per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health checks for search indexes to catch cases where an index exists but cannot answer queries.
  * Search checks now report critical issues for query rejections, with the rejection details included.
  * Success now requires expected indexes to be both present and responding correctly.
  * Expanded test coverage for query rejection and probe failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->