### PR TITLE
fix(rc5): search warm deadlock (load-then-index) + agent connect binding chicken-and-egg

### DIFF
--- a/cmd/indexer/rebuild_gate.go
+++ b/cmd/indexer/rebuild_gate.go
@@ -30,7 +30,6 @@ const (
 type searchGate interface {
 	IndexesPresent(ctx context.Context) (bool, error)
 	SchemaCurrent(ctx context.Context) (bool, error)
-	Warm(ctx context.Context) error
 	Rebuild(ctx context.Context) error
 }
 
@@ -64,8 +63,14 @@ func startupSearchSync(ctx context.Context, gate searchGate, locker rebuildLocke
 			return fmt.Errorf("check search schema fingerprint: %w", err)
 		}
 		if current {
-			logger.Info("search indexes present and schema current; warming without destructive flush")
-			return gate.Warm(ctx)
+			// Already built and schema-current. Do NOT bulk re-warm into a LIVE
+			// index: streaming a full reload of HSETs at an existing FT index
+			// deadlocks valkey-search's async writer (see Index.Rebuild / ADR 0027).
+			// The data is already indexed; the incremental worker keeps it live and
+			// the periodic reconcile corrects drift, so the reload is both unsafe
+			// and redundant — skip it.
+			logger.Info("search indexes present and schema current; skipping reload (incremental worker + periodic reconcile keep it current)")
+			return nil
 		}
 		logger.Info("search index schema changed since last rebuild; rebuild required")
 	}
@@ -75,12 +80,16 @@ func startupSearchSync(ctx context.Context, gate searchGate, locker rebuildLocke
 		return fmt.Errorf("acquire rebuild lock: %w", err)
 	}
 	if !acquired {
-		logger.Info("another indexer holds the rebuild lock; warming without flush")
-		return gate.Warm(ctx)
+		// Another indexer holds the lock and is performing the load-then-index
+		// rebuild, which will produce the complete index. Warming into its
+		// half-built/live index here would deadlock the async writer, so skip — the
+		// lock holder is the single source of the rebuild.
+		logger.Info("another indexer holds the rebuild lock; skipping (the lock holder rebuilds)")
+		return nil
 	}
 	defer release()
 
-	logger.Info("search indexes missing; performing destructive rebuild under lock")
+	logger.Info("search indexes missing or schema changed; performing load-then-index rebuild under lock")
 	return gate.Rebuild(ctx)
 }
 

--- a/cmd/indexer/rebuild_gate_test.go
+++ b/cmd/indexer/rebuild_gate_test.go
@@ -20,13 +20,11 @@ type fakeGate struct {
 	presentErr    error
 	schemaCurrent bool
 	schemaErr     error
-	warmCalls     int
 	rebuildCalls  int
 }
 
 func (f *fakeGate) IndexesPresent(context.Context) (bool, error) { return f.present, f.presentErr }
 func (f *fakeGate) SchemaCurrent(context.Context) (bool, error)  { return f.schemaCurrent, f.schemaErr }
-func (f *fakeGate) Warm(context.Context) error                   { f.warmCalls++; return nil }
 func (f *fakeGate) Rebuild(context.Context) error                { f.rebuildCalls++; return nil }
 
 type fakeLocker struct {
@@ -39,19 +37,22 @@ func (f *fakeLocker) TryLock(context.Context) (bool, func(), error) {
 	return f.acquired, func() { f.released++ }, f.err
 }
 
-// TestStartupSearchSync_GatesDestructiveRebuild pins WS13 #12: the destructive
-// flush+rebuild only happens when the indexes are MISSING and this indexer wins
-// the lock; otherwise it warms without flushing. A present-check error fails
-// closed (no flush).
+// TestStartupSearchSync_GatesDestructiveRebuild pins WS13 #12 + the load-then-
+// index fix (ADR 0027): the destructive flush+rebuild only happens when the
+// indexes are MISSING (or the schema changed) and this indexer wins the lock.
+// Otherwise the boot SKIPS the bulk reload entirely — re-streaming HSETs into a
+// LIVE index would deadlock valkey-search's async writer, and the data is already
+// indexed (the incremental worker + periodic reconcile keep it current). A
+// present-check error fails closed (no flush).
 func TestStartupSearchSync_GatesDestructiveRebuild(t *testing.T) {
 	ctx := context.Background()
 
-	t.Run("indexes present + schema current → warm only, never rebuild", func(t *testing.T) {
+	t.Run("indexes present + schema current → skip, never rebuild or reload", func(t *testing.T) {
 		g := &fakeGate{present: true, schemaCurrent: true}
 		l := &fakeLocker{acquired: true} // would acquire, but must not be consulted
 		require.NoError(t, startupSearchSync(ctx, g, l, gateTestLogger()))
-		assert.Equal(t, 1, g.warmCalls, "present indexes must be warmed")
 		assert.Equal(t, 0, g.rebuildCalls, "present+current indexes must NOT be destructively rebuilt")
+		assert.Equal(t, 0, l.released, "the lock must not even be consulted when present+current")
 	})
 
 	t.Run("indexes present but schema changed → rebuild under lock (#325)", func(t *testing.T) {
@@ -59,7 +60,6 @@ func TestStartupSearchSync_GatesDestructiveRebuild(t *testing.T) {
 		l := &fakeLocker{acquired: true}
 		require.NoError(t, startupSearchSync(ctx, g, l, gateTestLogger()))
 		assert.Equal(t, 1, g.rebuildCalls, "a schema change must trigger a drop+rebuild even when indexes exist")
-		assert.Equal(t, 0, g.warmCalls)
 		assert.Equal(t, 1, l.released)
 	})
 
@@ -68,7 +68,6 @@ func TestStartupSearchSync_GatesDestructiveRebuild(t *testing.T) {
 		l := &fakeLocker{acquired: true}
 		require.Error(t, startupSearchSync(ctx, g, l, gateTestLogger()))
 		assert.Equal(t, 0, g.rebuildCalls)
-		assert.Equal(t, 0, g.warmCalls)
 	})
 
 	t.Run("indexes missing + lock won → rebuild under lock", func(t *testing.T) {
@@ -76,16 +75,14 @@ func TestStartupSearchSync_GatesDestructiveRebuild(t *testing.T) {
 		l := &fakeLocker{acquired: true}
 		require.NoError(t, startupSearchSync(ctx, g, l, gateTestLogger()))
 		assert.Equal(t, 1, g.rebuildCalls, "missing indexes + lock held → rebuild")
-		assert.Equal(t, 0, g.warmCalls)
 		assert.Equal(t, 1, l.released, "the lock must be released after rebuild")
 	})
 
-	t.Run("indexes missing + lock lost → warm only (no racing wipe)", func(t *testing.T) {
+	t.Run("indexes missing + lock lost → skip (the lock holder rebuilds)", func(t *testing.T) {
 		g := &fakeGate{present: false}
 		l := &fakeLocker{acquired: false}
 		require.NoError(t, startupSearchSync(ctx, g, l, gateTestLogger()))
-		assert.Equal(t, 1, g.warmCalls, "a contender that lost the lock warms instead of flushing")
-		assert.Equal(t, 0, g.rebuildCalls, "only the lock holder may flush+rebuild")
+		assert.Equal(t, 0, g.rebuildCalls, "only the lock holder may flush+rebuild; a contender skips (no firehose into the live index)")
 		assert.Equal(t, 0, l.released, "release must not be called when the lock was not acquired")
 	})
 
@@ -95,7 +92,6 @@ func TestStartupSearchSync_GatesDestructiveRebuild(t *testing.T) {
 		require.Error(t, startupSearchSync(ctx, g, l, gateTestLogger()),
 			"a present-check error must be fatal, not treated as 'missing' (which would flush)")
 		assert.Equal(t, 0, g.rebuildCalls, "must NOT flush/rebuild on an indeterminate present-check")
-		assert.Equal(t, 0, g.warmCalls)
 	})
 }
 

--- a/docs/adr/0027-search-load-then-index.md
+++ b/docs/adr/0027-search-load-then-index.md
@@ -1,0 +1,84 @@
+# ADR 0027: Search rebuild uses load-then-index (not stream-into-live-index)
+
+Status: Accepted
+Date: 2026-06-27
+
+## Context
+
+The search indexer (`server/internal/search`) builds the FT search indexes from
+the Postgres projections. The cutover from RediSearch (redis-stack) to
+valkey-search (`valkey/valkey-bundle`) — see #319 — kept the original rebuild
+order:
+
+1. `FlushSearchData` — drop the FT indexes and the search keyspace,
+2. `EnsureIndexes` — `FT.CREATE` all indexes (now LIVE),
+3. `Warm` — bulk-pipeline an `HSET` per row into the now-live indexes.
+
+On a real deployment this **deadlocked the indexer on startup**: the warm of the
+`executions` scope (and any other scope with more than a few dozen rows) stalled
+for ~120s and failed with `warm executions: pipeline exec: i/o timeout`, then the
+indexer crash-looped / left search empty.
+
+### Root cause (empirically established)
+
+RediSearch indexed **synchronously** on the command, so streaming a bulk pipeline
+of `HSET`s at a live index was fine. valkey-search introduced an **asynchronous
+writer** (a small worker pool draining a mutation queue), and it applies
+**synchronous backpressure**: when the mutation queue passes its high-water mark
+the module stops replying to the writing command until the queue drains. The
+writer only makes progress when the main thread returns to the event loop, so a
+tight, un-flushed go-redis pipeline (which writes every command before reading
+any reply) starves the writer and **deadlocks** — the client blocks on a reply
+that never comes until its read timeout.
+
+This was isolated to the engine, not our data or driver:
+
+- Same valkey-bundle, same go-redis, same 151-HSET pipeline: into **FT-indexed**
+  keys it wedged at ~120s; into **un-indexed** keys it returned in **1 ms**.
+- Writing only the 6 indexed schema fields (no extra fields) still wedged → not a
+  data/field/type problem.
+- One-`HSET`-at-a-time (the live incremental path) completed every row → the
+  engine indexes our data fine; only the bulk firehose into a live index breaks.
+- Writing the keyspace **first** and creating the index **after** indexed **3020
+  rows in ~110 ms** (valkey-search backfills by scanning at its own pace).
+
+The live/incremental path (`internal/search/worker.go`, one `HSET` per event) was
+never affected — only the bulk `Warm`/`Rebuild` and the boot "re-warm into a
+present index" path.
+
+## Decision
+
+**Rebuild loads data, then indexes it.** `Index.Rebuild` is reordered to:
+
+1. `FlushSearchData`,
+2. `Warm` — write every search hash into the **index-less** keyspace (fast, no
+   writer backpressure),
+3. `EnsureIndexes` — `FT.CREATE`, which backfills the populated keyspace in the
+   background,
+4. `waitForBackfill` — poll `FT.INFO backfill_in_progress` until every index is
+   done, so a completed `Rebuild` guarantees a query-ready index.
+
+**The boot gate no longer re-warms a live index.** `startupSearchSync`
+(`cmd/indexer/rebuild_gate.go`) previously called `Warm` on a normal restart
+(indexes present + schema current) and on lock contention — both stream a full
+reload of `HSET`s into a live index and would deadlock at scale. Both now **skip**
+the bulk reload: the data is already indexed, the incremental worker keeps it
+live, and the periodic reconcile (`Rebuild`) corrects drift. The destructive
+load-then-index rebuild still runs only when indexes are missing or the schema
+fingerprint changed, under the single-writer lock (WS13 #12 is preserved).
+
+## Consequences
+
+- A big deployment warms on startup at any scale (regression test seeds 5000
+  executions and asserts `Rebuild` completes under a bounded context with every
+  row indexed).
+- During a rebuild the indexes are briefly absent (between flush and
+  `EnsureIndexes`) instead of present-but-partial; for a boot/reconcile this is an
+  acceptable, short, search-unavailable window rather than a deadlock.
+- No magic batch size and no engine change. Reverting to RediSearch (source-
+  available licensing; the single valkey-bundle also backs the Asynq queue) was
+  considered and rejected — the defect is a contained client-side ordering bug,
+  not an engine deficiency.
+- Upgrading in place from a wedged rc4 (indexes present, schema "current",
+  executions empty) self-heals on the next periodic reconcile; a fresh deploy
+  (indexes missing) is correct immediately.

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -61,8 +61,10 @@ type InternalHandler struct {
 }
 
 // SetDeviceGatewayResolver wires the device→gateway routing registry so every
-// InternalService request that carries a device_id is confined to the gateway
-// the device is actually live on (verifyDeviceGatewayBinding). Called from
+// credential-bearing InternalService request (ProxySync*/LUKS/LPS/terminal) is
+// confined to the gateway the device is actually live on
+// (verifyDeviceGatewayBinding). VerifyDevice is exempt — it is the pre-attach
+// bootstrap and would otherwise deadlock the device's own connection. Called from
 // main.go in HA/multi-gateway deployments; left nil for single-gateway.
 func (h *InternalHandler) SetDeviceGatewayResolver(r registry.DeviceGatewayLookup) {
 	h.deviceGatewayResolver = r
@@ -103,10 +105,19 @@ func (h *InternalHandler) VerifyDevice(ctx context.Context, req *connect.Request
 	if deviceID == "" {
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id is required")
 	}
-	if err := h.verifyDeviceGatewayBinding(ctx, req.Msg.DeviceId, req.Msg.GatewayId); err != nil {
-		return nil, err
-	}
 
+	// VerifyDevice deliberately does NOT call verifyDeviceGatewayBinding. It is the
+	// connection BOOTSTRAP: handler/agent.go calls it to admit a device's mTLS
+	// stream BEFORE AttachDevice publishes the device→gateway binding. Enforcing
+	// the binding here is a chicken-and-egg — the device can't verify (to connect)
+	// until it is live, and can't become live until it connects — so it rejects
+	// EVERY agent whenever the routing registry is wired (the server#404 regression
+	// these binding checks introduced). The SA-C2 confinement that binding protects
+	// does not apply: VerifyDevice reads only existence, returns no secret/action,
+	// and appends no event, and the device's identity is already proven by its mTLS
+	// client cert (agent.go checks cert device-id == hello device-id). The binding
+	// stays enforced on the credential-bearing ProxySync*/LUKS/LPS/terminal methods,
+	// which run only after the device is live.
 	_, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{ID: deviceID})
 	if err != nil {
 		h.logger.Warn("device verification failed", "device_id", deviceID, "error", err)

--- a/internal/api/internal_handler_gateway_binding_test.go
+++ b/internal/api/internal_handler_gateway_binding_test.go
@@ -65,10 +65,6 @@ func TestInternalHandlers_GatewayBindingIsSelfDiscovering(t *testing.T) {
 		name string
 		call func() error
 	}{
-		{"VerifyDevice", func() error {
-			_, e := h.VerifyDevice(ctx, connect.NewRequest(&pm.VerifyDeviceRequest{DeviceId: device, GatewayId: wrongGateway}))
-			return e
-		}},
 		{"ProxySyncActions", func() error {
 			_, e := h.ProxySyncActions(ctx, connect.NewRequest(&pm.InternalSyncActionsRequest{DeviceId: device, GatewayId: wrongGateway}))
 			return e
@@ -104,29 +100,63 @@ func TestInternalHandlers_GatewayBindingIsSelfDiscovering(t *testing.T) {
 			"%s must reject a gateway binding mismatch with PermissionDenied", c.name)
 	}
 
-	// Completeness: the table must cover EXACTLY the InternalService requests
-	// that carry a device_id (discovered from the proto descriptor), so a new
-	// device-origin RPC can't escape the binding by omission.
-	want := internalRequestsWithDeviceID(t)
-	assert.Equalf(t, want, len(cases),
-		"every InternalService request carrying device_id needs a binding case here (proto descriptor has %d, table has %d)", want, len(cases))
+	// VerifyDevice is the connection BOOTSTRAP and is intentionally exempt from the
+	// binding (enforcing it there deadlocks the device's own connect — see
+	// VerifyDevice in internal_handler.go). Prove the exemption is LIVE: with the
+	// device live on gw-A, a VerifyDevice claiming gw-B still SUCCEEDS.
+	_, verr := h.VerifyDevice(ctx, connect.NewRequest(&pm.VerifyDeviceRequest{DeviceId: device, GatewayId: wrongGateway}))
+	require.NoError(t, verr, "VerifyDevice is the pre-attach bootstrap and must NOT enforce the gateway binding")
+
+	// Completeness: EVERY InternalService request carrying a device_id must either
+	// have a binding case above OR be a justified exemption — so a new device-origin
+	// RPC can't escape the binding by omission, and an exemption can't go stale.
+	deviceRPCs := internalRequestsWithDeviceID(t)
+	covered := map[string]bool{}
+	for _, c := range cases {
+		covered[c.name] = true
+	}
+	for name := range deviceRPCs {
+		if bindingExemptInternalRPCs[name] {
+			continue
+		}
+		assert.Truef(t, covered[name],
+			"InternalService.%s carries device_id but enforces no binding case here — add a case above or a justified entry to bindingExemptInternalRPCs", name)
+	}
+	for name := range bindingExemptInternalRPCs {
+		assert.Truef(t, deviceRPCs[name],
+			"bindingExemptInternalRPCs[%q] is stale — that RPC no longer carries device_id", name)
+	}
 }
 
-// internalRequestsWithDeviceID counts InternalService methods whose request
-// message carries a device_id field — the self-discovering completeness anchor.
-func internalRequestsWithDeviceID(t *testing.T) int {
+// bindingExemptInternalRPCs are device-origin InternalService methods that
+// deliberately do NOT enforce verifyDeviceGatewayBinding. VerifyDevice is the
+// connection BOOTSTRAP: the gateway calls it to admit a device's mTLS stream
+// BEFORE AttachDevice publishes the device→gateway binding, so enforcing the
+// binding there is a chicken-and-egg that rejects every agent (the server#404
+// regression). It reads only existence, returns no secret/action, and appends no
+// event, so the SA-C2 confinement does not apply; the device's identity is
+// already proven by its mTLS client cert.
+var bindingExemptInternalRPCs = map[string]bool{
+	"VerifyDevice": true,
+}
+
+// internalRequestsWithDeviceID returns the set of InternalService method names
+// whose request message carries a device_id field — the self-discovering
+// completeness anchor for the binding guard.
+func internalRequestsWithDeviceID(t *testing.T) map[string]bool {
 	t.Helper()
 	svc := pm.File_pm_v1_internal_proto.Services().ByName("InternalService")
 	require.NotNil(t, svc, "InternalService descriptor must resolve")
-	n := 0
+	out := map[string]bool{}
 	methods := svc.Methods()
 	for i := 0; i < methods.Len(); i++ {
-		if methods.Get(i).Input().Fields().ByName("device_id") != nil {
-			n++
+		m := methods.Get(i)
+		if m.Input().Fields().ByName("device_id") != nil {
+			out[string(m.Name())] = true
 		}
 	}
-	require.NotZero(t, n, "matches-zero guard: no InternalService request carries device_id")
-	return n
+	require.NotZero(t, len(out), "matches-zero guard: no InternalService request carries device_id")
+	return out
 }
 
 // TestProxyGetLuksKey_GatewayBinding covers the LUKS-secret read path across all

--- a/internal/api/internal_handler_test.go
+++ b/internal/api/internal_handler_test.go
@@ -11,9 +11,19 @@ import (
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
 	"github.com/manchtools/power-manage/server/internal/terminal"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
+
+// notLiveResolver is a device→gateway routing registry that reports every device
+// as not currently live on any gateway (the state during a fresh connect, before
+// AttachDevice runs). Used to exercise the binding gate without a real Valkey.
+type notLiveResolver struct{}
+
+func (notLiveResolver) LookupDeviceGateway(context.Context, string) (string, error) {
+	return "", registry.ErrNoGateway
+}
 
 func TestVerifyDevice_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
@@ -48,6 +58,48 @@ func TestVerifyDevice_EmptyID(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// TestVerifyDevice_SucceedsWhenDeviceNotYetLive pins the bootstrap exemption: the
+// gateway calls VerifyDevice to admit a device's mTLS stream BEFORE AttachDevice
+// publishes the device→gateway binding, so VerifyDevice must succeed even with the
+// routing registry wired and the device reported as not-yet-live. The pre-fix code
+// enforced verifyDeviceGatewayBinding here and rejected every agent with "device
+// is not live on any gateway" — a chicken-and-egg that bricked all connections
+// (the server#404 regression). This test fails on that version and passes on the fix.
+func TestVerifyDevice_SucceedsWhenDeviceNotYetLive(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(notLiveResolver{}) // registry wired; device not live yet
+
+	deviceID := testutil.CreateTestDevice(t, st, "bootstrap-host")
+
+	resp, err := h.VerifyDevice(context.Background(), connect.NewRequest(&pm.VerifyDeviceRequest{
+		DeviceId:  deviceID,
+		GatewayId: "gw-1",
+	}))
+	require.NoError(t, err, "VerifyDevice must admit the bootstrap connection even though the device is not yet live in the registry")
+	assert.NotNil(t, resp)
+}
+
+// TestProxySyncActions_BindingStillEnforcedWhenNotLive is the guard for the fix
+// above: removing the binding from VerifyDevice must NOT weaken the credential-
+// bearing methods. With the routing registry wired and the device not live on the
+// claiming gateway, ProxySyncActions must still reject with FailedPrecondition —
+// the SA-C2 confinement (server#404) stays intact for the secret/action ops.
+func TestProxySyncActions_BindingStillEnforcedWhenNotLive(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(notLiveResolver{})
+
+	deviceID := testutil.CreateTestDevice(t, st, "secret-op-host")
+
+	_, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+		DeviceId:  deviceID,
+		GatewayId: "gw-1",
+	}))
+	require.Error(t, err, "a credential-bearing method must still enforce the device→gateway binding")
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err), "device-not-live binding rejection stays on ProxySyncActions")
 }
 
 func TestProxySyncActions_EmptyDeviceID(t *testing.T) {

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -1426,11 +1426,28 @@ func (idx *Index) Rebuild(ctx context.Context) error {
 	if err := idx.FlushSearchData(ctx); err != nil {
 		return fmt.Errorf("flush: %w", err)
 	}
+	// Load-then-index: populate the search keyspace BEFORE creating the FT
+	// indexes. valkey-search's async writer cannot absorb a bulk pipeline of HSETs
+	// aimed at a LIVE index — it applies write backpressure, stops replying
+	// mid-pipeline, and deadlocks the connection until the client read times out
+	// (~120s), so any deployment with more than a few dozen rows in a scope could
+	// never warm. Creating the indexes AFTER the keyspace is populated lets
+	// valkey-search backfill by scanning at its own pace (no client backpressure),
+	// which it handles cleanly at any scale. RediSearch indexed synchronously, so
+	// the old create-then-stream order was safe there; valkey-search's async
+	// writer is not. See ADR 0027.
+	if err := idx.Warm(ctx); err != nil {
+		return fmt.Errorf("warm: %w", err)
+	}
 	if err := idx.EnsureIndexes(ctx); err != nil {
 		return fmt.Errorf("ensure indexes: %w", err)
 	}
-	if err := idx.Warm(ctx); err != nil {
-		return fmt.Errorf("warm: %w", err)
+	// FT.CREATE returns immediately and backfills the pre-populated keyspace in the
+	// background; wait for that to finish so a completed Rebuild guarantees a
+	// fully-populated, query-ready index (the boot heartbeat, the doctor probe, and
+	// the list pages all rely on it being done).
+	if err := idx.waitForBackfill(ctx); err != nil {
+		return fmt.Errorf("await backfill: %w", err)
 	}
 	// Stamp the schema fingerprint so the next boot warms instead of rebuilding
 	// (until the schema changes again). Last step: only a fully-rebuilt index
@@ -1446,6 +1463,61 @@ func (idx *Index) Rebuild(ctx context.Context) error {
 		idx.logger.Warn("could not stamp reconcile heartbeat after rebuild", "error", err)
 	}
 	return nil
+}
+
+// waitForBackfill blocks until every FT index has finished the background
+// backfill that FT.CREATE kicks off over the pre-populated keyspace (the
+// load-then-index rebuild). Once it returns, a Rebuild has produced a fully
+// query-ready index. It polls FT.INFO's backfill_in_progress flag and honors ctx
+// for cancellation/deadline so a wedged backend can't hang the boot forever.
+func (idx *Index) waitForBackfill(ctx context.Context) error {
+	for _, ix := range IndexSchemas {
+		for {
+			done, err := idx.backfillDone(ctx, ix.Name)
+			if err != nil {
+				return err
+			}
+			if done {
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+	}
+	return nil
+}
+
+// backfillDone reports whether the named index has finished backfilling, read
+// from FT.INFO's backfill_in_progress field (0 = done). FT.INFO returns a flat
+// [field, value, ...] map; an absent field (a backend that doesn't report it) is
+// treated as done so the wait can never hang on a missing signal.
+func (idx *Index) backfillDone(ctx context.Context, name string) (bool, error) {
+	res, err := idx.rdb.Do(ctx, "FT.INFO", name).Result()
+	if err != nil {
+		return false, fmt.Errorf("FT.INFO %s: %w", name, err)
+	}
+	pairs, ok := res.([]any)
+	if !ok {
+		return true, nil // unexpected shape — don't hang the boot
+	}
+	for i := 0; i+1 < len(pairs); i += 2 {
+		k, _ := pairs[i].(string)
+		if k != "backfill_in_progress" {
+			continue
+		}
+		switch v := pairs[i+1].(type) {
+		case int64:
+			return v == 0, nil
+		case string:
+			return v == "0", nil
+		default:
+			return true, nil
+		}
+	}
+	return true, nil // field absent → assume done
 }
 
 // StampReconciled records that a reconcile just completed (LastReconcileKey,

--- a/internal/search/indexer_test.go
+++ b/internal/search/indexer_test.go
@@ -274,6 +274,63 @@ func TestFlushAndRebuild(t *testing.T) {
 	assert.Equal(t, int64(1), count)
 }
 
+// TestRebuild_BulkLoadAtScaleDoesNotStall is the regression for the
+// valkey-search async-writer deadlock (ADR 0027). A big deployment must warm on
+// startup under ANY scale: the pre-fix Rebuild created the FT indexes BEFORE
+// warming, so the bulk pipeline of HSETs hit a LIVE index, overran
+// valkey-search's async writer, and deadlocked the connection until the client
+// read timed out (~120s) — the indexer could never start. The fixed order
+// (FlushSearchData → Warm into the index-less keyspace → EnsureIndexes → backfill)
+// lets valkey-search index by scanning at its own pace and completes in well under
+// a second even for thousands of rows.
+//
+// The pre-fix order makes this test hang (caught by the bounded context below);
+// the fixed order makes it pass quickly. Seeds THOUSANDS of executions on purpose
+// — a handful would not overrun the writer and would pass on BOTH orders.
+func TestRebuild_BulkLoadAtScaleDoesNotStall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	st := testutil.SetupPostgres(t)
+	rdb := setupRedis(t)
+	ctx := context.Background()
+
+	userID := testutil.CreateTestUser(t, st, "admin@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "bulk-load-host")
+	actionID := testutil.CreateTestAction(t, st, userID, "Bulk Load Action", 100)
+
+	// Materialise the projection rows directly — thousands of real ExecutionCreated
+	// events would dominate the test runtime, and the warm reads the projection, not
+	// the event log. One statement seeds them all (created_at inside the warm's
+	// 90-day window, action_type matching the action above so the TAG query finds
+	// them).
+	const n = 5000
+	_, err := st.TestingPool().Exec(ctx, `
+		INSERT INTO executions_projection (id, device_id, action_id, action_type, status, created_at)
+		SELECT 'bulk_exec_' || g::text, $1, $2, 100, 'success', now() - (g || ' seconds')::interval
+		FROM generate_series(1, $3) g`, deviceID, actionID, n)
+	require.NoError(t, err)
+
+	idx := search.New(rdb, st, nil, testLogger())
+
+	// A correct load-then-index rebuild finishes in well under a second; the pre-fix
+	// order deadlocks and never returns. Bound it so a regression fails fast instead
+	// of hanging the whole suite for the go-redis read timeout.
+	rebuildCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	require.NoError(t, idx.Rebuild(rebuildCtx),
+		"a big deployment must warm on startup without stalling valkey-search's async writer")
+
+	// Rebuild waits for the backfill, so every seeded execution must already be
+	// indexed and queryable — no polling.
+	result, err := rdb.Do(ctx, "FT.SEARCH", "idx:executions", "@action_type:{100}", "LIMIT", 0, 0).Result()
+	require.NoError(t, err)
+	arr, ok := result.([]any)
+	require.True(t, ok)
+	count, _ := arr[0].(int64)
+	assert.Equal(t, int64(n), count, "every one of the %d bulk-loaded executions must be indexed", n)
+}
+
 func TestSearchExecutionsByTag(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")


### PR DESCRIPTION
Two release-blocking fixes for 2026.07-rc5, both root-caused, reproduced, and validated red-green.

## 1. Search warm deadlocks valkey-search on startup (load-then-index)

The indexer's `Rebuild` created the FT indexes BEFORE warming, so the bulk `HSET` pipeline streamed into a LIVE index and overran valkey-search 1.2.0's async writer — the warm stalled ~120s (`pipeline exec: i/o timeout`) and the indexer never started on any deployment with more than a few dozen rows in a scope. RediSearch indexed synchronously, so the old create-then-stream order was fine there; valkey-search's async writer is not.

**Fix:** `Rebuild` = `FlushSearchData` → `Warm` (into the index-less keyspace, fast) → `EnsureIndexes` (which backfills by scanning at its own pace) → `waitForBackfill`. The boot gate no longer re-streams a full reload into a live index on a normal restart / lock contention.

- Regression: warm **5000** executions and assert `Rebuild` completes under a bounded context with every row indexed (old order times out).
- Verified end-to-end against a real DB dump: 151 executions + **166K audit events** warm in **2.43s**, 0 skipped.
- ADR 0027.

## 2. Agents can't connect — `VerifyDevice` binding chicken-and-egg

#404 added the device→gateway binding to every device-origin `InternalService` method, including `VerifyDevice` — the pre-attach **bootstrap**. The gateway calls `VerifyDevice` to admit a device's mTLS stream BEFORE `AttachDevice` marks it live, so requiring the binding there rejects every agent with `device is not live on any gateway` whenever the routing registry is wired (any Valkey-backed deployment).

**Fix:** exempt `VerifyDevice` (existence-only; no secret/action/event; identity already proven by the mTLS client cert). The binding stays enforced on the credential-bearing `ProxySync*`/LUKS/LPS methods; the self-discovering completeness guard records the exemption explicitly.

- Regression: `VerifyDevice` succeeds with the registry wired + device not yet live; a complementary test asserts `ProxySyncActions` still rejects (binding intact).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search rebuilds now complete only after the index is fully query-ready, improving reliability after restarts or upgrades.
  * Device bootstrap now works even when a device is not yet registered as live on a gateway.

* **Bug Fixes**
  * Avoids unnecessary search index reloads when the index already exists and the schema matches.
  * Prevents partial index warming during rebuild contention, reducing stalls and deadlocks.
  * Improves handling of large bulk rebuilds so searches become available without hanging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->