### PR TITLE
refactor(taskqueue): action results as binary protobuf, not protojson over the wire

### DIFF
--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hibiken/asynq"
 	"github.com/oklog/ulid/v2"
-	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
@@ -219,12 +219,10 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		return fmt.Errorf("unmarshal execution result: %w", err)
 	}
 
-	// The ActionResultJSON is a protojson-encoded pm.ActionResult.
-	// We must use protojson.Unmarshal (not json.Unmarshal) because protojson
-	// encodes int64 fields as JSON strings per the protobuf spec, which
-	// standard json.Unmarshal cannot decode into Go int64 fields.
+	// The result rides as BINARY protobuf — no proto message is ever sent as JSON
+	// over the gateway→control queue.
 	var result pm.ActionResult
-	if err := protojson.Unmarshal(payload.ActionResultJSON, &result); err != nil {
+	if err := proto.Unmarshal(payload.ActionResultProto, &result); err != nil {
 		return fmt.Errorf("unmarshal action result: %w", err)
 	}
 

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hibiken/asynq"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -185,7 +184,7 @@ func TestHandleExecutionResult_Success(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Build action result with protojson
+	// Build action result (binary proto)
 	result := &pm.ActionResult{
 		ActionId:    &pm.ActionId{Value: executionID},
 		Status:      pm.ExecutionStatus_EXECUTION_STATUS_SUCCESS,
@@ -198,12 +197,12 @@ func TestHandleExecutionResult_Success(t *testing.T) {
 			ExitCode: 0,
 		},
 	}
-	resultJSON, err := protojson.Marshal(result)
+	resultProto, err := proto.Marshal(result)
 	require.NoError(t, err)
 
 	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
-		DeviceID:         deviceID,
-		ActionResultJSON: resultJSON,
+		DeviceID:          deviceID,
+		ActionResultProto: resultProto,
 	})
 
 	err = mux.ProcessTask(context.Background(), task)
@@ -255,11 +254,11 @@ func TestHandleExecutionResult_RejectsCrossDeviceSpoof(t *testing.T) {
 		CompletedAt: timestamppb.Now(),
 		Output:      &pm.CommandOutput{Stdout: "FORGED", ExitCode: 0},
 	}
-	resultJSON, err := protojson.Marshal(result)
+	resultProto, err := proto.Marshal(result)
 	require.NoError(t, err)
 	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
-		DeviceID:         attackerDevice,
-		ActionResultJSON: resultJSON,
+		DeviceID:          attackerDevice,
+		ActionResultProto: resultProto,
 	})
 
 	err = mux.ProcessTask(context.Background(), task)
@@ -343,12 +342,12 @@ func TestHandleExecutionResult_Failed(t *testing.T) {
 			ExitCode: 1,
 		},
 	}
-	resultJSON, err := protojson.Marshal(result)
+	resultProto, err := proto.Marshal(result)
 	require.NoError(t, err)
 
 	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
-		DeviceID:         deviceID,
-		ActionResultJSON: resultJSON,
+		DeviceID:          deviceID,
+		ActionResultProto: resultProto,
 	})
 
 	err = mux.ProcessTask(context.Background(), task)
@@ -376,12 +375,12 @@ func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 		DurationMs:  200,
 		CompletedAt: timestamppb.Now(),
 	}
-	resultJSON, err := protojson.Marshal(result)
+	resultProto, err := proto.Marshal(result)
 	require.NoError(t, err)
 
 	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
-		DeviceID:         deviceID,
-		ActionResultJSON: resultJSON,
+		DeviceID:          deviceID,
+		ActionResultProto: resultProto,
 	})
 
 	err = mux.ProcessTask(context.Background(), task)
@@ -783,12 +782,12 @@ func TestInbox_RejectsCrossGatewayDeviceOrigin(t *testing.T) {
 			CompletedAt: timestamppb.Now(),
 			Output:      &pm.CommandOutput{Stdout: "ok", ExitCode: 0},
 		}
-		resultJSON, err := protojson.Marshal(result)
+		resultProto, err := proto.Marshal(result)
 		require.NoError(t, err)
 		raw, err := json.Marshal(taskqueue.ExecutionResultPayload{
-			DeviceID:         deviceID,
-			ActionResultJSON: resultJSON,
-			GatewayID:        claimedGateway,
+			DeviceID:          deviceID,
+			ActionResultProto: resultProto,
+			GatewayID:         claimedGateway,
 		})
 		require.NoError(t, err)
 		// Wrap exactly as the producer does so the mux's VerifyMiddleware

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
-	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
@@ -593,14 +593,16 @@ func (h *AgentHandler) handleActionResult(ctx context.Context, deviceID string, 
 		return err
 	}
 
-	resultJSON, err := protojson.Marshal(result)
+	// Binary protobuf, not protojson: no proto message is serialized as JSON over
+	// the gateway→control queue (the result rides as binary inside the task).
+	resultProto, err := proto.Marshal(result)
 	if err != nil {
 		return fmt.Errorf("marshal action result: %w", err)
 	}
 	return h.aqClient.EnqueueToControl(taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
-		DeviceID:         deviceID,
-		ActionResultJSON: resultJSON,
-		GatewayID:        h.gatewayID,
+		DeviceID:          deviceID,
+		ActionResultProto: resultProto,
+		GatewayID:         h.gatewayID,
 	})
 }
 

--- a/internal/handler/agent_action_result_test.go
+++ b/internal/handler/agent_action_result_test.go
@@ -94,7 +94,7 @@ func TestHandleActionResult_NoMetadata_EnqueuesExecutionResult(t *testing.T) {
 	payload, ok := last.payload.(taskqueue.ExecutionResultPayload)
 	require.True(t, ok, "payload should be ExecutionResultPayload, got %T", last.payload)
 	assert.Equal(t, "dev-1", payload.DeviceID)
-	assert.NotEmpty(t, payload.ActionResultJSON, "marshalled result must be non-empty")
+	assert.NotEmpty(t, payload.ActionResultProto, "marshalled result must be non-empty")
 }
 
 // =============================================================================

--- a/internal/taskqueue/payloads.go
+++ b/internal/taskqueue/payloads.go
@@ -170,11 +170,13 @@ type DeviceHeartbeatPayload struct {
 }
 
 // ExecutionResultPayload is the payload for TypeExecutionResult tasks.
-// Contains the protojson-encoded ActionResult plus the device ID.
+// Carries the pm.ActionResult as BINARY protobuf (no protojson on the wire).
 type ExecutionResultPayload struct {
 	DeviceID string `json:"device_id"`
-	// ActionResultJSON is the protojson-serialized pm.ActionResult.
-	ActionResultJSON []byte `json:"action_result_json"`
+	// ActionResultProto is the deterministic BINARY-protobuf-serialized
+	// pm.ActionResult (proto.Marshal), so no proto message is ever sent as JSON
+	// over the gateway→control queue.
+	ActionResultProto []byte `json:"action_result_proto"`
 	// GatewayID — see DeviceHelloPayload.GatewayID.
 	GatewayID string `json:"gateway_id"`
 }


### PR DESCRIPTION
The gateway→control execution-result task carried `pm.ActionResult` as **protojson** (`ActionResultJSON`). It now rides as deterministic **binary protobuf** (`ActionResultProto`), so **no proto message is ever serialized as JSON on a wire**. The signed action envelope (control→gateway→agent) was already binary, so this was the last proto-as-JSON hop.

No compat shim — the field is replaced outright. A coordinated control+gateway deploy drains the queue, and Asynq retries any straggler.

Tests updated to enqueue/assert the binary field; taskqueue + handler + control-inbox suites pass.