### PR TITLE
fix(permissions): clarify ValidateDynamicQuery is device-group-specific

### DIFF
--- a/internal/auth/permissions.go
+++ b/internal/auth/permissions.go
@@ -159,7 +159,7 @@ func AllPermissions() []PermissionInfo {
 		{"DeleteDeviceGroup", "Device Groups", "Delete device groups", TargetDevice},
 		{"AddDeviceToGroup", "Device Groups", "Add devices to groups", TargetDevice},
 		{"RemoveDeviceFromGroup", "Device Groups", "Remove devices from groups", TargetDevice},
-		{"ValidateDynamicQuery", "Device Groups", "Validate dynamic queries", TargetUnspecified},
+		{"ValidateDynamicQuery", "Device Groups", "Validate dynamic device group queries", TargetUnspecified},
 		{"EvaluateDynamicGroup", "Device Groups", "Evaluate dynamic groups", TargetUnspecified},
 		{"SetDeviceGroupSyncInterval", "Device Groups", "Set device group sync interval", TargetDevice},
 		{"SetDeviceGroupMaintenanceWindow", "Device Groups", "Set device group maintenance window", TargetDevice},


### PR DESCRIPTION
The `ValidateDynamicQuery` permission key (unchanged — existing roles keep it) was labeled the generic *'Validate dynamic queries'*, which reads as if it also covers user groups. It is device-group-only; the user-group equivalent is the separate `ValidateUserGroupQuery`. Relabels it **'Validate dynamic device group queries'** so the role editor distinguishes the two. Description-only; no behavior or key change.