### PR TITLE
test(actionparams): allow_redirect rides in the signed binary envelope (SDK bump)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/manchtools/power-manage-sdk v0.5.1
+	github.com/manchtools/power-manage-sdk v0.5.2-0.20260627185002-2d416498d990
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/manchtools/power-manage-sdk v0.5.2-0.20260627185002-2d416498d990
+	github.com/manchtools/power-manage-sdk v0.5.2
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/manchtools/power-manage-sdk v0.5.1 h1:SFNBq+zaMCR6/ElvMEo0ia37OK40rQa
 github.com/manchtools/power-manage-sdk v0.5.1/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/manchtools/power-manage-sdk v0.5.2-0.20260627185002-2d416498d990 h1:NuXoEqhutDzw+JSeM1YY6YkWXcMPOi4EFyqHOVFYXsY=
 github.com/manchtools/power-manage-sdk v0.5.2-0.20260627185002-2d416498d990/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
+github.com/manchtools/power-manage-sdk v0.5.2 h1:WMkt1sxtiBGz9N9+/IZ6wwEaJYgRuDsOp5Ve/9xbxL0=
+github.com/manchtools/power-manage-sdk v0.5.2/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/manchtools/power-manage-sdk v0.5.1 h1:SFNBq+zaMCR6/ElvMEo0ia37OK40rQaWOLN3/YMtwU0=
 github.com/manchtools/power-manage-sdk v0.5.1/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
+github.com/manchtools/power-manage-sdk v0.5.2-0.20260627185002-2d416498d990 h1:NuXoEqhutDzw+JSeM1YY6YkWXcMPOi4EFyqHOVFYXsY=
+github.com/manchtools/power-manage-sdk v0.5.2-0.20260627185002-2d416498d990/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/actionparams/actionparams_test.go
+++ b/internal/actionparams/actionparams_test.go
@@ -204,6 +204,35 @@ func TestBuildAndSignEnvelope_SignsExactTransportedBytes(t *testing.T) {
 	assert.Equal(t, "echo hi", env.GetShell().Script)
 }
 
+// TestBuildAndSignEnvelope_AgentUpdateAllowRedirect proves the operator's
+// allow_redirect flag rides inside the SIGNED BINARY envelope — not just the
+// JSON input. It must survive populate (JSON -> typed oneof) -> deterministic
+// proto marshal -> the exact bytes the signer signs and the agent verifies.
+// This is the server-side guarantee that a new self-update proto field is
+// covered by the signature without any hand-rolled per-field handling.
+func TestBuildAndSignEnvelope_AgentUpdateAllowRedirect(t *testing.T) {
+	signer := &recordingEnvelopeSigner{}
+	envBytes, _, err := actionparams.BuildAndSignEnvelope(
+		signer,
+		"exec-au-1",
+		int32(pm.ActionType_ACTION_TYPE_AGENT_UPDATE),
+		[]byte(`{"amd64":{"binaryUrl":"https://h/bin","checksumUrl":"https://h/sums"},"allowRedirect":true}`),
+		int32(pm.DesiredState_DESIRED_STATE_PRESENT),
+		300,
+		nil,
+		"device-au",
+	)
+	require.NoError(t, err)
+	require.Len(t, signer.signed, 1)
+	assert.Equal(t, envBytes, signer.signed[0], "signed bytes must equal transported bytes")
+
+	var env pm.SignedActionEnvelope
+	require.NoError(t, proto.Unmarshal(envBytes, &env))
+	require.NotNil(t, env.GetAgentUpdate())
+	assert.True(t, env.GetAgentUpdate().GetAllowRedirect(),
+		"allow_redirect must ride inside the signed binary envelope the agent verifies")
+}
+
 // TestBuildAndSignEnvelope_NilSignerRejected pins fail-closed on a nil signer —
 // a wiring bug must not produce an unsigned envelope.
 func TestBuildAndSignEnvelope_NilSignerRejected(t *testing.T) {


### PR DESCRIPTION
Depends on power-manage-sdk#256 (pinned to its branch commit via pseudo-version; re-pinned to `v0.5.2` once the SDK tags).

## Why a server change at all

The self-update `allow_redirect` flag is set by the operator, carried in the request, and must end up inside the **CA-signed action envelope** the agent verifies. The server signs the **deterministic binary proto** of `SignedActionEnvelope` (`proto.MarshalOptions{Deterministic:true}` — not JSON), with params bound into the typed oneof by `PopulateEnvelope`. For the field to be recognised and signed, the server's generated proto must include it — hence the **SDK bump**. Validation, the params registry, and signing are all reflection/protojson-based, so there is **no logic change**.

## Change

- Bump SDK to pick up `AgentUpdateParams.allow_redirect`.
- Add `TestBuildAndSignEnvelope_AgentUpdateAllowRedirect`: builds an AGENT_UPDATE envelope with `allowRedirect:true` in the params JSON, signs it, unmarshals the **signed transported bytes**, and asserts `GetAgentUpdate().GetAllowRedirect()` — proving the flag rides inside the signature, not just the JSON input.