### PR TITLE
chore(deps): bump power-manage-sdk to v0.5.3-pre (align GA SDK pin, sdk#257)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/manchtools/power-manage-sdk v0.5.2
+	github.com/manchtools/power-manage-sdk v0.5.3-0.20260628101136-f4e5e6dabfed
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -111,12 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.5.1 h1:SFNBq+zaMCR6/ElvMEo0ia37OK40rQaWOLN3/YMtwU0=
-github.com/manchtools/power-manage-sdk v0.5.1/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
-github.com/manchtools/power-manage-sdk v0.5.2-0.20260627185002-2d416498d990 h1:NuXoEqhutDzw+JSeM1YY6YkWXcMPOi4EFyqHOVFYXsY=
-github.com/manchtools/power-manage-sdk v0.5.2-0.20260627185002-2d416498d990/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
-github.com/manchtools/power-manage-sdk v0.5.2 h1:WMkt1sxtiBGz9N9+/IZ6wwEaJYgRuDsOp5Ve/9xbxL0=
-github.com/manchtools/power-manage-sdk v0.5.2/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
+github.com/manchtools/power-manage-sdk v0.5.3-0.20260628101136-f4e5e6dabfed h1:o4uhtYAk4J/wUcS4ImrRpUdQAejg1ANnb8Dk5GrwtzA=
+github.com/manchtools/power-manage-sdk v0.5.3-0.20260628101136-f4e5e6dabfed/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=


### PR DESCRIPTION
## What

Bump the `power-manage-sdk` pin from `v0.5.2` to SDK `main`
(`v0.5.3-0.20260628101136-f4e5e6dabfed`), matching the agent's bump
(agent#157), so the GA release ships a single SDK revision across both repos.

## Impact

The only delta from `v0.5.2` is **sdk#257** (`pkg/apt` — apt security-only
upgrade absolute-path resolution). The server doesn't import `pkg/apt` and the
proto/generated code is unchanged, so this is a **pin alignment with no
functional effect on the server**.

## Why a pseudo-version

The change is on SDK `main`, one commit past `v0.5.2`; pinned by pseudo-version
rather than cutting a new SDK release. Re-pin to the tag if/when one is cut at
GA.

## Verification

`GOWORK=off go build ./... && go vet ./...` clean. Only `go.mod` / `go.sum`
change.
