### PR TITLE
feat(doctor): terminal (TTY) health check + valkey keyspace-notifications

### DIFF
--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -104,13 +104,14 @@ Flags:
 - `--env-file <path>` — also inspect this `.env` (default `.env`, silently skipped if absent). Values in the file take precedence over the process environment — it is the operator's stored config, the source of truth for what was configured.
 <!-- docref: end -->
 
-<!-- docref: begin src=internal/doctor/registry.go#DefaultChecks:401eacc2 -->
+<!-- docref: begin src=internal/doctor/registry.go#DefaultChecks:650fcb22 -->
 It reports placeholder/weak secrets, mandatory at-rest encryption key, a
 credentialed CORS wildcard, an internal mTLS listener bound to all interfaces, a
 floating `IMAGE_TAG`, certificate file permissions and approaching expiry,
 Postgres/Valkey reachability, Asynq dead-letter depth, search-index presence
-and indexer liveness (reconcile heartbeat), and a bootstrap admin still on the
-default email.
+and indexer liveness (reconcile heartbeat), remote-terminal (TTY) routing and
+config consistency (Valkey keyspace notifications, web-listener and TTY-host
+config), and a bootstrap admin still on the default email.
 <!-- docref: end -->
 
 ### Exit codes

--- a/deploy/valkey.conf.template
+++ b/deploy/valkey.conf.template
@@ -38,3 +38,17 @@ port 6379
 # control, gateway, indexer, and traefik. The password is the only
 # auth gate.
 protected-mode no
+
+# Keyspace notifications — REQUIRED for Traefik's Redis provider to WATCH
+# the KV. Each gateway replica self-registers its Traefik routes (agent mTLS
+# passthrough + the per-replica TTY HTTP router) into this KV at startup and
+# refreshes them on a TTL. Traefik's redis provider subscribes to keyspace
+# notifications to pick up those writes live; without this, Valkey emits no
+# notifications, Traefik's WatchTree channel closes ("the WatchTree channel is
+# closed" / "Provider error, retrying"), and Traefik only ever sees the
+# snapshot it read at its own startup. The practical failure: a gateway
+# (re)deployed AFTER Traefik publishes routes Traefik never loads — most
+# visibly the TTY router, so terminal WebSockets 404 until Traefik is manually
+# restarted. KEA = keyspace + keyevent + all event classes (the set+del+expire
+# events the watch needs). Cheap for a config-sized keyspace.
+notify-keyspace-events KEA

--- a/internal/doctor/check_tty.go
+++ b/internal/doctor/check_tty.go
@@ -1,0 +1,97 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// TerminalCheck validates the remote-terminal (TTY) plumbing the control relies
+// on (spec 15). The failure mode it primarily catches is the one hit in the
+// field: the gateway self-registers its Traefik routes — including the
+// per-replica TTY HTTP router — into Valkey, and Traefik's Redis provider
+// WATCHES that keyspace. But the watch only works if Valkey emits keyspace
+// notifications; with them off (the Redis default), Traefik reads the keyspace
+// once at boot and never sees a (re)deployed gateway's terminal route, so
+// terminal WebSockets 404 with nothing obvious in any log. It also flags two
+// config inconsistencies that silently break terminals.
+type TerminalCheck struct{}
+
+func (TerminalCheck) ID() string { return "terminal" }
+
+func (c TerminalCheck) Run(ctx context.Context, env *Env) ([]Finding, error) {
+	// Remote terminal is opt-in — the gateway only mints/serves sessions when the
+	// public terminal URL template is set. Unset ⇒ disabled, nothing to check.
+	if env.Get("GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE") == "" {
+		return []Finding{info(c.ID(), "remote terminal disabled (GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE unset)")}, nil
+	}
+
+	var findings []Finding
+
+	// Config: the gateway serves the terminal WebSocket on GATEWAY_WEB_LISTEN_ADDR.
+	// Minting terminal URLs while that listener is off advertises sessions the
+	// gateway cannot serve — the browser WebSocket just fails.
+	if env.Get("GATEWAY_WEB_LISTEN_ADDR") == "" {
+		findings = append(findings, warn(c.ID(),
+			"GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE is set but GATEWAY_WEB_LISTEN_ADDR is empty — the gateway will not serve terminal WebSockets",
+			"set GATEWAY_WEB_LISTEN_ADDR (e.g. :8443) on the gateway and recreate the container"))
+	}
+
+	// Config: the TTY host must differ from the gateway mTLS host, or Traefik's
+	// TCP-passthrough router for the gateway SNI shadows the TTY HTTP router on
+	// the shared :443 entrypoint.
+	ttyHost := firstNonEmptyVar(env, "GATEWAY_TRAEFIK_TTY_HOST", "GATEWAY_TTY_DOMAIN", "GATEWAY_DOMAIN")
+	gwHost := firstNonEmptyVar(env, "GATEWAY_TRAEFIK_MTLS_HOST", "GATEWAY_DOMAIN")
+	if ttyHost != "" && ttyHost == gwHost {
+		findings = append(findings, warn(c.ID(),
+			"the TTY host equals the gateway mTLS host — Traefik's TCP-passthrough router shadows the terminal HTTP router on the shared SNI",
+			"set a dedicated GATEWAY_TTY_DOMAIN distinct from GATEWAY_DOMAIN"))
+	}
+
+	// Live: Valkey keyspace notifications must be on so Traefik can WATCH the
+	// gateway's self-registered routes. Only relevant when the gateway self-
+	// registers via the Redis KV provider (the default; disabled only by an
+	// explicit GATEWAY_TRAEFIK_SELF_REGISTER=false).
+	if env.Get("GATEWAY_TRAEFIK_SELF_REGISTER") != "false" {
+		skip, proceed := cacheReady(ctx, c, env)
+		if !proceed {
+			return append(findings, skip...), nil
+		}
+		notif, err := env.Cache.KeyspaceNotifications(ctx)
+		if err != nil {
+			// Valkey is reachable (cacheReady pinged it) but CONFIG GET failed —
+			// the check could not run, not a clean pass.
+			return nil, fmt.Errorf("read Valkey notify-keyspace-events: %w", err)
+		}
+		if !keyspaceNotificationsSufficient(notif) {
+			f := warn(c.ID(),
+				"Valkey keyspace notifications are off — Traefik cannot watch the gateway's self-registered routes, so a (re)deployed gateway's terminal route is not picked up until Traefik is restarted (terminal WebSockets 404)",
+				`set notify-keyspace-events to "KEA" in valkey.conf, then restart Valkey and Traefik`)
+			f.Detail = fmt.Sprintf("notify-keyspace-events=%q", notif)
+			findings = append(findings, f)
+		}
+	}
+
+	if len(findings) == 0 {
+		return []Finding{ok(c.ID(), "remote terminal config consistent; Valkey keyspace notifications enabled for Traefik route watching")}, nil
+	}
+	return findings, nil
+}
+
+// keyspaceNotificationsSufficient reports whether notify-keyspace-events is
+// configured enough for Traefik's Redis provider to WATCH the KV: it needs a
+// channel flag (K=keyspace or E=keyevent) AND event classes (A=all, or at least
+// generic 'g'). Empty (the Redis default) is the common broken case.
+func keyspaceNotificationsSufficient(s string) bool {
+	return strings.ContainsAny(s, "KE") && strings.ContainsAny(s, "Ag")
+}
+
+// firstNonEmptyVar returns the first non-empty env value among keys.
+func firstNonEmptyVar(env *Env, keys ...string) string {
+	for _, k := range keys {
+		if v := env.Get(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/doctor/check_tty_test.go
+++ b/internal/doctor/check_tty_test.go
@@ -1,0 +1,124 @@
+package doctor
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// runTerminal runs TerminalCheck against vars + cache and fails on a could-not-run.
+func runTerminal(t *testing.T, vars map[string]string, cache CacheProbe) []Finding {
+	t.Helper()
+	env := NewEnv(vars)
+	env.Cache = cache
+	fs, err := TerminalCheck{}.Run(context.Background(), env)
+	require.NoError(t, err)
+	return fs
+}
+
+// worstSev returns the highest severity among findings.
+func worstSev(fs []Finding) Severity {
+	worst := SeverityOK
+	for _, f := range fs {
+		if f.Severity > worst {
+			worst = f.Severity
+		}
+	}
+	return worst
+}
+
+// healthyTerminalVars is a consistent terminal config (distinct TTY host, web
+// listener set) for the cases that vary one thing at a time.
+func healthyTerminalVars() map[string]string {
+	return map[string]string{
+		"GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE": "wss://tty.example.com/gw/{id}/terminal",
+		"GATEWAY_WEB_LISTEN_ADDR":              ":8443",
+		"GATEWAY_DOMAIN":                       "gateway.example.com",
+		"GATEWAY_TTY_DOMAIN":                   "tty.example.com",
+	}
+}
+
+func TestTerminalCheck_DisabledIsInfo(t *testing.T) {
+	fs := runTerminal(t, map[string]string{}, fakeCache{})
+	require.Len(t, fs, 1)
+	assert.Equal(t, SeverityInfo, fs[0].Severity, "terminal unconfigured ⇒ info, not a finding")
+}
+
+func TestTerminalCheck_HealthyIsOK(t *testing.T) {
+	fs := runTerminal(t, healthyTerminalVars(), fakeCache{keyspaceNotif: "AKE"})
+	require.Len(t, fs, 1)
+	assert.Equal(t, SeverityOK, fs[0].Severity)
+}
+
+func TestTerminalCheck_WebListenAddrMissingWarns(t *testing.T) {
+	vars := healthyTerminalVars()
+	delete(vars, "GATEWAY_WEB_LISTEN_ADDR")
+	fs := runTerminal(t, vars, fakeCache{keyspaceNotif: "AKE"})
+	assert.Equal(t, SeverityWarning, worstSev(fs))
+	assert.True(t, anyRemediationContains(fs, "GATEWAY_WEB_LISTEN_ADDR"))
+}
+
+func TestTerminalCheck_TTYHostCollisionWarns(t *testing.T) {
+	// TTY domain falls back to GATEWAY_DOMAIN ⇒ collides with the mTLS host.
+	vars := map[string]string{
+		"GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE": "wss://gateway.example.com/gw/{id}/terminal",
+		"GATEWAY_WEB_LISTEN_ADDR":              ":8443",
+		"GATEWAY_DOMAIN":                       "gateway.example.com",
+	}
+	fs := runTerminal(t, vars, fakeCache{keyspaceNotif: "AKE"})
+	assert.Equal(t, SeverityWarning, worstSev(fs))
+}
+
+func TestTerminalCheck_KeyspaceNotificationsOffWarns(t *testing.T) {
+	// Empty notify-keyspace-events is the Redis default — the field bug.
+	fs := runTerminal(t, healthyTerminalVars(), fakeCache{keyspaceNotif: ""})
+	assert.Equal(t, SeverityWarning, worstSev(fs))
+	assert.True(t, anyRemediationContains(fs, "notify-keyspace-events"),
+		"the keyspace warning must name the fix")
+}
+
+func TestTerminalCheck_SelfRegisterFalseSkipsKeyspace(t *testing.T) {
+	// Notifications off, but the gateway isn't using the KV provider — so Traefik
+	// isn't watching it and the keyspace state is irrelevant.
+	vars := healthyTerminalVars()
+	vars["GATEWAY_TRAEFIK_SELF_REGISTER"] = "false"
+	fs := runTerminal(t, vars, fakeCache{keyspaceNotif: ""})
+	require.Len(t, fs, 1)
+	assert.Equal(t, SeverityOK, fs[0].Severity)
+}
+
+func TestTerminalCheck_KeyspaceProbeErrorIsExecError(t *testing.T) {
+	env := NewEnv(healthyTerminalVars())
+	env.Cache = fakeCache{keyspaceErr: errors.New("CONFIG GET refused")}
+	_, err := TerminalCheck{}.Run(context.Background(), env)
+	require.Error(t, err, "a reachable-Valkey CONFIG GET failure is a could-not-run (exit 2), not a clean pass")
+}
+
+func TestKeyspaceNotificationsSufficient(t *testing.T) {
+	for _, tc := range []struct {
+		val  string
+		want bool
+	}{
+		{"", false},   // Redis default — off
+		{"Ex", false}, // keyevent channel but no event class beyond expired
+		{"K", false},  // keyspace channel, no event classes
+		{"AKE", true}, // canonical form of "KEA"
+		{"KEA", true}, // operator's literal value
+		{"Kg", true},  // keyspace + generic events
+	} {
+		assert.Equalf(t, tc.want, keyspaceNotificationsSufficient(tc.val), "notify-keyspace-events=%q", tc.val)
+	}
+}
+
+func anyRemediationContains(fs []Finding, sub string) bool {
+	for _, f := range fs {
+		if strings.Contains(f.Remediation, sub) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -39,6 +39,8 @@ type fakeCache struct {
 	reconcileErr  error
 	rejected      map[string]string
 	rejectErr     error
+	keyspaceNotif string
+	keyspaceErr   error
 }
 
 func (f fakeCache) Ping(context.Context) error { return f.pingErr }
@@ -54,6 +56,9 @@ func (f fakeCache) LastReconcile(context.Context) (time.Time, bool, error) {
 }
 func (f fakeCache) SearchQueryRejections(context.Context, []string) (map[string]string, error) {
 	return f.rejected, f.rejectErr
+}
+func (f fakeCache) KeyspaceNotifications(context.Context) (string, error) {
+	return f.keyspaceNotif, f.keyspaceErr
 }
 
 func testEnv(vars map[string]string) *Env {

--- a/internal/doctor/env.go
+++ b/internal/doctor/env.go
@@ -165,4 +165,9 @@ type CacheProbe interface {
 	// that is present but cannot answer. Missing indexes are skipped (covered by
 	// MissingIndexes).
 	SearchQueryRejections(ctx context.Context, indexNames []string) (map[string]string, error)
+	// KeyspaceNotifications returns Valkey's notify-keyspace-events config value
+	// (empty = off, the Redis default). Traefik's Redis provider WATCHES the
+	// gateway's self-registered routes via keyspace notifications, so an empty
+	// value silently breaks dynamic gateway routing (incl. the terminal route).
+	KeyspaceNotifications(ctx context.Context) (string, error)
 }

--- a/internal/doctor/probe.go
+++ b/internal/doctor/probe.go
@@ -134,6 +134,17 @@ func (v *ValkeyProbe) SearchQueryRejections(ctx context.Context, names []string)
 	return rejected, nil
 }
 
+// KeyspaceNotifications reads Valkey's notify-keyspace-events config (empty = the
+// Redis default = off). Traefik's Redis provider needs it to WATCH the gateway's
+// self-registered routes.
+func (v *ValkeyProbe) KeyspaceNotifications(ctx context.Context) (string, error) {
+	m, err := v.rdb.ConfigGet(ctx, "notify-keyspace-events").Result()
+	if err != nil {
+		return "", err
+	}
+	return m["notify-keyspace-events"], nil
+}
+
 // LastReconcile reads the indexer heartbeat (search.LastReconcileKey, RFC3339).
 func (v *ValkeyProbe) LastReconcile(ctx context.Context) (time.Time, bool, error) {
 	raw, err := v.rdb.Get(ctx, search.LastReconcileKey).Result()

--- a/internal/doctor/registry.go
+++ b/internal/doctor/registry.go
@@ -15,6 +15,7 @@ func DefaultChecks() []Check {
 		DatastoresCheck{},
 		QueuesCheck{},
 		SearchCheck{},
+		TerminalCheck{},
 		AdminCheck{},
 	}
 }


### PR DESCRIPTION
## `control doctor` now validates the remote-terminal plumbing

Adds a **`terminal`** check that targets the exact failure surface that silently
broke terminals in the field:

**Valkey keyspace notifications (the real bug).** The gateway self-registers its
Traefik routes — including the per-replica TTY HTTP router — into Valkey, and
Traefik's Redis provider **watches** that keyspace. With `notify-keyspace-events`
off (the Redis default), Traefik reads the keyspace once at boot and **never sees
a (re)deployed gateway's terminal route** → terminal WebSockets 404 with nothing
obvious in any log. The check reads `CONFIG GET notify-keyspace-events` and warns
when it's insufficient for the watch.

**Config consistency.** Two misconfigs that silently break terminals:
- `GATEWAY_PUBLIC_TERMINAL_URL_TEMPLATE` set but `GATEWAY_WEB_LISTEN_ADDR` empty
  → the gateway won't serve the WebSocket.
- TTY host == gateway mTLS host → Traefik's TCP-passthrough router shadows the
  TTY HTTP router on the shared SNI.

Terminal is opt-in, so the check is `info` (skipped) when the URL template is
unset, and the keyspace probe is skipped when `GATEWAY_TRAEFIK_SELF_REGISTER=false`.

## Also

`notify-keyspace-events KEA` in `valkey.conf.template` so new deployments get a
watchable KV by default (existing deploys re-render via `setup.sh` or add the
line + restart Valkey/Traefik).

## Wiring

- `CacheProbe.KeyspaceNotifications` + `ValkeyProbe` impl (`CONFIG GET`).
- `TerminalCheck` registered in `DefaultChecks()`; the self-discovering
  completeness guard requires (and gets) a unit test.
- Tests: disabled→info, healthy→ok, each misconfig→warning, self-register-false
  skips the keyspace probe, reachable-Valkey CONFIG GET failure → could-not-run.
