### PR TITLE
test(archtest): self-discovering CI package-coverage guard + 10 missing packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,11 +38,11 @@ jobs:
       # Audit N020: the per-package list is intentionally explicit; the
       # split between unit and integration jobs is load-bearing because
       # integration tests bring up testcontainers (Postgres, Valkey) and
-      # take 5–20× longer. When you add a new internal/<pkg>, drop it
-      # in the right list. eventtypes/... is pure-Go (no DB, no network)
-      # so it lives here.
+      # take 5–20× longer. When you add a new package with tests, drop it
+      # in the right list — archtest's TestCIRunsEveryTestBearingPackage
+      # fails the build if a test-bearing package lands in neither (#481).
       - name: Run unit tests
-        run: go test -count=1 ./internal/archtest/... ./internal/auth/... ./internal/connection/... ./internal/middleware/... ./internal/taskqueue/... ./internal/config/... ./internal/mtls/... ./internal/crypto/... ./internal/eventtypes/...
+        run: go test -count=1 ./internal/archtest/... ./internal/auth/... ./internal/connection/... ./internal/middleware/... ./internal/taskqueue/... ./internal/config/... ./internal/mtls/... ./internal/crypto/... ./internal/eventtypes/... ./internal/actionparams/... ./internal/crl/... ./internal/dynamicquery/... ./cmd/gateway/... ./cmd/indexer/...
 
   # Integration tests are sharded across parallel runners so wall-clock is
   # the slowest shard rather than the sum of all packages (#338). Each shard
@@ -70,7 +70,7 @@ jobs:
             packages: ./internal/store/... ./internal/projectors/...
             run: '.'
           - name: handlers-services
-            packages: ./internal/handler/... ./internal/search/... ./internal/control/... ./internal/gateway/... ./internal/scim/... ./internal/ca/... ./internal/idp/... ./internal/doctor/...
+            packages: ./internal/handler/... ./internal/search/... ./internal/control/... ./internal/gateway/... ./internal/scim/... ./internal/ca/... ./internal/idp/... ./internal/doctor/... ./internal/compliance/... ./internal/dyngroupeval/... ./internal/resolution/... ./internal/terminal/... ./cmd/control/...
             run: '.'
     steps:
       - uses: actions/checkout@v5

--- a/internal/archtest/ci_coverage_test.go
+++ b/internal/archtest/ci_coverage_test.go
@@ -1,0 +1,128 @@
+package archtest
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// TestCIRunsEveryTestBearingPackage guards the hardcoded package lists in
+// .github/workflows/test.yml against failing open. The unit job and the
+// integration shard matrix enumerate packages by hand (a deliberate choice:
+// the unit/integration split is load-bearing because integration packages
+// bring up testcontainers and take 5-20x longer). The failure mode of a
+// hand-maintained list is silent: a new package with tests that lands in no
+// list is never tested by CI at all — which is exactly how
+// internal/{compliance,dyngroupeval,resolution,terminal} and cmd/{control,
+// gateway} accumulated test files that had never run on any PR (#481).
+//
+// This guard discovers every package in the module that contains _test.go
+// files and asserts each one is matched by at least one `./pkg/...` pattern
+// referenced in test.yml. It is package-granular by design: shard `-run`
+// filters (the ^Test[A-L] api split) partition WITHIN a package and are not
+// this guard's concern.
+//
+// release.yml is intentionally out of scope: it re-tests a subset as a
+// pre-publish smoke gate, while test.yml gates every PR and push — the
+// list that must be complete is test.yml's.
+func TestCIRunsEveryTestBearingPackage(t *testing.T) {
+	root := moduleRoot(t)
+
+	testedPkgs := discoverTestBearingPackages(t, root)
+	if len(testedPkgs) == 0 {
+		t.Fatal("matches-zero guard: discovered no packages with _test.go files; the walk is broken")
+	}
+
+	workflow := filepath.Join(root, ".github", "workflows", "test.yml")
+	raw, err := os.ReadFile(workflow)
+	if err != nil {
+		t.Fatalf("read %s: %v", workflow, err)
+	}
+	patterns := extractPackagePatterns(string(raw))
+	if len(patterns) == 0 {
+		t.Fatal("matches-zero guard: extracted no ./pkg/... patterns from test.yml; the parser is broken")
+	}
+
+	// A pattern referencing a directory that no longer exists is a stale
+	// list entry — the same rot this guard exists to prevent, in the other
+	// direction.
+	for _, p := range patterns {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(p))); err != nil {
+			t.Errorf("test.yml references ./%s/... but that directory does not exist (stale list entry)", p)
+		}
+	}
+
+	for _, pkg := range testedPkgs {
+		if !coveredBy(pkg, patterns) {
+			t.Errorf("package %s has _test.go files but is matched by no ./pkg/... pattern in test.yml — its tests never run in CI; add it to the unit list or an integration shard", pkg)
+		}
+	}
+}
+
+// discoverTestBearingPackages returns the module-relative, slash-separated
+// directory of every package under root that contains at least one _test.go
+// file. vendor/, testdata/, .git/ and hidden directories are skipped.
+func discoverTestBearingPackages(t *testing.T, root string) []string {
+	t.Helper()
+	seen := map[string]bool{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			name := d.Name()
+			if name == "vendor" || name == "testdata" || (strings.HasPrefix(name, ".") && path != root) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		rel, err := filepath.Rel(root, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		seen[filepath.ToSlash(rel)] = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	pkgs := make([]string, 0, len(seen))
+	for p := range seen {
+		pkgs = append(pkgs, p)
+	}
+	return pkgs
+}
+
+// pkgPattern matches the `./internal/api/...` package-tree arguments used in
+// test.yml `go test` invocations and shard matrix `packages:` values.
+var pkgPattern = regexp.MustCompile(`\./([A-Za-z0-9_/-]+)/\.\.\.`)
+
+// extractPackagePatterns returns the deduplicated module-relative directory
+// prefixes referenced as ./dir/... anywhere in the workflow text.
+func extractPackagePatterns(workflow string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, m := range pkgPattern.FindAllStringSubmatch(workflow, -1) {
+		if !seen[m[1]] {
+			seen[m[1]] = true
+			out = append(out, m[1])
+		}
+	}
+	return out
+}
+
+// coveredBy reports whether pkg (e.g. internal/compliance) is inside any
+// ./pattern/... tree (e.g. internal/compliance or internal).
+func coveredBy(pkg string, patterns []string) bool {
+	for _, p := range patterns {
+		if pkg == p || strings.HasPrefix(pkg, p+"/") {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #481.

## What

Ten packages with `_test.go` files ran in **no** CI workflow — the hand-maintained lists in test.yml had drifted, so their tests never executed on any PR, push, or release:

- integration-tier (testcontainer-backed) → added to the `handlers-services` shard (the fastest one): `internal/compliance`, `internal/dyngroupeval`, `internal/resolution`, `internal/terminal`, `cmd/control`
- unit-tier → added to the unit list: `internal/actionparams`, `internal/crl`, `internal/dynamicquery`, `cmd/gateway`, `cmd/indexer`

All ten pass locally against main (verified before adding — this PR turns latent coverage on, it does not fix broken tests).

## Guard

`TestCIRunsEveryTestBearingPackage` (internal/archtest) makes the drift impossible to repeat:
- discovers every package in the module containing `_test.go` files (self-discovering, no hardcoded list)
- extracts the `./pkg/...` patterns from test.yml
- fails on any test-bearing package covered by no pattern
- matches-zero guards on both sides (empty discovery or empty pattern parse = fail), plus a stale-entry check for patterns whose directory no longer exists

Red-verified: the guard failed listing exactly the ten packages before the test.yml fix, green after.

release.yml is intentionally out of scope — it re-tests a subset as a pre-publish smoke gate; test.yml is the load-bearing per-PR gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded CI test coverage to include more packages in unit and integration test runs.
  * Added a safeguard that checks CI test configuration stays aligned with all packages that contain tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->