### PR TITLE
fix(api): reject system actions in AddActionToSet (#477 guard gap)

### DIFF
--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -348,6 +348,15 @@ func (h *ActionSetHandler) AddActionToSet(ctx context.Context, req *connect.Requ
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}
 
+	// System-managed actions (the SSH/TTY/provisioning grants owned by the
+	// SystemActionManager) must never be pulled into a user-controlled set:
+	// as a set member the action's name resurfaces in the set's search index
+	// and the action becomes dispatchable via DispatchActionSet. Reject like
+	// every other action-referencing mutation (#477 / #484).
+	if err := rejectSystemAction(ctx, action); err != nil {
+		return nil, err
+	}
+
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "action_set",
 		StreamID:   req.Msg.SetId,

--- a/internal/api/system_action_immutability_test.go
+++ b/internal/api/system_action_immutability_test.go
@@ -141,6 +141,32 @@ func TestDeleteAssignment_SystemActionSourceRejected(t *testing.T) {
 	requireSystemActionRejected(t, err)
 }
 
+// TestAddActionToSet_SystemActionRejected closes the gap the pre-GA security
+// sweep found (#484): a system action added to a user-controlled set would
+// resurface its name in the set's search index AND become dispatchable via
+// DispatchActionSet — defeating the exact #477 fix. AddActionToSet must reject
+// a system action like every other action-referencing mutation.
+func TestAddActionToSet_SystemActionRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionSetHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	setID := testutil.CreateTestActionSet(t, st, adminID, "Test Set")
+	sysActionID := testutil.CreateTestSystemAction(t, st, "pm-tty-paul", int(pm.ActionType_ACTION_TYPE_SHELL))
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.AddActionToSet(ctx, connect.NewRequest(&pm.AddActionToSetRequest{
+		SetId:    setID,
+		ActionId: sysActionID,
+	}))
+	requireSystemActionRejected(t, err)
+
+	// Positive control: the set gained no member from the rejected call.
+	resp, getErr := h.GetActionSet(ctx, connect.NewRequest(&pm.GetActionSetRequest{Id: setID}))
+	require.NoError(t, getErr)
+	assert.Equal(t, int32(0), resp.Msg.Set.MemberCount, "a rejected system action must not become a set member")
+}
+
 // recordingSearchIndex is a fake api.SearchIndex that records which entity IDs
 // the SearchListener tried to reindex vs. remove.
 type recordingSearchIndex struct {


### PR DESCRIPTION
Closes #484. Found by the pre-GA security sweep of the `v2026.07-rc6..main` delta.

The #477 system-action immutability guard (shipped in the GA delta) added `rejectSystemAction` to rename/update/delete/assign/unassign but **missed `AddActionToSet`** — it loads the action and feeds `action.Name` to the search index without the guard.

## Exploit (confirmed, operator/insider)
An **unrestricted** caller (full-scope role, not necessarily super-admin) with the ordinary `AddActionToSet` permission:
1. Discovers a system action ID via `GetUserAssignments`/`GetDeviceAssignments` (neither filters `is_system`).
2. `AddActionToSet` passes — `enforceObjectReadScope` returns nil for unrestricted callers.

Impacts: (a) the system action name resurfaces in the set's member search index — the exact leak #477's search purge closes; (b) `DispatchActionSet` → `ListActionsInSet` re-signs and dispatches members with no `is_system` filter, so the operator can fire the SSH/TTY/provisioning grant against an arbitrary in-scope device on their own timing. Scope-restricted callers were already blocked (system actions have no scope groups → NotFound).

## Fix
One-line guard at the single entry point (`AddActionToSet`, after `Action.Get`), mirroring the six existing #477 guards. `AddActionSetToDefinition` references a *set*, not an action, so guarding set membership closes the whole action→set→definition→dispatch chain.

Regression test `TestAddActionToSet_SystemActionRejected` added to the #477 suite; red-verified (a system action was accepted into a set before the guard). Gate: gofmt/vet/staticcheck + full SystemAction suite green; local CodeRabbit clean.