### PR TITLE
chore(deps): pin power-manage-sdk to the v0.5.3 release tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/manchtools/power-manage-sdk v0.5.3-0.20260702054146-a3146410f71a
+	github.com/manchtools/power-manage-sdk v0.5.3
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/manchtools/power-manage-sdk v0.5.3-0.20260628101136-f4e5e6dabfed h1:o
 github.com/manchtools/power-manage-sdk v0.5.3-0.20260628101136-f4e5e6dabfed/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/manchtools/power-manage-sdk v0.5.3-0.20260702054146-a3146410f71a h1:08eqBt9aJSIiTzeBVDeVYb+zoPAWJG7fb0c5nrrktPI=
 github.com/manchtools/power-manage-sdk v0.5.3-0.20260702054146-a3146410f71a/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
+github.com/manchtools/power-manage-sdk v0.5.3 h1:x5GtlO0VwuzMV4NUyOBr+iCE3jSQpNG6DYWnVHxB9mk=
+github.com/manchtools/power-manage-sdk v0.5.3/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=


### PR DESCRIPTION
Repin the SDK from the pseudo-version (`a3146410`, #264 merge) to the tagged **v0.5.3** release so the upcoming server rc consumes a clean tagged SDK. v0.5.3 is a superset (adds the #265 `SyncActionsResult.LpsPublicKey` facade field, unused by the server); go.mod/go.sum only, no code change. Build/vet green.