### PR TITLE
fix(api): GetAction hides system-managed actions (content leak via execution pivot)

### DIFF
--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -134,6 +134,15 @@ func (h *ActionHandler) GetAction(ctx context.Context, req *connect.Request[pm.G
 		return nil, handleGetError(ctx, err, ErrActionNotFound, "action not found")
 	}
 
+	// System-managed actions (SSH/TTY/provisioning grants) are internal: the
+	// server resolves them via the store for dispatch/sync, but they are never
+	// user-readable. Hide them as NotFound so their content — e.g. a grant
+	// ShellParams script — can't be pivoted to from a device→execution→action_id
+	// link (#488). ListActions already excludes is_system at the query level.
+	if action.IsSystem {
+		return nil, apiErrorCtx(ctx, ErrActionNotFound, connect.CodeNotFound, "action not found")
+	}
+
 	return connect.NewResponse(&pm.GetActionResponse{
 		Action: h.actionToProto(action),
 	}), nil

--- a/internal/api/system_action_immutability_test.go
+++ b/internal/api/system_action_immutability_test.go
@@ -98,9 +98,35 @@ func TestDeleteAction_SystemActionRejected(t *testing.T) {
 	_, err := h.DeleteAction(ctx, connect.NewRequest(&pm.DeleteActionRequest{Id: sysActionID}))
 	requireSystemActionRejected(t, err)
 
-	// Positive control: the system action is still there (not deleted).
-	_, getErr := h.GetAction(ctx, connect.NewRequest(&pm.GetActionRequest{Id: sysActionID}))
-	require.NoError(t, getErr, "system action must survive the rejected delete")
+	// Positive control: the system action is still there (not deleted). Query
+	// the store directly — GetAction now hides system actions as NotFound
+	// (#488), so it can't be used to assert survival.
+	_, storeErr := st.Repos().Action.Get(context.Background(), sysActionID)
+	require.NoError(t, storeErr, "system action must survive the rejected delete")
+}
+
+// TestGetAction_SystemActionNotFound pins that a system-managed action's
+// content is not readable through GetAction (#488): an admin who pivots
+// device → execution → action_id must not be able to fetch the SSH/TTY/
+// provisioning grant script. Hidden as NotFound (uniform with out-of-scope),
+// while ordinary actions stay gettable.
+func TestGetAction_SystemActionNotFound(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	sysActionID := testutil.CreateTestSystemAction(t, st, "pm-tty-paul", int(pm.ActionType_ACTION_TYPE_SHELL))
+	normalID := testutil.CreateTestAction(t, st, adminID, "Normal", int(pm.ActionType_ACTION_TYPE_SHELL))
+	ctx := testutil.AdminContext(adminID)
+
+	_, err := h.GetAction(ctx, connect.NewRequest(&pm.GetActionRequest{Id: sysActionID}))
+	require.Error(t, err, "a system action must not be readable via GetAction")
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err), "hidden as NotFound, not a leaky code")
+
+	// Positive control: a normal action is still gettable.
+	resp, err := h.GetAction(ctx, connect.NewRequest(&pm.GetActionRequest{Id: normalID}))
+	require.NoError(t, err)
+	require.NotNil(t, resp.Msg.Action)
 }
 
 func TestCreateAssignment_SystemActionSourceRejected(t *testing.T) {


### PR DESCRIPTION
Closes #488.

#477/#485 blocked *mutating* system actions and `ListActions` already excludes them (`WHERE is_system = FALSE`), and the SearchListener purges them from the index (#477). But **`GetAction` by id still returned full content** — an admin could pivot device → execution → `action_id` → `GetAction` and read the SSH/TTY/provisioning grant `ShellParams` script. No mutation possible, but the (potentially sensitive) content leaked.

`GetAction` now returns **NotFound** for `is_system` actions — hides existence + content uniformly (out-of-scope reads already 404). The server still resolves system actions internally via the store for dispatch/sync; only the user-facing RPC is closed.

Regression test: a system action is NotFound while a normal action stays gettable (red-checked). The delete-rejection test's survival assertion moved to a direct store read (GetAction no longer surfaces system actions). Gate: gofmt/vet/staticcheck/build + system-action suite green; local CodeRabbit clean.