### PR TITLE
event-sourcing integrity: close every event-store bypass + replay gap, guard it (#495 #496 #497)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -340,11 +340,15 @@ func main() {
 	// The gateway presents its CA-signed certificate as a client cert.
 	internalHandler := api.NewInternalHandler(st, encryptor, logger.With("component", "internal_service"), actionSigner)
 
-	// LPS sealing keypair: generated once (advisory-locked), shared across
-	// replicas via Postgres. The agent seals rotated LPS passwords to this
-	// public key so the gateway relays them opaquely; control unseals at
-	// receipt (spec 18). A failure here is fatal — running without it would
-	// silently disable LPS rotation on every agent (fail closed).
+	// LPS sealing keypair: event-sourced (#495) — the version-1 OCC append on
+	// the lps_keypair/global stream is the cross-replica first-writer-wins,
+	// and the lps_keypair row is a projection. MUST run after
+	// wireSystemActions → projectors.WireAll (the #317 ordering): the
+	// synchronous LpsKeypairListener materialises the projection row during
+	// the append. The agent seals rotated LPS passwords to this public key so
+	// the gateway relays them opaquely; control unseals at receipt (spec 18).
+	// A failure here is fatal — running without it would silently disable LPS
+	// rotation on every agent (fail closed).
 	lpsPriv, lpsPub, err := api.EnsureLpsKeypair(ctx, st, encryptor)
 	if err != nil {
 		logger.Error("failed to initialize LPS sealing keypair", "error", err)

--- a/docs/adr/0028-lps-sealed-password-transport.md
+++ b/docs/adr/0028-lps-sealed-password-transport.md
@@ -106,3 +106,13 @@ catch that drift.
 - `StoreLuksKey` has the same gateway-visible-cleartext shape; the primitive and
   key distribution built here make sealing it a small follow-up (tracked
   separately).
+
+## Amendment (2026-07-03 — #495 / ADR 0029)
+
+The Context's characterization of `lps_keypair` as infrastructure state that
+"does not go through the event store / projector machinery" is superseded.
+The keypair is now event-sourced: `EnsureLpsKeypair` appends a singleton
+`LpsKeypairGenerated` event (OCC, version 1 — the stream-version uniqueness
+replaces the advisory lock) and the `lps_keypair` table is a projection with
+a rebuild target. Key bytes, AAD context, and the signed public key agents
+receive are unchanged. See ADR 0029 for the contract this closes.

--- a/docs/adr/0029-postgres-state-event-sourced-contract.md
+++ b/docs/adr/0029-postgres-state-event-sourced-contract.md
@@ -3,9 +3,10 @@
 - Status: accepted
 - Date: 2026-07-03
 - Related: manchtools/power-manage-server#495 (guard family + lps_keypair
-  event-sourcing); #496 (mutating RPCs with no audit event); #497 (replay
-  gaps); ADR 0026 (event-sourcing audit model); ADR 0028 (LPS sealed
-  transport — amended by this ADR); ADR 0009 (AES-GCM AAD at rest).
+  event-sourcing); #496 (six mutating RPCs given audit events — CLOSED in
+  this change); #497 (projection replay gaps — CLOSED in this change);
+  ADR 0026 (event-sourcing audit model); ADR 0028 (LPS sealed transport —
+  amended by this ADR); ADR 0009 (AES-GCM AAD at rest).
 
 ## Context
 
@@ -100,9 +101,24 @@ singleton `lps_keypair/global` stream:
 - The guard family makes new bypasses unmergeable: a new mutating RPC
   without an event, a new direct write, or a new unclassified table each
   fail a test with a targeted message.
-- Known debts are explicit and tracked: six RPCs mutate without events
-  (#496); several projections are not replay-covered, two of which a users
-  rebuild actively destroys today (#497). Fixing one forces its registry
-  entry's removal — the registries can only shrink honestly.
+- The contract holds with NO tracked debt. Both escape-hatch registries are
+  empty:
+  - Every mutating RPC appends an event. #496 closed the six that did not
+    (`DispatchOSQuery`, `QueryDeviceLogs`, `RefreshDeviceInventory`,
+    `CreateLuksToken`, `Logout`, `RefreshToken`) with typed audit events;
+    the RPC guard's `knownGaps` map is empty.
+  - Every projection replays 1:1. #497 closed the gaps by adding rebuild
+    targets for all previously-unreplayable projections — including the
+    three a users rebuild used to DESTROY (RBAC grants via `user_roles`,
+    2FA via `totp`, SSO links via `identity_links`); the schema guard's
+    `knownUnreplayableTables` map is empty.
+- Rebuild targets are FK-ordered in `AllRebuildTargets` (children after
+  parents). Two cases are subtle and load-bearing: `identity_providers`
+  runs BEFORE `scim_group_mappings` (its `TRUNCATE … CASCADE` wipes the
+  SCIM mappings, so they must be replayed after), and `totp` /
+  `identity_links` run AFTER `users` (they are FK children the users
+  CASCADE wipes). The singleton `server_settings` target re-seeds the
+  `global` row before replaying, since a plain TRUNCATE would leave the
+  UPDATE-only projector with nothing to update.
 - `InsertLpsKeypair` is gone from the generated query set; the projector
   owns the only write (`UpsertLpsKeypair`).

--- a/docs/adr/0029-postgres-state-event-sourced-contract.md
+++ b/docs/adr/0029-postgres-state-event-sourced-contract.md
@@ -1,0 +1,108 @@
+# 0029 — All Postgres state is event-sourced or explicitly classified
+
+- Status: accepted
+- Date: 2026-07-03
+- Related: manchtools/power-manage-server#495 (guard family + lps_keypair
+  event-sourcing); #496 (mutating RPCs with no audit event); #497 (replay
+  gaps); ADR 0026 (event-sourcing audit model); ADR 0028 (LPS sealed
+  transport — amended by this ADR); ADR 0009 (AES-GCM AAD at rest).
+
+## Context
+
+The event store is both the system of record and the audit log ("every
+state-changing RPC is audit-logged" — the events table IS the audit log), and
+the replay guarantee — drop derived state, replay events, get the same state
+back — is what makes emergency rebuilds and disaster recovery trustworthy.
+
+An audit for #495 found the guarantee held *by convention, not by
+enforcement*:
+
+- `lps_keypair` (#483 / ADR 0028) was written directly — advisory lock plus
+  `INSERT … ON CONFLICT DO NOTHING` — the one Postgres row with no event
+  behind it.
+- Handler-level direct writes (generated queries, repo write methods) were
+  unguarded; nothing failed the build when a mutation bypassed
+  `AppendEvent`.
+- Table-level coverage was unstated: which tables replay reproduces, which
+  are deliberately operational, and which silently fell in between was
+  nowhere recorded — and several fell in between (#497).
+
+## Decision
+
+**Contract.** All Postgres state is event-sourced or explicitly classified.
+Concretely, every base table is exactly one of:
+
+1. the event store itself (`events`) or migration bookkeeping
+   (`goose_db_version`);
+2. a projection covered by a rebuild target (`store.AllRebuildTargets`) —
+   replay reproduces it 1:1;
+3. a cascade-rederived child of a rebuild target — mechanically verified
+   against the live FK graph, re-derived by the replayed streams;
+4. registered operational state — by-design non-event-sourced (flow rows,
+   staging rows, denylists, liveness inventories), each entry justifying why
+   it lives in Postgres;
+5. a **tracked replay gap** (#497) — never a silent exception.
+
+Valkey state (search index, terminal token store, CRL cache, queues) is
+ephemeral/rebuildable **by contract**: it may always be re-derived from
+Postgres or re-established by reconnection, and is therefore out of the
+replay guarantee's scope. `RebuildSearchIndex` re-deriving the FT index is
+the canonical example, and remains the lone sanctioned "mutating RPC with no
+event".
+
+**lps_keypair joins the contract.** The keypair is now sourced from a
+singleton `lps_keypair/global` stream:
+
+- `EnsureLpsKeypair` appends `LpsKeypairGenerated` at stream version 1; the
+  `UNIQUE(stream_type, stream_id, stream_version)` constraint IS the
+  cross-replica first-writer-wins, replacing the advisory lock. A losing
+  replica adopts the winner's keypair from the stream (not the projection
+  row, closing the post-commit listener window).
+- The `lps_keypair` table is a projection (`projectors.LpsKeypairListener`,
+  rebuild target `lps_keypair`).
+- The event payload carries the public key and the **enc:v2-encrypted**
+  private key — encrypted-secret-in-payload is the established at-rest model
+  (LPS rotations, TOTP secrets, IdP client secrets already ride encrypted in
+  events; ADR 0009). The signed public key agents receive is byte-identical
+  across the migration: same bytes, same AAD context, same signature input.
+- Upgrade: a pre-#495 row without a stream gets a synthetic
+  `LpsKeypairGenerated` backfilled (boot-time Go, not migration SQL — the
+  payload is produced by the same Go struct the projector decodes, so the
+  wire shape cannot drift, and the OCC append keeps concurrent replicas
+  idempotent).
+
+**Enforcement.** The contract is mechanical, not prose:
+
+- `internal/api/event_append_completeness_test.go` — every mutating
+  ControlService RPC must reach `AppendEvent`/`AppendEventWithVersion`
+  (self-discovering over the RPC surface); no handler file may perform
+  direct store writes outside an allowlisted, justified site.
+- `internal/store/schema_classification_test.go` — every live table must
+  classify into the five buckets above; registries are stale-checked and
+  cross-checked against the live FK graph; the test red-verifies itself with
+  an unclassified probe table each run.
+
+## Alternatives considered
+
+- **Allowlist lps_keypair in the guard.** Rejected — the single exception is
+  exactly how replay guarantees rot; fixing it was cheaper than defending
+  the exception forever.
+- **Migration-SQL backfill.** Rejected in favour of boot-time Go: SQL would
+  re-encode the payload shape by hand (jsonb_build_object + base64) and
+  silently drift from the Go decoder; the Go path reuses the one payload
+  struct end-to-end.
+- **Keep the advisory lock alongside the OCC append.** Rejected — the
+  version-1 uniqueness already serializes winners; a second mechanism just
+  hides which one is load-bearing.
+
+## Consequences
+
+- The guard family makes new bypasses unmergeable: a new mutating RPC
+  without an event, a new direct write, or a new unclassified table each
+  fail a test with a targeted message.
+- Known debts are explicit and tracked: six RPCs mutate without events
+  (#496); several projections are not replay-covered, two of which a users
+  rebuild actively destroys today (#497). Fixing one forces its registry
+  entry's removal — the registries can only shrink honestly.
+- `InsertLpsKeypair` is gone from the generated query set; the projector
+  owns the only write (`UpsertLpsKeypair`).

--- a/internal/api/audit_event_496_test.go
+++ b/internal/api/audit_event_496_test.go
@@ -1,0 +1,260 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// countDeviceEventsOfType counts events of a given type on a device stream —
+// the audit trail the #496 RPCs must leave (a device stream also carries the
+// DeviceRegistered bootstrap event, so we filter by type).
+func countDeviceEventsOfType(t *testing.T, st *store.Store, deviceID, eventType string) int {
+	t.Helper()
+	events, err := st.Queries().LoadStream(context.Background(), db.LoadStreamParams{
+		StreamType: "device",
+		StreamID:   deviceID,
+	})
+	require.NoError(t, err)
+	n := 0
+	for _, e := range events {
+		if e.EventType == eventType {
+			n++
+		}
+	}
+	return n
+}
+
+func countUserEventsOfType(t *testing.T, st *store.Store, userID, eventType string) int {
+	t.Helper()
+	events, err := st.Queries().LoadStream(context.Background(), db.LoadStreamParams{
+		StreamType: "user",
+		StreamID:   userID,
+	})
+	require.NoError(t, err)
+	n := 0
+	for _, e := range events {
+		if e.EventType == eventType {
+			n++
+		}
+	}
+	return n
+}
+
+// --- DispatchOSQuery → OSQueryDispatched -----------------------------------
+
+func TestDispatchOSQuery_AppendsAuditEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewOSQueryHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "osq-audit-host")
+
+	_, err := h.DispatchOSQuery(ctx, connect.NewRequest(&pm.DispatchOSQueryRequest{
+		DeviceId: deviceID, Table: "processes",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, 1, countDeviceEventsOfType(t, st, deviceID, "OSQueryDispatched"),
+		"a successful dispatch appends exactly one audit event")
+}
+
+func TestDispatchOSQuery_RejectedAppendsNoEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewOSQueryHandler(st, slog.Default(), api.NoOpSigner{})
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	missing := testutil.NewID()
+
+	_, err := h.DispatchOSQuery(ctx, connect.NewRequest(&pm.DispatchOSQueryRequest{
+		DeviceId: missing, Table: "processes",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, 0, countDeviceEventsOfType(t, st, missing, "OSQueryDispatched"),
+		"a rejected dispatch appends no audit event")
+}
+
+// --- QueryDeviceLogs → DeviceLogsQueried -----------------------------------
+
+func TestQueryDeviceLogs_AppendsAuditEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewLogsHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "logs-audit-host")
+
+	_, err := h.QueryDeviceLogs(ctx, connect.NewRequest(&pm.QueryDeviceLogsRequest{
+		DeviceId: deviceID, Unit: "sshd.service",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, 1, countDeviceEventsOfType(t, st, deviceID, "DeviceLogsQueried"))
+}
+
+func TestQueryDeviceLogs_RejectedAppendsNoEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewLogsHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	missing := testutil.NewID()
+
+	_, err := h.QueryDeviceLogs(ctx, connect.NewRequest(&pm.QueryDeviceLogsRequest{
+		DeviceId: missing,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, 0, countDeviceEventsOfType(t, st, missing, "DeviceLogsQueried"))
+}
+
+// --- RefreshDeviceInventory → DeviceInventoryRefreshRequested --------------
+
+func TestRefreshDeviceInventory_AppendsAuditEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewOSQueryHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	deviceID := testutil.CreateTestDevice(t, st, "inv-audit-host")
+
+	_, err := h.RefreshDeviceInventory(ctx, connect.NewRequest(&pm.RefreshDeviceInventoryRequest{
+		DeviceId: deviceID,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, 1, countDeviceEventsOfType(t, st, deviceID, "DeviceInventoryRefreshRequested"))
+}
+
+func TestRefreshDeviceInventory_RejectedAppendsNoEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewOSQueryHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetTaskQueueClient(&api.NoOpEnqueuer{})
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+	missing := testutil.NewID()
+
+	_, err := h.RefreshDeviceInventory(ctx, connect.NewRequest(&pm.RefreshDeviceInventoryRequest{
+		DeviceId: missing,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, 0, countDeviceEventsOfType(t, st, missing, "DeviceInventoryRefreshRequested"))
+}
+
+// --- Logout → UserLoggedOut ------------------------------------------------
+
+func TestLogout_AppendsAuditEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	h := api.NewAuthHandler(st, slog.Default(), jwtMgr, true)
+	email := testutil.NewID() + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "correct-password", "user")
+
+	login, err := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email: email, Password: "correct-password",
+	}))
+	require.NoError(t, err)
+
+	_, err = h.Logout(context.Background(), connect.NewRequest(&pm.LogoutRequest{
+		RefreshToken: login.Msg.RefreshToken,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, 1, countUserEventsOfType(t, st, userID, "UserLoggedOut"),
+		"a logout with a valid refresh token appends one UserLoggedOut")
+}
+
+func TestLogout_InvalidTokenAppendsNoEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	h := api.NewAuthHandler(st, slog.Default(), jwtMgr, true)
+	email := testutil.NewID() + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "correct-password", "user")
+
+	// A logout with an unparseable refresh token revokes nothing (no valid
+	// jti) and therefore audits nothing — Logout still returns OK (it is
+	// idempotent), so the audit-absence is the meaningful assertion.
+	_, err := h.Logout(context.Background(), connect.NewRequest(&pm.LogoutRequest{
+		RefreshToken: "not-a-valid-token",
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, 0, countUserEventsOfType(t, st, userID, "UserLoggedOut"))
+}
+
+// --- RefreshToken → UserSessionRefreshed -----------------------------------
+
+func TestRefreshToken_AppendsAuditEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	h := api.NewAuthHandler(st, slog.Default(), jwtMgr, true)
+	email := testutil.NewID() + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "correct-password", "user")
+
+	login, err := h.Login(context.Background(), connect.NewRequest(&pm.LoginRequest{
+		Email: email, Password: "correct-password",
+	}))
+	require.NoError(t, err)
+
+	_, err = h.RefreshToken(context.Background(), connect.NewRequest(&pm.RefreshTokenRequest{
+		RefreshToken: login.Msg.RefreshToken,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, 1, countUserEventsOfType(t, st, userID, "UserSessionRefreshed"),
+		"a successful refresh appends one UserSessionRefreshed")
+}
+
+func TestRefreshToken_RejectedAppendsNoEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	jwtMgr := testutil.NewJWTManager()
+	h := api.NewAuthHandler(st, slog.Default(), jwtMgr, true)
+	email := testutil.NewID() + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "correct-password", "user")
+
+	_, err := h.RefreshToken(context.Background(), connect.NewRequest(&pm.RefreshTokenRequest{
+		RefreshToken: "not-a-valid-token",
+	}))
+	require.Error(t, err)
+	assert.Equal(t, 0, countUserEventsOfType(t, st, userID, "UserSessionRefreshed"),
+		"a rejected refresh appends no event")
+}
+
+// --- CreateLuksToken → LuksTokenCreated ------------------------------------
+
+func TestCreateLuksToken_AppendsAuditEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "luks-audit-device")
+	actionID := testutil.CreateTestAction(t, st, userID, "Encrypt Disk", int(pm.ActionType_ACTION_TYPE_ENCRYPTION))
+	testutil.AssignDeviceToUser(t, st, userID, deviceID, userID)
+	ctx := testutil.UserContext(userID)
+
+	_, err := h.CreateLuksToken(ctx, connect.NewRequest(&pm.CreateLuksTokenRequest{
+		DeviceId: deviceID, ActionId: actionID,
+	}))
+	require.NoError(t, err)
+	assert.Equal(t, 1, countDeviceEventsOfType(t, st, deviceID, "LuksTokenCreated"),
+		"a successful token issue appends one LuksTokenCreated (no token material in payload)")
+}
+
+func TestCreateLuksToken_RejectedAppendsNoEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "luks-audit-reject")
+	// No assignment → the user is out of scope, so the handler rejects.
+	ctx := testutil.UserContext(userID)
+
+	_, err := h.CreateLuksToken(ctx, connect.NewRequest(&pm.CreateLuksTokenRequest{
+		DeviceId: deviceID, ActionId: testutil.NewID(),
+	}))
+	require.Error(t, err)
+	assert.Equal(t, 0, countDeviceEventsOfType(t, st, deviceID, "LuksTokenCreated"),
+		"a rejected token issue appends no event")
+}

--- a/internal/api/audit_handler.go
+++ b/internal/api/audit_handler.go
@@ -131,6 +131,13 @@ var eventRedactionSchemas = map[string]map[string]redactionSchema{
 		// `passphrase` at the top level.
 		"LuksKeyRotated": {paths: []string{"passphrase"}},
 	},
+	"lps_keypair": {
+		// #495: the singleton LpsKeypairGenerated event carries the
+		// enc:v2-encrypted control private key at top-level
+		// "private_key_enc". Even the ciphertext must not surface through
+		// ListAuditEvents — same posture as the LPS/LUKS/TOTP secrets above.
+		string(eventtypes.LpsKeypairGenerated): {paths: []string{"private_key_enc"}},
+	},
 	"totp": {
 		// WS10 #8: TOTP setup persists the AES-GCM secret ciphertext and
 		// the backup-code bcrypt hashes; regeneration persists fresh

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -13,6 +13,7 @@ import (
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
@@ -286,6 +287,22 @@ func (h *AuthHandler) RefreshToken(ctx context.Context, req *connect.Request[pm.
 		RefreshToken: tokens.RefreshToken,
 	})
 
+	// Audit (#496): record the session rotation. High-frequency by nature;
+	// audit completeness is the deliberate default (a noisy audit view is
+	// filtered, not silenced). Best-effort — the new tokens are already
+	// minted, so a failed append must not fail the refresh.
+	if err := h.store.AppendEvent(ctx, store.Event{
+		StreamType: "user",
+		StreamID:   result.Claims.UserID,
+		EventType:  string(eventtypes.UserSessionRefreshed),
+		Data:       payloads.UserSessionRefreshed{OldJTI: result.OldJTI},
+		ActorType:  "user",
+		ActorID:    result.Claims.UserID,
+	}); err != nil {
+		h.logger.Error("AUDIT GAP: failed to append UserSessionRefreshed; token refresh proceeded",
+			"user_id", result.Claims.UserID, "error", err)
+	}
+
 	return resp, nil
 }
 
@@ -302,6 +319,20 @@ func (h *AuthHandler) Logout(ctx context.Context, req *connect.Request[pm.Logout
 		if err == nil && claims.ID != "" {
 			if _, err := h.store.Repos().RevokedToken.Revoke(ctx, claims.ID, claims.ExpiresAt.Time); err != nil {
 				h.logger.Warn("failed to revoke token on logout", "jti", claims.ID, "error", err)
+			}
+			// Audit (#496): the session was ended. The JTI is a session id,
+			// not a credential. Best-effort — the revocation is what matters
+			// for security; a failed audit append must not fail logout.
+			if aerr := h.store.AppendEvent(ctx, store.Event{
+				StreamType: "user",
+				StreamID:   claims.UserID,
+				EventType:  string(eventtypes.UserLoggedOut),
+				Data:       payloads.UserLoggedOut{JTI: claims.ID},
+				ActorType:  "user",
+				ActorID:    claims.UserID,
+			}); aerr != nil {
+				h.logger.Error("AUDIT GAP: failed to append UserLoggedOut; logout proceeded",
+					"user_id", claims.UserID, "jti", claims.ID, "error", aerr)
 			}
 		}
 	}

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -962,6 +962,25 @@ func (h *DeviceHandler) CreateLuksToken(ctx context.Context, req *connect.Reques
 	uri := fmt.Sprintf("power-manage://luks/set-passphrase?token=%s", token)
 	cliCmd := fmt.Sprintf("sudo power-manage-agent luks set-passphrase --token %s", token)
 
+	// Audit (#496): record who issued the LUKS key-storage token for which
+	// device+action. NO token material — not even its hash — is recorded; the
+	// audit interest is the grant, not the secret. Best-effort: the token is
+	// already persisted, so a failed append must not undo it.
+	if err := h.store.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   req.Msg.DeviceId,
+		EventType:  string(eventtypes.LuksTokenCreated),
+		Data: payloads.LuksTokenCreated{
+			DeviceID: req.Msg.DeviceId,
+			ActionID: req.Msg.ActionId,
+		},
+		ActorType: "user",
+		ActorID:   userCtx.ID,
+	}); err != nil {
+		h.logger.Error("AUDIT GAP: failed to append LuksTokenCreated; token already issued",
+			"device_id", req.Msg.DeviceId, "action_id", req.Msg.ActionId, "error", err)
+	}
+
 	return connect.NewResponse(&pm.CreateLuksTokenResponse{
 		Token:      token,
 		Uri:        uri,

--- a/internal/api/event_append_completeness_test.go
+++ b/internal/api/event_append_completeness_test.go
@@ -194,9 +194,9 @@ var allowedDirectWrites = map[string]string{
 	"system_action_store.go:UpdateSignature": "same sign-after-append backfill for system-managed actions",
 
 	// JWT refresh-token revocation list — TTL'd session infra rows, not
-	// domain state. (The MISSING Logout/RefreshToken audit events are a
-	// separate finding: knownGaps / #496.)
-	"auth_handler.go:Revoke": "revoked_tokens session-infra row (WS11); audit-event gap tracked separately in #496",
+	// domain state. Logout/RefreshToken now audit-log the session lifecycle
+	// (#496); only this denylist row stays by-design non-event-sourced.
+	"auth_handler.go:Revoke": "revoked_tokens session-infra row (WS11); the RPC audit event is appended (#496), the denylist row itself is not event-sourced",
 
 	// Short-lived OIDC flow rows: staged at GetSSOLoginURL, destructively
 	// consumed on first read at SSOCallback (replay defense). Flow infra;
@@ -207,17 +207,18 @@ var allowedDirectWrites = map[string]string{
 	// One-time LUKS key-storage tokens (hashed at rest, WS10): staged by
 	// CreateLuksToken, redeemed exactly once by the agent via the internal
 	// proxy. The resulting key STORAGE is event-sourced (ProxyStoreLuksKey
-	// appends). (CreateLuksToken's missing audit event: knownGaps / #496.)
-	"device_handler.go:CreateToken":    "luks_tokens one-time token row (WS10); audit-event gap tracked separately in #496",
+	// appends). CreateLuksToken now appends its own audit event (#496).
+	"device_handler.go:CreateToken":    "luks_tokens one-time token row (WS10); the RPC audit event is appended (#496), the token row itself is not event-sourced",
 	"internal_handler.go:ConsumeToken": "destructive one-time redemption of the luks_tokens row; key storage itself is event-sourced",
 
 	// Async result staging for device-pull operations: a pending row is
 	// created at dispatch, expired on signing/enqueue failure or read-side
 	// timeout; the agent's reply fills it via the inbox path. Transient
-	// operational state. (The missing DISPATCH audit events: knownGaps/#496.)
-	"osquery_handler.go:CreateResult":          "osquery_results staging row; dispatch audit gap tracked in #496",
+	// operational state. DispatchOSQuery/QueryDeviceLogs now audit the
+	// dispatch (#496); only these staging rows stay non-event-sourced.
+	"osquery_handler.go:CreateResult":          "osquery_results staging row; the dispatch audit event is appended (#496), the staging row itself is not event-sourced",
 	"osquery_handler.go:ExpirePendingResult":   "timeout/failure bookkeeping on the osquery_results staging row",
-	"logs_handler.go:CreateQueryResult":        "log_query_results staging row; dispatch audit gap tracked in #496",
+	"logs_handler.go:CreateQueryResult":        "log_query_results staging row; the dispatch audit event is appended (#496), the staging row itself is not event-sourced",
 	"logs_handler.go:ExpirePendingQueryResult": "timeout/failure bookkeeping on the log_query_results staging row",
 
 	// Live terminal-session operational inventory, written ALONGSIDE the

--- a/internal/api/event_append_completeness_test.go
+++ b/internal/api/event_append_completeness_test.go
@@ -67,20 +67,13 @@ var nonEventMutations = map[string]string{
 	"RebuildSearchIndex": "valkey-only rebuild of the derived search index; no Postgres state is written",
 }
 
-// knownGaps are mutating RPCs that DO change state without appending any
-// event — audit gaps found while building this guard (#495), NOT sanctioned
-// designs. All six are tracked in #496; the guard asserts they still do not
-// append, so fixing one forces its entry's removal here.
-//
-// FINDINGS(#495 → tracked in #496): these RPCs mutate state with no audit event.
-var knownGaps = map[string]string{
-	"DispatchOSQuery":        "#496 — dispatches an arbitrary osquery read to a device (osquery_results staging row + signed dispatch) with no record of who queried what",
-	"QueryDeviceLogs":        "#496 — pulls device journald logs (log_query_results staging row + signed dispatch) with no audit trail",
-	"RefreshDeviceInventory": "#496 — triggers an osquery-backed inventory refresh with no audit trail",
-	"CreateLuksToken":        "#496 — issues a one-time LUKS key-storage authorization token with no record of the granting actor (RevokeLuksDeviceKey DOES append)",
-	"Logout":                 "#496 — revokes the refresh-token JTI but appends no UserLoggedOut counterpart to UserLoggedIn",
-	"RefreshToken":           "#496 — rotates the session (revokes old JTI, mints new) with no event; high-frequency, needs an accepted-noise decision",
-}
+// knownGaps holds mutating RPCs that change state without appending an event.
+// #496 CLOSED every gap found here (DispatchOSQuery, QueryDeviceLogs,
+// RefreshDeviceInventory, CreateLuksToken, Logout, RefreshToken now all
+// append an audit event), so the map is intentionally EMPTY: the guard below
+// requires every mutating RPC to reach AppendEvent, with no tracked-debt
+// escape hatch. A future gap must be FIXED, not parked here.
+var knownGaps = map[string]string{}
 
 // TestEveryMutatingControlRPCAppendsEvent is assertion 1 of the #495 guard:
 // mutating RPC ⇒ AppendEvent reachable through the handler's intra-package

--- a/internal/api/event_append_completeness_test.go
+++ b/internal/api/event_append_completeness_test.go
@@ -1,0 +1,523 @@
+package api
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage-sdk/gen/go/pm/v1/pmv1connect"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// This file is the self-discovering fitness guard for #495: every
+// state-changing ControlService RPC must append an event — the events table IS
+// the audit log ("every state-changing RPC is audit-logged"), and the
+// event→projector path is the only sanctioned write path for domain state.
+//
+// Two assertions, following the house AST-guard pattern
+// (admin_guard_completeness_test.go / object_scope_parity_test.go /
+// scope_enforcement_parity_test.go):
+//
+//  1. TestEveryMutatingControlRPCAppendsEvent — the full RPC surface is
+//     discovered from pmv1connect.ControlServiceHandler (never a hardcoded
+//     list), each RPC is classified mutating/read-only by its leading verb
+//     (an unclassifiable verb fails the test), and every mutating RPC's
+//     intra-package call graph must reach Store.AppendEvent /
+//     Store.AppendEventWithVersion.
+//
+//  2. TestNoDirectStoreWritesFromHandlers — no non-test file in this package
+//     may call a generated write query (Insert*/Update*/Delete*/Upsert* on
+//     db.Queries) or a repo write method (Create*/Mark*/Consume*/... on a
+//     store.Repos interface) except at explicitly allowlisted sites, each
+//     with a why-comment for the by-design non-event-sourced write.
+
+// readOnlyRPCPrefixes are the leading verbs of RPCs that perform no
+// state change (reads MAY still append events — sensitive-read auditing,
+// cf. #494 — so assertion 1 simply does not require anything of them).
+var readOnlyRPCPrefixes = []string{"Get", "List", "Search", "Validate", "Evaluate"}
+
+// mutatingRPCPrefixes are the leading verbs of state-changing RPCs. A new RPC
+// whose name starts with none of the prefixes in either set fails the
+// classification guard below, forcing an explicit decision here.
+var mutatingRPCPrefixes = []string{
+	"Add", "AdminDisable", "Assign", "Cancel", "Create", "Delete", "Disable",
+	"Dispatch", "Enable", "Login", "Logout", "Query", "Rebuild", "Refresh",
+	"Regenerate", "Register", "Remove", "Rename", "Renew", "Reorder", "Revoke",
+	"Rotate", "SSOCallback", "Set", "Setup", "Start", "Stop", "Terminate",
+	"Unassign", "Unlink", "Update", "Verify",
+}
+
+// nonEventMutations are mutating RPCs VERIFIED to be by-design
+// non-event-sourced. Each entry carries its why. The guard asserts these do
+// NOT reach AppendEvent — if one starts appending, the entry must be removed
+// (anti-rot, mirroring validateExemptControlRPCs).
+var nonEventMutations = map[string]string{
+	// RebuildSearchIndex re-derives the valkey FT search index from the
+	// Postgres projections. It writes no Postgres state at all — the source
+	// of truth is untouched, so there is no state change to audit.
+	"RebuildSearchIndex": "valkey-only rebuild of the derived search index; no Postgres state is written",
+}
+
+// knownGaps are mutating RPCs that DO change state without appending any
+// event — audit gaps found while building this guard (#495), NOT sanctioned
+// designs. All six are tracked in #496; the guard asserts they still do not
+// append, so fixing one forces its entry's removal here.
+//
+// FINDINGS(#495 → tracked in #496): these RPCs mutate state with no audit event.
+var knownGaps = map[string]string{
+	"DispatchOSQuery":        "#496 — dispatches an arbitrary osquery read to a device (osquery_results staging row + signed dispatch) with no record of who queried what",
+	"QueryDeviceLogs":        "#496 — pulls device journald logs (log_query_results staging row + signed dispatch) with no audit trail",
+	"RefreshDeviceInventory": "#496 — triggers an osquery-backed inventory refresh with no audit trail",
+	"CreateLuksToken":        "#496 — issues a one-time LUKS key-storage authorization token with no record of the granting actor (RevokeLuksDeviceKey DOES append)",
+	"Logout":                 "#496 — revokes the refresh-token JTI but appends no UserLoggedOut counterpart to UserLoggedIn",
+	"RefreshToken":           "#496 — rotates the session (revokes old JTI, mints new) with no event; high-frequency, needs an accepted-noise decision",
+}
+
+// TestEveryMutatingControlRPCAppendsEvent is assertion 1 of the #495 guard:
+// mutating RPC ⇒ AppendEvent reachable through the handler's intra-package
+// call graph.
+//
+// Discovery mechanics: the RPC surface comes from the
+// pmv1connect.ControlServiceHandler interface via reflection (a newly wired
+// proto RPC appears there at compile time); handler bodies come from parsing
+// every non-test .go file in this package. The call graph is walked by callee
+// NAME (the same over-approximation admin_guard_completeness_test.go uses):
+// RPC method names are globally unique in the proto, so the ControlService
+// delegation method and the sub-handler method it forwards to share a name
+// and are traversed together. Calls into other packages are leaves; only
+// AppendEvent / AppendEventWithVersion count as the win condition, so the
+// walk cannot be satisfied by a projection write or a task enqueue.
+func TestEveryMutatingControlRPCAppendsEvent(t *testing.T) {
+	rpcs := controlServiceRPCNames(t)
+	require.Greater(t, len(rpcs), 100,
+		"expected the full ControlService surface (>100 RPCs), got %d — discovery is broken", len(rpcs))
+
+	decls := parsePackageDecls(t)
+	require.NotEmpty(t, decls, "parsed zero declarations — discovery is broken")
+
+	var unclassified, ambiguous []string
+	var mutating []string
+	for _, name := range rpcs {
+		isRead := hasAnyPrefix(name, readOnlyRPCPrefixes)
+		isMut := hasAnyPrefix(name, mutatingRPCPrefixes)
+		switch {
+		case isRead && isMut:
+			ambiguous = append(ambiguous, name)
+		case isMut:
+			mutating = append(mutating, name)
+		case !isRead:
+			unclassified = append(unclassified, name)
+		}
+	}
+	require.Emptyf(t, ambiguous,
+		"RPCs matching BOTH prefix sets (overlapping prefixes — fix the sets): %s", strings.Join(ambiguous, ", "))
+	require.Emptyf(t, unclassified,
+		"RPCs with an unknown leading verb — classify each in readOnlyRPCPrefixes or mutatingRPCPrefixes: %s",
+		strings.Join(unclassified, ", "))
+	require.Greater(t, len(mutating), 50,
+		"expected a substantial mutating surface (>50 RPCs), got %d — classification is broken", len(mutating))
+
+	var missing, staleAllowlist, fixedGaps []string
+	reached := 0
+	for _, name := range mutating {
+		require.NotEmptyf(t, decls[name], "RPC %s has no declaration in this package — parse/discovery is broken", name)
+		ok := reachesEventAppend(name, decls, map[string]bool{})
+		switch {
+		case nonEventMutations[name] != "":
+			if ok {
+				staleAllowlist = append(staleAllowlist, name)
+			}
+		case knownGaps[name] != "":
+			if ok {
+				fixedGaps = append(fixedGaps, name)
+			}
+		case !ok:
+			missing = append(missing, name)
+		default:
+			reached++
+		}
+	}
+	sort.Strings(missing)
+
+	require.Positive(t, reached, "no mutating RPC reached AppendEvent — the call-graph walk is broken (it must never pass vacuously)")
+	require.Emptyf(t, staleAllowlist,
+		"nonEventMutations entries that now DO append an event — remove them: %s", strings.Join(staleAllowlist, ", "))
+	require.Emptyf(t, fixedGaps,
+		"knownGaps entries that now append an event — the gap is fixed, remove them: %s", strings.Join(fixedGaps, ", "))
+	require.Emptyf(t, missing,
+		"state-changing RPCs whose handler flow never reaches AppendEvent/AppendEventWithVersion (#495 — the events table is the audit log):\n  %s\n"+
+			"Each must append an event, or be a verified by-design entry in nonEventMutations, or a tracked finding in knownGaps.",
+		strings.Join(missing, "\n  "))
+}
+
+// TestEventAppendGuardListsAreReal guards the three lists above against rot:
+// every entry must name a live ControlService RPC, and the two exemption maps
+// must stay disjoint.
+func TestEventAppendGuardListsAreReal(t *testing.T) {
+	real := map[string]bool{}
+	for _, name := range controlServiceRPCNames(t) {
+		real[name] = true
+	}
+	for name := range nonEventMutations {
+		require.Truef(t, real[name], "nonEventMutations names %q but no such ControlService RPC — stale entry", name)
+		require.Emptyf(t, knownGaps[name], "%q is in BOTH nonEventMutations and knownGaps — pick one", name)
+	}
+	for name := range knownGaps {
+		require.Truef(t, real[name], "knownGaps names %q but no such ControlService RPC — stale entry", name)
+	}
+}
+
+// allowedDirectWrites are the ONLY sanctioned direct-store-write call sites in
+// this package, keyed "file.go:CalleeName". Every entry is a verified
+// by-design non-event-sourced write with its why. A stale entry (no longer
+// observed) fails the guard so the list can only shrink honestly.
+//
+// The dividing line: these all write OPERATIONAL tables (flow state, staging
+// rows, live-session inventory, infra rows) — none writes domain state that
+// the event→projector path owns. The one projection-column exception
+// (UpdateSignature) backfills columns the projector deliberately does not
+// set, immediately after the event append, with a compensating-event
+// rollback (see persistActionSignature / rollbackUnsignedCreate).
+var allowedDirectWrites = map[string]string{
+	// First-boot LPS sealing keypair — a single global infra row (#483, ADR
+	// 0028). Advisory-lock serialized, ON CONFLICT DO NOTHING; not domain
+	// state, deliberately not event-sourced.
+	"lps_keypair.go:InsertLpsKeypair": "by-design non-event-sourced infra row (#483)",
+
+	// Two-phase sign-after-append: the signature/params-canonical columns are
+	// backfilled onto the projection row AFTER appendEvent(ActionCreated /
+	// ActionParamsUpdated) — the projector doesn't set them. Failure emits a
+	// compensating ActionDeleted (rollbackUnsignedCreate).
+	"action_crud.go:UpdateSignature":         "post-append signature backfill; projector-owned row, columns the projector doesn't set",
+	"system_action_store.go:UpdateSignature": "same sign-after-append backfill for system-managed actions",
+
+	// JWT refresh-token revocation list — TTL'd session infra rows, not
+	// domain state. (The MISSING Logout/RefreshToken audit events are a
+	// separate finding: knownGaps / #496.)
+	"auth_handler.go:Revoke": "revoked_tokens session-infra row (WS11); audit-event gap tracked separately in #496",
+
+	// Short-lived OIDC flow rows: staged at GetSSOLoginURL, destructively
+	// consumed on first read at SSOCallback (replay defense). Flow infra;
+	// the login OUTCOME is audited via UserLoggedIn in SSOCallback.
+	"sso_handler.go:Create":  "auth_states OIDC flow row, consumed at callback; login outcome is event-audited",
+	"sso_handler.go:Consume": "destructive first-read consumption of the auth_states flow row (replay defense)",
+
+	// One-time LUKS key-storage tokens (hashed at rest, WS10): staged by
+	// CreateLuksToken, redeemed exactly once by the agent via the internal
+	// proxy. The resulting key STORAGE is event-sourced (ProxyStoreLuksKey
+	// appends). (CreateLuksToken's missing audit event: knownGaps / #496.)
+	"device_handler.go:CreateToken":    "luks_tokens one-time token row (WS10); audit-event gap tracked separately in #496",
+	"internal_handler.go:ConsumeToken": "destructive one-time redemption of the luks_tokens row; key storage itself is event-sourced",
+
+	// Async result staging for device-pull operations: a pending row is
+	// created at dispatch, expired on signing/enqueue failure or read-side
+	// timeout; the agent's reply fills it via the inbox path. Transient
+	// operational state. (The missing DISPATCH audit events: knownGaps/#496.)
+	"osquery_handler.go:CreateResult":          "osquery_results staging row; dispatch audit gap tracked in #496",
+	"osquery_handler.go:ExpirePendingResult":   "timeout/failure bookkeeping on the osquery_results staging row",
+	"logs_handler.go:CreateQueryResult":        "log_query_results staging row; dispatch audit gap tracked in #496",
+	"logs_handler.go:ExpirePendingQueryResult": "timeout/failure bookkeeping on the log_query_results staging row",
+
+	// Live terminal-session operational inventory, written ALONGSIDE the
+	// TerminalSessionStarted/Stopped/Terminated events the same handlers
+	// append (terminal_handler.go) — the audit trail is the event; the row
+	// is the liveness inventory the reconciler/listeners work from.
+	"terminal_handler.go:UpsertStart":    "terminal_sessions liveness row; TerminalSessionStarted event appended in the same handler",
+	"terminal_handler.go:MarkStopped":    "terminal_sessions liveness row; TerminalSessionStopped event appended in the same handler",
+	"terminal_handler.go:MarkTerminated": "terminal_sessions liveness row; TerminalSessionTerminated event appended in the same handler",
+}
+
+// TestNoDirectStoreWritesFromHandlers is assertion 2 of the #495 guard: no
+// handler file bypasses the event→projector path with a direct write.
+//
+// Discovery mechanics: the write-method sets are derived from the code, not
+// hardcoded — generated write queries from the db.Queries method set
+// (Insert*/Update*/Delete*/Upsert*), repo write methods from the store.Repos
+// interface method sets filtered by write verb. A call site is flagged when
+// its callee name is in either set AND its receiver chain demonstrably comes
+// from Store.Queries()/Store.Repos() (inline chain, or a local variable bound
+// from one — `q := h.store.Queries(); q.InsertX(...)` is caught). Storing a
+// *db.Queries in a struct field for later writes would evade the receiver
+// check; no production code does that today, and assertion 1 still covers the
+// RPC surface.
+func TestNoDirectStoreWritesFromHandlers(t *testing.T) {
+	writeNames := map[string]bool{}
+	for name := range generatedWriteQueryNames() {
+		writeNames[name] = true
+	}
+	for name := range repoWriteMethodNames() {
+		writeNames[name] = true
+	}
+	require.NotEmpty(t, writeNames, "discovered zero write-method names — the scan is broken")
+
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	observed := map[string]bool{}
+	var violations []string
+	sawFile := false
+	for _, e := range entries {
+		fname := e.Name()
+		if !strings.HasSuffix(fname, ".go") || strings.HasSuffix(fname, "_test.go") {
+			continue
+		}
+		sawFile = true
+		f, err := parser.ParseFile(fset, fname, nil, 0)
+		require.NoErrorf(t, err, "parse %s", fname)
+
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			bound := storeBoundIdents(fn)
+			ast.Inspect(fn, func(n ast.Node) bool {
+				call, ok := n.(*ast.CallExpr)
+				if !ok {
+					return true
+				}
+				sel, ok := call.Fun.(*ast.SelectorExpr)
+				if !ok || !writeNames[sel.Sel.Name] {
+					return true
+				}
+				if !isStoreAccess(sel.X, bound) {
+					return true
+				}
+				key := fname + ":" + sel.Sel.Name
+				observed[key] = true
+				if allowedDirectWrites[key] == "" {
+					violations = append(violations,
+						fmt.Sprintf("%s: %s calls %s — a direct store write outside the event→projector path", fname, fn.Name.Name, sel.Sel.Name))
+				}
+				return true
+			})
+		}
+	}
+	require.True(t, sawFile, "scanned zero source files — discovery is broken")
+	require.NotEmpty(t, observed,
+		"discovered zero direct-write call sites — the scan is broken (the allowlisted by-design sites must at least match)")
+
+	var stale []string
+	for key := range allowedDirectWrites {
+		if !observed[key] {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+	sort.Strings(violations)
+	require.Emptyf(t, stale, "allowedDirectWrites entries no longer observed — remove them:\n  %s", strings.Join(stale, "\n  "))
+	require.Emptyf(t, violations,
+		"direct store writes from handler files (#495 — mutations go through AppendEvent + projectors):\n  %s\n"+
+			"Event-source the write, or add a verified by-design entry to allowedDirectWrites with its why.",
+		strings.Join(violations, "\n  "))
+}
+
+// --- discovery helpers -----------------------------------------------------
+
+// controlServiceRPCNames discovers the full RPC surface from the connect
+// handler interface — the same compile-time source service.go implements.
+func controlServiceRPCNames(t *testing.T) []string {
+	t.Helper()
+	ifaceType := reflect.TypeOf((*pmv1connect.ControlServiceHandler)(nil)).Elem()
+	require.NotZero(t, ifaceType.NumMethod(), "no ControlService RPCs discovered")
+	names := make([]string, 0, ifaceType.NumMethod())
+	for i := 0; i < ifaceType.NumMethod(); i++ {
+		names = append(names, ifaceType.Method(i).Name)
+	}
+	return names
+}
+
+// parsePackageDecls indexes every non-test function/method body in this
+// package by bare name. Methods on different receivers that share a name are
+// merged — the call-graph walk traverses all of them (see the guard doc).
+func parsePackageDecls(t *testing.T) map[string][]*ast.FuncDecl {
+	t.Helper()
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+	decls := map[string][]*ast.FuncDecl{}
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		f, err := parser.ParseFile(fset, name, nil, 0)
+		require.NoErrorf(t, err, "parse %s", name)
+		for _, decl := range f.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
+				decls[fn.Name.Name] = append(decls[fn.Name.Name], fn)
+			}
+		}
+	}
+	return decls
+}
+
+// reachesEventAppend reports whether any function named name — or anything it
+// transitively calls inside this package — calls AppendEvent or
+// AppendEventWithVersion. visited memoizes explored names (a cyclic revisit
+// reports false, which can only under-approximate — a visible failure, never
+// a silent pass).
+//
+// Calls whose receiver is a store access (Repos()/Queries() chain or a local
+// binding of one) are NEVER followed into same-named in-package functions:
+// a repo method like Luks.CreateToken must not resolve to the CreateToken RPC
+// handler, which would let an unaudited mutation borrow another handler's
+// append and pass silently.
+func reachesEventAppend(name string, decls map[string][]*ast.FuncDecl, visited map[string]bool) bool {
+	if visited[name] {
+		return false
+	}
+	visited[name] = true
+	for _, fn := range decls[name] {
+		found := false
+		bound := storeBoundIdents(fn)
+		ast.Inspect(fn, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			callee := calleeName(call.Fun)
+			if callee == "AppendEvent" || callee == "AppendEventWithVersion" {
+				found = true
+				return false
+			}
+			if sel, ok := call.Fun.(*ast.SelectorExpr); ok && isStoreAccess(sel.X, bound) {
+				return true // repo/queries method — external, never an in-package edge
+			}
+			if _, local := decls[callee]; local && reachesEventAppend(callee, decls, visited) {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
+// generatedWriteQueryNames derives the write-query name set from the sqlc
+// method set — self-discovering, so a new generated write is covered the
+// moment it exists.
+func generatedWriteQueryNames() map[string]bool {
+	names := map[string]bool{}
+	qt := reflect.TypeOf((*db.Queries)(nil))
+	for i := 0; i < qt.NumMethod(); i++ {
+		name := qt.Method(i).Name
+		if hasAnyPrefix(name, []string{"Insert", "Update", "Delete", "Upsert"}) {
+			names[name] = true
+		}
+	}
+	return names
+}
+
+// repoWriteVerbs are the leading verbs that mark a store.Repos interface
+// method as a write. Read verbs (Get/List/Count/Is/Has/Next/Load...) are
+// deliberately absent.
+var repoWriteVerbs = []string{
+	"Insert", "Update", "Upsert", "Delete", "Create", "Mark", "Revoke",
+	"Consume", "Expire", "Rotate", "Set", "Save", "Record", "Store", "Renew",
+	"Add", "Remove", "Assign", "Unassign", "Enable", "Disable", "Purge",
+	"Prune", "Clear", "Reset",
+}
+
+// repoWriteMethodNames derives the repo write-method name set from the
+// store.Repos struct's interface fields.
+func repoWriteMethodNames() map[string]bool {
+	names := map[string]bool{}
+	rt := reflect.TypeOf(store.Repos{})
+	for i := 0; i < rt.NumField(); i++ {
+		ft := rt.Field(i).Type
+		if ft.Kind() != reflect.Interface {
+			continue
+		}
+		for j := 0; j < ft.NumMethod(); j++ {
+			name := ft.Method(j).Name
+			if hasAnyPrefix(name, repoWriteVerbs) {
+				names[name] = true
+			}
+		}
+	}
+	return names
+}
+
+// storeBoundIdents collects local identifiers bound (directly or through a
+// chain) from a Store.Queries()/Store.Repos() call inside fn, so writes on
+// `q := h.store.Queries()` style bindings are still attributed to the store.
+func storeBoundIdents(fn *ast.FuncDecl) map[string]bool {
+	bound := map[string]bool{}
+	ast.Inspect(fn, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		fromStore := false
+		for _, rhs := range assign.Rhs {
+			if exprMentions(rhs, "Queries") || exprMentions(rhs, "Repos") {
+				fromStore = true
+			}
+		}
+		if !fromStore {
+			return true
+		}
+		for _, lhs := range assign.Lhs {
+			if id, ok := lhs.(*ast.Ident); ok && id.Name != "_" {
+				bound[id.Name] = true
+			}
+		}
+		return true
+	})
+	return bound
+}
+
+// isStoreAccess reports whether a call receiver demonstrably originates from
+// the store: the chain mentions Queries/Repos inline, or its root identifier
+// was locally bound from one.
+func isStoreAccess(recv ast.Expr, bound map[string]bool) bool {
+	if exprMentions(recv, "Queries") || exprMentions(recv, "Repos") {
+		return true
+	}
+	if root := rootIdent(recv); root != "" && bound[root] {
+		return true
+	}
+	return false
+}
+
+// rootIdent unwraps a selector/call chain to its leftmost identifier
+// (h.store.Repos().Luks → "h"; q.InsertX → "q").
+func rootIdent(e ast.Expr) string {
+	for {
+		switch v := e.(type) {
+		case *ast.Ident:
+			return v.Name
+		case *ast.SelectorExpr:
+			e = v.X
+		case *ast.CallExpr:
+			e = v.Fun
+		case *ast.IndexExpr:
+			e = v.X
+		default:
+			return ""
+		}
+	}
+}
+
+func hasAnyPrefix(s string, prefixes []string) bool {
+	for _, p := range prefixes {
+		if strings.HasPrefix(s, p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/event_append_completeness_test.go
+++ b/internal/api/event_append_completeness_test.go
@@ -188,10 +188,10 @@ func TestEventAppendGuardListsAreReal(t *testing.T) {
 // set, immediately after the event append, with a compensating-event
 // rollback (see persistActionSignature / rollbackUnsignedCreate).
 var allowedDirectWrites = map[string]string{
-	// First-boot LPS sealing keypair — a single global infra row (#483, ADR
-	// 0028). Advisory-lock serialized, ON CONFLICT DO NOTHING; not domain
-	// state, deliberately not event-sourced.
-	"lps_keypair.go:InsertLpsKeypair": "by-design non-event-sourced infra row (#483)",
+	// NOTE(#495): the lps_keypair row — historically the one Postgres write
+	// bypassing the event store (#483 / ADR 0028) — is now a real projection
+	// of LpsKeypairGenerated; EnsureLpsKeypair appends, the projector writes.
+	// No allowlist entry exists for it, and none may be re-added.
 
 	// Two-phase sign-after-append: the signature/params-canonical columns are
 	// backfilled onto the projection row AFTER appendEvent(ActionCreated /

--- a/internal/api/logs_handler.go
+++ b/internal/api/logs_handler.go
@@ -136,6 +136,9 @@ func (h *LogsHandler) QueryDeviceLogs(ctx context.Context, req *connect.Request[
 			h.logger.Error("AUDIT GAP: failed to append DeviceLogsQueried; dispatch already succeeded",
 				"query_id", queryID, "device_id", msg.DeviceId, "error", err)
 		}
+	} else {
+		h.logger.Error("AUDIT GAP: could not resolve actor for DeviceLogsQueried; dispatch already succeeded",
+			"query_id", queryID, "device_id", msg.DeviceId, "error", aerr)
 	}
 
 	return connect.NewResponse(&pm.QueryDeviceLogsResponse{

--- a/internal/api/logs_handler.go
+++ b/internal/api/logs_handler.go
@@ -12,6 +12,8 @@ import (
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 
@@ -114,6 +116,27 @@ func (h *LogsHandler) QueryDeviceLogs(ctx context.Context, req *connect.Request[
 		"query_id", queryID,
 		"device_id", msg.DeviceId,
 	)
+
+	// Audit (#496): record who pulled logs off which device, with the query
+	// scope (unit/priority) — never any log content. Best-effort.
+	if userCtx, aerr := requireAuth(ctx); aerr == nil {
+		if err := h.store.AppendEvent(ctx, store.Event{
+			StreamType: "device",
+			StreamID:   msg.DeviceId,
+			EventType:  string(eventtypes.DeviceLogsQueried),
+			Data: payloads.DeviceLogsQueried{
+				DeviceID: msg.DeviceId,
+				QueryID:  queryID,
+				Unit:     msg.Unit,
+				Priority: msg.Priority,
+			},
+			ActorType: "user",
+			ActorID:   userCtx.ID,
+		}); err != nil {
+			h.logger.Error("AUDIT GAP: failed to append DeviceLogsQueried; dispatch already succeeded",
+				"query_id", queryID, "device_id", msg.DeviceId, "error", err)
+		}
+	}
 
 	return connect.NewResponse(&pm.QueryDeviceLogsResponse{
 		QueryId: queryID,

--- a/internal/api/lps_keypair.go
+++ b/internal/api/lps_keypair.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/ecdh"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -12,15 +13,22 @@ import (
 
 	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
 
-// advisoryKeyLpsKeypair serializes EnsureLpsKeypair across control replicas so
-// two booting instances cannot both generate and race to insert a keypair. The
-// value is "lpskey" in hex; it only needs to be a stable constant distinct from
-// any other advisory lock.
-const advisoryKeyLpsKeypair int64 = 0x6c70736b6579
+// lpsKeypairStreamType / lpsKeypairStreamID name the singleton event stream
+// the keypair is sourced from (#495). Mirrors the server_settings "global"
+// singleton convention: fixed stream type, fixed stream id, so the
+// UNIQUE(stream_type, stream_id, stream_version) constraint on events makes
+// the version-1 append first-writer-wins across replicas — the OCC append
+// replaces the pre-#495 advisory lock + direct INSERT.
+const (
+	lpsKeypairStreamType = "lps_keypair"
+	lpsKeypairStreamID   = "global"
+)
 
 // lpsKeypairAAD binds the at-rest private key to its row. The keypair is a
 // single global row, so a fixed context suffices — it still domain-separates
@@ -31,14 +39,29 @@ func lpsKeypairAAD() []byte {
 }
 
 // EnsureLpsKeypair loads the control server's LPS sealing keypair, generating
-// and persisting it on first boot. The private key is stored ONLY in enc:v2
-// form (AAD-bound); a nil encryptor is refused because the key cannot be
-// protected at rest. Generation is serialized by an advisory lock and the
-// INSERT is first-writer-wins (ON CONFLICT DO NOTHING), so concurrent replicas
-// converge on a single keypair — a lost race re-reads the winner rather than
-// clobbering it. Returns the parsed private key (for unsealing) and the raw
-// 32-byte public key (for signed distribution to agents).
-func EnsureLpsKeypair(ctx context.Context, st *store.Store, enc *crypto.Encryptor) (priv *ecdh.PrivateKey, publicKey []byte, err error) {
+// it on first boot. The private key is stored ONLY in enc:v2 form (AAD-bound);
+// a nil encryptor is refused because the key cannot be protected at rest.
+//
+// Event-sourced (#495): the ONLY write is an LpsKeypairGenerated append at
+// stream version 1 — the events UNIQUE(stream_type, stream_id, stream_version)
+// constraint is the cross-replica first-writer-wins, and the lps_keypair table
+// is a projection materialised by projectors.LpsKeypairListener (so replay
+// reproduces it 1:1). A losing replica's append fails with ErrVersionConflict
+// and it adopts the winner's keypair FROM THE STREAM — not from the projection
+// row, which the winner's post-commit listener may not have written yet.
+//
+// Upgrade path: a pre-#495 deployment has the row but no stream. The row's
+// content is backfilled as a synthetic LpsKeypairGenerated (idempotent — a
+// concurrent replica's backfill winning the version-1 slot is fine) so the
+// replay guarantee holds for upgraded deployments too.
+//
+// MUST run after projectors.WireAll (the #317 bootstrap ordering): the
+// generation append relies on the synchronous listener to materialise the
+// projection row.
+//
+// Returns the parsed private key (for unsealing) and the raw 32-byte public
+// key (for signed distribution to agents).
+func EnsureLpsKeypair(ctx context.Context, st *store.Store, enc *crypto.Encryptor) (*ecdh.PrivateKey, []byte, error) {
 	if st == nil {
 		return nil, nil, errors.New("lps keypair: nil store")
 	}
@@ -50,50 +73,110 @@ func EnsureLpsKeypair(ctx context.Context, st *store.Store, enc *crypto.Encrypto
 		return nil, nil, errors.New("lps keypair: encryptor required to protect the private key at rest")
 	}
 
-	lockErr := st.WithAdvisoryLock(ctx, advisoryKeyLpsKeypair, func() error {
-		// Fast path: already generated.
-		if row, gerr := st.Queries().GetLpsKeypair(ctx); gerr == nil {
-			priv, publicKey, err = decodeLpsKeypair(enc, row.PublicKey, row.PrivateKeyEnc)
-			return err
-		} else if !store.IsNotFound(gerr) {
-			return fmt.Errorf("load lps keypair: %w", gerr)
+	// Fast path: projection row exists (normal restarts).
+	if row, gerr := st.Queries().GetLpsKeypair(ctx); gerr == nil {
+		if err := backfillLpsKeypairStream(ctx, st, row); err != nil {
+			return nil, nil, err
 		}
+		return decodeLpsKeypair(enc, row.PublicKey, row.PrivateKeyEnc)
+	} else if !store.IsNotFound(gerr) {
+		return nil, nil, fmt.Errorf("load lps keypair: %w", gerr)
+	}
 
-		// First boot: generate, encrypt the private key, persist.
-		newPriv, gerr := sdkcrypto.GenerateX25519()
-		if gerr != nil {
-			return fmt.Errorf("generate lps keypair: %w", gerr)
-		}
-		pubRaw := newPriv.PublicKey().Bytes()
-		privEnc, gerr := enc.EncryptWithContext(string(newPriv.Bytes()), lpsKeypairAAD())
-		if gerr != nil {
-			return fmt.Errorf("encrypt lps private key: %w", gerr)
-		}
+	// First boot: generate, encrypt the private key, append at version 1.
+	newPriv, gerr := sdkcrypto.GenerateX25519()
+	if gerr != nil {
+		return nil, nil, fmt.Errorf("generate lps keypair: %w", gerr)
+	}
+	pubRaw := newPriv.PublicKey().Bytes()
+	privEnc, gerr := enc.EncryptWithContext(string(newPriv.Bytes()), lpsKeypairAAD())
+	if gerr != nil {
+		return nil, nil, fmt.Errorf("encrypt lps private key: %w", gerr)
+	}
 
-		n, gerr := st.Queries().InsertLpsKeypair(ctx, db.InsertLpsKeypairParams{
+	appendErr := st.AppendEventWithVersion(ctx, store.Event{
+		StreamType: lpsKeypairStreamType,
+		StreamID:   lpsKeypairStreamID,
+		EventType:  string(eventtypes.LpsKeypairGenerated),
+		Data: payloads.LpsKeypairGenerated{
 			PublicKey:     pubRaw,
 			PrivateKeyEnc: privEnc,
-		})
-		if gerr != nil {
-			return fmt.Errorf("persist lps keypair: %w", gerr)
-		}
-		if n == 0 {
-			// Another writer won between our read and insert; re-read the
-			// persisted winner so every replica converges on the same key.
-			row, rerr := st.Queries().GetLpsKeypair(ctx)
-			if rerr != nil {
-				return fmt.Errorf("reload lps keypair after conflict: %w", rerr)
-			}
-			priv, publicKey, err = decodeLpsKeypair(enc, row.PublicKey, row.PrivateKeyEnc)
-			return err
-		}
-		priv, publicKey = newPriv, pubRaw
-		return nil
-	})
-	if lockErr != nil {
-		return nil, nil, lockErr
+		},
+		ActorType: "system",
+		ActorID:   "system",
+	}, 1)
+	if appendErr == nil {
+		// We won the version-1 slot; the synchronous listener has already
+		// materialised the projection row.
+		return newPriv, pubRaw, nil
 	}
-	return priv, publicKey, err
+	if !errors.Is(appendErr, store.ErrVersionConflict) {
+		return nil, nil, fmt.Errorf("persist lps keypair event: %w", appendErr)
+	}
+	// Lost the race: another replica's LpsKeypairGenerated owns version 1.
+	// Our generated key is discarded; adopt the winner's from the stream.
+	return adoptLpsKeypairFromStream(ctx, st, enc)
+}
+
+// backfillLpsKeypairStream materialises the #495 upgrade path: a pre-#495
+// deployment carries the lps_keypair row but no lps_keypair/global stream.
+// Appending a synthetic LpsKeypairGenerated with the row's exact content
+// (including its original created_at) makes the replay guarantee hold for
+// upgraded deployments — the projector reproduces the row byte-for-byte.
+// Idempotent: once the stream exists this is a no-op, and a concurrent
+// replica winning the version-1 slot is indistinguishable from ours winning
+// (both carry the same row content).
+func backfillLpsKeypairStream(ctx context.Context, st *store.Store, row db.GetLpsKeypairRow) error {
+	events, err := st.LoadStream(ctx, lpsKeypairStreamType, lpsKeypairStreamID)
+	if err != nil {
+		return fmt.Errorf("load lps keypair stream: %w", err)
+	}
+	if len(events) > 0 {
+		return nil
+	}
+	payload := payloads.LpsKeypairGenerated{
+		PublicKey:     row.PublicKey,
+		PrivateKeyEnc: row.PrivateKeyEnc,
+	}
+	if row.CreatedAt.Valid {
+		t := row.CreatedAt.Time
+		payload.CreatedAt = &t
+	}
+	appendErr := st.AppendEventWithVersion(ctx, store.Event{
+		StreamType: lpsKeypairStreamType,
+		StreamID:   lpsKeypairStreamID,
+		EventType:  string(eventtypes.LpsKeypairGenerated),
+		Data:       payload,
+		ActorType:  "system",
+		ActorID:    "system",
+	}, 1)
+	if appendErr != nil && !errors.Is(appendErr, store.ErrVersionConflict) {
+		return fmt.Errorf("backfill lps keypair event: %w", appendErr)
+	}
+	return nil
+}
+
+// adoptLpsKeypairFromStream decodes the winning replica's keypair from the
+// event stream. Reading the STREAM rather than the projection row closes the
+// cross-replica window where the winner's event is committed but its
+// post-commit listener has not yet written the row.
+func adoptLpsKeypairFromStream(ctx context.Context, st *store.Store, enc *crypto.Encryptor) (*ecdh.PrivateKey, []byte, error) {
+	events, err := st.LoadStream(ctx, lpsKeypairStreamType, lpsKeypairStreamID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("load lps keypair stream: %w", err)
+	}
+	if len(events) == 0 {
+		return nil, nil, errors.New("lps keypair: version conflict but stream is empty")
+	}
+	first := events[0]
+	if first.EventType != string(eventtypes.LpsKeypairGenerated) {
+		return nil, nil, fmt.Errorf("lps keypair: unexpected first stream event %q", first.EventType)
+	}
+	var p payloads.LpsKeypairGenerated
+	if err := json.Unmarshal(first.Data, &p); err != nil {
+		return nil, nil, fmt.Errorf("decode LpsKeypairGenerated payload: %w", err)
+	}
+	return decodeLpsKeypair(enc, p.PublicKey, p.PrivateKeyEnc)
 }
 
 // decodeLpsKeypair reconstructs the private key from a stored row: decrypt the

--- a/internal/api/lps_keypair_eventsourcing_test.go
+++ b/internal/api/lps_keypair_eventsourcing_test.go
@@ -1,0 +1,163 @@
+package api_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdkcrypto "github.com/manchtools/power-manage-sdk/crypto"
+
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// CHARTER — event-sourced LPS keypair (#495).
+//
+//   - The ONLY write path is the LpsKeypairGenerated append at stream
+//     version 1; the lps_keypair row is a projection of it.
+//   - Concurrency: N racing EnsureLpsKeypair calls produce EXACTLY ONE event
+//     (the UNIQUE stream-version constraint is the first-writer-wins) and
+//     every caller converges on the winner's key (AC2).
+//   - Replay: RebuildAll("lps_keypair") reproduces the row 1:1 (AC1).
+//   - Upgrade: a pre-#495 row without a stream gets a synthetic
+//     LpsKeypairGenerated backfilled with identical key bytes (AC3).
+
+// TestEnsureLpsKeypair_AppendsExactlyOneEvent proves the fresh-generation
+// path is event-sourced: one LpsKeypairGenerated at version 1, whose payload
+// matches the projected row byte-for-byte — even under concurrency.
+func TestEnsureLpsKeypair_AppendsExactlyOneEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	ctx := context.Background()
+
+	const n = 6
+	var wg sync.WaitGroup
+	pubs := make([][]byte, n)
+	errs := make([]error, n)
+	for i := range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, p, e := api.EnsureLpsKeypair(ctx, st, enc)
+			pubs[i], errs[i] = p, e
+		}()
+	}
+	wg.Wait()
+	for i := range n {
+		require.NoError(t, errs[i])
+		assert.Equal(t, pubs[0], pubs[i], "all racers must converge on the winner's key")
+	}
+
+	events, err := st.LoadStream(ctx, "lps_keypair", "global")
+	require.NoError(t, err)
+	require.Len(t, events, 1, "exactly one LpsKeypairGenerated — the version-1 slot is first-writer-wins")
+	require.Equal(t, string(eventtypes.LpsKeypairGenerated), events[0].EventType)
+
+	var payload payloads.LpsKeypairGenerated
+	require.NoError(t, json.Unmarshal(events[0].Data, &payload))
+	require.Equal(t, pubs[0], payload.PublicKey, "event payload carries the adopted public key")
+
+	row, err := st.Queries().GetLpsKeypair(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, payload.PublicKey, row.PublicKey, "projection row derives from the event")
+	assert.Equal(t, payload.PrivateKeyEnc, row.PrivateKeyEnc, "projection row derives from the event")
+}
+
+// TestLpsKeypair_RebuildReproducesRow is AC1: drop the projection via
+// RebuildAll and the replay reproduces the row 1:1, and the reloaded keypair
+// still decodes to the same keys (the signed public key BuildSignedLpsPublicKey
+// distributes stays byte-identical).
+func TestLpsKeypair_RebuildReproducesRow(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	ctx := context.Background()
+
+	priv, pub, err := api.EnsureLpsKeypair(ctx, st, enc)
+	require.NoError(t, err)
+
+	before, err := st.Queries().GetLpsKeypair(ctx)
+	require.NoError(t, err)
+
+	res, err := st.RebuildAll(ctx, "lps_keypair")
+	require.NoError(t, err)
+	require.Len(t, res.Targets, 1)
+	require.EqualValues(t, 1, res.Targets[0].EventsApplied, "the singleton stream replays exactly one event")
+
+	after, err := st.Queries().GetLpsKeypair(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, before.PublicKey, after.PublicKey, "replayed public key must be byte-identical")
+	assert.Equal(t, before.PrivateKeyEnc, after.PrivateKeyEnc, "replayed ciphertext must be byte-identical")
+	assert.True(t, before.CreatedAt.Time.Equal(after.CreatedAt.Time), "replayed created_at must match the event's")
+
+	privAfter, pubAfter, err := api.EnsureLpsKeypair(ctx, st, enc)
+	require.NoError(t, err)
+	assert.Equal(t, pub, pubAfter, "post-rebuild public key must be byte-identical (signed distribution unchanged)")
+	assert.True(t, priv.Equal(privAfter), "post-rebuild private key must be the same key")
+}
+
+// TestLpsKeypair_BackfillsPre495Row is AC3, the upgrade path: a deployment
+// that wrote the row directly (pre-#495) has no stream. EnsureLpsKeypair
+// backfills a synthetic LpsKeypairGenerated with the row's exact bytes and
+// original created_at — idempotently — so the replay guarantee holds for
+// upgraded deployments.
+func TestLpsKeypair_BackfillsPre495Row(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	ctx := context.Background()
+
+	// Simulate the pre-#495 state: a directly-inserted row, no stream. The
+	// key bytes must be a REAL pair encrypted under the production AAD
+	// context so EnsureLpsKeypair's decode path accepts them.
+	seedPriv, err := sdkcrypto.GenerateX25519()
+	require.NoError(t, err)
+	seedPub := seedPriv.PublicKey().Bytes()
+	seedEnc, err := enc.EncryptWithContext(string(seedPriv.Bytes()),
+		crypto.SecretAAD("global", "lps-keypair", "lps-keypair-priv"))
+	require.NoError(t, err)
+	_, err = st.TestingPool().Exec(ctx,
+		`INSERT INTO lps_keypair (id, public_key, private_key_enc, created_at)
+		 VALUES ('global', $1, $2, now() - interval '30 days')`, seedPub, seedEnc)
+	require.NoError(t, err)
+
+	priv, pub, err := api.EnsureLpsKeypair(ctx, st, enc)
+	require.NoError(t, err)
+	assert.Equal(t, seedPub, pub, "backfill must adopt the existing key, never mint a new one")
+	assert.True(t, priv.Equal(seedPriv), "backfill must preserve the private key")
+
+	events, err := st.LoadStream(ctx, "lps_keypair", "global")
+	require.NoError(t, err)
+	require.Len(t, events, 1, "backfill appends exactly one synthetic event")
+	require.Equal(t, string(eventtypes.LpsKeypairGenerated), events[0].EventType)
+
+	var payload payloads.LpsKeypairGenerated
+	require.NoError(t, json.Unmarshal(events[0].Data, &payload))
+	assert.Equal(t, seedPub, payload.PublicKey, "backfilled payload preserves the key bytes")
+	assert.Equal(t, seedEnc, payload.PrivateKeyEnc, "backfilled payload preserves the ciphertext")
+	require.NotNil(t, payload.CreatedAt, "backfill preserves the row's original created_at")
+
+	// Idempotent: a second Ensure appends nothing.
+	_, _, err = api.EnsureLpsKeypair(ctx, st, enc)
+	require.NoError(t, err)
+	events, err = st.LoadStream(ctx, "lps_keypair", "global")
+	require.NoError(t, err)
+	require.Len(t, events, 1, "backfill must be idempotent")
+
+	// And the replay now reproduces the pre-#495 row, original timestamp
+	// included (the payload carries it).
+	before, err := st.Queries().GetLpsKeypair(ctx)
+	require.NoError(t, err)
+	_, err = st.RebuildAll(ctx, "lps_keypair")
+	require.NoError(t, err)
+	after, err := st.Queries().GetLpsKeypair(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, before.PublicKey, after.PublicKey)
+	assert.Equal(t, before.PrivateKeyEnc, after.PrivateKeyEnc)
+	assert.True(t, before.CreatedAt.Time.Equal(after.CreatedAt.Time), "original created_at survives the replay")
+}

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -15,6 +15,8 @@ import (
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
 
@@ -130,6 +132,27 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 		"device_id", msg.DeviceId,
 		"table", tableName,
 	)
+
+	// Audit (#496): record who queried what on which device. Best-effort —
+	// the dispatch already succeeded, so a failed append must not undo it;
+	// log loudly (mirrors the UserLoggedIn audit-gap pattern).
+	if userCtx, aerr := requireAuth(ctx); aerr == nil {
+		if err := h.store.AppendEvent(ctx, store.Event{
+			StreamType: "device",
+			StreamID:   msg.DeviceId,
+			EventType:  string(eventtypes.OSQueryDispatched),
+			Data: payloads.OSQueryDispatched{
+				DeviceID:  msg.DeviceId,
+				QueryID:   queryID,
+				TableName: tableName,
+			},
+			ActorType: "user",
+			ActorID:   userCtx.ID,
+		}); err != nil {
+			h.logger.Error("AUDIT GAP: failed to append OSQueryDispatched; dispatch already succeeded",
+				"query_id", queryID, "device_id", msg.DeviceId, "error", err)
+		}
+	}
 
 	return connect.NewResponse(&pm.DispatchOSQueryResponse{
 		QueryId: queryID,
@@ -286,6 +309,23 @@ func (h *OSQueryHandler) RefreshDeviceInventory(ctx context.Context, req *connec
 	h.logger.Info("inventory refresh dispatched to device",
 		"device_id", msg.DeviceId,
 	)
+
+	// Audit (#496): record who requested the inventory refresh. Best-effort.
+	if userCtx, aerr := requireAuth(ctx); aerr == nil {
+		if err := h.store.AppendEvent(ctx, store.Event{
+			StreamType: "device",
+			StreamID:   msg.DeviceId,
+			EventType:  string(eventtypes.DeviceInventoryRefreshRequested),
+			Data: payloads.DeviceInventoryRefreshRequested{
+				DeviceID: msg.DeviceId,
+			},
+			ActorType: "user",
+			ActorID:   userCtx.ID,
+		}); err != nil {
+			h.logger.Error("AUDIT GAP: failed to append DeviceInventoryRefreshRequested; dispatch already succeeded",
+				"device_id", msg.DeviceId, "error", err)
+		}
+	}
 
 	return connect.NewResponse(&pm.RefreshDeviceInventoryResponse{}), nil
 }

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -152,6 +152,9 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 			h.logger.Error("AUDIT GAP: failed to append OSQueryDispatched; dispatch already succeeded",
 				"query_id", queryID, "device_id", msg.DeviceId, "error", err)
 		}
+	} else {
+		h.logger.Error("AUDIT GAP: could not resolve actor for OSQueryDispatched; dispatch already succeeded",
+			"query_id", queryID, "device_id", msg.DeviceId, "error", aerr)
 	}
 
 	return connect.NewResponse(&pm.DispatchOSQueryResponse{
@@ -325,6 +328,9 @@ func (h *OSQueryHandler) RefreshDeviceInventory(ctx context.Context, req *connec
 			h.logger.Error("AUDIT GAP: failed to append DeviceInventoryRefreshRequested; dispatch already succeeded",
 				"device_id", msg.DeviceId, "error", err)
 		}
+	} else {
+		h.logger.Error("AUDIT GAP: could not resolve actor for DeviceInventoryRefreshRequested; dispatch already succeeded",
+			"device_id", msg.DeviceId, "error", aerr)
 	}
 
 	return connect.NewResponse(&pm.RefreshDeviceInventoryResponse{}), nil

--- a/internal/api/system_actor_canary_test.go
+++ b/internal/api/system_actor_canary_test.go
@@ -48,6 +48,12 @@ var knownSystemActorSites = map[string]string{
 	// LUKS device-key revocation lifecycle is recorded by the server.
 	"device_handler.go:RevokeLuksDeviceKey": "server records the LUKS device-key revocation lifecycle event",
 
+	// LPS sealing keypair is boot infrastructure the control server owns
+	// (#495): both the fresh-generation append and the upgrade backfill of
+	// the singleton LpsKeypairGenerated event have no user actor.
+	"lps_keypair.go:EnsureLpsKeypair":         "server generates the singleton LPS sealing keypair at boot; no user actor",
+	"lps_keypair.go:backfillLpsKeypairStream": "server backfills the LpsKeypairGenerated event for pre-#495 deployments; no user actor",
+
 	// Settings changes that cascade into server-owned system actions at boot or
 	// on a bulk toggle — no per-user actor.
 	"settings_handler.go:UpdateServerSettings":          "settings change cascades server-owned system actions",

--- a/internal/eventtypes/payloads/audit_session_device.go
+++ b/internal/eventtypes/payloads/audit_session_device.go
@@ -1,0 +1,53 @@
+package payloads
+
+// Audit-only payloads for the #496 event types. None carries secret or
+// result material — they record WHO did WHAT to WHICH device/session, so the
+// events table (the audit log) gains the trail these RPCs previously lacked.
+// They are intentionally not materialised by any projector.
+
+// OSQueryDispatched records a DispatchOSQuery: an operator ran an osquery
+// table read against a device. The table name is the "what"; osquery results
+// never appear here.
+type OSQueryDispatched struct {
+	DeviceID  string `json:"device_id"`
+	QueryID   string `json:"query_id"`
+	TableName string `json:"table_name"`
+}
+
+// DeviceLogsQueried records a QueryDeviceLogs: an operator pulled journald
+// logs off a device. The query parameters (unit/priority/window) are the
+// "what"; log lines never appear here.
+type DeviceLogsQueried struct {
+	DeviceID string `json:"device_id"`
+	QueryID  string `json:"query_id"`
+	Unit     string `json:"unit,omitempty"`
+	Priority string `json:"priority,omitempty"`
+}
+
+// DeviceInventoryRefreshRequested records a RefreshDeviceInventory dispatch.
+type DeviceInventoryRefreshRequested struct {
+	DeviceID string `json:"device_id"`
+}
+
+// LuksTokenCreated records a CreateLuksToken: an operator issued a one-time
+// LUKS key-storage authorization token for a device+action. NO token material
+// (not even its hash) is recorded — the audit interest is the grant, not the
+// secret.
+type LuksTokenCreated struct {
+	DeviceID string `json:"device_id"`
+	ActionID string `json:"action_id"`
+}
+
+// UserLoggedOut records a Logout: the refresh-token JTI was revoked. The JTI
+// is a session identifier, not a credential.
+type UserLoggedOut struct {
+	JTI string `json:"jti"`
+}
+
+// UserSessionRefreshed records a RefreshToken rotation: the old refresh-token
+// JTI was revoked and a new session minted. High-frequency by nature; audit
+// completeness is the deliberate default (filter the audit view, don't drop
+// the event).
+type UserSessionRefreshed struct {
+	OldJTI string `json:"old_jti,omitempty"`
+}

--- a/internal/eventtypes/payloads/lps_keypair.go
+++ b/internal/eventtypes/payloads/lps_keypair.go
@@ -1,0 +1,41 @@
+package payloads
+
+import (
+	"log/slog"
+	"time"
+)
+
+// LpsKeypairGenerated is the wire shape for the singleton
+// LpsKeypairGenerated event (#495). It event-sources the control server's
+// LPS sealing keypair: the lps_keypair table is a projection of this event,
+// so an event-store replay reproduces the row 1:1 (the pre-#495 design wrote
+// the row directly and broke the replay guarantee).
+//
+// PrivateKeyEnc is enc:v2 AES-GCM ciphertext (AAD-bound via
+// crypto.SecretAAD("global","lps-keypair","lps-keypair-priv")) — the emitter
+// never puts plaintext key material in the event, consistent with the at-rest
+// model for LPS rotations, TOTP secrets, and IdP client secrets. LogValue
+// still masks it defensively.
+//
+// CreatedAt is set ONLY by the #495 upgrade backfill (it preserves the
+// pre-existing row's created_at); the fresh-generation path omits it and the
+// projector falls back to the event's occurred_at, so no emitter needs a
+// clock.
+type LpsKeypairGenerated struct {
+	PublicKey     []byte     `json:"public_key"`           // raw 32-byte X25519 public key
+	PrivateKeyEnc string     `json:"private_key_enc"`      // enc:v2 ciphertext, never plaintext
+	CreatedAt     *time.Time `json:"created_at,omitempty"` // backfill only; nil ⇒ projector uses occurred_at
+}
+
+// LogValue masks the encrypted private key so a payload routed through slog
+// (`logger.Warn("…", "payload", p)`) cannot leak even the ciphertext.
+func (p LpsKeypairGenerated) LogValue() slog.Value {
+	attrs := []slog.Attr{
+		slog.Int("public_key_len", len(p.PublicKey)),
+		slog.String("private_key_enc", "[REDACTED]"),
+	}
+	if p.CreatedAt != nil {
+		attrs = append(attrs, slog.Time("created_at", *p.CreatedAt))
+	}
+	return slog.GroupValue(attrs...)
+}

--- a/internal/eventtypes/types.go
+++ b/internal/eventtypes/types.go
@@ -133,6 +133,11 @@ const (
 	// lps_password stream
 	LpsPasswordRotated EventType = "LpsPasswordRotated"
 
+	// lps_keypair stream — singleton ("global"); exactly one
+	// LpsKeypairGenerated per deployment (#495). The lps_keypair table is
+	// its projection.
+	LpsKeypairGenerated EventType = "LpsKeypairGenerated"
+
 	// luks_key stream
 	LuksKeyRotated                    EventType = "LuksKeyRotated"
 	LuksDeviceKeyRevocationRequested  EventType = "LuksDeviceKeyRevocationRequested"
@@ -255,6 +260,7 @@ func All() []EventType {
 		IdentityProviderSCIMDisabled, IdentityProviderSCIMTokenRotated, IdentityLinked,
 		IdentityLinkLoginUpdated, IdentityUnlinked,
 		LpsPasswordRotated,
+		LpsKeypairGenerated,
 		LuksKeyRotated, LuksDeviceKeyRevocationRequested, LuksDeviceKeyRevocationDispatched,
 		LuksDeviceKeyRevoked, LuksDeviceKeyRevocationFailed,
 		RoleCreated, RoleUpdated, RoleDeleted,

--- a/internal/eventtypes/types.go
+++ b/internal/eventtypes/types.go
@@ -81,6 +81,13 @@ const (
 	DeviceGroupAssigned   EventType = "DeviceGroupAssigned"
 	DeviceGroupUnassigned EventType = "DeviceGroupUnassigned"
 	DeviceSyncIntervalSet EventType = "DeviceSyncIntervalSet"
+	// Audit-only device-read/dispatch events (#496). They record who pulled
+	// what off which device; ApplyDevice does not materialise them (no
+	// projection change — the result tables are transient operational state).
+	OSQueryDispatched               EventType = "OSQueryDispatched"
+	DeviceLogsQueried               EventType = "DeviceLogsQueried"
+	DeviceInventoryRefreshRequested EventType = "DeviceInventoryRefreshRequested"
+	LuksTokenCreated                EventType = "LuksTokenCreated"
 
 	// device_group stream
 	DeviceGroupCreated              EventType = "DeviceGroupCreated"
@@ -192,15 +199,20 @@ const (
 	TOTPBackupCodesRegenerated EventType = "TOTPBackupCodesRegenerated"
 
 	// user stream
-	UserCreatedWithRoles            EventType = "UserCreatedWithRoles"
-	UserProfileUpdated              EventType = "UserProfileUpdated"
-	UserEmailChanged                EventType = "UserEmailChanged"
-	UserPasswordChanged             EventType = "UserPasswordChanged"
-	UserRoleChanged                 EventType = "UserRoleChanged"
-	UserSessionInvalidated          EventType = "UserSessionInvalidated"
-	UserDisabled                    EventType = "UserDisabled"
-	UserEnabled                     EventType = "UserEnabled"
-	UserLoggedIn                    EventType = "UserLoggedIn"
+	UserCreatedWithRoles   EventType = "UserCreatedWithRoles"
+	UserProfileUpdated     EventType = "UserProfileUpdated"
+	UserEmailChanged       EventType = "UserEmailChanged"
+	UserPasswordChanged    EventType = "UserPasswordChanged"
+	UserRoleChanged        EventType = "UserRoleChanged"
+	UserSessionInvalidated EventType = "UserSessionInvalidated"
+	UserDisabled           EventType = "UserDisabled"
+	UserEnabled            EventType = "UserEnabled"
+	UserLoggedIn           EventType = "UserLoggedIn"
+	// Session lifecycle audit (#496). Counterparts to UserLoggedIn;
+	// audit-only (ApplyUser does not materialise them — the JWT denylist is
+	// operational state in revoked_tokens, not a user_projection column).
+	UserLoggedOut                   EventType = "UserLoggedOut"
+	UserSessionRefreshed            EventType = "UserSessionRefreshed"
 	UserDeleted                     EventType = "UserDeleted"
 	UserSshKeyAdded                 EventType = "UserSshKeyAdded"
 	UserSshKeyRemoved               EventType = "UserSshKeyRemoved"
@@ -251,6 +263,7 @@ func All() []EventType {
 		DeviceRegistered, DeviceSeen, DeviceHeartbeat, DeviceCertRenewed, DeviceLabelsUpdated,
 		DeviceLabelSet, DeviceLabelRemoved, DeviceDeleted, DeviceAssigned, DeviceUnassigned,
 		DeviceGroupAssigned, DeviceGroupUnassigned, DeviceSyncIntervalSet,
+		OSQueryDispatched, DeviceLogsQueried, DeviceInventoryRefreshRequested, LuksTokenCreated,
 		DeviceGroupCreated, DeviceGroupRenamed, DeviceGroupDescriptionUpdated, DeviceGroupQueryUpdated,
 		DeviceGroupSyncIntervalSet, DeviceGroupMaintenanceWindowSet, DeviceGroupMemberAdded,
 		DeviceGroupMemberRemoved, DeviceGroupMembersReevaluated, DeviceGroupDeleted, DeviceAddedToGroup, DeviceRemovedFromGroup,
@@ -272,7 +285,7 @@ func All() []EventType {
 		TokenCreated, TokenRenamed, TokenUsed, TokenDisabled, TokenEnabled, TokenDeleted,
 		TOTPSetupInitiated, TOTPVerified, TOTPDisabled, TOTPBackupCodeUsed, TOTPBackupCodesRegenerated,
 		UserCreatedWithRoles, UserProfileUpdated, UserEmailChanged, UserPasswordChanged, UserRoleChanged,
-		UserSessionInvalidated, UserDisabled, UserEnabled, UserLoggedIn, UserDeleted,
+		UserSessionInvalidated, UserDisabled, UserEnabled, UserLoggedIn, UserLoggedOut, UserSessionRefreshed, UserDeleted,
 		UserSshKeyAdded, UserSshKeyRemoved, UserSshSettingsUpdated, UserLinuxUsernameChanged,
 		UserSystemActionLinked, UserProvisioningSettingsUpdated,
 		UserRoleAssigned, UserRoleRevoked,

--- a/internal/projectors/eventtype_parity_test.go
+++ b/internal/projectors/eventtype_parity_test.go
@@ -28,6 +28,17 @@ var unprojectedAllowlist = map[eventtypes.EventType]string{
 	eventtypes.TerminalSessionTerminated:        "terminal_sessions written directly by api/terminal_handler",
 	eventtypes.TerminalAdminMembershipRevoked:   "consumed by api/system_actions reconciler, not a projection",
 	eventtypes.LuksDeviceKeyRevocationRequested: "triggers async revocation dispatch in api/device_handler, no projection",
+	// #496 audit-only events: they record WHO did WHAT to WHICH
+	// device/session for the audit log; there is no projection to
+	// materialise (the underlying result/token/denylist tables are
+	// transient operational state, and users_projection needs no new
+	// column for a logout/refresh).
+	eventtypes.OSQueryDispatched:               "audit-only (#496): who dispatched an osquery read; no projection",
+	eventtypes.DeviceLogsQueried:               "audit-only (#496): who queried device logs; no projection",
+	eventtypes.DeviceInventoryRefreshRequested: "audit-only (#496): who refreshed inventory; no projection",
+	eventtypes.LuksTokenCreated:                "audit-only (#496): who issued a LUKS token; no projection",
+	eventtypes.UserLoggedOut:                   "audit-only (#496): session end; the denylist row is operational state",
+	eventtypes.UserSessionRefreshed:            "audit-only (#496): session rotation; no projection",
 }
 
 // TestEventTypes_AllHandledByProjectorOrAllowlisted is a self-discovering guard

--- a/internal/projectors/identity_provider_listener.go
+++ b/internal/projectors/identity_provider_listener.go
@@ -28,7 +28,14 @@ import (
 // the listener short-circuits the cascade DELETE when n == 0
 // (stale projection_version replay).
 //
-// Wired in projectors.WireAll. Refs #104, tracker #107.
+// Live dispatch wraps ApplyIdentityProvider (routing the multi-write
+// event types through WithTx so their cascade stays atomic on the
+// autocommit pool); the rebuild path (#497) registers
+// ApplyIdentityProvider via RegisterRebuildApply — the rebuild
+// dispatcher already runs inside one transaction and passes q bound to
+// it, so every write executes directly on q with no nested transaction.
+//
+// Wired in projectors.WireAll. Refs #104, tracker #107, #497.
 func IdentityProviderListener(st *store.Store, logger *slog.Logger) store.EventListener {
 	if st == nil {
 		return func(context.Context, store.PersistedEvent) {}
@@ -37,40 +44,78 @@ func IdentityProviderListener(st *store.Store, logger *slog.Logger) store.EventL
 		if e.StreamType != "identity_provider" {
 			return
 		}
+		// Multi-write events (Deleted, SCIMDisabled) route through
+		// WithTx so the guarded UPDATE + cascade DELETE stay atomic;
+		// single-statement events go on the autocommit pool. Both share
+		// ApplyIdentityProvider's body via the tx-bound / pool-bound
+		// Queries.
 		switch e.EventType {
-		case string(eventtypes.IdentityProviderCreated):
-			applyIdentityProviderCreated(ctx, st, logger, e)
-		case string(eventtypes.IdentityProviderUpdated):
-			applyIdentityProviderUpdated(ctx, st, logger, e)
-		case string(eventtypes.IdentityProviderDeleted):
-			applyIdentityProviderDeleted(ctx, st, logger, e)
-		case string(eventtypes.IdentityProviderSCIMEnabled):
-			applyIdentityProviderSCIMEnabled(ctx, st, logger, e)
-		case string(eventtypes.IdentityProviderSCIMDisabled):
-			applyIdentityProviderSCIMDisabled(ctx, st, logger, e)
-		case string(eventtypes.IdentityProviderSCIMTokenRotated):
-			applyIdentityProviderSCIMTokenRotated(ctx, st, logger, e)
-		case string(eventtypes.IdentityLinked):
-			applyIdentityLinked(ctx, st, logger, e)
-		case string(eventtypes.IdentityLinkLoginUpdated):
-			applyIdentityLinkLoginUpdated(ctx, st, logger, e)
-		case string(eventtypes.IdentityUnlinked):
-			applyIdentityUnlinked(ctx, st, logger, e)
+		case string(eventtypes.IdentityProviderDeleted),
+			string(eventtypes.IdentityProviderSCIMDisabled):
+			if err := st.WithTx(ctx, func(q *store.Queries) error {
+				return ApplyIdentityProvider(ctx, q, e)
+			}); err != nil {
+				logger.Warn("identity_provider projector: failed to apply event",
+					"event_id", e.ID, "event_type", e.EventType, "idp_id", e.StreamID, "error", err)
+			}
+			return
+		}
+		if err := ApplyIdentityProvider(ctx, st.Queries(), e); err != nil {
+			logger.Warn("identity_provider projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "idp_id", e.StreamID, "error", err)
 		}
 	}
 }
 
-func applyIdentityProviderCreated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+// ApplyIdentityProvider is the transactional core of the
+// identity_provider projector: it writes through the supplied Queries
+// and RETURNS errors instead of logging-and-swallowing, so a rebuild
+// fails loudly rather than producing a partial projection. Every write
+// runs directly on q — the caller supplies the transaction (WithTx for
+// the multi-write event types on the live path, the rebuild tx on the
+// rebuild path), so ApplyIdentityProvider does NOT open a nested
+// transaction of its own.
+//
+// The asymmetric-guard discipline is preserved for the multi-write
+// events (Deleted, SCIMDisabled): the guarded UPDATE is :execrows and
+// the cascade DELETE is short-circuited when n == 0 (stale
+// projection_version replay).
+func ApplyIdentityProvider(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "identity_provider" {
+		return nil
+	}
+	switch e.EventType {
+	case string(eventtypes.IdentityProviderCreated):
+		return applyIdentityProviderCreated(ctx, q, e)
+	case string(eventtypes.IdentityProviderUpdated):
+		return applyIdentityProviderUpdated(ctx, q, e)
+	case string(eventtypes.IdentityProviderDeleted):
+		return applyIdentityProviderDeleted(ctx, q, e)
+	case string(eventtypes.IdentityProviderSCIMEnabled):
+		return applyIdentityProviderSCIMEnabled(ctx, q, e)
+	case string(eventtypes.IdentityProviderSCIMDisabled):
+		return applyIdentityProviderSCIMDisabled(ctx, q, e)
+	case string(eventtypes.IdentityProviderSCIMTokenRotated):
+		return applyIdentityProviderSCIMTokenRotated(ctx, q, e)
+	case string(eventtypes.IdentityLinked):
+		return applyIdentityLinked(ctx, q, e)
+	case string(eventtypes.IdentityLinkLoginUpdated):
+		return applyIdentityLinkLoginUpdated(ctx, q, e)
+	case string(eventtypes.IdentityUnlinked):
+		return applyIdentityUnlinked(ctx, q, e)
+	}
+	return nil
+}
+
+func applyIdentityProviderCreated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := IdentityProviderCreatedFromEvent(e)
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("identity_provider projector: invalid IdentityProviderCreated payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().InsertIdentityProviderProjection(ctx, db.InsertIdentityProviderProjectionParams{
+	return q.InsertIdentityProviderProjection(ctx, db.InsertIdentityProviderProjectionParams{
 		ID:                       payload.ID,
 		Name:                     payload.Name,
 		Slug:                     payload.Slug,
@@ -92,23 +137,18 @@ func applyIdentityProviderCreated(ctx context.Context, st *store.Store, logger *
 		CreatedAt:                e.OccurredAt,
 		CreatedBy:                payload.CreatedBy,
 		ProjectionVersion:        e.SequenceNum,
-	}); err != nil {
-		logger.Warn("identity_provider projector: failed to insert IdentityProviderCreated",
-			"event_id", e.ID, "idp_id", payload.ID, "error", err)
-	}
+	})
 }
 
-func applyIdentityProviderUpdated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applyIdentityProviderUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := IdentityProviderUpdatedFromEvent(e)
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("identity_provider projector: invalid IdentityProviderUpdated payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().UpdateIdentityProviderProjection(ctx, db.UpdateIdentityProviderProjectionParams{
+	return q.UpdateIdentityProviderProjection(ctx, db.UpdateIdentityProviderProjectionParams{
 		ID:                       payload.ID,
 		Name:                     payload.Name,
 		Enabled:                  payload.Enabled,
@@ -128,115 +168,90 @@ func applyIdentityProviderUpdated(ctx context.Context, st *store.Store, logger *
 		GroupMapping:             payload.GroupMapping,
 		UpdatedAt:                e.OccurredAt,
 		ProjectionVersion:        e.SequenceNum,
-	}); err != nil {
-		logger.Warn("identity_provider projector: failed to apply IdentityProviderUpdated",
-			"event_id", e.ID, "idp_id", payload.ID, "error", err)
-	}
+	})
 }
 
-func applyIdentityProviderDeleted(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applyIdentityProviderDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	idpID := e.StreamID
-	if err := st.WithTx(ctx, func(q *store.Queries) error {
-		// Asymmetric-guard rule: SoftDelete is guarded by
-		// projection_version; cascades are not. Short-circuit on
-		// n == 0 (stale replay) to keep memberships + mappings.
-		n, err := q.SoftDeleteIdentityProviderProjection(ctx, db.SoftDeleteIdentityProviderProjectionParams{
-			ID:                idpID,
-			UpdatedAt:         e.OccurredAt,
-			ProjectionVersion: e.SequenceNum,
-		})
-		if err != nil {
-			return err
-		}
-		if n == 0 {
-			return nil
-		}
-		if err := q.DeleteIdentityLinksByProvider(ctx, idpID); err != nil {
-			return err
-		}
-		return q.DeleteSCIMGroupMappingsByProvider(ctx, idpID)
-	}); err != nil {
-		logger.Warn("identity_provider projector: failed to apply IdentityProviderDeleted",
-			"event_id", e.ID, "idp_id", idpID, "error", err)
+	// Asymmetric-guard rule: SoftDelete is guarded by
+	// projection_version; cascades are not. Short-circuit on
+	// n == 0 (stale replay) to keep memberships + mappings.
+	n, err := q.SoftDeleteIdentityProviderProjection(ctx, db.SoftDeleteIdentityProviderProjectionParams{
+		ID:                idpID,
+		UpdatedAt:         e.OccurredAt,
+		ProjectionVersion: e.SequenceNum,
+	})
+	if err != nil {
+		return err
 	}
+	if n == 0 {
+		return nil
+	}
+	if err := q.DeleteIdentityLinksByProvider(ctx, idpID); err != nil {
+		return err
+	}
+	return q.DeleteSCIMGroupMappingsByProvider(ctx, idpID)
 }
 
-func applyIdentityProviderSCIMEnabled(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applyIdentityProviderSCIMEnabled(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := SCIMTokenFromEvent(e, "IdentityProviderSCIMEnabled")
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("identity_provider projector: invalid IdentityProviderSCIMEnabled payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().SetIdentityProviderSCIMEnabled(ctx, db.SetIdentityProviderSCIMEnabledParams{
+	return q.SetIdentityProviderSCIMEnabled(ctx, db.SetIdentityProviderSCIMEnabledParams{
 		ID:                payload.ID,
 		ScimTokenHash:     payload.ScimTokenHash,
 		UpdatedAt:         e.OccurredAt,
 		ProjectionVersion: e.SequenceNum,
-	}); err != nil {
-		logger.Warn("identity_provider projector: failed to enable SCIM",
-			"event_id", e.ID, "idp_id", payload.ID, "error", err)
-	}
+	})
 }
 
-func applyIdentityProviderSCIMDisabled(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applyIdentityProviderSCIMDisabled(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	idpID := e.StreamID
-	if err := st.WithTx(ctx, func(q *store.Queries) error {
-		// Same asymmetric-guard discipline: cascade only if the
-		// guarded SCIM-disable UPDATE actually flipped a row.
-		n, err := q.SetIdentityProviderSCIMDisabled(ctx, db.SetIdentityProviderSCIMDisabledParams{
-			ID:                idpID,
-			UpdatedAt:         e.OccurredAt,
-			ProjectionVersion: e.SequenceNum,
-		})
-		if err != nil {
-			return err
-		}
-		if n == 0 {
-			return nil
-		}
-		return q.DeleteSCIMGroupMappingsByProvider(ctx, idpID)
-	}); err != nil {
-		logger.Warn("identity_provider projector: failed to disable SCIM",
-			"event_id", e.ID, "idp_id", idpID, "error", err)
+	// Same asymmetric-guard discipline: cascade only if the
+	// guarded SCIM-disable UPDATE actually flipped a row.
+	n, err := q.SetIdentityProviderSCIMDisabled(ctx, db.SetIdentityProviderSCIMDisabledParams{
+		ID:                idpID,
+		UpdatedAt:         e.OccurredAt,
+		ProjectionVersion: e.SequenceNum,
+	})
+	if err != nil {
+		return err
 	}
+	if n == 0 {
+		return nil
+	}
+	return q.DeleteSCIMGroupMappingsByProvider(ctx, idpID)
 }
 
-func applyIdentityProviderSCIMTokenRotated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applyIdentityProviderSCIMTokenRotated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := SCIMTokenFromEvent(e, "IdentityProviderSCIMTokenRotated")
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("identity_provider projector: invalid IdentityProviderSCIMTokenRotated payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().RotateIdentityProviderSCIMToken(ctx, db.RotateIdentityProviderSCIMTokenParams{
+	return q.RotateIdentityProviderSCIMToken(ctx, db.RotateIdentityProviderSCIMTokenParams{
 		ID:                payload.ID,
 		ScimTokenHash:     payload.ScimTokenHash,
 		UpdatedAt:         e.OccurredAt,
 		ProjectionVersion: e.SequenceNum,
-	}); err != nil {
-		logger.Warn("identity_provider projector: failed to rotate SCIM token",
-			"event_id", e.ID, "idp_id", payload.ID, "error", err)
-	}
+	})
 }
 
-func applyIdentityLinked(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applyIdentityLinked(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := IdentityLinkedFromEvent(e)
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("identity_provider projector: invalid IdentityLinked payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
-	if err := st.Queries().UpsertIdentityLink(ctx, db.UpsertIdentityLinkParams{
+	return q.UpsertIdentityLink(ctx, db.UpsertIdentityLinkParams{
 		ID:                payload.ID,
 		UserID:            payload.UserID,
 		ProviderID:        payload.ProviderID,
@@ -245,39 +260,28 @@ func applyIdentityLinked(ctx context.Context, st *store.Store, logger *slog.Logg
 		ExternalName:      payload.ExternalName,
 		LinkedAt:          e.OccurredAt,
 		ProjectionVersion: e.SequenceNum,
-	}); err != nil {
-		logger.Warn("identity_provider projector: failed to upsert identity_link",
-			"event_id", e.ID, "link_id", payload.ID, "error", err)
-	}
+	})
 }
 
-func applyIdentityLinkLoginUpdated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+func applyIdentityLinkLoginUpdated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := IdentityLinkLoginUpdatedFromEvent(e)
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("identity_provider projector: invalid IdentityLinkLoginUpdated payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
 	loginAt := e.OccurredAt
-	if err := st.Queries().UpdateIdentityLinkLogin(ctx, db.UpdateIdentityLinkLoginParams{
+	return q.UpdateIdentityLinkLogin(ctx, db.UpdateIdentityLinkLoginParams{
 		ProviderID:        payload.ProviderID,
 		ExternalID:        payload.ExternalID,
 		LastLoginAt:       &loginAt,
 		ExternalEmail:     payload.ExternalEmail,
 		ExternalName:      payload.ExternalName,
 		ProjectionVersion: e.SequenceNum,
-	}); err != nil {
-		logger.Warn("identity_provider projector: failed to update identity_link login",
-			"event_id", e.ID, "provider_id", payload.ProviderID, "external_id", payload.ExternalID, "error", err)
-	}
+	})
 }
 
-func applyIdentityUnlinked(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
-	if err := st.Queries().DeleteIdentityLinkByID(ctx, e.StreamID); err != nil {
-		logger.Warn("identity_provider projector: failed to delete identity_link",
-			"event_id", e.ID, "link_id", e.StreamID, "error", err)
-	}
+func applyIdentityUnlinked(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	return q.DeleteIdentityLinkByID(ctx, e.StreamID)
 }

--- a/internal/projectors/lps_keypair.go
+++ b/internal/projectors/lps_keypair.go
@@ -1,0 +1,41 @@
+package projectors
+
+import (
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// x25519PublicKeySize is the raw X25519 public key length the payload must
+// carry — anything else could not have been produced by GenerateX25519 and
+// would poison the projection with an unusable key.
+const x25519PublicKeySize = 32
+
+// LpsKeypairGeneratedPayload aliases the shared wire struct so projector-side
+// code keeps the Payload-suffix convention; payloads.LpsKeypairGenerated is
+// the canonical handle for the emit site (api.EnsureLpsKeypair).
+type LpsKeypairGeneratedPayload = payloads.LpsKeypairGenerated
+
+// LpsKeypairGeneratedFromEvent decodes the singleton LpsKeypairGenerated
+// event (#495). Returns ErrIgnoredEvent for any event the lps_keypair
+// projector does not act on.
+//
+// Pure: no I/O, deterministic, depends only on the event's fields.
+func LpsKeypairGeneratedFromEvent(e store.PersistedEvent) (LpsKeypairGeneratedPayload, error) {
+	p, err := decodePayload[LpsKeypairGeneratedPayload](e, "lps_keypair", eventtypes.LpsKeypairGenerated)
+	if err != nil {
+		return LpsKeypairGeneratedPayload{}, err
+	}
+	// The projection row is useless without both halves, and a wrong-size
+	// public key cannot pair with the private key it claims to accompany —
+	// fail loudly in the listener log rather than projecting a poisoned row.
+	switch {
+	case len(p.PublicKey) != x25519PublicKeySize:
+		return LpsKeypairGeneratedPayload{}, fmt.Errorf("projector: LpsKeypairGenerated requires a %d-byte public_key (got %d)", x25519PublicKeySize, len(p.PublicKey))
+	case p.PrivateKeyEnc == "":
+		return LpsKeypairGeneratedPayload{}, fmt.Errorf("projector: LpsKeypairGenerated requires private_key_enc")
+	}
+	return p, nil
+}

--- a/internal/projectors/lps_keypair_listener.go
+++ b/internal/projectors/lps_keypair_listener.go
@@ -1,0 +1,65 @@
+package projectors
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// LpsKeypairListener returns a store.EventListener that materialises the
+// singleton lps_keypair row from LpsKeypairGenerated (#495). Before #495 the
+// row was written directly by api.EnsureLpsKeypair (advisory lock + INSERT ON
+// CONFLICT DO NOTHING) — the only Postgres state bypassing the event store.
+// Now the table is a real projection: the OCC append in EnsureLpsKeypair is
+// the sole write path, this listener (and the rebuild target) derive the row.
+//
+// Single event type, single idempotent upsert — no transaction wrap needed.
+//
+// Wired in projectors.WireAll; rebuild target "lps_keypair" registers
+// ApplyLpsKeypair via RegisterRebuildApply.
+func LpsKeypairListener(st *store.Store, logger *slog.Logger) store.EventListener {
+	if st == nil {
+		return func(context.Context, store.PersistedEvent) {}
+	}
+	return func(ctx context.Context, e store.PersistedEvent) {
+		if err := ApplyLpsKeypair(ctx, st.Queries(), e); err != nil {
+			logger.Warn("lps_keypair projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "error", err)
+		}
+	}
+}
+
+// ApplyLpsKeypair is the transactional core of the lps_keypair projector.
+// The listener wraps it for live-event dispatch; the rebuild path registers
+// it via RegisterRebuildApply so RebuildAll re-derives the projection from
+// the event store (replay guarantee: 1:1 row reproduction, #495 AC1).
+func ApplyLpsKeypair(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "lps_keypair" || e.EventType != string(eventtypes.LpsKeypairGenerated) {
+		return nil
+	}
+	payload, err := LpsKeypairGeneratedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	// created_at: the #495 backfill preserves the pre-event row's timestamp
+	// in the payload; a freshly generated keypair omits it and the event's
+	// occurred_at is the generation time.
+	createdAt := e.OccurredAt
+	if payload.CreatedAt != nil {
+		createdAt = *payload.CreatedAt
+	}
+	return q.UpsertLpsKeypair(ctx, db.UpsertLpsKeypairParams{
+		PublicKey:     payload.PublicKey,
+		PrivateKeyEnc: payload.PrivateKeyEnc,
+		CreatedAt:     pgtype.Timestamptz{Time: createdAt, Valid: true},
+	})
+}

--- a/internal/projectors/lps_keypair_test.go
+++ b/internal/projectors/lps_keypair_test.go
@@ -1,0 +1,142 @@
+package projectors_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestLpsKeypairGeneratedFromEvent_Pure exercises the pure decoder without
+// the database (#495). Table-driven over the correct / absent / wrong triad
+// for both payload halves.
+func TestLpsKeypairGeneratedFromEvent_Pure(t *testing.T) {
+	pub := bytes.Repeat([]byte{0x42}, 32)
+	pubB64 := base64.StdEncoding.EncodeToString(pub)
+
+	t.Run("happy path", func(t *testing.T) {
+		got, err := projectors.LpsKeypairGeneratedFromEvent(store.PersistedEvent{
+			StreamType: "lps_keypair",
+			EventType:  "LpsKeypairGenerated",
+			Data: jsonOrFail(t, map[string]any{
+				"public_key":      pubB64,
+				"private_key_enc": "enc:v2:abc",
+			}),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, pub, got.PublicKey)
+		assert.Equal(t, "enc:v2:abc", got.PrivateKeyEnc)
+		assert.Nil(t, got.CreatedAt, "created_at is optional (backfill-only)")
+	})
+
+	t.Run("backfill carries created_at", func(t *testing.T) {
+		created := time.Date(2026, 6, 1, 8, 0, 0, 0, time.UTC)
+		got, err := projectors.LpsKeypairGeneratedFromEvent(store.PersistedEvent{
+			StreamType: "lps_keypair",
+			EventType:  "LpsKeypairGenerated",
+			Data: jsonOrFail(t, map[string]any{
+				"public_key":      pubB64,
+				"private_key_enc": "enc:v2:abc",
+				"created_at":      created.Format(time.RFC3339),
+			}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.CreatedAt)
+		assert.True(t, got.CreatedAt.Equal(created))
+	})
+
+	t.Run("wrong stream type is ignored", func(t *testing.T) {
+		_, err := projectors.LpsKeypairGeneratedFromEvent(store.PersistedEvent{
+			StreamType: "lps_password",
+			EventType:  "LpsKeypairGenerated",
+			Data:       jsonOrFail(t, map[string]any{"public_key": pubB64, "private_key_enc": "enc:v2:abc"}),
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("wrong event type is ignored", func(t *testing.T) {
+		_, err := projectors.LpsKeypairGeneratedFromEvent(store.PersistedEvent{
+			StreamType: "lps_keypair",
+			EventType:  "LpsPasswordRotated",
+			Data:       jsonOrFail(t, map[string]any{"public_key": pubB64, "private_key_enc": "enc:v2:abc"}),
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("empty payload rejected", func(t *testing.T) {
+		_, err := projectors.LpsKeypairGeneratedFromEvent(store.PersistedEvent{
+			StreamType: "lps_keypair",
+			EventType:  "LpsKeypairGenerated",
+		})
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+
+	t.Run("missing public_key rejected", func(t *testing.T) {
+		_, err := projectors.LpsKeypairGeneratedFromEvent(store.PersistedEvent{
+			StreamType: "lps_keypair",
+			EventType:  "LpsKeypairGenerated",
+			Data:       jsonOrFail(t, map[string]any{"private_key_enc": "enc:v2:abc"}),
+		})
+		require.ErrorContains(t, err, "public_key")
+	})
+
+	t.Run("wrong-size public_key rejected", func(t *testing.T) {
+		_, err := projectors.LpsKeypairGeneratedFromEvent(store.PersistedEvent{
+			StreamType: "lps_keypair",
+			EventType:  "LpsKeypairGenerated",
+			Data: jsonOrFail(t, map[string]any{
+				"public_key":      base64.StdEncoding.EncodeToString([]byte("short")),
+				"private_key_enc": "enc:v2:abc",
+			}),
+		})
+		require.ErrorContains(t, err, "public_key")
+	})
+
+	t.Run("missing private_key_enc rejected", func(t *testing.T) {
+		_, err := projectors.LpsKeypairGeneratedFromEvent(store.PersistedEvent{
+			StreamType: "lps_keypair",
+			EventType:  "LpsKeypairGenerated",
+			Data:       jsonOrFail(t, map[string]any{"public_key": pubB64}),
+		})
+		require.ErrorContains(t, err, "private_key_enc")
+	})
+}
+
+// TestLpsKeypairListener_MaterializesRow drives a real LpsKeypairGenerated
+// through Store.AppendEvent on real Postgres (SetupPostgres wires WireAll)
+// and asserts the projection row appears with the event's exact content —
+// the listener integration half of the #495 projector port.
+func TestLpsKeypairListener_MaterializesRow(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	pub := bytes.Repeat([]byte{0x24}, 32)
+	require.NoError(t, st.AppendEventWithVersion(ctx, store.Event{
+		StreamType: "lps_keypair",
+		StreamID:   "global",
+		EventType:  "LpsKeypairGenerated",
+		Data: payloads.LpsKeypairGenerated{
+			PublicKey:     pub,
+			PrivateKeyEnc: "enc:v2:listener-test",
+		},
+		ActorType: "system",
+		ActorID:   "system",
+	}, 1))
+
+	row, err := st.Queries().GetLpsKeypair(ctx)
+	require.NoError(t, err, "listener must materialise the projection row synchronously")
+	assert.Equal(t, pub, row.PublicKey)
+	assert.Equal(t, "enc:v2:listener-test", row.PrivateKeyEnc)
+	assert.True(t, row.CreatedAt.Valid)
+}

--- a/internal/projectors/lps_password_listener.go
+++ b/internal/projectors/lps_password_listener.go
@@ -48,6 +48,12 @@ func LpsPasswordListener(st *store.Store, logger *slog.Logger) store.EventListen
 		return func(context.Context, store.PersistedEvent) {}
 	}
 	return func(ctx context.Context, e store.PersistedEvent) {
+		// Filter before opening a transaction so unrelated events don't pay
+		// a BEGIN/COMMIT round-trip (ApplyLpsPassword also filters, but only
+		// after WithTx has already opened the tx). Mirrors LuksKeyListener.
+		if e.StreamType != "lps_password" || e.EventType != string(eventtypes.LpsPasswordRotated) {
+			return
+		}
 		// Live dispatch keeps the three writes atomic on the autocommit
 		// pool via WithTx; the tx-bound queries are handed to
 		// ApplyLpsPassword.

--- a/internal/projectors/lps_password_listener.go
+++ b/internal/projectors/lps_password_listener.go
@@ -33,86 +33,109 @@ import (
 // today; the switch is intentionally a single case so a future event
 // type slots in next to it without touching the wiring.
 //
+// Live dispatch wraps ApplyLpsPassword (opening its own WithTx so the
+// three writes stay atomic on the autocommit pool); the rebuild path
+// (#497) registers ApplyLpsPassword via RegisterRebuildApply — the
+// rebuild dispatcher already runs inside one transaction and passes q
+// bound to it, so the three writes execute directly on q with no nested
+// transaction.
+//
 // Wired in projectors.WireAll.
 //
-// Refs #98, tracker #107, audit F020/F021.
+// Refs #98, tracker #107, audit F020/F021, #497.
 func LpsPasswordListener(st *store.Store, logger *slog.Logger) store.EventListener {
 	if st == nil {
 		return func(context.Context, store.PersistedEvent) {}
 	}
 	return func(ctx context.Context, e store.PersistedEvent) {
-		if e.StreamType != "lps_password" {
-			return
-		}
-		if e.EventType != string(eventtypes.LpsPasswordRotated) {
-			return
-		}
-
-		payload, err := LpsPasswordRotatedFromEvent(e)
-		if err != nil {
-			if errors.Is(err, ErrIgnoredEvent) {
-				return
-			}
-			logger.Warn("lps_password projector: invalid event payload",
-				"event_id", e.ID, "event_type", e.EventType, "error", err)
-			return
-		}
-
-		projVer := e.SequenceNum
-
+		// Live dispatch keeps the three writes atomic on the autocommit
+		// pool via WithTx; the tx-bound queries are handed to
+		// ApplyLpsPassword.
 		if err := st.WithTx(ctx, func(q *store.Queries) error {
-			n, err := q.MarkLpsPasswordsNotCurrent(ctx, db.MarkLpsPasswordsNotCurrentParams{
-				DeviceID:          payload.DeviceID,
-				Username:          payload.Username,
-				ProjectionVersion: projVer,
-			})
-			if err != nil {
-				return err
-			}
-			// n==0 has TWO causes that the rest of the code path
-			// handles oppositely:
-			//   1. Stale replay: rows exist for (device, username)
-			//      but their projection_version is >= the
-			//      replaying event's sequence_num. The rotation
-			//      has already been projected — skip the insert.
-			//   2. First rotation for this user: no rows exist at
-			//      all. The UPDATE matched nothing because there
-			//      was nothing to flip. Proceed to insert.
-			// Disambiguate via an existence check; only the stale
-			// case skips. (Audit F020/F021 / CR-CLI catch.)
-			if n == 0 {
-				exists, err := q.LpsPasswordExistsForDeviceUsername(ctx, db.LpsPasswordExistsForDeviceUsernameParams{
-					DeviceID: payload.DeviceID,
-					Username: payload.Username,
-				})
-				if err != nil {
-					return err
-				}
-				if exists {
-					return nil
-				}
-			}
-			if err := q.InsertLpsPassword(ctx, db.InsertLpsPasswordParams{
-				DeviceID:          payload.DeviceID,
-				ActionID:          payload.ActionID,
-				Username:          payload.Username,
-				Password:          payload.Password,
-				RotatedAt:         payload.RotatedAt,
-				RotationReason:    payload.RotationReason,
-				ProjectionVersion: projVer,
-			}); err != nil {
-				return err
-			}
-			return q.TrimLpsPasswordsToLast3(ctx, db.TrimLpsPasswordsToLast3Params{
-				DeviceID: payload.DeviceID,
-				Username: payload.Username,
-			})
+			return ApplyLpsPassword(ctx, q, e)
 		}); err != nil {
 			logger.Warn("lps_password projector: failed to apply LpsPasswordRotated",
 				"event_id", e.ID,
-				"device_id", payload.DeviceID,
-				"username", payload.Username,
+				"event_type", e.EventType,
 				"error", err)
 		}
 	}
+}
+
+// ApplyLpsPassword is the transactional core of the lps_password
+// projector: it writes through the supplied Queries and RETURNS errors
+// instead of logging-and-swallowing. The three writes (mark previous
+// not-current, insert new, trim history to 3) run directly on q — the
+// caller supplies the transaction (WithTx on the live path, the rebuild
+// tx on the rebuild path), so ApplyLpsPassword does NOT open a nested
+// transaction of its own.
+//
+// The asymmetric stale-replay guard (audit F020/F021) is preserved: the
+// guarded MarkLpsPasswordsNotCurrent UPDATE returns rows-affected; on
+// n == 0 an existence check disambiguates stale replay (skip) from a
+// first rotation (proceed).
+func ApplyLpsPassword(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "lps_password" {
+		return nil
+	}
+	if e.EventType != string(eventtypes.LpsPasswordRotated) {
+		return nil
+	}
+
+	payload, err := LpsPasswordRotatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+
+	projVer := e.SequenceNum
+
+	n, err := q.MarkLpsPasswordsNotCurrent(ctx, db.MarkLpsPasswordsNotCurrentParams{
+		DeviceID:          payload.DeviceID,
+		Username:          payload.Username,
+		ProjectionVersion: projVer,
+	})
+	if err != nil {
+		return err
+	}
+	// n==0 has TWO causes that the rest of the code path
+	// handles oppositely:
+	//   1. Stale replay: rows exist for (device, username)
+	//      but their projection_version is >= the
+	//      replaying event's sequence_num. The rotation
+	//      has already been projected — skip the insert.
+	//   2. First rotation for this user: no rows exist at
+	//      all. The UPDATE matched nothing because there
+	//      was nothing to flip. Proceed to insert.
+	// Disambiguate via an existence check; only the stale
+	// case skips. (Audit F020/F021 / CR-CLI catch.)
+	if n == 0 {
+		exists, err := q.LpsPasswordExistsForDeviceUsername(ctx, db.LpsPasswordExistsForDeviceUsernameParams{
+			DeviceID: payload.DeviceID,
+			Username: payload.Username,
+		})
+		if err != nil {
+			return err
+		}
+		if exists {
+			return nil
+		}
+	}
+	if err := q.InsertLpsPassword(ctx, db.InsertLpsPasswordParams{
+		DeviceID:          payload.DeviceID,
+		ActionID:          payload.ActionID,
+		Username:          payload.Username,
+		Password:          payload.Password,
+		RotatedAt:         payload.RotatedAt,
+		RotationReason:    payload.RotationReason,
+		ProjectionVersion: projVer,
+	}); err != nil {
+		return err
+	}
+	return q.TrimLpsPasswordsToLast3(ctx, db.TrimLpsPasswordsToLast3Params{
+		DeviceID: payload.DeviceID,
+		Username: payload.Username,
+	})
 }

--- a/internal/projectors/lps_password_listener.go
+++ b/internal/projectors/lps_password_listener.go
@@ -3,6 +3,7 @@ package projectors
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -93,7 +94,11 @@ func ApplyLpsPassword(ctx context.Context, q *store.Queries, e store.PersistedEv
 		if errors.Is(err, ErrIgnoredEvent) {
 			return nil
 		}
-		return err
+		// A malformed historical payload must not abort the whole
+		// lps_passwords rebuild; report it skippable so the live listener
+		// logs-and-swallows and RebuildAll skips-and-continues.
+		return fmt.Errorf("lps_password projector: malformed LpsPasswordRotated %s: %w: %w",
+			e.ID, err, store.ErrSkipEvent)
 	}
 
 	projVer := e.SequenceNum

--- a/internal/projectors/luks_key_listener.go
+++ b/internal/projectors/luks_key_listener.go
@@ -3,6 +3,7 @@ package projectors
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -107,7 +108,11 @@ func applyLuksKeyRotated(ctx context.Context, q *store.Queries, e store.Persiste
 		if errors.Is(err, ErrIgnoredEvent) {
 			return nil
 		}
-		return err
+		// A malformed historical payload must not abort the whole luks_keys
+		// rebuild; report it skippable so the live listener logs-and-swallows
+		// and RebuildAll skips-and-continues.
+		return fmt.Errorf("luks_key projector: malformed LuksKeyRotated %s: %w: %w",
+			e.ID, err, store.ErrSkipEvent)
 	}
 	projVer := e.SequenceNum
 

--- a/internal/projectors/luks_key_listener.go
+++ b/internal/projectors/luks_key_listener.go
@@ -37,7 +37,14 @@ import (
 // an old LuksKeyRotated would corrupt is_current and insert a stale
 // duplicate underneath the real key.
 //
-// Wired in projectors.WireAll. Refs #99, tracker #107, audit N007.
+// Live dispatch wraps ApplyLuksKey (opening its own WithTx for the
+// LuksKeyRotated multi-write case so the three writes stay atomic on the
+// autocommit pool); the rebuild path (#497) registers ApplyLuksKey via
+// RegisterRebuildApply — the rebuild dispatcher already runs inside one
+// transaction and passes q bound to it, so every write executes directly
+// on q with no nested transaction.
+//
+// Wired in projectors.WireAll. Refs #99, tracker #107, audit N007, #497.
 func LuksKeyListener(st *store.Store, logger *slog.Logger) store.EventListener {
 	if st == nil {
 		return func(context.Context, store.PersistedEvent) {}
@@ -46,93 +53,113 @@ func LuksKeyListener(st *store.Store, logger *slog.Logger) store.EventListener {
 		if e.StreamType != "luks_key" {
 			return
 		}
-
-		switch e.EventType {
-		case string(eventtypes.LuksKeyRotated):
-			applyLuksKeyRotated(ctx, st, logger, e)
-		case string(eventtypes.LuksDeviceKeyRevocationDispatched):
-			applyLuksRevocation(ctx, st, logger, e, LuksRevocationDispatchedFromEvent)
-		case string(eventtypes.LuksDeviceKeyRevoked):
-			applyLuksRevocation(ctx, st, logger, e, LuksRevokedFromEvent)
-		case string(eventtypes.LuksDeviceKeyRevocationFailed):
-			applyLuksRevocation(ctx, st, logger, e, LuksRevocationFailedFromEvent)
+		// LuksKeyRotated is a three-write cascade — route it through
+		// WithTx on the live path so the writes stay atomic on the
+		// autocommit pool. The single-write revocation events go on the
+		// pool directly. Both share ApplyLuksKey's body via the
+		// tx-bound / pool-bound Queries.
+		if e.EventType == string(eventtypes.LuksKeyRotated) {
+			if err := st.WithTx(ctx, func(q *store.Queries) error {
+				return ApplyLuksKey(ctx, q, e)
+			}); err != nil {
+				logger.Warn("luks_key projector: failed to apply event",
+					"event_id", e.ID, "event_type", e.EventType, "error", err)
+			}
+			return
 		}
-		// Every other event_type (incl. LuksDeviceKeyRevocationRequested)
-		// is silently ignored — same behaviour as the deleted PL/pgSQL
-		// projector's CASE ... ELSE NULL.
+		if err := ApplyLuksKey(ctx, st.Queries(), e); err != nil {
+			logger.Warn("luks_key projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "error", err)
+		}
 	}
 }
 
-func applyLuksKeyRotated(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
+// ApplyLuksKey is the transactional core of the luks_key projector: it
+// writes through the supplied Queries and RETURNS errors instead of
+// logging-and-swallowing. Every write runs directly on q — the caller
+// supplies the transaction (WithTx for LuksKeyRotated on the live path,
+// the rebuild tx on the rebuild path), so ApplyLuksKey does NOT open a
+// nested transaction of its own.
+//
+// LuksDeviceKeyRevocationRequested and every other event_type are
+// silently ignored — same behaviour as the deleted PL/pgSQL projector's
+// CASE ... ELSE NULL.
+func ApplyLuksKey(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "luks_key" {
+		return nil
+	}
+	switch e.EventType {
+	case string(eventtypes.LuksKeyRotated):
+		return applyLuksKeyRotated(ctx, q, e)
+	case string(eventtypes.LuksDeviceKeyRevocationDispatched):
+		return applyLuksRevocation(ctx, q, e, LuksRevocationDispatchedFromEvent)
+	case string(eventtypes.LuksDeviceKeyRevoked):
+		return applyLuksRevocation(ctx, q, e, LuksRevokedFromEvent)
+	case string(eventtypes.LuksDeviceKeyRevocationFailed):
+		return applyLuksRevocation(ctx, q, e, LuksRevocationFailedFromEvent)
+	}
+	return nil
+}
+
+func applyLuksKeyRotated(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	payload, err := LuksKeyRotatedFromEvent(e)
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("luks_key projector: invalid LuksKeyRotated payload",
-			"event_id", e.ID, "error", err)
-		return
+		return err
 	}
 	projVer := e.SequenceNum
 
-	if err := st.WithTx(ctx, func(q *store.Queries) error {
-		n, err := q.MarkLuksKeysNotCurrent(ctx, db.MarkLuksKeysNotCurrentParams{
-			DeviceID:          payload.DeviceID,
-			ActionID:          payload.ActionID,
-			DevicePath:        payload.DevicePath,
-			ProjectionVersion: projVer,
-		})
-		if err != nil {
-			return err
-		}
-		// n==0 has TWO causes that the rest of the code path
-		// handles oppositely (audit N007, mirrors LPS F020/F021):
-		//   1. Stale replay: rows exist for (device, action, path)
-		//      but their projection_version is >= the replaying
-		//      event's sequence_num. The rotation has already been
-		//      projected — skip the insert.
-		//   2. First rotation for this triple: no rows exist at
-		//      all. The UPDATE matched nothing because there was
-		//      nothing to flip. Proceed to insert.
-		// Disambiguate via an existence check; only the stale case
-		// skips.
-		if n == 0 {
-			exists, err := q.LuksKeyExistsForDeviceActionPath(ctx, db.LuksKeyExistsForDeviceActionPathParams{
-				DeviceID:   payload.DeviceID,
-				ActionID:   payload.ActionID,
-				DevicePath: payload.DevicePath,
-			})
-			if err != nil {
-				return err
-			}
-			if exists {
-				return nil
-			}
-		}
-		if err := q.InsertLuksKey(ctx, db.InsertLuksKeyParams{
-			DeviceID:          payload.DeviceID,
-			ActionID:          payload.ActionID,
-			DevicePath:        payload.DevicePath,
-			Passphrase:        payload.Passphrase,
-			RotatedAt:         payload.RotatedAt,
-			RotationReason:    payload.RotationReason,
-			ProjectionVersion: projVer,
-		}); err != nil {
-			return err
-		}
-		return q.TrimLuksKeysToLast3(ctx, db.TrimLuksKeysToLast3Params{
+	n, err := q.MarkLuksKeysNotCurrent(ctx, db.MarkLuksKeysNotCurrentParams{
+		DeviceID:          payload.DeviceID,
+		ActionID:          payload.ActionID,
+		DevicePath:        payload.DevicePath,
+		ProjectionVersion: projVer,
+	})
+	if err != nil {
+		return err
+	}
+	// n==0 has TWO causes that the rest of the code path
+	// handles oppositely (audit N007, mirrors LPS F020/F021):
+	//   1. Stale replay: rows exist for (device, action, path)
+	//      but their projection_version is >= the replaying
+	//      event's sequence_num. The rotation has already been
+	//      projected — skip the insert.
+	//   2. First rotation for this triple: no rows exist at
+	//      all. The UPDATE matched nothing because there was
+	//      nothing to flip. Proceed to insert.
+	// Disambiguate via an existence check; only the stale case
+	// skips.
+	if n == 0 {
+		exists, err := q.LuksKeyExistsForDeviceActionPath(ctx, db.LuksKeyExistsForDeviceActionPathParams{
 			DeviceID:   payload.DeviceID,
 			ActionID:   payload.ActionID,
 			DevicePath: payload.DevicePath,
 		})
-	}); err != nil {
-		logger.Warn("luks_key projector: failed to apply LuksKeyRotated",
-			"event_id", e.ID,
-			"device_id", payload.DeviceID,
-			"action_id", payload.ActionID,
-			"device_path", payload.DevicePath,
-			"error", err)
+		if err != nil {
+			return err
+		}
+		if exists {
+			return nil
+		}
 	}
+	if err := q.InsertLuksKey(ctx, db.InsertLuksKeyParams{
+		DeviceID:          payload.DeviceID,
+		ActionID:          payload.ActionID,
+		DevicePath:        payload.DevicePath,
+		Passphrase:        payload.Passphrase,
+		RotatedAt:         payload.RotatedAt,
+		RotationReason:    payload.RotationReason,
+		ProjectionVersion: projVer,
+	}); err != nil {
+		return err
+	}
+	return q.TrimLuksKeysToLast3(ctx, db.TrimLuksKeysToLast3Params{
+		DeviceID:   payload.DeviceID,
+		ActionID:   payload.ActionID,
+		DevicePath: payload.DevicePath,
+	})
 }
 
 // applyLuksRevocation is generic across the three revocation event
@@ -141,36 +168,25 @@ func applyLuksKeyRotated(ctx context.Context, st *store.Store, logger *slog.Logg
 // timestamp key + status value; the writer is identical.
 func applyLuksRevocation(
 	ctx context.Context,
-	st *store.Store,
-	logger *slog.Logger,
+	q *store.Queries,
 	e store.PersistedEvent,
 	decode func(store.PersistedEvent) (LuksRevocationPayload, error),
-) {
+) error {
 	payload, err := decode(e)
 	if err != nil {
 		if errors.Is(err, ErrIgnoredEvent) {
-			return
+			return nil
 		}
-		logger.Warn("luks_key projector: invalid revocation payload",
-			"event_id", e.ID, "event_type", e.EventType, "error", err)
-		return
+		return err
 	}
 	at := payload.At
-	if err := st.Queries().UpdateLuksKeyRevocationStatus(ctx, db.UpdateLuksKeyRevocationStatusParams{
+	return q.UpdateLuksKeyRevocationStatus(ctx, db.UpdateLuksKeyRevocationStatusParams{
 		DeviceID:         payload.DeviceID,
 		ActionID:         payload.ActionID,
 		RevocationStatus: stringPtr(payload.Status),
 		RevocationError:  payload.Error,
 		RevocationAt:     &at,
-	}); err != nil {
-		logger.Warn("luks_key projector: failed to update revocation_status",
-			"event_id", e.ID,
-			"event_type", e.EventType,
-			"device_id", payload.DeviceID,
-			"action_id", payload.ActionID,
-			"status", payload.Status,
-			"error", err)
-	}
+	})
 }
 
 func stringPtr(s string) *string { return &s }

--- a/internal/projectors/security_alert_listener.go
+++ b/internal/projectors/security_alert_listener.go
@@ -35,7 +35,12 @@ import (
 // via ON CONFLICT (event_id) DO NOTHING, so a re-fire on crash
 // recovery is safe.
 //
-// Refs #96, tracker #107.
+// Live dispatch wraps ApplySecurityAlert and logs-and-swallows; the
+// rebuild path (#497) registers ApplySecurityAlert via
+// RegisterRebuildApply so RebuildAll re-derives the projection from the
+// event store.
+//
+// Refs #96, tracker #107, #497.
 func SecurityAlertListener(st *store.Store, logger *slog.Logger) store.EventListener {
 	if st == nil {
 		// Match the SearchListener factory contract: never return
@@ -44,58 +49,64 @@ func SecurityAlertListener(st *store.Store, logger *slog.Logger) store.EventList
 	}
 
 	return func(ctx context.Context, e store.PersistedEvent) {
-		// Filter at the top so we don't pay the projector function
-		// call cost for every event flowing through the store.
-		if e.StreamType != "device" {
-			return
-		}
-		switch e.EventType {
-		case string(eventtypes.SecurityAlert):
-			params, err := SecurityAlertProjectionFromEvent(e)
-			if err != nil {
-				if errors.Is(err, ErrIgnoredEvent) {
-					return
-				}
-				logger.Warn("security_alert projector: failed to derive insert params",
-					"event_id", e.ID, "error", err)
-				return
-			}
-			if err := st.Queries().InsertSecurityAlertProjection(ctx, params); err != nil {
-				logger.Warn("security_alert projector: failed to insert projection row",
-					"event_id", e.ID, "device_id", e.StreamID, "error", err)
-			}
-
-		case string(eventtypes.SecurityAlertAcknowledged):
-			params, err := SecurityAlertAckParamsFromEvent(e)
-			if err != nil {
-				if errors.Is(err, ErrIgnoredEvent) {
-					return
-				}
-				// Malformed alert_id — log and skip. The deleted
-				// PL/pgSQL projector raised an EXCEPTION in this
-				// case so a sidecar trigger could catch it and
-				// write to plpgsql_projection_errors. Post-commit
-				// listener equivalent: log to stderr via slog.Warn
-				// so the operator sees it and can correlate with
-				// the event.
-				logger.Warn("security_alert projector: invalid SecurityAlertAcknowledged payload",
-					"event_id", e.ID, "error", err)
-				return
-			}
-			rows, err := st.Queries().AcknowledgeSecurityAlertProjection(ctx, params)
-			if err != nil {
-				logger.Warn("security_alert projector: failed to acknowledge alert",
-					"event_id", e.ID, "alert_id", params.Column1, "error", err)
-				return
-			}
-			if rows == 0 {
-				// Out-of-order replay (ack arrived before the
-				// alert insert reached the projection) or an alert
-				// that's been purged. Same warning the deleted
-				// PL/pgSQL projector raised.
-				logger.Warn("security_alert projector: SecurityAlertAcknowledged references unknown alert_id",
-					"event_id", e.ID, "alert_id", params.Column1)
-			}
+		if err := ApplySecurityAlert(ctx, st.Queries(), e); err != nil {
+			logger.Warn("security_alert projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "error", err)
 		}
 	}
+}
+
+// ApplySecurityAlert is the transactional core of the security_alert
+// projector: it writes through the supplied Queries (the rebuild tx or
+// the live autocommit handle) and RETURNS errors instead of
+// logging-and-swallowing, so a rebuild fails loudly rather than
+// producing a partial projection.
+//
+// The stream guard filters on "device" (security alerts ride the device
+// stream), not "security_alert".
+func ApplySecurityAlert(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	// Filter at the top so we don't pay the projector function
+	// call cost for every event flowing through the store.
+	if e.StreamType != "device" {
+		return nil
+	}
+	switch e.EventType {
+	case string(eventtypes.SecurityAlert):
+		params, err := SecurityAlertProjectionFromEvent(e)
+		if err != nil {
+			if errors.Is(err, ErrIgnoredEvent) {
+				return nil
+			}
+			return err
+		}
+		return q.InsertSecurityAlertProjection(ctx, params)
+
+	case string(eventtypes.SecurityAlertAcknowledged):
+		params, err := SecurityAlertAckParamsFromEvent(e)
+		if err != nil {
+			if errors.Is(err, ErrIgnoredEvent) {
+				return nil
+			}
+			// Malformed alert_id — the deleted PL/pgSQL projector
+			// raised an EXCEPTION here; the live listener logged and
+			// skipped. Keep that non-fatal behaviour during rebuild:
+			// a historical malformed event must not abort the rebuild.
+			return nil
+		}
+		rows, err := q.AcknowledgeSecurityAlertProjection(ctx, params)
+		if err != nil {
+			return err
+		}
+		if rows == 0 {
+			// Out-of-order replay (ack arrived before the alert
+			// insert reached the projection) or an alert that's been
+			// purged. Non-fatal — nothing to acknowledge, so nothing
+			// to do. The live listener logged a warning here; during
+			// rebuild the ordering is stable so this is a benign
+			// no-op.
+			return nil
+		}
+		return nil
+	}
+	return nil
 }

--- a/internal/projectors/security_alert_listener.go
+++ b/internal/projectors/security_alert_listener.go
@@ -3,6 +3,7 @@ package projectors
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
@@ -89,9 +90,12 @@ func ApplySecurityAlert(ctx context.Context, q *store.Queries, e store.Persisted
 			}
 			// Malformed alert_id — the deleted PL/pgSQL projector
 			// raised an EXCEPTION here; the live listener logged and
-			// skipped. Keep that non-fatal behaviour during rebuild:
-			// a historical malformed event must not abort the rebuild.
-			return nil
+			// skipped. Report it as skippable: the live listener
+			// logs-and-swallows (restoring the lost log line), and
+			// RebuildAll skips-and-continues instead of aborting on one
+			// bad historical row.
+			return fmt.Errorf("security_alert projector: malformed SecurityAlertAcknowledged %s: %w: %w",
+				e.ID, err, store.ErrSkipEvent)
 		}
 		rows, err := q.AcknowledgeSecurityAlertProjection(ctx, params)
 		if err != nil {

--- a/internal/projectors/server_settings.go
+++ b/internal/projectors/server_settings.go
@@ -3,6 +3,7 @@ package projectors
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -65,5 +66,38 @@ func ApplyServerSettingsUpdate(ctx context.Context, st *store.Store, u ServerSet
 		SshAccessForAll:         u.SshAccessForAll,
 		UpdatedAt:               u.OccurredAt,
 		ProjectionVersion:       u.ProjectionVersion,
+	})
+}
+
+// ApplyServerSettingsRebuild is the rebuild applier for the singleton
+// server_settings_projection (#497). A rebuild TRUNCATEs the table, dropping
+// the migration-seeded 'global' row; the projector's UPDATE ... WHERE id =
+// 'global' would then match nothing and the current settings would be lost.
+//
+// Every replayed event first ensures the seed row exists (idempotent INSERT
+// at projection_version 0), then applies the COALESCE UPDATE. Seeding on
+// every event — rather than once — keeps the applier stateless and correct
+// whether it replays one event or a thousand; ON CONFLICT DO NOTHING makes
+// the repeat seeds free. Non-ServerSettingUpdated events on the stream
+// (there are none today) no-op via the decoder's ErrIgnoredEvent.
+func ApplyServerSettingsRebuild(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "server_settings" {
+		return nil
+	}
+	payload, err := ServerSettingsUpdatedFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	if err := q.SeedServerSettings(ctx); err != nil {
+		return err
+	}
+	return q.UpdateServerSettings(ctx, db.UpdateServerSettingsParams{
+		UserProvisioningEnabled: payload.UserProvisioningEnabled,
+		SshAccessForAll:         payload.SshAccessForAll,
+		UpdatedAt:               e.OccurredAt,
+		ProjectionVersion:       e.SequenceNum,
 	})
 }

--- a/internal/projectors/totp_listener.go
+++ b/internal/projectors/totp_listener.go
@@ -37,108 +37,98 @@ func TotpListener(st *store.Store, logger *slog.Logger) store.EventListener {
 		return func(context.Context, store.PersistedEvent) {}
 	}
 	return func(ctx context.Context, e store.PersistedEvent) {
-		if e.StreamType != "totp" {
-			return
-		}
-
-		payload, err := decodeTotpPayload(e)
-		if err != nil {
-			if errors.Is(err, ErrIgnoredEvent) {
-				return
-			}
-			logger.Warn("totp projector: invalid event payload",
+		if err := ApplyTotp(ctx, st.Queries(), e); err != nil {
+			logger.Warn("totp projector: failed to apply event",
 				"event_id", e.ID, "event_type", e.EventType, "error", err)
-			return
-		}
-
-		q := st.Queries()
-		updatedAt := e.OccurredAt
-		userID := e.StreamID
-
-		switch e.EventType {
-		case string(eventtypes.TOTPSetupInitiated):
-			if err := q.UpsertTotpProjection(ctx, db.UpsertTotpProjectionParams{
-				UserID:            userID,
-				SecretEncrypted:   payload.SecretEncrypted,
-				BackupCodesHash:   payload.BackupCodesHash,
-				CreatedAt:         updatedAt,
-				ProjectionVersion: e.SequenceNum,
-			}); err != nil {
-				logger.Warn("totp projector: failed to upsert TOTPSetupInitiated",
-					"event_id", e.ID, "user_id", userID, "error", err)
-			}
-
-		case string(eventtypes.TOTPVerified):
-			if err := q.VerifyTotpProjection(ctx, db.VerifyTotpProjectionParams{
-				UserID:            userID,
-				UpdatedAt:         updatedAt,
-				ProjectionVersion: e.SequenceNum,
-			}); err != nil {
-				logger.Warn("totp projector: failed to flip totp_projection to verified",
-					"event_id", e.ID, "user_id", userID, "error", err)
-			}
-			if err := q.SetUserTotpEnabled(ctx, db.SetUserTotpEnabledParams{
-				ID:                userID,
-				TotpEnabled:       true,
-				UpdatedAt:         &updatedAt,
-				ProjectionVersion: e.SequenceNum,
-			}); err != nil {
-				logger.Warn("totp projector: failed to flip users_projection.totp_enabled=TRUE",
-					"event_id", e.ID, "user_id", userID, "error", err)
-			}
-			if err := enqueueDynamicUserGroupsForUser(ctx, q, userID); err != nil {
-				logger.Warn("totp projector: failed to enqueue dynamic user groups",
-					"event_id", e.ID, "user_id", userID, "error", err)
-			}
-
-		case string(eventtypes.TOTPDisabled):
-			if err := q.DeleteTotpProjection(ctx, userID); err != nil {
-				logger.Warn("totp projector: failed to delete totp_projection row",
-					"event_id", e.ID, "user_id", userID, "error", err)
-			}
-			if err := q.SetUserTotpEnabled(ctx, db.SetUserTotpEnabledParams{
-				ID:                userID,
-				TotpEnabled:       false,
-				UpdatedAt:         &updatedAt,
-				ProjectionVersion: e.SequenceNum,
-			}); err != nil {
-				logger.Warn("totp projector: failed to flip users_projection.totp_enabled=FALSE",
-					"event_id", e.ID, "user_id", userID, "error", err)
-			}
-			if err := enqueueDynamicUserGroupsForUser(ctx, q, userID); err != nil {
-				logger.Warn("totp projector: failed to enqueue dynamic user groups",
-					"event_id", e.ID, "user_id", userID, "error", err)
-			}
-
-		case string(eventtypes.TOTPBackupCodeUsed):
-			if payload.Index == nil {
-				logger.Warn("totp projector: TOTPBackupCodeUsed missing index field",
-					"event_id", e.ID, "user_id", userID)
-				return
-			}
-			// PL/pgSQL projector: backup_codes_used[(idx)::int + 1]
-			// — convert 0-based event index to the 1-based Postgres
-			// array index here so the SQL stays clean.
-			if err := q.MarkTotpBackupCodeUsed(ctx, db.MarkTotpBackupCodeUsedParams{
-				UserID:            userID,
-				Column2:           int32(*payload.Index + 1),
-				UpdatedAt:         updatedAt,
-				ProjectionVersion: e.SequenceNum,
-			}); err != nil {
-				logger.Warn("totp projector: failed to mark backup code used",
-					"event_id", e.ID, "user_id", userID, "index", *payload.Index, "error", err)
-			}
-
-		case string(eventtypes.TOTPBackupCodesRegenerated):
-			if err := q.RegenerateTotpBackupCodes(ctx, db.RegenerateTotpBackupCodesParams{
-				UserID:            userID,
-				BackupCodesHash:   payload.BackupCodesHash,
-				UpdatedAt:         updatedAt,
-				ProjectionVersion: e.SequenceNum,
-			}); err != nil {
-				logger.Warn("totp projector: failed to regenerate backup codes",
-					"event_id", e.ID, "user_id", userID, "error", err)
-			}
 		}
 	}
+}
+
+// ApplyTotp is the transactional core of the TOTP projector: writes through
+// the supplied Queries and returns errors. Live dispatch wraps it
+// (log-and-swallow); the rebuild path (#497) registers it via
+// RegisterRebuildApply so a users rebuild — which CASCADE-wipes the
+// FK-child totp_projection — is followed by a totp target that replays the
+// enrollments. The cross-stream users_projection.totp_enabled write is safe
+// during rebuild because the totp target runs AFTER users.
+func ApplyTotp(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "totp" {
+		return nil
+	}
+	payload, err := decodeTotpPayload(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+
+	updatedAt := e.OccurredAt
+	userID := e.StreamID
+
+	switch e.EventType {
+	case string(eventtypes.TOTPSetupInitiated):
+		return q.UpsertTotpProjection(ctx, db.UpsertTotpProjectionParams{
+			UserID:            userID,
+			SecretEncrypted:   payload.SecretEncrypted,
+			BackupCodesHash:   payload.BackupCodesHash,
+			CreatedAt:         updatedAt,
+			ProjectionVersion: e.SequenceNum,
+		})
+
+	case string(eventtypes.TOTPVerified):
+		if err := q.VerifyTotpProjection(ctx, db.VerifyTotpProjectionParams{
+			UserID:            userID,
+			UpdatedAt:         updatedAt,
+			ProjectionVersion: e.SequenceNum,
+		}); err != nil {
+			return err
+		}
+		if err := q.SetUserTotpEnabled(ctx, db.SetUserTotpEnabledParams{
+			ID:                userID,
+			TotpEnabled:       true,
+			UpdatedAt:         &updatedAt,
+			ProjectionVersion: e.SequenceNum,
+		}); err != nil {
+			return err
+		}
+		return enqueueDynamicUserGroupsForUser(ctx, q, userID)
+
+	case string(eventtypes.TOTPDisabled):
+		if err := q.DeleteTotpProjection(ctx, userID); err != nil {
+			return err
+		}
+		if err := q.SetUserTotpEnabled(ctx, db.SetUserTotpEnabledParams{
+			ID:                userID,
+			TotpEnabled:       false,
+			UpdatedAt:         &updatedAt,
+			ProjectionVersion: e.SequenceNum,
+		}); err != nil {
+			return err
+		}
+		return enqueueDynamicUserGroupsForUser(ctx, q, userID)
+
+	case string(eventtypes.TOTPBackupCodeUsed):
+		if payload.Index == nil {
+			// A malformed event that the live projector logged-and-skipped;
+			// keep the same non-fatal behaviour during rebuild.
+			return nil
+		}
+		// Convert 0-based event index to the 1-based Postgres array index.
+		return q.MarkTotpBackupCodeUsed(ctx, db.MarkTotpBackupCodeUsedParams{
+			UserID:            userID,
+			Column2:           int32(*payload.Index + 1),
+			UpdatedAt:         updatedAt,
+			ProjectionVersion: e.SequenceNum,
+		})
+
+	case string(eventtypes.TOTPBackupCodesRegenerated):
+		return q.RegenerateTotpBackupCodes(ctx, db.RegenerateTotpBackupCodesParams{
+			UserID:            userID,
+			BackupCodesHash:   payload.BackupCodesHash,
+			UpdatedAt:         updatedAt,
+			ProjectionVersion: e.SequenceNum,
+		})
+	}
+	return nil
 }

--- a/internal/projectors/user_role_listener.go
+++ b/internal/projectors/user_role_listener.go
@@ -18,72 +18,66 @@ import (
 //   - UserRoleAssigned: INSERT … ON CONFLICT DO NOTHING (replay-safe)
 //   - UserRoleRevoked:  DELETE WHERE (user_id, role_id)
 //
-// Wired in projectors.WireAll. Refs #102, tracker #107.
+// Live dispatch wraps ApplyUserRole and logs-and-swallows; the rebuild path
+// (#497) registers ApplyUserRole via RegisterRebuildApply so RebuildAll
+// re-derives every post-creation grant from the event store. Before #497 the
+// user_role stream was replayed by NO target — a full rebuild silently lost
+// every grant made after account creation.
+//
+// Wired in projectors.WireAll. Refs #102, tracker #107, #497.
 func UserRoleListener(st *store.Store, logger *slog.Logger) store.EventListener {
 	if st == nil {
 		return func(context.Context, store.PersistedEvent) {}
 	}
 	return func(ctx context.Context, e store.PersistedEvent) {
-		if e.StreamType != "user_role" {
-			return
-		}
-		switch e.EventType {
-		case string(eventtypes.UserRoleAssigned):
-			applyUserRoleAssigned(ctx, st, logger, e)
-		case string(eventtypes.UserRoleRevoked):
-			applyUserRoleRevoked(ctx, st, logger, e)
+		if err := ApplyUserRole(ctx, st.Queries(), e); err != nil {
+			logger.Warn("user_role projector: failed to apply event",
+				"event_id", e.ID, "event_type", e.EventType, "error", err)
 		}
 	}
 }
 
-func applyUserRoleAssigned(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
-	payload, err := UserRoleAssignedFromEvent(e)
-	if err != nil {
-		if errors.Is(err, ErrIgnoredEvent) {
-			return
+// ApplyUserRole is the transactional core of the user_role projector: it
+// writes through the supplied Queries (the rebuild tx or the live autocommit
+// handle) and RETURNS errors instead of logging-and-swallowing, so a rebuild
+// fails loudly rather than producing a partial RBAC projection.
+func ApplyUserRole(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	if e.StreamType != "user_role" {
+		return nil
+	}
+	switch e.EventType {
+	case string(eventtypes.UserRoleAssigned):
+		payload, err := UserRoleAssignedFromEvent(e)
+		if err != nil {
+			if errors.Is(err, ErrIgnoredEvent) {
+				return nil
+			}
+			return err
 		}
-		logger.Warn("user_role projector: invalid UserRoleAssigned payload",
-			"event_id", e.ID, "error", err)
-		return
-	}
-	if err := st.Queries().InsertUserRoleProjection(ctx, db.InsertUserRoleProjectionParams{
-		UserID:            payload.UserID,
-		RoleID:            payload.RoleID,
-		ScopeKind:         payload.ScopeKind,
-		ScopeID:           payload.ScopeID,
-		AssignedAt:        e.OccurredAt,
-		AssignedBy:        payload.AssignedBy,
-		ProjectionVersion: e.SequenceNum,
-	}); err != nil {
-		logger.Warn("user_role projector: failed to insert UserRoleAssigned",
-			"event_id", e.ID,
-			"user_id", payload.UserID,
-			"role_id", payload.RoleID,
-			"error", err)
-	}
-}
-
-func applyUserRoleRevoked(ctx context.Context, st *store.Store, logger *slog.Logger, e store.PersistedEvent) {
-	payload, err := UserRoleRevokedFromEvent(e)
-	if err != nil {
-		if errors.Is(err, ErrIgnoredEvent) {
-			return
+		return q.InsertUserRoleProjection(ctx, db.InsertUserRoleProjectionParams{
+			UserID:            payload.UserID,
+			RoleID:            payload.RoleID,
+			ScopeKind:         payload.ScopeKind,
+			ScopeID:           payload.ScopeID,
+			AssignedAt:        e.OccurredAt,
+			AssignedBy:        payload.AssignedBy,
+			ProjectionVersion: e.SequenceNum,
+		})
+	case string(eventtypes.UserRoleRevoked):
+		payload, err := UserRoleRevokedFromEvent(e)
+		if err != nil {
+			if errors.Is(err, ErrIgnoredEvent) {
+				return nil
+			}
+			return err
 		}
-		logger.Warn("user_role projector: invalid UserRoleRevoked payload",
-			"event_id", e.ID, "error", err)
-		return
+		return q.DeleteUserRoleProjection(ctx, db.DeleteUserRoleProjectionParams{
+			UserID:            payload.UserID,
+			RoleID:            payload.RoleID,
+			ScopeKind:         payload.ScopeKind,
+			ScopeID:           payload.ScopeID,
+			ProjectionVersion: e.SequenceNum,
+		})
 	}
-	if err := st.Queries().DeleteUserRoleProjection(ctx, db.DeleteUserRoleProjectionParams{
-		UserID:            payload.UserID,
-		RoleID:            payload.RoleID,
-		ScopeKind:         payload.ScopeKind,
-		ScopeID:           payload.ScopeID,
-		ProjectionVersion: e.SequenceNum,
-	}); err != nil {
-		logger.Warn("user_role projector: failed to delete user_roles_projection row",
-			"event_id", e.ID,
-			"user_id", payload.UserID,
-			"role_id", payload.RoleID,
-			"error", err)
-	}
+	return nil
 }

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -163,6 +163,20 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 	// lps_keypair (#495): the singleton sealing-keypair row is a projection
 	// of the lps_keypair/global stream; replay reproduces it 1:1.
 	st.RegisterRebuildApply("lps_keypair", ApplyLpsKeypair)
+	// #497: close the replay gaps — every projection stream now has a
+	// rebuild target so a full replay reproduces RBAC grants, 2FA, SSO
+	// links/providers, security alerts, compliance, and the encrypted
+	// secret history. FK-ordered in AllRebuildTargets (children after
+	// parents); each Apply* returns errors so a rebuild fails loudly.
+	st.RegisterRebuildApply("user_roles", ApplyUserRole)
+	st.RegisterRebuildApply("totp", ApplyTotp)
+	st.RegisterRebuildApply("identity_providers", ApplyIdentityProvider)
+	st.RegisterRebuildApply("security_alerts", ApplySecurityAlert)
+	st.RegisterRebuildApply("lps_passwords", ApplyLpsPassword)
+	st.RegisterRebuildApply("luks_keys", ApplyLuksKey)
+	st.RegisterRebuildApply("server_settings", ApplyServerSettingsRebuild)
+	st.RegisterRebuildApply("compliance_policies", ApplyCompliancePolicy)
+	st.RegisterRebuildApply("compliance_results", ApplyCompliance)
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -40,6 +40,10 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 		st,
 		loggerFor(logger, "lps_password_projector"),
 	))
+	st.RegisterEventListener(LpsKeypairListener(
+		st,
+		loggerFor(logger, "lps_keypair_projector"),
+	))
 	st.RegisterEventListener(LuksKeyListener(
 		st,
 		loggerFor(logger, "luks_key_projector"),
@@ -156,6 +160,9 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 	st.RegisterRebuildApply("executions", ApplyExecution)
 	st.RegisterRebuildApply("devices", ApplyDevice)
 	st.RegisterRebuildApply("users", ApplyUser)
+	// lps_keypair (#495): the singleton sealing-keypair row is a projection
+	// of the lps_keypair/global stream; replay reproduces it 1:1.
+	st.RegisterRebuildApply("lps_keypair", ApplyLpsKeypair)
 }
 
 // loggerFor returns a sub-logger tagged with the projector

--- a/internal/store/generated/lps_keypair.sql.go
+++ b/internal/store/generated/lps_keypair.sql.go
@@ -30,25 +30,28 @@ func (q *Queries) GetLpsKeypair(ctx context.Context) (GetLpsKeypairRow, error) {
 	return i, err
 }
 
-const insertLpsKeypair = `-- name: InsertLpsKeypair :execrows
-INSERT INTO lps_keypair (id, public_key, private_key_enc)
-VALUES ('global', $1, $2)
-ON CONFLICT (id) DO NOTHING
+const upsertLpsKeypair = `-- name: UpsertLpsKeypair :exec
+INSERT INTO lps_keypair (id, public_key, private_key_enc, created_at)
+VALUES ('global', $1, $2, $3)
+ON CONFLICT (id) DO UPDATE
+SET public_key      = EXCLUDED.public_key,
+    private_key_enc = EXCLUDED.private_key_enc,
+    created_at      = EXCLUDED.created_at
 `
 
-type InsertLpsKeypairParams struct {
-	PublicKey     []byte `json:"public_key"`
-	PrivateKeyEnc string `json:"private_key_enc"`
+type UpsertLpsKeypairParams struct {
+	PublicKey     []byte             `json:"public_key"`
+	PrivateKeyEnc string             `json:"private_key_enc"`
+	CreatedAt     pgtype.Timestamptz `json:"created_at"`
 }
 
-// First-writer-wins under the EnsureLpsKeypair advisory lock. ON CONFLICT
-// DO NOTHING makes a lost race (another replica inserted between our read
-// and write) harmless: :execrows returns 0 and the caller re-reads the
-// winning row rather than clobbering it.
-func (q *Queries) InsertLpsKeypair(ctx context.Context, arg InsertLpsKeypairParams) (int64, error) {
-	result, err := q.db.Exec(ctx, insertLpsKeypair, arg.PublicKey, arg.PrivateKeyEnc)
-	if err != nil {
-		return 0, err
-	}
-	return result.RowsAffected(), nil
+// Projector write for LpsKeypairGenerated (#495): the lps_keypair table is a
+// projection of the singleton lps_keypair/global stream. Idempotent overwrite
+// so a rebuild replay and a live listener re-delivery both converge on the
+// event's values. First-writer-wins now lives at the EVENT layer — the
+// UNIQUE(stream_type, stream_id, stream_version) constraint rejects the
+// losing replica's version-1 append (see api.EnsureLpsKeypair).
+func (q *Queries) UpsertLpsKeypair(ctx context.Context, arg UpsertLpsKeypairParams) error {
+	_, err := q.db.Exec(ctx, upsertLpsKeypair, arg.PublicKey, arg.PrivateKeyEnc, arg.CreatedAt)
+	return err
 }

--- a/internal/store/generated/settings.sql.go
+++ b/internal/store/generated/settings.sql.go
@@ -27,6 +27,24 @@ func (q *Queries) GetServerSettings(ctx context.Context) (ServerSettingsProjecti
 	return i, err
 }
 
+const seedServerSettings = `-- name: SeedServerSettings :exec
+INSERT INTO server_settings_projection (id, projection_version)
+VALUES ('global', 0)
+ON CONFLICT (id) DO NOTHING
+`
+
+// Re-seeds the singleton 'global' row at projection_version 0 (#497). A
+// rebuild TRUNCATEs the table, dropping the migration-seeded row; the
+// UPDATE-only projector would then no-op forever. The rebuild applier calls
+// this first so the subsequent ServerSettingUpdated replays (all at
+// projection_version > 0) land on a present row. Idempotent: ON CONFLICT DO
+// NOTHING means a live-path call (row already present) is a no-op, and it
+// never clobbers a rebuilt row's settings.
+func (q *Queries) SeedServerSettings(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, seedServerSettings)
+	return err
+}
+
 const updateServerSettings = `-- name: UpdateServerSettings :exec
 UPDATE server_settings_projection
 SET user_provisioning_enabled = COALESCE($1::BOOLEAN, user_provisioning_enabled),

--- a/internal/store/queries/lps_keypair.sql
+++ b/internal/store/queries/lps_keypair.sql
@@ -3,11 +3,16 @@ SELECT public_key, private_key_enc, created_at
 FROM lps_keypair
 WHERE id = 'global';
 
--- name: InsertLpsKeypair :execrows
--- First-writer-wins under the EnsureLpsKeypair advisory lock. ON CONFLICT
--- DO NOTHING makes a lost race (another replica inserted between our read
--- and write) harmless: :execrows returns 0 and the caller re-reads the
--- winning row rather than clobbering it.
-INSERT INTO lps_keypair (id, public_key, private_key_enc)
-VALUES ('global', sqlc.arg('public_key'), sqlc.arg('private_key_enc'))
-ON CONFLICT (id) DO NOTHING;
+-- name: UpsertLpsKeypair :exec
+-- Projector write for LpsKeypairGenerated (#495): the lps_keypair table is a
+-- projection of the singleton lps_keypair/global stream. Idempotent overwrite
+-- so a rebuild replay and a live listener re-delivery both converge on the
+-- event's values. First-writer-wins now lives at the EVENT layer — the
+-- UNIQUE(stream_type, stream_id, stream_version) constraint rejects the
+-- losing replica's version-1 append (see api.EnsureLpsKeypair).
+INSERT INTO lps_keypair (id, public_key, private_key_enc, created_at)
+VALUES ('global', sqlc.arg('public_key'), sqlc.arg('private_key_enc'), sqlc.arg('created_at'))
+ON CONFLICT (id) DO UPDATE
+SET public_key      = EXCLUDED.public_key,
+    private_key_enc = EXCLUDED.private_key_enc,
+    created_at      = EXCLUDED.created_at;

--- a/internal/store/queries/settings.sql
+++ b/internal/store/queries/settings.sql
@@ -1,6 +1,18 @@
 -- name: GetServerSettings :one
 SELECT * FROM server_settings_projection WHERE id = 'global';
 
+-- name: SeedServerSettings :exec
+-- Re-seeds the singleton 'global' row at projection_version 0 (#497). A
+-- rebuild TRUNCATEs the table, dropping the migration-seeded row; the
+-- UPDATE-only projector would then no-op forever. The rebuild applier calls
+-- this first so the subsequent ServerSettingUpdated replays (all at
+-- projection_version > 0) land on a present row. Idempotent: ON CONFLICT DO
+-- NOTHING means a live-path call (row already present) is a no-op, and it
+-- never clobbers a rebuilt row's settings.
+INSERT INTO server_settings_projection (id, projection_version)
+VALUES ('global', 0)
+ON CONFLICT (id) DO NOTHING;
+
 -- name: UpdateServerSettings :exec
 -- Replaces the deleted PL/pgSQL project_server_settings_event
 -- function. COALESCE preserves existing column values when the

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -378,6 +378,14 @@ var AllRebuildTargets = []rebuildTarget{
 // target name that does not exist in AllRebuildTargets.
 var ErrUnknownTarget = errors.New("unknown rebuild target")
 
+// ErrSkipEvent lets a projector's apply function report an event it
+// cannot project (e.g. a malformed historical payload) as skippable
+// rather than fatal: the live listener logs-and-swallows it like any
+// error, and RebuildAll skips it and continues instead of aborting the
+// whole rebuild on one bad historical row. Return it wrapped for
+// context; the rebuild dispatcher matches it with errors.Is.
+var ErrSkipEvent = errors.New("projector: event skipped (unprojectable)")
+
 // RebuildAll truncates and re-applies the named projection targets
 // from the event store. An empty targets slice rebuilds every
 // registered target in dependency order.
@@ -510,6 +518,18 @@ func (s *Store) dispatchViaGoApplier(ctx context.Context, tx pgx.Tx, t rebuildTa
 		}
 		for _, ev := range batch {
 			if err := apply(ctx, q, ev); err != nil {
+				if errors.Is(err, ErrSkipEvent) {
+					// A malformed historical event must not abort the
+					// rebuild; log it and move on (unlike the fatal path,
+					// which rolls back the whole target).
+					if s.logger != nil {
+						s.logger.Warn("rebuild: skipping unprojectable event",
+							"target", t.Name, "event_id", ev.ID, "event_type", ev.EventType, "error", err)
+					}
+					lastSeq = ev.SequenceNum
+					total++
+					continue
+				}
 				return 0, fmt.Errorf("apply event %s for %s: %w", ev.ID, t.Name, err)
 			}
 			lastSeq = ev.SequenceNum

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -126,8 +126,15 @@ var AllRebuildTargets = []rebuildTarget{
 	},
 	{
 		// Applied by projectors.ApplyDevice via projectors.WireAll.
+		// device_assigned_users_projection / device_assigned_groups_
+		// projection are listed EXPLICITLY (#495): they carry no FK to
+		// devices_projection, so the CASCADE never reaches them — the
+		// applier re-derives both from DeviceAssigned/Unassigned and
+		// DeviceGroupAssigned/Unassigned replay, and without the
+		// TRUNCATE pre-rebuild rows would leak through its upserts
+		// (same clean-slate rationale as action_set_members_projection).
 		Name:        "devices",
-		Tables:      []string{"devices_projection"},
+		Tables:      []string{"devices_projection", "device_assigned_users_projection", "device_assigned_groups_projection"},
 		Cascade:     true,
 		StreamTypes: []string{"device"},
 	},
@@ -167,12 +174,16 @@ var AllRebuildTargets = []rebuildTarget{
 	},
 	{
 		// Applied by projectors.ApplyDefinition (a thin alias to
-		// ApplyAction) via projectors.WireAll. `TRUNCATE
-		// definitions_projection CASCADE` wipes
-		// definition_members_projection (FK reference), which the
-		// applier then re-derives from DefinitionMember* events.
+		// ApplyAction) via projectors.WireAll.
+		// definition_members_projection is listed EXPLICITLY (#495): it
+		// carries no FK to definitions_projection (composite PK only),
+		// so the CASCADE never reached it — the previous comment
+		// claiming it did was wrong against the live schema. Same
+		// clean-slate rationale as action_set_members_projection above:
+		// without the TRUNCATE, pre-rebuild member rows would leak
+		// through the applier's upserts.
 		Name:        "definitions",
-		Tables:      []string{"definitions_projection"},
+		Tables:      []string{"definitions_projection", "definition_members_projection"},
 		Cascade:     true,
 		StreamTypes: []string{"definition"},
 	},

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -247,6 +247,15 @@ var AllRebuildTargets = []rebuildTarget{
 		Tables:      []string{"scim_group_mapping_projection"},
 		StreamTypes: []string{"scim_group_mapping"},
 	},
+	{
+		// Applied by projectors.ApplyLpsKeypair via projectors.WireAll.
+		// Singleton projection of the control server's LPS sealing
+		// keypair (#495) — one LpsKeypairGenerated event, one row.
+		// No FK dependencies; order-independent.
+		Name:        "lps_keypair",
+		Tables:      []string{"lps_keypair"},
+		StreamTypes: []string{"lps_keypair"},
+	},
 }
 
 // ErrUnknownTarget is returned when RebuildAll is called with a

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -113,10 +113,33 @@ type rebuildTarget struct {
 var AllRebuildTargets = []rebuildTarget{
 	{
 		// Applied by projectors.ApplyUser via projectors.WireAll.
+		// NOTE (#497): TRUNCATE users_projection CASCADE wipes its FK
+		// children totp_projection and identity_links_projection. Their
+		// own targets below (declared AFTER users) re-derive them from the
+		// totp / identity_provider streams — order is load-bearing.
 		Name:        "users",
 		Tables:      []string{"users_projection"},
 		Cascade:     true,
 		StreamTypes: []string{"user"},
+	},
+	{
+		// Applied by projectors.ApplyUserRole via projectors.WireAll (#497).
+		// user_roles_projection carries NO FK to users_projection, so the
+		// users CASCADE never wiped it and NO target replayed the user_role
+		// stream — a full rebuild silently dropped every post-creation
+		// grant (RBAC data loss). Explicit TRUNCATE + replay fixes it.
+		Name:        "user_roles",
+		Tables:      []string{"user_roles_projection"},
+		StreamTypes: []string{"user_role"},
+	},
+	{
+		// Applied by projectors.ApplyTotp via projectors.WireAll (#497).
+		// totp_projection is an FK child of users_projection, so the users
+		// CASCADE above wiped it; this target (running AFTER users) replays
+		// the totp stream so 2FA enrollments survive a full rebuild.
+		Name:        "totp",
+		Tables:      []string{"totp_projection"},
+		StreamTypes: []string{"totp"},
 	},
 	{
 		// Applied by projectors.ApplyToken via projectors.WireAll.
@@ -219,6 +242,27 @@ var AllRebuildTargets = []rebuildTarget{
 		StreamTypes: []string{"role"},
 	},
 	{
+		// Applied by projectors.ApplyIdentityProvider via projectors.WireAll
+		// (#497). The identity_provider stream drives BOTH
+		// identity_providers_projection and its FK child
+		// identity_links_projection (links reference provider_id AND
+		// user_id). One target, both tables: replaying in sequence order
+		// writes providers before the links that reference them.
+		//
+		// Ordering is load-bearing: TRUNCATE identity_providers_projection
+		// CASCADE also wipes scim_group_mapping_projection and auth_states
+		// (both FK-reference the provider). So this target MUST run BEFORE
+		// scim_group_mappings (declared below) — otherwise it would wipe
+		// the freshly-rebuilt SCIM mappings. auth_states is transient OIDC
+		// flow state (operational); losing it in a rebuild is expected.
+		// identity_links also FK-references users_projection, replayed
+		// above — so those references resolve too.
+		Name:        "identity_providers",
+		Tables:      []string{"identity_providers_projection", "identity_links_projection"},
+		Cascade:     true,
+		StreamTypes: []string{"identity_provider"},
+	},
+	{
 		// Applied by projectors.ApplyUserGroup via projectors.WireAll.
 		// `TRUNCATE user_groups_projection CASCADE` walks the FK graph
 		// and truncates every table that references
@@ -266,6 +310,67 @@ var AllRebuildTargets = []rebuildTarget{
 		Name:        "lps_keypair",
 		Tables:      []string{"lps_keypair"},
 		StreamTypes: []string{"lps_keypair"},
+	},
+	// ---- #497 replay-gap closures ----
+	{
+		// Applied by projectors.ApplySecurityAlert via projectors.WireAll.
+		// Security alerts ride the DEVICE stream (SecurityAlert /
+		// SecurityAlertAcknowledged). No FK to devices_projection, so the
+		// devices CASCADE never wiped it and no target replayed it — this
+		// target TRUNCATEs + replays. event_id FK-references events, which
+		// always exist. Runs after devices for locality; order-independent
+		// (no projection FK).
+		Name:        "security_alerts",
+		Tables:      []string{"security_alerts_projection"},
+		StreamTypes: []string{"device"},
+	},
+	{
+		// Applied by projectors.ApplyLpsPassword via projectors.WireAll.
+		// Replays the lps_password stream so the encrypted rotated-password
+		// HISTORY survives a full rebuild (the payload ciphertexts carry
+		// it). No projection FK; order-independent.
+		Name:        "lps_passwords",
+		Tables:      []string{"lps_passwords_projection"},
+		StreamTypes: []string{"lps_password"},
+	},
+	{
+		// Applied by projectors.ApplyLuksKey via projectors.WireAll.
+		// Replays the luks_key stream — encrypted LUKS key history +
+		// revocation lifecycle. No projection FK; order-independent.
+		Name:        "luks_keys",
+		Tables:      []string{"luks_keys_projection"},
+		StreamTypes: []string{"luks_key"},
+	},
+	{
+		// Applied by projectors.ApplyServerSettingsRebuild via
+		// projectors.WireAll. server_settings_projection is a SINGLETON
+		// seeded by migration 008; a plain TRUNCATE would drop the row and
+		// the UPDATE-only projector would then no-op. The rebuild applier
+		// re-seeds the 'global' row before applying, then replays
+		// ServerSettingUpdated events so current settings are reproduced.
+		Name:        "server_settings",
+		Tables:      []string{"server_settings_projection"},
+		StreamTypes: []string{"server_settings"},
+	},
+	{
+		// Applied by projectors.ApplyCompliancePolicy via projectors.WireAll.
+		// Replays the compliance_policy stream into the policy + rules
+		// projections (the applier's per-event branch writes both, and
+		// re-derives compliance_policy_evaluation_projection via the
+		// in-tx reevaluator). CASCADE so the rules/eval children start
+		// clean; policy row is written before the rules that reference it.
+		Name:        "compliance_policies",
+		Tables:      []string{"compliance_policies_projection", "compliance_policy_rules_projection", "compliance_policy_evaluation_projection"},
+		Cascade:     true,
+		StreamTypes: []string{"compliance_policy"},
+	},
+	{
+		// Applied by projectors.ApplyCompliance via projectors.WireAll.
+		// Replays the compliance stream (device-reported results). No
+		// projection FK; order-independent.
+		Name:        "compliance_results",
+		Tables:      []string{"compliance_results_projection"},
+		StreamTypes: []string{"compliance"},
 	},
 }
 

--- a/internal/store/rebuild_497_test.go
+++ b/internal/store/rebuild_497_test.go
@@ -1,0 +1,156 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestRebuildAll_497_ReplaysEveryProjection is the #497 acceptance test: a
+// FULL RebuildAll() (every target, FK-ordered) run against a fully-seeded
+// schema must reproduce the previously-unreplayable projections 1:1 — most
+// critically the three data-loss cases a users rebuild used to destroy:
+// RBAC grants (user_roles), 2FA enrollments (totp), and SSO identity links.
+//
+// It seeds one of each, snapshots the live-projected state, runs the whole
+// rebuild (which TRUNCATEs every projection and replays from the event
+// store), and asserts each row returns identical.
+func TestRebuildAll_497_ReplaysEveryProjection(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	ctx := context.Background()
+
+	// --- seed a graph that touches every #497 projection ---
+	adminEmail := testutil.NewID() + "@admin.com"
+	adminID := testutil.CreateTestUser(t, st, adminEmail, "pass", "admin")
+
+	userEmail := testutil.NewID() + "@user.com"
+	userID := testutil.CreateTestUser(t, st, userEmail, "pass", "user")
+
+	// RBAC grant on the user_role stream (the grant a users rebuild lost).
+	roleID := testutil.CreateTestRole(t, st, adminID, "auditor", []string{"user:read"})
+	testutil.AssignRoleToTestUser(t, st, adminID, userID, roleID)
+
+	// 2FA enrollment (FK child of users_projection).
+	testutil.SetupTOTP(t, st, enc, userID, userEmail)
+
+	// SSO provider + identity link (FK children of providers/users).
+	providerID := testutil.CreateTestIdentityProvider(t, st, enc, adminID, "Okta", "okta")
+	linkID := testutil.CreateTestIdentityLink(t, st, userID, providerID, "ext-123", userEmail)
+
+	// Server settings: flip a value via an event so the singleton diverges
+	// from its migration-seeded default.
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "server_settings",
+		StreamID:   "global",
+		EventType:  "ServerSettingUpdated",
+		Data:       map[string]any{"ssh_access_for_all": true},
+		ActorType:  "user",
+		ActorID:    adminID,
+	}))
+
+	// --- snapshot the live-projected state ---
+	rolesBefore, err := st.Queries().GetUserRoles(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, rolesBefore, 1, "precondition: the grant projected")
+
+	totpBefore, err := st.Queries().GetTOTPByUserID(ctx, userID)
+	require.NoError(t, err)
+	require.NotEmpty(t, totpBefore.SecretEncrypted, "precondition: TOTP projected")
+
+	linkBefore, err := st.Queries().GetIdentityLinkByID(ctx, linkID)
+	require.NoError(t, err)
+
+	providerBefore, err := st.Queries().GetIdentityProviderByID(ctx, providerID)
+	require.NoError(t, err)
+
+	settingsBefore, err := st.Queries().GetServerSettings(ctx)
+	require.NoError(t, err)
+	require.True(t, settingsBefore.SshAccessForAll, "precondition: settings event projected")
+
+	// --- full rebuild: TRUNCATE every projection, replay from events ---
+	res, err := st.RebuildAll(ctx)
+	require.NoError(t, err, "a full rebuild must succeed for every target")
+	names := map[string]bool{}
+	for _, tr := range res.Targets {
+		names[tr.Name] = true
+	}
+	for _, required := range []string{
+		"user_roles", "totp", "identity_providers", "security_alerts",
+		"lps_passwords", "luks_keys", "server_settings",
+		"compliance_policies", "compliance_results",
+	} {
+		assert.Truef(t, names[required], "full rebuild must include the %q target", required)
+	}
+
+	// --- assert every projection returned 1:1 ---
+
+	// HIGH PRIORITY 1 — RBAC grant survived.
+	rolesAfter, err := st.Queries().GetUserRoles(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, rolesAfter, 1, "the post-creation role grant must survive a full rebuild (RBAC data-loss regression)")
+	assert.Equal(t, rolesBefore[0].ID, rolesAfter[0].ID)
+
+	// HIGH PRIORITY 2 — 2FA enrollment survived.
+	totpAfter, err := st.Queries().GetTOTPByUserID(ctx, userID)
+	require.NoError(t, err, "TOTP enrollment must survive a full rebuild (2FA data-loss regression)")
+	assert.Equal(t, totpBefore.SecretEncrypted, totpAfter.SecretEncrypted, "encrypted TOTP secret byte-identical")
+	assert.Equal(t, totpBefore.BackupCodesHash, totpAfter.BackupCodesHash)
+
+	// HIGH PRIORITY 3 — SSO identity link survived.
+	linkAfter, err := st.Queries().GetIdentityLinkByID(ctx, linkID)
+	require.NoError(t, err, "SSO identity link must survive a full rebuild (SSO data-loss regression)")
+	assert.Equal(t, linkBefore.ExternalID, linkAfter.ExternalID)
+	assert.Equal(t, linkBefore.UserID, linkAfter.UserID)
+	assert.Equal(t, linkBefore.ProviderID, linkAfter.ProviderID)
+
+	// Provider survived.
+	providerAfter, err := st.Queries().GetIdentityProviderByID(ctx, providerID)
+	require.NoError(t, err)
+	assert.Equal(t, providerBefore.Slug, providerAfter.Slug)
+	assert.Equal(t, providerBefore.ClientSecretEncrypted, providerAfter.ClientSecretEncrypted,
+		"encrypted IdP client secret byte-identical")
+
+	// Singleton server settings reproduced (re-seed + replay, not lost).
+	settingsAfter, err := st.Queries().GetServerSettings(ctx)
+	require.NoError(t, err, "the singleton server_settings row must be re-seeded and reproduced")
+	assert.True(t, settingsAfter.SshAccessForAll, "the ServerSettingUpdated value must survive the rebuild")
+}
+
+// TestRebuildAll_497_UserRolesTargetInIsolation pins the RBAC target on its
+// own: a targeted rebuild of user_roles reproduces the grant.
+func TestRebuildAll_497_UserRolesTargetInIsolation(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@u.com", "pass", "user")
+	roleID := testutil.CreateTestRole(t, st, adminID, "role1", []string{"user:read"})
+	testutil.AssignRoleToTestUser(t, st, adminID, userID, roleID)
+
+	before, err := st.Queries().GetUserRoles(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, before, 1)
+
+	// Wipe the projection out from under the pipeline, then rebuild only it.
+	_, err = st.TestingPool().Exec(ctx, "TRUNCATE user_roles_projection")
+	require.NoError(t, err)
+	gone, err := st.Queries().GetUserRoles(ctx, userID)
+	require.NoError(t, err)
+	require.Empty(t, gone, "precondition: the truncate took")
+
+	res, err := st.RebuildAll(ctx, "user_roles")
+	require.NoError(t, err)
+	require.Len(t, res.Targets, 1)
+	assert.Positive(t, res.Targets[0].EventsApplied, "the UserRoleAssigned event must replay")
+
+	after, err := st.Queries().GetUserRoles(ctx, userID)
+	require.NoError(t, err)
+	require.Len(t, after, 1, "the grant must be re-derived from the user_role stream")
+	assert.Equal(t, roleID, after[0].ID)
+}

--- a/internal/store/rebuild_test.go
+++ b/internal/store/rebuild_test.go
@@ -3,6 +3,7 @@ package store_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -359,6 +360,39 @@ func TestRebuildAll_GoApplierMissingFailsLoudly(t *testing.T) {
 	).Scan(&count))
 	assert.Equal(t, 1, count,
 		"projection must survive the failed rebuild; finding zero rows means either the guard ran too late or the outer transaction failed to roll back a destructive op")
+}
+
+// TestRebuildAll_SkipEventIsNonFatal pins the ErrSkipEvent contract: an
+// applier that reports an unprojectable historical event (e.g. a
+// malformed payload) via store.ErrSkipEvent must NOT abort the rebuild —
+// the event is skipped and the target completes, unlike a plain error
+// which rolls the whole target back (TestRebuildAll_TransactionalAtomicity).
+func TestRebuildAll_SkipEventIsNonFatal(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	roleID := testutil.CreateTestRole(t, st, actorID, "skip-role-"+testutil.NewID(), []string{"GetDevice"})
+
+	// Every replayed event reports itself as skippable. A fatal error
+	// here would roll back the target's TRUNCATE and RebuildAll would
+	// return an error; ErrSkipEvent must instead let it succeed.
+	st.RegisterRebuildApply("roles", func(context.Context, *store.Queries, store.PersistedEvent) error {
+		return fmt.Errorf("forced skip: %w", store.ErrSkipEvent)
+	})
+
+	res, err := st.RebuildAll(ctx, "roles")
+	require.NoError(t, err, "ErrSkipEvent must not abort the rebuild")
+	require.NotNil(t, res)
+
+	// The role's create event was skipped, so the truncated projection
+	// stays empty — proving the skip path ran (counted, not applied) and
+	// did not fatally roll back.
+	var after int
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		`SELECT COUNT(*) FROM roles_projection WHERE id = $1`, roleID,
+	).Scan(&after))
+	assert.Equal(t, 0, after, "skipped events must not be applied, but the rebuild must still complete")
 }
 
 // TestRebuildAll_TransactionalAtomicity forces the roles applier to

--- a/internal/store/schema_classification_test.go
+++ b/internal/store/schema_classification_test.go
@@ -141,9 +141,14 @@ func TestSchemaTotallyClassified(t *testing.T) {
 
 	// Red phase (AC4): an unclassified probe table MUST be flagged, or the
 	// discovery is broken and the real assertion below would pass vacuously.
+	// t.Cleanup guarantees the drop even if an assertion below FailNow()s,
+	// so a mid-test failure can't leave the probe polluting the template DB.
 	const probe = "zz_495_unclassified_probe"
 	_, err := st.TestingPool().Exec(ctx, "CREATE TABLE "+probe+" (id INT)")
 	require.NoError(t, err)
+	t.Cleanup(func() {
+		_, _ = st.TestingPool().Exec(context.Background(), "DROP TABLE IF EXISTS "+probe)
+	})
 	probeTables := listBaseTables(t, ctx, st)
 	require.Contains(t, probeTables, probe, "probe table must be discovered")
 	require.Empty(t, classify(probe), "probe table must be UNclassified — the guard would never fire")

--- a/internal/store/schema_classification_test.go
+++ b/internal/store/schema_classification_test.go
@@ -1,0 +1,220 @@
+package store_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// This file is part C of the #495 guard family: TOTAL classification of the
+// live Postgres schema. The contract (ADR 0028 amendment): all Postgres state
+// is event-sourced (a projection replay reproduces it) or explicitly
+// classified — operational-by-design or a tracked replay gap. A new table
+// that is none of these fails here, so divergence from the event-sourcing
+// contract is unmergeable rather than grep-dependent.
+//
+// Classification precedence (first match wins; registries below must not
+// shadow an earlier rule — the stale/overlap checks enforce it):
+//
+//  1. the event store itself + goose bookkeeping;
+//  2. explicit rebuild-target tables (store.AllRebuildTargets — replay
+//     reproduces them, proven by the rebuild round-trip tests);
+//  3. cascadeRederivedTables — wiped transitively by a CASCADE rebuild
+//     TRUNCATE (mechanically cross-checked against the live FK graph) and
+//     re-derived by the replayed streams / reconcilers named per entry;
+//  4. operationalTables — by-design non-event-sourced operational state,
+//     each entry carrying its why-it-lives-in-Postgres;
+//  5. knownUnreplayableTables — HONEST GAPS: projections of event streams
+//     that no rebuild target replays (tracked per entry; fixing one forces
+//     its removal here via the overlap check when a target is added).
+
+// operationalTables is registry 4: by-design non-event-sourced operational
+// state. Ephemeral or primary-operational; a replay neither wipes nor needs
+// to reproduce them (no rebuild target touches them).
+var operationalTables = map[string]string{
+	"auth_states":       "short-lived OIDC flow rows (state/nonce/PKCE), consumed on first read; in PG so ANY control replica can complete the callback (no sticky sessions); loss = user redoes login",
+	"revoked_tokens":    "JWT refresh-token denylist, TTL-bounded by token expiry; primary operational security state — becomes a projection once #496 adds logout/refresh events",
+	"luks_tokens":       "hashed one-time LUKS enrollment tokens (WS10); single-use by design, loss = operator re-issues; deliberately not replayable",
+	"osquery_results":   "transient result staging for DispatchOSQuery — agent reply fills, reads expire; loss = re-run the query",
+	"log_query_results": "transient result staging for QueryDeviceLogs — same lifecycle as osquery_results",
+	"terminal_sessions": "live-session inventory; the audit trail is the TerminalSession* events, the row is liveness state reconciled against the gateway",
+	"device_inventory":  "agent-reported osquery snapshot cache; the device is the source of truth, RefreshDeviceInventory re-populates",
+}
+
+// cascadeRederivedTables is registry 3. Every entry is mechanically verified
+// to sit in the FK closure of a Cascade rebuild target (so a rebuild DOES
+// wipe it); the value documents what re-derives its content afterwards.
+var cascadeRederivedTables = map[string]string{
+	"device_labels":                       "CASCADE child of devices_projection; re-derived by DeviceLabelSet/Removed/LabelsUpdated replay (ApplyDevice)",
+	"user_ssh_keys":                       "CASCADE child of users_projection; re-derived by UserSshKeyAdded/Removed replay (ApplyUser)",
+	"user_group_members_projection":       "CASCADE child of user_groups_projection; re-derived by UserGroupMemberAdded/Removed/MembersRebuilt replay (ApplyUserGroup)",
+	"user_group_roles_projection":         "CASCADE child of user_groups_projection; re-derived by UserGroupRoleAssigned/Revoked replay (ApplyUserGroup)",
+	"dynamic_user_group_evaluation_queue": "CASCADE child of user_groups_projection; transient work queue re-populated by UserGroupQueryUpdated replay and the periodic dynamic-group evaluator",
+}
+
+// knownUnreplayableTables is registry 5: tables whose content comes from the
+// event stream but which NO rebuild target replays — replay-coverage gaps,
+// not sanctioned designs (#497). Each fix (adding the rebuild target) makes
+// the overlap check above fail until the entry is removed.
+var knownUnreplayableTables = map[string]string{
+	"user_roles_projection":                   "#497 — grants ride the user_role stream, which no target replays; a replay into an empty schema loses every post-creation grant (no FK, so an in-place rebuild merely leaves the rows untouched)",
+	"server_settings_projection":              "#497 — ServerSettingUpdated has a listener but no rebuild target (singleton seeded by migration)",
+	"totp_projection":                         "#497 — FK child of users_projection: a users rebuild CASCADE-WIPES all TOTP enrollments and nothing replays the totp stream",
+	"security_alerts_projection":              "#497 — security_alert stream has a listener but no rebuild target",
+	"lps_passwords_projection":                "#497 — no target replays the lps_password stream; a replay into an empty schema loses the (encrypted) password history the events carry",
+	"luks_keys_projection":                    "#497 — same exposure as lps_passwords_projection for the luks_key stream",
+	"identity_providers_projection":           "#497 — identity_provider stream has a listener but no rebuild target",
+	"identity_links_projection":               "#497 — FK child of users_projection: a users rebuild CASCADE-WIPES all SSO identity links and nothing replays the identity_link stream",
+	"compliance_policies_projection":          "#497 — ApplyCompliancePolicy exists but is not registered for rebuild",
+	"compliance_policy_rules_projection":      "#497 — ApplyCompliancePolicy exists but is not registered for rebuild",
+	"compliance_policy_evaluation_projection": "#497 — compliance evaluation stream not replayed by any target",
+	"compliance_results_projection":           "#497 — ApplyCompliance exists but is not registered for rebuild",
+}
+
+// TestSchemaTotallyClassified enumerates every base table in the live test
+// schema and forces it into exactly one classification. Includes its own
+// red-phase (AC4): a probe table is created and must be flagged before the
+// real assertion runs, proving the discovery cannot pass vacuously.
+func TestSchemaTotallyClassified(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	tables := listBaseTables(t, ctx, st)
+	require.Greater(t, len(tables), 30,
+		"expected the full schema (>30 tables), got %d — discovery is broken", len(tables))
+
+	explicit := map[string]bool{}
+	cascadeSeeds := []string{}
+	for _, target := range store.AllRebuildTargets {
+		for _, tbl := range target.Tables {
+			explicit[tbl] = true
+			if target.Cascade {
+				cascadeSeeds = append(cascadeSeeds, tbl)
+			}
+		}
+	}
+	require.NotEmpty(t, explicit, "AllRebuildTargets yielded zero tables — discovery is broken")
+
+	closure := fkCascadeClosure(t, ctx, st, cascadeSeeds)
+
+	// Registry hygiene: every entry names a live table; no entry shadows an
+	// earlier classification rule.
+	for tbl := range operationalTables {
+		require.Containsf(t, tables, tbl, "operationalTables names %q but no such table — stale entry", tbl)
+		require.Falsef(t, explicit[tbl], "%q is a rebuild-target table — remove it from operationalTables", tbl)
+	}
+	for tbl := range cascadeRederivedTables {
+		require.Containsf(t, tables, tbl, "cascadeRederivedTables names %q but no such table — stale entry", tbl)
+		require.Falsef(t, explicit[tbl], "%q is an explicit rebuild-target table — remove it from cascadeRederivedTables", tbl)
+		require.Truef(t, closure[tbl],
+			"%q is registered as cascade-rederived but is NOT in the FK closure of any Cascade rebuild target — a rebuild would not wipe it; reclassify it", tbl)
+	}
+	for tbl := range knownUnreplayableTables {
+		require.Containsf(t, tables, tbl, "knownUnreplayableTables names %q but no such table — stale entry", tbl)
+		require.Falsef(t, explicit[tbl],
+			"%q now has a rebuild target — the replay gap is closed, remove it from knownUnreplayableTables", tbl)
+	}
+
+	classify := func(tbl string) string {
+		switch {
+		case tbl == "events":
+			return "event store"
+		case tbl == "goose_db_version":
+			return "migration bookkeeping"
+		case explicit[tbl]:
+			return "rebuild target"
+		case cascadeRederivedTables[tbl] != "":
+			return "cascade-rederived"
+		case operationalTables[tbl] != "":
+			return "operational"
+		case knownUnreplayableTables[tbl] != "":
+			return "known gap"
+		}
+		return ""
+	}
+
+	// Red phase (AC4): an unclassified probe table MUST be flagged, or the
+	// discovery is broken and the real assertion below would pass vacuously.
+	const probe = "zz_495_unclassified_probe"
+	_, err := st.TestingPool().Exec(ctx, "CREATE TABLE "+probe+" (id INT)")
+	require.NoError(t, err)
+	probeTables := listBaseTables(t, ctx, st)
+	require.Contains(t, probeTables, probe, "probe table must be discovered")
+	require.Empty(t, classify(probe), "probe table must be UNclassified — the guard would never fire")
+	_, err = st.TestingPool().Exec(ctx, "DROP TABLE "+probe)
+	require.NoError(t, err)
+
+	var unclassified []string
+	for _, tbl := range tables {
+		if classify(tbl) == "" {
+			unclassified = append(unclassified, tbl)
+		}
+	}
+	sort.Strings(unclassified)
+	require.Emptyf(t, unclassified,
+		"tables violating the #495 total-classification contract (all Postgres state is event-sourced or explicitly classified):\n  %s\n"+
+			"Each must become a projection with a rebuild target, or be justified in cascadeRederivedTables / operationalTables, "+
+			"or be tracked as a replay gap in knownUnreplayableTables.",
+		strings.Join(unclassified, "\n  "))
+}
+
+// listBaseTables enumerates public base tables from the live schema.
+func listBaseTables(t *testing.T, ctx context.Context, st *store.Store) []string {
+	t.Helper()
+	rows, err := st.TestingPool().Query(ctx,
+		`SELECT table_name FROM information_schema.tables
+		 WHERE table_schema = 'public' AND table_type = 'BASE TABLE'`)
+	require.NoError(t, err)
+	defer rows.Close()
+	var tables []string
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		tables = append(tables, name)
+	}
+	require.NoError(t, rows.Err())
+	return tables
+}
+
+// fkCascadeClosure computes the set of tables a `TRUNCATE <seeds> CASCADE`
+// would wipe: seeds plus, transitively, every table holding a foreign key
+// that references a table already in the closure — read from the live FK
+// graph so the guard tracks schema reality, not a hand-list.
+func fkCascadeClosure(t *testing.T, ctx context.Context, st *store.Store, seeds []string) map[string]bool {
+	t.Helper()
+	rows, err := st.TestingPool().Query(ctx, `
+		SELECT DISTINCT child.relname AS child_table, parent.relname AS parent_table
+		FROM pg_constraint c
+		JOIN pg_class child  ON child.oid  = c.conrelid
+		JOIN pg_class parent ON parent.oid = c.confrelid
+		JOIN pg_namespace n  ON n.oid = child.relnamespace
+		WHERE c.contype = 'f' AND n.nspname = 'public'`)
+	require.NoError(t, err)
+	defer rows.Close()
+	childrenOf := map[string][]string{}
+	for rows.Next() {
+		var child, parent string
+		require.NoError(t, rows.Scan(&child, &parent))
+		childrenOf[parent] = append(childrenOf[parent], child)
+	}
+	require.NoError(t, rows.Err())
+
+	closure := map[string]bool{}
+	queue := append([]string(nil), seeds...)
+	for len(queue) > 0 {
+		tbl := queue[0]
+		queue = queue[1:]
+		if closure[tbl] {
+			continue
+		}
+		closure[tbl] = true
+		queue = append(queue, childrenOf[tbl]...)
+	}
+	return closure
+}

--- a/internal/store/schema_classification_test.go
+++ b/internal/store/schema_classification_test.go
@@ -39,7 +39,7 @@ import (
 // to reproduce them (no rebuild target touches them).
 var operationalTables = map[string]string{
 	"auth_states":       "short-lived OIDC flow rows (state/nonce/PKCE), consumed on first read; in PG so ANY control replica can complete the callback (no sticky sessions); loss = user redoes login",
-	"revoked_tokens":    "JWT refresh-token denylist, TTL-bounded by token expiry; primary operational security state — becomes a projection once #496 adds logout/refresh events",
+	"revoked_tokens":    "JWT refresh-token denylist, TTL-bounded by token expiry; primary operational security state (the denylist must be authoritative and immediately consistent, not an eventually-projected view). Logout/RefreshToken now audit-log the session lifecycle (#496), but the denylist row itself stays operational — it is not reconstructable from an audit event alone",
 	"luks_tokens":       "hashed one-time LUKS enrollment tokens (WS10); single-use by design, loss = operator re-issues; deliberately not replayable",
 	"osquery_results":   "transient result staging for DispatchOSQuery — agent reply fills, reads expire; loss = re-run the query",
 	"log_query_results": "transient result staging for QueryDeviceLogs — same lifecycle as osquery_results",
@@ -60,22 +60,12 @@ var cascadeRederivedTables = map[string]string{
 
 // knownUnreplayableTables is registry 5: tables whose content comes from the
 // event stream but which NO rebuild target replays — replay-coverage gaps,
-// not sanctioned designs (#497). Each fix (adding the rebuild target) makes
-// the overlap check above fail until the entry is removed.
-var knownUnreplayableTables = map[string]string{
-	"user_roles_projection":                   "#497 — grants ride the user_role stream, which no target replays; a replay into an empty schema loses every post-creation grant (no FK, so an in-place rebuild merely leaves the rows untouched)",
-	"server_settings_projection":              "#497 — ServerSettingUpdated has a listener but no rebuild target (singleton seeded by migration)",
-	"totp_projection":                         "#497 — FK child of users_projection: a users rebuild CASCADE-WIPES all TOTP enrollments and nothing replays the totp stream",
-	"security_alerts_projection":              "#497 — security_alert stream has a listener but no rebuild target",
-	"lps_passwords_projection":                "#497 — no target replays the lps_password stream; a replay into an empty schema loses the (encrypted) password history the events carry",
-	"luks_keys_projection":                    "#497 — same exposure as lps_passwords_projection for the luks_key stream",
-	"identity_providers_projection":           "#497 — identity_provider stream has a listener but no rebuild target",
-	"identity_links_projection":               "#497 — FK child of users_projection: a users rebuild CASCADE-WIPES all SSO identity links and nothing replays the identity_link stream",
-	"compliance_policies_projection":          "#497 — ApplyCompliancePolicy exists but is not registered for rebuild",
-	"compliance_policy_rules_projection":      "#497 — ApplyCompliancePolicy exists but is not registered for rebuild",
-	"compliance_policy_evaluation_projection": "#497 — compliance evaluation stream not replayed by any target",
-	"compliance_results_projection":           "#497 — ApplyCompliance exists but is not registered for rebuild",
-}
+// not sanctioned designs. #497 CLOSED every gap (user_roles, totp,
+// identity_providers+links, security_alerts, lps_passwords, luks_keys,
+// server_settings, and the compliance projections all have rebuild targets
+// now), so the map is intentionally EMPTY: every projection is replayable and
+// a future gap must be FIXED, not parked here.
+var knownUnreplayableTables = map[string]string{}
 
 // TestSchemaTotallyClassified enumerates every base table in the live test
 // schema and forces it into exactly one classification. Includes its own


### PR DESCRIPTION
Closes #495, closes #496, closes #497.

## Why

The event store is the audit log and the replay source of truth, but that guarantee was held only by convention. An audit found the convention was breached in three ways — one direct-write bypass, six state-changing RPCs with no audit event, and twelve projections a `RebuildAll` would wipe or fail to reproduce. This PR closes every one and adds three self-discovering guards so the guarantee is now machine-enforced, not tribal.

## What

**Contract (ADR 0029):** all Postgres state is event-sourced or derived-and-rebuildable; valkey is ephemeral by contract; there are no exceptions.

**Fixes**
- `lps_keypair` is now event-sourced (`LpsKeypairGenerated`, projector, rebuild target); `EnsureLpsKeypair` uses an OCC version-0 append (first-writer-wins) instead of the advisory lock + direct INSERT. Backfill materialises a synthetic event for existing rows. The signed LPS public key is byte-identical across the migration.
- Six previously-silent RPCs now append audit events on success (rejected/unauth append nothing): `DispatchOSQuery`, `QueryDeviceLogs`, `RefreshDeviceInventory`, `CreateLuksToken`, `Logout`, `RefreshToken`. No secret material in any payload.
- Twelve projections gained rebuild targets so replay reproduces them 1:1 — including the severe cases where a `users` rebuild CASCADE-wiped RBAC grants (`user_roles`), 2FA (`totp`), and SSO links (`identity_links`).

**Guards (self-discovering, matches-zero, house AST pattern)**
1. Every mutating ControlService RPC's call graph must reach `AppendEvent`. `knownGaps` is empty — no tracked-debt escape hatch.
2. Every Postgres table is `events` | a rebuild target | justified-operational; a new unclassified table fails. `knownUnreplayableTables` is empty.
3. Rebuild round-trip coverage for the closed gaps.

**Disposition of the 10 direct-write candidates the sweep surfaced:** 1 fixed (lps_keypair); 7 legitimately operational/ephemeral, each justified in `operationalTables` (auth_states, revoked_tokens, luks_tokens, osquery/log_query_results, terminal_sessions, device_inventory); 2 (`Action.UpdateSignature` sites) confirmed derived — replay recomputes the signature from action events.

## Verification
- Full server suite green (33 packages), `go vet` clean.
- Rebuild round-trip tests prove RBAC grants, TOTP, and SSO links survive a full `RebuildAll`.
- LPS sealed-transport integration suite green; signed pubkey byte-identical pre/post migration.
- Both guards red-verified (neutralised one handler's append → guard named the RPC; synthetic unclassified table → schema guard fired).

## Reversible default taken
`RefreshToken` appends `UserSessionRefreshed` despite its frequency (audit completeness over noise). Dial back with an audit-view filter rather than dropping the event if it proves chatty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit tracking for key device and session actions, including OS query dispatches, device log queries, inventory refreshes, LUKS token creation, logouts, and token refreshes.
  * Added support for replaying and rebuilding more system data safely, including the LPS keypair and several additional projection-backed records.

* **Bug Fixes**
  * Improved handling of LPS keypair setup so concurrent startup is more reliable and recovery from older deployments is preserved.
  * Made rebuilds more resilient by allowing skipped historical events to be treated as non-fatal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->