### PR TITLE
feat(crypto+store): single AAD-bound enc:v1 format + ULID identifiers everywhere (spec 20)

### DIFF
--- a/cmd/control/valkey.go
+++ b/cmd/control/valkey.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/hibiken/asynq"
-	"github.com/oklog/ulid/v2"
 	"github.com/redis/go-redis/v9"
 
 	"github.com/manchtools/power-manage/server/internal/api"
@@ -293,7 +292,7 @@ func configureTerminalAdminFanout(cfg *Config, termHandler *api.TerminalHandler,
 // panic can't crash the server. (Round-5 review fix.)
 func auditIndexListener(idx *search.Index, logger *slog.Logger) store.EventListener {
 	return func(_ context.Context, ev store.PersistedEvent) {
-		id := ulid.ULID(ev.ID).String()
+		id := ev.ID
 		data := &taskqueue.SearchEntityData{
 			EventType:  ev.EventType,
 			StreamType: ev.StreamType,

--- a/docs/adr/0030-single-aad-at-rest-format-ulid-ids.md
+++ b/docs/adr/0030-single-aad-at-rest-format-ulid-ids.md
@@ -1,0 +1,52 @@
+# 0030 — One AAD-bound at-rest format; ULID identifiers everywhere
+
+- Status: accepted
+- Date: 2026-07-04
+- Related: spec 20 (docs repo, `06-specs/20-single-aad-encryption-format.md`);
+  manchtools/power-manage-server#504; ADR 0009 (AES-GCM AAD at rest —
+  **superseded** by this ADR's single-format framing); ADR 0001 (key
+  rotation — unchanged); TECH_DEBT_AUDIT.md F-06 + F-15; spec 19
+  (retention/erasure — its per-user DEKs wrap under this format).
+
+## Context
+
+At-rest secret encryption shipped two wire formats: `enc:v1` (nil-AAD,
+IdP client secrets + TOTP secrets — the WS10 deferral) and `enc:v2`
+(AAD-bound, LPS/LUKS/the LPS keypair, per ADR 0009). The public naked
+`Encrypt`/`Decrypt` invited new nil-AAD call sites, and a ciphertext
+could be relocated across rows/contexts undetected in the nil-AAD
+domains. Separately, `luks_keys`, `luks_tokens`, `lps_passwords`,
+`security_alerts.event_id`, and `events.id` still used DB-minted
+`gen_random_uuid()` identifiers — two ID regimes in one schema, and,
+for projection rows, ids a replay could not reproduce.
+
+## Decision
+
+1. **One at-rest format.** AAD-bound AES-256-GCM under the tag
+   `enc:v1`. The nil-AAD API is deleted; `EncryptWithContext` refuses
+   an empty AAD; `DecryptWithContext` errors loudly on any other
+   `enc:*` tag (a beta Path-A deployment reprovisions — retired
+   ciphertext is never silently mis-read). AAD dimensions: LPS/LUKS
+   keep `device|action|type`; IdP client secrets bind
+   `idp_id|idp-client-secret`; TOTP secrets bind `user_id|totp-secret`.
+   Guards: `TestAEADStaysInCryptoPackage` (no AEAD primitives outside
+   `internal/crypto`, no literal-nil AAD).
+2. **ULID identifiers, minted deterministically.** `events.id` is a
+   Go-minted ULID; secret-history and security-alert projection rows
+   take the raising event's ULID as their id, and their `created_at`
+   comes from the event — so a rebuild reproduces the rows
+   byte-identically (proven by the spec-21 full-fidelity round-trip).
+   `gen_random_uuid()` and uuid-typed columns are gone; the
+   `TestULIDOnlyIdentifiers` guard (no `google/uuid` import anywhere
+   including generated code; no uuid column/default in migrations)
+   keeps a third domain from copying the retired pattern.
+
+## Consequences
+
+- A version tag now marks a genuine incompatible crypto change, not a
+  functionality iteration; spec 19's per-user DEK envelope wraps under
+  this one format.
+- Pre-change deployments must reprovision (beta stance, Path A); the
+  decrypt error names the retired tag explicitly.
+- KEK custody and rotation are unchanged (ADR 0001); the envelope in
+  spec 19 will make hard rotation cheap for DEK'd data.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/google/uuid v1.6.0
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/manchtools/power-manage-sdk v0.5.3
@@ -54,6 +53,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,10 +111,6 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.5.3-0.20260628101136-f4e5e6dabfed h1:o4uhtYAk4J/wUcS4ImrRpUdQAejg1ANnb8Dk5GrwtzA=
-github.com/manchtools/power-manage-sdk v0.5.3-0.20260628101136-f4e5e6dabfed/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
-github.com/manchtools/power-manage-sdk v0.5.3-0.20260702054146-a3146410f71a h1:08eqBt9aJSIiTzeBVDeVYb+zoPAWJG7fb0c5nrrktPI=
-github.com/manchtools/power-manage-sdk v0.5.3-0.20260702054146-a3146410f71a/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/manchtools/power-manage-sdk v0.5.3 h1:x5GtlO0VwuzMV4NUyOBr+iCE3jSQpNG6DYWnVHxB9mk=
 github.com/manchtools/power-manage-sdk v0.5.3/go.mod h1:vt9jkT5k3HHURX0Mnp1fgP/6VC7gkk5TPkdbmElZQPc=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/internal/api/audit_handler.go
+++ b/internal/api/audit_handler.go
@@ -7,7 +7,6 @@ import (
 	"sort"
 
 	"connectrpc.com/connect"
-	"github.com/oklog/ulid/v2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
@@ -426,7 +425,7 @@ func splitArraySuffix(seg string) []string {
 
 func eventToProto(e db.Event) *pm.AuditEvent {
 	event := &pm.AuditEvent{
-		Id:         ulid.ULID(e.ID).String(),
+		Id:         e.ID,
 		EventType:  e.EventType,
 		StreamType: e.StreamType,
 		StreamId:   e.StreamID,

--- a/internal/api/idp_handler.go
+++ b/internal/api/idp_handler.go
@@ -53,15 +53,15 @@ func (h *IDPHandler) CreateIdentityProvider(ctx context.Context, req *connect.Re
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to check slug")
 	}
 
-	// Encrypt client secret
-	encryptedSecret, err := h.enc.Encrypt(req.Msg.ClientSecret)
-	if err != nil {
-		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to encrypt client secret")
-	}
-
 	groupMappingJSON, _ := json.Marshal(req.Msg.GroupMapping)
 
 	id := newULID()
+
+	// Encrypt client secret bound to this provider row (spec 20 / F-06).
+	encryptedSecret, err := h.enc.EncryptWithContext(req.Msg.ClientSecret, crypto.RowAAD(id, crypto.PurposeIdPClientSecret))
+	if err != nil {
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to encrypt client secret")
+	}
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   id,
@@ -207,7 +207,7 @@ func (h *IDPHandler) UpdateIdentityProvider(ctx context.Context, req *connect.Re
 	}
 
 	if req.Msg.ClientSecret != "" {
-		encryptedSecret, err := h.enc.Encrypt(req.Msg.ClientSecret)
+		encryptedSecret, err := h.enc.EncryptWithContext(req.Msg.ClientSecret, crypto.RowAAD(req.Msg.Id, crypto.PurposeIdPClientSecret))
 		if err != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to encrypt client secret")
 		}

--- a/internal/api/lps_sealed_transport_test.go
+++ b/internal/api/lps_sealed_transport_test.go
@@ -67,12 +67,12 @@ func TestEnsureLpsKeypair_IdempotentAndConcurrent(t *testing.T) {
 		assert.Equal(t, pub1, pubs[i], "all concurrent callers must see the same key")
 	}
 
-	// Exactly one row, and the stored private key is encrypted (enc:v2), never
-	// the raw 32 bytes.
+	// Exactly one row, and the stored private key is encrypted (the single
+	// AAD-bound enc:v1 format, spec 20), never the raw 32 bytes.
 	row, err := st.Queries().GetLpsKeypair(ctx)
 	require.NoError(t, err)
 	assert.NotEqual(t, string(priv1.Bytes()), row.PrivateKeyEnc, "private key stored in cleartext")
-	assert.Contains(t, row.PrivateKeyEnc, "enc:v2:", "private key must be AAD-encrypted at rest")
+	assert.Contains(t, row.PrivateKeyEnc, "enc:v1:", "private key must be AAD-encrypted at rest")
 
 	// A nil encryptor is refused — the key cannot be protected at rest.
 	freshDB := testutil.SetupPostgres(t)

--- a/internal/api/sso_handler.go
+++ b/internal/api/sso_handler.go
@@ -184,8 +184,8 @@ func (h *SSOHandler) GetSSOLoginURL(ctx context.Context, req *connect.Request[pm
 		return nil, apiErrorCtx(ctx, ErrProviderDisabled, connect.CodeFailedPrecondition, "provider is disabled")
 	}
 
-	// Decrypt client secret
-	clientSecret, err := h.enc.Decrypt(provider.ClientSecretEncrypted)
+	// Decrypt client secret bound to this provider row (spec 20 / F-06).
+	clientSecret, err := h.enc.DecryptWithContext(provider.ClientSecretEncrypted, crypto.RowAAD(provider.ID, crypto.PurposeIdPClientSecret))
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt client secret")
 	}
@@ -289,8 +289,8 @@ func (h *SSOHandler) SSOCallback(ctx context.Context, req *connect.Request[pm.SS
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "slug mismatch")
 	}
 
-	// Decrypt client secret
-	clientSecret, err := h.enc.Decrypt(provider.ClientSecretEncrypted)
+	// Decrypt client secret bound to this provider row (spec 20 / F-06).
+	clientSecret, err := h.enc.DecryptWithContext(provider.ClientSecretEncrypted, crypto.RowAAD(provider.ID, crypto.PurposeIdPClientSecret))
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt client secret")
 	}

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -99,8 +99,8 @@ func (h *TOTPHandler) SetupTOTP(ctx context.Context, req *connect.Request[pm.Set
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to generate backup codes")
 	}
 
-	// Encrypt the TOTP secret
-	encryptedSecret, err := h.encryptor.Encrypt(key.Secret())
+	// Encrypt the TOTP secret bound to this user row (spec 20 / F-06).
+	encryptedSecret, err := h.encryptor.EncryptWithContext(key.Secret(), crypto.RowAAD(userCtx.ID, crypto.PurposeTOTPSecret))
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to encrypt TOTP secret")
 	}
@@ -151,8 +151,8 @@ func (h *TOTPHandler) VerifyTOTP(ctx context.Context, req *connect.Request[pm.Ve
 		return nil, apiErrorCtx(ctx, ErrTOTPAlreadyEnabled, connect.CodeFailedPrecondition, "TOTP is already enabled")
 	}
 
-	// Decrypt secret and validate code
-	secret, err := h.encryptor.Decrypt(totpRecord.SecretEncrypted)
+	// Decrypt secret bound to this user row (spec 20 / F-06).
+	secret, err := h.encryptor.DecryptWithContext(totpRecord.SecretEncrypted, crypto.RowAAD(userCtx.ID, crypto.PurposeTOTPSecret))
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt TOTP secret")
 	}
@@ -382,8 +382,8 @@ func (h *TOTPHandler) VerifyLoginTOTP(ctx context.Context, req *connect.Request[
 		return nil, apiErrorCtx(ctx, ErrTOTPNotEnabled, connect.CodeFailedPrecondition, "TOTP is not enabled")
 	}
 
-	// Decrypt secret
-	secret, err := h.encryptor.Decrypt(totpRecord.SecretEncrypted)
+	// Decrypt secret bound to this user row (spec 20 / F-06).
+	secret, err := h.encryptor.DecryptWithContext(totpRecord.SecretEncrypted, crypto.RowAAD(claims.UserID, crypto.PurposeTOTPSecret))
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt TOTP secret")
 	}

--- a/internal/archtest/aead_containment_test.go
+++ b/internal/archtest/aead_containment_test.go
@@ -1,0 +1,77 @@
+package archtest
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+)
+
+// TestAEADStaysInCryptoPackage pins spec 20 / F-06's anti-regression:
+// the ONLY at-rest encryption surface is internal/crypto's AAD-bound
+// EncryptWithContext/DecryptWithContext. Two ways a new call site could
+// regress to unbound ciphertext, both forbidden here:
+//
+//  1. calling the AEAD primitives directly (gcm.Seal / gcm.Open)
+//     outside internal/crypto — that reopens the nil-AAD path the
+//     removed naked Encrypt/Decrypt used to hide;
+//  2. passing a literal nil/empty AAD to *WithContext — the runtime
+//     check refuses it, but the build should too.
+//
+// Seal is flagged unconditionally (no legitimate non-AEAD Seal exists
+// in this module); Open only at the AEAD arity (4 args: dst, nonce,
+// ciphertext, aad) so sql.Open / os.Open (1–2 args) stay untouched.
+func TestAEADStaysInCryptoPackage(t *testing.T) {
+	root := moduleRoot(t)
+	files := walkGoFiles(t, root, func(rel string) bool {
+		return !strings.HasPrefix(rel, "internal/store/generated/")
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero production Go files — detector is mis-scoped")
+	}
+
+	sawInsideCrypto := 0
+	for _, gf := range files {
+		insideCrypto := strings.HasPrefix(gf.rel, "internal/crypto/")
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			switch sel.Sel.Name {
+			case "Seal":
+				if insideCrypto {
+					sawInsideCrypto++
+					return true
+				}
+				t.Errorf("AEAD Seal outside internal/crypto at %s:%d — at-rest encryption goes through crypto.EncryptWithContext (single AAD-bound format, spec 20)", gf.rel, gf.line(call))
+			case "Open":
+				if len(call.Args) != 4 {
+					return true // sql.Open / os.Open etc.
+				}
+				if insideCrypto {
+					sawInsideCrypto++
+					return true
+				}
+				t.Errorf("AEAD Open outside internal/crypto at %s:%d — at-rest decryption goes through crypto.DecryptWithContext", gf.rel, gf.line(call))
+			case "EncryptWithContext", "DecryptWithContext":
+				// aad is the last argument; a literal nil / empty
+				// composite is a compile-visible unbound call.
+				if len(call.Args) == 0 {
+					return true
+				}
+				aad := call.Args[len(call.Args)-1]
+				if id, ok := aad.(*ast.Ident); ok && id.Name == "nil" {
+					t.Errorf("nil AAD passed to %s at %s:%d — every at-rest secret is context-bound (spec 20 / F-06); build a crypto.SecretAAD/RowAAD", sel.Sel.Name, gf.rel, gf.line(call))
+				}
+			}
+			return true
+		})
+	}
+	if sawInsideCrypto == 0 {
+		t.Fatal("matches-zero guard: found no AEAD Seal/Open inside internal/crypto — the detector is dead, the guard would pass vacuously")
+	}
+}

--- a/internal/archtest/ulid_only_test.go
+++ b/internal/archtest/ulid_only_test.go
@@ -78,7 +78,9 @@ func TestULIDOnlyIdentifiers(t *testing.T) {
 				}
 			}
 		}
-		f.Close()
+		if cerr := f.Close(); cerr != nil {
+			t.Fatalf("close %s: %v", e.Name(), cerr)
+		}
 		if err := sc.Err(); err != nil {
 			t.Fatalf("scan %s: %v", e.Name(), err)
 		}

--- a/internal/archtest/ulid_only_test.go
+++ b/internal/archtest/ulid_only_test.go
@@ -1,0 +1,89 @@
+package archtest
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestULIDOnlyIdentifiers pins the repo-wide mandatory-ULID rule
+// (spec 20 / audit F-15: "uuid usage is debt to fix, not to
+// accept-and-document"). Two enforcement surfaces, both with EMPTY
+// allowlists — a third domain cannot copy the retired uuid pattern:
+//
+//  1. Go: no github.com/google/uuid import anywhere, INCLUDING the
+//     sqlc-generated package — a new uuid column would resurface the
+//     import there even if no hand-written code touches it.
+//  2. Migrations: no `gen_random_uuid()` default and no `uuid`-typed
+//     column in any non-comment line — identifiers are text ULIDs
+//     minted in Go (crypto/rand-backed ulid.Make), so the DB never
+//     mints a random identifier the event replay cannot reproduce.
+func TestULIDOnlyIdentifiers(t *testing.T) {
+	root := moduleRoot(t)
+
+	// (1) Go imports — scan everything, generated included.
+	files := walkGoFiles(t, root, func(string) bool { return true })
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero Go files")
+	}
+	sawImports := 0
+	for _, gf := range files {
+		for _, imp := range gf.ast.Imports {
+			sawImports++
+			if strings.Contains(imp.Path.Value, "github.com/google/uuid") {
+				t.Errorf("google/uuid imported at %s — identifiers are ULIDs (oklog/ulid), never UUIDs (F-15). If sqlc regenerated this, a uuid-typed column crept back into the schema.", gf.rel)
+			}
+		}
+	}
+	if sawImports == 0 {
+		t.Fatal("matches-zero guard: saw zero imports — scan is broken")
+	}
+
+	// (2) Migration SQL.
+	migDir := filepath.Join(root, "internal", "store", "migrations")
+	entries, err := os.ReadDir(migDir)
+	if err != nil {
+		t.Fatalf("read migrations dir: %v", err)
+	}
+	scanned := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".sql") {
+			continue
+		}
+		scanned++
+		f, err := os.Open(filepath.Join(migDir, e.Name()))
+		if err != nil {
+			t.Fatalf("open %s: %v", e.Name(), err)
+		}
+		sc := bufio.NewScanner(f)
+		line := 0
+		for sc.Scan() {
+			line++
+			text := strings.TrimSpace(sc.Text())
+			if strings.HasPrefix(text, "--") {
+				continue // comment
+			}
+			lower := strings.ToLower(text)
+			if strings.Contains(lower, "gen_random_uuid") {
+				t.Errorf("gen_random_uuid() in migration %s:%d — the DB must not mint random identifiers (non-deterministic under replay); mint a ULID in Go", e.Name(), line)
+			}
+			// A uuid-typed column: "<name> uuid" optionally followed by
+			// constraints. Word-boundary match avoids substrings.
+			for _, tok := range strings.Fields(lower) {
+				if tok == "uuid" || tok == "uuid," {
+					t.Errorf("uuid-typed column in migration %s:%d (%q) — identifiers are text ULIDs (F-15)", e.Name(), line, text)
+					break
+				}
+			}
+		}
+		f.Close()
+		if err := sc.Err(); err != nil {
+			t.Fatalf("scan %s: %v", e.Name(), err)
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("matches-zero guard: scanned zero migration files")
+	}
+}

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -1,8 +1,19 @@
 // Package crypto provides application-level encryption for sensitive data
-// stored in the database (LUKS passphrases, LPS passwords).
+// stored in the database (LUKS passphrases, LPS passwords, IdP client
+// secrets, TOTP secrets).
 //
-// Uses AES-256-GCM with random nonces. The encryption key is shared between
-// the control server and gateway server via environment variable.
+// ONE at-rest format (spec 20, closes audit F-06 / the WS10 deferral):
+// AAD-bound AES-256-GCM under the prefix "enc:v1:". Every ciphertext is
+// bound to its row context via additional authenticated data, so a
+// DB-level attacker cannot relocate a secret from one row (or purpose)
+// to another and have it decrypt. There is deliberately NO nil-AAD API:
+// the naked Encrypt/Decrypt pair was removed so a new call site cannot
+// regress to unbound ciphertext (a guard test additionally pins that
+// AEAD primitives are not used outside this package).
+//
+// The encryption key is shared between the control server and gateway
+// server via environment variable (CONTROL_ENCRYPTION_KEY, mandatory
+// since WS11).
 package crypto
 
 import (
@@ -17,24 +28,35 @@ import (
 	"strings"
 )
 
+// prefix identifies AAD-bound AES-256-GCM ciphertext — the single
+// at-rest format. Values carrying any OTHER "enc:*" prefix (the retired
+// nil-AAD v1 or the pre-rename "enc:v2") fail loudly: the beta Path-A
+// migration is a reprovision, and silently passing unknown ciphertext
+// through as plaintext would be far worse than an error.
+const prefix = "enc:v1:"
+
+// Purpose tags for RowAAD — shared constants so the write and read
+// paths can never drift apart on the AAD purpose dimension.
 const (
-	// prefix (v1) identifies encrypted values sealed with NIL AAD. Kept for
-	// backward compatibility: every row written before the AAD-binding change
-	// (WS5 #8) carries this prefix and must keep decrypting.
-	prefix = "enc:v1:"
-	// prefixV2 identifies values sealed WITH context AAD (EncryptWithContext).
-	// The AAD binds the ciphertext to its row context (device|action|type), so
-	// a DB-level attacker cannot relocate a secret from one row to another and
-	// have it decrypt.
-	prefixV2 = "enc:v2:"
+	PurposeIdPClientSecret = "idp-client-secret"
+	PurposeTOTPSecret      = "totp-secret"
 )
 
-// SecretAAD builds the additional-authenticated-data that binds an at-rest
-// secret to its row context. deviceID and actionID are ULIDs (Crockford
-// base32 — they can never contain the '|' separator), and secretType is a fixed
-// literal ("luks" / "lps"), so the concatenation is unambiguous.
+// SecretAAD builds the additional-authenticated-data that binds a
+// device-scoped at-rest secret to its row context. deviceID and actionID
+// are ULIDs (Crockford base32 — they can never contain the '|'
+// separator), and secretType is a fixed literal ("luks" / "lps"), so the
+// concatenation is unambiguous.
 func SecretAAD(deviceID, actionID, secretType string) []byte {
 	return []byte(deviceID + "|" + actionID + "|" + secretType)
+}
+
+// RowAAD builds the AAD for a secret owned by a single row: the owning
+// row's ULID plus a fixed purpose literal (see the Purpose* constants).
+// Mirrors SecretAAD's unambiguous '|' concatenation; the two shapes
+// cannot collide because SecretAAD always has three segments.
+func RowAAD(rowID, purpose string) []byte {
+	return []byte(rowID + "|" + purpose)
 }
 
 // Encryptor handles AES-256-GCM encryption and decryption of secret values.
@@ -70,30 +92,20 @@ func NewEncryptor(keyHex string) (*Encryptor, error) {
 	return &Encryptor{gcm: gcm}, nil
 }
 
-// Encrypt encrypts plaintext and returns an "enc:v1:<base64>" string.
-// Returns plaintext unchanged if e is nil (encryption disabled).
-func (e *Encryptor) Encrypt(plaintext string) (string, error) {
-	if e == nil || plaintext == "" {
-		return plaintext, nil
-	}
-
-	nonce := make([]byte, e.gcm.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return "", fmt.Errorf("generate nonce: %w", err)
-	}
-
-	ciphertext := e.gcm.Seal(nonce, nonce, []byte(plaintext), nil)
-	return prefix + base64.StdEncoding.EncodeToString(ciphertext), nil
-}
-
 // EncryptWithContext encrypts plaintext bound to aad and returns an
-// "enc:v2:<base64>" string. The aad is authenticated (not stored in the
-// ciphertext) — DecryptWithContext must be given the SAME aad to open it, so a
-// secret sealed for one row context cannot be opened in another. Returns
-// plaintext unchanged if e is nil (encryption disabled) or plaintext is empty.
+// "enc:v1:<base64>" string. The aad is authenticated (not stored in the
+// ciphertext) — DecryptWithContext must be given the SAME aad to open
+// it, so a secret sealed for one row context cannot be opened in
+// another. An empty aad is refused (fail-closed): unbound ciphertext is
+// exactly the regression this package's single-format contract forbids.
+// Returns plaintext unchanged if e is nil (encryption disabled) or
+// plaintext is empty.
 func (e *Encryptor) EncryptWithContext(plaintext string, aad []byte) (string, error) {
 	if e == nil || plaintext == "" {
 		return plaintext, nil
+	}
+	if len(aad) == 0 {
+		return "", errors.New("crypto: refusing to encrypt without an AAD context (nil-AAD path was removed — spec 20 / F-06)")
 	}
 
 	nonce := make([]byte, e.gcm.NonceSize())
@@ -102,54 +114,26 @@ func (e *Encryptor) EncryptWithContext(plaintext string, aad []byte) (string, er
 	}
 
 	ciphertext := e.gcm.Seal(nonce, nonce, []byte(plaintext), aad)
-	return prefixV2 + base64.StdEncoding.EncodeToString(ciphertext), nil
+	return prefix + base64.StdEncoding.EncodeToString(ciphertext), nil
 }
 
-// Decrypt decrypts an "enc:v1:<base64>" string back to plaintext.
-// Returns the input unchanged if it doesn't have the encryption prefix
-// (supports reading pre-encryption plaintext data).
-// Returns the input unchanged if e is nil (encryption disabled).
-func (e *Encryptor) Decrypt(value string) (string, error) {
-	if e == nil {
-		return value, nil
-	}
-	if !strings.HasPrefix(value, prefix) {
-		// Not encrypted — return as-is (pre-migration data)
-		return value, nil
-	}
-
-	data, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, prefix))
-	if err != nil {
-		return "", fmt.Errorf("decode ciphertext: %w", err)
-	}
-
-	nonceSize := e.gcm.NonceSize()
-	if len(data) < nonceSize {
-		return "", errors.New("ciphertext too short")
-	}
-
-	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
-	plaintext, err := e.gcm.Open(nil, nonce, ciphertext, nil)
-	if err != nil {
-		return "", fmt.Errorf("decrypt: %w", err)
-	}
-
-	return string(plaintext), nil
-}
-
-// DecryptWithContext decrypts a value that may be either AAD-bound (enc:v2,
-// opened with aad) or legacy nil-AAD (enc:v1, opened with no aad). A
-// non-prefixed value is returned unchanged (pre-encryption plaintext). This is
-// the read path for the LUKS/LPS at-rest secrets: new rows are enc:v2 bound to
-// SecretAAD(device, action, type); rows written before the migration are still
-// enc:v1 and open via the legacy fallback — no backfill required.
+// DecryptWithContext decrypts an "enc:v1:<base64>" AAD-bound value.
+//
+//   - "enc:v1:" values open with the SAME aad they were sealed under;
+//     a mismatched aad or tampered ciphertext fails GCM authentication.
+//   - any OTHER "enc:*" prefix is a loud error: it is ciphertext from a
+//     retired format (pre-spec-20 nil-AAD v1 or "enc:v2"); the deployment
+//     must be reprovisioned (beta Path A), never silently mis-read.
+//   - a non-prefixed value is returned unchanged (pre-encryption
+//     plaintext; also the round-trip identity for the empty string).
+//   - if e is nil (encryption disabled) the input passes through.
 func (e *Encryptor) DecryptWithContext(value string, aad []byte) (string, error) {
 	if e == nil {
 		return value, nil
 	}
 	switch {
-	case strings.HasPrefix(value, prefixV2):
-		data, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, prefixV2))
+	case strings.HasPrefix(value, prefix):
+		data, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(value, prefix))
 		if err != nil {
 			return "", fmt.Errorf("decode ciphertext: %w", err)
 		}
@@ -163,9 +147,14 @@ func (e *Encryptor) DecryptWithContext(value string, aad []byte) (string, error)
 			return "", fmt.Errorf("decrypt: %w", err)
 		}
 		return string(plaintext), nil
-	case strings.HasPrefix(value, prefix):
-		// Legacy nil-AAD ciphertext (written before WS5 #8).
-		return e.Decrypt(value)
+	case strings.HasPrefix(value, "enc:"):
+		// Retired wire format (nil-AAD v1 or pre-rename enc:v2). Report
+		// only the format tag, never ciphertext bytes.
+		tag := value
+		if i := strings.Index(value[len("enc:"):], ":"); i >= 0 {
+			tag = value[:len("enc:")+i]
+		}
+		return "", fmt.Errorf("crypto: unsupported at-rest format %q — pre-spec-20 ciphertext requires reprovisioning (beta Path A), refusing to mis-read it", tag)
 	default:
 		// Pre-encryption plaintext.
 		return value, nil

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -46,115 +46,50 @@ func TestNewEncryptor_WrongLength(t *testing.T) {
 	assert.Contains(t, err.Error(), "must be 32 bytes")
 }
 
-func TestEncryptDecrypt_RoundTrip(t *testing.T) {
+// Spec 20 / F-06: ONE at-rest format — AAD-bound AES-256-GCM under
+// "enc:v1:". The nil-AAD Encrypt/Decrypt pair is gone; these tests pin
+// the surviving contract.
+
+func TestEncryptWithContext_SingleV1Prefix(t *testing.T) {
 	enc, err := crypto.NewEncryptor(testKey())
 	require.NoError(t, err)
 
-	plaintext := "my secret passphrase"
-	ciphertext, err := enc.Encrypt(plaintext)
+	ct, err := enc.EncryptWithContext("secret", crypto.RowAAD("01HROW", crypto.PurposeTOTPSecret))
 	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(ciphertext, "enc:v1:"))
-	assert.NotEqual(t, plaintext, ciphertext)
-
-	decrypted, err := enc.Decrypt(ciphertext)
-	require.NoError(t, err)
-	assert.Equal(t, plaintext, decrypted)
+	assert.True(t, strings.HasPrefix(ct, "enc:v1:"),
+		"the single AAD-bound format carries the enc:v1 prefix, got %q", ct)
+	assert.NotContains(t, ct, "enc:v2", "no second prefix exists anymore")
 }
 
-func TestEncryptDecrypt_EmptyString(t *testing.T) {
+func TestEncryptWithContext_EmptyAADRefused(t *testing.T) {
 	enc, err := crypto.NewEncryptor(testKey())
 	require.NoError(t, err)
 
-	ciphertext, err := enc.Encrypt("")
-	require.NoError(t, err)
-	assert.Equal(t, "", ciphertext, "empty string should pass through unchanged")
+	_, err = enc.EncryptWithContext("secret", nil)
+	require.Error(t, err, "encrypting without an AAD context must be refused (F-06 anti-regression)")
+	_, err = enc.EncryptWithContext("secret", []byte{})
+	require.Error(t, err)
 }
 
-func TestEncrypt_DifferentNonces(t *testing.T) {
+func TestEncryptWithContext_EmptyPlaintextPassthrough(t *testing.T) {
 	enc, err := crypto.NewEncryptor(testKey())
 	require.NoError(t, err)
-
-	ct1, err := enc.Encrypt("same data")
+	ct, err := enc.EncryptWithContext("", crypto.RowAAD("01HROW", crypto.PurposeTOTPSecret))
 	require.NoError(t, err)
-
-	ct2, err := enc.Encrypt("same data")
-	require.NoError(t, err)
-
-	assert.NotEqual(t, ct1, ct2, "encrypting the same data should produce different ciphertexts due to random nonces")
+	assert.Equal(t, "", ct, "empty secrets round-trip as empty, never as ciphertext")
 }
 
-func TestDecrypt_WrongKey(t *testing.T) {
-	enc1, err := crypto.NewEncryptor(testKey())
-	require.NoError(t, err)
-
-	enc2, err := crypto.NewEncryptor(differentKey())
-	require.NoError(t, err)
-
-	ciphertext, err := enc1.Encrypt("secret")
-	require.NoError(t, err)
-
-	_, err = enc2.Decrypt(ciphertext)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "decrypt")
-}
-
-func TestDecrypt_TamperedCiphertext(t *testing.T) {
+func TestEncryptWithContext_DifferentNonces(t *testing.T) {
 	enc, err := crypto.NewEncryptor(testKey())
 	require.NoError(t, err)
+	aad := crypto.RowAAD("01HROW", crypto.PurposeIdPClientSecret)
 
-	ciphertext, err := enc.Encrypt("secret")
+	a, err := enc.EncryptWithContext("same-plaintext", aad)
 	require.NoError(t, err)
-
-	// Tamper with the base64 data (flip some chars after the prefix)
-	tampered := ciphertext[:len("enc:v1:")+5] + "XXXX" + ciphertext[len("enc:v1:")+9:]
-
-	_, err = enc.Decrypt(tampered)
-	assert.Error(t, err)
+	b, err := enc.EncryptWithContext("same-plaintext", aad)
+	require.NoError(t, err)
+	assert.NotEqual(t, a, b, "random nonces: identical plaintext must not produce identical ciphertext")
 }
-
-func TestDecrypt_PlaintextPassthrough(t *testing.T) {
-	enc, err := crypto.NewEncryptor(testKey())
-	require.NoError(t, err)
-
-	// Values without the enc:v1: prefix should be returned unchanged (pre-migration data)
-	result, err := enc.Decrypt("plain text value")
-	require.NoError(t, err)
-	assert.Equal(t, "plain text value", result)
-}
-
-func TestDecrypt_InvalidBase64(t *testing.T) {
-	enc, err := crypto.NewEncryptor(testKey())
-	require.NoError(t, err)
-
-	_, err = enc.Decrypt("enc:v1:not-valid-base64!!!")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "decode ciphertext")
-}
-
-func TestDecrypt_TooShortCiphertext(t *testing.T) {
-	enc, err := crypto.NewEncryptor(testKey())
-	require.NoError(t, err)
-
-	// enc:v1: followed by a very short base64 value (less than nonce size)
-	_, err = enc.Decrypt("enc:v1:AA==")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "ciphertext too short")
-}
-
-func TestNilEncryptor_Passthrough(t *testing.T) {
-	// nil encryptor means encryption is disabled
-	var enc *crypto.Encryptor
-
-	ct, err := enc.Encrypt("hello")
-	require.NoError(t, err)
-	assert.Equal(t, "hello", ct)
-
-	pt, err := enc.Decrypt("hello")
-	require.NoError(t, err)
-	assert.Equal(t, "hello", pt)
-}
-
-// WS5 #8 — AES-GCM AAD binds an at-rest secret to its row context.
 
 func TestEncryptWithContext_AADBindsContext(t *testing.T) {
 	enc, err := crypto.NewEncryptor(testKey())
@@ -165,7 +100,6 @@ func TestEncryptWithContext_AADBindsContext(t *testing.T) {
 
 	ct, err := enc.EncryptWithContext("super-secret", aadA)
 	require.NoError(t, err)
-	assert.True(t, strings.HasPrefix(ct, "enc:v2:"), "AAD-bound ciphertext uses the v2 prefix")
 
 	// Correct AAD round-trips.
 	pt, err := enc.DecryptWithContext(ct, aadA)
@@ -178,6 +112,22 @@ func TestEncryptWithContext_AADBindsContext(t *testing.T) {
 	require.Error(t, err, "a secret sealed for one context must not open under another")
 }
 
+func TestRowAAD_BindsRowAndPurpose(t *testing.T) {
+	enc, err := crypto.NewEncryptor(testKey())
+	require.NoError(t, err)
+
+	ct, err := enc.EncryptWithContext("client-secret", crypto.RowAAD("01HIDPA", crypto.PurposeIdPClientSecret))
+	require.NoError(t, err)
+
+	// Different owning row: cross-provider ciphertext swap must fail.
+	_, err = enc.DecryptWithContext(ct, crypto.RowAAD("01HIDPB", crypto.PurposeIdPClientSecret))
+	require.Error(t, err, "a ciphertext relocated to another provider row must not open")
+
+	// Same row, different purpose: cross-purpose reuse must fail.
+	_, err = enc.DecryptWithContext(ct, crypto.RowAAD("01HIDPA", crypto.PurposeTOTPSecret))
+	require.Error(t, err, "a ciphertext reused under another purpose must not open")
+}
+
 func TestDecryptWithContext_ByteTamperedFails(t *testing.T) {
 	enc, err := crypto.NewEncryptor(testKey())
 	require.NoError(t, err)
@@ -187,7 +137,7 @@ func TestDecryptWithContext_ByteTamperedFails(t *testing.T) {
 	require.NoError(t, err)
 
 	// Flip a mid-string char of the base64 body — GCM integrity must reject.
-	body := strings.TrimPrefix(ct, "enc:v2:")
+	body := strings.TrimPrefix(ct, "enc:v1:")
 	b := []byte(body)
 	idx := len(b) / 2
 	if b[idx] == 'A' {
@@ -195,25 +145,44 @@ func TestDecryptWithContext_ByteTamperedFails(t *testing.T) {
 	} else {
 		b[idx] = 'A'
 	}
-	tampered := "enc:v2:" + string(b)
+	tampered := "enc:v1:" + string(b)
 	_, err = enc.DecryptWithContext(tampered, aad)
 	require.Error(t, err, "a byte-tampered ciphertext must fail GCM integrity")
 }
 
-func TestDecryptWithContext_LegacyV1StillDecrypts(t *testing.T) {
+// Spec 20 AC 5: the legacy formats are GONE. A pre-rename "enc:v2" blob
+// (or any other enc:* tag) errors loudly instead of being mis-read —
+// the beta Path-A migration is a reprovision.
+func TestDecryptWithContext_RetiredFormatsFailLoudly(t *testing.T) {
+	enc, err := crypto.NewEncryptor(testKey())
+	require.NoError(t, err)
+	aad := crypto.RowAAD("01HROW", crypto.PurposeTOTPSecret)
+
+	for _, legacy := range []string{
+		"enc:v2:QUFBQUFBQUFBQUFBQUFBQQ==", // pre-rename AAD format tag
+		"enc:v3:whatever",                 // unknown future tag
+	} {
+		_, err := enc.DecryptWithContext(legacy, aad)
+		require.Error(t, err, "retired/unknown format %q must fail loudly, never pass through", legacy)
+		assert.NotContains(t, err.Error(), "QUFBQUFB", "the error must not echo ciphertext bytes")
+	}
+}
+
+// An OLD nil-AAD blob carried the same "enc:v1:" tag. Post-spec-20 it
+// parses as the AAD-bound format and fails GCM authentication (the seal
+// used no AAD) — erroring loudly rather than silently mis-decrypting,
+// which is the documented reprovision-required behavior. Sealing under
+// one AAD and opening under another is the same failure class (AAD
+// mismatch at Open), since the nil-AAD seal path no longer exists to
+// construct a true legacy blob.
+func TestDecryptWithContext_LegacyNilAADv1FailsAuth(t *testing.T) {
 	enc, err := crypto.NewEncryptor(testKey())
 	require.NoError(t, err)
 
-	// A legacy row was sealed with the nil-AAD Encrypt (enc:v1).
-	legacy, err := enc.Encrypt("old-secret")
+	ct, err := enc.EncryptWithContext("old-secret", []byte("legacy-nil-aad-stand-in"))
 	require.NoError(t, err)
-	require.True(t, strings.HasPrefix(legacy, "enc:v1:"))
-
-	// DecryptWithContext must still open it (migration is non-breaking; no
-	// backfill). The aad is ignored for v1 values.
-	pt, err := enc.DecryptWithContext(legacy, crypto.SecretAAD("any", "any", "luks"))
-	require.NoError(t, err)
-	assert.Equal(t, "old-secret", pt)
+	_, err = enc.DecryptWithContext(ct, crypto.RowAAD("01HROW", crypto.PurposeTOTPSecret))
+	require.Error(t, err)
 }
 
 func TestDecryptWithContext_PlaintextPassthrough(t *testing.T) {
@@ -222,6 +191,10 @@ func TestDecryptWithContext_PlaintextPassthrough(t *testing.T) {
 	pt, err := enc.DecryptWithContext("not-encrypted", crypto.SecretAAD("d", "a", "luks"))
 	require.NoError(t, err)
 	assert.Equal(t, "not-encrypted", pt)
+
+	empty, err := enc.DecryptWithContext("", crypto.RowAAD("r", crypto.PurposeTOTPSecret))
+	require.NoError(t, err)
+	assert.Equal(t, "", empty, "the empty string round-trips (mirrors EncryptWithContext's empty passthrough)")
 }
 
 func TestDecryptWithContext_WrongKeyFails(t *testing.T) {
@@ -235,4 +208,33 @@ func TestDecryptWithContext_WrongKeyFails(t *testing.T) {
 	require.NoError(t, err)
 	_, err = encB.DecryptWithContext(ct, aad)
 	require.Error(t, err, "a different key must not open the ciphertext")
+}
+
+func TestDecryptWithContext_TooShortCiphertext(t *testing.T) {
+	enc, err := crypto.NewEncryptor(testKey())
+	require.NoError(t, err)
+	_, err = enc.DecryptWithContext("enc:v1:QQ==", crypto.RowAAD("r", crypto.PurposeTOTPSecret))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestDecryptWithContext_InvalidBase64(t *testing.T) {
+	enc, err := crypto.NewEncryptor(testKey())
+	require.NoError(t, err)
+	_, err = enc.DecryptWithContext("enc:v1:!!!not-base64!!!", crypto.RowAAD("r", crypto.PurposeTOTPSecret))
+	require.Error(t, err)
+}
+
+func TestNilEncryptor_Passthrough(t *testing.T) {
+	// nil encryptor means encryption is disabled (test setups only —
+	// production boot requires the key since WS11).
+	var enc *crypto.Encryptor
+
+	ct, err := enc.EncryptWithContext("hello", crypto.RowAAD("r", crypto.PurposeTOTPSecret))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", ct)
+
+	pt, err := enc.DecryptWithContext("hello", crypto.RowAAD("r", crypto.PurposeTOTPSecret))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", pt)
 }

--- a/internal/projectors/action_set_test.go
+++ b/internal/projectors/action_set_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -426,7 +426,7 @@ func TestActionSetListener_StaleMemberRemovedDoesNotWipeLiveMembership(t *testin
 	older := before.ProjectionVersion - 5
 	listener := projectors.ActionSetListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID: uuid.New(), SequenceNum: older,
+		ID: ulid.Make().String(), SequenceNum: older,
 		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberRemoved",
 		Data: jsonOrFail(t, map[string]any{"action_id": "act-A"}), ActorType: "user", ActorID: "u",
 	})
@@ -467,7 +467,7 @@ func TestActionSetListener_StaleMemberReorderedDoesNotClobberPosition(t *testing
 	older := before.ProjectionVersion - 5
 	listener := projectors.ActionSetListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID: uuid.New(), SequenceNum: older,
+		ID: ulid.Make().String(), SequenceNum: older,
 		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberReordered",
 		Data: jsonOrFail(t, map[string]any{"action_id": "act-A", "sort_order": 99}), ActorType: "user", ActorID: "u",
 	})
@@ -501,7 +501,7 @@ func TestActionSetListener_RecountAfterStaleEventStaysCorrect(t *testing.T) {
 	older := before.ProjectionVersion - 5
 	listener := projectors.ActionSetListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID: uuid.New(), SequenceNum: older,
+		ID: ulid.Make().String(), SequenceNum: older,
 		StreamType: "action_set", StreamID: setID, EventType: "ActionSetMemberAdded",
 		Data: jsonOrFail(t, map[string]any{"action_id": "act-STALE", "sort_order": 0}), ActorType: "user", ActorID: "u",
 	})
@@ -680,7 +680,7 @@ func TestActionSetListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 	staleAt := *live.CreatedAt
 	listener := projectors.ActionSetListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "action_set",
 		StreamID:    setID,
@@ -754,7 +754,7 @@ func TestActionSetListener_StaleMemberAddedDoesNotRecreateMembership(t *testing.
 	staleAt := *live.UpdatedAt
 	listener := projectors.ActionSetListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "action_set",
 		StreamID:    setID,

--- a/internal/projectors/action_test.go
+++ b/internal/projectors/action_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -466,7 +466,7 @@ func TestActionListener_StaleDeleteReplayDoesNotNukeCascade(t *testing.T) {
 	staleAt := *live.UpdatedAt
 	listener := projectors.ActionListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "action",
 		StreamID:    actionID,

--- a/internal/projectors/assignment_test.go
+++ b/internal/projectors/assignment_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -472,7 +472,7 @@ func TestAssignmentListener_StaleDeleteReplayDoesNotCascade(t *testing.T) {
 	staleAt := *live.CreatedAt
 	listener := projectors.AssignmentListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "assignment",
 		StreamID:    asnID,

--- a/internal/projectors/compliance_policy_test.go
+++ b/internal/projectors/compliance_policy_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -300,7 +300,7 @@ func createTestCompliancePolicy(t *testing.T, st *store.Store, actorID, name str
 // policies don't collide. Mirrors testutil.NewID() but lives here so
 // the helper file isn't dragged into testutil for one type.
 func newCompliancePolicyID() string {
-	return "cp-" + uuid.NewString()
+	return "cp-" + ulid.Make().String()
 }
 
 // TestCompliancePolicyListener_CreateRenameDescription covers the three
@@ -349,8 +349,8 @@ func TestCompliancePolicyListener_RuleLifecycle(t *testing.T) {
 	st := setupComplianceTestStore(t)
 	ctx := context.Background()
 	policyID := createTestCompliancePolicy(t, st, "u", "lifecycle")
-	actionA := "act-" + uuid.NewString()
-	actionB := "act-" + uuid.NewString()
+	actionA := "act-" + ulid.Make().String()
+	actionB := "act-" + ulid.Make().String()
 
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
@@ -412,7 +412,7 @@ func TestCompliancePolicyListener_RuleAddedUpsertReplacesFields(t *testing.T) {
 	st := setupComplianceTestStore(t)
 	ctx := context.Background()
 	policyID := createTestCompliancePolicy(t, st, "u", "upsert")
-	actionID := "act-" + uuid.NewString()
+	actionID := "act-" + ulid.Make().String()
 
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
@@ -450,7 +450,7 @@ func TestCompliancePolicyListener_RuleAddedPreservesActionNameOnEmptyReplay(t *t
 	st := setupComplianceTestStore(t)
 	ctx := context.Background()
 	policyID := createTestCompliancePolicy(t, st, "u", "preserve")
-	actionID := "act-" + uuid.NewString()
+	actionID := "act-" + ulid.Make().String()
 
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
@@ -488,8 +488,8 @@ func TestCompliancePolicyListener_DeleteCascadesRulesAndEvaluations(t *testing.T
 	st := setupComplianceTestStore(t)
 	ctx := context.Background()
 	policyID := createTestCompliancePolicy(t, st, "u", "to-delete")
-	actionID := "act-" + uuid.NewString()
-	deviceID := "dev-" + uuid.NewString()
+	actionID := "act-" + ulid.Make().String()
+	deviceID := "dev-" + ulid.Make().String()
 
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
@@ -547,9 +547,9 @@ func TestCompliancePolicyListener_RuleRemovedWipesEvaluations(t *testing.T) {
 	st := setupComplianceTestStore(t)
 	ctx := context.Background()
 	policyID := createTestCompliancePolicy(t, st, "u", "rule-removed-evals")
-	actionA := "act-" + uuid.NewString()
-	actionB := "act-" + uuid.NewString()
-	deviceID := "dev-" + uuid.NewString()
+	actionA := "act-" + ulid.Make().String()
+	actionB := "act-" + ulid.Make().String()
+	deviceID := "dev-" + ulid.Make().String()
 
 	for _, aid := range []string{actionA, actionB} {
 		require.NoError(t, st.AppendEvent(ctx, store.Event{
@@ -627,7 +627,7 @@ func TestCompliancePolicyListener_StaleDeleteReplayDoesNotNukeRules(t *testing.T
 	st := setupComplianceTestStore(t)
 	ctx := context.Background()
 	policyID := createTestCompliancePolicy(t, st, "u", "live-policy")
-	actionID := "act-" + uuid.NewString()
+	actionID := "act-" + ulid.Make().String()
 
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
@@ -644,7 +644,7 @@ func TestCompliancePolicyListener_StaleDeleteReplayDoesNotNukeRules(t *testing.T
 	older := live.ProjectionVersion - 5
 	listener := projectors.CompliancePolicyListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "compliance_policy",
 		StreamID:    policyID,
@@ -681,7 +681,7 @@ func TestCompliancePolicyListener_StaleRuleAddedDoesNotResurrectRemoved(t *testi
 	st := setupComplianceTestStore(t)
 	ctx := context.Background()
 	policyID := createTestCompliancePolicy(t, st, "u", "stale-rule-add")
-	actionID := "act-" + uuid.NewString()
+	actionID := "act-" + ulid.Make().String()
 
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
@@ -702,7 +702,7 @@ func TestCompliancePolicyListener_StaleRuleAddedDoesNotResurrectRemoved(t *testi
 	older := live.ProjectionVersion - 5
 	listener := projectors.CompliancePolicyListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "compliance_policy",
 		StreamID:    policyID,
@@ -734,7 +734,7 @@ func TestCompliancePolicyListener_StaleRuleUpdatedDoesNotChangeGrace(t *testing.
 	st := setupComplianceTestStore(t)
 	ctx := context.Background()
 	policyID := createTestCompliancePolicy(t, st, "u", "stale-rule-update")
-	actionID := "act-" + uuid.NewString()
+	actionID := "act-" + ulid.Make().String()
 
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "compliance_policy", StreamID: policyID, EventType: "CompliancePolicyRuleAdded",
@@ -754,7 +754,7 @@ func TestCompliancePolicyListener_StaleRuleUpdatedDoesNotChangeGrace(t *testing.
 	older := live.ProjectionVersion - 5
 	listener := projectors.CompliancePolicyListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "compliance_policy",
 		StreamID:    policyID,

--- a/internal/projectors/compliance_test.go
+++ b/internal/projectors/compliance_test.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -185,8 +185,8 @@ func appendComplianceResultUpdated(t *testing.T, st *store.Store, deviceID, acti
 func TestComplianceListener_UpsertLifecycle(t *testing.T) {
 	st := setupComplianceResultStore(t)
 	ctx := context.Background()
-	deviceID := "dev-" + uuid.NewString()
-	actionID := "act-" + uuid.NewString()
+	deviceID := "dev-" + ulid.Make().String()
+	actionID := "act-" + ulid.Make().String()
 
 	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
 		"device_id":        deviceID,
@@ -237,8 +237,8 @@ func TestComplianceListener_UpsertLifecycle(t *testing.T) {
 func TestComplianceListener_UpsertPreservesActionNameOnEmptyReplay(t *testing.T) {
 	st := setupComplianceResultStore(t)
 	ctx := context.Background()
-	deviceID := "dev-" + uuid.NewString()
-	actionID := "act-" + uuid.NewString()
+	deviceID := "dev-" + ulid.Make().String()
+	actionID := "act-" + ulid.Make().String()
 
 	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
 		"device_id":        deviceID,
@@ -270,8 +270,8 @@ func TestComplianceListener_UpsertPreservesActionNameOnEmptyReplay(t *testing.T)
 func TestComplianceListener_DeleteLifecycle(t *testing.T) {
 	st := setupComplianceResultStore(t)
 	ctx := context.Background()
-	deviceID := "dev-" + uuid.NewString()
-	actionID := "act-" + uuid.NewString()
+	deviceID := "dev-" + ulid.Make().String()
+	actionID := "act-" + ulid.Make().String()
 
 	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
 		"device_id":   deviceID,
@@ -309,8 +309,8 @@ func TestComplianceListener_DeleteLifecycle(t *testing.T) {
 func TestComplianceListener_StaleUpdateRejected(t *testing.T) {
 	st := setupComplianceResultStore(t)
 	ctx := context.Background()
-	deviceID := "dev-" + uuid.NewString()
-	actionID := "act-" + uuid.NewString()
+	deviceID := "dev-" + ulid.Make().String()
+	actionID := "act-" + ulid.Make().String()
 
 	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
 		"device_id":   deviceID,
@@ -330,7 +330,7 @@ func TestComplianceListener_StaleUpdateRejected(t *testing.T) {
 	older := currentVersion - 5
 	listener := projectors.ComplianceListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "compliance",
 		StreamID:    deviceID + "_" + actionID,
@@ -366,8 +366,8 @@ func TestComplianceListener_StaleUpdateRejected(t *testing.T) {
 func TestComplianceListener_StaleRemovedDoesNotWipeRevivedRow(t *testing.T) {
 	st := setupComplianceResultStore(t)
 	ctx := context.Background()
-	deviceID := "dev-" + uuid.NewString()
-	actionID := "act-" + uuid.NewString()
+	deviceID := "dev-" + ulid.Make().String()
+	actionID := "act-" + ulid.Make().String()
 
 	appendComplianceResultUpdated(t, st, deviceID, actionID, map[string]any{
 		"device_id":   deviceID,
@@ -407,7 +407,7 @@ func TestComplianceListener_StaleRemovedDoesNotWipeRevivedRow(t *testing.T) {
 	// Drive the listener directly with the OLDER Removed sequence.
 	listener := projectors.ComplianceListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: staleRemovedSeq,
 		StreamType:  "compliance",
 		StreamID:    deviceID + "_" + actionID,
@@ -433,8 +433,8 @@ func TestComplianceListener_StaleRemovedDoesNotWipeRevivedRow(t *testing.T) {
 func TestComplianceListener_IgnoresWrongStreamType(t *testing.T) {
 	st := setupComplianceResultStore(t)
 	ctx := context.Background()
-	deviceID := "dev-" + uuid.NewString()
-	actionID := "act-" + uuid.NewString()
+	deviceID := "dev-" + ulid.Make().String()
+	actionID := "act-" + ulid.Make().String()
 
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "device", // wrong stream

--- a/internal/projectors/definition_test.go
+++ b/internal/projectors/definition_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -422,7 +422,7 @@ func TestDefinitionListener_StaleMemberAddedDoesNotRecreateMembership(t *testing
 	staleAt := *live.UpdatedAt
 	listener := projectors.ActionListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "definition",
 		StreamID:    defID,

--- a/internal/projectors/device_group_test.go
+++ b/internal/projectors/device_group_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -638,7 +638,7 @@ func TestDeviceGroupListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 	staleAt := *live.CreatedAt
 	listener := projectors.DeviceGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "device_group",
 		StreamID:    groupID,
@@ -692,7 +692,7 @@ func TestDeviceGroupListener_StaleQueryUpdatedDoesNotNukeMembers(t *testing.T) {
 	staleAt := *live.CreatedAt
 	listener := projectors.DeviceGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "device_group",
 		StreamID:    groupID,
@@ -758,7 +758,7 @@ func TestDeviceGroupListener_StaleMemberAddedDoesNotRecreateMembership(t *testin
 	staleAt := *live.CreatedAt
 	listener := projectors.DeviceGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "device_group",
 		StreamID:    groupID,

--- a/internal/projectors/device_test.go
+++ b/internal/projectors/device_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -679,7 +679,7 @@ func TestDeviceListener_StaleDeleteReplayDoesNotNukeAssignments(t *testing.T) {
 	staleAt := *live.RegisteredAt
 	listener := projectors.DeviceListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "device",
 		StreamID:    deviceID,
@@ -763,7 +763,7 @@ func TestDeviceListener_StaleUnassignedAfterReAssignDoesNotWipeRow(t *testing.T)
 	staleAt := *getDeviceRegisteredAt(t, st, ctx, deviceID)
 	listener := projectors.DeviceListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: stale,
 		StreamType:  "device",
 		StreamID:    deviceID,

--- a/internal/projectors/execution_test.go
+++ b/internal/projectors/execution_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -556,7 +556,7 @@ func TestExecutionListener_StaleReplayRejected(t *testing.T) {
 	older := currentVersion - 5
 	listener := projectors.ExecutionListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "execution",
 		StreamID:    execID,

--- a/internal/projectors/identity_provider_test.go
+++ b/internal/projectors/identity_provider_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -434,7 +434,7 @@ func TestIdentityProviderListener_StaleDeleteReplay(t *testing.T) {
 	older := live.ProjectionVersion - 5
 	listener := projectors.IdentityProviderListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "identity_provider",
 		StreamID:    idpID,

--- a/internal/projectors/lps_password_listener.go
+++ b/internal/projectors/lps_password_listener.go
@@ -135,6 +135,9 @@ func ApplyLpsPassword(ctx context.Context, q *store.Queries, e store.PersistedEv
 		}
 	}
 	if err := q.InsertLpsPassword(ctx, db.InsertLpsPasswordParams{
+		// The rotating event's ULID: deterministic under replay
+		// (F-15 / spec 20) — a rebuild reproduces the same row id.
+		ID:                e.ID,
 		DeviceID:          payload.DeviceID,
 		ActionID:          payload.ActionID,
 		Username:          payload.Username,

--- a/internal/projectors/lps_password_listener.go
+++ b/internal/projectors/lps_password_listener.go
@@ -145,6 +145,9 @@ func ApplyLpsPassword(ctx context.Context, q *store.Queries, e store.PersistedEv
 		RotatedAt:         payload.RotatedAt,
 		RotationReason:    payload.RotationReason,
 		ProjectionVersion: projVer,
+		// created_at from the event, not now(): a rebuild must
+		// reproduce the row byte-identically (spec 21 AC 6).
+		CreatedAt: e.OccurredAt,
 	}); err != nil {
 		return err
 	}

--- a/internal/projectors/luks_key_listener.go
+++ b/internal/projectors/luks_key_listener.go
@@ -150,6 +150,9 @@ func applyLuksKeyRotated(ctx context.Context, q *store.Queries, e store.Persiste
 		}
 	}
 	if err := q.InsertLuksKey(ctx, db.InsertLuksKeyParams{
+		// The rotating event's ULID: deterministic under replay
+		// (F-15 / spec 20) — a rebuild reproduces the same row id.
+		ID:                e.ID,
 		DeviceID:          payload.DeviceID,
 		ActionID:          payload.ActionID,
 		DevicePath:        payload.DevicePath,

--- a/internal/projectors/luks_key_listener.go
+++ b/internal/projectors/luks_key_listener.go
@@ -160,6 +160,9 @@ func applyLuksKeyRotated(ctx context.Context, q *store.Queries, e store.Persiste
 		RotatedAt:         payload.RotatedAt,
 		RotationReason:    payload.RotationReason,
 		ProjectionVersion: projVer,
+		// created_at from the event, not now(): a rebuild must
+		// reproduce the row byte-identically (spec 21 AC 6).
+		CreatedAt: e.OccurredAt,
 	}); err != nil {
 		return err
 	}

--- a/internal/projectors/role_test.go
+++ b/internal/projectors/role_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -353,7 +353,7 @@ func TestRoleListener_StaleDeleteReplayDoesNotNukeMemberships(t *testing.T) {
 	staleAt := live.CreatedAt
 	listener := projectors.RoleListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "role",
 		StreamID:    roleID,

--- a/internal/projectors/security_alert.go
+++ b/internal/projectors/security_alert.go
@@ -24,8 +24,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/google/uuid"
-
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -98,16 +96,12 @@ func SecurityAlertAckParamsFromEvent(e store.PersistedEvent) (db.AcknowledgeSecu
 			fmt.Errorf("projector: invalid SecurityAlertAcknowledged payload: %w", err)
 	}
 
-	alertID, err := uuid.Parse(data.AlertID)
-	if err != nil {
-		return db.AcknowledgeSecurityAlertProjectionParams{},
-			fmt.Errorf("projector: invalid alert_id %q in SecurityAlertAcknowledged: %w", data.AlertID, err)
-	}
+	alertID := data.AlertID
 
 	occurredAt := e.OccurredAt
 	ackBy := data.AcknowledgedBy
 	return db.AcknowledgeSecurityAlertProjectionParams{
-		Column1:        alertID,
+		EventID:        alertID,
 		AcknowledgedAt: &occurredAt,
 		AcknowledgedBy: &ackBy,
 	}, nil

--- a/internal/projectors/security_alert.go
+++ b/internal/projectors/security_alert.go
@@ -24,6 +24,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/oklog/ulid/v2"
+
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -77,11 +79,10 @@ func SecurityAlertProjectionFromEvent(e store.PersistedEvent) (db.InsertSecurity
 // apply a `SecurityAlertAcknowledged` event to the projection.
 // Same purity contract as SecurityAlertProjectionFromEvent.
 //
-// alert_id arrives as a string in the event data and must round-trip
-// to a UUID for the WHERE clause to hit the primary-key index. A
-// malformed UUID is propagated as a validation error rather than
-// silently full-scanning and matching nothing — matches the deleted
-// PL/pgSQL projector's `(event.data->>'alert_id')::uuid` behaviour.
+// alert_id is the raising event's ULID (F-15 / spec 20). A malformed
+// id is propagated as a validation error rather than silently matching
+// nothing in the WHERE clause — the same fail-loud contract the
+// retired `(event.data->>'alert_id')::uuid` cast enforced.
 func SecurityAlertAckParamsFromEvent(e store.PersistedEvent) (db.AcknowledgeSecurityAlertProjectionParams, error) {
 	if e.StreamType != "device" || e.EventType != string(eventtypes.SecurityAlertAcknowledged) {
 		return db.AcknowledgeSecurityAlertProjectionParams{}, ErrIgnoredEvent
@@ -97,6 +98,10 @@ func SecurityAlertAckParamsFromEvent(e store.PersistedEvent) (db.AcknowledgeSecu
 	}
 
 	alertID := data.AlertID
+	if _, err := ulid.Parse(alertID); err != nil {
+		return db.AcknowledgeSecurityAlertProjectionParams{},
+			fmt.Errorf("projector: invalid alert_id %q in SecurityAlertAcknowledged: %w", alertID, err)
+	}
 
 	occurredAt := e.OccurredAt
 	ackBy := data.AcknowledgedBy

--- a/internal/projectors/security_alert.go
+++ b/internal/projectors/security_alert.go
@@ -72,6 +72,9 @@ func SecurityAlertProjectionFromEvent(e store.PersistedEvent) (db.InsertSecurity
 		Message:   data.Message,
 		Details:   []byte(data.Details),
 		RaisedAt:  e.OccurredAt,
+		// created_at from the event, not now(): a rebuild must
+		// reproduce the row byte-identically (spec 21 AC 6).
+		CreatedAt: e.OccurredAt,
 	}, nil
 }
 

--- a/internal/projectors/security_alert_test.go
+++ b/internal/projectors/security_alert_test.go
@@ -87,7 +87,7 @@ func TestSecurityAlertProjectionFromEvent_Pure(t *testing.T) {
 }
 
 func TestSecurityAlertAckParamsFromEvent_Pure(t *testing.T) {
-	alertID := "01J222222222222222222222222222"
+	alertID := "01J22222222222222222222222" // valid 26-char ULID
 	occurredAt := time.Date(2026, 5, 4, 13, 0, 0, 0, time.UTC)
 
 	t.Run("happy path", func(t *testing.T) {

--- a/internal/projectors/security_alert_test.go
+++ b/internal/projectors/security_alert_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -24,7 +23,7 @@ import (
 // share this function so they cannot diverge.
 func TestSecurityAlertProjectionFromEvent_Pure(t *testing.T) {
 	occurredAt := time.Date(2026, 5, 4, 12, 0, 0, 0, time.UTC)
-	eventID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	eventID := "01J111111111111111111111111111"
 
 	t.Run("happy path with all fields", func(t *testing.T) {
 		payload, _ := json.Marshal(map[string]any{
@@ -88,12 +87,12 @@ func TestSecurityAlertProjectionFromEvent_Pure(t *testing.T) {
 }
 
 func TestSecurityAlertAckParamsFromEvent_Pure(t *testing.T) {
-	alertID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	alertID := "01J222222222222222222222222222"
 	occurredAt := time.Date(2026, 5, 4, 13, 0, 0, 0, time.UTC)
 
 	t.Run("happy path", func(t *testing.T) {
 		payload, _ := json.Marshal(map[string]any{
-			"alert_id":        alertID.String(),
+			"alert_id":        alertID,
 			"acknowledged_by": "admin@example.com",
 		})
 		got, err := projectors.SecurityAlertAckParamsFromEvent(store.PersistedEvent{
@@ -101,7 +100,7 @@ func TestSecurityAlertAckParamsFromEvent_Pure(t *testing.T) {
 			Data: payload, OccurredAt: occurredAt,
 		})
 		require.NoError(t, err)
-		assert.Equal(t, alertID, got.Column1)
+		assert.Equal(t, alertID, got.EventID)
 		require.NotNil(t, got.AcknowledgedAt)
 		assert.Equal(t, occurredAt, *got.AcknowledgedAt)
 		require.NotNil(t, got.AcknowledgedBy)
@@ -186,7 +185,7 @@ func TestSecurityAlertListener_EndToEnd(t *testing.T) {
 		StreamID:   deviceID,
 		EventType:  "SecurityAlertAcknowledged",
 		Data: map[string]any{
-			"alert_id":        got.EventID.String(),
+			"alert_id":        got.EventID,
 			"acknowledged_by": "ops@example.com",
 		},
 		ActorType: "user",

--- a/internal/projectors/totp_test.go
+++ b/internal/projectors/totp_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -263,4 +262,3 @@ func pollForUserTotpEnabled(t *testing.T, st *store.Store, userID string, want b
 // future edit accidentally removes them from the test bodies.
 var _ = json.Marshal
 var _ = errors.Is
-var _ = uuid.New

--- a/internal/projectors/user_group_test.go
+++ b/internal/projectors/user_group_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -737,7 +737,7 @@ func TestUserGroupListener_StaleDeleteReplayDoesNotNukeMembers(t *testing.T) {
 	older := live.ProjectionVersion - 5
 	listener := projectors.UserGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "user_group",
 		StreamID:    groupID,
@@ -795,7 +795,7 @@ func TestUserGroupListener_StaleMemberAddedDoesNotRecreateMembership(t *testing.
 	older := live.ProjectionVersion - 5
 	listener := projectors.UserGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "user_group",
 		StreamID:    groupID + ":" + userID,
@@ -849,7 +849,7 @@ func TestUserGroupListener_StaleMembersRebuiltDoesNotOverwrite(t *testing.T) {
 	older := live.ProjectionVersion - 5
 	listener := projectors.UserGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "user_group",
 		StreamID:    groupID,
@@ -932,7 +932,7 @@ func TestUserGroupListener_StaleRoleAssignedDoesNotReinsertRevoked(t *testing.T)
 	older := live.ProjectionVersion - 5
 	listener := projectors.UserGroupListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "user_group",
 		StreamID:    groupID + ":role:" + roleID,

--- a/internal/projectors/user_test.go
+++ b/internal/projectors/user_test.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -746,7 +746,7 @@ func TestUserListener_StaleDeleteReplayDoesNotNukeIdentityLinks(t *testing.T) {
 	staleAt := *live.CreatedAt
 	listener := projectors.UserListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: older,
 		StreamType:  "user",
 		StreamID:    userID,
@@ -820,7 +820,7 @@ func TestUserListener_StaleDisableAfterReEnableKeepsSessionMonotonic(t *testing.
 	// changes.
 	listener := projectors.UserListener(st, slog.Default())
 	listener(ctx, store.PersistedEvent{
-		ID:          uuid.New(),
+		ID:          ulid.Make().String(),
 		SequenceNum: staleVer,
 		StreamType:  "user",
 		StreamID:    userID,

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/oklog/ulid/v2"
 	"github.com/redis/go-redis/v9"
 
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -1382,7 +1381,7 @@ func (idx *Index) warmAuditEvents(ctx context.Context) (int, error) {
 
 		pipe := idx.rdb.Pipeline()
 		for _, e := range events {
-			id := ulid.ULID(e.ID).String()
+			id := e.ID
 			eventFields := map[string]any{
 				"event_type":  e.EventType,
 				"stream_type": e.StreamType,

--- a/internal/store/generated/events.sql.go
+++ b/internal/store/generated/events.sql.go
@@ -11,16 +11,17 @@ import (
 
 const appendEvent = `-- name: AppendEvent :one
 INSERT INTO events (
-    stream_type, stream_id, stream_version,
+    id, stream_type, stream_id, stream_version,
     event_type, data, metadata,
     actor_type, actor_id
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
 )
 RETURNING id, sequence_num, stream_type, stream_id, stream_version, event_type, data, metadata, actor_type, actor_id, occurred_at
 `
 
 type AppendEventParams struct {
+	ID            string `json:"id"`
 	StreamType    string `json:"stream_type"`
 	StreamID      string `json:"stream_id"`
 	StreamVersion int32  `json:"stream_version"`
@@ -31,8 +32,11 @@ type AppendEventParams struct {
 	ActorID       string `json:"actor_id"`
 }
 
+// id is a ULID minted in Go (F-15 / spec 20) — the DB never mints a
+// random identifier.
 func (q *Queries) AppendEvent(ctx context.Context, arg AppendEventParams) (Event, error) {
 	row := q.db.QueryRow(ctx, appendEvent,
+		arg.ID,
 		arg.StreamType,
 		arg.StreamID,
 		arg.StreamVersion,

--- a/internal/store/generated/lps.sql.go
+++ b/internal/store/generated/lps.sql.go
@@ -96,8 +96,8 @@ func (q *Queries) GetLpsPasswordHistory(ctx context.Context, deviceID string) ([
 
 const insertLpsPassword = `-- name: InsertLpsPassword :exec
 INSERT INTO lps_passwords_projection
-    (id, device_id, action_id, username, password, rotated_at, rotation_reason, projection_version)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    (id, device_id, action_id, username, password, rotated_at, rotation_reason, projection_version, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 `
 
 type InsertLpsPasswordParams struct {
@@ -109,6 +109,7 @@ type InsertLpsPasswordParams struct {
 	RotatedAt         time.Time `json:"rotated_at"`
 	RotationReason    string    `json:"rotation_reason"`
 	ProjectionVersion int64     `json:"projection_version"`
+	CreatedAt         time.Time `json:"created_at"`
 }
 
 // Step 2 of LpsPasswordRotated projection. Inserts the new row only
@@ -129,6 +130,7 @@ func (q *Queries) InsertLpsPassword(ctx context.Context, arg InsertLpsPasswordPa
 		arg.RotatedAt,
 		arg.RotationReason,
 		arg.ProjectionVersion,
+		arg.CreatedAt,
 	)
 	return err
 }

--- a/internal/store/generated/lps.sql.go
+++ b/internal/store/generated/lps.sql.go
@@ -96,11 +96,12 @@ func (q *Queries) GetLpsPasswordHistory(ctx context.Context, deviceID string) ([
 
 const insertLpsPassword = `-- name: InsertLpsPassword :exec
 INSERT INTO lps_passwords_projection
-    (device_id, action_id, username, password, rotated_at, rotation_reason, projection_version)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+    (id, device_id, action_id, username, password, rotated_at, rotation_reason, projection_version)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 `
 
 type InsertLpsPasswordParams struct {
+	ID                string    `json:"id"`
 	DeviceID          string    `json:"device_id"`
 	ActionID          string    `json:"action_id"`
 	Username          string    `json:"username"`
@@ -116,8 +117,11 @@ type InsertLpsPasswordParams struct {
 // short-circuits when n==0, so this insert never runs against a
 // stale event. projection_version on the new row is the same
 // sequence_num that just guarded step 1.
+// id is the rotating event's ULID (F-15 / spec 20) — deterministic
+// under replay, supplied by the projector.
 func (q *Queries) InsertLpsPassword(ctx context.Context, arg InsertLpsPasswordParams) error {
 	_, err := q.db.Exec(ctx, insertLpsPassword,
+		arg.ID,
 		arg.DeviceID,
 		arg.ActionID,
 		arg.Username,

--- a/internal/store/generated/luks.sql.go
+++ b/internal/store/generated/luks.sql.go
@@ -11,12 +11,13 @@ import (
 )
 
 const createLuksToken = `-- name: CreateLuksToken :one
-INSERT INTO luks_tokens (device_id, action_id, token, min_length, complexity, expires_at)
-VALUES ($1, $2, $3, $4, $5, NOW() + INTERVAL '15 minutes')
+INSERT INTO luks_tokens (id, device_id, action_id, token, min_length, complexity, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6, NOW() + INTERVAL '15 minutes')
 RETURNING id, device_id, action_id, token, min_length, complexity, created_at, expires_at, used
 `
 
 type CreateLuksTokenParams struct {
+	ID         string `json:"id"`
 	DeviceID   string `json:"device_id"`
 	ActionID   string `json:"action_id"`
 	Token      string `json:"token"`
@@ -24,8 +25,10 @@ type CreateLuksTokenParams struct {
 	Complexity int32  `json:"complexity"`
 }
 
+// id is a ULID minted in Go (F-15 / spec 20).
 func (q *Queries) CreateLuksToken(ctx context.Context, arg CreateLuksTokenParams) (LuksToken, error) {
 	row := q.db.QueryRow(ctx, createLuksToken,
+		arg.ID,
 		arg.DeviceID,
 		arg.ActionID,
 		arg.Token,
@@ -172,11 +175,12 @@ func (q *Queries) GetLuksKeyHistory(ctx context.Context, deviceID string) ([]Luk
 
 const insertLuksKey = `-- name: InsertLuksKey :exec
 INSERT INTO luks_keys_projection
-    (device_id, action_id, device_path, passphrase, rotated_at, rotation_reason, projection_version)
-VALUES ($1, $2, $3, $4, $5, $6, $7)
+    (id, device_id, action_id, device_path, passphrase, rotated_at, rotation_reason, projection_version)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 `
 
 type InsertLuksKeyParams struct {
+	ID                string    `json:"id"`
 	DeviceID          string    `json:"device_id"`
 	ActionID          string    `json:"action_id"`
 	DevicePath        string    `json:"device_path"`
@@ -192,8 +196,11 @@ type InsertLuksKeyParams struct {
 // and a sibling row already exists, so this insert never runs against
 // a stale event. projection_version on the new row is the same
 // sequence_num that just guarded step 1.
+// id is the rotating event's ULID (F-15 / spec 20) — deterministic
+// under replay, supplied by the projector.
 func (q *Queries) InsertLuksKey(ctx context.Context, arg InsertLuksKeyParams) error {
 	_, err := q.db.Exec(ctx, insertLuksKey,
+		arg.ID,
 		arg.DeviceID,
 		arg.ActionID,
 		arg.DevicePath,

--- a/internal/store/generated/luks.sql.go
+++ b/internal/store/generated/luks.sql.go
@@ -175,8 +175,8 @@ func (q *Queries) GetLuksKeyHistory(ctx context.Context, deviceID string) ([]Luk
 
 const insertLuksKey = `-- name: InsertLuksKey :exec
 INSERT INTO luks_keys_projection
-    (id, device_id, action_id, device_path, passphrase, rotated_at, rotation_reason, projection_version)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+    (id, device_id, action_id, device_path, passphrase, rotated_at, rotation_reason, projection_version, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 `
 
 type InsertLuksKeyParams struct {
@@ -188,6 +188,7 @@ type InsertLuksKeyParams struct {
 	RotatedAt         time.Time `json:"rotated_at"`
 	RotationReason    string    `json:"rotation_reason"`
 	ProjectionVersion int64     `json:"projection_version"`
+	CreatedAt         time.Time `json:"created_at"`
 }
 
 // Step 2 of LuksKeyRotated projection. Inserts the new row only when
@@ -208,6 +209,7 @@ func (q *Queries) InsertLuksKey(ctx context.Context, arg InsertLuksKeyParams) er
 		arg.RotatedAt,
 		arg.RotationReason,
 		arg.ProjectionVersion,
+		arg.CreatedAt,
 	)
 	return err
 }

--- a/internal/store/generated/models.go
+++ b/internal/store/generated/models.go
@@ -7,7 +7,6 @@ package generated
 import (
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
@@ -219,7 +218,7 @@ type DynamicUserGroupEvaluationQueue struct {
 }
 
 type Event struct {
-	ID            uuid.UUID `json:"id"`
+	ID            string    `json:"id"`
 	SequenceNum   int64     `json:"sequence_num"`
 	StreamType    string    `json:"stream_type"`
 	StreamID      string    `json:"stream_id"`
@@ -318,7 +317,7 @@ type LpsKeypair struct {
 }
 
 type LpsPasswordsProjection struct {
-	ID                uuid.UUID `json:"id"`
+	ID                string    `json:"id"`
 	DeviceID          string    `json:"device_id"`
 	ActionID          string    `json:"action_id"`
 	Username          string    `json:"username"`
@@ -331,7 +330,7 @@ type LpsPasswordsProjection struct {
 }
 
 type LuksKeysProjection struct {
-	ID                uuid.UUID  `json:"id"`
+	ID                string     `json:"id"`
 	DeviceID          string     `json:"device_id"`
 	ActionID          string     `json:"action_id"`
 	DevicePath        string     `json:"device_path"`
@@ -347,7 +346,7 @@ type LuksKeysProjection struct {
 }
 
 type LuksToken struct {
-	ID         uuid.UUID `json:"id"`
+	ID         string    `json:"id"`
 	DeviceID   string    `json:"device_id"`
 	ActionID   string    `json:"action_id"`
 	Token      string    `json:"token"`
@@ -400,7 +399,7 @@ type ScimGroupMappingProjection struct {
 }
 
 type SecurityAlertsProjection struct {
-	EventID        uuid.UUID  `json:"event_id"`
+	EventID        string     `json:"event_id"`
 	DeviceID       string     `json:"device_id"`
 	AlertType      string     `json:"alert_type"`
 	Message        string     `json:"message"`

--- a/internal/store/generated/security_alerts.sql.go
+++ b/internal/store/generated/security_alerts.sql.go
@@ -113,8 +113,8 @@ func (q *Queries) GetSecurityAlert(ctx context.Context, eventID string) (GetSecu
 
 const insertSecurityAlertProjection = `-- name: InsertSecurityAlertProjection :exec
 INSERT INTO security_alerts_projection (
-    event_id, device_id, alert_type, message, details, raised_at
-) VALUES ($1, $2, $3, $4, $5, $6)
+    event_id, device_id, alert_type, message, details, raised_at, created_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (event_id) DO NOTHING
 `
 
@@ -125,6 +125,7 @@ type InsertSecurityAlertProjectionParams struct {
 	Message   string    `json:"message"`
 	Details   []byte    `json:"details"`
 	RaisedAt  time.Time `json:"raised_at"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // Write-side queries for the Go projector that replaced
@@ -140,6 +141,7 @@ func (q *Queries) InsertSecurityAlertProjection(ctx context.Context, arg InsertS
 		arg.Message,
 		arg.Details,
 		arg.RaisedAt,
+		arg.CreatedAt,
 	)
 	return err
 }

--- a/internal/store/generated/security_alerts.sql.go
+++ b/internal/store/generated/security_alerts.sql.go
@@ -8,8 +8,6 @@ package generated
 import (
 	"context"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 const acknowledgeSecurityAlertProjection = `-- name: AcknowledgeSecurityAlertProjection :execrows
@@ -17,11 +15,11 @@ UPDATE security_alerts_projection
 SET acknowledged = TRUE,
     acknowledged_at = $2,
     acknowledged_by = $3
-WHERE event_id = $1::uuid
+WHERE event_id = $1
 `
 
 type AcknowledgeSecurityAlertProjectionParams struct {
-	Column1        uuid.UUID  `json:"column_1"`
+	EventID        string     `json:"event_id"`
 	AcknowledgedAt *time.Time `json:"acknowledged_at"`
 	AcknowledgedBy *string    `json:"acknowledged_by"`
 }
@@ -32,7 +30,7 @@ type AcknowledgeSecurityAlertProjectionParams struct {
 // log it for operator visibility — matching the RAISE EXCEPTION
 // contract the deleted PL/pgSQL projector had.
 func (q *Queries) AcknowledgeSecurityAlertProjection(ctx context.Context, arg AcknowledgeSecurityAlertProjectionParams) (int64, error) {
-	result, err := q.db.Exec(ctx, acknowledgeSecurityAlertProjection, arg.Column1, arg.AcknowledgedAt, arg.AcknowledgedBy)
+	result, err := q.db.Exec(ctx, acknowledgeSecurityAlertProjection, arg.EventID, arg.AcknowledgedAt, arg.AcknowledgedBy)
 	if err != nil {
 		return 0, err
 	}
@@ -85,7 +83,7 @@ WHERE event_id = $1
 `
 
 type GetSecurityAlertRow struct {
-	EventID        uuid.UUID  `json:"event_id"`
+	EventID        string     `json:"event_id"`
 	DeviceID       string     `json:"device_id"`
 	AlertType      string     `json:"alert_type"`
 	Message        string     `json:"message"`
@@ -96,7 +94,7 @@ type GetSecurityAlertRow struct {
 	AcknowledgedBy *string    `json:"acknowledged_by"`
 }
 
-func (q *Queries) GetSecurityAlert(ctx context.Context, eventID uuid.UUID) (GetSecurityAlertRow, error) {
+func (q *Queries) GetSecurityAlert(ctx context.Context, eventID string) (GetSecurityAlertRow, error) {
 	row := q.db.QueryRow(ctx, getSecurityAlert, eventID)
 	var i GetSecurityAlertRow
 	err := row.Scan(
@@ -121,7 +119,7 @@ ON CONFLICT (event_id) DO NOTHING
 `
 
 type InsertSecurityAlertProjectionParams struct {
-	EventID   uuid.UUID `json:"event_id"`
+	EventID   string    `json:"event_id"`
 	DeviceID  string    `json:"device_id"`
 	AlertType string    `json:"alert_type"`
 	Message   string    `json:"message"`
@@ -166,7 +164,7 @@ type ListSecurityAlertsForDeviceParams struct {
 }
 
 type ListSecurityAlertsForDeviceRow struct {
-	EventID        uuid.UUID  `json:"event_id"`
+	EventID        string     `json:"event_id"`
 	DeviceID       string     `json:"device_id"`
 	AlertType      string     `json:"alert_type"`
 	Message        string     `json:"message"`
@@ -237,7 +235,7 @@ type ListUnacknowledgedSecurityAlertsParams struct {
 }
 
 type ListUnacknowledgedSecurityAlertsRow struct {
-	EventID        uuid.UUID  `json:"event_id"`
+	EventID        string     `json:"event_id"`
 	DeviceID       string     `json:"device_id"`
 	AlertType      string     `json:"alert_type"`
 	Message        string     `json:"message"`

--- a/internal/store/luks.go
+++ b/internal/store/luks.go
@@ -3,15 +3,13 @@ package store
 import (
 	"context"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // LuksKey is one rotated LUKS passphrase record for a (device,
 // action) pair. Passphrase is the decrypted secret — same blast-
 // radius rule as LPS: treat values as sensitive in callers.
 type LuksKey struct {
-	ID               uuid.UUID
+	ID               string
 	DeviceID         string
 	ActionID         string
 	DevicePath       string
@@ -29,7 +27,7 @@ type LuksKey struct {
 // when retrieving the current LUKS key. Tokens carry the minimum
 // password requirements the rotation must satisfy.
 type LuksToken struct {
-	ID         uuid.UUID
+	ID         string
 	DeviceID   string
 	ActionID   string
 	Token      string

--- a/internal/store/migrations/002_event_store.sql
+++ b/internal/store/migrations/002_event_store.sql
@@ -17,7 +17,10 @@
 --
 
 CREATE TABLE public.events (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    -- ULID minted in Go by AppendEvent (F-15 / spec 20): the DB never
+    -- mints a random identifier, so an event row is fully determined
+    -- by its insert and replay-derived state can reference it stably.
+    id text NOT NULL,
     sequence_num bigint NOT NULL,
     stream_type text NOT NULL,
     stream_id text NOT NULL,

--- a/internal/store/migrations/004_devices.sql
+++ b/internal/store/migrations/004_devices.sql
@@ -87,7 +87,9 @@ CREATE TABLE public.log_query_results (
 --
 
 CREATE TABLE public.lps_passwords_projection (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    -- The rotating event's ULID (F-15 / spec 20): deterministic under
+    -- replay, supplied by the projector, never DB-minted.
+    id text NOT NULL,
     device_id text NOT NULL,
     action_id text NOT NULL,
     username text NOT NULL,
@@ -104,7 +106,9 @@ CREATE TABLE public.lps_passwords_projection (
 --
 
 CREATE TABLE public.luks_keys_projection (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    -- The rotating event's ULID (F-15 / spec 20): deterministic under
+    -- replay, supplied by the projector, never DB-minted.
+    id text NOT NULL,
     device_id text NOT NULL,
     action_id text NOT NULL,
     device_path text NOT NULL,
@@ -124,7 +128,8 @@ CREATE TABLE public.luks_keys_projection (
 --
 
 CREATE TABLE public.luks_tokens (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    -- ULID minted in Go at token creation (F-15 / spec 20).
+    id text NOT NULL,
     device_id text NOT NULL,
     action_id text NOT NULL,
     token text NOT NULL,
@@ -156,7 +161,8 @@ CREATE TABLE public.osquery_results (
 --
 
 CREATE TABLE public.security_alerts_projection (
-    event_id uuid NOT NULL,
+    -- The raising event's ULID (F-15 / spec 20).
+    event_id text NOT NULL,
     device_id text NOT NULL,
     alert_type text NOT NULL,
     message text NOT NULL,

--- a/internal/store/postgres/lps.go
+++ b/internal/store/postgres/lps.go
@@ -44,7 +44,7 @@ func (l *Lps) ListHistory(ctx context.Context, deviceID string) ([]store.LpsPass
 
 func lpsFromRow(r generated.LpsPasswordsProjection) store.LpsPassword {
 	return store.LpsPassword{
-		ID:             r.ID.String(),
+		ID:             r.ID,
 		DeviceID:       r.DeviceID,
 		ActionID:       r.ActionID,
 		Username:       r.Username,

--- a/internal/store/postgres/luks.go
+++ b/internal/store/postgres/luks.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/oklog/ulid/v2"
+
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -57,6 +59,7 @@ func (l *Luks) GetCurrentForAction(ctx context.Context, key store.LuksKeyByActio
 
 func (l *Luks) CreateToken(ctx context.Context, p store.CreateLuksTokenParams) (store.LuksToken, error) {
 	row, err := l.q.CreateLuksToken(ctx, generated.CreateLuksTokenParams{
+		ID:         ulid.Make().String(),
 		DeviceID:   p.DeviceID,
 		ActionID:   p.ActionID,
 		Token:      p.Token,

--- a/internal/store/queries/events.sql
+++ b/internal/store/queries/events.sql
@@ -1,10 +1,12 @@
 -- name: AppendEvent :one
+-- id is a ULID minted in Go (F-15 / spec 20) — the DB never mints a
+-- random identifier.
 INSERT INTO events (
-    stream_type, stream_id, stream_version,
+    id, stream_type, stream_id, stream_version,
     event_type, data, metadata,
     actor_type, actor_id
 ) VALUES (
-    $1, $2, $3, $4, $5, $6, $7, $8
+    $1, $2, $3, $4, $5, $6, $7, $8, $9
 )
 RETURNING *;
 

--- a/internal/store/queries/lps.sql
+++ b/internal/store/queries/lps.sql
@@ -42,8 +42,8 @@ WHERE device_id = $1
 -- id is the rotating event's ULID (F-15 / spec 20) — deterministic
 -- under replay, supplied by the projector.
 INSERT INTO lps_passwords_projection
-    (id, device_id, action_id, username, password, rotated_at, rotation_reason, projection_version)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8);
+    (id, device_id, action_id, username, password, rotated_at, rotation_reason, projection_version, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);
 
 -- name: LpsPasswordExistsForDeviceUsername :one
 -- Companion to the asymmetric stale-replay guard in

--- a/internal/store/queries/lps.sql
+++ b/internal/store/queries/lps.sql
@@ -39,9 +39,11 @@ WHERE device_id = $1
 -- short-circuits when n==0, so this insert never runs against a
 -- stale event. projection_version on the new row is the same
 -- sequence_num that just guarded step 1.
+-- id is the rotating event's ULID (F-15 / spec 20) — deterministic
+-- under replay, supplied by the projector.
 INSERT INTO lps_passwords_projection
-    (device_id, action_id, username, password, rotated_at, rotation_reason, projection_version)
-VALUES ($1, $2, $3, $4, $5, $6, $7);
+    (id, device_id, action_id, username, password, rotated_at, rotation_reason, projection_version)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8);
 
 -- name: LpsPasswordExistsForDeviceUsername :one
 -- Companion to the asymmetric stale-replay guard in

--- a/internal/store/queries/luks.sql
+++ b/internal/store/queries/luks.sql
@@ -50,9 +50,11 @@ WHERE device_id = $1
 -- and a sibling row already exists, so this insert never runs against
 -- a stale event. projection_version on the new row is the same
 -- sequence_num that just guarded step 1.
+-- id is the rotating event's ULID (F-15 / spec 20) — deterministic
+-- under replay, supplied by the projector.
 INSERT INTO luks_keys_projection
-    (device_id, action_id, device_path, passphrase, rotated_at, rotation_reason, projection_version)
-VALUES ($1, $2, $3, $4, $5, $6, $7);
+    (id, device_id, action_id, device_path, passphrase, rotated_at, rotation_reason, projection_version)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8);
 
 -- name: LuksKeyExistsForDeviceActionPath :one
 -- Companion to the asymmetric stale-replay guard in
@@ -101,8 +103,9 @@ WHERE device_id  = $1
   AND is_current = TRUE;
 
 -- name: CreateLuksToken :one
-INSERT INTO luks_tokens (device_id, action_id, token, min_length, complexity, expires_at)
-VALUES ($1, $2, $3, $4, $5, NOW() + INTERVAL '15 minutes')
+-- id is a ULID minted in Go (F-15 / spec 20).
+INSERT INTO luks_tokens (id, device_id, action_id, token, min_length, complexity, expires_at)
+VALUES ($1, $2, $3, $4, $5, $6, NOW() + INTERVAL '15 minutes')
 RETURNING *;
 
 -- name: ValidateAndConsumeLuksToken :one

--- a/internal/store/queries/luks.sql
+++ b/internal/store/queries/luks.sql
@@ -53,8 +53,8 @@ WHERE device_id = $1
 -- id is the rotating event's ULID (F-15 / spec 20) — deterministic
 -- under replay, supplied by the projector.
 INSERT INTO luks_keys_projection
-    (id, device_id, action_id, device_path, passphrase, rotated_at, rotation_reason, projection_version)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8);
+    (id, device_id, action_id, device_path, passphrase, rotated_at, rotation_reason, projection_version, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9);
 
 -- name: LuksKeyExistsForDeviceActionPath :one
 -- Companion to the asymmetric stale-replay guard in

--- a/internal/store/queries/security_alerts.sql
+++ b/internal/store/queries/security_alerts.sql
@@ -73,4 +73,4 @@ UPDATE security_alerts_projection
 SET acknowledged = TRUE,
     acknowledged_at = $2,
     acknowledged_by = $3
-WHERE event_id = $1::uuid;
+WHERE event_id = $1;

--- a/internal/store/queries/security_alerts.sql
+++ b/internal/store/queries/security_alerts.sql
@@ -58,8 +58,8 @@ WHERE device_id = $1
 --
 -- name: InsertSecurityAlertProjection :exec
 INSERT INTO security_alerts_projection (
-    event_id, device_id, alert_type, message, details, raised_at
-) VALUES ($1, $2, $3, $4, $5, $6)
+    event_id, device_id, alert_type, message, details, raised_at, created_at
+) VALUES ($1, $2, $3, $4, $5, $6, $7)
 ON CONFLICT (event_id) DO NOTHING;
 
 -- AcknowledgeSecurityAlertProjection updates the ack columns. Returns

--- a/internal/store/rebuild_fidelity_test.go
+++ b/internal/store/rebuild_fidelity_test.go
@@ -86,6 +86,58 @@ func seedRichFixture(t *testing.T, st *store.Store) {
 	enc := testutil.NewEncryptor(t)
 	providerID := testutil.CreateTestIdentityProvider(t, st, enc, adminID, "Fidelity IdP", "fidelity-"+testutil.NewID()[:8])
 	testutil.EnableSCIMForProvider(t, st, adminID, providerID)
+
+	// Secret-history + security-alert projections: their row ids are the
+	// rotating/raising event's ULID (spec 20 / F-15) — before that
+	// change they were DB-minted random uuids, which a rebuild silently
+	// re-minted. These rows make the round-trip prove the determinism.
+	rotatedAt := "2026-07-01T10:00:00Z"
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "lps_password",
+		StreamID:   deviceID + ":" + actionID + ":root",
+		EventType:  "LpsPasswordRotated",
+		Data: map[string]any{
+			"device_id": deviceID, "action_id": actionID, "username": "root",
+			"password": "enc:v1:fixture-lps", "rotated_at": rotatedAt, "rotation_reason": "scheduled",
+		},
+		ActorType: "device",
+		ActorID:   deviceID,
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "luks_key",
+		StreamID:   deviceID + ":" + actionID + ":/dev/sda2",
+		EventType:  "LuksKeyRotated",
+		Data: map[string]any{
+			"device_id": deviceID, "action_id": actionID, "device_path": "/dev/sda2",
+			"passphrase": "enc:v1:fixture-luks", "rotated_at": rotatedAt, "rotation_reason": "scheduled",
+		},
+		ActorType: "device",
+		ActorID:   deviceID,
+	}))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   deviceID,
+		EventType:  "SecurityAlert",
+		Data: map[string]any{
+			"alert_type": "fidelity-probe", "message": "round-trip fixture alert",
+		},
+		ActorType: "device",
+		ActorID:   deviceID,
+	}))
+	// Acknowledge it by the raising event's ULID so the ack column set
+	// (a projection UPDATE keyed by the id) is exercised too.
+	var alertEventID string
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		`SELECT id FROM events WHERE event_type = 'SecurityAlert' AND stream_id = $1
+		 ORDER BY sequence_num DESC LIMIT 1`, deviceID).Scan(&alertEventID))
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   deviceID,
+		EventType:  "SecurityAlertAcknowledged",
+		Data:       map[string]any{"alert_id": alertEventID, "acknowledged_by": adminID},
+		ActorType:  "user",
+		ActorID:    adminID,
+	}))
 }
 
 // TestRebuildAll_FullFidelityRoundTrip pins spec 21 AC 6: a no-arg

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	_ "github.com/jackc/pgx/v5/stdlib" // pgx database/sql driver
+	"github.com/oklog/ulid/v2"
 	"github.com/pressly/goose/v3"
 
 	"github.com/manchtools/power-manage/server/internal/store/generated"
@@ -595,6 +596,7 @@ func (s *Store) AppendEvent(ctx context.Context, event Event) error {
 		}
 
 		row, err := s.queries.AppendEvent(ctx, generated.AppendEventParams{
+			ID:            ulid.Make().String(),
 			StreamType:    event.StreamType,
 			StreamID:      event.StreamID,
 			StreamVersion: version + 1,
@@ -635,6 +637,7 @@ func (s *Store) AppendEventWithVersion(ctx context.Context, event Event, expecte
 	}
 
 	row, err := s.queries.AppendEvent(ctx, generated.AppendEventParams{
+		ID:            ulid.Make().String(),
 		StreamType:    event.StreamType,
 		StreamID:      event.StreamID,
 		StreamVersion: expectedVersion,

--- a/internal/testutil/factories_idp.go
+++ b/internal/testutil/factories_idp.go
@@ -39,7 +39,7 @@ func SetupTOTP(t *testing.T, st *store.Store, enc *crypto.Encryptor, userID, ema
 		t.Fatalf("generate TOTP key: %v", err)
 	}
 
-	encryptedSecret, err := enc.Encrypt(key.Secret())
+	encryptedSecret, err := enc.EncryptWithContext(key.Secret(), crypto.RowAAD(userID, crypto.PurposeTOTPSecret))
 	if err != nil {
 		t.Fatalf("encrypt TOTP secret: %v", err)
 	}
@@ -93,7 +93,7 @@ func SetupTOTPCheapBackup(t *testing.T, st *store.Store, enc *crypto.Encryptor, 
 	if err != nil {
 		t.Fatalf("generate TOTP key: %v", err)
 	}
-	encryptedSecret, err := enc.Encrypt(key.Secret())
+	encryptedSecret, err := enc.EncryptWithContext(key.Secret(), crypto.RowAAD(userID, crypto.PurposeTOTPSecret))
 	if err != nil {
 		t.Fatalf("encrypt TOTP secret: %v", err)
 	}
@@ -136,7 +136,7 @@ func CreateTestIdentityProvider(t *testing.T, st *store.Store, enc *crypto.Encry
 	ctx := context.Background()
 	id := NewID()
 
-	encSecret, err := enc.Encrypt("test-client-secret")
+	encSecret, err := enc.EncryptWithContext("test-client-secret", crypto.RowAAD(id, crypto.PurposeIdPClientSecret))
 	if err != nil {
 		t.Fatalf("encrypt test secret: %v", err)
 	}


### PR DESCRIPTION
Closes #504. Implements spec 20 — the last spec-19 prerequisite (after #511/#512). Spec 19's per-user DEK envelope wraps under this single format.

## Stage 1 — one at-rest format (F-06, the WS10 deferral)

- `internal/crypto` ships ONE format: AAD-bound AES-256-GCM under `enc:v1`. The naked nil-AAD `Encrypt`/`Decrypt` pair is **deleted**; `EncryptWithContext` refuses an empty AAD at runtime; `DecryptWithContext` opens only `enc:v1` and errors **loudly** on any other `enc:*` tag (reporting only the format tag, never ciphertext) — a retired `enc:v2` blob must never silently pass through as plaintext. Plain non-prefixed values still pass through (pre-encryption plaintext + empty-string identity).
- New `RowAAD(rowID, purpose)` + shared `Purpose*` constants: IdP client secrets bind `idp_id|idp-client-secret` (create/update + both SSO decrypts), TOTP secrets bind `user_id|totp-secret` (setup + both verify paths). LPS/LUKS keep `SecretAAD`. testutil factories seed with the same AADs as the read paths.
- **Guard** `TestAEADStaysInCryptoPackage`: AEAD `Seal`/`Open` (at AEAD arity) forbidden outside `internal/crypto`; literal-nil AAD forbidden at `*WithContext` call sites.

## Stage 2 — ULID identifiers (F-15)

- `events.id`, `lps_passwords_projection.id`, `luks_keys_projection.id`, `luks_tokens.id`, `security_alerts_projection.event_id`: uuid → **text ULID**. `gen_random_uuid()` defaults removed — the DB never mints a random identifier.
- `AppendEvent`/`AppendEventWithVersion` mint the event ULID in Go; secret-history projection rows take the **rotating event's ULID** as their id and `created_at` from the event's `occurred_at` — so a rebuild reproduces them **byte-identically**. The extended full-fidelity fixture (lps password, luks key, security alert + ack) proves it; before this change those ids/timestamps were silently non-deterministic under replay (invisible only because the fixture left those tables empty).
- `SecurityAlertAckParamsFromEvent` validates `alert_id` as a ULID — preserving the fail-loud contract of the retired `::uuid` cast, pinned by the existing malformed-alert-id test.
- `google/uuid` is gone from all first-party code (only an indirect module dep remains). **Guard** `TestULIDOnlyIdentifiers`: no `google/uuid` import anywhere (generated code included, so a uuid column can't sneak back via sqlc), no uuid column type / `gen_random_uuid()` in migrations. Empty allowlist — red-checked at 13 findings before the migration.
- ADR 0030 records both decisions (supersedes ADR 0009's dual-version framing).

## Migration stance

Beta Path A (per the spec): reprovision; no dual-read shim, no backfill. Pre-change ciphertext fails decryption with an error that names the retired tag; pre-change uuid rows are discarded with the reprovision.

## Verification

- `go vet`, `staticcheck`, `gofmt`, `docref check` clean; full `go test ./... -count=1`: 33 packages ok, 0 failures.
- Red-checks: prefix pin flipped → format test fails; ULID guard was red (13 findings) before the migration; wrong-AAD / cross-row / cross-purpose / retired-format / tampered paths unit-tested.
- Local `coderabbit review` on the rebased branch: no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced stricter at-rest encryption handling with context-bound secrets, improving protection for identity provider, SSO, and TOTP data.
  * Standardized record identifiers to ULIDs across stored events and related projections.

* **Bug Fixes**
  * Fixed audit and search reindexing to use the stored event ID consistently.
  * Improved rebuild consistency so projection data and timestamps can be reproduced byte-for-byte during recovery.

* **Tests**
  * Expanded coverage for encryption format validation, identifier rules, and deterministic replay behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->