### PR TITLE
feat(pii): crypto-shred erasure on delete (spec 19 stage B)

### DIFF
--- a/internal/api/idp_handler.go
+++ b/internal/api/idp_handler.go
@@ -308,7 +308,10 @@ func (h *IDPHandler) DeleteIdentityProvider(ctx context.Context, req *connect.Re
 			// error) we leave the user in place rather than fail the whole
 			// provider deletion — best-effort, matching the surrounding loop.
 			if err := guardedAdminMutation(ctx, h.store, link.UserID, func() error {
-				return h.store.AppendEvent(ctx, store.Event{
+				// Auto-delete is still a delete: crypto-shred via the shared
+				// flow (spec 19 AC 7) so an orphaned SSO user is erased, not
+				// merely soft-deleted with recoverable PII.
+				return h.store.AppendUserDeletionWithShred(ctx, store.Event{
 					StreamType: "user",
 					StreamID:   link.UserID,
 					EventType:  string(eventtypes.UserDeleted),

--- a/internal/api/shred_delete_handler_test.go
+++ b/internal/api/shred_delete_handler_test.go
@@ -1,0 +1,98 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+func hasDEKRepo(t *testing.T, st *store.Store, userID string) bool {
+	t.Helper()
+	_, err := st.Repos().UserEncryptionKey.Get(context.Background(), userID)
+	if err == nil {
+		return true
+	}
+	require.True(t, store.IsNotFound(err))
+	return false
+}
+
+// TestDeleteUser_ShredsDEK pins AC 7/8 on the API path: DeleteUser
+// destroys the user's DEK (crypto-shred), not merely soft-deletes.
+func TestDeleteUser_ShredsDEK(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+
+	adminID := testutil.CreateTestUser(t, st, "adm-"+testutil.NewID()[:8]+"@test.com", "pass", "admin")
+	victim := testutil.CreateTestUser(t, st, "vic-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	require.True(t, hasDEKRepo(t, st, victim), "precondition: victim has a DEK")
+
+	h := api.NewUserHandler(st, slog.Default(), nil)
+	_, err := h.DeleteUser(testutil.AdminContext(adminID),
+		connect.NewRequest(&pm.DeleteUserRequest{Id: victim}))
+	require.NoError(t, err)
+
+	assert.False(t, hasDEKRepo(t, st, victim), "DeleteUser must crypto-shred the DEK (AC 7/8)")
+}
+
+// TestDeleteUser_IdempotentAndNoOracle pins AC 13: deleting an
+// already-deleted (still visible to the caller) user is idempotent OK;
+// deleting an absent id returns NotFound (no existence oracle).
+func TestDeleteUser_IdempotentAndNoOracle(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+
+	adminID := testutil.CreateTestUser(t, st, "adm2-"+testutil.NewID()[:8]+"@test.com", "pass", "admin")
+	h := api.NewUserHandler(st, slog.Default(), nil)
+
+	// Absent target → NotFound.
+	_, err := h.DeleteUser(testutil.AdminContext(adminID),
+		connect.NewRequest(&pm.DeleteUserRequest{Id: testutil.NewID()}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err), "absent target must be NotFound (no oracle)")
+}
+
+// TestReAddSameEmailAfterErase_MintsFreshDEK pins AC 15: after erasing
+// a user, creating a new user with the same email succeeds (the erased
+// row is is_deleted and excluded from the active-email unique index),
+// mints a NEW DEK, and the old user's ciphertext stays unreadable.
+func TestReAddSameEmailAfterErase_MintsFreshDEK(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	adminID := testutil.CreateTestUser(t, st, "adm3-"+testutil.NewID()[:8]+"@test.com", "pass", "admin")
+	h := api.NewUserHandler(st, slog.Default(), nil)
+	email := "reuse-" + testutil.NewID()[:8] + "@test.com"
+
+	first, err := h.CreateUser(testutil.AuthContext(adminID, "a@t", auth.AdminPermissions()),
+		connect.NewRequest(&pm.CreateUserRequest{Email: email, Password: "s3cret-password"}))
+	require.NoError(t, err)
+	firstID := first.Msg.User.Id
+	firstDEK, err := st.Repos().UserEncryptionKey.Get(ctx, firstID)
+	require.NoError(t, err)
+
+	_, err = h.DeleteUser(testutil.AdminContext(adminID),
+		connect.NewRequest(&pm.DeleteUserRequest{Id: firstID}))
+	require.NoError(t, err)
+	require.False(t, hasDEKRepo(t, st, firstID), "erased user's DEK is gone")
+
+	// Re-add the same email — must succeed (active-email index is
+	// WHERE is_deleted = false) and mint a fresh, different DEK.
+	second, err := h.CreateUser(testutil.AuthContext(adminID, "a@t", auth.AdminPermissions()),
+		connect.NewRequest(&pm.CreateUserRequest{Email: email, Password: "s3cret-password"}))
+	require.NoError(t, err, "re-adding an erased user's email must succeed (AC 15)")
+	secondID := second.Msg.User.Id
+	require.NotEqual(t, firstID, secondID)
+
+	secondDEK, err := st.Repos().UserEncryptionKey.Get(ctx, secondID)
+	require.NoError(t, err)
+	assert.NotEqual(t, firstDEK.WrappedDEK, secondDEK.WrappedDEK,
+		"the re-added user gets fresh random key material — the old ciphertext stays permanently unreadable")
+}

--- a/internal/api/shred_provisioning_isolation_test.go
+++ b/internal/api/shred_provisioning_isolation_test.go
@@ -1,0 +1,91 @@
+package api
+
+// Spec 19 Section E — provisioning isolation. An erased user must never
+// (re)acquire a system action. Three existing invariants make this hold;
+// these tests PIN them so a future refactor can't silently break them.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestAffectedFromEvent_UserDeletedIsSyncOpNone pins AC 33: UserDeleted
+// must classify to SyncOpNone — a deletion schedules NO system-action
+// sync (which would otherwise try to provision the just-erased user).
+func TestAffectedFromEvent_UserDeletedIsSyncOpNone(t *testing.T) {
+	op, users := AffectedFromEvent(store.PersistedEvent{
+		StreamType: "user",
+		StreamID:   "01JUSERAAAAAAAAAAAAAAAAAAA",
+		EventType:  string(eventtypes.UserDeleted),
+	})
+	assert.Equal(t, SyncOpNone, op, "UserDeleted must never map to a sync op (spec 19 AC 33)")
+	assert.Empty(t, users)
+}
+
+// TestSyncUserSystemActions_RefusesDeletedUser pins AC 32: the
+// generation choke point refuses a deleted/erased user explicitly —
+// no system action is created or distributed for them.
+func TestSyncUserSystemActions_RefusesDeletedUser(t *testing.T) {
+	m, st := newManagerForTest(t)
+	ctx := context.Background()
+
+	userID := testutil.CreateTestUser(t, st, "prov-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	setLinuxUsername(t, st, userID, "provuser")
+	enableGlobalProvisioning(t, st)
+
+	// Delete (crypto-shred) the user.
+	require.NoError(t, st.AppendUserDeletionWithShred(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: string(eventtypes.UserDeleted),
+		Data: map[string]any{}, ActorType: "user", ActorID: userID,
+	}))
+
+	// The generation path must refuse — gracefully, no error, no action.
+	require.NoError(t, m.SyncUserSystemActions(ctx, userID),
+		"syncing an erased user is a graceful no-op, not an error")
+
+	var n int
+	require.NoError(t, st.TestingPool().QueryRow(ctx,
+		`SELECT COUNT(*) FROM actions_projection WHERE is_system = TRUE AND name LIKE 'system:user-provision:%' AND name LIKE '%'||$1||'%'`,
+		userID).Scan(&n))
+	assert.Zero(t, n, "no system USER action may be generated for an erased user (AC 32)")
+}
+
+// TestRebuildAll_DispatchesNoSystemActions pins AC 34: a full rebuild
+// dispatches NO system actions — provisioning is a live-only
+// post-commit listener (RegisterEventListener), not a rebuild applier
+// (RegisterRebuildApply), so a restore materialises the user rows
+// without ever generating a provisioning action. An erased user
+// therefore comes back as (is_deleted, sentinel) with no account.
+func TestRebuildAll_DispatchesNoSystemActions(t *testing.T) {
+	m, st := newManagerForTest(t)
+	ctx := context.Background()
+	_ = m
+
+	userID := testutil.CreateTestUser(t, st, "rb-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	setLinuxUsername(t, st, userID, "rbuser")
+	enableGlobalProvisioning(t, st)
+
+	// A rebuild replays only rebuild appliers; the system-action
+	// listener is not one, so no provisioning-action rows are created
+	// by the replay. Count system USER actions before and after.
+	countSystemUserActions := func() int {
+		var n int
+		require.NoError(t, st.TestingPool().QueryRow(ctx,
+			`SELECT COUNT(*) FROM actions_projection WHERE is_system = TRUE`).Scan(&n))
+		return n
+	}
+	before := countSystemUserActions()
+
+	_, err := st.RebuildAll(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, before, countSystemUserActions(),
+		"a rebuild must not generate system actions — provisioning is a live-only listener, not a rebuild applier (AC 34)")
+}

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -166,8 +166,22 @@ func (m *SystemActionManager) StartReconciliation(ctx context.Context, interval,
 // Idempotent and safe to call after any user mutation.
 func (m *SystemActionManager) SyncUserSystemActions(ctx context.Context, userID string) error {
 	user, err := m.store.Repos().User.Get(ctx, userID)
+	if store.IsNotFound(err) {
+		// Deleted (or never-existed) user: NEVER generate or distribute a
+		// system action for them (spec 19 E / AC 32 — an erased user must
+		// never re-acquire a provisioning action). Graceful skip, not an
+		// error, so a reconcile sweep doesn't log noise for erased users.
+		return nil
+	}
 	if err != nil {
 		return fmt.Errorf("get user: %w", err)
+	}
+	// Explicit fail-closed delete-state check at the generation choke
+	// point (spec 19 AC 32). Does NOT lean on Get's incidental
+	// is_deleted = FALSE filter: if a future Get is changed to return
+	// soft-deleted rows, provisioning must STILL refuse an erased user.
+	if user.IsDeleted {
+		return nil
 	}
 
 	// Skip users with no linux username (shouldn't happen after migration)

--- a/internal/api/user_handler.go
+++ b/internal/api/user_handler.go
@@ -492,10 +492,14 @@ func (h *UserHandler) DeleteUser(ctx context.Context, req *connect.Request[pm.De
 	}
 
 	// Refuse to delete the last enabled administrator (#365); run the guard +
-	// UserDeleted append under one advisory lock so concurrent deletes can't
+	// the delete-with-shred under one advisory lock so concurrent deletes can't
 	// both pass and race to zero admins (#369). A no-op for non-admins.
+	//
+	// Spec 19 AC 7/8/14: deletion ALWAYS crypto-shreds — the shared flow
+	// appends UserDeleted and destroys the DEK in one transaction, so there
+	// is no half-erased state and the same shred runs for API + SCIM.
 	err = guardedAdminMutation(ctx, h.store, req.Msg.Id, func() error {
-		if err := h.store.AppendEvent(ctx, store.Event{
+		if err := h.store.AppendUserDeletionWithShred(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   req.Msg.Id,
 			EventType:  string(eventtypes.UserDeleted),
@@ -514,7 +518,10 @@ func (h *UserHandler) DeleteUser(ctx context.Context, req *connect.Request[pm.De
 	// Search-index removal is handled by api.SearchListener (post-commit
 	// dispatch on UserDeleted) — handler-side enqueue removed in N005.
 
-	// Clean up system actions
+	// Clean up system actions using the PRE-delete snapshot loaded above
+	// (spec 19 AC 35: teardown rides on this snapshot, captured before the
+	// shred, so the plaintext linux_username is still available even though
+	// the projection is now redacted).
 	if err := h.systemActions.CleanupDeletedUserActions(ctx, user); err != nil {
 		h.logger.Error("failed to cleanup system actions for deleted user", "user_id", req.Msg.Id, "error", err)
 	}

--- a/internal/projectors/user_listener.go
+++ b/internal/projectors/user_listener.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 
+	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
@@ -342,10 +343,15 @@ func applyUserLoggedIn(ctx context.Context, q *store.Queries, e store.PersistedE
 
 func applyUserDeleted(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
 	updatedAt := e.OccurredAt
+	// Spec 19 AC 7: soft-delete AND overwrite every PII column with the
+	// redaction sentinel in one statement. The Email param feeds all
+	// seven PII columns (sqlc names the shared $4 after the first one);
+	// live delete and rebuild both run this, so both redact identically.
 	n, err := q.SoftDeleteUserProjection(ctx, db.SoftDeleteUserProjectionParams{
 		ID:                e.StreamID,
 		UpdatedAt:         &updatedAt,
 		ProjectionVersion: e.SequenceNum,
+		Email:             crypto.RedactionSentinel,
 	})
 	if err != nil {
 		return err

--- a/internal/scim/users.go
+++ b/internal/scim/users.go
@@ -259,7 +259,12 @@ func (h *Handler) deleteUser(w http.ResponseWriter, r *http.Request) {
 		// every device the deleted user was assigned to.
 		user, loadErr := h.store.Repos().User.Get(ctx, userID)
 
-		err = h.store.AppendEvent(ctx, store.Event{
+		// Spec 19 AC 8: the SCIM delete path routes through the SAME
+		// shared shred flow as the API DeleteUser — the DEK is destroyed
+		// and PII redacted identically. (SCIM only reaches here when the
+		// last identity link is removed; disable via active=false emits
+		// UserDisabled and never shreds.)
+		err = h.store.AppendUserDeletionWithShred(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
 			EventType:  string(eventtypes.UserDeleted),

--- a/internal/scim/users_test.go
+++ b/internal/scim/users_test.go
@@ -138,3 +138,63 @@ func TestGetNextLinuxUID_ReturnsPositive(t *testing.T) {
 	require.NoError(t, err)
 	assert.Greater(t, uid, int32(0), "GetNextLinuxUID must return a positive UID")
 }
+
+// TestSCIMDeleteUser_ShredsDEK pins spec 19 AC 8: the SCIM DELETE path
+// (last identity link removed → UserDeleted) routes through the SAME
+// shared shred flow as the API DeleteUser — the user's DEK is
+// destroyed, not merely soft-deleted.
+func TestSCIMDeleteUser_ShredsDEK(t *testing.T) {
+	env := setupSCIM(t)
+	ctx := context.Background()
+
+	user := map[string]any{
+		"schemas":    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+		"userName":   "shred-scim-" + testutil.NewID()[:6] + "@example.com",
+		"externalId": "ext-shred-" + testutil.NewID()[:6],
+	}
+	createResp := env.request("POST", "/Users", user)
+	require.Equal(t, http.StatusCreated, createResp.Code)
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(createResp.Body.Bytes(), &created))
+	userID := created["id"].(string)
+
+	// Precondition: SCIM-created user has a DEK (AC 1, SCIM path).
+	_, err := env.st.Repos().UserEncryptionKey.Get(ctx, userID)
+	require.NoError(t, err, "SCIM-created user must have a DEK")
+
+	w := env.request("DELETE", "/Users/"+userID)
+	require.Equal(t, http.StatusNoContent, w.Code)
+
+	_, err = env.st.Repos().UserEncryptionKey.Get(ctx, userID)
+	assert.True(t, store.IsNotFound(err), "SCIM delete must crypto-shred the DEK (AC 8)")
+}
+
+// TestSCIMDisable_DoesNotShred pins the Security-considerations note:
+// SCIM PATCH active=false emits UserDisabled and must NOT shred — a
+// disable is not a delete, the DEK stays intact.
+func TestSCIMDisable_DoesNotShred(t *testing.T) {
+	env := setupSCIM(t)
+	ctx := context.Background()
+
+	user := map[string]any{
+		"schemas":    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+		"userName":   "disable-scim-" + testutil.NewID()[:6] + "@example.com",
+		"externalId": "ext-disable-" + testutil.NewID()[:6],
+		"active":     true,
+	}
+	createResp := env.request("POST", "/Users", user)
+	require.Equal(t, http.StatusCreated, createResp.Code)
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(createResp.Body.Bytes(), &created))
+	userID := created["id"].(string)
+
+	patch := map[string]any{
+		"schemas":    []string{"urn:ietf:params:scim:api:messages:2.0:PatchOp"},
+		"Operations": []map[string]any{{"op": "replace", "path": "active", "value": false}},
+	}
+	w := env.request("PATCH", "/Users/"+userID, patch)
+	require.Equal(t, http.StatusOK, w.Code, "%s", w.Body.String())
+
+	_, err := env.st.Repos().UserEncryptionKey.Get(ctx, userID)
+	require.NoError(t, err, "disable must NOT shred the DEK — a disabled user is not erased")
+}

--- a/internal/store/generated/users.sql.go
+++ b/internal/store/generated/users.sql.go
@@ -656,7 +656,14 @@ const softDeleteUserProjection = `-- name: SoftDeleteUserProjection :execrows
 UPDATE users_projection
 SET is_deleted         = TRUE,
     updated_at         = $2,
-    projection_version = $3
+    projection_version = $3,
+    email              = $4,
+    display_name       = $4,
+    given_name         = $4,
+    family_name        = $4,
+    preferred_username = $4,
+    picture            = $4,
+    linux_username     = $4
 WHERE id = $1
   AND projection_version < $3
 `
@@ -665,6 +672,7 @@ type SoftDeleteUserProjectionParams struct {
 	ID                string     `json:"id"`
 	UpdatedAt         *time.Time `json:"updated_at"`
 	ProjectionVersion int64      `json:"projection_version"`
+	Email             string     `json:"email"`
 }
 
 // UserDeleted handler — first half. Returns rows-affected so the
@@ -674,8 +682,19 @@ type SoftDeleteUserProjectionParams struct {
 // the reconciler would silently nuke a freshly-restored user's
 // identity links (multi-write asymmetric-guard discipline, CR catch
 // on PR #101 pattern).
+//
+// Spec 19 AC 7: overwrite every PII column with the redaction
+// sentinel ($4 = crypto.RedactionSentinel) in the same statement, so
+// an erased user's projection holds no personal data — never
+// ciphertext, never null (the columns are NOT NULL). Live delete and
+// rebuild share this one path, so both redact identically.
 func (q *Queries) SoftDeleteUserProjection(ctx context.Context, arg SoftDeleteUserProjectionParams) (int64, error) {
-	result, err := q.db.Exec(ctx, softDeleteUserProjection, arg.ID, arg.UpdatedAt, arg.ProjectionVersion)
+	result, err := q.db.Exec(ctx, softDeleteUserProjection,
+		arg.ID,
+		arg.UpdatedAt,
+		arg.ProjectionVersion,
+		arg.Email,
+	)
 	if err != nil {
 		return 0, err
 	}

--- a/internal/store/queries/users.sql
+++ b/internal/store/queries/users.sql
@@ -161,10 +161,23 @@ WHERE id = $1
 -- the reconciler would silently nuke a freshly-restored user's
 -- identity links (multi-write asymmetric-guard discipline, CR catch
 -- on PR #101 pattern).
+--
+-- Spec 19 AC 7: overwrite every PII column with the redaction
+-- sentinel ($4 = crypto.RedactionSentinel) in the same statement, so
+-- an erased user's projection holds no personal data — never
+-- ciphertext, never null (the columns are NOT NULL). Live delete and
+-- rebuild share this one path, so both redact identically.
 UPDATE users_projection
 SET is_deleted         = TRUE,
     updated_at         = $2,
-    projection_version = $3
+    projection_version = $3,
+    email              = $4,
+    display_name       = $4,
+    given_name         = $4,
+    family_name        = $4,
+    preferred_username = $4,
+    picture            = $4,
+    linux_username     = $4
 WHERE id = $1
   AND projection_version < $3;
 

--- a/internal/store/rebuild_fidelity_test.go
+++ b/internal/store/rebuild_fidelity_test.go
@@ -46,6 +46,16 @@ func seedRichFixture(t *testing.T, st *store.Store) {
 	adminID := testutil.CreateTestUser(t, st, "fidelity-"+testutil.NewID()[:8]+"@test.com", "pass", "admin")
 	userID, _, groupID := seedUsersCascadeChildren(t, st) // user + TOTP + identity link + group membership
 
+	// A crypto-shredded user (spec 19 AC 11): a rebuild must reproduce
+	// their projection as the redaction sentinel — the delete redaction
+	// and the rebuild share one path, so the full-row dump stays
+	// byte-identical across the prune/rebuild round-trip.
+	erased := testutil.CreateTestUser(t, st, "fidelity-erased-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	require.NoError(t, st.AppendUserDeletionWithShred(ctx, store.Event{
+		StreamType: "user", StreamID: erased, EventType: "UserDeleted",
+		Data: map[string]any{}, ActorType: "user", ActorID: adminID,
+	}))
+
 	roleID := testutil.CreateTestRole(t, st, adminID, "fidelity-role-"+testutil.NewID()[:8], []string{"GetDevice"})
 	require.NoError(t, st.AppendEvent(ctx, store.Event{
 		StreamType: "user_role",

--- a/internal/store/shred.go
+++ b/internal/store/shred.go
@@ -1,0 +1,110 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// AppendUserDeletionWithShred is the shared delete-with-shred flow
+// (spec 19 AC 7/8/14). It appends the caller's UserDeleted event AND
+// destroys the subject's DEK in ONE transaction — all-or-nothing:
+//
+//   - AC 7: deletion always crypto-shreds; there is no separate erase.
+//   - AC 8: both the API DeleteUser and the SCIM delete path call this,
+//     so the shred is identical across packages.
+//   - AC 14: if the DEK delete fails, the transaction rolls back — no
+//     UserDeleted event, no projection change, no half-erased state.
+//
+// event.StreamID is the user being deleted (and whose DEK is shredded).
+// Post-commit listeners fire AFTER the tx commits, exactly as
+// AppendEvent does, so the UserDeleted projector (soft-delete +
+// PII-column redaction) runs on the durable event.
+//
+// Idempotent (AC 13): re-running for an already-deleted user still
+// appends a UserDeleted event (harmless — the projector's
+// projection_version guard no-ops the stale replay) and the DEK delete
+// reports zero rows without error, so the DEK stays absent.
+func (s *Store) AppendUserDeletionWithShred(ctx context.Context, event Event) error {
+	if event.StreamType != "user" {
+		return fmt.Errorf("shred flow: event must be on the user stream, got %q", event.StreamType)
+	}
+	if event.StreamID == "" {
+		return fmt.Errorf("shred flow: event requires a stream_id (the user to shred)")
+	}
+	if event.ActorType == "" || event.ActorID == "" {
+		return fmt.Errorf("shred flow: event actor_type and actor_id are required")
+	}
+
+	// UserDeleted carries no PII, but seal for generality (no-op when
+	// the payload has no tagged fields).
+	event, err := s.sealPII(ctx, event)
+	if err != nil {
+		return fmt.Errorf("shred flow: seal PII: %w", err)
+	}
+	data, err := json.Marshal(event.Data)
+	if err != nil {
+		return fmt.Errorf("shred flow: marshal event data: %w", err)
+	}
+	metadata := []byte("{}")
+	if event.Metadata != nil {
+		if metadata, err = json.Marshal(event.Metadata); err != nil {
+			return fmt.Errorf("shred flow: marshal event metadata: %w", err)
+		}
+	}
+
+	const maxRetries = 5
+	for i := 0; i < maxRetries; i++ {
+		var appended PersistedEvent
+		conflict := false
+		err := s.WithTx(ctx, func(q *Queries) error {
+			version, verr := q.GetStreamVersion(ctx, generated.GetStreamVersionParams{
+				StreamType: event.StreamType,
+				StreamID:   event.StreamID,
+			})
+			if verr != nil {
+				return fmt.Errorf("get stream version: %w", verr)
+			}
+			row, aerr := q.AppendEvent(ctx, generated.AppendEventParams{
+				ID:            ulid.Make().String(),
+				StreamType:    event.StreamType,
+				StreamID:      event.StreamID,
+				StreamVersion: version + 1,
+				EventType:     event.EventType,
+				Data:          data,
+				Metadata:      metadata,
+				ActorType:     event.ActorType,
+				ActorID:       event.ActorID,
+			})
+			if aerr != nil {
+				if IsVersionConflict(aerr) {
+					conflict = true
+				}
+				return fmt.Errorf("append UserDeleted: %w", aerr)
+			}
+			// THE crypto-shred, in the SAME transaction (AC 7/14). A
+			// failure here rolls the UserDeleted append back too.
+			if _, derr := q.DeleteUserEncryptionKey(ctx, event.StreamID); derr != nil {
+				return fmt.Errorf("shred DEK: %w", derr)
+			}
+			appended = row
+			return nil
+		})
+		if err == nil {
+			// Post-commit listeners (projector redaction, search index)
+			// run only after the event is durable — same contract as
+			// AppendEvent.
+			s.fireListeners(ctx, appended)
+			return nil
+		}
+		if conflict && i < maxRetries-1 {
+			continue // OCC retry; the DEK delete is idempotent
+		}
+		return err
+	}
+	return fmt.Errorf("shred flow: exhausted retries appending UserDeleted for %s", event.StreamID)
+}

--- a/internal/store/shred_redaction_test.go
+++ b/internal/store/shred_redaction_test.go
@@ -1,0 +1,87 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// userProjectionPII reads the raw PII columns of a (possibly deleted)
+// user projection row — Repos().User.Get filters is_deleted, so the
+// erased row is only reachable by direct query.
+func userProjectionPII(t *testing.T, st *store.Store, userID string) map[string]string {
+	t.Helper()
+	cols := map[string]string{}
+	var email, display, given, family, preferred, picture, linux string
+	err := st.TestingPool().QueryRow(context.Background(),
+		`SELECT email, display_name, given_name, family_name, preferred_username, picture, linux_username
+		   FROM users_projection WHERE id = $1`, userID).
+		Scan(&email, &display, &given, &family, &preferred, &picture, &linux)
+	require.NoError(t, err)
+	cols["email"], cols["display_name"], cols["given_name"] = email, display, given
+	cols["family_name"], cols["preferred_username"], cols["picture"], cols["linux_username"] = family, preferred, picture, linux
+	return cols
+}
+
+func seedUserWithProfile(t *testing.T, st *store.Store) string {
+	t.Helper()
+	ctx := context.Background()
+	userID := testutil.CreateTestUser(t, st, "prof-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	dn, gn, fn := "Alice Example", "Alice", "Example"
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user", StreamID: userID, EventType: "UserProfileUpdated",
+		Data:      map[string]any{"display_name": dn, "given_name": gn, "family_name": fn},
+		ActorType: "user", ActorID: userID,
+	}))
+	return userID
+}
+
+// TestUserDeleted_RedactsAllPIIColumns pins AC 7: the UserDeleted
+// projector overwrites every PII column with the redaction sentinel.
+func TestUserDeleted_RedactsAllPIIColumns(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	userID := seedUserWithProfile(t, st)
+	before := userProjectionPII(t, st, userID)
+	require.Equal(t, "Alice", before["given_name"], "precondition: profile projected in plaintext")
+
+	require.NoError(t, st.AppendUserDeletionWithShred(ctx, userDeletedEvent(userID)))
+
+	after := userProjectionPII(t, st, userID)
+	for col, v := range after {
+		assert.Equalf(t, crypto.RedactionSentinel, v,
+			"PII column %q must be redacted after delete, got %q", col, v)
+	}
+}
+
+// TestUserDeleted_RebuildReproducesSentinel pins AC 11: a rebuild
+// reproduces the deleted user's PII as the sentinel while live users
+// reproduce 1:1 — live delete and rebuild share the one redaction path.
+func TestUserDeleted_RebuildReproducesSentinel(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	deleted := seedUserWithProfile(t, st)
+	liveEmail := "live-" + testutil.NewID()[:8] + "@test.com"
+	live := testutil.CreateTestUser(t, st, liveEmail, "pass", "user")
+
+	require.NoError(t, st.AppendUserDeletionWithShred(ctx, userDeletedEvent(deleted)))
+
+	_, err := st.RebuildAll(ctx)
+	require.NoError(t, err)
+
+	after := userProjectionPII(t, st, deleted)
+	assert.Equal(t, crypto.RedactionSentinel, after["email"],
+		"deleted user's PII reproduces as the sentinel after rebuild")
+
+	liveUser, err := st.Repos().User.Get(ctx, live)
+	require.NoError(t, err)
+	assert.Equal(t, liveEmail, liveUser.Email, "live users reproduce 1:1")
+}

--- a/internal/store/shred_test.go
+++ b/internal/store/shred_test.go
@@ -1,0 +1,93 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// Spec 19 AC 7/14 — the shared delete-with-shred flow: appending
+// UserDeleted and destroying the user's DEK happen in ONE transaction,
+// all-or-nothing.
+
+func hasDEK(t *testing.T, st *store.Store, userID string) bool {
+	t.Helper()
+	_, err := st.Repos().UserEncryptionKey.Get(context.Background(), userID)
+	if err == nil {
+		return true
+	}
+	require.True(t, store.IsNotFound(err), "unexpected error: %v", err)
+	return false
+}
+
+func userDeletedEvent(userID string) store.Event {
+	return store.Event{
+		StreamType: "user",
+		StreamID:   userID,
+		EventType:  "UserDeleted",
+		Data:       map[string]any{},
+		ActorType:  "user",
+		ActorID:    userID,
+	}
+}
+
+func countUserEvents(t *testing.T, st *store.Store, userID, eventType string) int {
+	t.Helper()
+	var n int
+	require.NoError(t, st.TestingPool().QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM events WHERE stream_id = $1 AND event_type = $2`,
+		userID, eventType).Scan(&n))
+	return n
+}
+
+// TestAppendUserDeletionWithShred_AppendsAndShredsAtomically pins AC 7:
+// the DEK is destroyed and the UserDeleted event is appended together.
+func TestAppendUserDeletionWithShred_AppendsAndShredsAtomically(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	userID := testutil.CreateTestUser(t, st, "shred-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	require.True(t, hasDEK(t, st, userID), "precondition: user has a DEK")
+
+	require.NoError(t, st.AppendUserDeletionWithShred(ctx, userDeletedEvent(userID)))
+
+	assert.False(t, hasDEK(t, st, userID), "the DEK must be destroyed (crypto-shred)")
+	assert.Equal(t, 1, countUserEvents(t, st, userID, "UserDeleted"), "UserDeleted appended exactly once")
+}
+
+// TestAppendUserDeletionWithShred_FiresProjector pins that the
+// post-commit listeners run — the UserDeleted projector soft-deletes
+// and redacts (AC 7 end to end).
+func TestAppendUserDeletionWithShred_FiresProjector(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	email := "fire-" + testutil.NewID()[:8] + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "pass", "user")
+
+	require.NoError(t, st.AppendUserDeletionWithShred(ctx, userDeletedEvent(userID)))
+
+	// Soft-deleted: no longer visible via the active-user query.
+	_, err := st.Repos().User.GetByEmail(ctx, email)
+	assert.True(t, store.IsNotFound(err), "deleted user must not resolve by email")
+}
+
+// TestAppendUserDeletionWithShred_Idempotent pins AC 13: re-running for
+// an already-deleted user is a no-op success — DEK stays absent, no
+// duplicate/orphaned writes.
+func TestAppendUserDeletionWithShred_Idempotent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	userID := testutil.CreateTestUser(t, st, "idem-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	require.NoError(t, st.AppendUserDeletionWithShred(ctx, userDeletedEvent(userID)))
+	require.NoError(t, st.AppendUserDeletionWithShred(ctx, userDeletedEvent(userID)),
+		"a second shred of an already-erased user is a no-op success")
+
+	assert.False(t, hasDEK(t, st, userID))
+}


### PR DESCRIPTION
Part 2 of 4 for #502 (spec 19). Builds on the merged PR A envelope (#514). Covers ACs 7–15 and Section E (32–36): **deletion always crypto-shreds — there is no separate erase operation.** Retention/prune (PR C) and doctor key-invariant checks (PR D) follow.

## Shared shred flow (AC 7/8/14)

`store.AppendUserDeletionWithShred` appends the `UserDeleted` event **and** destroys the user's DEK in **one transaction** — all-or-nothing (a failed DEK delete rolls the event back; no half-erased state, AC 14), then fires post-commit listeners exactly like `AppendEvent`. OCC-retry safe (the DEK delete is idempotent, AC 13). All **three** `UserDeleted` emit sites route through it so the shred is identical everywhere (AC 8): API `DeleteUser`, the SCIM last-link delete, and the idp orphaned-passwordless-user auto-delete.

## Projector redaction (AC 7/11)

`SoftDeleteUserProjection` now overwrites all **seven** PII columns (email, display/given/family name, preferred_username, picture, linux_username) with `crypto.RedactionSentinel` (`[redacted]` — never null, never ciphertext) in the same statement as the soft-delete. Live delete and rebuild share this one path, so a rebuild reproduces a deleted user as the sentinel while live users reproduce 1:1 (the full-fidelity fixture now seeds an erased user, so the byte-identical round-trip proves it).

## Provisioning isolation (Section E, 32–36)

- **AC 32**: `SyncUserSystemActions` gains an **explicit** fail-closed delete-state check at the generation choke point — not the incidental `is_deleted = FALSE` filter, so a future `Get` change can't silently re-enable provisioning for an erased user — plus a graceful NotFound skip.
- **AC 33**: `AffectedFromEvent(UserDeleted) == SyncOpNone` pinned.
- **AC 34**: a rebuild dispatches no system actions — provisioning is a live-only `RegisterEventListener`, never a `RegisterRebuildApply` applier; guard test seeds a provisioned user, rebuilds, asserts no new system-action rows.

## Tests (real Postgres)

DEK shredded on **both** API and SCIM delete (AC 8); SCIM `active=false` disable does **not** shred; absent target → NotFound, no oracle (AC 13); re-add same email after erase mints a **fresh** DEK and the old ciphertext stays unreadable (AC 15); all seven PII columns redacted and reproduced as the sentinel on rebuild (AC 7/11); the three E-guards; shred flow atomicity + idempotency at the store level.

**By construction** (noted, not separately tested): AC 12 — a deleted user's `actor_id` on unrelated events replays fine because `actor_id` is never a sealed field (pseudonymization, the accepted residual-risk posture); AC 14 tx rollback — `WithTx` is atomic and there is no DB fault seam to inject.

## Verification

gofmt/vet/staticcheck clean; full `go test ./... -count=1`: 34 packages, 0 failures. Redaction red-checked (columns keep plaintext when the sentinel param is neutralized — the fixture's own precondition asserts the pre-state). Local `coderabbit review`: no findings.