### PR TITLE
fix(retention): spec-19 Phase-C audit — trigger double-condition, fail-closed rebuild, archive-chain restore, determinism guard

### DIFF
--- a/cmd/control/rebuild.go
+++ b/cmd/control/rebuild.go
@@ -12,9 +12,11 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/archive"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/doctor"
 	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/retention"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/store/postgres"
 )
@@ -35,10 +37,19 @@ import (
 func runRebuildProjections(args []string) int {
 	fs := flag.NewFlagSet("rebuild-projections", flag.ContinueOnError)
 	envFile := fs.String("env-file", ".env", "deploy .env file to read CONTROL_DATABASE_URL from (skipped if absent)")
+	archiveDir := fs.String("archive-dir", "", "retention archive directory (filesystem backend); restores pruned history via the EventLogPruned marker chain, then replays live events (spec 19 AC 21)")
 	if err := fs.Parse(args); err != nil {
 		if errors.Is(err, flag.ErrHelp) {
 			return 0
 		}
+		return 2
+	}
+
+	// A restore is always a FULL rebuild: the archived history spans every
+	// stream, and partial-target semantics would reintroduce the cascade
+	// data-loss class the restore exists to prevent.
+	if *archiveDir != "" && len(fs.Args()) > 0 {
+		fmt.Fprintln(os.Stderr, "rebuild-projections: --archive-dir restores every projection; target selection is not supported with it")
 		return 2
 	}
 
@@ -75,32 +86,63 @@ func runRebuildProjections(args []string) int {
 	st.SetRepos(postgres.NewRepos(st.Queries()))
 	projectors.WireAll(st, logger)
 
-	targets := fs.Args()
-	plan, err := st.ResolveTargets(ctx, targets...)
-	if err != nil {
-		if errors.Is(err, store.ErrUnknownTarget) {
-			valid := make([]string, len(store.AllRebuildTargets))
-			for i, tgt := range store.AllRebuildTargets {
-				valid[i] = tgt.Name
-			}
-			fmt.Fprintf(os.Stderr, "rebuild-projections: %v\nvalid targets: %s\n", err, strings.Join(valid, ", "))
+	var res store.RebuildResult
+	if *archiveDir != "" {
+		// Restore path (spec 19 AC 21): chain-load the pruned history from
+		// the retention archives (integrity-checked against the marker
+		// hashes), then replay it + the live events > N in one transaction.
+		arch, aerr := archive.New(archive.Config{Backend: archive.BackendFilesystem, FilesystemPath: *archiveDir})
+		if aerr != nil {
+			fmt.Fprintf(os.Stderr, "rebuild-projections: open archive: %v\n", aerr)
 			return 2
 		}
-		fmt.Fprintf(os.Stderr, "rebuild-projections: %v\n", err)
-		return 2
-	}
+		hist, herr := retention.LoadArchivedHistory(ctx, st, arch)
+		if herr != nil {
+			fmt.Fprintf(os.Stderr, "rebuild-projections: load archived history: %v\n", herr)
+			return 2
+		}
+		fmt.Printf("restoring every projection from %d archived event(s) + the live log\n", len(hist))
+		res, err = st.RebuildAllFromArchive(ctx, hist)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "rebuild-projections: restore FAILED, all changes rolled back: %v\n", err)
+			return 1
+		}
+	} else {
+		targets := fs.Args()
+		plan, perr := st.ResolveTargets(ctx, targets...)
+		if perr != nil {
+			if errors.Is(perr, store.ErrUnknownTarget) {
+				valid := make([]string, len(store.AllRebuildTargets))
+				for i, tgt := range store.AllRebuildTargets {
+					valid[i] = tgt.Name
+				}
+				fmt.Fprintf(os.Stderr, "rebuild-projections: %v\nvalid targets: %s\n", perr, strings.Join(valid, ", "))
+				return 2
+			}
+			fmt.Fprintf(os.Stderr, "rebuild-projections: %v\n", perr)
+			return 2
+		}
 
-	// Print the plan BEFORE any destructive statement runs, including
-	// what cascade safety widened the selection to.
-	fmt.Printf("rebuilding %d projection target(s): %s\n", len(plan), strings.Join(plan, ", "))
-	if len(targets) > 0 && len(plan) > len(targets) {
-		fmt.Println("selection widened for cascade safety: a partial rebuild must replay every table its TRUNCATE ... CASCADE wipes")
-	}
+		// Print the plan BEFORE any destructive statement runs, including
+		// what cascade safety widened the selection to.
+		fmt.Printf("rebuilding %d projection target(s): %s\n", len(plan), strings.Join(plan, ", "))
+		if len(targets) > 0 && len(plan) > len(targets) {
+			fmt.Println("selection widened for cascade safety: a partial rebuild must replay every table its TRUNCATE ... CASCADE wipes")
+		}
 
-	res, err := st.RebuildAll(ctx, targets...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "rebuild-projections: FAILED, all changes rolled back: %v\n", err)
-		return 1
+		res, err = st.RebuildAll(ctx, targets...)
+		if err != nil {
+			if errors.Is(err, store.ErrHistoryPruned) {
+				// Not a failed rebuild — the rebuild refused to run because
+				// it would destroy pruned state (spec 19 AC 21). Actionable:
+				// re-run with --archive-dir pointing at the retention
+				// archives. Exit 2 = could-not-run, doctor convention.
+				fmt.Fprintf(os.Stderr, "rebuild-projections: %v\n", err)
+				return 2
+			}
+			fmt.Fprintf(os.Stderr, "rebuild-projections: FAILED, all changes rolled back: %v\n", err)
+			return 1
+		}
 	}
 	for _, tr := range res.Targets {
 		fmt.Printf("  %-24s applied=%-8d skipped=%-6d %s\n",

--- a/cmd/control/rebuild_test.go
+++ b/cmd/control/rebuild_test.go
@@ -21,3 +21,9 @@ func TestRunRebuildProjections_HelpIsSuccess(t *testing.T) {
 	code := runRebuildProjections([]string{"-h"})
 	assert.Equal(t, 0, code, "-h is a successful help request, not a failure")
 }
+
+func TestRunRebuildProjections_ArchiveDirWithTargetsIsCouldNotRun(t *testing.T) {
+	t.Setenv("CONTROL_DATABASE_URL", "")
+	code := runRebuildProjections([]string{"--env-file", "/nonexistent/never.env", "--archive-dir", "/tmp/x", "users"})
+	assert.Equal(t, 2, code, "--archive-dir restores every projection; combining it with target selection must exit 2")
+}

--- a/cmd/control/rebuild_test.go
+++ b/cmd/control/rebuild_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"io"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // The store layer carries the behavioral coverage for the rebuild
@@ -24,6 +27,20 @@ func TestRunRebuildProjections_HelpIsSuccess(t *testing.T) {
 
 func TestRunRebuildProjections_ArchiveDirWithTargetsIsCouldNotRun(t *testing.T) {
 	t.Setenv("CONTROL_DATABASE_URL", "")
+
+	// Capture stderr: exit 2 is shared with env/config failures, so the
+	// assertion must prove THIS guard fired, not a missing database URL.
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
 	code := runRebuildProjections([]string{"--env-file", "/nonexistent/never.env", "--archive-dir", "/tmp/x", "users"})
+	os.Stderr = orig
+	require.NoError(t, w.Close())
+	out, err := io.ReadAll(r)
+	require.NoError(t, err)
+
 	assert.Equal(t, 2, code, "--archive-dir restores every projection; combining it with target selection must exit 2")
+	assert.Contains(t, string(out), "target selection is not supported",
+		"the exit must come from the archive-target guard, not an unrelated config failure")
 }

--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -156,18 +156,29 @@ docker compose exec control control rebuild-projections users devices
 ```
 <!-- docref: end -->
 
-<!-- docref: begin src=cmd/control/rebuild.go#runRebuildProjections:233aab6e -->
+<!-- docref: begin src=cmd/control/rebuild.go#runRebuildProjections:3f101b6f -->
 The command prints the resolved target list before touching anything. A
 partial selection is widened automatically when a selected table's
 `TRUNCATE ... CASCADE` would wipe tables owned by other targets — a
 partial rebuild never destroys data it does not replay. Each target
 reports events applied and events skipped (unprojectable historical
-payloads) separately. Everything runs in a single transaction: a failure
-rolls back to the pre-rebuild state. After a successful rebuild the
-system-role permissions are re-reconciled from the code registry, so no
-Control restart is needed.
+payloads) separately. Everything runs in a single transaction (one
+consistent snapshot): a failure rolls back to the pre-rebuild state.
+After a successful rebuild the system-role permissions are re-reconciled
+from the code registry, so no Control restart is needed.
+
+Once audit-log retention has pruned history, a plain rebuild **refuses to
+run** — the surviving live log no longer contains events up to the prune
+checkpoint, and replaying only it would silently lose that state. Pass
+`--archive-dir <path>` (the retention archive directory, filesystem
+backend) instead: the command walks the `EventLogPruned` marker chain,
+verifies every sealed archive against the hash recorded in the
+tamper-evident log, and rebuilds every projection from the archived
+history plus the live events. Target selection is not supported with
+`--archive-dir` — a restore is always a full rebuild.
 
 Exit codes: `0` success · `1` rebuild failed (rolled back) · `2` could
-not run (bad flags, unknown target, no database). `--env-file <path>`
-works like doctor's (default `.env`).
+not run (bad flags, unknown target, no database, pruned history without
+`--archive-dir`). `--env-file <path>` works like doctor's (default
+`.env`).
 <!-- docref: end -->

--- a/internal/archtest/projector_determinism_test.go
+++ b/internal/archtest/projector_determinism_test.go
@@ -36,11 +36,15 @@ import (
 
 // mapRangeAllowlist lists the only sanctioned map iterations in the
 // projector set, each with the reason its loop body is order-independent.
-// Keyed "<module-rel path> :: <ranged expression>". assertNoStale fails
-// the build if an entry stops matching.
+// Keyed "<module-rel path> :: <enclosing func> :: <ranged expression>" —
+// the enclosing function makes each entry SITE-unique (CR): a new
+// `range payload.Labels` elsewhere in the same file must justify itself
+// rather than inherit an existing exemption. assertNoStale fails the
+// build if an entry stops matching.
 var mapRangeAllowlist = map[string]string{
-	"internal/projectors/device.go :: any":                     "map→map transform (raw JSON labels → map[string]string): writes only out[k] per key, no I/O, no ordering side effects — the resulting map is identical regardless of iteration order.",
-	"internal/projectors/device_listener.go :: payload.Labels": "Per-key SetDeviceLabel upsert (ON CONFLICT (device_id, key)): each key writes exactly its own row, so the final device_labels row set is identical regardless of iteration order.",
+	"internal/projectors/device.go :: decodeLabelsMap :: any":                              "map→map transform (raw JSON labels → map[string]string): writes only out[k] per key, no I/O, no ordering side effects — the resulting map is identical regardless of iteration order.",
+	"internal/projectors/device_listener.go :: applyDeviceRegistered :: payload.Labels":    "Per-key SetDeviceLabel upsert (ON CONFLICT (device_id, key)): each key writes exactly its own row, so the final device_labels row set is identical regardless of iteration order.",
+	"internal/projectors/device_listener.go :: applyDeviceLabelsUpdated :: payload.Labels": "Per-key SetDeviceLabel upsert after the full-replace DELETE: each key writes exactly its own row, so the final device_labels row set is identical regardless of iteration order.",
 }
 
 // TestProjectorDeterminism pins spec 19 AC 17a for the projector set.
@@ -104,7 +108,7 @@ func TestProjectorDeterminism(t *testing.T) {
 			if !looksMapTyped(rs.X, localMaps, mapFields) {
 				return true
 			}
-			key := gf.rel + " :: " + render(gf.fset, rs.X)
+			key := gf.rel + " :: " + enclosingFuncName(gf.ast, rs.Pos()) + " :: " + render(gf.fset, rs.X)
 			if allow.exempt(key) {
 				return true
 			}

--- a/internal/archtest/projector_determinism_test.go
+++ b/internal/archtest/projector_determinism_test.go
@@ -2,6 +2,8 @@ package archtest
 
 import (
 	"go/ast"
+	"go/parser"
+	"go/token"
 	"strings"
 	"testing"
 )
@@ -117,6 +119,39 @@ func TestProjectorDeterminism(t *testing.T) {
 	allow.assertNoStale(t)
 }
 
+// TestFileLocalMapIdents_DetectsEveryDeclarationForm pins the detector
+// itself: every way a file can visibly declare a map-typed identifier
+// must be recognized, or a projector ranging over one silently passes
+// the determinism guard (the false-negative CR flagged for
+// `var x = make(map…)`).
+func TestFileLocalMapIdents_DetectsEveryDeclarationForm(t *testing.T) {
+	src := `package p
+func f(param map[string]int) (ret map[string]int) {
+	var typed map[string]bool
+	var inferredMake = make(map[string]int)
+	var inferredLit = map[string]int{"a": 1}
+	shortMake := make(map[string]string)
+	shortLit := map[string]bool{}
+	notAMap := []string{"x"}
+	_ = typed; _ = inferredMake; _ = inferredLit; _ = shortMake; _ = shortLit; _ = notAMap
+	return nil
+}`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "snippet.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse snippet: %v", err)
+	}
+	got := fileLocalMapIdents(f)
+	for _, want := range []string{"param", "ret", "typed", "inferredMake", "inferredLit", "shortMake", "shortLit"} {
+		if !got[want] {
+			t.Errorf("map-typed identifier %q not detected — a `range %s` would silently evade the determinism guard", want, want)
+		}
+	}
+	if got["notAMap"] {
+		t.Error("slice identifier misclassified as a map")
+	}
+}
+
 // fileLocalMapIdents collects identifier names visibly declared
 // map-typed within one file: var declarations, := / = assignments from a
 // map literal or make(map…), and function parameters/results.
@@ -128,6 +163,16 @@ func fileLocalMapIdents(f *ast.File) map[string]bool {
 			if _, isMap := x.Type.(*ast.MapType); isMap {
 				for _, name := range x.Names {
 					out[name.Name] = true
+				}
+			}
+			// `var x = make(map…)` / `var x = map[…]{…}`: no explicit
+			// type, the map-ness lives in the initializer (CR).
+			for i, val := range x.Values {
+				if i >= len(x.Names) {
+					break
+				}
+				if isMapProducer(val) {
+					out[x.Names[i].Name] = true
 				}
 			}
 		case *ast.AssignStmt:

--- a/internal/archtest/projector_determinism_test.go
+++ b/internal/archtest/projector_determinism_test.go
@@ -1,0 +1,197 @@
+package archtest
+
+import (
+	"go/ast"
+	"strings"
+	"testing"
+)
+
+// Spec 19 AC 17a: projector determinism is ENFORCED statically, not just
+// tested. The AC 16/17 round-trip tests catch non-determinism only when
+// the offending input happens to differ between two runs — a projector
+// that consults a non-deterministic source can pass CI by coincidence.
+// This guard fails the build for the two sources the WS0 clock seam
+// (TestNoUnabstractedTimeNow) does not cover:
+//
+//   - math/rand (v1 or v2) anywhere in the projector set;
+//   - iteration over a MAP, whose order Go randomizes per run. A map
+//     range inside an applier is only safe when the loop body is
+//     order-independent (pure per-key upserts, map→map transforms);
+//     every such site must be allowlisted with that justification.
+//
+// Detection is pure-AST (archtest convention — no type checker), so
+// map-typed expressions are recognized heuristically:
+//
+//   - a composite literal / make() of an *ast.MapType;
+//   - an identifier declared map-typed in the SAME FILE (var decl,
+//     := / = from a map literal or make(map…), func param or result);
+//   - a selector (x.Labels) whose FIELD NAME is map-typed in any struct
+//     declared in the projector or payloads packages.
+//
+// The heuristic over-approximates (a same-named non-map field elsewhere
+// would flag too) — that is the right failure mode for a guard: flag
+// loud, justify in the allowlist.
+
+// mapRangeAllowlist lists the only sanctioned map iterations in the
+// projector set, each with the reason its loop body is order-independent.
+// Keyed "<module-rel path> :: <ranged expression>". assertNoStale fails
+// the build if an entry stops matching.
+var mapRangeAllowlist = map[string]string{
+	"internal/projectors/device.go :: any":                     "map→map transform (raw JSON labels → map[string]string): writes only out[k] per key, no I/O, no ordering side effects — the resulting map is identical regardless of iteration order.",
+	"internal/projectors/device_listener.go :: payload.Labels": "Per-key SetDeviceLabel upsert (ON CONFLICT (device_id, key)): each key writes exactly its own row, so the final device_labels row set is identical regardless of iteration order.",
+}
+
+// TestProjectorDeterminism pins spec 19 AC 17a for the projector set.
+func TestProjectorDeterminism(t *testing.T) {
+	root := moduleRoot(t)
+
+	files := walkGoFiles(t, root, func(rel string) bool {
+		return strings.HasPrefix(rel, "internal/projectors/")
+	})
+	if len(files) == 0 {
+		t.Fatal("matches-zero guard: walked zero projector files — the guard is mis-scoped")
+	}
+
+	// Map-typed struct FIELD names, indexed across the projector and
+	// payloads packages (covers `payload.Labels` where the struct is
+	// declared in another file/package, and inline decode structs).
+	fieldFiles := walkGoFiles(t, root, func(rel string) bool {
+		return strings.HasPrefix(rel, "internal/projectors/") ||
+			strings.HasPrefix(rel, "internal/eventtypes/payloads/")
+	})
+	mapFields := map[string]bool{}
+	for _, gf := range fieldFiles {
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			st, ok := n.(*ast.StructType)
+			if !ok {
+				return true
+			}
+			for _, f := range st.Fields.List {
+				if _, isMap := f.Type.(*ast.MapType); isMap {
+					for _, name := range f.Names {
+						mapFields[name.Name] = true
+					}
+				}
+			}
+			return true
+		})
+	}
+	if len(mapFields) == 0 {
+		t.Fatal("matches-zero guard: found no map-typed struct fields in projectors/payloads — the field index is broken and selector ranges would pass vacuously")
+	}
+
+	allow := newAllowlist(mapRangeAllowlist)
+	rangeStmts := 0
+	for _, gf := range files {
+		// (a) math/rand is banned outright in the projector set.
+		for _, imp := range gf.ast.Imports {
+			path := strings.Trim(imp.Path.Value, `"`)
+			if path == "math/rand" || path == "math/rand/v2" {
+				t.Errorf("non-deterministic source at %s: import %q — projectors must be deterministic (spec 19 AC 17a); derive randomness-free values from the event", gf.rel, path)
+			}
+		}
+
+		// (b) map iterations must be allowlisted as order-independent.
+		localMaps := fileLocalMapIdents(gf.ast)
+		ast.Inspect(gf.ast, func(n ast.Node) bool {
+			rs, ok := n.(*ast.RangeStmt)
+			if !ok {
+				return true
+			}
+			rangeStmts++
+			if !looksMapTyped(rs.X, localMaps, mapFields) {
+				return true
+			}
+			key := gf.rel + " :: " + render(gf.fset, rs.X)
+			if allow.exempt(key) {
+				return true
+			}
+			t.Errorf("map iteration at %s:%d — `range %s`\n  Go randomizes map order per run, so an order-dependent body breaks snapshot equivalence (spec 19 AC 17/17a). Make the body order-independent (per-key upserts only) and add a justified mapRangeAllowlist entry, or iterate sorted keys.",
+				gf.rel, gf.line(rs), render(gf.fset, rs.X))
+			return true
+		})
+	}
+	if rangeStmts == 0 {
+		t.Fatal("matches-zero guard: found no range statements in the projector set at all — the detector is mis-scoped and would pass vacuously")
+	}
+	allow.assertNoStale(t)
+}
+
+// fileLocalMapIdents collects identifier names visibly declared
+// map-typed within one file: var declarations, := / = assignments from a
+// map literal or make(map…), and function parameters/results.
+func fileLocalMapIdents(f *ast.File) map[string]bool {
+	out := map[string]bool{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		switch x := n.(type) {
+		case *ast.ValueSpec:
+			if _, isMap := x.Type.(*ast.MapType); isMap {
+				for _, name := range x.Names {
+					out[name.Name] = true
+				}
+			}
+		case *ast.AssignStmt:
+			for i, rhs := range x.Rhs {
+				if i >= len(x.Lhs) {
+					break
+				}
+				if !isMapProducer(rhs) {
+					continue
+				}
+				if id, ok := x.Lhs[i].(*ast.Ident); ok {
+					out[id.Name] = true
+				}
+			}
+		case *ast.FuncType:
+			for _, fl := range []*ast.FieldList{x.Params, x.Results} {
+				if fl == nil {
+					continue
+				}
+				for _, fld := range fl.List {
+					if _, isMap := fld.Type.(*ast.MapType); isMap {
+						for _, name := range fld.Names {
+							out[name.Name] = true
+						}
+					}
+				}
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// isMapProducer reports whether an expression syntactically yields a map:
+// a map composite literal or make(map[...]...).
+func isMapProducer(e ast.Expr) bool {
+	switch x := e.(type) {
+	case *ast.CompositeLit:
+		_, isMap := x.Type.(*ast.MapType)
+		return isMap
+	case *ast.CallExpr:
+		if id, ok := x.Fun.(*ast.Ident); ok && id.Name == "make" && len(x.Args) > 0 {
+			_, isMap := x.Args[0].(*ast.MapType)
+			return isMap
+		}
+	}
+	return false
+}
+
+// looksMapTyped reports whether a ranged expression is (heuristically)
+// map-typed: a map literal, a file-locally-declared map identifier, or a
+// selector whose field name is map-typed somewhere in the indexed
+// packages.
+func looksMapTyped(e ast.Expr, localMaps, mapFields map[string]bool) bool {
+	switch x := e.(type) {
+	case *ast.CompositeLit:
+		_, isMap := x.Type.(*ast.MapType)
+		return isMap
+	case *ast.Ident:
+		return localMaps[x.Name]
+	case *ast.SelectorExpr:
+		return mapFields[x.Sel.Name]
+	case *ast.ParenExpr:
+		return looksMapTyped(x.X, localMaps, mapFields)
+	}
+	return false
+}

--- a/internal/retention/restore.go
+++ b/internal/retention/restore.go
@@ -1,0 +1,82 @@
+package retention
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/manchtools/power-manage/server/internal/archive"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// LoadArchivedHistory loads the FULL pruned history by walking the
+// EventLogPruned marker chain (spec 19 AC 21): each marker records the
+// range's archive ref and the sha256 the sealed artifact must match.
+// A single later archive is NOT sufficient — events ≤ an earlier
+// checkpoint were already deleted when it was written — so every
+// marker's archive is fetched, integrity-checked against the
+// tamper-evident marker hash (stronger than the archive's own sidecar:
+// the marker lives in the append-only log), parsed, and concatenated in
+// sequence order.
+//
+// The result feeds store.RebuildAllFromArchive, whose own completeness
+// check independently verifies the slice covers the latest checkpoint.
+//
+// ponytail: whole artifacts are buffered in memory (hash-then-parse);
+// stream in two passes if a recovery ever outgrows RAM — this is a rare,
+// operator-invoked path.
+func LoadArchivedHistory(ctx context.Context, st *store.Store, arch archive.ArchiveStore) ([]store.PersistedEvent, error) {
+	markers, err := st.ListPruneMarkers(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if len(markers) == 0 {
+		return nil, fmt.Errorf("retention: no EventLogPruned markers in the log — nothing was pruned, use a plain rebuild")
+	}
+
+	seen := map[string]bool{}
+	var out []store.PersistedEvent
+	for _, m := range markers {
+		rc, err := arch.Get(ctx, m.ArchiveRef)
+		if err != nil {
+			return nil, fmt.Errorf("retention: fetch archive %s (checkpoint %d): %w", m.ArchiveRef, m.UpToSeq, err)
+		}
+		data, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			return nil, fmt.Errorf("retention: read archive %s: %w", m.ArchiveRef, err)
+		}
+
+		sum := sha256.Sum256(data)
+		if got := hex.EncodeToString(sum[:]); got != m.ArchiveSHA256 {
+			return nil, fmt.Errorf("retention: archive %s does not match its tamper-evident marker hash (marker %s, artifact %s) — the artifact was modified or replaced; refusing to restore", m.ArchiveRef, m.ArchiveSHA256, got)
+		}
+
+		upTo, rows, err := ReadArtifact(bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("retention: parse archive %s: %w", m.ArchiveRef, err)
+		}
+		if upTo != m.UpToSeq {
+			return nil, fmt.Errorf("retention: archive %s header checkpoint %d does not match its marker checkpoint %d", m.ArchiveRef, upTo, m.UpToSeq)
+		}
+		evs, err := store.DecodeArchivedEvents(rows)
+		if err != nil {
+			return nil, fmt.Errorf("retention: decode archive %s: %w", m.ArchiveRef, err)
+		}
+		// Later archives re-contain earlier EventLogPruned markers (they
+		// survive pruning, so they are ≤ the later checkpoint); dedupe by
+		// event id so the concatenation is each event exactly once.
+		for _, ev := range evs {
+			if !seen[ev.ID] {
+				seen[ev.ID] = true
+				out = append(out, ev)
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SequenceNum < out[j].SequenceNum })
+	return out, nil
+}

--- a/internal/retention/restore.go
+++ b/internal/retention/restore.go
@@ -69,8 +69,15 @@ func LoadArchivedHistory(ctx context.Context, st *store.Store, arch archive.Arch
 		}
 		// Later archives re-contain earlier EventLogPruned markers (they
 		// survive pruning, so they are ≤ the later checkpoint); dedupe by
-		// event id so the concatenation is each event exactly once.
+		// event id so the concatenation is each event exactly once. A row
+		// BEYOND its own archive's checkpoint cannot legitimately exist
+		// (writeArtifact bounds ≤ N) — refuse it rather than let it skew
+		// the restore's live-replay cutoff (max archived seq) past events
+		// that were never archived.
 		for _, ev := range evs {
+			if ev.SequenceNum > m.UpToSeq {
+				return nil, fmt.Errorf("retention: archive %s contains event %s (seq %d) beyond its checkpoint %d — malformed artifact; refusing to restore", m.ArchiveRef, ev.ID, ev.SequenceNum, m.UpToSeq)
+			}
 			if !seen[ev.ID] {
 				seen[ev.ID] = true
 				out = append(out, ev)

--- a/internal/store/migrations/013_v2026_08.sql
+++ b/internal/store/migrations/013_v2026_08.sql
@@ -22,6 +22,13 @@
 --
 -- The per-row EXISTS is cheap: idx_events_type (002) narrows it to the
 -- handful of EventLogPruned rows.
+--
+-- Version floor: pg_current_xact_id() and the xid8→xid cast require
+-- PostgreSQL 13+ (the project pins 17 in tests, 18 in deploy). The
+-- xmin comparison is same-transaction-safe: the prune method appends the
+-- marker in this very transaction with no savepoints, so the marker row's
+-- xmin IS the top-level xid pg_current_xact_id() returns; 32-bit
+-- truncation of the current xid always matches its own xmin.
 
 -- +goose Up
 

--- a/internal/store/migrations/013_v2026_08.sql
+++ b/internal/store/migrations/013_v2026_08.sql
@@ -1,0 +1,86 @@
+-- 2026.08 — spec 19 (audit retention), Phase-C audit fix F1: enforce the
+-- FULL double condition on the prune exemption at the trigger layer.
+--
+-- The spec (19-audit-retention-and-erasure, tech design) sanctions a
+-- DELETE on events only when BOTH hold in the same transaction:
+--   1. the SET LOCAL guard (pm.prune_active + pm.prune_up_to_seq) is set
+--      by the privileged prune path, AND
+--   2. an EventLogPruned marker was appended IN THE SAME TRANSACTION.
+--
+-- Migration 011 implemented only condition 1 (+ the range bound) and left
+-- condition 2 to the Go method — which means any session holding DB
+-- credentials could SET LOCAL both guards and silently delete history
+-- with NO tamper-evident marker. This migration closes that hole: the
+-- trigger itself verifies a marker row whose xmin is the current
+-- transaction and whose up_to_seq matches the sanctioned range guard.
+-- (The marker is appended BEFORE the delete by the prune method, so it is
+-- visible to the trigger's query within the same transaction.)
+--
+-- Additionally, EventLogPruned rows themselves are now hard-undeletable
+-- (AC 24 pinned at the DB layer): the prune chain must stay visible in
+-- the live log forever, even inside an otherwise-sanctioned transaction.
+--
+-- The per-row EXISTS is cheap: idx_events_type (002) narrows it to the
+-- handful of EventLogPruned rows.
+
+-- +goose Up
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.events_block_mutation() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    prune_active text := current_setting('pm.prune_active', true);
+    prune_up_to  text := current_setting('pm.prune_up_to_seq', true);
+BEGIN
+    -- The ONLY permitted mutation: a DELETE by the sanctioned prune path,
+    -- bounded to the archived checkpoint range, never of a marker row,
+    -- and only alongside an EventLogPruned marker appended in THIS
+    -- transaction for THIS range (the spec's double condition).
+    IF TG_OP = 'DELETE'
+       AND prune_active = 'on'
+       AND prune_up_to IS NOT NULL
+       AND prune_up_to <> ''
+       AND OLD.sequence_num <= prune_up_to::bigint
+       AND OLD.event_type <> 'EventLogPruned'
+       AND EXISTS (
+           SELECT 1
+             FROM public.events m
+            WHERE m.event_type = 'EventLogPruned'
+              AND m.xmin = pg_current_xact_id()::xid
+              AND (m.data->>'up_to_seq')::bigint = prune_up_to::bigint
+       ) THEN
+        RETURN OLD;
+    END IF;
+
+    RAISE EXCEPTION 'events is append-only: % is not permitted on public.events', TG_OP;
+END;
+$$;
+-- +goose StatementEnd
+
+-- The existing triggers already point at this function; replacing the
+-- function body is enough.
+
+-- +goose Down
+
+-- Restore the 011 body (guard + range only, marker enforced in Go).
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION public.events_block_mutation() RETURNS trigger
+    LANGUAGE plpgsql
+AS $$
+DECLARE
+    prune_active text := current_setting('pm.prune_active', true);
+    prune_up_to  text := current_setting('pm.prune_up_to_seq', true);
+BEGIN
+    IF TG_OP = 'DELETE'
+       AND prune_active = 'on'
+       AND prune_up_to IS NOT NULL
+       AND prune_up_to <> ''
+       AND OLD.sequence_num <= prune_up_to::bigint THEN
+        RETURN OLD;
+    END IF;
+
+    RAISE EXCEPTION 'events is append-only: % is not permitted on public.events', TG_OP;
+END;
+$$;
+-- +goose StatementEnd

--- a/internal/store/prune.go
+++ b/internal/store/prune.go
@@ -154,6 +154,35 @@ func (s *Store) PruneCheckpointBefore(ctx context.Context, cutoff time.Time) (in
 	return n, nil
 }
 
+// ListPruneMarkers returns every EventLogPruned marker in the live log in
+// sequence order — the authoritative ledger of what was pruned when,
+// where each range's sealed archive lives, and the hash it must match.
+// Markers are exempt from pruning (AC 24), so the chain is always
+// complete; the archive-restore path walks it to load the FULL pruned
+// history (a single later archive no longer contains earlier ranges).
+func (s *Store) ListPruneMarkers(ctx context.Context) ([]payloads.EventLogPruned, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT data FROM events WHERE event_type = $1 ORDER BY sequence_num`,
+		EventLogPrunedType)
+	if err != nil {
+		return nil, fmt.Errorf("prune: list markers: %w", err)
+	}
+	defer rows.Close()
+	var out []payloads.EventLogPruned
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, fmt.Errorf("prune: scan marker: %w", err)
+		}
+		var m payloads.EventLogPruned
+		if err := json.Unmarshal(raw, &m); err != nil {
+			return nil, fmt.Errorf("prune: decode marker: %w", err)
+		}
+		out = append(out, m)
+	}
+	return out, rows.Err()
+}
+
 // StreamEventsUpTo calls fn with every event (sequence_num <= upToSeq)
 // as a to_jsonb row, in sequence order — the archive payload. Streams
 // row-by-row so a large history is never fully buffered.

--- a/internal/store/prune.go
+++ b/internal/store/prune.go
@@ -41,12 +41,15 @@ const EventLogPrunedType = "EventLogPruned"
 //  3. DELETEs events with sequence_num <= upToSeq, EXCEPT EventLogPruned
 //     markers (the prune chain stays visible in the live log — AC 24).
 //
-// The trigger's own range bound (OLD.sequence_num <= pm.prune_up_to_seq)
-// plus this method's WHERE clause are defense in depth: neither alone
-// can delete an event beyond the archived checkpoint. Callers must have
-// durably written the sealed archive for upToSeq BEFORE calling this
-// (archive-then-delete ordering — AC 28); this method only performs the
-// delete leg.
+// The trigger (013) independently enforces the FULL double condition:
+// the SET LOCAL guard, the range bound (OLD.sequence_num <=
+// pm.prune_up_to_seq), the marker exemption, AND an EventLogPruned row
+// appended in the same transaction for the same range — so even a raw
+// SQL session with the guards set cannot delete history without leaving
+// the tamper-evident marker. This method's append-first ordering is what
+// satisfies that trigger check. Callers must have durably written the
+// sealed archive for upToSeq BEFORE calling this (archive-then-delete
+// ordering — AC 28); this method only performs the delete leg.
 //
 // Returns the number of events deleted.
 func (s *Store) PruneEventsUpTo(ctx context.Context, upToSeq int64, archiveRef, archiveSHA256 string) (int64, error) {

--- a/internal/store/prune_test.go
+++ b/internal/store/prune_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -97,6 +98,58 @@ func TestEvents_NonPruneMutationStillRejected(t *testing.T) {
 
 	// Events survived every rejected attempt.
 	assert.Positive(t, eventCount(t, st))
+}
+
+// TestEvents_GuardedDeleteWithoutMarkerRejected pins the spec's double
+// condition on the prune exemption (spec 19 tech design): a DELETE is
+// sanctioned only when the SET LOCAL guard is set AND an EventLogPruned
+// marker was appended in the SAME transaction. A session that sets both
+// guards but appends no marker (e.g. leaked DB credentials trying to
+// silently erase history) must still be rejected — otherwise the
+// tamper-evidence chain has a hole the Go method alone cannot close.
+func TestEvents_GuardedDeleteWithoutMarkerRejected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	testutil.CreateTestUser(t, st, "nomarker-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	before := eventCount(t, st)
+	require.Positive(t, before)
+
+	_, err := st.TestingPool().Exec(ctx,
+		`BEGIN; SET LOCAL pm.prune_active = 'on'; SET LOCAL pm.prune_up_to_seq = '999999';
+		 DELETE FROM events WHERE sequence_num >= 1; COMMIT;`)
+	require.Error(t, err,
+		"a guarded DELETE with no in-tx EventLogPruned marker must be rejected (double condition)")
+	assert.Contains(t, err.Error(), "append-only")
+	assert.Equal(t, before, eventCount(t, st), "no event may be deleted without the marker")
+}
+
+// TestEvents_MarkerRowsNotDeletableEvenUnderGuard pins AC 24 at the DB
+// layer: EventLogPruned rows themselves are never deletable, even inside
+// a fully-sanctioned prune transaction — the prune chain must stay
+// visible in the live log forever.
+func TestEvents_MarkerRowsNotDeletableEvenUnderGuard(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	testutil.CreateTestUser(t, st, "keepmark-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+
+	// A real prune leaves a marker behind.
+	_, err := st.PruneEventsUpTo(ctx, maxSeq(t, st), "prune-keepmark", "sha")
+	require.NoError(t, err)
+	require.Equal(t, int64(1), countByType(t, st, store.EventLogPrunedType))
+
+	// Even a fully-guarded transaction that appends a fresh marker cannot
+	// delete an existing marker row.
+	markerSeq := maxSeq(t, st) // the marker is the highest surviving event
+	_, err = st.TestingPool().Exec(ctx, fmt.Sprintf(
+		`BEGIN; SET LOCAL pm.prune_active = 'on'; SET LOCAL pm.prune_up_to_seq = '%d';
+		 INSERT INTO events (id, stream_type, stream_id, stream_version, event_type, data, metadata, actor_type, actor_id)
+		 VALUES ('01JZZZZZZZZZZZZZZZZZZZZZZZ', 'retention', 'global', 999, 'EventLogPruned',
+		         '{"up_to_seq": %d, "archive_ref": "x", "archive_sha256": "x"}', '{}', 'system', 'attacker');
+		 DELETE FROM events WHERE event_type = 'EventLogPruned' AND sequence_num <= %d; COMMIT;`,
+		markerSeq, markerSeq, markerSeq))
+	require.Error(t, err, "EventLogPruned rows must never be deletable, even under a sanctioned guard")
+	assert.GreaterOrEqual(t, countByType(t, st, store.EventLogPrunedType), int64(1),
+		"the prune chain survives")
 }
 
 // TestPruneEventsUpTo_RangeBounded pins that the guard bounds deletion

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -466,7 +466,15 @@ func (s *Store) RebuildAll(ctx context.Context, targetNames ...string) (RebuildR
 	start := s.now()
 	result := RebuildResult{Targets: make([]TargetResult, 0, len(targets))}
 
-	err = pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+	// REPEATABLE READ: the pruned-history guard below and every per-target
+	// replay read must share ONE snapshot. Under READ COMMITTED each
+	// statement sees a fresh snapshot, so a prune committing between the
+	// guard and a later target's read would silently delete events
+	// mid-replay — reproducing the data-loss class the guard closes
+	// (proven by TestRebuildAll_ConsistentSnapshotUnderConcurrentPrune).
+	// Writes don't overlap a prune's (projections vs events), so no
+	// serialization failures are introduced.
+	err = pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{IsoLevel: pgx.RepeatableRead}, func(tx pgx.Tx) error {
 		// Fail closed on pruned history (spec 19 AC 21): if any
 		// EventLogPruned marker exists, events ≤ its checkpoint are gone
 		// from the live log — a TRUNCATE-and-replay here would silently

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -425,6 +425,14 @@ var AllRebuildTargets = []rebuildTarget{
 // target name that does not exist in AllRebuildTargets.
 var ErrUnknownTarget = errors.New("unknown rebuild target")
 
+// ErrHistoryPruned is returned when RebuildAll runs against a log whose
+// history has been pruned (an EventLogPruned marker exists): a plain
+// TRUNCATE-and-replay of the surviving events would silently reproduce
+// projections missing all state ≤ N (spec 19 AC 21). Recovery must go
+// through the archive-restore path (RebuildAllFromArchive fed by the
+// marker chain's sealed archives) instead.
+var ErrHistoryPruned = errors.New("event history has been pruned: a plain rebuild would lose all state up to the prune checkpoint; restore from the retention archives instead (rebuild-projections --archive-dir)")
+
 // ErrSkipEvent lets a projector's apply function report an event it
 // cannot project (e.g. a malformed historical payload) as skippable
 // rather than fatal: the live listener logs-and-swallows it like any
@@ -459,6 +467,22 @@ func (s *Store) RebuildAll(ctx context.Context, targetNames ...string) (RebuildR
 	result := RebuildResult{Targets: make([]TargetResult, 0, len(targets))}
 
 	err = pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+		// Fail closed on pruned history (spec 19 AC 21): if any
+		// EventLogPruned marker exists, events ≤ its checkpoint are gone
+		// from the live log — a TRUNCATE-and-replay here would silently
+		// rebuild projections missing all of that state. Checked inside
+		// the transaction, BEFORE any TRUNCATE, so the refusal leaves the
+		// live projection untouched.
+		var pruned bool
+		if err := tx.QueryRow(ctx,
+			`SELECT EXISTS (SELECT 1 FROM events WHERE event_type = $1)`,
+			EventLogPrunedType).Scan(&pruned); err != nil {
+			return fmt.Errorf("check for pruned history: %w", err)
+		}
+		if pruned {
+			return ErrHistoryPruned
+		}
+
 		// Cascade safety (spec 21 AC 4 / F-03): a partial selection is
 		// widened so no TRUNCATE ... CASCADE wipes a table whose
 		// replaying target is missing from the run. Computed inside the

--- a/internal/store/restore.go
+++ b/internal/store/restore.go
@@ -45,6 +45,23 @@ func (s *Store) RebuildAllFromArchive(ctx context.Context, archived []PersistedE
 	result := RebuildResult{Targets: make([]TargetResult, 0, len(AllRebuildTargets))}
 
 	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+		// Completeness (spec 19 AC 21): the live marker chain is the
+		// authoritative ledger of what was pruned. The archived slice must
+		// reach at least the LATEST recorded checkpoint — a later archive
+		// alone no longer contains events ≤ an earlier N (they were
+		// already deleted when it was written), and a stale earlier
+		// archive misses (N_old, N_latest]. Refuse rather than restore
+		// with a silent hole. Checked in-tx, before any TRUNCATE.
+		var latestMarker int64
+		if err := tx.QueryRow(ctx,
+			`SELECT COALESCE(MAX((data->>'up_to_seq')::bigint), 0) FROM events WHERE event_type = $1`,
+			EventLogPrunedType).Scan(&latestMarker); err != nil {
+			return fmt.Errorf("restore: read prune marker chain: %w", err)
+		}
+		if latestMarker > upToSeq {
+			return fmt.Errorf("restore: archived history (≤ %d) does not cover the latest prune checkpoint %d — chain ALL retention archives per the EventLogPruned markers, not a single artifact", upToSeq, latestMarker)
+		}
+
 		for _, t := range AllRebuildTargets {
 			tStart := s.now()
 			applied, skipped, runErr := s.restoreOneTarget(ctx, tx, t, archived, upToSeq)

--- a/internal/store/restore.go
+++ b/internal/store/restore.go
@@ -50,20 +50,50 @@ func (s *Store) RebuildAllFromArchive(ctx context.Context, archived []PersistedE
 	// after the check passed and leave a silent gap.
 	err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{IsoLevel: pgx.RepeatableRead}, func(tx pgx.Tx) error {
 		// Completeness (spec 19 AC 21): the live marker chain is the
-		// authoritative ledger of what was pruned. The archived slice must
-		// reach at least the LATEST recorded checkpoint — a later archive
-		// alone no longer contains events ≤ an earlier N (they were
-		// already deleted when it was written), and a stale earlier
-		// archive misses (N_old, N_latest]. Refuse rather than restore
-		// with a silent hole. Checked in-tx, before any TRUNCATE.
-		var latestMarker int64
-		if err := tx.QueryRow(ctx,
-			`SELECT COALESCE(MAX((data->>'up_to_seq')::bigint), 0) FROM events WHERE event_type = $1`,
-			EventLogPrunedType).Scan(&latestMarker); err != nil {
+		// authoritative ledger of what was pruned, and the slice must be
+		// the FULL chain, not one artifact. Two checks, in-tx, before any
+		// TRUNCATE:
+		//
+		//  1. The slice reaches the LATEST checkpoint — a stale earlier
+		//     archive misses (N_old, N_latest].
+		//  2. The slice contains EVERY marker's checkpoint event (the
+		//     event with sequence_num == up_to_seq). That event exists in
+		//     exactly ONE archive — its own: it is non-marker (checkpoint
+		//     selection excludes markers), it was deleted by its own prune,
+		//     so every LATER archive was written after it left the live
+		//     log. A latest-archive-only slice reaches N_latest (passes
+		//     check 1) yet misses every earlier range — check 2 refuses it.
+		rows, err := tx.Query(ctx,
+			`SELECT (data->>'up_to_seq')::bigint FROM events WHERE event_type = $1 ORDER BY sequence_num`,
+			EventLogPrunedType)
+		if err != nil {
 			return fmt.Errorf("restore: read prune marker chain: %w", err)
 		}
-		if latestMarker > upToSeq {
-			return fmt.Errorf("restore: archived history (≤ %d) does not cover the latest prune checkpoint %d — chain ALL retention archives per the EventLogPruned markers, not a single artifact", upToSeq, latestMarker)
+		var checkpoints []int64
+		for rows.Next() {
+			var n int64
+			if err := rows.Scan(&n); err != nil {
+				rows.Close()
+				return fmt.Errorf("restore: scan marker checkpoint: %w", err)
+			}
+			checkpoints = append(checkpoints, n)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return fmt.Errorf("restore: iterate marker chain: %w", err)
+		}
+
+		haveSeq := make(map[int64]bool, len(archived))
+		for _, e := range archived {
+			haveSeq[e.SequenceNum] = true
+		}
+		for _, cp := range checkpoints {
+			if cp > upToSeq {
+				return fmt.Errorf("restore: archived history (≤ %d) does not cover the latest prune checkpoint %d — chain ALL retention archives per the EventLogPruned markers, not a single artifact", upToSeq, cp)
+			}
+			if !haveSeq[cp] {
+				return fmt.Errorf("restore: archived history is missing the checkpoint event for prune marker %d — that event exists only in that range's own archive, so the slice is not the full marker chain (a latest archive alone does not contain earlier pruned ranges)", cp)
+			}
 		}
 
 		for _, t := range AllRebuildTargets {

--- a/internal/store/restore.go
+++ b/internal/store/restore.go
@@ -44,7 +44,11 @@ func (s *Store) RebuildAllFromArchive(ctx context.Context, archived []PersistedE
 	start := s.now()
 	result := RebuildResult{Targets: make([]TargetResult, 0, len(AllRebuildTargets))}
 
-	err := pgx.BeginFunc(ctx, s.pool, func(tx pgx.Tx) error {
+	// REPEATABLE READ for the same reason as RebuildAll: the completeness
+	// check and the per-target live-event reads (> N) must share one
+	// snapshot, or a prune committing mid-restore could delete live events
+	// after the check passed and leave a silent gap.
+	err := pgx.BeginTxFunc(ctx, s.pool, pgx.TxOptions{IsoLevel: pgx.RepeatableRead}, func(tx pgx.Tx) error {
 		// Completeness (spec 19 AC 21): the live marker chain is the
 		// authoritative ledger of what was pruned. The archived slice must
 		// reach at least the LATEST recorded checkpoint — a later archive

--- a/internal/store/restore_test.go
+++ b/internal/store/restore_test.go
@@ -11,6 +11,7 @@ package store_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,10 +24,58 @@ import (
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/projectors"
 	"github.com/manchtools/power-manage/server/internal/retention"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
+
+// TestRebuildAll_ConsistentSnapshotUnderConcurrentPrune pins the
+// guard-vs-replay TOCTOU: RebuildAll checks for pruned history once, then
+// re-reads events per target. If a concurrent prune commits BETWEEN the
+// guard check and a later target's read, a READ COMMITTED transaction
+// (fresh snapshot per statement) silently loses the pruned events
+// mid-replay — the exact data-loss class the guard exists to close. The
+// rebuild transaction must run at REPEATABLE READ so the guard and every
+// replay read share ONE snapshot; the concurrent prune then commits
+// harmlessly after the fact.
+//
+// Deterministic race: the "users" applier (the FIRST rebuild target) is
+// wrapped to commit a full prune on a separate connection before the
+// first user event applies — so every later target's events are already
+// deleted from the live table when that target reads them.
+func TestRebuildAll_ConsistentSnapshotUnderConcurrentPrune(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	testutil.CreateTestUser(t, st, "race-"+testutil.NewID()[:8]+"@test.com", "pass", "admin")
+	testutil.CreateTestDevice(t, st, "race-host-"+testutil.NewID()[:6])
+	checkpoint := maxSeq(t, st)
+	baseline := dumpRebuildTables(t, st)
+
+	pruned := false
+	st.RegisterRebuildApply("users", func(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+		if !pruned {
+			pruned = true
+			// A concurrent prune (separate pool connection) commits while
+			// the rebuild transaction is mid-flight.
+			if _, err := st.PruneEventsUpTo(ctx, checkpoint, "prune-race", "sha-race"); err != nil {
+				return fmt.Errorf("concurrent prune: %w", err)
+			}
+		}
+		return projectors.ApplyUserWithRoles(ctx, q, e)
+	})
+
+	_, err := st.RebuildAll(ctx)
+	require.NoError(t, err)
+	require.True(t, pruned, "the race must actually have fired")
+
+	after := dumpRebuildTables(t, st)
+	for tbl, rows := range baseline {
+		assert.Equalf(t, rows, after[tbl],
+			"projection table %q lost rows to a prune that committed mid-rebuild — the rebuild transaction must hold one consistent snapshot (REPEATABLE READ) across the guard and every replay read", tbl)
+	}
+}
 
 // collectArchivedEvents returns every event ≤ upToSeq as the raw
 // to_jsonb rows the retention artifact would carry — the archived

--- a/internal/store/restore_test.go
+++ b/internal/store/restore_test.go
@@ -218,6 +218,38 @@ func TestRebuildAllFromArchive_RefusesIncompleteArchive(t *testing.T) {
 	assert.Contains(t, err.Error(), "does not cover")
 }
 
+// TestRebuildAllFromArchive_RefusesLatestArchiveOnly pins the other half
+// of the completeness check (CR): the LATEST archive alone reaches the
+// latest checkpoint (max seq == N2), but after a second prune it no
+// longer contains events ≤ N1 — they were already deleted when it was
+// written. Every marker's checkpoint event (seq == up_to_seq) exists in
+// exactly ONE archive (its own: later prunes deleted it from the live
+// log before their archives were written), so a slice missing any
+// marker's checkpoint event cannot be the full chain and must be
+// refused.
+func TestRebuildAllFromArchive_RefusesLatestArchiveOnly(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	testutil.CreateTestUser(t, st, "lat1-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	cp1 := maxSeq(t, st)
+	_, err := st.PruneEventsUpTo(ctx, cp1, "prune-lat-1", "sha1")
+	require.NoError(t, err)
+
+	testutil.CreateTestUser(t, st, "lat2-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	cp2 := maxSeq(t, st)
+	// What archive 2 holds: the events surviving ≤ N2 at prune-2 time —
+	// (N1, N2] plus marker 1, but NOTHING ≤ N1.
+	archive2 := collectArchivedEvents(t, st, cp2)
+	_, err = st.PruneEventsUpTo(ctx, cp2, "prune-lat-2", "sha2")
+	require.NoError(t, err)
+
+	_, err = st.RebuildAllFromArchive(ctx, archive2)
+	require.Error(t, err,
+		"the latest archive alone reaches N2 but misses everything ≤ N1 — restore must demand the full marker chain")
+	assert.Contains(t, err.Error(), "checkpoint")
+}
+
 // pruneWorker builds a retention worker over a real fs archive whose
 // clock is far in the future, so every already-appended event is
 // prune-eligible (positive window + safety floor both satisfied).

--- a/internal/store/restore_test.go
+++ b/internal/store/restore_test.go
@@ -11,14 +11,19 @@ package store_test
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/manchtools/power-manage/server/internal/archive"
 	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/retention"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/testutil"
 )
@@ -105,6 +110,148 @@ func TestRebuildAllFromArchive_FullFidelity(t *testing.T) {
 		assert.Equalf(t, rows, after[tbl],
 			"projection table %q not byte-identical after prune@N + restore(archived ≤ N)+replay(> N) — snapshot/replay infidelity (spec 19 AC 17)", tbl)
 	}
+}
+
+// TestRebuildAll_RefusesAfterPrune pins the AC 21 fail-closed leg: once
+// history has been pruned, a plain RebuildAll (TRUNCATE + replay of the
+// surviving live log) would silently reproduce projections MISSING all
+// state ≤ N — the #497 data-loss class through the front door. It must
+// refuse with ErrHistoryPruned and point the operator at the
+// archive-restore path instead of destroying state.
+func TestRebuildAll_RefusesAfterPrune(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	email := "refuse-" + testutil.NewID()[:8] + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "pass", "user")
+	_, err := st.PruneEventsUpTo(ctx, maxSeq(t, st), "prune-refuse", "sha")
+	require.NoError(t, err)
+
+	_, err = st.RebuildAll(ctx)
+	require.Error(t, err, "RebuildAll after a prune would destroy all state ≤ N — it must refuse")
+	require.ErrorIs(t, err, store.ErrHistoryPruned)
+
+	// Fail-closed means NOTHING was truncated: the live projection still
+	// resolves the user.
+	got, err := st.Repos().User.Get(ctx, userID)
+	require.NoError(t, err, "the refusal must roll back before any TRUNCATE")
+	assert.Equal(t, email, got.Email)
+
+	// A partial rebuild is refused just the same.
+	_, err = st.RebuildAll(ctx, "users")
+	require.ErrorIs(t, err, store.ErrHistoryPruned)
+}
+
+// TestRebuildAllFromArchive_RefusesIncompleteArchive pins the restore
+// completeness check: the archived slice must cover the LATEST prune
+// checkpoint recorded in the live marker chain. Handing only a later
+// archive (which, after a second prune, no longer contains events ≤ N1 —
+// they were already deleted when it was written) or a stale earlier one
+// must be refused, not silently restored with a hole.
+func TestRebuildAllFromArchive_RefusesIncompleteArchive(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	testutil.CreateTestUser(t, st, "inc1-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	cp1 := maxSeq(t, st)
+	archive1 := collectArchivedEvents(t, st, cp1)
+	_, err := st.PruneEventsUpTo(ctx, cp1, "prune-inc-1", "sha1")
+	require.NoError(t, err)
+
+	testutil.CreateTestUser(t, st, "inc2-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	cp2 := maxSeq(t, st)
+	_, err = st.PruneEventsUpTo(ctx, cp2, "prune-inc-2", "sha2")
+	require.NoError(t, err)
+
+	// archive1 stops at N1 < N2 (the latest marker): incomplete.
+	_, err = st.RebuildAllFromArchive(ctx, archive1)
+	require.Error(t, err, "an archive that does not cover the latest prune checkpoint must be refused")
+	assert.Contains(t, err.Error(), "does not cover")
+}
+
+// pruneWorker builds a retention worker over a real fs archive whose
+// clock is far in the future, so every already-appended event is
+// prune-eligible (positive window + safety floor both satisfied).
+func pruneWorker(t *testing.T, st *store.Store, dir string) (*retention.Worker, archive.ArchiveStore) {
+	t.Helper()
+	arch, err := archive.New(archive.Config{Backend: archive.BackendFilesystem, FilesystemPath: dir})
+	require.NoError(t, err)
+	w, err := retention.NewWorker(st, arch, retention.Config{Window: time.Hour}, nil)
+	require.NoError(t, err)
+	future := time.Now().Add(1000 * time.Hour)
+	w.SetNowForTest(func() time.Time { return future })
+	return w, arch
+}
+
+// TestRestore_MultiPruneChain_FullFidelity is the end-to-end recovery
+// contract across MULTIPLE prunes (spec 19 AC 21): after two prunes, the
+// latest archive alone no longer contains events ≤ N1 — the full history
+// exists only as the marker-chained set of archives. LoadArchivedHistory
+// walks the chain (verifying each artifact against its tamper-evident
+// marker hash) and RebuildAllFromArchive must then reproduce the live
+// projection state byte-identically.
+func TestRestore_MultiPruneChain_FullFidelity(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	w, arch := pruneWorker(t, st, t.TempDir())
+
+	// Batch 1 → prune 1 (takes everything so far as checkpoint N1).
+	testutil.CreateTestUser(t, st, "chain1-"+testutil.NewID()[:8]+"@test.com", "pass", "admin")
+	testutil.CreateTestDevice(t, st, "chain1-host-"+testutil.NewID()[:6])
+	res1, err := w.Prune(ctx)
+	require.NoError(t, err)
+	require.True(t, res1.Pruned)
+
+	// Batch 2 → prune 2 (N2 > N1; its archive holds only (N1, N2]).
+	testutil.CreateTestUser(t, st, "chain2-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	testutil.CreateTestDevice(t, st, "chain2-host-"+testutil.NewID()[:6])
+	res2, err := w.Prune(ctx)
+	require.NoError(t, err)
+	require.True(t, res2.Pruned)
+	require.Greater(t, res2.Checkpoint, res1.Checkpoint)
+
+	// The live projections (built by the live listeners) are the truth.
+	baseline := dumpRebuildTables(t, st)
+
+	// Chain-load the full pruned history and restore.
+	archived, err := retention.LoadArchivedHistory(ctx, st, arch)
+	require.NoError(t, err)
+	require.NotEmpty(t, archived)
+	_, err = st.RebuildAllFromArchive(ctx, archived)
+	require.NoError(t, err)
+
+	after := dumpRebuildTables(t, st)
+	for tbl, rows := range baseline {
+		assert.Equalf(t, rows, after[tbl],
+			"projection table %q not byte-identical after a multi-prune chain restore (spec 19 AC 21)", tbl)
+	}
+}
+
+// TestLoadArchivedHistory_TamperDetected pins the integrity leg of the
+// chain restore: an archived artifact that no longer matches the sha256
+// recorded in its tamper-evident EventLogPruned marker is refused — a
+// modified or replaced cold archive must never be silently replayed.
+func TestLoadArchivedHistory_TamperDetected(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	w, arch := pruneWorker(t, st, dir)
+
+	testutil.CreateTestUser(t, st, "tamper-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	res, err := w.Prune(ctx)
+	require.NoError(t, err)
+	require.True(t, res.Pruned)
+
+	// Corrupt one byte of the sealed artifact on disk.
+	path := filepath.Join(dir, res.ArchiveRef)
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	data[len(data)/2] ^= 0xFF
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	_, err = retention.LoadArchivedHistory(ctx, st, arch)
+	require.Error(t, err, "a tampered archive must be refused")
+	assert.Contains(t, err.Error(), "marker hash")
 }
 
 // TestRebuildAllFromArchive_ErasedWithoutDEKsIsSentinel pins AC 21a:


### PR DESCRIPTION
Post-merge audit of the spec-19 Phase-C work (#516/#517) against the spec text found four off-spec gaps plus one additional race surfaced by local review. All fixed test-first (every behavioral fix has a RED-before-GREEN test).

## F1 — Trigger enforced only half the sanctioned-prune contract (security)

The spec requires a DELETE on `events` to be permitted only when the `SET LOCAL` guard is set **and** an `EventLogPruned` marker was appended in the same transaction. Migration 011 checked only the guard + range, leaving the marker to the Go method — so any session with DB credentials could `SET LOCAL` both guards and silently erase history with **no tamper-evident marker**.

**Migration 013**: the trigger now also requires an in-tx `EventLogPruned` (xmin = `pg_current_xact_id()`, `up_to_seq` matching the range guard) and hard-refuses deleting marker rows themselves (AC 24 at the DB layer). PG13+ floor documented (project pins 17 in tests / 18 in deploy); `idx_events_type` keeps the per-row EXISTS cheap.

## F2 — Plain `RebuildAll` after a prune destroyed all state ≤ N (AC 21)

`RebuildAll` TRUNCATE-and-replayed only the surviving live log — reachable via the shipped `rebuild-projections` CLI, it would silently rebuild projections missing everything up to the prune checkpoint. And the restore contract had no production entry point at all.

- `RebuildAll` now refuses with `ErrHistoryPruned` (checked in-tx, before any TRUNCATE — the refusal leaves projections untouched).
- `retention.LoadArchivedHistory` walks the `EventLogPruned` marker chain — the authoritative pruned-history ledger — fetching **every** range's archive and verifying each against the tamper-evident marker sha256. A single later archive is not sufficient: after a second prune it no longer contains events ≤ N1.
- `RebuildAllFromArchive` independently verifies the slice covers the latest marker checkpoint.
- CLI: `rebuild-projections --archive-dir=<path>` restores everything from the chained archives + live log; plain runs hitting `ErrHistoryPruned` exit 2 with the actionable pointer.

Proven by a multi-prune chain restore test (byte-identical over every `AllRebuildTargets` table) and a tampered-artifact refusal test.

## TOCTOU — guard-vs-replay race (found by local review, proven real)

`RebuildAll` checked for pruned history once, then re-read events per target under READ COMMITTED — a prune committing mid-rebuild deleted events between the guard and a later target's read. A deterministic race test (wrapped `users` applier commits a full prune on a separate connection mid-replay) went RED: `devices_projection` lost rows. Both rebuild transactions now run at **REPEATABLE READ** — one snapshot across the guard and every replay read; rebuild writes (projections) never overlap prune writes (events), so no serialization failures.

## F3 — AC 17a static determinism guard was missing

`TestProjectorDeterminism`: `math/rand` (v1/v2) banned in the projector set, and every map iteration must carry an order-independence justification in the allowlist (Go randomizes map order per run — an order-dependent applier body breaks snapshot equivalence). Pure-AST per archtest convention; red-checked; detector unit-tested across all declaration forms.

## Also

Spec tech-design text amended in the docs repo (the stale bullet describing a projection-dump artifact — the artifact is the ciphertext events).

## Verification

gofmt/vet/staticcheck/build clean; store, retention, archtest, cmd/control suites green against real Postgres. Local CodeRabbit findings all addressed (the TOCTOU above, a detector false-negative for `var x = make(map…)`, the PG-version floor note).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an archive-based rebuild mode for restoring projections from retention archives.
  * Added stronger protection for rebuilds when history has been pruned, with clearer operator guidance.
  * Added checks to verify archive completeness and detect tampering during restore.

* **Bug Fixes**
  * Rebuilds now use a consistent snapshot to avoid race conditions during concurrent pruning.
  * Database pruning now requires both the prune guard and a matching prune marker before deletes are allowed.
  * Prune marker rows are now protected from accidental deletion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->