### PR TITLE
feat(retention): env-configured prune scheduler + doctor retention posture (spec 19 D2, AC 29)

### DIFF
--- a/cmd/control/README.md
+++ b/cmd/control/README.md
@@ -77,6 +77,11 @@ Environment variables override command-line flags:
 | `CONTROL_VALKEY_DB` | Valkey/Redis database number (default: `0`) |
 | `CONTROL_AUTO_UPDATE_REPO` | GitHub repo for agent releases in `owner/repo` format (default: `MANCHTOOLS/power-manage-agent`) |
 | `CONTROL_DISABLE_AUTO_UPDATE` | Disable agent auto-update entirely (set to `true` or `1`). Overrides the `auto_update_agents` server setting. |
+| `CONTROL_RETENTION_ENABLED` | Enable audit-log retention (spec 19): events older than the window are sealed into cold archives and pruned from the live log (default: `false`) |
+| `CONTROL_RETENTION_WINDOW` | Retention window as a Go duration, **min `24h`** (e.g., `2160h` = 90 days). Required when retention is enabled; an invalid value refuses to boot — this knob decides what history is destroyed, so it is never silently clamped. |
+| `CONTROL_RETENTION_ARCHIVE_BACKEND` | Cold-archive backend for pruned history (default and only v1 value: `filesystem`) |
+| `CONTROL_RETENTION_ARCHIVE_PATH` | **Absolute** directory for sealed retention archives. Required when enabled — the archives are the ONLY copy of pruned history; back them up together with `user_encryption_keys`. |
+| `CONTROL_RETENTION_INTERVAL` | How often the retention worker checks for prunable history (default `1h`, clamped `10m`–`24h`) |
 
 ## Setup
 

--- a/cmd/control/config_guard_test.go
+++ b/cmd/control/config_guard_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 // validJWTSecret is 64 hex chars = 32 decoded bytes, the entropy floor
@@ -129,5 +130,50 @@ func TestValidateConfig_AdminPasswordFloor(t *testing.T) {
 				t.Fatalf("expected this config to pass, got: %v", err)
 			}
 		})
+	}
+}
+
+// TestValidateConfig_RetentionGate pins the spec-19 boot invariant: a
+// destructive retention config either validates fully or the server does
+// not boot. The per-field rules live in retention.EnvConfig.Validate
+// (unit-tested there); this pins that validateConfig actually calls it.
+func TestValidateConfig_RetentionGate(t *testing.T) {
+	base := func() *Config {
+		return &Config{JWTSecret: validJWTSecret, ListenAddr: "127.0.0.1:8081"}
+	}
+
+	// Disabled retention (the default zero value) boots.
+	if err := validateConfig(base()); err != nil {
+		t.Fatalf("disabled retention must boot: %v", err)
+	}
+
+	// Enabled but unconfigured (no window/path) must refuse to boot.
+	cfg := base()
+	cfg.Retention.Enabled = true
+	err := validateConfig(cfg)
+	if err == nil {
+		t.Fatal("enabled retention without window/path must be fatal at boot")
+	}
+	if !strings.Contains(err.Error(), "CONTROL_RETENTION_WINDOW") {
+		t.Fatalf("the error must name the offending variable, got: %v", err)
+	}
+
+	// Enabled with Interval=0 must be fatal: config.ClampInterval
+	// preserves zero (its "0 disables" convention), but retention has an
+	// explicit Enabled flag — a zero interval would panic time.NewTicker.
+	cfg = base()
+	cfg.Retention.Enabled = true
+	cfg.Retention.Window = 90 * 24 * time.Hour
+	cfg.Retention.Backend = "filesystem"
+	cfg.Retention.ArchivePath = "/var/lib/power-manage/archive"
+	cfg.Retention.Interval = 0
+	if err := validateConfig(cfg); err == nil {
+		t.Fatal("enabled retention with a zero interval must be fatal at boot (NewTicker would panic)")
+	}
+
+	// Fully valid enabled config boots.
+	cfg.Retention.Interval = time.Hour
+	if err := validateConfig(cfg); err != nil {
+		t.Fatalf("valid enabled retention must boot: %v", err)
 	}
 }

--- a/cmd/control/flags.go
+++ b/cmd/control/flags.go
@@ -50,6 +50,14 @@ func parseFlags() *Config {
 	flag.StringVar(&cfg.InternalTLSCert, "internal-tls-cert", "/certs/control.crt", "TLS certificate for internal mTLS listener")
 	flag.StringVar(&cfg.InternalTLSKey, "internal-tls-key", "/certs/control.key", "TLS private key for internal mTLS listener")
 
+	// Spec 19 audit-log retention (disabled by default; env-only in
+	// production, flags provided for parity with the rest of the knobs).
+	flag.BoolVar(&cfg.Retention.Enabled, "retention-enabled", false, "Enable the audit-log retention prune worker (spec 19)")
+	flag.DurationVar(&cfg.Retention.Window, "retention-window", 0, "Retention window: events older than this are archived and pruned (min 24h, e.g. 2160h for 90 days)")
+	flag.StringVar(&cfg.Retention.Backend, "retention-archive-backend", "filesystem", "Cold-archive backend for pruned history (v1: filesystem)")
+	flag.StringVar(&cfg.Retention.ArchivePath, "retention-archive-path", "", "Absolute directory for sealed retention archives (required when retention is enabled)")
+	flag.DurationVar(&cfg.Retention.Interval, "retention-interval", time.Hour, "How often the retention worker checks for prunable history")
+
 	flag.Parse()
 
 	applyEnvOverrides(cfg)
@@ -99,6 +107,12 @@ func applyEnvOverrides(cfg *Config) {
 	config.EnvString(&cfg.ValkeyAddr, "CONTROL_VALKEY_ADDR")
 	config.EnvString(&cfg.ValkeyPassword, "CONTROL_VALKEY_PASSWORD")
 	config.EnvInt(&cfg.ValkeyDB, "CONTROL_VALKEY_DB")
+
+	config.EnvBool(&cfg.Retention.Enabled, "CONTROL_RETENTION_ENABLED", []string{"true", "1"}, []string{"false", "0"})
+	config.EnvDuration(&cfg.Retention.Window, "CONTROL_RETENTION_WINDOW")
+	config.EnvString(&cfg.Retention.Backend, "CONTROL_RETENTION_ARCHIVE_BACKEND")
+	config.EnvString(&cfg.Retention.ArchivePath, "CONTROL_RETENTION_ARCHIVE_PATH")
+	config.EnvDuration(&cfg.Retention.Interval, "CONTROL_RETENTION_INTERVAL")
 }
 
 // clampDurations enforces safe bounds on the duration knobs.
@@ -111,6 +125,13 @@ func clampDurations(cfg *Config) {
 	config.ClampInterval(&cfg.DynamicGroupEvalInterval, 30*time.Minute, 8*time.Hour)
 	config.ClampInterval(&cfg.SystemActionReconcileInterval, 10*time.Second, 8*time.Hour)
 	config.ClampDurationFloor(&cfg.SystemActionReconcileTimeout, 5*time.Minute, 0)
+	// The retention TICK cadence is an operational knob — clamping is safe
+	// (it only changes how often we check). The WINDOW is deliberately NOT
+	// clamped: it decides what history is destroyed, so a bad value is
+	// fatal in validateConfig instead (retention.EnvConfig.Validate).
+	if cfg.Retention.Enabled {
+		config.ClampInterval(&cfg.Retention.Interval, 10*time.Minute, 24*time.Hour)
+	}
 }
 
 // mustValidateConfig enforces the boot-time invariants that turn a
@@ -145,6 +166,11 @@ func validateConfig(cfg *Config) error {
 	// expose a credential-less reflect-any-origin CORS policy to the internet.
 	if cfg.CORSAllowAll && (cfg.TLSEnabled || !listenAddrIsLocalhost(cfg.ListenAddr)) {
 		return fmt.Errorf("CONTROL_CORS_ALLOW_ALL is development-only and must not be set when TLS is enabled or the listen address is not localhost (got %q); set CONTROL_CORS_ORIGINS to an explicit allow-list instead", cfg.ListenAddr)
+	}
+	// Spec 19: retention deletes history — refuse to boot on an invalid
+	// retention config rather than run the prune worker on a guess.
+	if err := cfg.Retention.Validate(); err != nil {
+		return err
 	}
 	return nil
 }

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -15,12 +15,14 @@ import (
 	"github.com/manchtools/power-manage-sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage-sdk/logging"
 	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/archive"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/ca"
 	"github.com/manchtools/power-manage/server/internal/middleware"
 	"github.com/manchtools/power-manage/server/internal/mtls"
 	"github.com/manchtools/power-manage/server/internal/pii"
 	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/retention"
 	"github.com/manchtools/power-manage/server/internal/scim"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"github.com/manchtools/power-manage/server/internal/store/postgres"
@@ -75,6 +77,12 @@ type Config struct {
 	// context deadline so a hung query can't pile up missed ticks.
 	SystemActionReconcileInterval time.Duration
 	SystemActionReconcileTimeout  time.Duration
+
+	// Spec 19 audit-log retention (env-only config by decision — no
+	// RPC/UI surface). Retention.Enabled activates the rolling
+	// snapshot+prune worker; validation is fatal at boot (a destructive
+	// feature must never run on a half-read config).
+	Retention retention.EnvConfig
 }
 
 func main() {
@@ -189,6 +197,26 @@ func main() {
 	}
 
 	startStaleExecutionExpiry(ctx, st, logger, time.Now)
+
+	// Spec 19 audit-log retention: rolling snapshot + prune of the event
+	// log. Config was validated at parse time (fatal on violation); the
+	// archive store and worker construction are fatal too — a destructive
+	// worker either boots correctly or the server does not boot.
+	if cfg.Retention.Enabled {
+		arch, err := archive.New(cfg.Retention.ArchiveConfig())
+		if err != nil {
+			logger.Error("failed to initialize retention archive store", "error", err)
+			os.Exit(1)
+		}
+		if err := startRetentionWorker(ctx, st, arch, cfg.Retention, logger); err != nil {
+			logger.Error("failed to start retention worker", "error", err)
+			os.Exit(1)
+		}
+		logger.Info("audit-log retention enabled",
+			"window", cfg.Retention.Window, "interval", cfg.Retention.Interval, "archive_path", cfg.Retention.ArchivePath)
+	} else {
+		logger.Info("audit-log retention disabled (CONTROL_RETENTION_ENABLED=false); the event log grows unbounded")
+	}
 
 	// Start periodic cleanup of stale OSQuery results
 	go runPeriodic(ctx, 5*time.Minute, func() {

--- a/cmd/control/periodic.go
+++ b/cmd/control/periodic.go
@@ -11,9 +11,11 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/manchtools/power-manage/server/internal/archive"
 	"github.com/manchtools/power-manage/server/internal/dyngroupeval"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/retention"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -33,6 +35,49 @@ func runPeriodic(ctx context.Context, interval time.Duration, fn func(), runImme
 			return
 		}
 	}
+}
+
+// startRetentionWorker launches the spec-19 audit-log retention worker:
+// every tick it runs one advisory-lock-single-flighted prune cycle
+// (choose checkpoint → seal ciphertext events ≤ N into the archive →
+// delete ≤ N with the in-tx EventLogPruned marker). Construction errors
+// (nil archive, non-positive window) are returned for a FATAL boot — a
+// destructive worker must not be silently skipped. The first cycle runs
+// immediately: enabled means active, and the worker no-ops when nothing
+// is prune-eligible (its 1h safety floor additionally protects fresh
+// events).
+//
+// The per-tick timeout bounds a wedged DB/archive call so a hung cycle
+// cannot pin its goroutine forever; a slow-but-healthy prune simply
+// delays the next tick (runPeriodic calls fn synchronously).
+func startRetentionWorker(ctx context.Context, st *store.Store, arch archive.ArchiveStore, cfg retention.EnvConfig, logger *slog.Logger) error {
+	w, err := retention.NewWorker(st, arch, retention.Config{Window: cfg.Window}, logger)
+	if err != nil {
+		return err
+	}
+	go runPeriodic(ctx, cfg.Interval, func() {
+		// A panic in one prune cycle must not crash the whole control
+		// server — recover, log, and let the next tick retry (WS15
+		// posture: background jobs are isolated, not load-bearing).
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Error("retention prune cycle panicked", "panic", r)
+			}
+		}()
+		tickCtx, cancel := context.WithTimeout(ctx, 30*time.Minute)
+		defer cancel()
+		res, err := w.Prune(tickCtx)
+		if err != nil {
+			logger.Error("retention prune cycle failed", "error", err)
+			return
+		}
+		if !res.Ran {
+			logger.Debug("retention prune skipped — another replica holds the lock")
+		}
+		// Pruned outcomes are logged by the worker itself (checkpoint,
+		// events_deleted, archive_ref); no-op runs stay quiet by design.
+	}, true)
+	return nil
 }
 
 // dynamicQueueBatch is what one drain iteration reports: how many rows

--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -104,7 +104,7 @@ Flags:
 - `--env-file <path>` — also inspect this `.env` (default `.env`, silently skipped if absent). Values in the file take precedence over the process environment — it is the operator's stored config, the source of truth for what was configured.
 <!-- docref: end -->
 
-<!-- docref: begin src=internal/doctor/registry.go#DefaultChecks:293ef4cc -->
+<!-- docref: begin src=internal/doctor/registry.go#DefaultChecks:dd5d9b84 -->
 It reports placeholder/weak secrets, mandatory at-rest encryption key, a
 credentialed CORS wildcard, an internal mTLS listener bound to all interfaces, a
 floating `IMAGE_TAG`, certificate file permissions and approaching expiry,
@@ -113,9 +113,12 @@ and indexer liveness (reconcile heartbeat), remote-terminal (TTY) routing and
 config consistency (Valkey keyspace notifications, web-listener and TTY-host
 config), a bootstrap admin still on the default email, the per-user
 encryption-key invariants that crypto-shred erasure depends on (every live
-user's DEK unwraps; no erased user retains one), and projection drift (a
+user's DEK unwraps; no erased user retains one), projection drift (a
 projection that has stopped applying events, caught before retention prunes
-the source events).
+the source events), and the audit-log retention posture (event count, oldest
+event age, configured window, last prune — plus a critical finding when
+retention is enabled but misconfigured, since the next restart would refuse
+to boot).
 <!-- docref: end -->
 
 ### Exit codes

--- a/internal/doctor/check_retention.go
+++ b/internal/doctor/check_retention.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/retention"
 )
 
 // DEKInvariantCheck verifies the per-user encryption-key invariants that
@@ -118,6 +120,92 @@ func (c ProjectionDriftCheck) Run(ctx context.Context, env *Env) ([]Finding, err
 	}
 	return []Finding{ok(c.ID(),
 		fmt.Sprintf("every projection is current with the event log (%d targets checked)", len(drifts)))}, nil
+}
+
+// RetentionPostureCheck reports the audit-log retention posture (spec 19
+// AC 29): oldest live event age, event row count, the configured window,
+// and the last successful prune (checkpoint + time + archive ref). It
+// never mutates or prunes anything.
+//
+// Config-shape violations (enabled but invalid window/backend/path) are
+// Critical: the control server refuses to BOOT on them, so seeing one
+// here means the running server was started before the variable changed —
+// the next restart will fail.
+type RetentionPostureCheck struct{}
+
+func (RetentionPostureCheck) ID() string { return "retention" }
+
+func (c RetentionPostureCheck) Run(ctx context.Context, env *Env) ([]Finding, error) {
+	cfg, malformed := retentionEnvConfig(env)
+	if cfg.Enabled && len(malformed) > 0 {
+		// An unparseable duration would otherwise surface as a misleading
+		// "window too small (got 0s)" — name the actual broken value (CR).
+		return []Finding{crit(c.ID(),
+			fmt.Sprintf("retention is enabled but %s — the value is not a valid Go duration (e.g. \"2160h\" for 90 days)", strings.Join(malformed, "; ")),
+			"fix the variable(s) named above; at boot the server falls back to the flag default and may refuse to start")}, nil
+	}
+	if err := cfg.Validate(); err != nil {
+		return []Finding{crit(c.ID(),
+			fmt.Sprintf("retention is enabled but misconfigured: %v", err),
+			"fix the CONTROL_RETENTION_* variable named above; the control server will refuse to boot with this configuration")}, nil
+	}
+
+	if skip, proceed := dbReady(ctx, c, env); !proceed {
+		return skip, nil
+	}
+	p, err := env.DB.RetentionPosture(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("read retention posture: %w", err)
+	}
+
+	oldest := "empty log"
+	if !p.OldestEventAt.IsZero() {
+		oldest = fmt.Sprintf("oldest event %s old", env.Now().Sub(p.OldestEventAt).Round(time.Hour))
+	}
+	lastPrune := "never pruned"
+	if !p.LastPruneAt.IsZero() {
+		lastPrune = fmt.Sprintf("last prune at %s (checkpoint %d, archive %s)",
+			p.LastPruneAt.Format(time.RFC3339), p.LastPruneCheckpoint, p.LastPruneRef)
+	}
+
+	if !cfg.Enabled {
+		return []Finding{info(c.ID(),
+			fmt.Sprintf("retention is disabled — the event log grows unbounded (%d events, %s; %s)", p.EventCount, oldest, lastPrune))}, nil
+	}
+	return []Finding{ok(c.ID(),
+		fmt.Sprintf("retention enabled (window %s): %d events, %s; %s", cfg.Window, p.EventCount, oldest, lastPrune))}, nil
+}
+
+// retentionEnvConfig mirrors cmd/control's flag/env mapping for the
+// doctor's standalone read (doctor runs without booting the server).
+// malformed lists human-readable descriptions of duration variables that
+// are set but do not parse — the caller reports them explicitly instead
+// of letting the zero fallback masquerade as a too-small value.
+func retentionEnvConfig(env *Env) (cfg retention.EnvConfig, malformed []string) {
+	enabled := env.Get("CONTROL_RETENTION_ENABLED")
+	backend := env.Get("CONTROL_RETENTION_ARCHIVE_BACKEND")
+	if backend == "" {
+		backend = "filesystem" // the boot-side flag default
+	}
+	parse := func(key string, def time.Duration) time.Duration {
+		raw := env.Get(key)
+		if raw == "" {
+			return def
+		}
+		d, err := time.ParseDuration(raw)
+		if err != nil {
+			malformed = append(malformed, fmt.Sprintf("%s=%q", key, raw))
+			return def
+		}
+		return d
+	}
+	return retention.EnvConfig{
+		Enabled:     enabled == "true" || enabled == "1",
+		Window:      parse("CONTROL_RETENTION_WINDOW", 0),
+		Backend:     backend,
+		ArchivePath: env.Get("CONTROL_RETENTION_ARCHIVE_PATH"),
+		Interval:    parse("CONTROL_RETENTION_INTERVAL", time.Hour), // the boot-side flag default
+	}, malformed
 }
 
 // sample renders up to three ids for a finding message; user ids are ULIDs

--- a/internal/doctor/check_retention_test.go
+++ b/internal/doctor/check_retention_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -109,6 +110,71 @@ func TestProjectionDriftCheck_DriftIsCritical(t *testing.T) {
 func TestProjectionDriftCheck_DBDownSkips(t *testing.T) {
 	env := testEnv(nil) // DB nil
 	fs := run1(t, ProjectionDriftCheck{}, env)
+	assert.NotEqual(t, SeverityCritical, worst(fs))
+}
+
+func TestRetentionPostureCheck_DisabledIsInfo(t *testing.T) {
+	env := testEnv(nil) // no CONTROL_RETENTION_* vars
+	env.DB = fakeDB{posture: store.RetentionPosture{
+		EventCount:    1234,
+		OldestEventAt: env.Now().Add(-90 * 24 * time.Hour),
+	}}
+	fs := run1(t, RetentionPostureCheck{}, env)
+	require.Equal(t, SeverityInfo, worst(fs), "disabled retention is posture info, not a failure")
+	txt := findingText(fs)
+	assert.Contains(t, txt, "disabled")
+	assert.Contains(t, txt, "1234 events")
+	assert.Contains(t, txt, "never pruned")
+}
+
+func TestRetentionPostureCheck_EnabledHealthyReportsLastPrune(t *testing.T) {
+	env := testEnv(map[string]string{
+		"CONTROL_RETENTION_ENABLED":      "true",
+		"CONTROL_RETENTION_WINDOW":       "2160h",
+		"CONTROL_RETENTION_ARCHIVE_PATH": "/var/lib/pm/archive",
+	})
+	env.DB = fakeDB{posture: store.RetentionPosture{
+		EventCount:          500,
+		OldestEventAt:       env.Now().Add(-30 * 24 * time.Hour),
+		LastPruneAt:         env.Now().Add(-2 * time.Hour),
+		LastPruneCheckpoint: 4711,
+		LastPruneRef:        "prune-00000000000000004711",
+	}}
+	fs := run1(t, RetentionPostureCheck{}, env)
+	require.Equal(t, SeverityOK, worst(fs))
+	txt := findingText(fs)
+	assert.Contains(t, txt, "2160h", "the configured window is reported")
+	assert.Contains(t, txt, "checkpoint 4711")
+	assert.Contains(t, txt, "prune-00000000000000004711")
+}
+
+func TestRetentionPostureCheck_MisconfiguredIsCritical(t *testing.T) {
+	// Enabled but no window/path: the running server predates the change —
+	// the next restart will refuse to boot. Reported without touching the DB.
+	env := testEnv(map[string]string{"CONTROL_RETENTION_ENABLED": "true"})
+	fs := run1(t, RetentionPostureCheck{}, env)
+	require.Equal(t, SeverityCritical, worst(fs))
+	assert.Contains(t, findingText(fs), "CONTROL_RETENTION_WINDOW")
+}
+
+func TestRetentionPostureCheck_MalformedDurationNamed(t *testing.T) {
+	// "90d" is not a valid Go duration — the finding must name the broken
+	// value instead of a misleading "window too small (got 0s)" (CR).
+	env := testEnv(map[string]string{
+		"CONTROL_RETENTION_ENABLED":      "true",
+		"CONTROL_RETENTION_WINDOW":       "90d",
+		"CONTROL_RETENTION_ARCHIVE_PATH": "/var/lib/pm/archive",
+	})
+	fs := run1(t, RetentionPostureCheck{}, env)
+	require.Equal(t, SeverityCritical, worst(fs))
+	txt := findingText(fs)
+	assert.Contains(t, txt, `CONTROL_RETENTION_WINDOW="90d"`, "the unparseable value is named")
+	assert.Contains(t, txt, "not a valid Go duration")
+}
+
+func TestRetentionPostureCheck_DBDownSkips(t *testing.T) {
+	env := testEnv(nil) // DB nil, retention disabled (valid config)
+	fs := run1(t, RetentionPostureCheck{}, env)
 	assert.NotEqual(t, SeverityCritical, worst(fs))
 }
 

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -28,6 +28,8 @@ type fakeDB struct {
 	deletedErr  error
 	drift       []store.TargetDrift
 	driftErr    error
+	posture     store.RetentionPosture
+	postureErr  error
 }
 
 func (f fakeDB) Ping(context.Context) error { return f.pingErr }
@@ -42,6 +44,9 @@ func (f fakeDB) DeletedUsersWithDEK(context.Context) ([]string, error) {
 }
 func (f fakeDB) ProjectionDrift(context.Context) ([]store.TargetDrift, error) {
 	return f.drift, f.driftErr
+}
+func (f fakeDB) RetentionPosture(context.Context) (store.RetentionPosture, error) {
+	return f.posture, f.postureErr
 }
 
 type fakeCache struct {

--- a/internal/doctor/env.go
+++ b/internal/doctor/env.go
@@ -153,6 +153,9 @@ type DBProbe interface {
 	// ProjectionDrift compares each rebuild target's projection high-water
 	// against the events it should have applied (spec 19 AC 31a).
 	ProjectionDrift(ctx context.Context) ([]store.TargetDrift, error)
+	// RetentionPosture reports event-log size/age and the last prune
+	// (spec 19 AC 29).
+	RetentionPosture(ctx context.Context) (store.RetentionPosture, error)
 }
 
 // CacheProbe is the narrow live-Valkey surface the cache/search/queue checks need.

--- a/internal/doctor/probe.go
+++ b/internal/doctor/probe.go
@@ -58,6 +58,10 @@ func (p *PGProbe) ProjectionDrift(ctx context.Context) ([]store.TargetDrift, err
 	return store.ComputeProjectionDrift(ctx, p.pool)
 }
 
+func (p *PGProbe) RetentionPosture(ctx context.Context) (store.RetentionPosture, error) {
+	return store.ReadRetentionPosture(ctx, p.pool)
+}
+
 // Close releases the pool.
 func (p *PGProbe) Close() {
 	if p.pool != nil {

--- a/internal/doctor/registry.go
+++ b/internal/doctor/registry.go
@@ -19,5 +19,6 @@ func DefaultChecks() []Check {
 		AdminCheck{},
 		DEKInvariantCheck{},
 		ProjectionDriftCheck{},
+		RetentionPostureCheck{},
 	}
 }

--- a/internal/retention/config.go
+++ b/internal/retention/config.go
@@ -1,0 +1,75 @@
+package retention
+
+import (
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/manchtools/power-manage/server/internal/archive"
+)
+
+// EnvConfig is the operator-facing retention configuration, sourced from
+// the CONTROL_RETENTION_* environment variables (spec 19 D2 — env-only by
+// decision, no RPC/UI surface):
+//
+//	CONTROL_RETENTION_ENABLED         "true"/"1" to activate the prune worker
+//	CONTROL_RETENTION_WINDOW          Go duration, e.g. "2160h" (90 days)
+//	CONTROL_RETENTION_ARCHIVE_BACKEND "filesystem" (the only v1 backend)
+//	CONTROL_RETENTION_ARCHIVE_PATH    absolute directory for sealed archives
+//	CONTROL_RETENTION_INTERVAL        how often the prune ticks (default 1h)
+//
+// Validate is shared by the control boot path (fatal on violation — a
+// destructive feature must never run on a half-read config) and the
+// doctor's posture check (reports the same violations as findings).
+type EnvConfig struct {
+	Enabled     bool
+	Window      time.Duration
+	Backend     string
+	ArchivePath string
+	Interval    time.Duration
+}
+
+// MinWindow is the smallest permitted retention window. Deliberately
+// validated (fatal), not clamped: silently stretching an operator's typo
+// ("90m" meant "90 days") into a different retention period would prune
+// history they intended to keep. The worker's own pruneSafetyMargin (1h)
+// is a last-resort floor, not a substitute for a sane window.
+const MinWindow = 24 * time.Hour
+
+// MinInterval is the smallest permitted tick interval. Validated here —
+// not only clamped at boot — because config.ClampInterval preserves a
+// zero value ("0 means disabled" convention), but retention has an
+// explicit Enabled flag, so an enabled config with Interval <= 0 is
+// simply invalid and would panic time.NewTicker at runtime. The boot
+// clamp additionally raises anything below 10m.
+const MinInterval = time.Minute
+
+// Validate returns the first configuration violation, or nil. A disabled
+// config is always valid — the other variables are simply unused.
+func (c EnvConfig) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
+	if c.Window < MinWindow {
+		return fmt.Errorf("retention: CONTROL_RETENTION_WINDOW must be at least %s when retention is enabled (got %s); use a Go duration, e.g. \"2160h\" for 90 days", MinWindow, c.Window)
+	}
+	if c.Interval < MinInterval {
+		return fmt.Errorf("retention: CONTROL_RETENTION_INTERVAL must be at least %s when retention is enabled (got %s)", MinInterval, c.Interval)
+	}
+	if archive.Backend(c.Backend) != archive.BackendFilesystem {
+		return fmt.Errorf("retention: CONTROL_RETENTION_ARCHIVE_BACKEND %q is not supported; the only backend is %q", c.Backend, archive.BackendFilesystem)
+	}
+	if c.ArchivePath == "" {
+		return fmt.Errorf("retention: CONTROL_RETENTION_ARCHIVE_PATH is required when retention is enabled — the sealed archives are the ONLY copy of pruned history")
+	}
+	if !filepath.IsAbs(c.ArchivePath) {
+		return fmt.Errorf("retention: CONTROL_RETENTION_ARCHIVE_PATH must be absolute (got %q) — a relative path silently depends on the process working directory", c.ArchivePath)
+	}
+	return nil
+}
+
+// ArchiveConfig maps the validated env config onto the archive
+// constructor's config.
+func (c EnvConfig) ArchiveConfig() archive.Config {
+	return archive.Config{Backend: archive.Backend(c.Backend), FilesystemPath: c.ArchivePath}
+}

--- a/internal/retention/config_test.go
+++ b/internal/retention/config_test.go
@@ -1,0 +1,82 @@
+package retention
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func validEnvConfig() EnvConfig {
+	return EnvConfig{
+		Enabled:     true,
+		Window:      90 * 24 * time.Hour,
+		Backend:     "filesystem",
+		ArchivePath: "/var/lib/power-manage/archive",
+		Interval:    time.Hour,
+	}
+}
+
+func TestEnvConfig_ValidIsAccepted(t *testing.T) {
+	require.NoError(t, validEnvConfig().Validate())
+}
+
+func TestEnvConfig_DisabledSkipsAllChecks(t *testing.T) {
+	// Disabled means the rest is unused — even a fully-zero config is valid.
+	require.NoError(t, EnvConfig{}.Validate())
+}
+
+// Correct / absent / wrong per field (enabled configs only).
+
+func TestEnvConfig_WindowBelowFloorRejected(t *testing.T) {
+	c := validEnvConfig()
+	c.Window = 90 * time.Minute // the "90m meant 90 days" typo
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CONTROL_RETENTION_WINDOW")
+
+	c.Window = 0 // absent
+	require.Error(t, c.Validate())
+}
+
+func TestEnvConfig_IntervalBelowFloorRejected(t *testing.T) {
+	c := validEnvConfig()
+	c.Interval = 0 // absent — ClampInterval's "0 disables" must not slip through here
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CONTROL_RETENTION_INTERVAL")
+
+	c.Interval = time.Second // wrong: below the floor
+	require.Error(t, c.Validate())
+}
+
+func TestEnvConfig_UnknownBackendRejected(t *testing.T) {
+	c := validEnvConfig()
+	c.Backend = "s3" // not in v1
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not supported")
+
+	c.Backend = "" // absent
+	require.Error(t, c.Validate())
+}
+
+func TestEnvConfig_ArchivePathRequiredAndAbsolute(t *testing.T) {
+	c := validEnvConfig()
+	c.ArchivePath = "" // absent
+	err := c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "ONLY copy of pruned history")
+
+	c.ArchivePath = "archives/here" // wrong: relative
+	err = c.Validate()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "absolute")
+}
+
+func TestEnvConfig_ArchiveConfigMapsToFilesystem(t *testing.T) {
+	ac := validEnvConfig().ArchiveConfig()
+	assert.Equal(t, "filesystem", string(ac.Backend))
+	assert.Equal(t, "/var/lib/power-manage/archive", ac.FilesystemPath)
+}

--- a/internal/store/observability.go
+++ b/internal/store/observability.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -82,6 +83,56 @@ func DeletedUsersWithDEK(ctx context.Context, pool *pgxpool.Pool) ([]string, err
 		out = append(out, id)
 	}
 	return out, rows.Err()
+}
+
+// RetentionPosture is the read-only snapshot `control doctor` reports for
+// AC 29: how big/old the live event log is and when retention last acted.
+type RetentionPosture struct {
+	EventCount    int64
+	OldestEventAt time.Time // zero when the log is empty
+	// Last prune, from the newest EventLogPruned marker (zero values when
+	// no prune has ever run).
+	LastPruneAt         time.Time
+	LastPruneCheckpoint int64
+	LastPruneRef        string
+}
+
+// ReadRetentionPosture gathers the AC 29 posture in two cheap queries.
+// Read-only — doctor never mutates or prunes (AC 29).
+func ReadRetentionPosture(ctx context.Context, pool *pgxpool.Pool) (RetentionPosture, error) {
+	var p RetentionPosture
+	var oldest *time.Time
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*), MIN(occurred_at) FROM events`).Scan(&p.EventCount, &oldest); err != nil {
+		return RetentionPosture{}, fmt.Errorf("observability: event log posture: %w", err)
+	}
+	if oldest != nil {
+		p.OldestEventAt = *oldest
+	}
+
+	var upToSeq *int64
+	var ref *string
+	var at *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT (data->>'up_to_seq')::bigint, data->>'archive_ref', occurred_at
+		FROM events WHERE event_type = $1
+		ORDER BY sequence_num DESC LIMIT 1`,
+		EventLogPrunedType).Scan(&upToSeq, &ref, &at); err != nil {
+		if IsNotFound(err) {
+			return p, nil // never pruned — zero-valued last-prune fields
+		}
+		return RetentionPosture{}, fmt.Errorf("observability: last prune marker: %w", err)
+	}
+	if upToSeq != nil {
+		p.LastPruneCheckpoint = *upToSeq
+	}
+	if ref != nil {
+		p.LastPruneRef = *ref
+	}
+	if at != nil {
+		p.LastPruneAt = *at
+	}
+	return p, nil
 }
 
 // TargetDrift is one rebuild target's projection-freshness comparison.

--- a/internal/store/observability_test.go
+++ b/internal/store/observability_test.go
@@ -149,6 +149,33 @@ func TestComputeProjectionDrift_PerTableNotMaskedByFreshSibling(t *testing.T) {
 		"and its own high-water, not the target-wide max (which is the fresh sibling's)")
 }
 
+// TestReadRetentionPosture pins the AC 29 data source: log size + oldest
+// event before any prune, and the last-prune marker fields after one.
+func TestReadRetentionPosture(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	testutil.CreateTestUser(t, st, "posture-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+
+	p, err := store.ReadRetentionPosture(ctx, st.TestingPool())
+	require.NoError(t, err)
+	assert.Positive(t, p.EventCount)
+	assert.False(t, p.OldestEventAt.IsZero(), "a non-empty log has an oldest event")
+	assert.Zero(t, p.LastPruneCheckpoint, "never pruned → zero last-prune fields")
+	assert.True(t, p.LastPruneAt.IsZero())
+
+	// After a prune, the marker surfaces as the last-prune posture.
+	cp := maxSeq(t, st)
+	_, err = st.PruneEventsUpTo(ctx, cp, "prune-posture", "sha-posture")
+	require.NoError(t, err)
+
+	p, err = store.ReadRetentionPosture(ctx, st.TestingPool())
+	require.NoError(t, err)
+	assert.Equal(t, cp, p.LastPruneCheckpoint)
+	assert.Equal(t, "prune-posture", p.LastPruneRef)
+	assert.False(t, p.LastPruneAt.IsZero(), "the marker's occurred_at is the last-prune time")
+}
+
 func findTargetDrift(t *testing.T, ds []store.TargetDrift, name string) store.TargetDrift {
 	t.Helper()
 	for _, d := range ds {


### PR DESCRIPTION
Spec 19 Phase D, part 2 — **this activates retention**. The prune worker, archive chain, and restore path (merged in C1/C2/#518) existed but nothing ran them; this wires the scheduler and the operator surface. With this PR, spec 19 is functionally complete (A: PII envelope · B: crypto-shred · C: retention/prune/restore · D: observability + activation).

## Configuration — environment-only (maintainer decision, spec amended)

```
CONTROL_RETENTION_ENABLED=true
CONTROL_RETENTION_WINDOW=2160h          # min 24h — never silently clamped
CONTROL_RETENTION_ARCHIVE_BACKEND=filesystem
CONTROL_RETENTION_ARCHIVE_PATH=/var/lib/power-manage/archive
CONTROL_RETENTION_INTERVAL=1h           # tick cadence, clamped 10m–24h
```

`retention.EnvConfig.Validate()` is shared by the boot path (**fatal** — a destructive feature never runs on a half-read config) and the doctor. The window is deliberately validated rather than clamped: a "90m meant 90 days" typo must not silently stretch into a different destruction window. The interval is validated too — `config.ClampInterval` preserves zero (its "0 disables" convention), but retention has an explicit `Enabled` flag, and a zero interval would panic `time.NewTicker`.

## Scheduler

`startRetentionWorker` runs one advisory-lock-single-flighted `Prune` per tick: first cycle immediately (enabled means active; the worker no-ops when nothing is eligible, and its 1h safety floor protects fresh events), 30-minute per-tick timeout, and panic recovery so one broken cycle cannot crash the control server. Archive-store and worker construction are fatal at boot.

## Doctor: retention posture (AC 29)

Read-only: event count, oldest-event age, configured window, and the last prune (checkpoint + time + archive ref from the newest `EventLogPruned` marker). **Critical** when retention is enabled but misconfigured — the running server predates the change and the next restart will refuse to boot — including an **unparseable duration value named explicitly** (instead of masquerading as "window too small (got 0s)"). Backed by `store.ReadRetentionPosture`, using `store.IsNotFound` for the never-pruned row.

## Verification

Pure config validation (correct/absent/wrong per field), boot-gate tests (including the zero-interval NewTicker guard), posture check severity tests via `fakeDB`, `ReadRetentionPosture` against real Postgres, full suites green (retention/store/doctor/archtest/cmd-control), docref re-pinned. Local CodeRabbit findings addressed pre-push (interval validation, tick panic recovery, malformed-duration reporting); its archive-`Close` suggestion doesn't apply — the filesystem backend is stateless.