### PR TITLE
feat: NOT_APPLICABLE execution status through the pipeline (spec 23)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/manchtools/power-manage/server
 
-go 1.25.11
+go 1.25.12
 
 require (
 	connectrpc.com/connect v1.18.1
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260707202812-87ad575e7e37
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260709091948-db56f7940806
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.5.4-0.20260707202812-87ad575e7e37 h1:QSEaaLBZsEt99Szw7Lx887lzptS1b+nqLoYw8/uyVfw=
-github.com/manchtools/power-manage-sdk v0.5.4-0.20260707202812-87ad575e7e37/go.mod h1:BoYIiUzWVAy6JTT3exkbJQIiTcgyI2AhayUm9bWVmOs=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260709091948-db56f7940806 h1:t8MytdUUMUj4goYBUEY83wkD3nMCRszu4cHwDdj36q8=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260709091948-db56f7940806/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -194,6 +194,10 @@ func statusToString(s pm.ExecutionStatus) string {
 		return "scheduled"
 	case pm.ExecutionStatus_EXECUTION_STATUS_CANCELLED:
 		return "cancelled"
+	case pm.ExecutionStatus_EXECUTION_STATUS_SKIPPED:
+		return "skipped"
+	case pm.ExecutionStatus_EXECUTION_STATUS_NOT_APPLICABLE:
+		return "not_applicable"
 	default:
 		return ""
 	}
@@ -217,6 +221,10 @@ func stringToStatus(s string) pm.ExecutionStatus {
 		return pm.ExecutionStatus_EXECUTION_STATUS_SCHEDULED
 	case "cancelled":
 		return pm.ExecutionStatus_EXECUTION_STATUS_CANCELLED
+	case "skipped":
+		return pm.ExecutionStatus_EXECUTION_STATUS_SKIPPED
+	case "not_applicable":
+		return pm.ExecutionStatus_EXECUTION_STATUS_NOT_APPLICABLE
 	default:
 		return pm.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED
 	}

--- a/internal/api/status_mapping_test.go
+++ b/internal/api/status_mapping_test.go
@@ -1,0 +1,38 @@
+package api
+
+import (
+	"testing"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+)
+
+// TestExecutionStatusMapping_RoundTripsEveryEnumValue is self-discovering
+// over the proto enum registry: every ExecutionStatus the SDK defines
+// (except UNSPECIFIED) must map to a non-empty projection string and back
+// to itself. A new enum value added in the SDK without a statusToString /
+// stringToStatus case fails here instead of silently mapping to "" —
+// which would corrupt the ListExecutions status filter and GetExecution
+// responses.
+func TestExecutionStatusMapping_RoundTripsEveryEnumValue(t *testing.T) {
+	checked := 0
+	for num, name := range pm.ExecutionStatus_name {
+		s := pm.ExecutionStatus(num)
+		if s == pm.ExecutionStatus_EXECUTION_STATUS_UNSPECIFIED {
+			continue
+		}
+		checked++
+		str := statusToString(s)
+		if str == "" {
+			t.Errorf("statusToString(%s) = \"\" — add a case for the new enum value", name)
+			continue
+		}
+		if got := stringToStatus(str); got != s {
+			t.Errorf("stringToStatus(statusToString(%s)) = %s, want %s", name, got, s)
+		}
+	}
+	// Matches-zero guard: if the registry iteration ever finds nothing,
+	// the test is broken, not the code.
+	if checked == 0 {
+		t.Fatal("enum registry iteration found no ExecutionStatus values — test harness broken")
+	}
+}

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -402,6 +402,15 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 			data = payloads.ExecutionReason{}
 		}
 
+	case pm.ExecutionStatus_EXECUTION_STATUS_NOT_APPLICABLE:
+		eventType = "ExecutionNotApplicable"
+		if result.Error != "" {
+			reason := result.Error
+			data = payloads.ExecutionReason{Reason: &reason}
+		} else {
+			data = payloads.ExecutionReason{}
+		}
+
 	default:
 		return fmt.Errorf("unknown execution status: %s", result.Status.String())
 	}

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -358,6 +358,63 @@ func TestHandleExecutionResult_Failed(t *testing.T) {
 	assert.Equal(t, "failed", exec.Status)
 }
 
+// TestHandleExecutionResult_NotApplicable pins spec 23 AC 4: a
+// NOT_APPLICABLE result flows through the existing pipeline (event →
+// projection) with the machine-readable reason landing in the error
+// column — a distinct terminal state, not FAILED and not SUCCESS.
+func TestHandleExecutionResult_NotApplicable(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	mux := worker.NewMux()
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "exec-na-host")
+	actionID := testutil.CreateTestAction(t, st, adminID, "NA Action", int(pm.ActionType_ACTION_TYPE_UPDATE))
+
+	executionID := testutil.NewID()
+	err := st.AppendEvent(context.Background(), store.Event{
+		StreamType: "execution",
+		StreamID:   executionID,
+		EventType:  "ExecutionCreated",
+		Data: map[string]any{
+			"device_id":       deviceID,
+			"action_id":       actionID,
+			"action_type":     int(pm.ActionType_ACTION_TYPE_UPDATE),
+			"desired_state":   0,
+			"params":          map[string]any{},
+			"timeout_seconds": 300,
+			"executed_at":     time.Now().Format(time.RFC3339Nano),
+		},
+		ActorType: "user",
+		ActorID:   adminID,
+	})
+	require.NoError(t, err)
+
+	result := &pm.ActionResult{
+		ActionId:    &pm.ActionId{Value: executionID},
+		Status:      pm.ExecutionStatus_EXECUTION_STATUS_NOT_APPLICABLE,
+		Error:       "security-only upgrades unsupported: pacman has no security-patch scoping",
+		DurationMs:  120,
+		CompletedAt: timestamppb.Now(),
+	}
+	resultProto, err := proto.Marshal(result)
+	require.NoError(t, err)
+
+	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
+		DeviceID:          deviceID,
+		ActionResultProto: resultProto,
+	})
+
+	err = mux.ProcessTask(context.Background(), task)
+	require.NoError(t, err)
+
+	exec, err := st.Queries().GetExecutionByID(context.Background(), executionID)
+	require.NoError(t, err)
+	assert.Equal(t, "not_applicable", exec.Status)
+	require.NotNil(t, exec.Error)
+	assert.Equal(t, "security-only upgrades unsupported: pacman has no security-patch scoping", *exec.Error)
+}
+
 func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)

--- a/internal/eventtypes/types.go
+++ b/internal/eventtypes/types.go
@@ -130,6 +130,11 @@ const (
 	ExecutionTimedOut   EventType = "ExecutionTimedOut"
 	ExecutionSkipped    EventType = "ExecutionSkipped"
 	ExecutionCancelled  EventType = "ExecutionCancelled"
+	// ExecutionNotApplicable is the terminal, non-error outcome for an
+	// action that is structurally inapplicable to the device (spec 23):
+	// security_only on a backend with no security-patch scoping, a DEB
+	// action on an rpm host, etc. The reason travels in the payload.
+	ExecutionNotApplicable EventType = "ExecutionNotApplicable"
 	// OutputChunk is emitted on the execution stream for streaming
 	// terminal/output payloads (LoadOutputChunks reads them back).
 	OutputChunk EventType = "OutputChunk"
@@ -283,7 +288,7 @@ func All() []EventType {
 		DeviceGroupSyncIntervalSet, DeviceGroupInventoryIntervalSet, DeviceGroupMaintenanceWindowSet, DeviceGroupMemberAdded,
 		DeviceGroupMemberRemoved, DeviceGroupMembersReevaluated, DeviceGroupDeleted, DeviceAddedToGroup, DeviceRemovedFromGroup,
 		ExecutionCreated, ExecutionScheduled, ExecutionDispatched, ExecutionStarted, ExecutionCompleted,
-		ExecutionFailed, ExecutionTimedOut, ExecutionSkipped, ExecutionCancelled, OutputChunk,
+		ExecutionFailed, ExecutionTimedOut, ExecutionSkipped, ExecutionCancelled, ExecutionNotApplicable, OutputChunk,
 		IdentityProviderCreated, IdentityProviderUpdated, IdentityProviderDeleted, IdentityProviderSCIMEnabled,
 		IdentityProviderSCIMDisabled, IdentityProviderSCIMTokenRotated, IdentityLinked,
 		IdentityLinkLoginUpdated, IdentityUnlinked,

--- a/internal/projectors/execution.go
+++ b/internal/projectors/execution.go
@@ -269,10 +269,11 @@ func ExecutionTimedOutFromEvent(e store.PersistedEvent) (ExecutionTimedOutPayloa
 	return out, nil
 }
 
-// ExecutionReasonPayload covers ExecutionSkipped and ExecutionCancelled.
-// Both events write completed_at = event.occurred_at unconditionally
-// (no payload fallback in the PL/pgSQL source) and stash the reason in
-// the error column. Decoder shapes them identically.
+// ExecutionReasonPayload covers ExecutionSkipped, ExecutionCancelled
+// and ExecutionNotApplicable. These events write completed_at =
+// event.occurred_at unconditionally (no payload fallback in the
+// PL/pgSQL source) and stash the reason in the error column. Decoder
+// shapes them identically.
 type ExecutionReasonPayload struct {
 	ID          string
 	CompletedAt time.Time
@@ -285,6 +286,14 @@ func ExecutionSkippedFromEvent(e store.PersistedEvent) (ExecutionReasonPayload, 
 		return ExecutionReasonPayload{}, ErrIgnoredEvent
 	}
 	return decodeReason(e, "ExecutionSkipped")
+}
+
+// ExecutionNotApplicableFromEvent decodes ExecutionNotApplicable.
+func ExecutionNotApplicableFromEvent(e store.PersistedEvent) (ExecutionReasonPayload, error) {
+	if e.StreamType != "execution" || e.EventType != string(eventtypes.ExecutionNotApplicable) {
+		return ExecutionReasonPayload{}, ErrIgnoredEvent
+	}
+	return decodeReason(e, "ExecutionNotApplicable")
 }
 
 // ExecutionCancelledFromEvent decodes ExecutionCancelled.

--- a/internal/projectors/execution_listener.go
+++ b/internal/projectors/execution_listener.go
@@ -77,6 +77,8 @@ func ApplyExecution(ctx context.Context, q *store.Queries, e store.PersistedEven
 		return applyExecutionTimedOut(ctx, q, e)
 	case string(eventtypes.ExecutionSkipped):
 		return applyExecutionSkipped(ctx, q, e)
+	case string(eventtypes.ExecutionNotApplicable):
+		return applyExecutionNotApplicable(ctx, q, e)
 	case string(eventtypes.ExecutionCancelled):
 		return applyExecutionCancelled(ctx, q, e)
 	}
@@ -257,6 +259,26 @@ func applyExecutionSkipped(ctx context.Context, q *store.Queries, e store.Persis
 	}
 	completedAt := payload.CompletedAt
 	if _, err := q.UpdateExecutionSkippedProjection(ctx, db.UpdateExecutionSkippedProjectionParams{
+		ID:                payload.ID,
+		CompletedAt:       &completedAt,
+		Error:             payload.Reason,
+		ProjectionVersion: e.SequenceNum,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func applyExecutionNotApplicable(ctx context.Context, q *store.Queries, e store.PersistedEvent) error {
+	payload, err := ExecutionNotApplicableFromEvent(e)
+	if err != nil {
+		if errors.Is(err, ErrIgnoredEvent) {
+			return nil
+		}
+		return err
+	}
+	completedAt := payload.CompletedAt
+	if _, err := q.UpdateExecutionNotApplicableProjection(ctx, db.UpdateExecutionNotApplicableProjectionParams{
 		ID:                payload.ID,
 		CompletedAt:       &completedAt,
 		Error:             payload.Reason,

--- a/internal/projectors/execution_test.go
+++ b/internal/projectors/execution_test.go
@@ -273,6 +273,25 @@ func TestExecutionSkippedFromEvent_Pure(t *testing.T) {
 	})
 }
 
+func TestExecutionNotApplicableFromEvent_Pure(t *testing.T) {
+	t.Run("reason surfaces", func(t *testing.T) {
+		got, err := projectors.ExecutionNotApplicableFromEvent(store.PersistedEvent{
+			StreamType: "execution", StreamID: "exec-1", EventType: "ExecutionNotApplicable",
+			Data: jsonOrFail(t, map[string]any{"reason": "no supported .deb package manager available on this system"}),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, got.Reason)
+		assert.Equal(t, "no supported .deb package manager available on this system", *got.Reason)
+	})
+
+	t.Run("wrong stream/event_type → ErrIgnoredEvent", func(t *testing.T) {
+		_, err := projectors.ExecutionNotApplicableFromEvent(store.PersistedEvent{
+			StreamType: "user", EventType: "ExecutionNotApplicable",
+		})
+		assert.True(t, errors.Is(err, projectors.ErrIgnoredEvent))
+	})
+}
+
 func TestExecutionCancelledFromEvent_Pure(t *testing.T) {
 	t.Run("reason surfaces", func(t *testing.T) {
 		got, err := projectors.ExecutionCancelledFromEvent(store.PersistedEvent{
@@ -475,6 +494,20 @@ func TestExecutionListener_TerminalStates(t *testing.T) {
 		assert.Equal(t, "skipped", got.Status)
 		require.NotNil(t, got.Error)
 		assert.Equal(t, "outside maintenance window", *got.Error)
+	})
+
+	t.Run("NotApplicable", func(t *testing.T) {
+		id := mkPending(t)
+		require.NoError(t, st.AppendEvent(ctx, store.Event{
+			StreamType: "execution", StreamID: id, EventType: "ExecutionNotApplicable",
+			Data:      map[string]any{"reason": "flatpak not available on this system"},
+			ActorType: "device", ActorID: "dev-1",
+		}))
+		got, err := st.Queries().GetExecutionByID(ctx, id)
+		require.NoError(t, err)
+		assert.Equal(t, "not_applicable", got.Status)
+		require.NotNil(t, got.Error)
+		assert.Equal(t, "flatpak not available on this system", *got.Error)
 	})
 
 	t.Run("Cancelled flips a pending row", func(t *testing.T) {

--- a/internal/store/generated/executions.sql.go
+++ b/internal/store/generated/executions.sql.go
@@ -284,6 +284,39 @@ func (q *Queries) UpdateExecutionFailedProjection(ctx context.Context, arg Updat
 	return result.RowsAffected(), nil
 }
 
+const updateExecutionNotApplicableProjection = `-- name: UpdateExecutionNotApplicableProjection :execrows
+UPDATE executions_projection
+SET status             = 'not_applicable',
+    completed_at       = $2,
+    error              = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4
+`
+
+type UpdateExecutionNotApplicableProjectionParams struct {
+	ID                string     `json:"id"`
+	CompletedAt       *time.Time `json:"completed_at"`
+	Error             *string    `json:"error"`
+	ProjectionVersion int64      `json:"projection_version"`
+}
+
+// ExecutionNotApplicable handler (spec 23). Same shape as Skipped:
+// completed_at is event.occurred_at; error column carries the
+// inapplicability reason.
+func (q *Queries) UpdateExecutionNotApplicableProjection(ctx context.Context, arg UpdateExecutionNotApplicableProjectionParams) (int64, error) {
+	result, err := q.db.Exec(ctx, updateExecutionNotApplicableProjection,
+		arg.ID,
+		arg.CompletedAt,
+		arg.Error,
+		arg.ProjectionVersion,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 const updateExecutionSkippedProjection = `-- name: UpdateExecutionSkippedProjection :execrows
 UPDATE executions_projection
 SET status             = 'skipped',

--- a/internal/store/queries/executions.sql
+++ b/internal/store/queries/executions.sql
@@ -130,6 +130,18 @@ SET status             = 'skipped',
 WHERE id = $1
   AND projection_version < $4;
 
+-- name: UpdateExecutionNotApplicableProjection :execrows
+-- ExecutionNotApplicable handler (spec 23). Same shape as Skipped:
+-- completed_at is event.occurred_at; error column carries the
+-- inapplicability reason.
+UPDATE executions_projection
+SET status             = 'not_applicable',
+    completed_at       = $2,
+    error              = $3,
+    projection_version = $4
+WHERE id = $1
+  AND projection_version < $4;
+
 -- name: UpdateExecutionCancelledProjection :execrows
 -- ExecutionCancelled handler. The PL/pgSQL projector layered TWO
 -- guards: the status whitelist (only flip rows still in 'scheduled'


### PR DESCRIPTION
Implements the server side of spec 23: a `NOT_APPLICABLE` agent result flows inbox → `ExecutionNotApplicable` event → projector → `executions_projection` (status `not_applicable`, reason in the error column) → `GetExecution`/`ListExecutions`, mirroring the SKIPPED shape including the projection_version replay guard. No migration — the status column is unconstrained text and the execution stream is already a Go projector.

**Drive-by real bug fixed**: the new self-discovering enum-mapping parity test (`TestExecutionStatusMapping_RoundTripsEveryEnumValue`, iterates the proto enum registry) caught that `statusToString`/`stringToStatus` had **no case for SKIPPED** — a skipped execution came back as UNSPECIFIED from `GetExecution` and the SKIPPED list filter matched nothing. Fixed alongside; the parity test keeps every future enum value from repeating this.

Tests (all red-checked before implementation):
- `TestHandleExecutionResult_NotApplicable` — inbox → event → projection round-trip with reason (AC 4)
- `TestExecutionNotApplicableFromEvent_Pure` + `TerminalStates/NotApplicable` — projector decode + listener against real Postgres
- enum-mapping parity test (self-discovering, matches-zero guard)

Gate: go vet, gofmt, staticcheck, full suite (37 packages) green. Local CodeRabbit review: no findings.

Depends on manchtools/power-manage-sdk#304 (merged; go.mod bumped to it).

Refs manchtools/power-manage-server#475