### PR TITLE
feat: audit events for secret reads (spec 24)

### DIFF
--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -823,10 +823,47 @@ func (h *DeviceHandler) loadDeviceHostnamesByIDs(ctx context.Context, ids []stri
 	return out
 }
 
+// auditSecretRead appends a secret-read audit event (spec 24 / #494).
+// Best-effort by design: on the success path the decrypted material is
+// already committed to the response, and on the denied path the
+// caller-visible error is already fixed — an append failure must not alter
+// either, so it is logged loudly instead (AUDIT GAP, mirroring the #496
+// dispatch audits).
+func (h *DeviceHandler) auditSecretRead(ctx context.Context, deviceID string, eventType eventtypes.EventType, payload any) {
+	userCtx, aerr := requireAuth(ctx)
+	if aerr != nil {
+		h.logger.Error("AUDIT GAP: could not resolve actor for secret-read audit event",
+			"event_type", string(eventType), "device_id", deviceID, "error", aerr)
+		return
+	}
+	if err := h.store.AppendEvent(ctx, store.Event{
+		StreamType: "device",
+		StreamID:   deviceID,
+		EventType:  string(eventType),
+		Data:       payload,
+		ActorType:  "user",
+		ActorID:    userCtx.ID,
+	}); err != nil {
+		h.logger.Error("AUDIT GAP: failed to append secret-read audit event",
+			"event_type", string(eventType), "device_id", deviceID, "error", err)
+	}
+}
+
 // GetDeviceLpsPasswords returns current and historical LPS passwords for a device.
 func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.Request[pm.GetDeviceLpsPasswordsRequest]) (*connect.Response[pm.GetDeviceLpsPasswordsResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
+	}
+
+	// Spec 24: the audit trail attributes the read to a real device — an
+	// absent device is a NotFound denial (audited below), not the empty
+	// success it used to be.
+	if _, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{ID: req.Msg.DeviceId}); err != nil {
+		if store.IsNotFound(err) {
+			h.auditSecretRead(ctx, req.Msg.DeviceId, eventtypes.LpsPasswordsViewDenied,
+				payloads.LpsPasswordsViewDenied{DeviceID: req.Msg.DeviceId, Reason: "device not found"})
+		}
+		return nil, handleGetError(ctx, err, ErrDeviceNotFound, "device not found")
 	}
 
 	// Get current passwords
@@ -870,6 +907,8 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 			// operators can triage without re-running the RPC.
 			h.logger.Error("failed to decrypt LPS password (current)",
 				"device_id", p.DeviceID, "action_id", p.ActionID, "error", err)
+			h.auditSecretRead(ctx, req.Msg.DeviceId, eventtypes.LpsPasswordsViewDenied,
+				payloads.LpsPasswordsViewDenied{DeviceID: req.Msg.DeviceId, Reason: "decrypt failure on stored material"})
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LPS password")
 		}
 		entry := &pm.LpsPassword{
@@ -890,6 +929,8 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 		if err != nil {
 			h.logger.Error("failed to decrypt LPS password (history)",
 				"device_id", p.DeviceID, "action_id", p.ActionID, "error", err)
+			h.auditSecretRead(ctx, req.Msg.DeviceId, eventtypes.LpsPasswordsViewDenied,
+				payloads.LpsPasswordsViewDenied{DeviceID: req.Msg.DeviceId, Reason: "decrypt failure on stored material"})
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LPS password")
 		}
 		entry := &pm.LpsPassword{
@@ -904,6 +945,19 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 		resp.History = append(resp.History, entry)
 	}
 
+	// Spec 24 AC 1/5: exactly one view event per successful call, listing
+	// the returned entries by identifier — appended before the response,
+	// best-effort (the material above is already decrypted for return).
+	viewedEntries := make([]payloads.LpsViewedEntry, 0, len(current)+len(history))
+	for _, p := range current {
+		viewedEntries = append(viewedEntries, payloads.LpsViewedEntry{RotationID: p.ID, Username: p.Username, Current: true})
+	}
+	for _, p := range history {
+		viewedEntries = append(viewedEntries, payloads.LpsViewedEntry{RotationID: p.ID, Username: p.Username})
+	}
+	h.auditSecretRead(ctx, req.Msg.DeviceId, eventtypes.LpsPasswordsViewed,
+		payloads.LpsPasswordsViewed{DeviceID: req.Msg.DeviceId, Entries: viewedEntries})
+
 	return connect.NewResponse(resp), nil
 }
 
@@ -911,6 +965,16 @@ func (h *DeviceHandler) GetDeviceLpsPasswords(ctx context.Context, req *connect.
 func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Request[pm.GetDeviceLuksKeysRequest]) (*connect.Response[pm.GetDeviceLuksKeysResponse], error) {
 	if err := Validate(ctx, req.Msg); err != nil {
 		return nil, err
+	}
+
+	// Spec 24: absent device → audited NotFound denial (see the LPS
+	// counterpart above).
+	if _, err := h.store.Repos().Device.Get(ctx, store.GetDeviceKey{ID: req.Msg.DeviceId}); err != nil {
+		if store.IsNotFound(err) {
+			h.auditSecretRead(ctx, req.Msg.DeviceId, eventtypes.LuksKeysViewDenied,
+				payloads.LuksKeysViewDenied{DeviceID: req.Msg.DeviceId, Reason: "device not found"})
+		}
+		return nil, handleGetError(ctx, err, ErrDeviceNotFound, "device not found")
 	}
 
 	current, err := h.store.Repos().Luks.ListCurrent(ctx, req.Msg.DeviceId)
@@ -945,6 +1009,8 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 		if err != nil {
 			h.logger.Error("failed to decrypt LUKS passphrase (current)",
 				"device_id", k.DeviceID, "action_id", k.ActionID, "device_path", k.DevicePath, "error", err)
+			h.auditSecretRead(ctx, req.Msg.DeviceId, eventtypes.LuksKeysViewDenied,
+				payloads.LuksKeysViewDenied{DeviceID: req.Msg.DeviceId, Reason: "decrypt failure on stored material"})
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LUKS passphrase")
 		}
 		entry := &pm.LuksKey{
@@ -974,6 +1040,8 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 		if err != nil {
 			h.logger.Error("failed to decrypt LUKS passphrase (history)",
 				"device_id", k.DeviceID, "action_id", k.ActionID, "device_path", k.DevicePath, "error", err)
+			h.auditSecretRead(ctx, req.Msg.DeviceId, eventtypes.LuksKeysViewDenied,
+				payloads.LuksKeysViewDenied{DeviceID: req.Msg.DeviceId, Reason: "decrypt failure on stored material"})
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to decrypt LUKS passphrase")
 		}
 		entry := &pm.LuksKey{
@@ -987,6 +1055,18 @@ func (h *DeviceHandler) GetDeviceLuksKeys(ctx context.Context, req *connect.Requ
 		entry.RotatedAt = timestamppb.New(k.RotatedAt)
 		resp.History = append(resp.History, entry)
 	}
+
+	// Spec 24 AC 2/5: exactly one view event per successful call, listing
+	// the returned key identifiers — best-effort, before the response.
+	viewedEntries := make([]payloads.LuksViewedEntry, 0, len(current)+len(history))
+	for _, k := range current {
+		viewedEntries = append(viewedEntries, payloads.LuksViewedEntry{RotationID: k.ID, DevicePath: k.DevicePath, Current: true})
+	}
+	for _, k := range history {
+		viewedEntries = append(viewedEntries, payloads.LuksViewedEntry{RotationID: k.ID, DevicePath: k.DevicePath})
+	}
+	h.auditSecretRead(ctx, req.Msg.DeviceId, eventtypes.LuksKeysViewed,
+		payloads.LuksKeysViewed{DeviceID: req.Msg.DeviceId, Entries: viewedEntries})
 
 	return connect.NewResponse(resp), nil
 }

--- a/internal/api/secret_read_audit_test.go
+++ b/internal/api/secret_read_audit_test.go
@@ -1,0 +1,301 @@
+package api_test
+
+// Spec 24 (server#494): audit events for secret reads. GetDeviceLpsPasswords
+// and GetDeviceLuksKeys return decrypted credential material; every
+// successful read must append exactly one LpsPasswordsViewed /
+// LuksKeysViewed event (identifiers only — never the secret), and every
+// handler-tier rejection (absent device, decrypt failure) must append a
+// *ViewDenied event without changing the caller-visible response.
+// Interceptor-tier rejections never reach the handler and stay journal-only
+// — structurally guaranteed because the appends live inside the handler.
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// seedLpsRotation appends one LpsPasswordRotated event with REAL ciphertext
+// (the projector materialises the row the handler will read and decrypt).
+func seedLpsRotation(t *testing.T, st *store.Store, enc *crypto.Encryptor, deviceID, actionID, username, plaintext string, rotatedAt time.Time) {
+	t.Helper()
+	ciphertext, err := enc.EncryptWithContext(plaintext, crypto.SecretAAD(deviceID, actionID, "lps"))
+	require.NoError(t, err)
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "lps_password",
+		StreamID:   deviceID + ":" + actionID + ":" + username,
+		EventType:  "LpsPasswordRotated",
+		Data: map[string]any{
+			"device_id": deviceID, "action_id": actionID, "username": username,
+			"password": ciphertext, "rotated_at": rotatedAt.Format(time.RFC3339Nano),
+			"rotation_reason": "scheduled",
+		},
+		ActorType: "device",
+		ActorID:   deviceID,
+	}))
+}
+
+// seedLuksRotation appends one LuksKeyRotated event with real ciphertext.
+func seedLuksRotation(t *testing.T, st *store.Store, enc *crypto.Encryptor, deviceID, actionID, devicePath, plaintext string, rotatedAt time.Time) {
+	t.Helper()
+	ciphertext, err := enc.EncryptWithContext(plaintext, crypto.SecretAAD(deviceID, actionID, "luks"))
+	require.NoError(t, err)
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "luks_key",
+		StreamID:   deviceID + ":" + actionID + ":" + devicePath,
+		EventType:  "LuksKeyRotated",
+		Data: map[string]any{
+			"device_id": deviceID, "action_id": actionID, "device_path": devicePath,
+			"passphrase": ciphertext, "rotated_at": rotatedAt.Format(time.RFC3339Nano),
+			"rotation_reason": "scheduled",
+		},
+		ActorType: "device",
+		ActorID:   deviceID,
+	}))
+}
+
+// auditEventsOfType returns (count, dataJSON of the last one, actorID) for a
+// device-stream event type, straight from the events table — the audit
+// ground truth, not a projection.
+func auditEventsOfType(t *testing.T, st *store.Store, deviceID, eventType string) (int, string, string) {
+	t.Helper()
+	rows, err := st.TestingPool().Query(context.Background(),
+		`SELECT data::text, actor_id FROM events
+		 WHERE stream_type = 'device' AND stream_id = $1 AND event_type = $2
+		 ORDER BY sequence_num`, deviceID, eventType)
+	require.NoError(t, err)
+	defer rows.Close()
+	count, data, actor := 0, "", ""
+	for rows.Next() {
+		count++
+		require.NoError(t, rows.Scan(&data, &actor))
+	}
+	require.NoError(t, rows.Err())
+	return count, data, actor
+}
+
+func TestGetDeviceLpsPasswords_Success_AppendsOneViewedEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	h := api.NewDeviceHandler(st, enc, slog.Default(), api.NoOpSigner{})
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "lps-view-host")
+	actionID := testutil.CreateTestAction(t, st, userID, "LPS Action", int(pm.ActionType_ACTION_TYPE_LPS))
+
+	// Two rotations of the same account → one history row + one current row,
+	// so the event must list BOTH identifiers.
+	base := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	seedLpsRotation(t, st, enc, deviceID, actionID, "root", "old-Secret-1", base)
+	seedLpsRotation(t, st, enc, deviceID, actionID, "root", "new-Secret-2", base.Add(24*time.Hour))
+
+	resp, err := h.GetDeviceLpsPasswords(testutil.UserContext(userID), connect.NewRequest(
+		&pm.GetDeviceLpsPasswordsRequest{DeviceId: deviceID}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Current, 1)
+	require.Len(t, resp.Msg.History, 1)
+
+	count, data, actor := auditEventsOfType(t, st, deviceID, "LpsPasswordsViewed")
+	assert.Equal(t, 1, count, "exactly ONE viewed event per successful call (spec 24 AC 5)")
+	assert.Equal(t, userID, actor, "the viewing operator is the actor")
+	assert.Contains(t, data, "root", "the returned username is an identifier in the payload")
+	assert.Contains(t, data, deviceID)
+
+	// Never the secret — neither plaintext nor ciphertext, under any key.
+	assert.NotContains(t, data, "old-Secret-1")
+	assert.NotContains(t, data, "new-Secret-2")
+	assert.NotContains(t, data, "enc:", "ciphertext must not ride along in the audit payload")
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(data), &payload))
+	assert.NotContains(t, payload, "password")
+
+	// AC 4: surfaced by ListAuditEvents (and clean there too).
+	auditH := api.NewAuditHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	auditResp, err := auditH.ListAuditEvents(testutil.AdminContext(adminID), connect.NewRequest(
+		&pm.ListAuditEventsRequest{StreamType: "device"}))
+	require.NoError(t, err)
+	var saw bool
+	for _, e := range auditResp.Msg.Events {
+		if e.EventType == "LpsPasswordsViewed" {
+			saw = true
+			assert.NotContains(t, e.Data, "old-Secret-1")
+			assert.NotContains(t, e.Data, "new-Secret-2")
+		}
+	}
+	assert.True(t, saw, "LpsPasswordsViewed must surface via ListAuditEvents")
+}
+
+func TestGetDeviceLuksKeys_Success_AppendsOneViewedEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	enc := testutil.NewEncryptor(t)
+	h := api.NewDeviceHandler(st, enc, slog.Default(), api.NoOpSigner{})
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "luks-view-host")
+	actionID := testutil.CreateTestAction(t, st, userID, "LUKS Action", int(pm.ActionType_ACTION_TYPE_ENCRYPTION))
+
+	seedLuksRotation(t, st, enc, deviceID, actionID, "/dev/sda2", "luks-Pass-1", time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC))
+
+	resp, err := h.GetDeviceLuksKeys(testutil.UserContext(userID), connect.NewRequest(
+		&pm.GetDeviceLuksKeysRequest{DeviceId: deviceID}))
+	require.NoError(t, err)
+	require.Len(t, resp.Msg.Current, 1)
+
+	count, data, actor := auditEventsOfType(t, st, deviceID, "LuksKeysViewed")
+	assert.Equal(t, 1, count, "exactly ONE viewed event per successful call (spec 24 AC 5)")
+	assert.Equal(t, userID, actor)
+	assert.Contains(t, data, "/dev/sda2", "the device path is the key identifier")
+	assert.NotContains(t, data, "luks-Pass-1")
+	assert.NotContains(t, data, "enc:")
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal([]byte(data), &payload))
+	assert.NotContains(t, payload, "passphrase")
+}
+
+func TestGetDeviceLpsPasswords_AbsentDevice_NotFoundAndDeniedEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	ghostID := testutil.NewID()
+
+	_, err := h.GetDeviceLpsPasswords(testutil.UserContext(userID), connect.NewRequest(
+		&pm.GetDeviceLpsPasswordsRequest{DeviceId: ghostID}))
+	require.Error(t, err, "an absent device must be NotFound, not an empty success")
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "device not found", "uniform NotFound — no existence oracle")
+
+	denied, data, actor := auditEventsOfType(t, st, ghostID, "LpsPasswordsViewDenied")
+	assert.Equal(t, 1, denied, "exactly one denied event (spec 24 AC 3)")
+	assert.Equal(t, userID, actor)
+	assert.Contains(t, data, "device not found")
+	viewed, _, _ := auditEventsOfType(t, st, ghostID, "LpsPasswordsViewed")
+	assert.Zero(t, viewed, "no view event on a denied read")
+}
+
+func TestGetDeviceLuksKeys_AbsentDevice_NotFoundAndDeniedEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	ghostID := testutil.NewID()
+
+	_, err := h.GetDeviceLuksKeys(testutil.UserContext(userID), connect.NewRequest(
+		&pm.GetDeviceLuksKeysRequest{DeviceId: ghostID}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+
+	denied, data, actor := auditEventsOfType(t, st, ghostID, "LuksKeysViewDenied")
+	assert.Equal(t, 1, denied)
+	assert.Equal(t, userID, actor)
+	assert.Contains(t, data, "device not found")
+	viewed, _, _ := auditEventsOfType(t, st, ghostID, "LuksKeysViewed")
+	assert.Zero(t, viewed)
+}
+
+func TestGetDeviceLpsPasswords_DecryptFailure_DeniedEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "lps-decfail-host")
+	actionID := testutil.CreateTestAction(t, st, userID, "LPS Action", int(pm.ActionType_ACTION_TYPE_LPS))
+
+	// Undecryptable fixture ciphertext (not produced by this encryptor).
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "lps_password",
+		StreamID:   deviceID + ":" + actionID + ":root",
+		EventType:  "LpsPasswordRotated",
+		Data: map[string]any{
+			"device_id": deviceID, "action_id": actionID, "username": "root",
+			"password": "enc:v1:fixture-undecryptable", "rotated_at": "2026-07-01T10:00:00Z",
+			"rotation_reason": "scheduled",
+		},
+		ActorType: "device",
+		ActorID:   deviceID,
+	}))
+
+	_, err := h.GetDeviceLpsPasswords(testutil.UserContext(userID), connect.NewRequest(
+		&pm.GetDeviceLpsPasswordsRequest{DeviceId: deviceID}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+
+	denied, data, actor := auditEventsOfType(t, st, deviceID, "LpsPasswordsViewDenied")
+	assert.Equal(t, 1, denied, "decrypt failure appends a denied event (spec 24 AC 3)")
+	assert.Equal(t, userID, actor)
+	assert.Contains(t, strings.ToLower(data), "decrypt")
+	assert.NotContains(t, data, "fixture-undecryptable", "not even broken ciphertext may enter the audit payload")
+	viewed, _, _ := auditEventsOfType(t, st, deviceID, "LpsPasswordsViewed")
+	assert.Zero(t, viewed, "no view event when nothing was returned")
+}
+
+func TestGetDeviceLuksKeys_DecryptFailure_DeniedEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "luks-decfail-host")
+	actionID := testutil.CreateTestAction(t, st, userID, "LUKS Action", int(pm.ActionType_ACTION_TYPE_ENCRYPTION))
+
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "luks_key",
+		StreamID:   deviceID + ":" + actionID + ":/dev/sda2",
+		EventType:  "LuksKeyRotated",
+		Data: map[string]any{
+			"device_id": deviceID, "action_id": actionID, "device_path": "/dev/sda2",
+			"passphrase": "enc:v1:fixture-undecryptable", "rotated_at": "2026-07-01T10:00:00Z",
+			"rotation_reason": "scheduled",
+		},
+		ActorType: "device",
+		ActorID:   deviceID,
+	}))
+
+	_, err := h.GetDeviceLuksKeys(testutil.UserContext(userID), connect.NewRequest(
+		&pm.GetDeviceLuksKeysRequest{DeviceId: deviceID}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+
+	denied, data, actor := auditEventsOfType(t, st, deviceID, "LuksKeysViewDenied")
+	assert.Equal(t, 1, denied)
+	assert.Equal(t, userID, actor)
+	assert.Contains(t, strings.ToLower(data), "decrypt")
+	assert.NotContains(t, data, "fixture-undecryptable", "not even broken ciphertext may enter the audit payload")
+	viewed, _, _ := auditEventsOfType(t, st, deviceID, "LuksKeysViewed")
+	assert.Zero(t, viewed)
+}
+
+// TestSecretReadHandlers_EmptyDeviceStillViewedEvent pins the boundary with
+// the EXISTING empty-state behavior: a real device with no rotations is a
+// successful (empty) read — it must audit as a VIEW with zero identifiers,
+// not as a denial, and must not regress to NotFound.
+func TestSecretReadHandlers_EmptyDeviceStillViewedEvent(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewDeviceHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+
+	userID := testutil.CreateTestUser(t, st, testutil.NewID()+"@user.com", "pass", "user")
+	deviceID := testutil.CreateTestDevice(t, st, "empty-secret-host")
+
+	resp, err := h.GetDeviceLpsPasswords(testutil.UserContext(userID), connect.NewRequest(
+		&pm.GetDeviceLpsPasswordsRequest{DeviceId: deviceID}))
+	require.NoError(t, err, "an existing device with no rotations stays a successful empty read")
+	assert.Empty(t, resp.Msg.Current)
+
+	viewed, _, _ := auditEventsOfType(t, st, deviceID, "LpsPasswordsViewed")
+	assert.Equal(t, 1, viewed, "an empty successful read is still a read — audited as a view")
+	denied, _, _ := auditEventsOfType(t, st, deviceID, "LpsPasswordsViewDenied")
+	assert.Zero(t, denied)
+}

--- a/internal/api/secret_read_audit_test.go
+++ b/internal/api/secret_read_audit_test.go
@@ -148,22 +148,42 @@ func TestGetDeviceLuksKeys_Success_AppendsOneViewedEvent(t *testing.T) {
 	deviceID := testutil.CreateTestDevice(t, st, "luks-view-host")
 	actionID := testutil.CreateTestAction(t, st, userID, "LUKS Action", int(pm.ActionType_ACTION_TYPE_ENCRYPTION))
 
-	seedLuksRotation(t, st, enc, deviceID, actionID, "/dev/sda2", "luks-Pass-1", time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC))
+	base := time.Date(2026, 7, 1, 10, 0, 0, 0, time.UTC)
+	seedLuksRotation(t, st, enc, deviceID, actionID, "/dev/sda2", "luks-Pass-1", base)
+	seedLuksRotation(t, st, enc, deviceID, actionID, "/dev/sda2", "luks-Pass-2", base.Add(24*time.Hour))
 
 	resp, err := h.GetDeviceLuksKeys(testutil.UserContext(userID), connect.NewRequest(
 		&pm.GetDeviceLuksKeysRequest{DeviceId: deviceID}))
 	require.NoError(t, err)
 	require.Len(t, resp.Msg.Current, 1)
+	require.Len(t, resp.Msg.History, 1)
 
 	count, data, actor := auditEventsOfType(t, st, deviceID, "LuksKeysViewed")
 	assert.Equal(t, 1, count, "exactly ONE viewed event per successful call (spec 24 AC 5)")
 	assert.Equal(t, userID, actor)
 	assert.Contains(t, data, "/dev/sda2", "the device path is the key identifier")
 	assert.NotContains(t, data, "luks-Pass-1")
+	assert.NotContains(t, data, "luks-Pass-2")
 	assert.NotContains(t, data, "enc:")
 	var payload map[string]any
 	require.NoError(t, json.Unmarshal([]byte(data), &payload))
 	assert.NotContains(t, payload, "passphrase")
+
+	// AC 4: surfaced by ListAuditEvents (and clean there too).
+	auditH := api.NewAuditHandler(st, slog.Default())
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@admin.com", "pass", "admin")
+	auditResp, err := auditH.ListAuditEvents(testutil.AdminContext(adminID), connect.NewRequest(
+		&pm.ListAuditEventsRequest{StreamType: "device"}))
+	require.NoError(t, err)
+	var saw bool
+	for _, e := range auditResp.Msg.Events {
+		if e.EventType == "LuksKeysViewed" {
+			saw = true
+			assert.NotContains(t, e.Data, "luks-Pass-1")
+			assert.NotContains(t, e.Data, "luks-Pass-2")
+		}
+	}
+	assert.True(t, saw, "LuksKeysViewed must surface via ListAuditEvents")
 }
 
 func TestGetDeviceLpsPasswords_AbsentDevice_NotFoundAndDeniedEvent(t *testing.T) {
@@ -298,4 +318,15 @@ func TestSecretReadHandlers_EmptyDeviceStillViewedEvent(t *testing.T) {
 	assert.Equal(t, 1, viewed, "an empty successful read is still a read — audited as a view")
 	denied, _, _ := auditEventsOfType(t, st, deviceID, "LpsPasswordsViewDenied")
 	assert.Zero(t, denied)
+
+	// LUKS counterpart: same boundary — an empty read is a view, not a denial.
+	luksResp, err := h.GetDeviceLuksKeys(testutil.UserContext(userID), connect.NewRequest(
+		&pm.GetDeviceLuksKeysRequest{DeviceId: deviceID}))
+	require.NoError(t, err, "an existing device with no rotations stays a successful empty read")
+	assert.Empty(t, luksResp.Msg.Current)
+
+	luksViewed, _, _ := auditEventsOfType(t, st, deviceID, "LuksKeysViewed")
+	assert.Equal(t, 1, luksViewed, "an empty successful read is still a read — audited as a view")
+	luksDenied, _, _ := auditEventsOfType(t, st, deviceID, "LuksKeysViewDenied")
+	assert.Zero(t, luksDenied)
 }

--- a/internal/eventtypes/payloads/audit_session_device.go
+++ b/internal/eventtypes/payloads/audit_session_device.go
@@ -38,6 +38,54 @@ type LuksTokenCreated struct {
 	ActionID string `json:"action_id"`
 }
 
+// LpsViewedEntry identifies one returned LPS password row — the rotation
+// row's ID plus the account it belongs to. Never the password.
+type LpsViewedEntry struct {
+	RotationID string `json:"rotation_id"`
+	Username   string `json:"username"`
+	Current    bool   `json:"current"`
+}
+
+// LpsPasswordsViewed records a successful GetDeviceLpsPasswords: an operator
+// retrieved a device's decrypted LPS passwords (spec 24 / #494). Exactly one
+// event per call, listing the returned entries by identifier — the secret
+// material never appears here.
+type LpsPasswordsViewed struct {
+	DeviceID string           `json:"device_id"`
+	Entries  []LpsViewedEntry `json:"entries"`
+}
+
+// LuksViewedEntry identifies one returned LUKS key row — the rotation row's
+// ID plus the encrypted volume it unlocks. Never the passphrase.
+type LuksViewedEntry struct {
+	RotationID string `json:"rotation_id"`
+	DevicePath string `json:"device_path"`
+	Current    bool   `json:"current"`
+}
+
+// LuksKeysViewed records a successful GetDeviceLuksKeys (spec 24 / #494).
+// Exactly one event per call; identifiers only.
+type LuksKeysViewed struct {
+	DeviceID string            `json:"device_id"`
+	Entries  []LuksViewedEntry `json:"entries"`
+}
+
+// LpsPasswordsViewDenied records a handler-tier rejection of a
+// GetDeviceLpsPasswords (absent device, decrypt failure): who wanted to read
+// which device's credentials without getting them. The reason is a fixed
+// classification string — no secret material, and the caller-visible
+// response (uniform NotFound / Internal) is unchanged by this event.
+type LpsPasswordsViewDenied struct {
+	DeviceID string `json:"device_id"`
+	Reason   string `json:"reason"`
+}
+
+// LuksKeysViewDenied is the LUKS counterpart of LpsPasswordsViewDenied.
+type LuksKeysViewDenied struct {
+	DeviceID string `json:"device_id"`
+	Reason   string `json:"reason"`
+}
+
 // UserLoggedOut records a Logout: the refresh-token JTI was revoked. The JTI
 // is a session identifier, not a credential.
 type UserLoggedOut struct {

--- a/internal/eventtypes/types.go
+++ b/internal/eventtypes/types.go
@@ -91,7 +91,17 @@ const (
 	OSQueryDispatched               EventType = "OSQueryDispatched"
 	DeviceLogsQueried               EventType = "DeviceLogsQueried"
 	DeviceInventoryRefreshRequested EventType = "DeviceInventoryRefreshRequested"
-	LuksTokenCreated                EventType = "LuksTokenCreated"
+	// Secret-read audit events (spec 24 / #494): an operator retrieved —
+	// or was denied at the handler tier (absent device, decrypt failure) —
+	// a device's decrypted LPS passwords / LUKS keys. Payloads carry
+	// identifiers only, never secret material. Audit-only: no projector
+	// materialises these; they exist so ListAuditEvents answers "who read
+	// which device's break-glass credentials, when".
+	LpsPasswordsViewed     EventType = "LpsPasswordsViewed"
+	LuksKeysViewed         EventType = "LuksKeysViewed"
+	LpsPasswordsViewDenied EventType = "LpsPasswordsViewDenied"
+	LuksKeysViewDenied     EventType = "LuksKeysViewDenied"
+	LuksTokenCreated       EventType = "LuksTokenCreated"
 
 	// device_group stream
 	DeviceGroupCreated            EventType = "DeviceGroupCreated"
@@ -284,6 +294,7 @@ func All() []EventType {
 		DeviceLabelSet, DeviceLabelRemoved, DeviceDeleted, DeviceAssigned, DeviceUnassigned,
 		DeviceGroupAssigned, DeviceGroupUnassigned, DeviceSyncIntervalSet, DeviceInventoryIntervalSet,
 		OSQueryDispatched, DeviceLogsQueried, DeviceInventoryRefreshRequested, LuksTokenCreated,
+		LpsPasswordsViewed, LuksKeysViewed, LpsPasswordsViewDenied, LuksKeysViewDenied,
 		DeviceGroupCreated, DeviceGroupRenamed, DeviceGroupDescriptionUpdated, DeviceGroupQueryUpdated,
 		DeviceGroupSyncIntervalSet, DeviceGroupInventoryIntervalSet, DeviceGroupMaintenanceWindowSet, DeviceGroupMemberAdded,
 		DeviceGroupMemberRemoved, DeviceGroupMembersReevaluated, DeviceGroupDeleted, DeviceAddedToGroup, DeviceRemovedFromGroup,

--- a/internal/projectors/eventtype_parity_test.go
+++ b/internal/projectors/eventtype_parity_test.go
@@ -39,7 +39,14 @@ var unprojectedAllowlist = map[eventtypes.EventType]string{
 	eventtypes.LuksTokenCreated:                "audit-only (#496): who issued a LUKS token; no projection",
 	eventtypes.UserLoggedOut:                   "audit-only (#496): session end; the denylist row is operational state",
 	eventtypes.UserSessionRefreshed:            "audit-only (#496): session rotation; no projection",
-	eventtypes.EventLogPruned:                  "retention marker (spec 19): records a prune checkpoint + archive pointer; no projection — doctor reads it directly for retention posture",
+	// Spec 24 (#494) secret-read audit events: who retrieved (or was
+	// denied) a device's decrypted LPS/LUKS material. Identifiers only;
+	// nothing to materialise.
+	eventtypes.LpsPasswordsViewed:     "audit-only (spec 24): who viewed a device's LPS passwords; no projection",
+	eventtypes.LuksKeysViewed:         "audit-only (spec 24): who viewed a device's LUKS keys; no projection",
+	eventtypes.LpsPasswordsViewDenied: "audit-only (spec 24): denied LPS password read; no projection",
+	eventtypes.LuksKeysViewDenied:     "audit-only (spec 24): denied LUKS key read; no projection",
+	eventtypes.EventLogPruned:         "retention marker (spec 19): records a prune checkpoint + archive pointer; no projection — doctor reads it directly for retention posture",
 }
 
 // TestEventTypes_AllHandledByProjectorOrAllowlisted is a self-discovering guard

--- a/internal/scim/handler.go
+++ b/internal/scim/handler.go
@@ -72,7 +72,10 @@ func NewHandler(st *store.Store, logger *slog.Logger, systemActions SystemAction
 
 	mux := http.NewServeMux()
 
-	// Discovery endpoints (no auth required)
+	// Discovery endpoints — bearer-auth-gated like every other route.
+	// SCIM discovery MAY be served unauthenticated per RFC 7644, but these
+	// endpoints leak provider slugs and schema detail, so they sit behind
+	// withAuth deliberately.
 	mux.HandleFunc("GET /scim/v2/{slug}/ServiceProviderConfig", h.withAuth(h.serviceProviderConfig))
 	mux.HandleFunc("GET /scim/v2/{slug}/Schemas", h.withAuth(h.schemas))
 	mux.HandleFunc("GET /scim/v2/{slug}/ResourceTypes", h.withAuth(h.resourceTypes))


### PR DESCRIPTION
Implements spec 24 (closes #494): `GetDeviceLpsPasswords` / `GetDeviceLuksKeys` return decrypted credential material but appended no audit record — the exact read class NIS2/SOC 2 expects logged (cf. AD LAPS retrieval auditing).

**What lands:**
- `LpsPasswordsViewed` / `LuksKeysViewed` — exactly one per successful call (spec-pinned granularity), listing the returned entries by identifier (rotation IDs, usernames / device paths) — **never** the secret, and appended before the response, best-effort with `AUDIT GAP` logging (the #496 contract).
- `LpsPasswordsViewDenied` / `LuksKeysViewDenied` on handler-tier rejections (absent device, decrypt failure) — 'who wanted to read it without access' becomes auditable; the caller-visible response is unchanged (uniform NotFound — no existence oracle). Interceptor-tier rejections stay journal-only per the spec's carve-out (structurally guaranteed: the appends live in the handler).
- **Pinned behavior change**: an absent device is now NotFound instead of an empty success; an existing device with no rotations stays a successful, audited, empty read (dedicated regression test).
- Events registered in the projector parity allow-list (audit-only, nothing to materialise); payloads carry no secret-named fields so the self-discovering redaction guards cover them.
- Rider: SCIM discovery-route comment corrected ('no auth required' → documents the deliberate withAuth gating).

**Tests** (all red-checked before implementation): success → exactly one viewed event with actor/identifiers and no plaintext/ciphertext under any key, surfaced via `ListAuditEvents`; absent-device and decrypt-failure → exactly one denied event, zero viewed, response unchanged; empty-read boundary pinned.

Gate: go vet, gofmt, staticcheck, full suite (37 packages) green. Local CodeRabbit review: 1 finding (asymmetric test assertion), fixed.

Refs the #496 write-side audit-completeness work; read-side complement per spec 24.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audit tracking for device secret reads, including successful views and denied access cases.
  * Audit entries now record only non-sensitive identifiers for password/key reads.

* **Bug Fixes**
  * Missing devices now return a not-found response and generate a denied audit event.
  * Secret decryption failures now emit denied audit events instead of only logging errors.

* **Tests**
  * Added coverage for successful reads, denied reads, empty-device behavior, and audit event contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->