### PR TITLE
fix: retry gateway terminal registration instead of one-shot fail-open

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -354,12 +354,13 @@ func main() {
 			)
 			cancelRegister()
 			if err != nil {
-				// Fail-open: the terminal feature is optional, so a
-				// transient registry failure at startup must not kill
-				// the gateway's agent-mTLS service. Log loudly and
-				// leave terminal sessions disabled for this replica
-				// until the operator restarts.
-				logger.Warn("failed to register gateway in terminal registry — terminal sessions disabled on this replica",
+				// Only CONFIG errors land here now (#524): empty
+				// id/url or refresh >= ttl. A transient publish
+				// failure is fail-open inside RegisterGateway — its
+				// refresh loop retries until the backend recovers, so
+				// a Valkey blip at startup no longer disables terminal
+				// sessions until an operator restarts.
+				logger.Warn("terminal registry registration misconfigured — terminal sessions disabled on this replica",
 					"error", err)
 			} else {
 				defer stop()

--- a/internal/gateway/registry/registry.go
+++ b/internal/gateway/registry/registry.go
@@ -137,9 +137,18 @@ func (r *Registry) RegisterGateway(ctx context.Context, gatewayID, terminalURL s
 	}
 
 	// Initial publish so subsequent control lookups can find us
-	// immediately, before the first heartbeat tick.
+	// immediately, before the first heartbeat tick. A FAILED initial
+	// publish is deliberately fail-open (#524): the refresh loop below
+	// re-Sets the key every tick and is the natural retry, so the key
+	// appears on the first tick after the backend recovers. Returning an
+	// error here instead meant a gateway that (re)started during a
+	// transient Valkey blip lost terminal sessions PERMANENTLY (observed
+	// in production: five days dark), while the internal-URL and Traefik
+	// registrations — which retry — recovered on their own. Validation
+	// errors above still fail hard; only the publish is transient.
 	if err := r.backend.Set(ctx, gatewayKey(gatewayID), terminalURL, ttl); err != nil {
-		return nil, fmt.Errorf("registry: initial gateway publish: %w", err)
+		r.logger.Warn("registry: initial gateway publish failed — refresh loop will retry until the backend recovers",
+			"gateway_id", gatewayID, "error", err)
 	}
 
 	stopCh := make(chan struct{})

--- a/internal/gateway/registry/registry_test.go
+++ b/internal/gateway/registry/registry_test.go
@@ -222,6 +222,84 @@ func TestRegistry_RegisterGateway_RefreshLoop(t *testing.T) {
 	}
 }
 
+// TestRegistry_RegisterGateway_InitialPublishFailureRecovers is the
+// regression lock for #524: a gateway that (re)starts during a transient
+// Valkey outage must NOT lose terminal sessions until an operator restarts
+// it. RegisterGateway's refresh loop IS the retry mechanism — a failed
+// initial publish starts it anyway, and the key appears on the first tick
+// after the backend recovers. Observed in production 2026-07-04→09: a
+// Valkey blip at gateway startup left StartTerminal dead for five days
+// while the internal-URL and Traefik registrations (which retry) recovered
+// on their own.
+func TestRegistry_RegisterGateway_InitialPublishFailureRecovers(t *testing.T) {
+	flaky := &flakyBackend{inner: NewFakeBackend(nil), failFirst: 2}
+	r := New(flaky, nil)
+
+	stop, err := r.RegisterGateway(context.Background(), "gw-A", "wss://x", DefaultGatewayTTL, 20*time.Millisecond)
+	if err != nil {
+		t.Fatalf("a transient initial-publish failure must not disable registration (fail-open into the refresh loop): %v", err)
+	}
+	defer stop()
+
+	// The key must appear once the backend recovers — within a few ticks.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got, gErr := r.LookupGatewayTerminalURL(context.Background(), "gw-A"); gErr == nil && got == "wss://x" {
+			return // recovered
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("terminal URL never appeared after the backend recovered — the refresh loop is not retrying the failed initial publish")
+}
+
+// TestRegistry_RegisterGateway_ValidationErrorsStillFail pins the split:
+// config/validation errors (empty id/url, refresh >= ttl) must STILL return
+// an error — only the transient publish failure is fail-open.
+func TestRegistry_RegisterGateway_ValidationErrorsStillFail(t *testing.T) {
+	r := New(&flakyBackend{inner: NewFakeBackend(nil), failFirst: 1}, nil)
+	if _, err := r.RegisterGateway(context.Background(), "", "wss://x", DefaultGatewayTTL, DefaultGatewayRefreshInterval); err == nil {
+		t.Error("empty gatewayID must error")
+	}
+	if _, err := r.RegisterGateway(context.Background(), "gw-A", "", DefaultGatewayTTL, DefaultGatewayRefreshInterval); err == nil {
+		t.Error("empty terminalURL must error")
+	}
+	if _, err := r.RegisterGateway(context.Background(), "gw-A", "wss://x", time.Second, time.Second); err == nil {
+		t.Error("refreshInterval >= ttl must error")
+	}
+}
+
+// flakyBackend fails the first failFirst Set calls, then delegates —
+// simulating a Valkey outage window at gateway startup.
+type flakyBackend struct {
+	inner     Backend
+	mu        sync.Mutex
+	failFirst int
+	setCalls  int
+}
+
+func (b *flakyBackend) Set(ctx context.Context, key, value string, ttl time.Duration) error {
+	b.mu.Lock()
+	b.setCalls++
+	failing := b.setCalls <= b.failFirst
+	b.mu.Unlock()
+	if failing {
+		return errors.New("dial tcp: connect: connection refused")
+	}
+	return b.inner.Set(ctx, key, value, ttl)
+}
+
+func (b *flakyBackend) Get(ctx context.Context, key string) (string, error) {
+	return b.inner.Get(ctx, key)
+}
+
+func (b *flakyBackend) Delete(ctx context.Context, key string) error {
+	return b.inner.Delete(ctx, key)
+}
+
+func (b *flakyBackend) ScanPrefix(ctx context.Context, prefix string) (map[string]string, error) {
+	return b.inner.ScanPrefix(ctx, prefix)
+}
+
 // TestRegistry_AttachDevice_RequiresFields locks the input
 // validation contract.
 func TestRegistry_AttachDevice_RequiresFields(t *testing.T) {


### PR DESCRIPTION
Fixes #524 — root-caused from today's production incident.

**What happened**: Valkey restarted briefly on 2026-07-04 20:42; the gateway restarted inside that window; its initial terminal-registry publish got `connection refused`; `RegisterGateway` returned the error and never started its refresh goroutine; `cmd/gateway` treated that as fail-open-until-operator-restart. Terminal sessions were dead for **five days** (every `StartTerminal` → `unavailable: gateway has not published its terminal URL`) while the internal-URL and Traefik registrations — which both retry — recovered on their own within seconds. The single startup WARN had long scrolled away.

**Fix**: the refresh loop IS the retry — it re-`Set`s the key with TTL every tick and already warns per failure. A failed initial publish now logs a warning and starts the loop anyway, so the key appears on the first tick after the backend recovers. Validation errors (empty id/URL, refresh ≥ ttl) still fail hard; the `cmd/gateway` fail-open branch now only fires for those and its message says so.

**Regression locks** (red-checked): `TestRegistry_RegisterGateway_InitialPublishFailureRecovers` (flaky backend failing the first N Sets — key must appear after recovery) and `TestRegistry_RegisterGateway_ValidationErrorsStillFail` (the error split).

Gate: registry + cmd/gateway suites green, `go vet`/build green (standalone — the workspace currently pairs sdk main with the in-flight spec-25 server branch). Local CodeRabbit: no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration now handles temporary backend/publish failures more gracefully, keeping terminal sessions available and retrying in the background.
  * Validation errors still fail normally for invalid settings, such as missing identifiers or unsafe refresh timing.

* **Tests**
  * Added regression coverage for recovery after an initial registration failure.
  * Added checks to confirm invalid registration inputs still return errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->