### PR TITLE
feat!: unseal LUKS passphrases at control; gateway relays opaque (spec 25)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260709091948-db56f7940806
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260709181148-195cb8038eec
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.5.4-0.20260709091948-db56f7940806 h1:t8MytdUUMUj4goYBUEY83wkD3nMCRszu4cHwDdj36q8=
-github.com/manchtools/power-manage-sdk v0.5.4-0.20260709091948-db56f7940806/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260709181148-195cb8038eec h1:RULgLkZQaT7rKe6gZ/XerbKM/tVh5Npf7THwGMbE2Hs=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260709181148-195cb8038eec/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -461,14 +461,34 @@ func (h *InternalHandler) ProxyStoreLuksKey(ctx context.Context, req *connect.Re
 		return nil, err
 	}
 
-	if req.Msg.DeviceId == "" || req.Msg.ActionId == "" || req.Msg.Passphrase == "" {
-		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id, action_id, and passphrase are required")
+	if req.Msg.DeviceId == "" || req.Msg.ActionId == "" || len(req.Msg.SealedPassphrase) == 0 {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "device_id, action_id, and sealed_passphrase are required")
 	}
 	if err := h.verifyDeviceGatewayBinding(ctx, req.Msg.DeviceId, req.Msg.GatewayId); err != nil {
 		return nil, err
 	}
 
-	encPassphrase, err := h.encryptor.EncryptWithContext(req.Msg.Passphrase, crypto.SecretAAD(req.Msg.DeviceId, req.Msg.ActionId, "luks"))
+	// Unsealing requires the control private key (the same keypair LPS
+	// sealing uses). A nil key is a wiring/config failure: fail closed
+	// rather than accept bytes we cannot open — there is no cleartext
+	// fallback path (spec 25).
+	if h.lpsPrivateKey == nil {
+		h.logger.Error("LUKS store: nil private key — keypair not configured", "device_id", req.Msg.DeviceId)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "control keypair not configured")
+	}
+
+	// Unseal under the reconstructed device|action|"luks" AAD (spec 25). A
+	// failure — tampered, wrong key, wrong context, or a blob sealed under
+	// the LPS domain — is permanent, so reject with InvalidArgument: no
+	// event appended, and the caller does not retry a blob that can never
+	// open. Neither the blob nor any plaintext appears in logs.
+	plaintext, err := sdkcrypto.OpenLuksPassphrase(h.lpsPrivateKey, req.Msg.SealedPassphrase, req.Msg.DeviceId, req.Msg.ActionId)
+	if err != nil {
+		h.logger.Error("failed to unseal LUKS passphrase", "error", err, "device_id", req.Msg.DeviceId, "action_id", req.Msg.ActionId)
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "failed to unseal passphrase")
+	}
+
+	encPassphrase, err := h.encryptor.EncryptWithContext(plaintext, crypto.SecretAAD(req.Msg.DeviceId, req.Msg.ActionId, "luks"))
 	if err != nil {
 		h.logger.Error("failed to encrypt LUKS passphrase", "error", err)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to encrypt passphrase")

--- a/internal/api/internal_handler_gateway_binding_test.go
+++ b/internal/api/internal_handler_gateway_binding_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"context"
+	"crypto/ecdh"
 	"log/slog"
 	"testing"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	sdkcrypto "github.com/manchtools/power-manage-sdk/crypto"
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/api"
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
@@ -30,6 +32,17 @@ func wiredHandler(t *testing.T, st *store.Store, deviceID, gatewayID string) (*a
 	require.NoError(t, reg.AttachDevice(context.Background(), deviceID, gatewayID, registry.DefaultDeviceTTL))
 	h.SetDeviceGatewayResolver(reg)
 	return h, reg
+}
+
+// wireSealKeypair equips the handler with a control keypair (spec 25) and
+// returns the public key so tests can seal seed passphrases the handler can
+// actually unseal.
+func wireSealKeypair(t *testing.T, h *api.InternalHandler) *ecdh.PublicKey {
+	t.Helper()
+	priv, err := sdkcrypto.GenerateX25519()
+	require.NoError(t, err)
+	h.SetLpsKeypair(priv, nil)
+	return priv.PublicKey()
 }
 
 // countEvents returns how many events of the given type exist.
@@ -79,7 +92,7 @@ func TestInternalHandlers_GatewayBindingIsSelfDiscovering(t *testing.T) {
 		}},
 		{"ProxyStoreLuksKey", func() error {
 			_, e := h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
-				DeviceId: device, ActionId: actionID, DevicePath: "/dev/sda1", Passphrase: "secret", RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL, GatewayId: wrongGateway,
+				DeviceId: device, ActionId: actionID, DevicePath: "/dev/sda1", SealedPassphrase: make([]byte, 61), RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL, GatewayId: wrongGateway,
 			}))
 			return e
 		}},
@@ -166,12 +179,15 @@ func TestProxyGetLuksKey_GatewayBinding(t *testing.T) {
 	device := testutil.CreateTestDevice(t, st, "luks-host")
 	const liveGateway = "gw-A"
 	h, _ := wiredHandler(t, st, device, liveGateway)
+	pub := wireSealKeypair(t, h)
 	ctx := context.Background()
 	actionID := newULID()
 
-	// Seed a key through the correctly-bound store path.
-	_, err := h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
-		DeviceId: device, ActionId: actionID, DevicePath: "/dev/sda1", Passphrase: "topsecret",
+	// Seed a key through the correctly-bound store path (sealed, spec 25).
+	sealed, err := sdkcrypto.SealLuksPassphrase(pub, "topsecret", device, actionID)
+	require.NoError(t, err)
+	_, err = h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+		DeviceId: device, ActionId: actionID, DevicePath: "/dev/sda1", SealedPassphrase: sealed,
 		RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL, GatewayId: liveGateway,
 	}))
 	require.NoError(t, err)
@@ -224,13 +240,16 @@ func TestProxyGetLuksKey_DeviceScopingAcrossDevices(t *testing.T) {
 	deviceB := testutil.CreateTestDevice(t, st, "luks-scope-b")
 	const gwA, gwB = "gw-A", "gw-B"
 	h, reg := wiredHandler(t, st, deviceA, gwA)
+	pub := wireSealKeypair(t, h)
 	require.NoError(t, reg.AttachDevice(context.Background(), deviceB, gwB, registry.DefaultDeviceTTL))
 	ctx := context.Background()
 	actionID := newULID()
 
-	// Seed a secret for device A via its correctly-bound gateway.
-	_, err := h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
-		DeviceId: deviceA, ActionId: actionID, DevicePath: "/dev/sda1", Passphrase: "A-secret",
+	// Seed a secret for device A via its correctly-bound gateway (sealed).
+	sealedA, err := sdkcrypto.SealLuksPassphrase(pub, "A-secret", deviceA, actionID)
+	require.NoError(t, err)
+	_, err = h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+		DeviceId: deviceA, ActionId: actionID, DevicePath: "/dev/sda1", SealedPassphrase: sealedA,
 		RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL, GatewayId: gwA,
 	}))
 	require.NoError(t, err)
@@ -312,7 +331,7 @@ func TestProxyStoreLuksKey_NoEventOnGatewayMismatch(t *testing.T) {
 
 	before := countEvents(t, st, "LuksKeyRotated")
 	_, err := h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
-		DeviceId: device, ActionId: newULID(), DevicePath: "/dev/sda1", Passphrase: "secret",
+		DeviceId: device, ActionId: newULID(), DevicePath: "/dev/sda1", SealedPassphrase: make([]byte, 61),
 		RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL, GatewayId: "gw-B",
 	}))
 	require.Error(t, err)

--- a/internal/api/internal_handler_test.go
+++ b/internal/api/internal_handler_test.go
@@ -230,24 +230,6 @@ func TestProxySyncActions_UninstallActionSetForcesAbsent(t *testing.T) {
 		"UNINSTALL on the container overrides per-action desired_state")
 }
 
-func TestProxyStoreLuksKey(t *testing.T) {
-	st := testutil.SetupPostgres(t)
-	enc := testutil.NewEncryptor(t)
-	h := api.NewInternalHandler(st, enc, slog.Default(), api.NoOpSigner{})
-
-	deviceID := testutil.CreateTestDevice(t, st, "luks-store-host")
-
-	resp, err := h.ProxyStoreLuksKey(context.Background(), connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
-		DeviceId:       deviceID,
-		ActionId:       testutil.NewID(),
-		DevicePath:     "/dev/sda1",
-		Passphrase:     "super-secret-key",
-		RotationReason: pm.RotationReason_ROTATION_REASON_INITIAL,
-	}))
-	require.NoError(t, err)
-	assert.True(t, resp.Msg.Success)
-}
-
 func TestProxyStoreLuksKey_MissingFields(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})

--- a/internal/api/luks_sealed_transport_test.go
+++ b/internal/api/luks_sealed_transport_test.go
@@ -1,0 +1,162 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdkcrypto "github.com/manchtools/power-manage-sdk/crypto"
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// CHARTER — sealed LUKS passphrase transport (spec 25, SERVER side).
+//
+// The agent seals each managed LUKS passphrase to the control X25519 key
+// (the SAME keypair LPS uses, distinct HKDF info/AAD); the gateway relays
+// opaque bytes; ProxyStoreLuksKey unseals at receipt and re-encrypts with
+// the at-rest path. An unsealable blob — tampered, wrong key, wrong
+// context, or sealed under the LPS domain — is rejected with
+// InvalidArgument and appends no event; a nil keypair fails closed.
+
+// TestProxyStoreLuksKey_SealedRoundTrip covers spec 25 AC 2 end-to-end: the
+// agent-sealed passphrase unseals at control, re-encrypts at rest, and
+// decrypts back to the original under the at-rest AAD.
+func TestProxyStoreLuksKey_SealedRoundTrip(t *testing.T) {
+	h, st, enc, pub, _ := newLpsHandler(t)
+	ctx := context.Background()
+	deviceID := testutil.CreateTestDevice(t, st, "luks-seal-host")
+	actionID := testutil.NewID()
+	const passphrase = "disk-Passphrase-0riginal-42"
+
+	sealed, err := sdkcrypto.SealLuksPassphrase(pub, passphrase, deviceID, actionID)
+	require.NoError(t, err)
+
+	resp, err := h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+		DeviceId:         deviceID,
+		ActionId:         actionID,
+		DevicePath:       "/dev/sda2",
+		SealedPassphrase: sealed,
+		RotationReason:   pm.RotationReason_ROTATION_REASON_INITIAL,
+	}))
+	require.NoError(t, err)
+	require.True(t, resp.Msg.Success)
+
+	current, err := st.Repos().Luks.ListCurrent(ctx, deviceID)
+	require.NoError(t, err)
+	require.Len(t, current, 1)
+	assert.Equal(t, "/dev/sda2", current[0].DevicePath)
+	dec, err := enc.DecryptWithContext(current[0].Passphrase, crypto.SecretAAD(deviceID, actionID, "luks"))
+	require.NoError(t, err)
+	assert.Equal(t, passphrase, dec, "stored passphrase must decrypt to the agent's original")
+}
+
+// TestProxyStoreLuksKey_RejectsUnsealable covers spec 25 AC 3: tampered,
+// wrong-key, or wrong-context blobs are rejected with InvalidArgument and no
+// luks_key event is appended.
+func TestProxyStoreLuksKey_RejectsUnsealable(t *testing.T) {
+	h, st, _, pub, _ := newLpsHandler(t)
+	ctx := context.Background()
+	deviceID := testutil.CreateTestDevice(t, st, "luks-reject-host")
+	otherDevice := testutil.CreateTestDevice(t, st, "luks-other-host")
+	actionID := testutil.NewID()
+
+	good, err := sdkcrypto.SealLuksPassphrase(pub, "pw-secret", deviceID, actionID)
+	require.NoError(t, err)
+
+	tampered := append([]byte(nil), good...)
+	tampered[len(tampered)-1] ^= 0xFF
+
+	otherPriv, err := sdkcrypto.GenerateX25519()
+	require.NoError(t, err)
+	wrongKey, err := sdkcrypto.SealLuksPassphrase(otherPriv.PublicKey(), "pw-secret", deviceID, actionID)
+	require.NoError(t, err)
+
+	// Sealed for another device: valid blob, wrong AAD context on open.
+	wrongDevice, err := sdkcrypto.SealLuksPassphrase(pub, "pw-secret", otherDevice, actionID)
+	require.NoError(t, err)
+	wrongAction, err := sdkcrypto.SealLuksPassphrase(pub, "pw-secret", deviceID, testutil.NewID())
+	require.NoError(t, err)
+
+	cases := map[string][]byte{
+		"tampered":     tampered,
+		"wrong key":    wrongKey,
+		"wrong device": wrongDevice,
+		"wrong action": wrongAction,
+	}
+	for name, blob := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+				DeviceId:         deviceID,
+				ActionId:         actionID,
+				DevicePath:       "/dev/sda2",
+				SealedPassphrase: blob,
+				RotationReason:   pm.RotationReason_ROTATION_REASON_INITIAL,
+			}))
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+			// The rejection must not echo secret material or the blob.
+			assert.NotContains(t, err.Error(), "pw-secret")
+		})
+	}
+
+	events, err := st.LoadStreamByType(ctx, "luks_key", 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, events, "a rejected unseal must append no event")
+}
+
+// TestProxyStoreLuksKey_RejectsCrossDomainBlob covers spec 25 AC 4: a blob
+// sealed under the LPS domain — even with a byte-identical AAD (username
+// "luks") — must not open in the LUKS store path.
+func TestProxyStoreLuksKey_RejectsCrossDomainBlob(t *testing.T) {
+	h, st, _, pub, _ := newLpsHandler(t)
+	ctx := context.Background()
+	deviceID := testutil.CreateTestDevice(t, st, "luks-xdomain-host")
+	actionID := testutil.NewID()
+
+	lpsBlob, err := sdkcrypto.SealLpsPassword(pub, "pw-secret", deviceID, actionID, "luks")
+	require.NoError(t, err)
+
+	_, err = h.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+		DeviceId:         deviceID,
+		ActionId:         actionID,
+		DevicePath:       "/dev/sda2",
+		SealedPassphrase: lpsBlob,
+		RotationReason:   pm.RotationReason_ROTATION_REASON_INITIAL,
+	}))
+	require.Error(t, err, "an LPS-domain blob must not unseal in the LUKS store path")
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	events, err := st.LoadStreamByType(ctx, "luks_key", 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, events)
+}
+
+// TestProxyStoreLuksKey_NilKeypairFailsClosed pins that a handler without a
+// configured keypair refuses the store rather than accepting bytes it cannot
+// open (no cleartext fallback path exists to fall back to).
+func TestProxyStoreLuksKey_NilKeypairFailsClosed(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	deviceID := testutil.CreateTestDevice(t, st, "luks-nokey-host")
+
+	_, err := h.ProxyStoreLuksKey(context.Background(), connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+		DeviceId:         deviceID,
+		ActionId:         testutil.NewID(),
+		DevicePath:       "/dev/sda2",
+		SealedPassphrase: make([]byte, 61),
+		RotationReason:   pm.RotationReason_ROTATION_REASON_INITIAL,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
+
+	events, err := st.LoadStreamByType(context.Background(), "luks_key", 100, 0)
+	require.NoError(t, err)
+	assert.Empty(t, events, "no event may be appended without an unseal")
+}

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	sdkcrypto "github.com/manchtools/power-manage-sdk/crypto"
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage-sdk/gen/go/pm/v1/pmv1connect"
 	"github.com/manchtools/power-manage/server/internal/ca"
@@ -820,7 +821,26 @@ func (h *AgentHandler) handleGetLuksKey(ctx context.Context, deviceID, msgID str
 }
 
 func (h *AgentHandler) handleStoreLuksKey(ctx context.Context, deviceID, msgID string, req *pm.StoreLuksKeyRequest) error {
-	resp, err := h.controlProxy.StoreLuksKey(ctx, deviceID, req.ActionId, req.DevicePath, req.Passphrase, req.RotationReason)
+	// Legacy-cleartext guard (spec 25): a pre-sealed-transport agent puts a
+	// cleartext passphrase where sealed bytes belong (string→bytes is
+	// wire-compatible). Anything shorter than a minimal sealed blob cannot
+	// be one — drop it loudly and never proxy. Control's unseal is the
+	// authority for the remainder; the gateway just refuses the obvious.
+	if len(req.SealedPassphrase) < sdkcrypto.MinSealedLen {
+		h.logger.Error("dropping LUKS key store without a sealed passphrase (agent predates sealed LUKS transport)",
+			"device_id", deviceID, "action_id", req.ActionId)
+		return h.manager.Send(deviceID, &pm.ServerMessage{
+			Id: msgID,
+			Payload: &pm.ServerMessage_Error{
+				Error: &pm.Error{
+					Code:    connect.CodeInvalidArgument.String(),
+					Message: "sealed passphrase required: update the agent (sealed LUKS transport, spec 25)",
+				},
+			},
+		})
+	}
+
+	resp, err := h.controlProxy.StoreLuksKey(ctx, deviceID, req.ActionId, req.DevicePath, req.SealedPassphrase, req.RotationReason)
 	if err != nil {
 		return h.manager.Send(deviceID, &pm.ServerMessage{
 			Id: msgID,

--- a/internal/handler/agent_luks_test.go
+++ b/internal/handler/agent_luks_test.go
@@ -20,6 +20,7 @@ package handler
 // Documented as a follow-up.
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -150,11 +151,12 @@ func TestHandleStoreLuksKey_PropagatesAllRequestFieldsToProxy(t *testing.T) {
 	h, stub := setupAgentForLuksTest(t)
 	stub.storeLuksKeyResp = &pm.StoreLuksKeyResponse{Success: true}
 
+	sealed := bytes.Repeat([]byte{0xAB}, 61) // shaped like a minimal sealed blob
 	err := h.handleStoreLuksKey(context.Background(), "dev-1", "msg-1", &pm.StoreLuksKeyRequest{
-		ActionId:       "act-2",
-		DevicePath:     "/dev/sda1",
-		Passphrase:     "new-passphrase",
-		RotationReason: pm.RotationReason_ROTATION_REASON_SCHEDULED,
+		ActionId:         "act-2",
+		DevicePath:       "/dev/sda1",
+		SealedPassphrase: sealed,
+		RotationReason:   pm.RotationReason_ROTATION_REASON_SCHEDULED,
 	})
 	require.Error(t, err, "no agent registered → manager.Send returns ErrAgentNotConnected")
 	assert.ErrorIs(t, err, connection.ErrAgentNotConnected)
@@ -163,7 +165,8 @@ func TestHandleStoreLuksKey_PropagatesAllRequestFieldsToProxy(t *testing.T) {
 	assert.Equal(t, "dev-1", stub.lastStoreLuksKey.DeviceId)
 	assert.Equal(t, "act-2", stub.lastStoreLuksKey.ActionId)
 	assert.Equal(t, "/dev/sda1", stub.lastStoreLuksKey.DevicePath)
-	assert.Equal(t, "new-passphrase", stub.lastStoreLuksKey.Passphrase)
+	assert.Equal(t, sealed, stub.lastStoreLuksKey.SealedPassphrase,
+		"the sealed bytes must pass through the gateway untouched — it relays opaquely (spec 25)")
 	assert.Equal(t, pm.RotationReason_ROTATION_REASON_SCHEDULED, stub.lastStoreLuksKey.RotationReason,
 		"RotationReason MUST round-trip — the audit log keys on this for 'why was this LUKS key rotated'")
 }
@@ -173,9 +176,27 @@ func TestHandleStoreLuksKey_ProxyErrorReachesSendPath(t *testing.T) {
 	stub.storeLuksKeyErr = connect.NewError(connect.CodeInternal, errors.New("encrypt failed"))
 
 	err := h.handleStoreLuksKey(context.Background(), "dev-1", "msg-1", &pm.StoreLuksKeyRequest{
-		ActionId: "act-2", DevicePath: "/dev/sda1", Passphrase: "x",
+		ActionId: "act-2", DevicePath: "/dev/sda1", SealedPassphrase: bytes.Repeat([]byte{0xCD}, 61),
 	})
 	require.Error(t, err)
 	assert.ErrorIs(t, err, connection.ErrAgentNotConnected)
 	require.NotNil(t, stub.lastStoreLuksKey, "proxy was still called even though it returned error")
+}
+
+// TestHandleStoreLuksKey_DropsLegacyCleartext pins the spec 25 compatibility
+// row: a pre-sealed-transport agent's cleartext passphrase (anything shorter
+// than a minimal sealed blob) is dropped at the gateway with a loud error —
+// NEVER proxied toward control.
+func TestHandleStoreLuksKey_DropsLegacyCleartext(t *testing.T) {
+	h, stub := setupAgentForLuksTest(t)
+
+	err := h.handleStoreLuksKey(context.Background(), "dev-1", "msg-1", &pm.StoreLuksKeyRequest{
+		ActionId:         "act-2",
+		DevicePath:       "/dev/sda1",
+		SealedPassphrase: []byte("legacy-cleartext-pw"),
+		RotationReason:   pm.RotationReason_ROTATION_REASON_SCHEDULED,
+	})
+	require.Error(t, err, "the error-response send path is exercised (no agent connected)")
+	assert.ErrorIs(t, err, connection.ErrAgentNotConnected)
+	assert.Nil(t, stub.lastStoreLuksKey, "legacy cleartext must never reach the proxy")
 }

--- a/internal/handler/control_proxy.go
+++ b/internal/handler/control_proxy.go
@@ -106,17 +106,19 @@ func (p *ControlProxy) GetLuksKey(ctx context.Context, deviceID, actionID string
 	return resp.Msg, nil
 }
 
-// StoreLuksKey encrypts and stores a new LUKS key via the control server.
-func (p *ControlProxy) StoreLuksKey(ctx context.Context, deviceID, actionID, devicePath, passphrase string, reason pm.RotationReason) (*pm.StoreLuksKeyResponse, error) {
+// StoreLuksKey relays an agent-sealed LUKS passphrase to the control server
+// for unsealing and storage. The gateway never sees the cleartext — the
+// sealed bytes pass through opaquely (spec 25).
+func (p *ControlProxy) StoreLuksKey(ctx context.Context, deviceID, actionID, devicePath string, sealedPassphrase []byte, reason pm.RotationReason) (*pm.StoreLuksKeyResponse, error) {
 	ctx, cancel := withProxyDeadline(ctx)
 	defer cancel()
 	resp, err := p.client.ProxyStoreLuksKey(ctx, connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
-		DeviceId:       deviceID,
-		ActionId:       actionID,
-		DevicePath:     devicePath,
-		Passphrase:     passphrase,
-		RotationReason: reason,
-		GatewayId:      p.gatewayID,
+		DeviceId:         deviceID,
+		ActionId:         actionID,
+		DevicePath:       devicePath,
+		SealedPassphrase: sealedPassphrase,
+		RotationReason:   reason,
+		GatewayId:        p.gatewayID,
 	}))
 	if err != nil {
 		return nil, err

--- a/internal/handler/control_proxy_test.go
+++ b/internal/handler/control_proxy_test.go
@@ -254,7 +254,8 @@ func TestControlProxy_StoreLuksKey_HappyPath(t *testing.T) {
 	p, fake := setupProxy(t)
 	fake.storeLuksKeyResp = &pm.StoreLuksKeyResponse{Success: true}
 
-	resp, err := p.StoreLuksKey(context.Background(), "dev-1", "act-2", "/dev/sda1", "passphrase", pm.RotationReason_ROTATION_REASON_INITIAL)
+	sealed := []byte("opaque-sealed-blob-relayed-untouched-by-the-gateway-spec25xx")
+	resp, err := p.StoreLuksKey(context.Background(), "dev-1", "act-2", "/dev/sda1", sealed, pm.RotationReason_ROTATION_REASON_INITIAL)
 	require.NoError(t, err)
 	assert.True(t, resp.Success)
 
@@ -262,7 +263,7 @@ func TestControlProxy_StoreLuksKey_HappyPath(t *testing.T) {
 	assert.Equal(t, "dev-1", fake.lastStoreLuksKey.DeviceId)
 	assert.Equal(t, "act-2", fake.lastStoreLuksKey.ActionId)
 	assert.Equal(t, "/dev/sda1", fake.lastStoreLuksKey.DevicePath)
-	assert.Equal(t, "passphrase", fake.lastStoreLuksKey.Passphrase)
+	assert.Equal(t, sealed, fake.lastStoreLuksKey.SealedPassphrase)
 	assert.Equal(t, pm.RotationReason_ROTATION_REASON_INITIAL, fake.lastStoreLuksKey.RotationReason)
 }
 


### PR DESCRIPTION
Implements the server side of spec 25 (refs manchtools/power-manage-agent#165, spec 18 / ADR 0028 pattern): LUKS passphrases stop crossing the gateway in cleartext.

**Control (`ProxyStoreLuksKey`)** — fail-closes on a missing control keypair (no cleartext fallback path exists), unseals the agent-sealed blob under the reconstructed `device|action|luks` AAD, then the unchanged at-rest path. An unsealable blob — tampered, wrong key, wrong device/action context, or a blob sealed under the **LPS domain** — is InvalidArgument with **nothing stored** and no secret logged.

**Gateway** — relays `sealed_passphrase` opaquely; sub-minimum legacy cleartext from a pre-spec-25 agent is dropped loudly and never proxied (`TestHandleStoreLuksKey_DropsLegacyCleartext`).

**Test charter** mirrors the spec-18 LPS suite (all red-checked): sealed round-trip to at-rest storage decrypting back to the agent's original; unsealable/cross-domain rejection with zero `luks_key` events; nil-keypair fail-closed; gateway propagation + legacy drop; the device→gateway **binding regressions** re-seeded with real seals (AC 6).

Depends on sdk#307 (merged; go.mod bumped). Companion agent PR follows.

Gate: go vet, gofmt, staticcheck, full suite (37 packages) green; local CodeRabbit: no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for storing LUKS passphrases in sealed form end-to-end, improving secret handling during key rotation.
  * Gateway and control paths now relay sealed passphrase data without exposing cleartext.

* **Bug Fixes**
  * Tightened validation for LUKS storage requests and added safer failure behavior when required key material is unavailable.
  * Requests with invalid or incompatible sealed data are now rejected more consistently.

* **Tests**
  * Expanded coverage for sealed passphrase storage, decryption, rejection cases, and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->