### PR TITLE
feat(api): ExportAuditEvents — chunked CSV/JSON audit-log export (spec 26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,7 @@ OIDC identity provider management for SSO authentication.
 | Method | Description |
 |--------|-------------|
 | `ListAuditEvents` | Paginated event log. Filters: `actor_id`, `stream_type`, `event_type`. Returns raw event data from the event store. |
+| `ExportAuditEvents` | Chunked CSV/JSON export of the filtered log (spec 26). Unary keyset-paginated (client loops `next_page_token`, concatenates chunks into one valid artifact); same read-side redaction and same `ListAuditEvents` permission as the list. Filters: `actor_id`, `stream_types` set, `event_type` substring, `occurred_at` range. |
 
 ### Search
 
@@ -733,6 +734,7 @@ Each test spins up a PostgreSQL container and tests handler methods directly.
 | `internal/api/device_group_handler_test.go` | 10 | CreateDeviceGroup (static), GetDeviceGroup (found, not found), ListDeviceGroups, RenameDeviceGroup, DeleteDeviceGroup, AddDeviceToGroup, RemoveDeviceFromGroup, SetDeviceGroupSyncInterval, ValidateDynamicQuery |
 | `internal/api/assignment_handler_test.go` | 10 | CreateAssignment (action→device, set→group, user target, user_group target, idempotent), DeleteAssignment, ListAssignments, GetDeviceAssignments, GetUserAssignments |
 | `internal/api/audit_handler_test.go` | 4 | ListAuditEvents, filter by stream_type, filter by event_type, pagination |
+| `internal/api/audit_export_test.go` | 9 | ExportAuditEvents: CSV/JSON artifacts, chunk concatenation without duplicates, redaction via the real CreateAction emit, actor/date/event-type filters (incl. ILIKE metachar regression), unsupported format, invalid page token, stream_types slice cap |
 | `internal/api/totp_handler_test.go` | 14 | SetupTOTP, VerifyTOTP (valid/invalid/replay), DisableTOTP, GetTOTPStatus, RegenerateBackupCodes, backup code login |
 | `internal/api/user_group_handler_test.go` | 20 | CreateUserGroup, GetUserGroup, ListUserGroups, UpdateUserGroup, DeleteUserGroup, AddUserToGroup, RemoveUserFromGroup, AssignRoleToUserGroup, RevokeRoleFromUserGroup, ListUserGroupsForUser, additive permissions |
 | `internal/api/idp_handler_test.go` | 15 | CreateIdentityProvider (success, duplicate slug, group mapping), Get/List/Update/Delete IDP, EnableSCIM (success, already enabled), DisableSCIM (success, not enabled), RotateSCIMToken (success, not enabled) |

--- a/cmd/control/README.md
+++ b/cmd/control/README.md
@@ -616,8 +616,10 @@ The `ListAuditEvents` RPC's `event_type` filter is a **literal substring match**
 `%` and `_` in the filter value are matched as those exact characters, not as
 SQL wildcards (they are escaped before the `ILIKE`). So filtering `User_Created`
 returns only events whose type literally contains `User_Created`, never
-`UserXCreated`. The `events` table is append-only at the DB layer (migration 011
-trigger; see ADR 0005), so no audit row can be mutated or deleted after commit.
+`UserXCreated`. The `ExportAuditEvents` RPC (spec 26) applies the same
+semantics to its `event_type` filter. The `events` table is append-only at the
+DB layer (migration 011 trigger; see ADR 0005), so no audit row can be mutated
+or deleted after commit.
 
 ### Time Travel
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260709181148-195cb8038eec
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260710151251-40990896bb10
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.5.4-0.20260709181148-195cb8038eec h1:RULgLkZQaT7rKe6gZ/XerbKM/tVh5Npf7THwGMbE2Hs=
-github.com/manchtools/power-manage-sdk v0.5.4-0.20260709181148-195cb8038eec/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260710151251-40990896bb10 h1:R6xSxbhIM1x2VOJnJ0PKHdESluv+EC/fovrKCAKqZIg=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260710151251-40990896bb10/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/audit_export.go
+++ b/internal/api/audit_export.go
@@ -1,0 +1,192 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"strconv"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/jackc/pgx/v5/pgtype"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// exportPageSize bounds how many events one ExportAuditEvents call
+// reads and formats — the server never holds more than one page of the
+// export in memory (spec 26 AC5). Package-var seam so tests can shrink
+// it and prove the chunking without seeding a thousand events.
+var exportPageSize = 1000
+
+// exportCSVHeader is the column set of the CSV artifact. The columns
+// mirror the AuditEvent proto (and the JSON export keys) so the two
+// formats carry identical information.
+var exportCSVHeader = []string{"id", "occurred_at", "actor_type", "actor_id", "stream_type", "stream_id", "event_type", "data"}
+
+// exportEvent is one row of the JSON export artifact. It is built from
+// the *pm.AuditEvent that eventToProto returns, so the read-side
+// redaction (redactEventData) is on the path by construction — the
+// export can never expose a field ListAuditEvents would scrub. Keys
+// are snake_case to match the CSV header.
+type exportEvent struct {
+	ID         string `json:"id"`
+	OccurredAt string `json:"occurred_at"`
+	ActorType  string `json:"actor_type"`
+	ActorID    string `json:"actor_id"`
+	StreamType string `json:"stream_type"`
+	StreamID   string `json:"stream_id"`
+	EventType  string `json:"event_type"`
+	// Data is the redacted event payload as a JSON string — embedded
+	// verbatim from the audit API surface, not re-parsed, so a payload
+	// that fails to decode there stays byte-identical here.
+	Data string `json:"data"`
+}
+
+// ExportAuditEvents streams the audit log as CSV or JSON for DSAR /
+// external review (spec 26). It is a unary, chunked export: the
+// client passes next_page_token back until it comes back empty and
+// concatenates the chunks into one valid artifact. Unary on purpose —
+// the control server's interceptors are deliberately fail-closed on
+// streaming RPCs, so this reuses the entire unary auth/authz/validate
+// chain, and the authz interceptor gates it with the ListAuditEvents
+// permission (procedureAlternatives): the export cannot widen access.
+//
+// Pagination is keyset on sequence_num, not OFFSET, so events appended
+// while an export runs cannot shift rows into a later page and
+// duplicate them in the artifact.
+func (h *AuditHandler) ExportAuditEvents(ctx context.Context, req *connect.Request[pm.ExportAuditEventsRequest]) (*connect.Response[pm.ExportAuditEventsResponse], error) {
+	if err := Validate(ctx, req.Msg); err != nil {
+		return nil, err
+	}
+
+	// Defense in depth behind the proto tag's oneof=csv json.
+	format := req.Msg.Format
+	if format != "csv" && format != "json" {
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "unsupported export format")
+	}
+
+	first := req.Msg.PageToken == ""
+	var beforeSeq int64
+	if !first {
+		v, err := strconv.ParseInt(req.Msg.PageToken, 10, 64)
+		if err != nil || v <= 0 {
+			return nil, apiErrorCtx(ctx, ErrInvalidPageToken, connect.CodeInvalidArgument, "invalid page token")
+		}
+		beforeSeq = v
+	}
+
+	var occurredFrom, occurredTo pgtype.Timestamptz
+	if req.Msg.OccurredFrom != nil {
+		occurredFrom = pgtype.Timestamptz{Time: req.Msg.OccurredFrom.AsTime(), Valid: true}
+	}
+	if req.Msg.OccurredTo != nil {
+		occurredTo = pgtype.Timestamptz{Time: req.Msg.OccurredTo.AsTime(), Valid: true}
+	}
+
+	events, err := h.store.Queries().ExportAuditEvents(ctx, db.ExportAuditEventsParams{
+		ActorID:      req.Msg.ActorId,
+		StreamTypes:  req.Msg.StreamTypes,
+		EventType:    req.Msg.EventType,
+		OccurredFrom: occurredFrom,
+		OccurredTo:   occurredTo,
+		BeforeSeq:    beforeSeq,
+		PageSize:     int32(exportPageSize),
+	})
+	if err != nil {
+		h.logger.Error("audit export query failed", "error", err)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to export audit events")
+	}
+
+	// A full page means there may be more rows; a short page is the
+	// end of the export. The cursor is the last row's sequence_num.
+	last := len(events) < exportPageSize
+	nextToken := ""
+	if !last {
+		nextToken = strconv.FormatInt(events[len(events)-1].SequenceNum, 10)
+	}
+
+	rows := make([]exportEvent, len(events))
+	for i, e := range events {
+		ev := eventToProto(e) // the ListAuditEvents redaction path
+		rows[i] = exportEvent{
+			ID:         ev.Id,
+			OccurredAt: ev.OccurredAt.AsTime().Format(time.RFC3339Nano),
+			ActorType:  ev.ActorType,
+			ActorID:    ev.ActorId,
+			StreamType: ev.StreamType,
+			StreamID:   ev.StreamId,
+			EventType:  ev.EventType,
+			Data:       ev.Data,
+		}
+	}
+
+	var chunk []byte
+	if format == "csv" {
+		chunk, err = exportChunkCSV(rows, first)
+	} else {
+		chunk, err = exportChunkJSON(rows, first, last)
+	}
+	if err != nil {
+		h.logger.Error("audit export encoding failed", "error", err, "format", format)
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to encode audit export")
+	}
+
+	return connect.NewResponse(&pm.ExportAuditEventsResponse{
+		Chunk:         chunk,
+		NextPageToken: nextToken,
+	}), nil
+}
+
+// exportChunkCSV renders one page of export rows as CSV lines; the
+// first chunk carries the header so concatenated chunks form a single
+// valid CSV document.
+func exportChunkCSV(rows []exportEvent, first bool) ([]byte, error) {
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+	if first {
+		if err := w.Write(exportCSVHeader); err != nil {
+			return nil, err
+		}
+	}
+	for _, r := range rows {
+		if err := w.Write([]string{r.ID, r.OccurredAt, r.ActorType, r.ActorID, r.StreamType, r.StreamID, r.EventType, r.Data}); err != nil {
+			return nil, err
+		}
+	}
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// exportChunkJSON renders one page of export rows as a fragment of a
+// JSON array: the first chunk opens it, the last closes it, and a
+// non-first chunk with rows leads with a separator (a next_page_token
+// is only ever issued after a full page, so rows always precede it).
+// Concatenating every chunk yields one valid JSON document — an empty
+// result is "[]".
+func exportChunkJSON(rows []exportEvent, first, last bool) ([]byte, error) {
+	var buf bytes.Buffer
+	if first {
+		buf.WriteByte('[')
+	}
+	for i, r := range rows {
+		if i > 0 || !first {
+			buf.WriteByte(',')
+		}
+		buf.WriteByte('\n')
+		b, err := json.Marshal(r)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(b)
+	}
+	if last {
+		buf.WriteString("\n]")
+	}
+	return buf.Bytes(), nil
+}

--- a/internal/api/audit_export_test.go
+++ b/internal/api/audit_export_test.go
@@ -1,0 +1,349 @@
+package api_test
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+func TestExportAuditEvents_CSVRespectsFilters(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewAuditHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	testutil.CreateTestDevice(t, st, "export-host-a")
+	testutil.CreateTestDevice(t, st, "export-host-b")
+	ctx := testutil.AdminContext(adminID)
+
+	var artifact bytes.Buffer
+	chunks := 0
+	token := ""
+	for {
+		resp, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+			Format:      "csv",
+			StreamTypes: []string{"device"},
+			PageToken:   token,
+		}))
+		require.NoError(t, err)
+		artifact.Write(resp.Msg.Chunk)
+		chunks++
+		token = resp.Msg.NextPageToken
+		if token == "" {
+			break
+		}
+	}
+
+	records, err := csv.NewReader(&artifact).ReadAll()
+	require.NoError(t, err, "export must be one valid CSV document")
+	require.NotEmpty(t, records)
+	assert.Equal(t, []string{"id", "occurred_at", "actor_type", "actor_id", "stream_type", "stream_id", "event_type", "data"}, records[0])
+	require.GreaterOrEqual(t, len(records), 3, "expected the header plus both seeded device events")
+	for _, row := range records[1:] {
+		assert.Equal(t, "device", row[4], "stream_types filter must reach the query, row: %v", row)
+	}
+	_ = chunks
+}
+
+func TestExportAuditEvents_JSONChunksConcatenateToOneDocument(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewAuditHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	for i := 0; i < 5; i++ {
+		testutil.CreateTestDevice(t, st, testutil.NewID()+"-host")
+	}
+	ctx := testutil.AdminContext(adminID)
+
+	// Shrink the server-side page so the export must span several
+	// chunks — this is what proves AC5 (bounded pages, no full-set
+	// buffering) rather than a single lucky chunk.
+	restore := api.SetExportPageSizeForTest(2)
+	defer restore()
+
+	var artifact bytes.Buffer
+	chunks := 0
+	token := ""
+	for {
+		resp, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+			Format:    "json",
+			PageToken: token,
+		}))
+		require.NoError(t, err)
+		artifact.Write(resp.Msg.Chunk)
+		chunks++
+		token = resp.Msg.NextPageToken
+		if token == "" {
+			break
+		}
+	}
+
+	require.Greater(t, chunks, 2, "5+ events at page size 2 must take several chunks")
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(artifact.Bytes(), &rows),
+		"concatenated chunks must form one valid JSON array: %s", artifact.String())
+	require.GreaterOrEqual(t, len(rows), 6, "5 devices + admin user events")
+
+	// Row count must match what the list endpoint reports for the
+	// same (empty) filter — the export may not silently drop rows.
+	listResp, err := h.ListAuditEvents(ctx, connect.NewRequest(&pm.ListAuditEventsRequest{PageSize: 100}))
+	require.NoError(t, err)
+	assert.Equal(t, int(listResp.Msg.TotalCount), len(rows))
+
+	// No duplicates: keyset pagination must not repeat rows across
+	// chunk boundaries.
+	seen := map[string]bool{}
+	for _, r := range rows {
+		id, _ := r["id"].(string)
+		require.NotEmpty(t, id)
+		assert.False(t, seen[id], "event %s exported twice", id)
+		seen[id] = true
+	}
+}
+
+// TestExportAuditEvents_RedactionApplied drives the REAL CreateAction
+// emit path (like TestListAuditEvents_RedactsActionSecrets) and then
+// asserts the export applies the same read-side redaction as
+// ListAuditEvents: the secret never appears, in either format.
+func TestExportAuditEvents_RedactionApplied(t *testing.T) {
+	const sentinel = "SENTINEL_EXPORT_9c2e"
+
+	for _, format := range []string{"csv", "json"} {
+		t.Run(format, func(t *testing.T) {
+			st := testutil.SetupPostgres(t)
+			actionH := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+			h := api.NewAuditHandler(st, slog.Default())
+			adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+			ctx := testutil.AdminContext(adminID)
+
+			_, err := actionH.CreateAction(ctx, connect.NewRequest(&pm.CreateActionRequest{
+				Name: "export-leak",
+				Type: pm.ActionType_ACTION_TYPE_SHELL,
+				Params: &pm.CreateActionRequest_Shell{
+					Shell: &pm.ShellParams{Script: sentinel},
+				},
+			}))
+			require.NoError(t, err)
+
+			var artifact bytes.Buffer
+			token := ""
+			for {
+				resp, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+					Format:    format,
+					PageToken: token,
+				}))
+				require.NoError(t, err)
+				artifact.Write(resp.Msg.Chunk)
+				token = resp.Msg.NextPageToken
+				if token == "" {
+					break
+				}
+			}
+
+			out := artifact.String()
+			assert.NotContains(t, out, sentinel, "secret leaked unredacted into the %s export", format)
+			assert.Contains(t, out, "[REDACTED]", "the ActionCreated payload must carry the redaction marker")
+		})
+	}
+}
+
+func TestExportAuditEvents_ActorFilter(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewAuditHandler(st, slog.Default())
+	actionH := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	otherID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	// The factories append events as actor "test", so give otherID a
+	// REAL handler-emitted event (ActionCreated) — without it a broken
+	// actor filter would pass vacuously on an empty result.
+	_, err := actionH.CreateAction(testutil.AdminContext(otherID), connect.NewRequest(&pm.CreateActionRequest{
+		Name: "actor-filter-probe",
+		Type: pm.ActionType_ACTION_TYPE_SHELL,
+		Params: &pm.CreateActionRequest_Shell{
+			Shell: &pm.ShellParams{Script: "true"},
+		},
+	}))
+	require.NoError(t, err)
+
+	var artifact bytes.Buffer
+	token := ""
+	for {
+		resp, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+			Format:    "json",
+			ActorId:   otherID,
+			PageToken: token,
+		}))
+		require.NoError(t, err)
+		artifact.Write(resp.Msg.Chunk)
+		token = resp.Msg.NextPageToken
+		if token == "" {
+			break
+		}
+	}
+
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(artifact.Bytes(), &rows))
+	require.NotEmpty(t, rows, "otherID's ActionCreated event must be exported")
+	for _, r := range rows {
+		assert.Equal(t, otherID, r["actor_id"], "actor filter must reach the query")
+	}
+}
+
+func TestExportAuditEvents_DateRangeFilter(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewAuditHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	// A lower bound far in the future matches nothing: the artifact
+	// must still be a VALID empty document (header-only CSV, "[]"
+	// JSON) with no next page.
+	future := timestamppb.New(time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	respJSON, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+		Format:       "json",
+		OccurredFrom: future,
+	}))
+	require.NoError(t, err)
+	assert.Empty(t, respJSON.Msg.NextPageToken)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(respJSON.Msg.Chunk, &rows))
+	assert.Empty(t, rows)
+
+	respCSV, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+		Format:       "csv",
+		OccurredFrom: future,
+	}))
+	require.NoError(t, err)
+	assert.Empty(t, respCSV.Msg.NextPageToken)
+	records, err := csv.NewReader(bytes.NewReader(respCSV.Msg.Chunk)).ReadAll()
+	require.NoError(t, err)
+	require.Len(t, records, 1, "empty export still carries the header row")
+
+	// And an unbounded export DOES return rows (sanity complement).
+	respAll, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+		Format: "json",
+	}))
+	require.NoError(t, err)
+	var allRows []map[string]any
+	require.NoError(t, json.Unmarshal(respAll.Msg.Chunk, &allRows))
+	assert.NotEmpty(t, allRows)
+}
+
+func TestExportAuditEvents_UnsupportedFormat(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewAuditHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	for _, format := range []string{"", "xml", "CSV "} {
+		_, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+			Format: format,
+		}))
+		require.Error(t, err, "format %q must be rejected", format)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	}
+}
+
+func TestExportAuditEvents_InvalidPageToken(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewAuditHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	for _, token := range []string{"abc", "-5", "1e9"} {
+		_, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+			Format:    "csv",
+			PageToken: token,
+		}))
+		require.Error(t, err, "page token %q must be rejected", token)
+		assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	}
+}
+
+// TestExportAuditEvents_StreamTypesSliceCapped is the regression test
+// for the local CR finding on the proto tag: `dive` scopes min/max to
+// the ELEMENTS, so the slice itself needs its own max — otherwise an
+// arbitrarily long stream_types list reaches the SQL filter.
+func TestExportAuditEvents_StreamTypesSliceCapped(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewAuditHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(adminID)
+
+	oversized := make([]string, 65)
+	for i := range oversized {
+		oversized[i] = "device"
+	}
+	_, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+		Format:      "csv",
+		StreamTypes: oversized,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	// 64 entries is the documented ceiling and must pass validation.
+	_, err = h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+		Format:      "csv",
+		StreamTypes: oversized[:64],
+	}))
+	require.NoError(t, err)
+}
+
+// TestExportAuditEvents_EventTypeFilterEscapesLikeMetachars pins that
+// the event_type substring filter keeps ListAuditEvents' ILIKE
+// escaping: a literal "_" in the filter must not act as a wildcard.
+func TestExportAuditEvents_EventTypeFilter(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewAuditHandler(st, slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	testutil.CreateTestDevice(t, st, "evt-filter-host")
+	ctx := testutil.AdminContext(adminID)
+
+	resp, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+		Format:    "json",
+		EventType: "UserCreated",
+	}))
+	require.NoError(t, err)
+	var rows []map[string]any
+	require.NoError(t, json.Unmarshal(resp.Msg.Chunk, &rows))
+	require.NotEmpty(t, rows)
+	for _, r := range rows {
+		et, _ := r["event_type"].(string)
+		assert.True(t, strings.Contains(et, "UserCreated"), "event_type filter must reach the query, got %q", et)
+	}
+
+	// LIKE-metachar regression: "User_" contains a literal underscore.
+	// With correct ILIKE escaping it matches NO event type (none carries
+	// "User_" literally); if the escaping regressed, "_" would act as a
+	// single-char wildcard and match UserCreatedWithRoles.
+	respMeta, err := h.ExportAuditEvents(ctx, connect.NewRequest(&pm.ExportAuditEventsRequest{
+		Format:    "json",
+		EventType: "User_",
+	}))
+	require.NoError(t, err)
+	var metaRows []map[string]any
+	require.NoError(t, json.Unmarshal(respMeta.Msg.Chunk, &metaRows))
+	assert.Empty(t, metaRows, "a literal underscore must not act as a LIKE wildcard")
+}

--- a/internal/api/event_append_completeness_test.go
+++ b/internal/api/event_append_completeness_test.go
@@ -43,7 +43,7 @@ import (
 // readOnlyRPCPrefixes are the leading verbs of RPCs that perform no
 // state change (reads MAY still append events — sensitive-read auditing,
 // cf. #494 — so assertion 1 simply does not require anything of them).
-var readOnlyRPCPrefixes = []string{"Get", "List", "Search", "Validate", "Evaluate"}
+var readOnlyRPCPrefixes = []string{"Get", "List", "Search", "Validate", "Evaluate", "Export"}
 
 // mutatingRPCPrefixes are the leading verbs of state-changing RPCs. A new RPC
 // whose name starts with none of the prefixes in either set fails the

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -33,3 +33,13 @@ func (h *AuthHandler) SetDummyVerifyForTest(fn func(password, hash string) bool)
 // freshness boundary tests can pin "now" against a fixed collected_at.
 // Compiled only into test binaries.
 func (h *DeviceHandler) SetNowForTest(now func() time.Time) { h.now = now }
+
+// SetExportPageSizeForTest shrinks the ExportAuditEvents page seam so
+// chunking tests can prove multi-chunk exports without seeding a
+// thousand events. Returns a restore func. Compiled only into test
+// binaries.
+func SetExportPageSizeForTest(n int) (restore func()) {
+	prev := exportPageSize
+	exportPageSize = n
+	return func() { exportPageSize = prev }
+}

--- a/internal/api/request_id_ulid_rule_test.go
+++ b/internal/api/request_id_ulid_rule_test.go
@@ -21,8 +21,10 @@ var idRuleExemptFields = map[string]bool{
 	"CreateIdentityProviderRequest.ClientId": true,
 	"UpdateIdentityProviderRequest.ClientId": true,
 	// Audit actor filter: an actor may be a user (ULID) OR a non-ULID system /
-	// device actor, so the filter accepts any non-empty string.
-	"ListAuditEventsRequest.ActorId": true,
+	// device actor, so the filter accepts any non-empty string. The export
+	// (spec 26) carries the same filter with the same semantics.
+	"ListAuditEventsRequest.ActorId":   true,
+	"ExportAuditEventsRequest.ActorId": true,
 	// Gateway identifier: an operator/registry-assigned gateway id (bounded
 	// string, not a ULID — see the device→gateway registry / WS2).
 	"VerifyDeviceRequest.GatewayId":              true,

--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -555,6 +555,10 @@ func (s *ControlService) ListAuditEvents(ctx context.Context, req *connect.Reque
 	return s.audit.ListAuditEvents(ctx, req)
 }
 
+func (s *ControlService) ExportAuditEvents(ctx context.Context, req *connect.Request[pm.ExportAuditEventsRequest]) (*connect.Response[pm.ExportAuditEventsResponse], error) {
+	return s.audit.ExportAuditEvents(ctx, req)
+}
+
 // LPS (Local Password Solution)
 func (s *ControlService) GetDeviceLpsPasswords(ctx context.Context, req *connect.Request[pm.GetDeviceLpsPasswordsRequest]) (*connect.Response[pm.GetDeviceLpsPasswordsResponse], error) {
 	return s.device.GetDeviceLpsPasswords(ctx, req)

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -83,6 +83,14 @@ var procedureAlternatives = map[string][]string{
 	"/pm.v1.ControlService/UpdateUserGroupQuery": {
 		"UpdateDynamicUserGroupQuery",
 	},
+	// ExportAuditEvents is gated by the SAME permission as the list
+	// (spec 26): the export is a formatting of what ListAuditEvents
+	// already returns, so a separate permission could only drift wider
+	// or narrower than the data it re-serves. No handler-level
+	// narrowing needed — the alternative IS the exact gate.
+	"/pm.v1.ControlService/ExportAuditEvents": {
+		"ListAuditEvents",
+	},
 }
 
 // ProcedureAlternativesSnapshot returns a deep copy of the
@@ -271,19 +279,20 @@ type RateLimiters struct {
 
 // isExpensiveProcedure reports whether an authenticated control procedure runs
 // a heavy operation — dynamic-group query evaluation, search, a projector
-// rebuild, or a log/osquery fan-out — that warrants a tighter per-user ceiling
-// than ordinary reads. It is self-discovered from the action name so a newly
-// added Evaluate* / Search* / Rebuild* / Query* / *Query RPC is covered
-// automatically rather than from a hand-maintained list that fails open. A test
-// (TestIsExpensiveProcedure_MatchesRealProcedures) walks the ControlService
-// descriptor and asserts the matcher recognises at least one real procedure, so
-// it can never silently match zero.
+// rebuild, a log/osquery fan-out, or a bulk export — that warrants a tighter
+// per-user ceiling than ordinary reads. It is self-discovered from the action
+// name so a newly added Evaluate* / Search* / Rebuild* / Query* / *Query /
+// Export* RPC is covered automatically rather than from a hand-maintained list
+// that fails open. A test (TestIsExpensiveProcedure_MatchesRealProcedures)
+// walks the ControlService descriptor and asserts the matcher recognises at
+// least one real procedure, so it can never silently match zero.
 func isExpensiveProcedure(action string) bool {
 	return strings.HasPrefix(action, "Evaluate") ||
 		strings.HasPrefix(action, "Search") ||
 		strings.HasPrefix(action, "Rebuild") ||
 		strings.HasPrefix(action, "Query") ||
-		strings.HasSuffix(action, "Query")
+		strings.HasSuffix(action, "Query") ||
+		strings.HasPrefix(action, "Export")
 }
 
 // procedureAction extracts the trailing method name from a Connect procedure

--- a/internal/auth/permissions_parity_test.go
+++ b/internal/auth/permissions_parity_test.go
@@ -206,6 +206,12 @@ func TestProcedureAlternatives_Exact(t *testing.T) {
 		"/pm.v1.ControlService/UpdateUserGroupQuery": {
 			"UpdateDynamicUserGroupQuery",
 		},
+		// Spec 26: the audit export is gated by exactly the list
+		// permission — it re-serves what ListAuditEvents returns and
+		// must never widen (or narrow) relative to it.
+		"/pm.v1.ControlService/ExportAuditEvents": {
+			"ListAuditEvents",
+		},
 	}
 	live := auth.ProcedureAlternativesSnapshot()
 	if len(expected) != len(live) {

--- a/internal/store/generated/events.sql.go
+++ b/internal/store/generated/events.sql.go
@@ -7,6 +7,8 @@ package generated
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const appendEvent = `-- name: AppendEvent :one
@@ -105,6 +107,74 @@ func (q *Queries) CountEventsByStreamType(ctx context.Context, streamType string
 	var count int64
 	err := row.Scan(&count)
 	return count, err
+}
+
+const exportAuditEvents = `-- name: ExportAuditEvents :many
+SELECT id, sequence_num, stream_type, stream_id, stream_version, event_type, data, metadata, actor_type, actor_id, occurred_at FROM events
+WHERE ($1::TEXT = '' OR actor_id = $1)
+  AND ($2::TEXT[] IS NULL OR cardinality($2::TEXT[]) = 0 OR stream_type = ANY($2))
+  AND ($3::TEXT = '' OR event_type ILIKE '%' || replace(replace(replace($3, '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!')
+  AND ($4::TIMESTAMPTZ IS NULL OR occurred_at >= $4)
+  AND ($5::TIMESTAMPTZ IS NULL OR occurred_at <= $5)
+  AND ($6::BIGINT = 0 OR sequence_num < $6)
+ORDER BY sequence_num DESC
+LIMIT $7
+`
+
+type ExportAuditEventsParams struct {
+	ActorID      string             `json:"actor_id"`
+	StreamTypes  []string           `json:"stream_types"`
+	EventType    string             `json:"event_type"`
+	OccurredFrom pgtype.Timestamptz `json:"occurred_from"`
+	OccurredTo   pgtype.Timestamptz `json:"occurred_to"`
+	BeforeSeq    int64              `json:"before_seq"`
+	PageSize     int32              `json:"page_size"`
+}
+
+// Keyset export feed for the audit-log export (spec 26). Same filter
+// semantics as ListAuditEvents (exact actor, ILIKE-escaped event-type
+// substring) plus a stream-type set and an occurred_at range to match
+// what the audit view can express. Keyset on sequence_num — not
+// OFFSET — so events appended mid-export can't shift rows into a
+// later page and duplicate them in the artifact.
+func (q *Queries) ExportAuditEvents(ctx context.Context, arg ExportAuditEventsParams) ([]Event, error) {
+	rows, err := q.db.Query(ctx, exportAuditEvents,
+		arg.ActorID,
+		arg.StreamTypes,
+		arg.EventType,
+		arg.OccurredFrom,
+		arg.OccurredTo,
+		arg.BeforeSeq,
+		arg.PageSize,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []Event{}
+	for rows.Next() {
+		var i Event
+		if err := rows.Scan(
+			&i.ID,
+			&i.SequenceNum,
+			&i.StreamType,
+			&i.StreamID,
+			&i.StreamVersion,
+			&i.EventType,
+			&i.Data,
+			&i.Metadata,
+			&i.ActorType,
+			&i.ActorID,
+			&i.OccurredAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const getLatestSequence = `-- name: GetLatestSequence :one

--- a/internal/store/queries/events.sql
+++ b/internal/store/queries/events.sql
@@ -78,6 +78,23 @@ WHERE stream_type = 'execution'
   AND event_type = 'OutputChunk'
 ORDER BY stream_version;
 
+-- name: ExportAuditEvents :many
+-- Keyset export feed for the audit-log export (spec 26). Same filter
+-- semantics as ListAuditEvents (exact actor, ILIKE-escaped event-type
+-- substring) plus a stream-type set and an occurred_at range to match
+-- what the audit view can express. Keyset on sequence_num — not
+-- OFFSET — so events appended mid-export can't shift rows into a
+-- later page and duplicate them in the artifact.
+SELECT * FROM events
+WHERE (@actor_id::TEXT = '' OR actor_id = @actor_id)
+  AND (@stream_types::TEXT[] IS NULL OR cardinality(@stream_types::TEXT[]) = 0 OR stream_type = ANY(@stream_types))
+  AND (@event_type::TEXT = '' OR event_type ILIKE '%' || replace(replace(replace(@event_type, '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!')
+  AND (@occurred_from::TIMESTAMPTZ IS NULL OR occurred_at >= @occurred_from)
+  AND (@occurred_to::TIMESTAMPTZ IS NULL OR occurred_at <= @occurred_to)
+  AND (@before_seq::BIGINT = 0 OR sequence_num < @before_seq)
+ORDER BY sequence_num DESC
+LIMIT @page_size;
+
 -- name: ListAuditEventsForWarm :many
 SELECT * FROM events
 WHERE occurred_at >= NOW() - INTERVAL '90 days'


### PR DESCRIPTION
Closes #501. SDK counterpart: manchtools/power-manage-sdk#309 (merged) + manchtools/power-manage-sdk#310 (TS wrapper). Web UI follows direct-to-main.

## What

Server side of spec 26: `ExportAuditEvents` — a **unary, chunked** export of the audit log as CSV or JSON for DSAR / external review. The client loops `next_page_token` until empty and concatenates chunks into one valid artifact.

**Why unary, not streaming:** both auth interceptors are deliberately fail-closed on streaming RPCs (`WrapStreamingHandler` → Unimplemented). A unary chunk loop reuses the entire existing auth/validate/authz/rate-limit chain unchanged; server memory stays bounded at one page (AC5).

- **Keyset pagination** on `sequence_num` (not OFFSET) — events appended mid-export can't shift rows into a later page and duplicate them. Page-size test seam (`SetExportPageSizeForTest`).
- **Redaction reused, not reimplemented** — export rows are built from `eventToProto`, the exact `ListAuditEvents` path; a test drives the REAL `CreateAction` emit and asserts the sentinel secret reaches neither format while `[REDACTED]` does.
- **Authz identical to the list** — `procedureAlternatives` gates the export by the `ListAuditEvents` permission (exclusively); the export can never widen access. `Export*` now also matches the expensive rate limiter.
- **Filters mirror the audit view** — exact actor, stream-type set, event-type substring (same ILIKE `!`-escaping), `occurred_at` range.

## Guard classifications (each conscious)

- `Export` added to `readOnlyRPCPrefixes` (event-append sweep) — the export appends no events.
- `ExportAuditEventsRequest.ActorId` shares the list filter's non-ULID exemption (system/device actors).
- `TestProcedureAlternatives_Exact` pin gains the export entry.

## Tests

9 handler tests against real Postgres: filters (stream set / actor / event-type / date range), chunk concatenation to one valid document with no duplicates, redaction in both formats, unsupported format, invalid page token, slice-cap regression (local CR finding), ILIKE metachar regression (red-checked by neutralizing the escaping in the query — fails for the right reason, restored via regen).

Local CodeRabbit review: 3 minor findings, all fixed (CSV row-count assertion, vacuous actor filter — the factories emit actor "test", so the test now drives a real handler as the probe actor — and the added LIKE-metachar case).

Verification gate: go vet ✓ staticcheck ✓ gofmt ✓ full `go test ./...` ✓ (workspace) + standalone `GOWORK=off go build` against merged sdk ✓.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added audit-event exports in CSV and JSON formats.
  - Supports paginated downloads with actor, stream type, event type, and date-range filters.
  - Exported data follows the same permissions and redaction rules as audit-event listings.
  - JSON exports combine paginated results into a single valid document.

- **Documentation**
  - Documented export behavior and literal event-type filtering semantics.

- **Tests**
  - Added coverage for filtering, pagination, validation, formatting, and redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->