### PR TITLE
fix(search): O(1) last_seen_at touch on DeviceHeartbeat (#499)

### DIFF
--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -24,11 +24,13 @@ import (
 //
 // Three methods, in order of how often they fire from this listener:
 //
+//   - TouchDeviceLastSeen — every device heartbeat (#499)
 //   - EnqueueReindex — every reindex op
 //   - EnqueueRemove  — every delete op
 //   - GetReverseMembers — only on remove for scopes with cascading
 //     parent rebuilds (action / action_set / definition)
 type SearchIndex interface {
+	TouchDeviceLastSeen(ctx context.Context, id string, lastSeen int64) error
 	EnqueueReindex(ctx context.Context, scope, id string, data *taskqueue.SearchEntityData) error
 	EnqueueRemove(ctx context.Context, scope, id string, cascadeIDs []string) error
 	GetReverseMembers(ctx context.Context, scope, id string) []string
@@ -57,6 +59,12 @@ const (
 	// so parent entities with denormalised member lists rebuild
 	// after the child disappears.
 	SearchOpRemove
+	// SearchOpTouchDeviceLastSeen — O(1) refresh of ONLY the device's
+	// indexed last_seen_at, carrying the event's occurred_at (#499).
+	// Deliberately not a SearchOpReindex: heartbeats are the highest-
+	// volume device event, and a full row reload per heartbeat would
+	// be fleet-size × heartbeat-rate projection reads for one field.
+	SearchOpTouchDeviceLastSeen
 )
 
 // SearchAffected is the classifier output: which scope is affected,
@@ -104,6 +112,12 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 		// sort (#325) but reindexing on every login is too costly; the value stays
 		// eventually-consistent via other user events + the periodic reconcile,
 		// which is fine for "sort by last login / find dormant accounts".
+		//
+		// Contrast with DeviceHeartbeat below (#499): last_seen_at drives the
+		// online/offline status FILTER — a correctness surface, not just a sort —
+		// so heartbeats DO refresh it, but as an O(1) field touch rather than a
+		// row reload. last_login_at stays excluded because sort order degrading
+		// gracefully under staleness is the deliberate trade.
 
 	case string(eventtypes.UserDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeUser, ID: e.StreamID}}
@@ -122,6 +136,14 @@ func AffectedSearchOps(e store.PersistedEvent) []SearchAffected {
 
 	case string(eventtypes.DeviceDeleted):
 		return []SearchAffected{{Op: SearchOpRemove, Scope: search.ScopeDevice, ID: e.StreamID}}
+
+	// The devices page computes online/offline against the INDEXED
+	// last_seen_at (deviceStatusClause, 5-minute window), so a healthy
+	// heartbeating device would show offline for up to an hour (the
+	// reconcile bound) without this case (#499). The op is an O(1)
+	// touch of the one changed field — see SearchOpTouchDeviceLastSeen.
+	case string(eventtypes.DeviceHeartbeat):
+		return []SearchAffected{{Op: SearchOpTouchDeviceLastSeen, Scope: search.ScopeDevice, ID: e.StreamID}}
 
 	// ---------------------------------------------------------
 	// DeviceGroup scope
@@ -447,6 +469,16 @@ func SearchListener(st *store.Store, idx SearchIndex, logger *slog.Logger) store
 				if err := idx.EnqueueRemove(ctx, op.Scope, op.ID, cascadeIDs); err != nil {
 					logger.Warn("search listener: failed to enqueue remove",
 						"scope", op.Scope, "id", op.ID, "event_type", e.EventType, "error", err)
+				}
+			case SearchOpTouchDeviceLastSeen:
+				// #499: single Valkey write, same cost class as the
+				// enqueue LPUSH this loop already tolerates. The
+				// timestamp is the event's occurred_at — the same
+				// value the Postgres projection writes for this
+				// heartbeat, so the two stores agree.
+				if err := idx.TouchDeviceLastSeen(ctx, op.ID, e.OccurredAt.Unix()); err != nil {
+					logger.Warn("search listener: failed to touch device last_seen_at",
+						"id", op.ID, "event_type", e.EventType, "error", err)
 				}
 			}
 		}

--- a/internal/api/search_listener_e2e_test.go
+++ b/internal/api/search_listener_e2e_test.go
@@ -25,6 +25,7 @@ import (
 	"log/slog"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,11 +59,17 @@ type removeCall struct {
 	CascadeIDs []string
 }
 
+type touchCall struct {
+	ID       string
+	LastSeen int64
+}
+
 type fakeSearchIndex struct {
 	mu sync.Mutex
 
 	reindexed []reindexCall
 	removed   []removeCall
+	touched   []touchCall
 
 	// reverse map keyed by scope+":"+id → cascade IDs returned by
 	// GetReverseMembers. Empty key returns nil (the production behaviour
@@ -106,6 +113,21 @@ func (f *fakeSearchIndex) GetReverseMembers(_ context.Context, scope, id string)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.reverse[scope+":"+id]
+}
+
+func (f *fakeSearchIndex) TouchDeviceLastSeen(_ context.Context, id string, lastSeen int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.touched = append(f.touched, touchCall{ID: id, LastSeen: lastSeen})
+	return nil
+}
+
+func (f *fakeSearchIndex) lastTouch(t *testing.T) touchCall {
+	t.Helper()
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	require.NotEmpty(t, f.touched, "expected at least one TouchDeviceLastSeen call")
+	return f.touched[len(f.touched)-1]
 }
 
 func (f *fakeSearchIndex) lastReindex(t *testing.T) reindexCall {
@@ -190,6 +212,36 @@ func TestSearchListener_DeviceRegistered_Reindexes(t *testing.T) {
 	assert.Equal(t, deviceID, last.ID)
 	require.NotNil(t, last.Data)
 	assert.Equal(t, "host-listener-1", last.Data.Hostname)
+}
+
+// TestSearchListener_DeviceHeartbeat_TouchesLastSeen is the #499
+// regression: a DeviceHeartbeat must refresh the INDEXED last_seen_at
+// (as an O(1) touch carrying the event's occurred_at) and must NOT
+// trigger a full row reload — otherwise a healthy, heartbeating device
+// shows offline in search for up to an hour (the reconcile bound).
+func TestSearchListener_DeviceHeartbeat_TouchesLastSeen(t *testing.T) {
+	st, fake := setupListener(t)
+	deviceID := testutil.CreateTestDevice(t, st, "host-heartbeat-1")
+	reindexesBefore := fake.reindexCount()
+
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "device",
+		StreamID:   deviceID,
+		EventType:  "DeviceHeartbeat",
+		Data:       map[string]any{"id": deviceID, "agent_version": "test"},
+		ActorType:  "device",
+		ActorID:    deviceID,
+	}))
+
+	touch := fake.lastTouch(t)
+	assert.Equal(t, deviceID, touch.ID)
+	// The touch carries the event's occurred_at (the same value the
+	// Postgres projection writes) — a fresh heartbeat must land inside
+	// the 5-minute online window.
+	now := time.Now().Unix()
+	assert.InDelta(t, now, touch.LastSeen, 60, "touch timestamp must be the heartbeat's occurred_at")
+	assert.Equal(t, reindexesBefore, fake.reindexCount(),
+		"a heartbeat must be an O(1) touch, never a full reindex row-reload")
 }
 
 // =============================================================================

--- a/internal/api/search_listener_test.go
+++ b/internal/api/search_listener_test.go
@@ -129,6 +129,14 @@ func TestAffectedSearchOps(t *testing.T) {
 			store.PersistedEvent{EventType: "DeviceDeleted", StreamID: "DEV1", StreamType: "device"},
 			[]api.SearchAffected{{Op: api.SearchOpRemove, Scope: search.ScopeDevice, ID: "DEV1"}},
 		},
+		{
+			// #499: the status filter computes online/offline against the
+			// INDEXED last_seen_at, so a heartbeat must refresh it — but as
+			// an O(1) field touch, never a full row reload per heartbeat.
+			"DeviceHeartbeat touches the indexed last_seen_at (O(1), not a reindex)",
+			store.PersistedEvent{EventType: "DeviceHeartbeat", StreamID: "DEV1", StreamType: "device"},
+			[]api.SearchAffected{{Op: api.SearchOpTouchDeviceLastSeen, Scope: search.ScopeDevice, ID: "DEV1"}},
+		},
 
 		// Device events that should NOT touch search.
 		{

--- a/internal/api/system_action_immutability_test.go
+++ b/internal/api/system_action_immutability_test.go
@@ -219,6 +219,10 @@ func (r *recordingSearchIndex) GetReverseMembers(_ context.Context, _, _ string)
 	return nil
 }
 
+func (r *recordingSearchIndex) TouchDeviceLastSeen(_ context.Context, _ string, _ int64) error {
+	return nil
+}
+
 // TestSearchListener_SystemActionExcludedFromIndex pins the visibility fix: a
 // system-managed action must be PURGED from (never reindexed into) the search
 // catalog, so it can't surface on the actions list page — while ordinary

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -1548,6 +1548,31 @@ func (idx *Index) StartReconciliation(ctx context.Context, interval time.Duratio
 
 // --- Enqueue helpers ---
 
+// touchDeviceLastSeenScript updates the last_seen_at field of an
+// EXISTING device search hash and does nothing otherwise. The
+// existence guard must be atomic with the write: a bare HSET on a
+// missing key (device not yet indexed, or removed concurrently) would
+// create a partial hash holding only last_seen_at, which enters the
+// FT index and surfaces as a hostname-less ghost row in device search.
+var touchDeviceLastSeenScript = redis.NewScript(`
+if redis.call('EXISTS', KEYS[1]) == 1 then
+	return redis.call('HSET', KEYS[1], 'last_seen_at', ARGV[1])
+end
+return -1
+`)
+
+// TouchDeviceLastSeen refreshes the indexed last_seen_at of one device
+// as a single O(1) Valkey write (#499). The device status filter
+// computes online/offline against this indexed value, so heartbeats
+// must keep it fresh — but a full row reload per heartbeat would be
+// fleet-size × heartbeat-rate row reads for one changed field. The FT
+// NUMERIC attribute follows the hash field automatically; a device
+// without a search row is left untouched (the registration reindex or
+// the hourly reconcile will index it with a fresh value anyway).
+func (idx *Index) TouchDeviceLastSeen(ctx context.Context, id string, lastSeen int64) error {
+	return touchDeviceLastSeenScript.Run(ctx, idx.rdb, []string{prefixDevice + id}, lastSeen).Err()
+}
+
 // EnqueueReindex enqueues a search:reindex task with pre-populated entity data.
 func (idx *Index) EnqueueReindex(ctx context.Context, scope, id string, data *taskqueue.SearchEntityData) error {
 	return idx.aqClient.EnqueueToSearch(taskqueue.TypeSearchReindex, taskqueue.SearchReindexPayload{

--- a/internal/search/touch_test.go
+++ b/internal/search/touch_test.go
@@ -1,0 +1,91 @@
+package search_test
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/search"
+)
+
+// ftCount extracts the hit count from a raw FT.SEARCH reply.
+func ftCount(t *testing.T, result any) int64 {
+	t.Helper()
+	arr, ok := result.([]any)
+	require.True(t, ok, "FT.SEARCH reply must be an array, got %T", result)
+	count, ok := arr[0].(int64)
+	require.True(t, ok, "FT.SEARCH count must be int64, got %T", arr[0])
+	return count
+}
+
+// onlineQuery mirrors the search handler's deviceStatusClause "online"
+// window: last_seen_at strictly newer than now-5m.
+func onlineQuery() string {
+	cutoff := time.Now().Add(-5 * time.Minute).Unix()
+	return fmt.Sprintf("@last_seen_at:[(%d +inf]", cutoff)
+}
+
+// TestTouchDeviceLastSeen_DeviceGoesOnline is the #499 regression: a
+// device whose indexed last_seen_at is stale shows offline in search
+// even while it heartbeats. The O(1) touch must advance the NUMERIC
+// field so the online status filter matches again — without a full
+// row reload.
+func TestTouchDeviceLastSeen_DeviceGoesOnline(t *testing.T) {
+	rdb := setupRedis(t)
+	idx := search.New(rdb, nil, nil, testLogger())
+	ctx := context.Background()
+	require.NoError(t, idx.EnsureIndexes(ctx))
+
+	// Seed an indexed device row with a 2-hour-stale last_seen_at, the
+	// way the indexer worker writes it (HSET on the search:device: prefix).
+	stale := time.Now().Add(-2 * time.Hour).Unix()
+	key := "search:device:DEVTOUCH1"
+	require.NoError(t, rdb.HSet(ctx, key, map[string]any{
+		"hostname":     "touch-host",
+		"last_seen_at": strconv.FormatInt(stale, 10),
+	}).Err())
+
+	result, err := rdb.Do(ctx, "FT.SEARCH", "idx:devices", onlineQuery(), "LIMIT", 0, 10).Result()
+	require.NoError(t, err)
+	require.Equal(t, int64(0), ftCount(t, result), "stale device must start offline")
+
+	now := time.Now().Unix()
+	require.NoError(t, idx.TouchDeviceLastSeen(ctx, "DEVTOUCH1", now))
+
+	// The FT NUMERIC attribute updates with the hash field: the device
+	// is online again for the same window query.
+	result, err = rdb.Do(ctx, "FT.SEARCH", "idx:devices", onlineQuery(), "LIMIT", 0, 10).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), ftCount(t, result), "touched device must match the online window")
+
+	val, err := rdb.HGet(ctx, key, "last_seen_at").Result()
+	require.NoError(t, err)
+	assert.Equal(t, strconv.FormatInt(now, 10), val)
+}
+
+// TestTouchDeviceLastSeen_NoPartialRowForUnindexedDevice pins the
+// guard: touching a device that has no search row (not yet indexed,
+// or already removed) must NOT create a partial hash — a hash holding
+// only last_seen_at would enter the FT index and surface as a
+// hostname-less ghost row in device search results.
+func TestTouchDeviceLastSeen_NoPartialRowForUnindexedDevice(t *testing.T) {
+	rdb := setupRedis(t)
+	idx := search.New(rdb, nil, nil, testLogger())
+	ctx := context.Background()
+	require.NoError(t, idx.EnsureIndexes(ctx))
+
+	require.NoError(t, idx.TouchDeviceLastSeen(ctx, "DEVGHOST1", time.Now().Unix()))
+
+	exists, err := rdb.Exists(ctx, "search:device:DEVGHOST1").Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), exists, "touch must not create a hash for an unindexed device")
+
+	result, err := rdb.Do(ctx, "FT.SEARCH", "idx:devices", onlineQuery(), "LIMIT", 0, 10).Result()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), ftCount(t, result), "no ghost row may enter the device index")
+}


### PR DESCRIPTION
Closes #499.

## What

`AffectedSearchOps` had no `DeviceHeartbeat` case, so the indexed `last_seen_at` only refreshed on other device events or the hourly reconcile — a healthy, heartbeating device showed **offline in device search for up to an hour** while Postgres was fresh.

Exactly the fix shape the issue pins:

- **O(1) touch, not a reindex**: new `SearchOpTouchDeviceLastSeen` — the listener writes ONLY the `last_seen_at` hash field (FT NUMERIC attribute updates automatically) with the event's `occurred_at`, the same value the Postgres projection writes for that heartbeat. No row reload per heartbeat, no widened 5-min window, no faster reconcile.
- **Guarded Lua script**: a bare `HSET` on a missing key would create a partial hash that enters the FT index as a hostname-less ghost row; the script only touches EXISTING device rows — unindexed devices are picked up by the registration reindex / reconcile with a fresh value anyway.
- **`UserLoggedIn`/`last_login_at` exclusion kept** and the distinction documented in the classifier (status filter = correctness surface; last-login = sort-only).

## Tests

- Classifier: `DeviceHeartbeat` → touch op (table case).
- Listener e2e (real Postgres): heartbeat event fires the touch with `occurred_at`, and does **NOT** enqueue a reindex.
- Valkey integration (real valkey-bundle): a device with 2-hour-stale indexed `last_seen_at` fails the online-window query, re-enters it after the touch; touching an unindexed id creates **no key** and no ghost row.

Local CodeRabbit review: no findings. Verification gate: vet ✓ gofmt ✓ staticcheck ✓ full `go test ./...` ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device heartbeat events now update a device’s “last seen” status in search results.
  * Devices can return to online search results promptly without a full data reload.
* **Bug Fixes**
  * Prevented missing or unindexed devices from appearing as incomplete (“ghost”) search results.
* **Tests**
  * Added coverage for heartbeat updates, online-status searches, and missing-device handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->