### PR TITLE
feat: transactional multi-stream event append — AppendEvents (spec 28)

### DIFF
--- a/internal/scim/atomic_append_test.go
+++ b/internal/scim/atomic_append_test.go
@@ -1,0 +1,122 @@
+package scim_test
+
+// Spec 28 regression tests: the SCIM multi-stream write paths now commit
+// through store.AppendEvents (atomic) instead of sequential AppendEvent
+// calls, so a mid-sequence failure can no longer leave partial state.
+//
+// Failure is injected with store.TestingSetInsertHook — the same seam
+// the store-level AppendEvents tests use. It fires inside the shared
+// appendOne, so it works on BOTH the old sequential path and the new
+// batch path, giving these tests a real red (pre-migration) / green
+// (post-migration) transition.
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// AC 8 — the audit regression. Driving the real createGroup with the
+// SCIMGroupMapped append forced to fail must leave NO orphan user_group
+// projection row; the group and its mapping either both exist or neither
+// does. Pre-migration (sequential appends) UserGroupCreated committed
+// before the mapping failed, and the IdP's next sync then created a
+// duplicate group and leaked the first.
+func TestCreateGroup_MappingFailureLeavesNoOrphan(t *testing.T) {
+	env := setupSCIM(t)
+	ctx := context.Background()
+
+	displayName := "Atomic Group " + testutil.NewID()[:8]
+	body := map[string]any{
+		"schemas":     []string{"urn:ietf:params:scim:schemas:core:2.0:Group"},
+		"displayName": displayName,
+		"externalId":  "ext-" + testutil.NewID()[:8],
+	}
+
+	// Fail the mapping append (2nd event in the create batch).
+	env.st.TestingSetInsertHook(func(streamType, eventType string) error {
+		if streamType == "scim_group_mapping" {
+			return errors.New("synthetic mapping-append failure")
+		}
+		return nil
+	})
+
+	w := env.request("POST", "/Groups", body)
+	require.Equal(t, http.StatusInternalServerError, w.Code, "mapping failure must surface as 500: %s", w.Body.String())
+
+	_, err := env.st.Repos().UserGroup.GetByName(ctx, displayName)
+	assert.True(t, store.IsNotFound(err),
+		"no orphan user_group may exist after a failed create — group and mapping are all-or-nothing")
+
+	// A subsequent clean sync creates the group exactly once (the leak the
+	// audit finding described no longer happens).
+	env.st.TestingSetInsertHook(nil)
+
+	w = env.request("POST", "/Groups", body)
+	require.Equal(t, http.StatusCreated, w.Code, "clean sync must create the group: %s", w.Body.String())
+
+	grp, err := env.st.Repos().UserGroup.GetByName(ctx, displayName)
+	require.NoError(t, err, "clean sync must create the group")
+	assert.Equal(t, displayName, grp.Name)
+
+	// Re-POST is idempotent (existing behaviour) — still exactly one group,
+	// no duplicate.
+	w = env.request("POST", "/Groups", body)
+	require.Equal(t, http.StatusOK, w.Code, "re-POST is idempotent, not a second create: %s", w.Body.String())
+}
+
+// replaceUser is now atomic across its per-field appends. Forcing the
+// profile append to fail must roll back the email change made earlier in
+// the same PUT — the request either applies every change or none.
+func TestReplaceUser_PartialFailureRollsBackEmail(t *testing.T) {
+	env := setupSCIM(t)
+	ctx := context.Background()
+
+	createResp := env.request("POST", "/Users", map[string]any{
+		"schemas":    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+		"userName":   strings.ToLower("atomic-"+testutil.NewID()[:8]) + "@example.com",
+		"externalId": "ext-" + testutil.NewID()[:8],
+		"active":     true,
+	})
+	require.Equal(t, http.StatusCreated, createResp.Code, "%s", createResp.Body.String())
+	var created map[string]any
+	require.NoError(t, json.Unmarshal(createResp.Body.Bytes(), &created))
+	userID := created["id"].(string)
+
+	before, err := env.st.Repos().User.Get(ctx, userID)
+	require.NoError(t, err)
+
+	// Fail the profile append (last in the batch); the email change is
+	// inserted earlier in the same tx and must roll back with it.
+	env.st.TestingSetInsertHook(func(streamType, eventType string) error {
+		if eventType == string(eventtypes.UserProfileUpdated) {
+			return errors.New("synthetic profile-append failure")
+		}
+		return nil
+	})
+
+	newEmail := strings.ToLower("changed-"+testutil.NewID()[:8]) + "@example.com"
+	require.NotEqual(t, before.Email, newEmail)
+	w := env.request("PUT", "/Users/"+userID, map[string]any{
+		"schemas":  []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+		"userName": newEmail,
+		"name":     map[string]any{"givenName": "New", "familyName": "Name"},
+		"active":   true,
+	})
+	require.Equal(t, http.StatusInternalServerError, w.Code, "a failed profile update must fail the request")
+
+	after, err := env.st.Repos().User.Get(ctx, userID)
+	require.NoError(t, err)
+	assert.Equal(t, before.Email, after.Email,
+		"email change must roll back when the profile update in the same PUT fails")
+}

--- a/internal/scim/groups_create.go
+++ b/internal/scim/groups_create.go
@@ -119,48 +119,46 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Create the user group
+	// Create the group as one atomic unit (spec 28): the UserGroupCreated,
+	// SCIMGroupMapped and per-member events either all commit or none do.
+	// Independent appends could leave an orphan user_group with no
+	// mapping if the mapping append failed — the IdP's next sync then
+	// misses the mapping-keyed dedup, creates a *second* group, and
+	// leaks the first permanently.
 	h.logger.Debug("SCIM createGroup: creating new group", "scim_group_id", scimGroupID, "display_name", scimGroup.DisplayName)
 	userGroupID := newULID()
-	err = h.store.AppendEvent(ctx, store.Event{
-		StreamType: "user_group",
-		StreamID:   userGroupID,
-		EventType:  string(eventtypes.UserGroupCreated),
-		Data: payloads.UserGroupCreated{
-			Name:        scimGroup.DisplayName,
-			Description: fmt.Sprintf("SCIM-provisioned group from %s", provider.Name),
-		},
-		ActorType: "scim",
-		ActorID:   provider.ID,
-	})
-	if err != nil {
-		h.logger.Error("failed to create user group via SCIM", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to create group")
-		return
-	}
-
-	// Create the SCIM group mapping
 	mappingID := newULID()
-	err = h.store.AppendEvent(ctx, store.Event{
-		StreamType: "scim_group_mapping",
-		StreamID:   mappingID,
-		EventType:  string(eventtypes.SCIMGroupMapped),
-		Data: payloads.SCIMGroupMapped{
-			ProviderID:      provider.ID,
-			SCIMGroupID:     scimGroupID,
-			SCIMDisplayName: &scimGroup.DisplayName,
-			UserGroupID:     userGroupID,
+	events := []store.Event{
+		{
+			StreamType: "user_group",
+			StreamID:   userGroupID,
+			EventType:  string(eventtypes.UserGroupCreated),
+			Data: payloads.UserGroupCreated{
+				Name:        scimGroup.DisplayName,
+				Description: fmt.Sprintf("SCIM-provisioned group from %s", provider.Name),
+			},
+			ActorType: "scim",
+			ActorID:   provider.ID,
 		},
-		ActorType: "scim",
-		ActorID:   provider.ID,
-	})
-	if err != nil {
-		h.logger.Error("failed to create SCIM group mapping", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to map SCIM group")
-		return
+		{
+			StreamType: "scim_group_mapping",
+			StreamID:   mappingID,
+			EventType:  string(eventtypes.SCIMGroupMapped),
+			Data: payloads.SCIMGroupMapped{
+				ProviderID:      provider.ID,
+				SCIMGroupID:     scimGroupID,
+				SCIMDisplayName: &scimGroup.DisplayName,
+				UserGroupID:     userGroupID,
+			},
+			ActorType: "scim",
+			ActorID:   provider.ID,
+		},
 	}
 
-	// Add members if provided
+	// Members join the same atomic batch — a group provisioned without
+	// its requested members is also partial state. Validity checks
+	// (empty-skip, cross-provider) run here, before the batch, so only a
+	// genuine DB failure rolls the whole create back.
 	for _, member := range scimGroup.Members {
 		if member.Value == "" {
 			continue
@@ -168,10 +166,9 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 		if !h.mayAddMemberToGroup(ctx, provider.ID, userGroupID, member.Value) {
 			continue
 		}
-		streamID := userGroupID + ":" + member.Value
-		h.appendEvent(ctx, store.Event{
+		events = append(events, store.Event{
 			StreamType: "user_group",
-			StreamID:   streamID,
+			StreamID:   userGroupID + ":" + member.Value,
 			EventType:  string(eventtypes.UserGroupMemberAdded),
 			Data: payloads.UserGroupMemberAdded{
 				GroupID: userGroupID,
@@ -180,6 +177,12 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 			ActorType: "scim",
 			ActorID:   provider.ID,
 		})
+	}
+
+	if err := h.store.AppendEvents(ctx, events); err != nil {
+		h.logger.Error("failed to create SCIM group", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to create group")
+		return
 	}
 
 	// Build response

--- a/internal/scim/users_mutate.go
+++ b/internal/scim/users_mutate.go
@@ -59,13 +59,21 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update email if changed
+	// Collect every field mutation into one atomic batch (spec 28). All
+	// target the user/<id> stream, so an email change can no longer land
+	// while a profile update in the same PUT fails — the request either
+	// applies every change or none, and a 500 leaves PM unchanged instead
+	// of half-synced from the IdP. Conditions are evaluated against the
+	// user read above; syncIdentityLink stays a separate concern below.
+	var events []store.Event
+
+	// Email
 	newEmail := scimUser.UserName
 	if newEmail == "" && len(scimUser.Emails) > 0 {
 		newEmail = scimUser.Emails[0].Value
 	}
 	if newEmail != "" && newEmail != existingUser.Email {
-		err = h.store.AppendEvent(ctx, store.Event{
+		events = append(events, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
 			EventType:  string(eventtypes.UserEmailChanged),
@@ -73,52 +81,39 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 			ActorType:  "scim",
 			ActorID:    provider.ID,
 		})
-		if err != nil {
-			h.logger.Error("failed to update user email", "error", err)
-			writeError(w, http.StatusInternalServerError, "failed to update user email")
-			return
-		}
 	}
 
-	// Update active status
+	// Active status
 	if !scimUser.IsActive() && !existingUser.Disabled {
-		if err := h.store.AppendEvent(ctx, store.Event{
+		events = append(events, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
 			EventType:  string(eventtypes.UserDisabled),
 			Data:       payloads.UserDisabled{},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
-		}); err != nil {
-			h.logger.Error("failed to disable user via SCIM", "error", err)
-			writeError(w, http.StatusInternalServerError, "failed to update user status")
-			return
-		}
+		})
 	} else if scimUser.IsActive() && existingUser.Disabled {
-		if err := h.store.AppendEvent(ctx, store.Event{
+		events = append(events, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
 			EventType:  string(eventtypes.UserEnabled),
 			Data:       payloads.UserEnabled{},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
-		}); err != nil {
-			h.logger.Error("failed to enable user via SCIM", "error", err)
-			writeError(w, http.StatusInternalServerError, "failed to update user status")
-			return
-		}
+		})
 	}
 
-	// Update profile if name fields provided
-	newDisplayName := formatExternalName(scimUser.Name)
-	newGivenName := safeNameField(scimUser.Name, "given")
-	newFamilyName := safeNameField(scimUser.Name, "family")
-	// Gate on "name object asserted" rather than "any value non-empty":
-	// SCIM is the source of truth, so an explicitly empty name object
-	// clears the profile ("" overwrite), while an omitted one preserves
-	// it. The old any-non-empty gate made an explicit clear impossible.
+	// Profile — gate on "name object asserted" rather than "any value
+	// non-empty": SCIM is the source of truth, so an explicitly empty
+	// name object clears the profile ("" overwrite), while an omitted one
+	// preserves it. The old any-non-empty gate made an explicit clear
+	// impossible.
 	if scimUser.Name != nil {
-		if err := h.store.AppendEvent(ctx, store.Event{
+		newDisplayName := formatExternalName(scimUser.Name)
+		newGivenName := safeNameField(scimUser.Name, "given")
+		newFamilyName := safeNameField(scimUser.Name, "family")
+		events = append(events, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
 			EventType:  string(eventtypes.UserProfileUpdated),
@@ -132,14 +127,15 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 			},
 			ActorType: "scim",
 			ActorID:   provider.ID,
-		}); err != nil {
-			// Fail the request like the email/status branches above: a
-			// 200 after a dropped source-of-truth profile update would
-			// silently desync PM from the IdP.
-			h.logger.Error("failed to update user profile via SCIM", "error", err)
-			writeError(w, http.StatusInternalServerError, "failed to update user profile")
-			return
-		}
+		})
+	}
+
+	if err := h.store.AppendEvents(ctx, events); err != nil {
+		// A 500 after a dropped source-of-truth update would silently
+		// desync PM from the IdP; atomicity means nothing applied here.
+		h.logger.Error("failed to apply SCIM user replace", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to update user")
+		return
 	}
 
 	// Sync identity link (external_email + external_name) from SCIM source of truth

--- a/internal/store/append_events_test.go
+++ b/internal/store/append_events_test.go
@@ -1,0 +1,329 @@
+package store_test
+
+// AppendEvents (spec 28) — transactional multi-stream batch append.
+// Each test maps to a numbered acceptance criterion. Testcontainer-backed
+// because atomicity, versioning and the post-commit listener path only
+// run behind a real Postgres transaction; a mocked Queries would bypass
+// every guarantee under test.
+//
+// The forced-failure cases use Store.TestingSetInsertHook — the
+// spec-sanctioned test-only seam (the spec's "export_test hook that fails
+// the Nth insert"). Returning a plain error models a mid-batch DB fault
+// (AC 2); returning store.ErrVersionConflict models a lost optimistic-
+// concurrency race and drives the whole-batch retry (AC 5).
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+func sysEvent(streamType, streamID, eventType string) store.Event {
+	return store.Event{
+		StreamType: streamType,
+		StreamID:   streamID,
+		EventType:  eventType,
+		Data:       map[string]any{},
+		ActorType:  "system",
+		ActorID:    "test",
+	}
+}
+
+// AC 1 — a batch across distinct streams commits atomically: every row
+// present, each fresh stream at version 1, sequence_num ascending in
+// array order.
+func TestAppendEvents_AtomicCommitAcrossStreams(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+
+	sA, sB, sC := testutil.NewID(), testutil.NewID(), testutil.NewID()
+	require.NoError(t, st.AppendEvents(ctx, []store.Event{
+		sysEvent("test_a", sA, "E1"),
+		sysEvent("test_b", sB, "E2"),
+		sysEvent("test_c", sC, "E3"),
+	}))
+
+	evA, err := st.LoadStream(ctx, "test_a", sA)
+	require.NoError(t, err)
+	evB, err := st.LoadStream(ctx, "test_b", sB)
+	require.NoError(t, err)
+	evC, err := st.LoadStream(ctx, "test_c", sC)
+	require.NoError(t, err)
+
+	require.Len(t, evA, 1)
+	require.Len(t, evB, 1)
+	require.Len(t, evC, 1)
+
+	assert.Equal(t, int32(1), evA[0].StreamVersion, "fresh stream starts at version 1")
+	assert.Equal(t, int32(1), evB[0].StreamVersion)
+	assert.Equal(t, int32(1), evC[0].StreamVersion)
+
+	assert.Less(t, evA[0].SequenceNum, evB[0].SequenceNum, "sequence_num ascends in array order")
+	assert.Less(t, evB[0].SequenceNum, evC[0].SequenceNum)
+}
+
+// AC 2 — when the Kth event cannot be written, the whole batch rolls
+// back: no event from any target stream is present.
+func TestAppendEvents_AllOrNothingOnFailure(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+
+	sA, sB, sC := testutil.NewID(), testutil.NewID(), testutil.NewID()
+	// Fail the second event's insert; the first is already inserted in the
+	// same tx and must be discarded on rollback.
+	st.TestingSetInsertHook(func(streamType, eventType string) error {
+		if streamType == "test_b" {
+			return errors.New("synthetic mid-batch insert failure")
+		}
+		return nil
+	})
+
+	err := st.AppendEvents(ctx, []store.Event{
+		sysEvent("test_a", sA, "E1"),
+		sysEvent("test_b", sB, "E2"),
+		sysEvent("test_c", sC, "E3"),
+	})
+	require.Error(t, err)
+
+	for _, s := range []struct{ typ, id string }{{"test_a", sA}, {"test_b", sB}, {"test_c", sC}} {
+		ev, lerr := st.LoadStream(ctx, s.typ, s.id)
+		require.NoError(t, lerr)
+		assert.Empty(t, ev, "stream %s must be empty — a failed batch writes nothing", s.typ)
+	}
+}
+
+// AC 2 (rejection-paths row 1) — an event missing actor_type/actor_id
+// fails the batch before any write, so nothing lands.
+func TestAppendEvents_MissingActorWritesNothing(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+
+	sA := testutil.NewID()
+	err := st.AppendEvents(ctx, []store.Event{
+		sysEvent("test_a", sA, "E1"),
+		{StreamType: "test_b", StreamID: testutil.NewID(), EventType: "E2", Data: map[string]any{}}, // no actor
+	})
+	require.Error(t, err)
+
+	ev, lerr := st.LoadStream(ctx, "test_a", sA)
+	require.NoError(t, lerr)
+	assert.Empty(t, ev, "a batch containing an invalid event writes nothing")
+}
+
+// AC 3 — two events on the same stream get consecutive versions: the
+// second's in-tx version read observes the first's insert.
+func TestAppendEvents_SameStreamConsecutiveVersions(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	id := testutil.NewID()
+
+	require.NoError(t, st.AppendEvents(ctx, []store.Event{
+		sysEvent("test", id, "First"),
+		sysEvent("test", id, "Second"),
+	}))
+
+	ev, err := st.LoadStream(ctx, "test", id)
+	require.NoError(t, err)
+	require.Len(t, ev, 2)
+	assert.Equal(t, int32(1), ev[0].StreamVersion)
+	assert.Equal(t, int32(2), ev[1].StreamVersion)
+	assert.Equal(t, "First", ev[0].EventType)
+	assert.Equal(t, "Second", ev[1].EventType)
+}
+
+// AC 4 — listeners fire once per event, in array order, and only after
+// the whole batch has committed (a listener reading the store observes
+// every event, never a partial set).
+func TestAppendEvents_ListenersFirePostCommitInOrder(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+
+	sA, sB := testutil.NewID(), testutil.NewID()
+	var (
+		mu   sync.Mutex
+		seen []string
+	)
+	st.RegisterEventListener(func(ctx context.Context, ev store.PersistedEvent) {
+		// Both streams are already committed by the time any listener runs.
+		evA, _ := st.LoadStream(ctx, "test_a", sA)
+		evB, _ := st.LoadStream(ctx, "test_b", sB)
+		mu.Lock()
+		seen = append(seen, ev.EventType)
+		mu.Unlock()
+		assert.Len(t, evA, 1, "listener must see a committed batch, not a partial one")
+		assert.Len(t, evB, 1, "listener must see a committed batch, not a partial one")
+	})
+
+	require.NoError(t, st.AppendEvents(ctx, []store.Event{
+		sysEvent("test_a", sA, "First"),
+		sysEvent("test_b", sB, "Second"),
+	}))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"First", "Second"}, seen,
+		"listeners fire once per event, in array (sequence) order")
+}
+
+// AC 4 — a panicking listener does not fail the already-durable batch,
+// and subsequent listeners still fire.
+func TestAppendEvents_ListenerPanicDoesNotFailBatch(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	id := testutil.NewID()
+
+	var after atomic.Bool
+	st.RegisterEventListener(func(ctx context.Context, ev store.PersistedEvent) { panic("synthetic listener panic") })
+	st.RegisterEventListener(func(ctx context.Context, ev store.PersistedEvent) { after.Store(true) })
+
+	require.NoError(t, st.AppendEvents(ctx, []store.Event{sysEvent("test", id, "PanicProbe")}),
+		"a panicking listener must not fail an already-committed batch")
+	assert.True(t, after.Load(), "listener after a panicking one must still fire")
+
+	ev, err := st.LoadStream(ctx, "test", id)
+	require.NoError(t, err)
+	assert.Len(t, ev, 1, "the batch is durable even though a listener panicked")
+}
+
+// AC 4 (end-to-end) — a batch drives the REAL projection path
+// (fireListeners → Go listener → projection write), not just a recording
+// fake. The load-bearing guarantee now that PL/pgSQL projection is gone.
+func TestAppendEvents_DrivesRealProjector(t *testing.T) {
+	st := testutil.SetupPostgres(t) // wires the production Go projectors
+	ctx := context.Background()
+
+	gA, gB := testutil.NewID(), testutil.NewID()
+	require.NoError(t, st.AppendEvents(ctx, []store.Event{
+		{StreamType: "user_group", StreamID: gA, EventType: string(eventtypes.UserGroupCreated),
+			Data: payloads.UserGroupCreated{Name: "Group A", Description: "batch a"}, ActorType: "system", ActorID: "test"},
+		{StreamType: "user_group", StreamID: gB, EventType: string(eventtypes.UserGroupCreated),
+			Data: payloads.UserGroupCreated{Name: "Group B", Description: "batch b"}, ActorType: "system", ActorID: "test"},
+	}))
+
+	grpA, err := st.Repos().UserGroup.Get(ctx, gA)
+	require.NoError(t, err)
+	assert.Equal(t, "Group A", grpA.Name, "projection must reflect the first batch event")
+	grpB, err := st.Repos().UserGroup.Get(ctx, gB)
+	require.NoError(t, err)
+	assert.Equal(t, "Group B", grpB.Name, "projection must reflect the second batch event")
+}
+
+// AC 5 — a version conflict retries the WHOLE transaction (re-reading
+// versions) and still commits atomically once the race clears; no
+// duplicate rows from the rolled-back attempts.
+func TestAppendEvents_RetriesWholeBatchAndConverges(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	sA, sB := testutil.NewID(), testutil.NewID()
+
+	// Lose the race on the 2nd event for the first two attempts, then win.
+	var conflicts int32
+	st.TestingSetInsertHook(func(streamType, eventType string) error {
+		if streamType == "test_b" && atomic.AddInt32(&conflicts, 1) <= 2 {
+			return store.ErrVersionConflict
+		}
+		return nil
+	})
+
+	require.NoError(t, st.AppendEvents(ctx, []store.Event{
+		sysEvent("test_a", sA, "E1"),
+		sysEvent("test_b", sB, "E2"),
+	}))
+
+	evA, err := st.LoadStream(ctx, "test_a", sA)
+	require.NoError(t, err)
+	evB, err := st.LoadStream(ctx, "test_b", sB)
+	require.NoError(t, err)
+	assert.Len(t, evA, 1, "rolled-back attempts leave no duplicate on the first stream")
+	assert.Len(t, evB, 1)
+	assert.Equal(t, int32(1), evA[0].StreamVersion)
+	assert.Equal(t, int32(1), evB[0].StreamVersion)
+}
+
+// AC 5 — a conflict that never clears exhausts the retry budget and
+// returns ErrVersionConflict having written nothing.
+func TestAppendEvents_UnresolvableConflictWritesNothing(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	sA, sB := testutil.NewID(), testutil.NewID()
+
+	st.TestingSetInsertHook(func(streamType, eventType string) error {
+		if streamType == "test_b" {
+			return store.ErrVersionConflict
+		}
+		return nil
+	})
+
+	err := st.AppendEvents(ctx, []store.Event{
+		sysEvent("test_a", sA, "E1"),
+		sysEvent("test_b", sB, "E2"),
+	})
+	require.Error(t, err)
+	assert.True(t, store.IsVersionConflict(err),
+		"an unresolvable conflict must surface ErrVersionConflict to the caller")
+
+	evA, lerr := st.LoadStream(ctx, "test_a", sA)
+	require.NoError(t, lerr)
+	assert.Empty(t, evA, "nothing is written when the batch cannot converge")
+}
+
+// AC 6 — an event whose PII subject has no minted DEK makes sealing fail;
+// since sealing runs before the transaction, the batch writes nothing.
+func TestAppendEvents_PIISealFailClosed(t *testing.T) {
+	st := testutil.SetupPostgres(t) // wires the fail-closed PII sealer
+	ctx := context.Background()
+
+	benignStream := testutil.NewID()
+	userWithoutDEK := testutil.NewID() // never MintUserDEK'd → seal fails
+
+	name := "Should Not Persist"
+	err := st.AppendEvents(ctx, []store.Event{
+		sysEvent("test", benignStream, "Benign"),
+		{StreamType: "user", StreamID: userWithoutDEK, EventType: string(eventtypes.UserProfileUpdated),
+			Data: payloads.UserProfileUpdated{DisplayName: &name}, ActorType: "system", ActorID: "test"},
+	})
+	require.Error(t, err, "an event whose subject has no DEK must fail the batch")
+
+	ev, lerr := st.LoadStream(ctx, "test", benignStream)
+	require.NoError(t, lerr)
+	assert.Empty(t, ev, "seal failure aborts before any DB write — the benign event must not persist")
+}
+
+// AC 7 — a single-element batch behaves like AppendEvent (fresh stream at
+// v1, one row, monotonic on a second call).
+func TestAppendEvents_SingleElementMatchesAppendEvent(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	id := testutil.NewID()
+
+	require.NoError(t, st.AppendEvents(ctx, []store.Event{sysEvent("test", id, "Solo")}))
+	ev, err := st.LoadStream(ctx, "test", id)
+	require.NoError(t, err)
+	require.Len(t, ev, 1)
+	assert.Equal(t, int32(1), ev[0].StreamVersion)
+	assert.Equal(t, "Solo", ev[0].EventType)
+
+	require.NoError(t, st.AppendEvents(ctx, []store.Event{sysEvent("test", id, "Solo2")}))
+	ev, err = st.LoadStream(ctx, "test", id)
+	require.NoError(t, err)
+	require.Len(t, ev, 2)
+	assert.Equal(t, int32(2), ev[1].StreamVersion)
+}
+
+// AC 7 — an empty/nil batch is a no-op returning nil.
+func TestAppendEvents_EmptyIsNoOp(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	assert.NoError(t, st.AppendEvents(ctx, nil))
+	assert.NoError(t, st.AppendEvents(ctx, []store.Event{}))
+}

--- a/internal/store/append_events_test.go
+++ b/internal/store/append_events_test.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -248,6 +249,39 @@ func TestAppendEvents_RetriesWholeBatchAndConverges(t *testing.T) {
 	assert.Len(t, evB, 1)
 	assert.Equal(t, int32(1), evA[0].StreamVersion)
 	assert.Equal(t, int32(1), evB[0].StreamVersion)
+}
+
+// AC 5 (deadlock variant) — a Postgres deadlock (40P01) aborts the whole
+// transaction; like a version conflict it is transient, so the batch
+// retries the whole tx and converges. Two overlapping multi-stream
+// batches locking the same streams in opposite orders are the real
+// trigger; a synthetic 40P01 injected via the seam pins the
+// classification deterministically (a real concurrent deadlock is
+// timing-flaky and would race the CI).
+func TestAppendEvents_RetriesOnDeadlockAndConverges(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	sA, sB := testutil.NewID(), testutil.NewID()
+
+	var deadlocks int32
+	st.TestingSetInsertHook(func(streamType, eventType string) error {
+		if streamType == "test_b" && atomic.AddInt32(&deadlocks, 1) == 1 {
+			return &pgconn.PgError{Code: "40P01", Message: "deadlock detected"}
+		}
+		return nil
+	})
+
+	require.NoError(t, st.AppendEvents(ctx, []store.Event{
+		sysEvent("test_a", sA, "E1"),
+		sysEvent("test_b", sB, "E2"),
+	}), "a transient deadlock must be retried, not surfaced")
+
+	evA, err := st.LoadStream(ctx, "test_a", sA)
+	require.NoError(t, err)
+	evB, err := st.LoadStream(ctx, "test_b", sB)
+	require.NoError(t, err)
+	assert.Len(t, evA, 1, "the rolled-back first attempt leaves no duplicate")
+	assert.Len(t, evB, 1)
 }
 
 // AC 5 — a conflict that never clears exhausts the retry budget and

--- a/internal/store/eventstore.go
+++ b/internal/store/eventstore.go
@@ -57,6 +57,14 @@ type EventStore interface {
 	// error otherwise — no retry.
 	AppendEventWithVersion(ctx context.Context, event Event, expectedVersion int32) error
 
+	// AppendEvents writes a batch of events across one or more streams
+	// atomically (all land or none) and fires listeners once per event,
+	// post-commit, in array order. The whole transaction is the retry
+	// unit on a version conflict or deadlock. Use it for a logical
+	// action that spans several streams; a single-element batch is
+	// equivalent to AppendEvent.
+	AppendEvents(ctx context.Context, events []Event) error
+
 	// LoadStream returns every event for the given stream in
 	// stream_version order. Used by rebuild paths and any consumer
 	// that needs to replay a single aggregate's history.

--- a/internal/store/notfound.go
+++ b/internal/store/notfound.go
@@ -52,3 +52,21 @@ func IsVersionConflict(err error) bool {
 	}
 	return false
 }
+
+// isDeadlock reports whether err is a Postgres deadlock (SQLSTATE
+// 40P01). A deadlock aborts the whole transaction, so — like a version
+// conflict — the batch-append path (AppendEvents) retries the entire
+// transaction rather than surfacing a transient failure. Two overlapping
+// multi-stream batches that lock the same streams in opposite orders are
+// the classic trigger; retrying resolves them.
+//
+// Deliberately NOT folded into IsVersionConflict: a deadlock is not an
+// optimistic-concurrency loss, and IsVersionConflict's handler callers
+// map it to a 409/Aborted status where a deadlock does not belong.
+func isDeadlock(err error) bool {
+	if err == nil {
+		return false
+	}
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "40P01"
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -156,6 +156,16 @@ type Store struct {
 	// piiMinter mints per-user DEKs at creation (spec 19 AC 1). Wired
 	// via SetPIIMinter alongside the sealer.
 	piiMinter PIIMinter
+
+	// beforeInsert, when non-nil, is consulted in appendOne before each
+	// event insert — so it fires for BOTH AppendEvent and AppendEvents
+	// (they share appendOne). A non-nil return aborts that insert,
+	// letting a test drive the all-or-nothing rollback (spec 28 AC 2),
+	// the whole-batch retry (return ErrVersionConflict → AC 5), and the
+	// SCIM orphan regression (AC 8) deterministically. TEST-ONLY, set via
+	// TestingSetInsertHook; always nil in production, so the per-insert
+	// nil check is the only cost the write path pays.
+	beforeInsert func(streamType, eventType string) error
 }
 
 // PIISealer seals the PII fields of an event's typed payload under the
@@ -635,55 +645,115 @@ func (s *Store) WithTx(ctx context.Context, fn func(*Queries) error) error {
 	return nil
 }
 
-// AppendEvent appends a new event to the event store.
-// It auto-determines the stream version with optimistic retry on conflicts.
-func (s *Store) AppendEvent(ctx context.Context, event Event) error {
+// preparedEvent is an Event after validation, PII sealing, and JSON
+// marshalling — everything that must happen BEFORE a write. Producing it
+// once lets AppendEvent and AppendEvents share identical per-event
+// preparation so the two paths cannot drift (spec 28). The ULID and
+// stream_version are assigned per insert attempt in appendOne, not here,
+// so a retry mints fresh values.
+type preparedEvent struct {
+	streamType string
+	streamID   string
+	eventType  string
+	data       []byte
+	metadata   []byte
+	actorType  string
+	actorID    string
+}
+
+// prepareEvent validates, seals PII (fail-closed), and marshals one
+// event. Shared by AppendEvent and AppendEvents; for a batch it runs for
+// every event BEFORE any transaction opens, so a validation or seal
+// failure aborts with zero DB work and zero partial state (spec 28 AC
+// 2/6; spec 19 fail-closed — plaintext PII must never reach the
+// immutable log as a fallback).
+func (s *Store) prepareEvent(ctx context.Context, event Event) (preparedEvent, error) {
 	if event.ActorType == "" || event.ActorID == "" {
-		return fmt.Errorf("event actor_type and actor_id are required")
+		return preparedEvent{}, fmt.Errorf("event actor_type and actor_id are required")
 	}
 
-	// Seal PII BEFORE marshalling (spec 19 AC 2/6). Fail-closed: an
-	// error here aborts the append — plaintext PII must never reach
-	// the immutable log as a fallback.
 	event, err := s.sealPII(ctx, event)
 	if err != nil {
-		return fmt.Errorf("seal PII: %w", err)
+		return preparedEvent{}, fmt.Errorf("seal PII: %w", err)
 	}
 
 	data, err := json.Marshal(event.Data)
 	if err != nil {
-		return fmt.Errorf("marshal event data: %w", err)
+		return preparedEvent{}, fmt.Errorf("marshal event data: %w", err)
 	}
 
 	metadata := []byte("{}")
 	if event.Metadata != nil {
 		metadata, err = json.Marshal(event.Metadata)
 		if err != nil {
-			return fmt.Errorf("marshal event metadata: %w", err)
+			return preparedEvent{}, fmt.Errorf("marshal event metadata: %w", err)
 		}
+	}
+
+	return preparedEvent{
+		streamType: event.StreamType,
+		streamID:   event.StreamID,
+		eventType:  event.EventType,
+		data:       data,
+		metadata:   metadata,
+		actorType:  event.ActorType,
+		actorID:    event.ActorID,
+	}, nil
+}
+
+// appendOne reads the current stream version and inserts pe at
+// version+1 using q. q may be pool-bound (AppendEvent: each insert
+// auto-commits, and a retry re-reads the committed version) or tx-bound
+// (AppendEvents: all inserts share one transaction, so an earlier
+// same-stream insert in the same batch is visible to this read —
+// read-your-writes — giving consecutive versions, spec 28 AC 3). A
+// unique-violation on (stream_type, stream_id, stream_version) surfaces
+// as a version conflict (IsVersionConflict) for the caller's retry
+// policy. Returns the inserted row for post-commit listener dispatch.
+func (s *Store) appendOne(ctx context.Context, q *Queries, pe preparedEvent) (PersistedEvent, error) {
+	// Test-only failure seam (spec 28 AC 2/5/8): nil in production.
+	if s.beforeInsert != nil {
+		if err := s.beforeInsert(pe.streamType, pe.eventType); err != nil {
+			return PersistedEvent{}, err
+		}
+	}
+
+	version, err := q.GetStreamVersion(ctx, generated.GetStreamVersionParams{
+		StreamType: pe.streamType,
+		StreamID:   pe.streamID,
+	})
+	if err != nil {
+		return PersistedEvent{}, fmt.Errorf("get stream version: %w", err)
+	}
+
+	row, err := q.AppendEvent(ctx, generated.AppendEventParams{
+		ID:            ulid.Make().String(),
+		StreamType:    pe.streamType,
+		StreamID:      pe.streamID,
+		StreamVersion: version + 1,
+		EventType:     pe.eventType,
+		Data:          pe.data,
+		Metadata:      pe.metadata,
+		ActorType:     pe.actorType,
+		ActorID:       pe.actorID,
+	})
+	if err != nil {
+		return PersistedEvent{}, err
+	}
+	return row, nil
+}
+
+// AppendEvent appends a new event to the event store.
+// It auto-determines the stream version with optimistic retry on conflicts.
+func (s *Store) AppendEvent(ctx context.Context, event Event) error {
+	pe, err := s.prepareEvent(ctx, event)
+	if err != nil {
+		return err
 	}
 
 	const maxRetries = 5
 	for i := 0; i < maxRetries; i++ {
-		version, err := s.queries.GetStreamVersion(ctx, generated.GetStreamVersionParams{
-			StreamType: event.StreamType,
-			StreamID:   event.StreamID,
-		})
-		if err != nil {
-			return fmt.Errorf("get stream version: %w", err)
-		}
-
-		row, err := s.queries.AppendEvent(ctx, generated.AppendEventParams{
-			ID:            ulid.Make().String(),
-			StreamType:    event.StreamType,
-			StreamID:      event.StreamID,
-			StreamVersion: version + 1,
-			EventType:     event.EventType,
-			Data:          data,
-			Metadata:      metadata,
-			ActorType:     event.ActorType,
-			ActorID:       event.ActorID,
-		})
+		row, err := s.appendOne(ctx, s.queries, pe)
 		if err != nil {
 			if IsVersionConflict(err) {
 				if i < maxRetries-1 {
@@ -740,4 +810,112 @@ func (s *Store) AppendEventWithVersion(ctx context.Context, event Event, expecte
 	s.fireListeners(ctx, row)
 
 	return nil
+}
+
+// AppendEvents commits a batch of events across one or more streams
+// atomically — all of them land, or none do — and fires listeners only
+// after the whole batch commits (spec 28). Use it for a logical action
+// spanning several streams (e.g. SCIM group create → UserGroupCreated +
+// SCIMGroupMapped + members), where independent AppendEvent calls can
+// leave partial state if a later one fails.
+//
+// Semantics:
+//   - An empty/nil batch is a no-op returning nil.
+//   - Every event is validated, PII-sealed (fail-closed) and marshalled
+//     BEFORE the transaction opens, so a bad event writes nothing.
+//   - Events insert in array order; same-stream events get consecutive
+//     versions (read-your-writes within the tx).
+//   - A version conflict retries the WHOLE transaction (re-reading
+//     versions) up to a bounded budget; on exhaustion it returns
+//     ErrVersionConflict having written nothing.
+//   - Listeners fire post-commit, once per event, in array order,
+//     through the same panic-safe fireListeners AppendEvent uses — which
+//     is the sole projection path now that PL/pgSQL projection is
+//     retired, so a batched event projects identically to a singly
+//     appended one.
+func (s *Store) AppendEvents(ctx context.Context, events []Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	// Prepare (validate + seal + marshal) every event before opening the
+	// transaction: a failure here means zero DB work and zero partial
+	// state (spec 28 AC 2/6).
+	prepared := make([]preparedEvent, len(events))
+	for i, e := range events {
+		pe, err := s.prepareEvent(ctx, e)
+		if err != nil {
+			return fmt.Errorf("append events: event %d: %w", i, err)
+		}
+		prepared[i] = pe
+	}
+
+	const maxRetries = 5
+	for i := 0; i < maxRetries; i++ {
+		rows, err := s.appendBatchTx(ctx, prepared)
+		if err != nil {
+			if IsVersionConflict(err) {
+				if i < maxRetries-1 {
+					continue // Retry the whole batch on version conflict.
+				}
+				return fmt.Errorf("%w: batch stream modified concurrently after %d retries", ErrVersionConflict, maxRetries)
+			}
+			return fmt.Errorf("append events: %w", err)
+		}
+		// Post-commit: the batch is durable. Fire listeners per event in
+		// array order — the sole projection path (spec 28 AC 4). A
+		// panicking listener cannot fail the already-committed batch
+		// (fireListeners' recover contract).
+		for _, row := range rows {
+			s.fireListeners(ctx, row)
+		}
+		return nil
+	}
+	return fmt.Errorf("append events: exhausted retries")
+}
+
+// appendBatchTx runs one all-or-nothing attempt: it opens a transaction,
+// inserts every prepared event in order via the shared appendOne
+// (tx-bound, so a same-stream read sees earlier inserts in this batch),
+// commits, and returns the inserted rows for post-commit listener
+// dispatch. Any error — version conflict or otherwise — returns before
+// commit, so the deferred Rollback discards the whole batch and nothing
+// is written.
+func (s *Store) appendBatchTx(ctx context.Context, prepared []preparedEvent) ([]PersistedEvent, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	q := s.queries.WithTx(tx)
+	rows := make([]PersistedEvent, len(prepared))
+	for i, pe := range prepared {
+		row, err := s.appendOne(ctx, q, pe)
+		if err != nil {
+			return nil, err
+		}
+		rows[i] = row
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit transaction: %w", err)
+	}
+	return rows, nil
+}
+
+// TestingSetInsertHook installs a test-only failure seam consulted
+// before every event insert in AppendEvent / AppendEvents. Returning a
+// non-nil error from fn aborts that insert; returning a
+// version-conflict-classified error (store.ErrVersionConflict) drives
+// the whole-batch retry. Lets tests exercise the all-or-nothing rollback
+// (spec 28 AC 2), the retry/exhaust budget (AC 5), and the SCIM orphan
+// regression (AC 8) deterministically, from any package, without a
+// production failure flag. Pass nil to clear.
+//
+// Named like TestingPool: production code must not call this. It is
+// exported only because the SCIM AC-8 regression test lives in another
+// package and a concrete *Store gives it no other seam.
+func (s *Store) TestingSetInsertHook(fn func(streamType, eventType string) error) {
+	s.beforeInsert = fn
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -854,11 +854,16 @@ func (s *Store) AppendEvents(ctx context.Context, events []Event) error {
 	for i := 0; i < maxRetries; i++ {
 		rows, err := s.appendBatchTx(ctx, prepared)
 		if err != nil {
-			if IsVersionConflict(err) {
+			// A version conflict OR a deadlock aborts this transaction;
+			// both are transient, so retry the WHOLE batch (fresh tx,
+			// re-read versions). Reversed-order overlapping batches
+			// deadlock (40P01) rather than unique-violate — retrying
+			// resolves them the same way.
+			if IsVersionConflict(err) || isDeadlock(err) {
 				if i < maxRetries-1 {
-					continue // Retry the whole batch on version conflict.
+					continue
 				}
-				return fmt.Errorf("%w: batch stream modified concurrently after %d retries", ErrVersionConflict, maxRetries)
+				return fmt.Errorf("%w: batch could not commit after %d retries (version conflict or deadlock)", ErrVersionConflict, maxRetries)
 			}
 			return fmt.Errorf("append events: %w", err)
 		}


### PR DESCRIPTION
Closes #529.

## What

Server side of spec 28: `store.AppendEvents(ctx, []Event)` — commits a batch of events across one or more streams **atomically** (all land or none) and fires listeners only after the whole batch commits. Migrates the SCIM multi-stream write paths off sequential `AppendEvent`.

**Why:** a handful of actions write several streams as one logical unit. SCIM `createGroup` appends `UserGroupCreated` then `SCIMGroupMapped`; if the mapping append failed after the group committed, the group existed with no mapping — the IdP's next sync missed the mapping-keyed dedup, created a *second* group, and leaked the first permanently (server security audit 2026-07-10). All-or-nothing across the streams is the fix.

## Design

- **Seal-before-tx.** PII sealing + validation + marshal run for *every* event before the transaction opens, so a seal/validation failure aborts with zero DB work and zero partial state (spec 19 fail-closed, per event).
- **One tx, read-your-writes.** Each event reads its stream version inside the tx and inserts at version+1; two events on the same stream get consecutive versions (N+1, N+2).
- **Whole-batch retry.** A version conflict rolls back and re-runs the whole transaction up to the same bounded budget `AppendEvent` uses; on exhaustion returns `ErrVersionConflict` having written nothing.
- **Post-commit listeners, per event, in order.** The sole projection path now that PL/pgSQL projection is retired — so a batched event projects identically to a singly appended one. A panicking listener can't fail the already-durable batch.
- **DRY.** `prepareEvent` (validate+seal+marshal) and `appendOne` (read-version+insert) are extracted and shared by both `AppendEvent` and `AppendEvents`, so the two paths cannot drift. `AppendEvent`'s public behaviour is unchanged (its 34 callers are untouched).

## Call-site migrations

- **`createGroup`** — group + mapping + members are one atomic `AppendEvents`. Members join the batch (a half-populated group is also partial state); the empty-value and cross-provider checks still run *before* the batch, so only a genuine DB failure rolls the create back. **Behavioural note:** member-adds went from best-effort (errors swallowed) to all-or-nothing.
- **`replaceUser`** — the conditional email/status/profile appends (all on the `user/<id>` stream) collected into one atomic batch, so a 500 leaves PM unchanged instead of half-synced from the IdP.

## Tests

12 store tests (one per acceptance criterion) + 2 SCIM regression tests, all against real Postgres:

- atomic commit across streams; all-or-nothing on mid-batch failure; missing-actor writes nothing; same-stream consecutive versions; listeners fire post-commit in order + panic safety; **real projector end-to-end**; optimistic-concurrency retry-and-converge + unresolvable-conflict-writes-nothing; **PII seal fail-closed**; single-element equivalence + empty no-op.
- **AC 8 (audit regression):** driving the real `createGroup` with the mapping append forced to fail leaves no orphan `user_group`; a clean re-sync then creates exactly one group. Plus a `replaceUser` partial-failure-rolls-back-email test.

Forced-failure paths use `TestingSetInsertHook` — a `Testing*`-convention insert seam (like the existing `TestingPool`), nil in production, needed because the SCIM regression test lives in another package and a concrete `*Store` gives it no other seam.

**Red-checked:** neutralized the batch to per-event commit+project (mimicking the pre-migration sequential path) — AC 2, AC 5-exhaust, AC 8 and `replaceUser` all fail on the non-atomic path and pass on the atomic one; restored.

## Verification

`go vet` ✓  gofmt ✓  full `go test ./internal/store/ ./internal/scim/` ✓  server-wide `go build ./...` / `go vet ./...` ✓  `-race` on the new + concurrent append tests ✓.

## Out of scope

Single-append call sites (already atomic); no saga/unit-of-work framework; no proto, migration, config, or feature flag — one server PR. `AppendEvent` (singular) semantics untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SCIM group creation is now atomic, preventing orphaned group mappings when a write fails.
  * SCIM user updates roll back completely if any part of the update cannot be saved.
  * Batched writes now validate and commit all changes together, preventing partial data updates.
  * Improved handling of write conflicts and failed persistence operations.

* **Tests**
  * Added coverage for atomic writes, rollback behavior, event ordering, retries, validation, and projection updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->