### PR TITLE
fix: object-scope on List*/Dispatch* + behavioral valkey-search test infra (spec 29 S1)

### DIFF
--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -14,6 +14,7 @@ import (
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -160,6 +161,36 @@ func (h *ActionHandler) ListActions(ctx context.Context, req *connect.Request[pm
 	}
 
 	typeFilter := int32(req.Msg.TypeFilter)
+
+	// Object scope (ADR 0024 / spec 29 S1): a scope-restricted caller sees only
+	// actions assigned within their scope groups. The projection has no scope
+	// column, so resolve the in-scope page from the search index (fail-closed)
+	// and hydrate full rows. Global admins fall through to the direct projection
+	// list below. (The scoped path confines by scope; type/unassigned filters are
+	// not applied there — unassigned objects have no scope groups and are already
+	// invisible to a scoped caller per ADR 0024.)
+	if _, restricted := auth.ObjectScopeListFilter(ctx); restricted {
+		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, "actions", offset, pageSize)
+		if serr != nil {
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list actions")
+		}
+		scopedActions := make([]*pm.ManagedAction, 0, len(ids))
+		for _, id := range ids {
+			a, gerr := h.store.Repos().Action.Get(ctx, id)
+			if gerr != nil {
+				if store.IsNotFound(gerr) {
+					continue // index lag vs projection — skip, never leak or fail open
+				}
+				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list actions")
+			}
+			scopedActions = append(scopedActions, h.actionToProto(a))
+		}
+		return connect.NewResponse(&pm.ListActionsResponse{
+			Actions:       scopedActions,
+			NextPageToken: buildNextPageToken(int32(len(scopedActions)), offset, pageSize, int64(total)),
+			TotalCount:    total,
+		}), nil
+	}
 
 	actions, err := h.store.Repos().Action.List(ctx, store.ListActionsFilter{ActionTypeFilter: typeFilter, Limit: pageSize, Offset: offset, UnassignedOnly: req.Msg.UnassignedOnly})
 	if err != nil {

--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -189,6 +189,13 @@ func (h *ActionHandler) ListActions(ctx context.Context, req *connect.Request[pm
 				}
 				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list actions")
 			}
+			// System-managed actions are never user-readable (GetAction hides them,
+			// Action.List excludes them at SQL). Repos().Action.Get does NOT, so
+			// guard here — a system action's ShellParams must never leak via a
+			// scoped list, self-contained rather than trusting the index to exclude.
+			if a.IsSystem {
+				continue
+			}
 			scopedActions = append(scopedActions, h.actionToProto(a))
 		}
 		return connect.NewResponse(&pm.ListActionsResponse{

--- a/internal/api/action_crud.go
+++ b/internal/api/action_crud.go
@@ -8,6 +8,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"connectrpc.com/connect"
 	"github.com/oklog/ulid/v2"
@@ -165,12 +166,17 @@ func (h *ActionHandler) ListActions(ctx context.Context, req *connect.Request[pm
 	// Object scope (ADR 0024 / spec 29 S1): a scope-restricted caller sees only
 	// actions assigned within their scope groups. The projection has no scope
 	// column, so resolve the in-scope page from the search index (fail-closed)
-	// and hydrate full rows. Global admins fall through to the direct projection
-	// list below. (The scoped path confines by scope; type/unassigned filters are
-	// not applied there — unassigned objects have no scope groups and are already
-	// invisible to a scoped caller per ADR 0024.)
+	// and hydrate full rows. The typeFilter is pushed into the index query so it
+	// still applies (and pagination totals stay accurate); UnassignedOnly is a
+	// no-op here — unassigned objects have no scope groups and are already
+	// invisible to a scoped caller (ADR 0024). Global admins fall through to the
+	// direct projection list below.
 	if _, restricted := auth.ObjectScopeListFilter(ctx); restricted {
-		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, "actions", offset, pageSize)
+		var typeClause string
+		if typeFilter != 0 {
+			typeClause = fmt.Sprintf("@type:{%d}", typeFilter) // index stores type as the enum int
+		}
+		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, h.logger, "actions", offset, pageSize, typeClause)
 		if serr != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list actions")
 		}
@@ -186,8 +192,10 @@ func (h *ActionHandler) ListActions(ctx context.Context, req *connect.Request[pm
 			scopedActions = append(scopedActions, h.actionToProto(a))
 		}
 		return connect.NewResponse(&pm.ListActionsResponse{
-			Actions:       scopedActions,
-			NextPageToken: buildNextPageToken(int32(len(scopedActions)), offset, pageSize, int64(total)),
+			Actions: scopedActions,
+			// Page token off the resolved page length (len(ids)), not the
+			// post-hydrate count — an index-lag skip must not signal "last page".
+			NextPageToken: buildNextPageToken(int32(len(ids)), offset, pageSize, int64(total)),
 			TotalCount:    total,
 		}), nil
 	}

--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -610,6 +610,10 @@ func (h *ActionHandler) DispatchToGroup(ctx context.Context, req *connect.Reques
 		if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "action_set", source.ActionSetId, ErrActionSetNotFound, "action set not found"); err != nil {
 			return nil, err
 		}
+	case *pm.DispatchToGroupRequest_DefinitionId:
+		if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "definition", source.DefinitionId, ErrDefinitionNotFound, "definition not found"); err != nil {
+			return nil, err
+		}
 	}
 
 	executions := make([]*pm.ActionExecution, 0)

--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -102,6 +102,14 @@ func (h *ActionHandler) DispatchAction(ctx context.Context, req *connect.Request
 			}
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get action")
 		}
+		// Object read-scope (spec 29 S1): a scope-restricted admin must not be
+		// able to execute a catalog action it cannot Get. Device scope alone
+		// (enforced above) confines WHERE it runs, not WHICH object runs. Mirrors
+		// the AddActionToSet/AddActionToPolicy read-scope gate. Out of scope →
+		// NotFound (no existence leak).
+		if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "action", source.ActionId, ErrActionNotFound, "action not found"); err != nil {
+			return nil, err
+		}
 		inputs.actionType = pm.ActionType(action.ActionType)
 		inputs.desiredState = pm.DesiredState_DESIRED_STATE_PRESENT // Default for ad-hoc dispatch
 		// The stored params JSONB is carried verbatim into the envelope
@@ -484,6 +492,12 @@ func (h *ActionHandler) DispatchActionSet(ctx context.Context, req *connect.Requ
 		return nil, err
 	}
 
+	// Object read-scope (spec 29 S1): confine WHICH set can be executed, not just
+	// which device it runs on. Out of scope → NotFound.
+	if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "action_set", req.Msg.ActionSetId, ErrActionSetNotFound, "action set not found"); err != nil {
+		return nil, err
+	}
+
 	actions, err := h.store.Queries().ListActionsInSet(ctx, req.Msg.ActionSetId)
 	if err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get actions in set")
@@ -516,6 +530,12 @@ func (h *ActionHandler) DispatchDefinition(ctx context.Context, req *connect.Req
 	}
 
 	if err := h.enforceDeviceScopeAll(ctx, "DispatchDefinition", []string{req.Msg.DeviceId}); err != nil {
+		return nil, err
+	}
+
+	// Object read-scope (spec 29 S1): confine WHICH definition can be executed.
+	// Out of scope → NotFound.
+	if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "definition", req.Msg.DefinitionId, ErrDefinitionNotFound, "definition not found"); err != nil {
 		return nil, err
 	}
 
@@ -576,6 +596,20 @@ func (h *ActionHandler) DispatchToGroup(ctx context.Context, req *connect.Reques
 	}
 	if err := h.enforceDeviceScopeAll(ctx, "DispatchToGroup", memberIDs); err != nil {
 		return nil, err
+	}
+
+	// Object read-scope (spec 29 S1): confine WHICH stored object the fan-out
+	// executes, once, before the per-device loop. Inline sources have no stored
+	// object to scope. Out of scope → NotFound.
+	switch source := req.Msg.ActionSource.(type) {
+	case *pm.DispatchToGroupRequest_ActionId:
+		if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "action", source.ActionId, ErrActionNotFound, "action not found"); err != nil {
+			return nil, err
+		}
+	case *pm.DispatchToGroupRequest_ActionSetId:
+		if err := enforceObjectReadScope(ctx, objScope(h.store), h.logger, "action_set", source.ActionSetId, ErrActionSetNotFound, "action set not found"); err != nil {
+			return nil, err
+		}
 	}
 
 	executions := make([]*pm.ActionExecution, 0)

--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -134,7 +134,7 @@ func (h *ActionSetHandler) ListActionSets(ctx context.Context, req *connect.Requ
 	// Object scope (ADR 0024 / spec 29 S1): a scope-restricted caller sees only
 	// in-scope sets, resolved from the search index (fail-closed) and hydrated.
 	if _, restricted := auth.ObjectScopeListFilter(ctx); restricted {
-		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, "action_sets", offset, pageSize)
+		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, h.logger, "action_sets", offset, pageSize)
 		if serr != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list action sets")
 		}
@@ -151,7 +151,7 @@ func (h *ActionSetHandler) ListActionSets(ctx context.Context, req *connect.Requ
 		}
 		return connect.NewResponse(&pm.ListActionSetsResponse{
 			Sets:          scopedSets,
-			NextPageToken: buildNextPageToken(int32(len(scopedSets)), offset, pageSize, int64(total)),
+			NextPageToken: buildNextPageToken(int32(len(ids)), offset, pageSize, int64(total)),
 			TotalCount:    total,
 		}), nil
 	}

--- a/internal/api/action_set_handler.go
+++ b/internal/api/action_set_handler.go
@@ -10,6 +10,7 @@ import (
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -128,6 +129,31 @@ func (h *ActionSetHandler) ListActionSets(ctx context.Context, req *connect.Requ
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err
+	}
+
+	// Object scope (ADR 0024 / spec 29 S1): a scope-restricted caller sees only
+	// in-scope sets, resolved from the search index (fail-closed) and hydrated.
+	if _, restricted := auth.ObjectScopeListFilter(ctx); restricted {
+		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, "action_sets", offset, pageSize)
+		if serr != nil {
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list action sets")
+		}
+		scopedSets := make([]*pm.ActionSet, 0, len(ids))
+		for _, id := range ids {
+			s, gerr := h.store.Repos().ActionSet.Get(ctx, id)
+			if gerr != nil {
+				if store.IsNotFound(gerr) {
+					continue
+				}
+				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list action sets")
+			}
+			scopedSets = append(scopedSets, h.actionSetToProto(s))
+		}
+		return connect.NewResponse(&pm.ListActionSetsResponse{
+			Sets:          scopedSets,
+			NextPageToken: buildNextPageToken(int32(len(scopedSets)), offset, pageSize, int64(total)),
+			TotalCount:    total,
+		}), nil
 	}
 
 	sets, err := h.store.Repos().ActionSet.List(ctx, store.ListActionSetsFilter{Limit: pageSize, Offset: offset, UnassignedOnly: req.Msg.UnassignedOnly})

--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -105,6 +105,31 @@ func (h *CompliancePolicyHandler) ListCompliancePolicies(ctx context.Context, re
 		return nil, err
 	}
 
+	// Object scope (ADR 0024 / spec 29 S1): a scope-restricted caller sees only
+	// in-scope policies, resolved from the search index (fail-closed).
+	if _, restricted := auth.ObjectScopeListFilter(ctx); restricted {
+		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, "compliance_policies", offset, pageSize)
+		if serr != nil {
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list compliance policies")
+		}
+		scopedPolicies := make([]*pm.CompliancePolicy, 0, len(ids))
+		for _, id := range ids {
+			p, gerr := h.store.Repos().Compliance.GetPolicy(ctx, id)
+			if gerr != nil {
+				if store.IsNotFound(gerr) {
+					continue
+				}
+				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list compliance policies")
+			}
+			scopedPolicies = append(scopedPolicies, h.policyToProto(p, nil))
+		}
+		return connect.NewResponse(&pm.ListCompliancePoliciesResponse{
+			Policies:      scopedPolicies,
+			NextPageToken: buildNextPageToken(int32(len(scopedPolicies)), offset, pageSize, int64(total)),
+			TotalCount:    total,
+		}), nil
+	}
+
 	policies, err := h.store.Repos().Compliance.ListPolicies(ctx, store.ListCompliancePoliciesFilter{
 		Limit:  pageSize,
 		Offset: offset,

--- a/internal/api/compliance_policy_handler.go
+++ b/internal/api/compliance_policy_handler.go
@@ -108,7 +108,7 @@ func (h *CompliancePolicyHandler) ListCompliancePolicies(ctx context.Context, re
 	// Object scope (ADR 0024 / spec 29 S1): a scope-restricted caller sees only
 	// in-scope policies, resolved from the search index (fail-closed).
 	if _, restricted := auth.ObjectScopeListFilter(ctx); restricted {
-		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, "compliance_policies", offset, pageSize)
+		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, h.logger, "compliance_policies", offset, pageSize)
 		if serr != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list compliance policies")
 		}
@@ -125,7 +125,7 @@ func (h *CompliancePolicyHandler) ListCompliancePolicies(ctx context.Context, re
 		}
 		return connect.NewResponse(&pm.ListCompliancePoliciesResponse{
 			Policies:      scopedPolicies,
-			NextPageToken: buildNextPageToken(int32(len(scopedPolicies)), offset, pageSize, int64(total)),
+			NextPageToken: buildNextPageToken(int32(len(ids)), offset, pageSize, int64(total)),
 			TotalCount:    total,
 		}), nil
 	}

--- a/internal/api/definition_handler.go
+++ b/internal/api/definition_handler.go
@@ -10,6 +10,7 @@ import (
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -126,6 +127,31 @@ func (h *DefinitionHandler) ListDefinitions(ctx context.Context, req *connect.Re
 	pageSize, offset, err := parsePagination(int32(req.Msg.PageSize), req.Msg.PageToken)
 	if err != nil {
 		return nil, err
+	}
+
+	// Object scope (ADR 0024 / spec 29 S1): a scope-restricted caller sees only
+	// in-scope definitions, resolved from the search index (fail-closed).
+	if _, restricted := auth.ObjectScopeListFilter(ctx); restricted {
+		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, "definitions", offset, pageSize)
+		if serr != nil {
+			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list definitions")
+		}
+		scopedDefs := make([]*pm.Definition, 0, len(ids))
+		for _, id := range ids {
+			d, gerr := h.store.Repos().Definition.Get(ctx, id)
+			if gerr != nil {
+				if store.IsNotFound(gerr) {
+					continue
+				}
+				return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list definitions")
+			}
+			scopedDefs = append(scopedDefs, h.definitionToProto(d))
+		}
+		return connect.NewResponse(&pm.ListDefinitionsResponse{
+			Definitions:   scopedDefs,
+			NextPageToken: buildNextPageToken(int32(len(scopedDefs)), offset, pageSize, int64(total)),
+			TotalCount:    total,
+		}), nil
 	}
 
 	defs, err := h.store.Repos().Definition.List(ctx, store.ListDefinitionsFilter{Limit: pageSize, Offset: offset})

--- a/internal/api/definition_handler.go
+++ b/internal/api/definition_handler.go
@@ -132,7 +132,7 @@ func (h *DefinitionHandler) ListDefinitions(ctx context.Context, req *connect.Re
 	// Object scope (ADR 0024 / spec 29 S1): a scope-restricted caller sees only
 	// in-scope definitions, resolved from the search index (fail-closed).
 	if _, restricted := auth.ObjectScopeListFilter(ctx); restricted {
-		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, "definitions", offset, pageSize)
+		ids, total, serr := scopedObjectIDs(ctx, h.searchIdx, h.logger, "definitions", offset, pageSize)
 		if serr != nil {
 			return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to list definitions")
 		}
@@ -149,7 +149,7 @@ func (h *DefinitionHandler) ListDefinitions(ctx context.Context, req *connect.Re
 		}
 		return connect.NewResponse(&pm.ListDefinitionsResponse{
 			Definitions:   scopedDefs,
-			NextPageToken: buildNextPageToken(int32(len(scopedDefs)), offset, pageSize, int64(total)),
+			NextPageToken: buildNextPageToken(int32(len(ids)), offset, pageSize, int64(total)),
 			TotalCount:    total,
 		}), nil
 	}

--- a/internal/api/object_scope_list.go
+++ b/internal/api/object_scope_list.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"context"
+	"strings"
+
+	"github.com/manchtools/power-manage/server/internal/search"
+)
+
+// scopedObjectIDs returns the page of in-scope object IDs (ordered created_at
+// DESC, matching the Postgres List* ordering) plus the total in-scope count, for
+// a scope-restricted caller, resolved from the search index.
+//
+// The object projections carry no scope column — the effective scope of an
+// object (its assignment groups + container walk) is materialized only in the
+// search index's @scope_group_ids TAG (the same materialization Search uses).
+// So a scoped List* filters there, then hydrates full rows from Postgres by ID.
+//
+// FAILS CLOSED (ADR 0024 / spec 29 S1): a restricted caller whose index is
+// unconfigured or not yet built sees NOTHING — never the unscoped catalog. Only
+// call this when auth.ObjectScopeListFilter reported restricted; scopeGroupClause
+// returns "" for an unrestricted caller, which also yields an empty (fail-closed)
+// result here as a defensive backstop.
+func scopedObjectIDs(ctx context.Context, idx *search.Index, scope string, offset, pageSize int32) (ids []string, total int32, err error) {
+	if idx == nil {
+		return nil, 0, nil
+	}
+	clause := scopeGroupClause(ctx, scope)
+	if clause == "" {
+		return nil, 0, nil
+	}
+	args := []any{"FT.SEARCH", "idx:" + scope, clause, "SORTBY", "created_at", "DESC", "LIMIT", offset, pageSize}
+	raw, err := idx.RDB().Do(ctx, args...).Result()
+	if err != nil {
+		// An index that doesn't exist yet (control started before the first
+		// Rebuild) fails CLOSED to an empty page, never the unscoped list.
+		msg := err.Error()
+		if strings.Contains(msg, "Unknown index") || strings.Contains(msg, "Unknown Index") || strings.Contains(msg, "not found") {
+			return nil, 0, nil
+		}
+		return nil, 0, err
+	}
+	parsed, count := parseFTSearchResult(raw, scope)
+	ids = make([]string, len(parsed))
+	for i, r := range parsed {
+		ids[i] = r.Id
+	}
+	return ids, count, nil
+}

--- a/internal/api/object_scope_list.go
+++ b/internal/api/object_scope_list.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/manchtools/power-manage/server/internal/search"
@@ -9,19 +11,22 @@ import (
 
 // scopedObjectIDs returns the page of in-scope object IDs (ordered created_at
 // DESC, matching the Postgres List* ordering) plus the total in-scope count, for
-// a scope-restricted caller, resolved from the search index.
+// a scope-restricted caller, resolved from the search index. extraClauses are
+// additional RediSearch clauses ANDed onto the scope filter (e.g. an @type TAG so
+// a scoped caller's typeFilter still applies and pagination stays accurate).
 //
 // The object projections carry no scope column — the effective scope of an
 // object (its assignment groups + container walk) is materialized only in the
-// search index's @scope_group_ids TAG (the same materialization Search uses).
-// So a scoped List* filters there, then hydrates full rows from Postgres by ID.
+// search index's @scope_group_ids TAG (the same materialization Search uses). So
+// a scoped List* filters there, then hydrates full rows from Postgres by ID.
 //
-// FAILS CLOSED (ADR 0024 / spec 29 S1): a restricted caller whose index is
-// unconfigured or not yet built sees NOTHING — never the unscoped catalog. Only
-// call this when auth.ObjectScopeListFilter reported restricted; scopeGroupClause
-// returns "" for an unrestricted caller, which also yields an empty (fail-closed)
-// result here as a defensive backstop.
-func scopedObjectIDs(ctx context.Context, idx *search.Index, scope string, offset, pageSize int32) (ids []string, total int32, err error) {
+// FAILS CLOSED (ADR 0024 / spec 29 S1): a restricted caller whose index is not
+// yet built sees NOTHING — never the unscoped catalog — and the fail-closed path
+// is logged so a missing index reads as an operational problem, not "zero
+// results". Only call this when auth.ObjectScopeListFilter reported restricted;
+// scopeGroupClause returns "" for an unrestricted caller, which also yields an
+// empty (fail-closed) result here as a defensive backstop.
+func scopedObjectIDs(ctx context.Context, idx *search.Index, logger *slog.Logger, scope string, offset, pageSize int32, extraClauses ...string) (ids []string, total int32, err error) {
 	if idx == nil {
 		return nil, 0, nil
 	}
@@ -29,16 +34,28 @@ func scopedObjectIDs(ctx context.Context, idx *search.Index, scope string, offse
 	if clause == "" {
 		return nil, 0, nil
 	}
-	args := []any{"FT.SEARCH", "idx:" + scope, clause, "SORTBY", "created_at", "DESC", "LIMIT", offset, pageSize}
+	q := clause
+	for _, c := range extraClauses {
+		if c != "" {
+			q += " " + c
+		}
+	}
+	args := []any{"FT.SEARCH", "idx:" + scope, q, "SORTBY", "created_at", "DESC", "LIMIT", offset, pageSize}
 	raw, err := idx.RDB().Do(ctx, args...).Result()
 	if err != nil {
-		// An index that doesn't exist yet (control started before the first
-		// Rebuild) fails CLOSED to an empty page, never the unscoped list.
-		msg := err.Error()
-		if strings.Contains(msg, "Unknown index") || strings.Contains(msg, "Unknown Index") || strings.Contains(msg, "not found") {
+		// A missing index (control started before the first Rebuild) is the ONLY
+		// error we fail closed on — matched specifically on RediSearch's
+		// "Unknown index" so an unrelated backend failure surfaces as an error,
+		// not a silent empty page. Fail-closed is logged; the caller sees zero
+		// results, never the unscoped list.
+		if strings.Contains(strings.ToLower(err.Error()), "unknown index") {
+			if logger != nil {
+				logger.Warn("scopedObjectIDs: search index not built, failing closed to empty page",
+					"scope", scope, "error", err)
+			}
 			return nil, 0, nil
 		}
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("scopedObjectIDs: FT.SEARCH idx:%s: %w", scope, err)
 	}
 	parsed, count := parseFTSearchResult(raw, scope)
 	ids = make([]string, len(parsed))

--- a/internal/api/object_scope_list.go
+++ b/internal/api/object_scope_list.go
@@ -48,7 +48,7 @@ func scopedObjectIDs(ctx context.Context, idx *search.Index, logger *slog.Logger
 		// "Unknown index" so an unrelated backend failure surfaces as an error,
 		// not a silent empty page. Fail-closed is logged; the caller sees zero
 		// results, never the unscoped list.
-		if strings.Contains(strings.ToLower(err.Error()), "unknown index") {
+		if strings.Contains(strings.ToLower(err.Error()), "unknown index name") {
 			if logger != nil {
 				logger.Warn("scopedObjectIDs: search index not built, failing closed to empty page",
 					"scope", scope, "error", err)

--- a/internal/api/object_scope_list_coverage_test.go
+++ b/internal/api/object_scope_list_coverage_test.go
@@ -27,10 +27,17 @@ import (
 func TestObjectListHandlers_AllScopeEnforced(t *testing.T) {
 	require.NotEmpty(t, objectTypeToIndexScope, "no scopable object types discovered — guard would pass vacuously")
 
-	// Expected List method name per object type, e.g. "actions" -> "ListActions".
-	found := map[string]bool{}
+	// Expected List method name -> the index scope it MUST pass to scopedObjectIDs,
+	// e.g. "ListActions" -> "actions". Validating the scope ARGUMENT (not just that
+	// the call exists) rejects a copy-paste bug like ListActionSets querying
+	// "actions".
+	expectedScope := map[string]string{}
 	for _, scope := range objectTypeToIndexScope {
-		found["List"+pascalFromSnake(scope)] = false
+		expectedScope["List"+pascalFromSnake(scope)] = scope
+	}
+	found := map[string]bool{}
+	for method := range expectedScope {
+		found[method] = false
 	}
 
 	fset := token.NewFileSet()
@@ -53,26 +60,37 @@ func TestObjectListHandlers_AllScopeEnforced(t *testing.T) {
 			if _, tracked := found[fn.Name.Name]; !tracked {
 				continue
 			}
-			calls := false
+			want := expectedScope[fn.Name.Name]
+			enforced := false
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
-				if c, ok := n.(*ast.CallExpr); ok && calleeName(c.Fun) == "scopedObjectIDs" {
-					calls = true
+				c, ok := n.(*ast.CallExpr)
+				if !ok || calleeName(c.Fun) != "scopedObjectIDs" {
+					return true
 				}
-				return !calls
+				// scopedObjectIDs(ctx, idx, logger, scope, offset, pageSize, ...):
+				// the scope arg (index 3) must be the literal for THIS handler, so a
+				// handler that copies the wrong scope string fails the guard.
+				if len(c.Args) > 3 {
+					if s, ok := stringLit(c.Args[3]); ok && s == want {
+						enforced = true
+					}
+				}
+				return !enforced
 			})
 			// OR-accumulate: the same method name exists on both the real
 			// handler (which calls scopedObjectIDs) and the ControlService
 			// delegator (which just forwards). The invariant is satisfied if
 			// ANY declaration enforces — don't let the delegator overwrite it.
-			found[fn.Name.Name] = found[fn.Name.Name] || calls
+			found[fn.Name.Name] = found[fn.Name.Name] || enforced
 		}
 	}
 	require.True(t, sawFile, "scanned zero source files — discovery is broken")
 
 	for method, ok := range found {
 		require.Truef(t, ok,
-			"%s does not route restricted callers through scopedObjectIDs — an object List RPC "+
-				"that skips scope enforcement leaks the out-of-scope catalog (spec 29 S1).", method)
+			"%s does not route restricted callers through scopedObjectIDs(ctx, idx, logger, %q, ...) — "+
+				"an object List RPC that skips scope enforcement (or passes the wrong scope) leaks the "+
+				"out-of-scope catalog (spec 29 S1).", method, expectedScope[method])
 	}
 }
 

--- a/internal/api/object_scope_list_coverage_test.go
+++ b/internal/api/object_scope_list_coverage_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestObjectListHandlers_AllScopeEnforced is the self-discovering guard that
+// closes spec 29 S1 for good: EVERY object-catalog List RPC must resolve a
+// scope-restricted caller's results through scopedObjectIDs (the scope-enforcing
+// search-index path). The scopable object types are DISCOVERED from
+// objectTypeToIndexScope — the same registry object_scope_parity_test.go uses —
+// and each List RPC name is derived from the index scope. A new scopable object
+// type, or a List handler that skips scopedObjectIDs, fails the build.
+//
+// This exists because the prior guards were type-level PRESENCE checks
+// (enforceObjectReadScope("action") appears in GetAction) and never verified that
+// EVERY read handler enforces — which is exactly how ListActions leaked. Here the
+// unit is the handler, discovered from the registry, so no object List can
+// silently skip scope now or in the future.
+func TestObjectListHandlers_AllScopeEnforced(t *testing.T) {
+	require.NotEmpty(t, objectTypeToIndexScope, "no scopable object types discovered — guard would pass vacuously")
+
+	// Expected List method name per object type, e.g. "actions" -> "ListActions".
+	found := map[string]bool{}
+	for _, scope := range objectTypeToIndexScope {
+		found["List"+pascalFromSnake(scope)] = false
+	}
+
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+	sawFile := false
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		sawFile = true
+		f, perr := parser.ParseFile(fset, name, nil, 0)
+		require.NoErrorf(t, perr, "parse %s", name)
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || fn.Body == nil {
+				continue
+			}
+			if _, tracked := found[fn.Name.Name]; !tracked {
+				continue
+			}
+			calls := false
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				if c, ok := n.(*ast.CallExpr); ok && calleeName(c.Fun) == "scopedObjectIDs" {
+					calls = true
+				}
+				return !calls
+			})
+			// OR-accumulate: the same method name exists on both the real
+			// handler (which calls scopedObjectIDs) and the ControlService
+			// delegator (which just forwards). The invariant is satisfied if
+			// ANY declaration enforces — don't let the delegator overwrite it.
+			found[fn.Name.Name] = found[fn.Name.Name] || calls
+		}
+	}
+	require.True(t, sawFile, "scanned zero source files — discovery is broken")
+
+	for method, ok := range found {
+		require.Truef(t, ok,
+			"%s does not route restricted callers through scopedObjectIDs — an object List RPC "+
+				"that skips scope enforcement leaks the out-of-scope catalog (spec 29 S1).", method)
+	}
+}
+
+// pascalFromSnake turns a snake_case index scope ("action_sets") into the
+// PascalCase suffix of its List RPC ("ActionSets").
+func pascalFromSnake(scope string) string {
+	parts := strings.Split(scope, "_")
+	for i, p := range parts {
+		if p != "" {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return strings.Join(parts, "")
+}

--- a/internal/api/scope_enforcement_dispatch_object_test.go
+++ b/internal/api/scope_enforcement_dispatch_object_test.go
@@ -1,0 +1,88 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// spec 29 S1: a dispatch RPC must enforce OBJECT read-scope on the referenced
+// action/set/definition, not only DEVICE scope. Here the caller's device scope
+// INCLUDES the target device, but the object is assigned only to a group OUTSIDE
+// the caller's scope — so only the object-scope check can deny it. Out of scope →
+// NotFound (no existence leak), matching GetAction. Without the object-scope
+// gate, device scope alone would let a scoped admin execute an object it cannot
+// even read.
+func TestDispatchObjectScope_OutOfScopeObjectDenied(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	dgIn := testutil.CreateTestDeviceGroup(t, st, actor, "In Scope")
+	dgObj := testutil.CreateTestDeviceGroup(t, st, actor, "Object Group") // caller NOT scoped here
+	devIn := testutil.CreateTestDevice(t, st, "in-scope-device")
+	testutil.AddDeviceToTestGroup(t, st, actor, dgIn, devIn)
+
+	// Objects assigned ONLY to dgObj (outside the caller's scope).
+	actionID := testutil.CreateTestAction(t, st, actor, "secret-script", int(pm.ActionType_ACTION_TYPE_SHELL))
+	testutil.CreateTestAssignment(t, st, actor, "action", actionID, "device_group", dgObj, 0)
+	setID := testutil.CreateTestActionSet(t, st, actor, "secret-set")
+	testutil.CreateTestAssignment(t, st, actor, "action_set", setID, "device_group", dgObj, 0)
+	defID := testutil.CreateTestDefinition(t, st, actor, "secret-def")
+	testutil.CreateTestAssignment(t, st, actor, "definition", defID, "device_group", dgObj, 0)
+
+	// Caller scoped to dgIn (device IS in scope) but NOT dgObj (object out of
+	// scope), holding every dispatch permission scoped to dgIn.
+	perms := []string{"DispatchAction", "DispatchActionSet", "DispatchDefinition", "DispatchToGroup"}
+	grants := make([]auth.ScopedGrant, len(perms))
+	for i, p := range perms {
+		grants[i] = auth.ScopedGrant{Permission: p, ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgIn}
+	}
+	scoped := func() context.Context {
+		return testutil.AuthContextScoped(testutil.NewID(), "scoped@test.com", perms, grants)
+	}
+
+	t.Run("DispatchAction on out-of-scope action → NotFound", func(t *testing.T) {
+		_, err := h.DispatchAction(scoped(), connect.NewRequest(&pm.DispatchActionRequest{
+			DeviceId:     devIn, // device IS in scope; only the object is out
+			ActionSource: &pm.DispatchActionRequest_ActionId{ActionId: actionID},
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err),
+			"object-scope must deny an out-of-scope action even when the device is in scope")
+	})
+
+	t.Run("DispatchActionSet on out-of-scope set → NotFound", func(t *testing.T) {
+		_, err := h.DispatchActionSet(scoped(), connect.NewRequest(&pm.DispatchActionSetRequest{
+			DeviceId: devIn, ActionSetId: setID,
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	})
+
+	t.Run("DispatchDefinition on out-of-scope definition → NotFound", func(t *testing.T) {
+		_, err := h.DispatchDefinition(scoped(), connect.NewRequest(&pm.DispatchDefinitionRequest{
+			DeviceId: devIn, DefinitionId: defID,
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	})
+
+	t.Run("DispatchToGroup with out-of-scope action → NotFound", func(t *testing.T) {
+		_, err := h.DispatchToGroup(scoped(), connect.NewRequest(&pm.DispatchToGroupRequest{
+			GroupId:      dgIn, // group's devices are in scope
+			ActionSource: &pm.DispatchToGroupRequest_ActionId{ActionId: actionID},
+		}))
+		require.Error(t, err)
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	})
+}

--- a/internal/api/valkey_scope_behavioral_test.go
+++ b/internal/api/valkey_scope_behavioral_test.go
@@ -1,0 +1,76 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestValkeySearch_ObjectScope_ConfinesOutOfScope validates the spec 29 S1 /
+// spec 30 test foundation: FT.SEARCH @scope_group_ids filtering, driven through
+// the REAL search handler against a REAL valkey-search backend, actually confines
+// a scope-restricted caller to in-scope objects. Until now this path was only
+// clause-string ("does the query contain @scope_group_ids") unit-tested — a
+// presence check, not behavior. This is the behavioral proof, and the template
+// the Valkey-scoped List* behavioral tests build on.
+func TestValkeySearch_ObjectScope_ConfinesOutOfScope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	admin := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+	dgA := testutil.CreateTestDeviceGroup(t, st, admin, "Fleet A") // caller is scoped here
+	dgB := testutil.CreateTestDeviceGroup(t, st, admin, "Fleet B") // out of scope
+
+	actionA := testutil.CreateTestAction(t, st, admin, "in-scope-action", int(pm.ActionType_ACTION_TYPE_SHELL))
+	testutil.CreateTestAssignment(t, st, admin, "action", actionA, "device_group", dgA, 0)
+	actionB := testutil.CreateTestAction(t, st, admin, "out-of-scope-action", int(pm.ActionType_ACTION_TYPE_SHELL))
+	testutil.CreateTestAssignment(t, st, admin, "action", actionB, "device_group", dgB, 0)
+
+	// Real valkey-search index, backfilled from Postgres (Rebuild computes each
+	// object's scope_group_ids from its assignments).
+	idx := testutil.SetupValkeySearch(t, st)
+	require.NoError(t, idx.Rebuild(ctx), "backfill the search index")
+
+	sh := api.NewSearchHandler(slog.Default())
+	sh.SetSearchIndex(idx)
+
+	search := func(c context.Context) map[string]bool {
+		resp, err := sh.Search(c, connect.NewRequest(&pm.SearchRequest{
+			Scope:    pm.SearchScope_SEARCH_SCOPE_ACTIONS,
+			PageSize: 100,
+		}))
+		require.NoError(t, err)
+		ids := map[string]bool{}
+		for _, r := range resp.Msg.Results {
+			ids[r.Id] = true
+		}
+		return ids
+	}
+
+	scopedToA := testutil.AuthContextScoped(testutil.NewID(), "scoped@test.com",
+		[]string{"Search"},
+		[]auth.ScopedGrant{{Permission: "Search", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgA}})
+	globalCaller := testutil.AuthContextScoped(admin, "g@test.com",
+		[]string{"Search"}, []auth.ScopedGrant{{Permission: "Search"}})
+
+	t.Run("scope-restricted caller sees only the in-scope object", func(t *testing.T) {
+		got := search(scopedToA)
+		assert.True(t, got[actionA], "in-scope action must be visible")
+		assert.False(t, got[actionB], "out-of-scope action must be confined by @scope_group_ids")
+	})
+
+	t.Run("global caller sees both", func(t *testing.T) {
+		got := search(globalCaller)
+		assert.True(t, got[actionA])
+		assert.True(t, got[actionB])
+	})
+}

--- a/internal/api/valkey_scope_behavioral_test.go
+++ b/internal/api/valkey_scope_behavioral_test.go
@@ -74,3 +74,54 @@ func TestValkeySearch_ObjectScope_ConfinesOutOfScope(t *testing.T) {
 		assert.True(t, got[actionB])
 	})
 }
+
+// TestValkeyList_ObjectScope_ConfinesOutOfScope is the S1 regression: ListActions
+// (the leaking read surface) must confine a scope-restricted caller to in-scope
+// actions — resolved from the search index, hydrated from Postgres — and never
+// return an out-of-scope action's script/file contents. Drives the REAL handler
+// against the REAL index; pre-fix ListActions returned the whole catalog.
+func TestValkeyList_ObjectScope_ConfinesOutOfScope(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	admin := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+	dgA := testutil.CreateTestDeviceGroup(t, st, admin, "Fleet A") // caller scoped here
+	dgB := testutil.CreateTestDeviceGroup(t, st, admin, "Fleet B") // out of scope
+
+	inScope := testutil.CreateTestAction(t, st, admin, "in-scope", int(pm.ActionType_ACTION_TYPE_SHELL))
+	testutil.CreateTestAssignment(t, st, admin, "action", inScope, "device_group", dgA, 0)
+	outScope := testutil.CreateTestAction(t, st, admin, "out-of-scope", int(pm.ActionType_ACTION_TYPE_SHELL))
+	testutil.CreateTestAssignment(t, st, admin, "action", outScope, "device_group", dgB, 0)
+
+	idx := testutil.SetupValkeySearch(t, st)
+	require.NoError(t, idx.Rebuild(ctx))
+
+	h := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	h.SetSearchIndex(idx)
+
+	list := func(c context.Context) (map[string]bool, int32) {
+		resp, err := h.ListActions(c, connect.NewRequest(&pm.ListActionsRequest{PageSize: 100}))
+		require.NoError(t, err)
+		ids := map[string]bool{}
+		for _, a := range resp.Msg.Actions {
+			ids[a.Id] = true
+		}
+		return ids, resp.Msg.TotalCount
+	}
+
+	t.Run("scope-restricted caller lists only the in-scope action", func(t *testing.T) {
+		got, total := list(testutil.AuthContextScoped(testutil.NewID(), "s@test.com",
+			[]string{"ListActions"},
+			[]auth.ScopedGrant{{Permission: "ListActions", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgA}}))
+		assert.True(t, got[inScope], "in-scope action must be listed")
+		assert.False(t, got[outScope], "out-of-scope action (and its script) must NOT be listed — this is the S1 leak")
+		assert.Equal(t, int32(1), total, "TotalCount reflects the scoped set")
+	})
+
+	t.Run("global caller lists both", func(t *testing.T) {
+		got, _ := list(testutil.AuthContextScoped(admin, "g@test.com",
+			[]string{"ListActions"}, []auth.ScopedGrant{{Permission: "ListActions"}}))
+		assert.True(t, got[inScope])
+		assert.True(t, got[outScope])
+	})
+}

--- a/internal/api/valkey_scope_behavioral_test.go
+++ b/internal/api/valkey_scope_behavioral_test.go
@@ -23,6 +23,9 @@ import (
 // presence check, not behavior. This is the behavioral proof, and the template
 // the Valkey-scoped List* behavioral tests build on.
 func TestValkeySearch_ObjectScope_ConfinesOutOfScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping valkey-search integration test in short mode")
+	}
 	st := testutil.SetupPostgres(t)
 	ctx := context.Background()
 
@@ -81,6 +84,9 @@ func TestValkeySearch_ObjectScope_ConfinesOutOfScope(t *testing.T) {
 // return an out-of-scope action's script/file contents. Drives the REAL handler
 // against the REAL index; pre-fix ListActions returned the whole catalog.
 func TestValkeyList_ObjectScope_ConfinesOutOfScope(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping valkey-search integration test in short mode")
+	}
 	st := testutil.SetupPostgres(t)
 	ctx := context.Background()
 

--- a/internal/testutil/valkey_search.go
+++ b/internal/testutil/valkey_search.go
@@ -1,0 +1,67 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/manchtools/power-manage/server/internal/search"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// SetupValkeySearch starts a valkey-bundle container (the valkey-search module
+// auto-loads), builds a *search.Index over st, and creates the FT indexes. It
+// returns the Index for a handler's SetSearchIndex + behavioral scope tests
+// against a REAL search backend.
+//
+// This is the load-bearing infra for spec 29 S1 / spec 30: FT.SEARCH scope
+// filtering (@scope_group_ids) can only be verified BEHAVIORALLY against a real
+// index — the in-memory api.SearchIndex fake and the clause-string unit tests
+// prove construction, not confinement (the presence-not-behavior gap that let
+// ListActions leak). Seed objects + assignments in Postgres, call
+// idx.Rebuild(ctx) to backfill, then drive the real handler with a
+// scope-restricted caller and assert the out-of-scope object is absent.
+//
+// The container is torn down on test cleanup. Skipped in -short mode. Mirrors
+// the search package's own setupRedis (image + wait strategy kept identical so a
+// clean run validates the same cutover, #319).
+func SetupValkeySearch(t *testing.T, st *store.Store) *search.Index {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping valkey-search integration test in short mode")
+	}
+	ctx := context.Background()
+
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "valkey/valkey-bundle:9.1.0",
+			ExposedPorts: []string{"6379/tcp"},
+			WaitingFor:   wait.ForLog("Ready to accept connections").WithStartupTimeout(30 * time.Second),
+		},
+		Started: true,
+	})
+	require.NoError(t, err, "start valkey-bundle container")
+	t.Cleanup(func() { _ = container.Terminate(context.Background()) })
+
+	host, err := container.Host(ctx)
+	require.NoError(t, err)
+	port, err := container.MappedPort(ctx, "6379")
+	require.NoError(t, err)
+
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     fmt.Sprintf("%s:%s", host, port.Port()),
+		Protocol: 2,
+	})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	idx := search.New(rdb, st, nil, slog.Default())
+	require.NoError(t, idx.EnsureIndexes(ctx), "create FT indexes")
+	return idx
+}


### PR DESCRIPTION
Closes #531.

## What

Remediates the **HIGH** finding S1 from the spec-29 second-pass audit: object-scope enforcement (ADR 0024) was bypassed by the object-catalog `List*` RPCs and the `Dispatch*` RPCs. `Get*`/`Search`/`Add*`/mutate were scoped; `List*`/`Dispatch*` were not, so a scope-restricted admin could **read every out-of-scope action's `ShellParams` script + `FileParams` contents** and **execute objects it cannot even Get** — contradicting ADR 0024:88 ("a scoped admin's object lists/reads/mutations are confined to their scope").

### Why it slipped past the existing guards
They were **presence** checks: `TestObjectScope_EnforcementMatchesIndexFiltering` asserts `enforceObjectReadScope("action")` appears *somewhere* (satisfied by `GetAction`) and modeled only Get + Search; `List*` is a third read surface and `Dispatch*` had only device-scope. No test drove the actual confinement.

## Changes

- **`Dispatch{Action,ActionSet,Definition,ToGroup}`** — enforce object read-scope on the referenced object before dispatch (live `enforceObjectReadScope`); out of scope → NotFound. Device scope confines *where* it runs, not *which* object.
- **`List{Actions,ActionSets,Definitions,CompliancePolicies}`** — a scope-restricted caller's results are resolved from the search index's `@scope_group_ids` (the only place effective object scope is materialized — the projections have no scope column), then hydrated from Postgres. **Fails closed** (empty, logged) if the index is absent; global admins keep the direct projection list. `typeFilter` is pushed into the index query.
- **Real valkey-search test container** (`testutil.SetupValkeySearch`) — so `FT.SEARCH` scope confinement is verified **behaviorally** through the real handler against a real backend, not by clause-string. This is the load-bearing unlock: valkey scope was previously only presence-tested (the gap that let this through).
- **Self-discovering guard** (`TestObjectListHandlers_AllScopeEnforced`) — discovers the scopable object types from `objectTypeToIndexScope`, derives each List RPC, and AST-asserts every List handler routes restricted callers through `scopedObjectIDs`. A new object type or a List that skips scope **fails the build**, named.

## Tests (behavioral, against a real valkey-search + Postgres)

- `TestValkeySearch_ObjectScope_ConfinesOutOfScope` — Search confines out-of-scope objects (first behavioral proof of valkey scope).
- `TestValkeyList_ObjectScope_ConfinesOutOfScope` — the S1 regression: an out-of-scope action (and its script) is never listed; TotalCount reflects the scoped set. Red-checked (neutralizing the scoped branch leaks it).
- `TestDispatchObjectScope_OutOfScopeObjectDenied` — device in scope, object out of scope → NotFound for all four dispatch RPCs. Red-checked.
- `TestObjectListHandlers_AllScopeEnforced` — self-discovering coverage guard. Red-checked (removing the scope path from a List handler fails, named).

## Notes / scope

- The permission axis was verified **already fully guarded** (`TestEveryRPCIsCoveredByPermissionOrPublic` + no-orphan + matches-zero) — no gap there.
- List* scope is **effective** via the index (matches Get); a no-Valkey deployment fails closed (scoped callers see empty) — safe over leak.
- The broader AST-driven "every read/write/delete path is covered" system is captured separately in spec 30 (in review); this PR is the concrete S1 fix + its behavioral foundation.

## Verification

`go vet ./...` ✓  gofmt ✓  build ✓  scope/coverage suite ✓  behavioral valkey+Postgres tests ✓  local CodeRabbit (5 findings, all addressed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Restricted listings now show only objects within the caller’s permitted scope.
  * Dispatch requests prevent access to out-of-scope actions, action sets, and definitions.
  * Out-of-scope resources are reported as not found.

* **Action Management**
  * Action signature and parameter handling is more reliable during creation and updates.
  * Default action timeouts and SSHD priority behavior are preserved.

* **Bug Fixes**
  * Scoped pagination and total counts now accurately reflect visible results.
  * Listing tolerates temporary search-index inconsistencies.

* **Tests**
  * Added coverage for scope enforcement across listing, search, and dispatch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->