### PR TITLE
fix: SSO hardening — OIDC takeover guard, GetSSOLoginURL throttle+GC, SSRF denylist (spec 29 S2/S3/S4)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -197,6 +197,15 @@ func main() {
 		}
 	}, false)
 
+	// Sweep expired SSO auth_states (spec 29 S3). They are otherwise deleted only
+	// on a successful Consume, so an unauthenticated GetSSOLoginURL flood would
+	// grow the table unboundedly. Same 1h cadence as the revocation sweep.
+	go runPeriodic(ctx, 1*time.Hour, func() {
+		if err := st.Queries().CleanupExpiredAuthStates(ctx); err != nil {
+			logger.Error("failed to cleanup expired SSO auth states", "error", err)
+		}
+	}, false)
+
 	if cfg.DynamicGroupEvalInterval > 0 {
 		logger.Info("starting dynamic group evaluation worker", "interval", cfg.DynamicGroupEvalInterval)
 		startDynamicGroupWorker(ctx, st, cfg.DynamicGroupEvalInterval, logger)
@@ -365,6 +374,7 @@ func main() {
 		Logout:      auth.NewRateLimiter(30, 1*time.Minute), // legitimate multi-session logout ceiling
 		RenewCert:   auth.NewRateLimiter(5, 1*time.Minute),  // cert rotation = once/lifetime, not in tight loop
 		AuthMethods: auth.NewRateLimiter(30, 1*time.Minute), // unauth email-lookup oracle — bound bulk enumeration
+		SSO:         auth.NewRateLimiter(10, 1*time.Minute), // expensive unauth endpoint (DB write + outbound discovery)
 		// WS11 #6 — per-USER ceilings on authenticated control RPCs (keyed by
 		// user ID, not IP). Authenticated is a generous general ceiling
 		// (~10 rps sustained per user) that bounds a stolen token / runaway

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -265,6 +265,11 @@ type RateLimiters struct {
 	// reflects whether an email exists and its auth config — an enumeration
 	// oracle if left unthrottled (audit). Keyed by client IP.
 	AuthMethods *RateLimiter
+	// SSO throttles the unauthenticated GetSSOLoginURL — the most expensive public
+	// endpoint: each call writes an auth_state row, AES-GCM-decrypts the provider
+	// secret, and performs an outbound OIDC discovery request (spec 29 S3). Left
+	// unthrottled it is a storage + outbound-amplification DoS. Keyed by client IP.
+	SSO *RateLimiter
 	// Authenticated is the general per-user ceiling applied to EVERY
 	// authenticated control RPC after the token validates (WS11 #6). It bounds
 	// a compromised token or a runaway client from hammering the API. Keyed by
@@ -382,6 +387,16 @@ func (i *AuthInterceptor) WrapUnary(next connect.UnaryFunc) connect.UnaryFunc {
 			ip := clientIP(req)
 			if !i.limiters.AuthMethods.Allow(ip) {
 				i.logger.Warn("rate limit exceeded", "limiter", "auth_methods", "ip", ip, "procedure", procedure)
+				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many requests, try again later")
+			}
+		}
+
+		// GetSSOLoginURL (public, spec 29 S3) — the most expensive unauthenticated
+		// endpoint (auth_state DB write + secret decrypt + outbound OIDC discovery).
+		if procedure == "/pm.v1.ControlService/GetSSOLoginURL" && i.limiters.SSO != nil {
+			ip := clientIP(req)
+			if !i.limiters.SSO.Allow(ip) {
+				i.logger.Warn("rate limit exceeded", "limiter", "sso", "ip", ip, "procedure", procedure)
 				return nil, authErrorCtx(ctx, errRateLimited, connect.CodeResourceExhausted, "too many requests, try again later")
 			}
 		}

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -654,6 +654,40 @@ func TestAuthInterceptor_ListAuthMethodsThrottled(t *testing.T) {
 	assert.Contains(t, err.Error(), "too many", "must trip the AuthMethods limiter, not some other gate")
 }
 
+// TestAuthInterceptor_GetSSOLoginURLThrottled pins spec 29 S3: the unauthenticated
+// GetSSOLoginURL — the most expensive public endpoint (auth_state DB write +
+// secret decrypt + outbound OIDC discovery per call) — is rate-limited by IP, so
+// a flood can't exhaust storage or amplify outbound discovery.
+func TestAuthInterceptor_GetSSOLoginURLThrottled(t *testing.T) {
+	jwtMgr := NewJWTManager(JWTConfig{Secret: []byte("test-secret"), AccessTokenExpiry: 15 * time.Minute})
+	interceptor := NewAuthInterceptor(testLogger, jwtMgr, RateLimiters{
+		SSO: NewRateLimiter(3, time.Minute),
+	})
+
+	procedure := "/pm.v1.ControlService/GetSSOLoginURL"
+	mux := http.NewServeMux()
+	mux.Handle(procedure, connect.NewUnaryHandler(
+		procedure,
+		func(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+			return connect.NewResponse(&emptypb.Empty{}), nil
+		},
+		connect.WithInterceptors(interceptor),
+	))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, srv.URL+procedure)
+
+	for i := 0; i < 3; i++ {
+		_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+		require.NoError(t, err, "request %d within the limit should succeed", i+1)
+	}
+	_, err := client.CallUnary(context.Background(), connect.NewRequest(&emptypb.Empty{}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))
+	assert.Contains(t, err.Error(), "too many", "must trip the SSO limiter")
+}
+
 // setupAuthRateLimitTest mounts the EvaluateDynamicGroup (expensive) procedure
 // behind the REAL AuthInterceptor with the supplied limiters, recording whether
 // the handler ran via a per-request header. Returns the server URL + manager.

--- a/internal/idp/linker.go
+++ b/internal/idp/linker.go
@@ -159,6 +159,19 @@ func (l *Linker) LinkOrCreate(ctx context.Context, provider store.IdentityProvid
 		slog.Debug("SSO linker: trying auto-link by email", "email", claims.Email)
 		user, err := l.queries.GetUserByEmail(ctx, claims.Email)
 		if err == nil {
+			// Account-takeover guard (spec 29 S2 — mirrors SCIM createUser WS5 #2).
+			// The IdP asserts this email; binding it to a pre-existing LOCAL
+			// PASSWORD account would let a compromised / self-service / over-trusted
+			// IdP seize that credential account (e.g. a local admin). email_verified
+			// is asserted by the same IdP being defended against, so it is not a
+			// backstop. Refuse unless the operator knowingly delegated identity to
+			// this provider via trust_email_assertions. Passwordless / already-SSO
+			// accounts are fine to link (no local credential to hijack).
+			if user.HasPassword && !provider.TrustEmailAssertions {
+				slog.Warn("SSO linker: refusing auto-link to a local password account by unverified email (spec 29 S2)",
+					"user_id", user.ID, "provider_id", provider.ID, "provider_slug", provider.Slug)
+				return nil, ErrNoMatchingAccount
+			}
 			// Info-level log on the actual link (audit F-28) — this
 			// is a trust-boundary event: the IdP's email-verification
 			// posture is what gates account hijack via this path, and

--- a/internal/idp/linker_test.go
+++ b/internal/idp/linker_test.go
@@ -260,6 +260,46 @@ func TestLinkOrCreate_AutoLinkByEmail_EmitsLinkForExistingUser(t *testing.T) {
 	}
 }
 
+// TestLinkOrCreate_AutoLinkByEmail_RefusesPasswordAccount pins spec 29 S2: with
+// AutoLinkByEmail on, an IdP-asserted email matching a LOCAL PASSWORD account is
+// NOT auto-linked unless the operator delegated identity via TrustEmailAssertions.
+// A compromised / self-service / over-trusted IdP stamping email_verified must
+// not seize a pre-existing credential account (e.g. a local admin). Mirrors the
+// SCIM createUser guard (scim/users_create.go WS5 #2).
+func TestLinkOrCreate_AutoLinkByEmail_RefusesPasswordAccount(t *testing.T) {
+	existing := db.UsersProjection{ID: "admin-local", Email: "admin@example.com", HasPassword: true}
+	querier := &mockQuerier{userByEmail: &existing}
+	appender := &mockAppender{}
+	linker := NewLinker(querier, appender)
+
+	provider := store.IdentityProvider{ID: "p1", Slug: "idp", AutoLinkByEmail: true, TrustEmailAssertions: false}
+	claims := &UserClaims{Subject: "ext-attacker", Email: "admin@example.com"}
+
+	_, err := linker.LinkOrCreate(context.Background(), provider, claims)
+	require.ErrorIs(t, err, ErrNoMatchingAccount,
+		"an IdP email must not auto-link to a local password account without TrustEmailAssertions")
+	assert.Equal(t, 0, countEventsOfType(appender, "IdentityLinked"),
+		"no link may be created to a password account: %v", eventTypes(appender))
+}
+
+// TestLinkOrCreate_AutoLinkByEmail_PasswordAccountLinkedWhenTrusted: once the
+// operator has knowingly delegated identity via TrustEmailAssertions, the link is
+// allowed even for a password account.
+func TestLinkOrCreate_AutoLinkByEmail_PasswordAccountLinkedWhenTrusted(t *testing.T) {
+	existing := db.UsersProjection{ID: "user-trusted", Email: "u@example.com", HasPassword: true}
+	querier := &mockQuerier{userByEmail: &existing}
+	appender := &mockAppender{}
+	linker := NewLinker(querier, appender)
+
+	provider := store.IdentityProvider{ID: "p1", Slug: "idp", AutoLinkByEmail: true, TrustEmailAssertions: true}
+	claims := &UserClaims{Subject: "ext-1", Email: "u@example.com"}
+
+	result, err := linker.LinkOrCreate(context.Background(), provider, claims)
+	require.NoError(t, err)
+	assert.Equal(t, "user-trusted", result.UserID)
+	assert.Equal(t, 1, countEventsOfType(appender, "IdentityLinked"))
+}
+
 // TestLinkOrCreate_AutoLinkDisabled_NoLink pins WS5 #3: with AutoLinkByEmail
 // AND AutoCreateUsers off, an existing-by-email user is NOT linked — the
 // rejection path returns ErrNoMatchingAccount and emits no IdentityLinked.

--- a/internal/idp/main_test.go
+++ b/internal/idp/main_test.go
@@ -1,0 +1,16 @@
+package idp
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain disables the OIDC SSRF dial-control (spec 29 S4) for the whole idp
+// test binary: the OIDC integration tests spin up httptest servers on loopback,
+// which the guard correctly refuses in production. The guard's logic is covered
+// directly by TestSSRFSafeDialControl, so disabling the wiring here loses no
+// coverage while letting the loopback-backed tests run.
+func TestMain(m *testing.M) {
+	oidcDialControl = nil
+	os.Exit(m.Run())
+}

--- a/internal/idp/oidc.go
+++ b/internal/idp/oidc.go
@@ -58,11 +58,23 @@ func ssrfSafeDialControl(_, address string, _ syscall.RawConn) error {
 	if ip == nil {
 		return fmt.Errorf("ssrf guard: dial address %q is not an IP", host)
 	}
-	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+	// net.IP.IsPrivate covers RFC1918 + ULA but NOT RFC 6598 shared address space
+	// (100.64.0.0/10), reachable as internal services behind CGNAT / in some cloud
+	// VPCs — block it explicitly.
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() || cgnatNet.Contains(ip) {
 		return fmt.Errorf("ssrf guard: refusing to dial internal address %s", ip)
 	}
 	return nil
 }
+
+// cgnatNet is RFC 6598 Shared Address Space (100.64.0.0/10).
+var cgnatNet = func() *net.IPNet {
+	_, n, err := net.ParseCIDR("100.64.0.0/10")
+	if err != nil {
+		panic(err)
+	}
+	return n
+}()
 
 // newBoundedOIDCClient returns an *http.Client with connect, TLS-handshake,
 // response-header and overall timeouts so no outbound OIDC call can hang, plus an

--- a/internal/idp/oidc.go
+++ b/internal/idp/oidc.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -36,13 +37,45 @@ type OIDCProvider struct {
 // fires without a multi-second wait.
 var oidcHTTPTimeout = 12 * time.Second
 
+// ssrfSafeDialControl is a net.Dialer.Control hook (spec 29 S4) that refuses to
+// connect to internal addresses. It runs AFTER DNS resolution with the concrete
+// IP being dialed, so it defends against SSRF regardless of the configured
+// issuer/token URL (including DNS that resolves a public name to a private IP).
+// Blocks loopback, RFC1918/ULA private, link-local (incl. 169.254.169.254 cloud
+// metadata), and the unspecified address.
+// oidcDialControl is the dial-control installed on the OIDC HTTP client. A
+// package var (like oidcHTTPTimeout) so the idp test binary can disable it —
+// httptest servers listen on loopback, which the guard correctly blocks in
+// production; the guard's logic is unit-tested via ssrfSafeDialControl directly.
+var oidcDialControl = ssrfSafeDialControl
+
+func ssrfSafeDialControl(_, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return fmt.Errorf("ssrf guard: cannot parse dial address %q: %w", address, err)
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("ssrf guard: dial address %q is not an IP", host)
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+		return fmt.Errorf("ssrf guard: refusing to dial internal address %s", ip)
+	}
+	return nil
+}
+
 // newBoundedOIDCClient returns an *http.Client with connect, TLS-handshake,
-// response-header and overall timeouts so no outbound OIDC call can hang.
+// response-header and overall timeouts so no outbound OIDC call can hang, plus an
+// SSRF dial-control denylist (spec 29 S4) so a misconfigured/attacker-set
+// issuer/token URL cannot make the server probe its internal network.
 func newBoundedOIDCClient() *http.Client {
 	return &http.Client{
 		Timeout: oidcHTTPTimeout,
 		Transport: &http.Transport{
-			DialContext:           (&net.Dialer{Timeout: 5 * time.Second}).DialContext,
+			DialContext: (&net.Dialer{
+				Timeout: 5 * time.Second,
+				Control: oidcDialControl,
+			}).DialContext,
 			TLSHandshakeTimeout:   5 * time.Second,
 			ResponseHeaderTimeout: 8 * time.Second,
 		},

--- a/internal/idp/oidc_ssrf_test.go
+++ b/internal/idp/oidc_ssrf_test.go
@@ -1,0 +1,32 @@
+package idp
+
+import "testing"
+
+// TestSSRFSafeDialControl pins spec 29 S4: the OIDC dial-control denylist refuses
+// internal addresses (loopback, RFC1918/ULA, link-local incl. cloud metadata,
+// unspecified) while allowing public ones. Runs against the concrete dialed IP,
+// so it holds even when a public hostname resolves to an internal address.
+func TestSSRFSafeDialControl(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1:443", "10.0.0.5:443", "192.168.1.1:80", "172.16.0.1:443",
+		"169.254.169.254:80", // cloud metadata
+		"[::1]:443", "[fe80::1]:443", "[fc00::1]:443", "0.0.0.0:443",
+	}
+	for _, a := range blocked {
+		if err := ssrfSafeDialControl("tcp", a, nil); err == nil {
+			t.Errorf("expected internal address %s to be blocked", a)
+		}
+	}
+	allowed := []string{"8.8.8.8:443", "1.1.1.1:443", "[2606:4700:4700::1111]:443"}
+	for _, a := range allowed {
+		if err := ssrfSafeDialControl("tcp", a, nil); err != nil {
+			t.Errorf("expected public address %s to be allowed, got %v", a, err)
+		}
+	}
+	// Malformed inputs fail closed (error), never allow.
+	for _, a := range []string{"not-an-address", "hostname:443", "1.2.3.4"} {
+		if err := ssrfSafeDialControl("tcp", a, nil); err == nil {
+			t.Errorf("expected malformed address %q to error (fail closed)", a)
+		}
+	}
+}

--- a/internal/idp/oidc_ssrf_test.go
+++ b/internal/idp/oidc_ssrf_test.go
@@ -9,7 +9,8 @@ import "testing"
 func TestSSRFSafeDialControl(t *testing.T) {
 	blocked := []string{
 		"127.0.0.1:443", "10.0.0.5:443", "192.168.1.1:80", "172.16.0.1:443",
-		"169.254.169.254:80", // cloud metadata
+		"169.254.169.254:80",                    // cloud metadata
+		"100.64.0.1:443", "100.127.255.254:443", // RFC 6598 CGNAT
 		"[::1]:443", "[fe80::1]:443", "[fc00::1]:443", "0.0.0.0:443",
 	}
 	for _, a := range blocked {


### PR DESCRIPTION
Closes #533. Second-pass audit findings S2/S3/S4 (spec 29).

- **S2** — OIDC `LinkOrCreate` Step 2 refuses to auto-link an IdP-asserted email to a local **password** account unless `TrustEmailAssertions` is set (mirrors SCIM `createUser` WS5 #2). A compromised/self-service IdP can no longer seize a pre-existing credential account. Red-checked.
- **S3** — `GetSSOLoginURL` (public) added to the per-IP rate-limit ladder; `CleanupExpiredAuthStates` scheduled hourly. Bounds the storage + outbound-OIDC-discovery DoS.
- **S4** — OIDC HTTP client gets an SSRF dial-control denylist (loopback/RFC1918/ULA/link-local incl. metadata/unspecified), enforced on the resolved dial IP. Guard unit-tested; a package-var seam disables it for the loopback OIDC integration tests.

Tests: S2 linker guard (+ positive-when-trusted), S3 throttle (mirrors ListAuthMethods pattern), S4 dial-control unit test (blocked/allowed/malformed). Full idp+auth suites green.