### PR TITLE
fix: store/crypto/settings hardening (spec 29 S8/S9/S11/S12)

### DIFF
--- a/internal/api/audit_handler.go
+++ b/internal/api/audit_handler.go
@@ -132,7 +132,7 @@ var eventRedactionSchemas = map[string]map[string]redactionSchema{
 	},
 	"lps_keypair": {
 		// #495: the singleton LpsKeypairGenerated event carries the
-		// enc:v2-encrypted control private key at top-level
+		// enc:v1-encrypted control private key at top-level
 		// "private_key_enc". Even the ciphertext must not surface through
 		// ListAuditEvents — same posture as the LPS/LUKS/TOTP secrets above.
 		string(eventtypes.LpsKeypairGenerated): {paths: []string{"private_key_enc"}},

--- a/internal/api/lps_keypair.go
+++ b/internal/api/lps_keypair.go
@@ -32,14 +32,14 @@ const (
 
 // lpsKeypairAAD binds the at-rest private key to its row. The keypair is a
 // single global row, so a fixed context suffices — it still domain-separates
-// the LPS private key from every other enc:v2 secret (LUKS/LPS passwords keyed
+// the LPS private key from every other enc:v1 secret (LUKS/LPS passwords keyed
 // by device|action|type).
 func lpsKeypairAAD() []byte {
 	return crypto.SecretAAD("global", "lps-keypair", "lps-keypair-priv")
 }
 
 // EnsureLpsKeypair loads the control server's LPS sealing keypair, generating
-// it on first boot. The private key is stored ONLY in enc:v2 form (AAD-bound);
+// it on first boot. The private key is stored ONLY in enc:v1 form (AAD-bound);
 // a nil encryptor is refused because the key cannot be protected at rest.
 //
 // Event-sourced (#495): the ONLY write is an LpsKeypairGenerated append at
@@ -180,7 +180,7 @@ func adoptLpsKeypairFromStream(ctx context.Context, st *store.Store, enc *crypto
 }
 
 // decodeLpsKeypair reconstructs the private key from a stored row: decrypt the
-// enc:v2 private key, parse both halves.
+// enc:v1 private key, parse both halves.
 func decodeLpsKeypair(enc *crypto.Encryptor, pubRaw []byte, privEnc string) (*ecdh.PrivateKey, []byte, error) {
 	privBytes, err := enc.DecryptWithContext(privEnc, lpsKeypairAAD())
 	if err != nil {

--- a/internal/api/settings_handler.go
+++ b/internal/api/settings_handler.go
@@ -71,6 +71,16 @@ func (h *SettingsHandler) UpdateServerSettings(ctx context.Context, req *connect
 		return nil, err
 	}
 
+	// Attribute the fleet-wide toggle to the acting admin (spec 29 S12): this is a
+	// powerful setting change (ssh_access_for_all / user_provisioning_enabled), so
+	// its audit record must be non-repudiable. The downstream system-action
+	// cascade in runSettingsPropagation stays "system"-actored (those grants are
+	// server-owned), but the top-level ServerSettingUpdated names who flipped it.
+	userCtx, err := requireAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "server_settings",
 		StreamID:   "global",
@@ -79,8 +89,8 @@ func (h *SettingsHandler) UpdateServerSettings(ctx context.Context, req *connect
 			UserProvisioningEnabled: &req.Msg.UserProvisioningEnabled,
 			SshAccessForAll:         &req.Msg.SshAccessForAll,
 		},
-		ActorType: "system",
-		ActorID:   "system",
+		ActorType: "user",
+		ActorID:   userCtx.ID,
 	}); err != nil {
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to update server settings")
 	}

--- a/internal/api/system_actor_canary_test.go
+++ b/internal/api/system_actor_canary_test.go
@@ -54,9 +54,10 @@ var knownSystemActorSites = map[string]string{
 	"lps_keypair.go:EnsureLpsKeypair":         "server generates the singleton LPS sealing keypair at boot; no user actor",
 	"lps_keypair.go:backfillLpsKeypairStream": "server backfills the LpsKeypairGenerated event for pre-#495 deployments; no user actor",
 
-	// Settings changes that cascade into server-owned system actions at boot or
-	// on a bulk toggle — no per-user actor.
-	"settings_handler.go:UpdateServerSettings":          "settings change cascades server-owned system actions",
+	// Settings cascades into server-owned system actions on a bulk toggle — no
+	// per-user actor. (The top-level ServerSettingUpdated event is now attributed
+	// to the acting admin — spec 29 S12 — so UpdateServerSettings is no longer a
+	// system-actor site.)
 	"settings_handler.go:enableSshAccessForAllUsers":    "bulk SSH-access enablement creates server-owned actions",
 	"settings_handler.go:enableProvisioningForAllUsers": "bulk provisioning enablement creates server-owned actions",
 }

--- a/internal/eventtypes/payloads/lps_keypair.go
+++ b/internal/eventtypes/payloads/lps_keypair.go
@@ -11,7 +11,7 @@ import (
 // so an event-store replay reproduces the row 1:1 (the pre-#495 design wrote
 // the row directly and broke the replay guarantee).
 //
-// PrivateKeyEnc is enc:v2 AES-GCM ciphertext (AAD-bound via
+// PrivateKeyEnc is enc:v1 AES-GCM ciphertext (AAD-bound via
 // crypto.SecretAAD("global","lps-keypair","lps-keypair-priv")) — the emitter
 // never puts plaintext key material in the event, consistent with the at-rest
 // model for LPS rotations, TOTP secrets, and IdP client secrets. LogValue
@@ -23,7 +23,7 @@ import (
 // clock.
 type LpsKeypairGenerated struct {
 	PublicKey     []byte     `json:"public_key"`           // raw 32-byte X25519 public key
-	PrivateKeyEnc string     `json:"private_key_enc"`      // enc:v2 ciphertext, never plaintext
+	PrivateKeyEnc string     `json:"private_key_enc"`      // enc:v1 ciphertext, never plaintext
 	CreatedAt     *time.Time `json:"created_at,omitempty"` // backfill only; nil ⇒ projector uses occurred_at
 }
 

--- a/internal/store/append_events_test.go
+++ b/internal/store/append_events_test.go
@@ -354,6 +354,51 @@ func TestAppendEvents_SingleElementMatchesAppendEvent(t *testing.T) {
 	assert.Equal(t, int32(2), ev[1].StreamVersion)
 }
 
+// Spec 29 S9 — sealPII fails CLOSED: an event carrying PII-tagged fields appended
+// to a store with NO sealer wired is refused, never written as plaintext to the
+// immutable log. A store without projectors has no sealer, so this exercises the
+// fail-closed path directly.
+func TestSealPII_FailsClosedWithoutSealer(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t) // no PII sealer wired
+	ctx := context.Background()
+	name := "Secret Display Name"
+	err := st.AppendEvent(ctx, store.Event{
+		StreamType: "user",
+		StreamID:   testutil.NewID(),
+		EventType:  string(eventtypes.UserProfileUpdated),
+		Data:       payloads.UserProfileUpdated{DisplayName: &name}, // DisplayName is pii:"true"
+		ActorType:  "system",
+		ActorID:    "test",
+	})
+	require.Error(t, err, "a PII event with no sealer wired must fail closed")
+	require.Contains(t, err.Error(), "sealer")
+}
+
+// Spec 29 S9 — a NON-PII event still appends fine without a sealer (bootstrap /
+// low-level store paths that predate the wiring are unaffected).
+func TestSealPII_NonPIIEventAppendsWithoutSealer(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	require.NoError(t, st.AppendEvent(ctx, sysEvent("test", testutil.NewID(), "NoPII")))
+}
+
+// Spec 29 S8 — AppendEventWithVersion (the OCC append path) must reject an event
+// with no actor, like AppendEvent/AppendEvents. The DB columns default to ” so
+// without this check an unattributable event would silently persist.
+func TestAppendEventWithVersion_RejectsMissingActor(t *testing.T) {
+	st := testutil.SetupPostgresWithoutProjectors(t)
+	ctx := context.Background()
+	err := st.AppendEventWithVersion(ctx, store.Event{
+		StreamType: "test",
+		StreamID:   testutil.NewID(),
+		EventType:  "NoActor",
+		Data:       map[string]any{},
+		// no ActorType / ActorID
+	}, 1)
+	require.Error(t, err, "AppendEventWithVersion must reject an event with no actor")
+	require.Contains(t, err.Error(), "actor")
+}
+
 // AC 7 — an empty/nil batch is a no-op returning nil.
 func TestAppendEvents_EmptyIsNoOp(t *testing.T) {
 	st := testutil.SetupPostgresWithoutProjectors(t)

--- a/internal/store/append_events_test.go
+++ b/internal/store/append_events_test.go
@@ -383,7 +383,7 @@ func TestSealPII_NonPIIEventAppendsWithoutSealer(t *testing.T) {
 }
 
 // Spec 29 S8 — AppendEventWithVersion (the OCC append path) must reject an event
-// with no actor, like AppendEvent/AppendEvents. The DB columns default to ” so
+// with no actor, like AppendEvent/AppendEvents. The DB columns default to the empty string, so
 // without this check an unattributable event would silently persist.
 func TestAppendEventWithVersion_RejectsMissingActor(t *testing.T) {
 	st := testutil.SetupPostgresWithoutProjectors(t)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -17,6 +17,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/pressly/goose/v3"
 
+	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/store/migrations"
 )
@@ -220,6 +221,15 @@ func (s *Store) sealPII(ctx context.Context, e Event) (Event, error) {
 	sealer := s.piiSealer
 	s.listenersMu.RUnlock()
 	if sealer == nil {
+		// Fail CLOSED (spec 29 S9): a nil sealer must never let PII-tagged fields
+		// reach the append-only log as plaintext — the log is immutable, so a
+		// single plaintext PII write is unerasable forever. A non-PII event passes
+		// (bootstrap paths that predate the wiring, low-level store tests); an
+		// event carrying PII-tagged fields with no sealer is refused. Symmetric
+		// with MintUserDEK, closing the sealer/minter asymmetry.
+		if e.Data != nil && len(crypto.PIIFieldNames(e.Data)) > 0 {
+			return Event{}, fmt.Errorf("store: refusing to append PII event %q with no PII sealer wired (call SetPIISealer at boot)", e.EventType)
+		}
 		return e, nil
 	}
 	return sealer.SealEvent(ctx, e)
@@ -771,35 +781,32 @@ func (s *Store) AppendEvent(ctx context.Context, event Event) error {
 
 // AppendEventWithVersion appends an event with an expected version for optimistic locking.
 func (s *Store) AppendEventWithVersion(ctx context.Context, event Event, expectedVersion int32) error {
-	// Same fail-closed PII seal as AppendEvent (spec 19 AC 2/6).
-	event, err := s.sealPII(ctx, event)
+	// Route through prepareEvent so this OCC path shares the SAME validation +
+	// fail-closed PII seal + marshal as AppendEvent/AppendEvents — including the
+	// actor_type/actor_id required check (spec 29 S8): all three append paths now
+	// reject an unattributable event rather than only AppendEvent doing so.
+	pe, err := s.prepareEvent(ctx, event)
 	if err != nil {
-		return fmt.Errorf("seal PII: %w", err)
+		return err
 	}
 
-	data, err := json.Marshal(event.Data)
-	if err != nil {
-		return fmt.Errorf("marshal event data: %w", err)
-	}
-
-	metadata := []byte("{}")
-	if event.Metadata != nil {
-		metadata, err = json.Marshal(event.Metadata)
-		if err != nil {
-			return fmt.Errorf("marshal event metadata: %w", err)
+	// Test-only failure seam, consistent with appendOne.
+	if s.beforeInsert != nil {
+		if berr := s.beforeInsert(pe.streamType, pe.eventType); berr != nil {
+			return berr
 		}
 	}
 
 	row, err := s.queries.AppendEvent(ctx, generated.AppendEventParams{
 		ID:            ulid.Make().String(),
-		StreamType:    event.StreamType,
-		StreamID:      event.StreamID,
+		StreamType:    pe.streamType,
+		StreamID:      pe.streamID,
 		StreamVersion: expectedVersion,
-		EventType:     event.EventType,
-		Data:          data,
-		Metadata:      metadata,
-		ActorType:     event.ActorType,
-		ActorID:       event.ActorID,
+		EventType:     pe.eventType,
+		Data:          pe.data,
+		Metadata:      pe.metadata,
+		ActorType:     pe.actorType,
+		ActorID:       pe.actorID,
 	})
 	if err != nil {
 		if IsVersionConflict(err) {


### PR DESCRIPTION
Closes #535. Second-pass audit findings S8/S9/S11/S12 (spec 29).

- **S8** — `AppendEventWithVersion` routed through `prepareEvent`, so the OCC path shares the actor-required check + fail-closed PII seal + marshal with the other append paths. Test: empty-actor event rejected.
- **S9** — `sealPII` fails **closed**: a PII-tagged event with no sealer wired is refused (plaintext PII must never reach the immutable log), symmetric with the fail-closed minter. Non-PII events still pass; full store/api/scim suites unaffected. Tests: fail-closed + non-PII-passes.
- **S11** — 6 stale `enc:v2` comments → `enc:v1` (the real `crypto.prefix`; `enc:v2` is a retired format the decryptor rejects).
- **S12** — `UpdateServerSettings` top-level event attributed to the acting admin (non-repudiation); cascades stay system-actored; system-actor canary allowlist updated.

Verification: vet ✓ gofmt ✓ full `internal/store` + `internal/api` + `internal/scim` suites ✓.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Events containing personal information are now rejected when required protection is unavailable.
  * Events must include valid actor information before being recorded.
  * Event recording paths now apply consistent validation and protection checks.

* **Auditability**
  * Server setting changes now identify the authenticated administrator who made them.

* **Documentation**
  * Corrected encryption-format documentation for generated private keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->