### PR TITLE
fix: spec 29 first-batch runtime hardening — XFF right-to-left, control-URL validation, audit-redaction backstop

### DIFF
--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -147,13 +147,12 @@ func main() {
 		logger.Error("GATEWAY_VALKEY_ADDR is required")
 		os.Exit(1)
 	}
-	if cfg.ControlURL == "" {
-		logger.Error("GATEWAY_CONTROL_URL is required")
-		os.Exit(1)
-	}
-	controlURL, err := url.Parse(cfg.ControlURL)
-	if err != nil || controlURL.Scheme != "https" {
-		logger.Error("GATEWAY_CONTROL_URL must use https for the internal mTLS control connection", "control_url", cfg.ControlURL, "error", err)
+	// Validate the control URL and derive a non-secret origin for logs (spec 29
+	// AC8-9): reject non-HTTPS, hostless, or credential/query/fragment-bearing
+	// values without ever echoing the raw (possibly credential-laden) string.
+	controlOrigin, err := config.ValidateControlURL(cfg.ControlURL)
+	if err != nil {
+		logger.Error("invalid GATEWAY_CONTROL_URL", "error", err)
 		os.Exit(1)
 	}
 
@@ -219,7 +218,7 @@ func main() {
 	}
 
 	controlProxy := handler.NewControlProxy(controlHTTPClient, cfg.ControlURL, gatewayID)
-	logger.Info("control proxy initialized", "control_url", cfg.ControlURL)
+	logger.Info("control proxy initialized", "control_url", controlOrigin)
 
 	// Create connection manager
 	manager := connection.NewManager()

--- a/internal/api/audit_handler.go
+++ b/internal/api/audit_handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"log/slog"
 	"sort"
+	"strings"
 
 	"connectrpc.com/connect"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -222,6 +223,17 @@ func redactEventData(streamType, eventType string, data []byte) string {
 
 	schema, ok := schemaFor(streamType, eventType, payload)
 	if !ok {
+		// No schema for this (stream,event): fall back to a narrow recursive
+		// key-name backstop (spec 29 AC10-12) so a future or legacy raw-map
+		// append using an unclassified event can't leak a secret-looking value.
+		// This runs ONLY when schema lookup found nothing — known schemas keep
+		// their exact-path redaction. Re-marshal only if something was replaced,
+		// so a payload with no secret key is returned byte-for-byte unchanged.
+		if redactUnknownSecrets(payload) {
+			if out, err := json.Marshal(payload); err == nil {
+				return string(out)
+			}
+		}
 		return string(data)
 	}
 
@@ -244,6 +256,60 @@ func redactEventData(streamType, eventType string, data []byte) string {
 		return string(data)
 	}
 	return string(out)
+}
+
+// matchesSecretKey reports whether a JSON key name looks like it holds a
+// secret, using the narrow deny rules of spec 29 AC10 — derived from the
+// codebase's ACTUAL secret-field names, not a generic guess. Exact:
+// `password`, `passphrase`, `psk`. Prefix: `private_key*`. Suffix: `*_secret`,
+// `*_hash`, `*_encrypted`, `*_enc`. The `*_encrypted`/`*_enc` suffixes exist
+// specifically to catch the ciphertext fields (`client_secret_encrypted`,
+// `secret_encrypted`, `private_key_enc`) that a `*_secret`/`*_hash`-only set
+// misses. Matching is case-insensitive.
+func matchesSecretKey(key string) bool {
+	k := strings.ToLower(key)
+	switch k {
+	case "password", "passphrase", "psk":
+		return true
+	}
+	if strings.HasPrefix(k, "private_key") {
+		return true
+	}
+	return strings.HasSuffix(k, "_secret") ||
+		strings.HasSuffix(k, "_hash") ||
+		strings.HasSuffix(k, "_encrypted") ||
+		strings.HasSuffix(k, "_enc")
+}
+
+// redactUnknownSecrets recursively walks a decoded JSON value and replaces the
+// value of every secret-looking key (matchesSecretKey) with "[REDACTED]",
+// descending into nested maps and arrays. It returns true if anything was
+// replaced. A matched key's value is replaced wholesale — the walk does not
+// descend into it — so a secret held as an object or array is fully scrubbed.
+// This is the unknown-schema backstop only (spec 29 AC10-12); schema-aware
+// redaction is unchanged.
+func redactUnknownSecrets(v any) bool {
+	changed := false
+	switch t := v.(type) {
+	case map[string]any:
+		for k, val := range t {
+			if matchesSecretKey(k) {
+				t[k] = "[REDACTED]"
+				changed = true
+				continue
+			}
+			if redactUnknownSecrets(val) {
+				changed = true
+			}
+		}
+	case []any:
+		for _, item := range t {
+			if redactUnknownSecrets(item) {
+				changed = true
+			}
+		}
+	}
+	return changed
 }
 
 // schemaFor selects the redactionSchema for an event. Action AND

--- a/internal/api/audit_redactor_internal_test.go
+++ b/internal/api/audit_redactor_internal_test.go
@@ -220,15 +220,91 @@ func TestRedactEventData_SCIMTokenHash(t *testing.T) {
 	}
 }
 
-// TestRedactEventData_UnknownShapesPassThrough locks the design contract that
-// the redactor is conservative for NON action/execution streams: an unknown
-// (stream,event) combination passes through unchanged.
-func TestRedactEventData_UnknownShapesPassThrough(t *testing.T) {
-	in := map[string]any{"name": "do-thing", "password": "not-redacted-unknown-schema"}
-	raw, err := json.Marshal(in)
-	require.NoError(t, err)
-	out := redactEventData("unknown_stream", "UnknownEvent", raw)
-	assert.Equal(t, string(raw), out)
+// TestRedactEventData_UnknownSchemaSecretBackstop pins the spec 29 AC10-12
+// key-name backstop: for a decoded object whose (stream,event) has NO redaction
+// schema, secret-looking keys are recursively redacted; everything else is byte-
+// identical passthrough. The deny set is derived from the codebase's real
+// secret-field names, so the ciphertext-suffix fields (`client_secret_encrypted`,
+// `secret_encrypted`, `private_key_enc`) — which a `*_secret`/`*_hash`-only set
+// would silently miss because they end in `_encrypted`/`_enc` — must be caught.
+func TestRedactEventData_UnknownSchemaSecretBackstop(t *testing.T) {
+	const secret = "SUPER-SECRET-VALUE"
+
+	t.Run("redacts secret-looking keys, recursively, in unknown-schema objects", func(t *testing.T) {
+		in := map[string]any{
+			"name":       "do-thing", // non-secret, must survive
+			"count":      7,
+			"password":   secret,
+			"passphrase": secret,
+			"psk":        secret,
+			"nested": map[string]any{
+				"private_key_pem":         secret, // private_key* prefix
+				"client_secret_encrypted": secret, // *_encrypted (NOT *_secret)
+				"secret_encrypted":        secret, // *_encrypted
+				"private_key_enc":         secret, // *_enc
+				"scim_token_hash":         secret, // *_hash
+			},
+			"items": []any{
+				map[string]any{"api_secret": secret}, // *_secret inside an array element
+				map[string]any{"label": "keep-me"},
+			},
+		}
+		raw, err := json.Marshal(in)
+		require.NoError(t, err)
+
+		out := redactEventData("unknown_stream", "UnknownEvent", raw)
+
+		// Every secret value is gone; the marker appears; non-secret data survives.
+		assert.NotContains(t, out, secret, "a secret value leaked through the backstop")
+		assert.Contains(t, out, "[REDACTED]")
+		assert.Contains(t, out, "do-thing")
+		assert.Contains(t, out, "keep-me")
+
+		// Structural check: exactly the secret keys were replaced.
+		var got map[string]any
+		require.NoError(t, json.Unmarshal([]byte(out), &got))
+		nested := got["nested"].(map[string]any)
+		for _, k := range []string{"private_key_pem", "client_secret_encrypted", "secret_encrypted", "private_key_enc", "scim_token_hash"} {
+			assert.Equal(t, "[REDACTED]", nested[k], "nested.%s not redacted", k)
+		}
+		assert.Equal(t, "[REDACTED]", got["password"])
+		assert.Equal(t, "[REDACTED]", got["passphrase"])
+		assert.Equal(t, "[REDACTED]", got["psk"])
+		items := got["items"].([]any)
+		assert.Equal(t, "[REDACTED]", items[0].(map[string]any)["api_secret"])
+		assert.Equal(t, "keep-me", items[1].(map[string]any)["label"])
+		assert.Equal(t, "do-thing", got["name"])
+	})
+
+	t.Run("ciphertext-suffix fields are NOT reachable by a _secret/_hash-only set", func(t *testing.T) {
+		// Documents why the deny set includes *_encrypted / *_enc: these field
+		// names end in neither _secret nor _hash, so a narrower set would miss
+		// them. Asserting the naming keeps the rationale honest against edits.
+		for _, k := range []string{"client_secret_encrypted", "secret_encrypted", "private_key_enc"} {
+			assert.False(t, strings.HasSuffix(k, "_secret") || strings.HasSuffix(k, "_hash"),
+				"%s unexpectedly ends in _secret/_hash — the *_encrypted/*_enc rules would be redundant", k)
+		}
+	})
+
+	t.Run("unknown-schema object with no secret key is byte-identical passthrough", func(t *testing.T) {
+		in := map[string]any{"name": "do-thing", "region": "eu", "replicas": 3}
+		raw, err := json.Marshal(in)
+		require.NoError(t, err)
+		out := redactEventData("unknown_stream", "UnknownEvent", raw)
+		assert.Equal(t, string(raw), out, "no secret key present — original bytes must be returned unchanged")
+	})
+
+	t.Run("non-object and malformed payloads are unchanged", func(t *testing.T) {
+		// A JSON array is a valid JSON value but not an object: unchanged.
+		arr := []byte(`[{"password":"x"}]`)
+		assert.Equal(t, string(arr), redactEventData("unknown_stream", "UnknownEvent", arr))
+		// A scalar is unchanged.
+		scalar := []byte(`"password"`)
+		assert.Equal(t, string(scalar), redactEventData("unknown_stream", "UnknownEvent", scalar))
+		// Malformed JSON is unchanged.
+		bad := []byte(`{"password": `)
+		assert.Equal(t, string(bad), redactEventData("unknown_stream", "UnknownEvent", bad))
+	})
 }
 
 // TestRedactEventData_ActionWithoutSecretsPassesThrough locks that a

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -177,6 +177,50 @@ func isTrustedProxy(addr string) bool {
 	return false
 }
 
+// resolveClientIP applies trusted-proxy semantics to a direct peer address and
+// its forwarded headers, returning the attributable client IP. It is the single
+// resolver shared by clientIP (Connect interceptor) and ClientIPFromHTTP, so the
+// two paths cannot drift.
+//
+// Proxy headers are honoured only when peerIP is itself a trusted proxy —
+// an untrusted direct peer's headers are ignored entirely. X-Forwarded-For is
+// walked RIGHT TO LEFT (spec 29): trusted-proxy hops are skipped and the first
+// untrusted address is the client. This defeats a spoofed leftmost entry, which
+// the previous first-hop selection trusted. A malformed hop encountered before a
+// trustworthy client is established, or an all-trusted chain, falls back to the
+// direct peer rather than to a farther-left, attacker-controllable value.
+// X-Real-IP is consulted only when X-Forwarded-For is absent. Returns peerIP
+// (unvalidated) when no forwarded value applies; callers decide how to treat an
+// unparsable peer.
+func resolveClientIP(peerIP, xff, xri string) string {
+	if !isTrustedProxy(peerIP) {
+		return peerIP
+	}
+	if xff != "" {
+		hops := strings.Split(xff, ",")
+		for i := len(hops) - 1; i >= 0; i-- {
+			hop := strings.TrimSpace(hops[i])
+			if net.ParseIP(hop) == nil {
+				// Malformed hop: the chain is untrustworthy from here leftward.
+				return peerIP
+			}
+			if isTrustedProxy(hop) {
+				continue // a proxy we placed, not the client
+			}
+			return hop // first untrusted address, walking right to left
+		}
+		// Every hop was a trusted proxy — the real client is farther upstream
+		// than any recorded address; fall back to the direct peer.
+		return peerIP
+	}
+	if xri != "" {
+		if ip := strings.TrimSpace(xri); net.ParseIP(ip) != nil {
+			return ip
+		}
+	}
+	return peerIP
+}
+
 // ClientIPFromHTTP is the http.Request analogue of clientIP — used by
 // non-Connect handlers (SCIM, /health, OIDC callback) that need the
 // same trusted-proxy semantics. Falls back to RemoteAddr when proxy
@@ -187,27 +231,13 @@ func isTrustedProxy(addr string) bool {
 // identify" and skip per-IP rate-limit bookkeeping rather than coalesce
 // every anonymous request onto a single bucket.
 func ClientIPFromHTTP(r *http.Request) string {
-	peerAddr := r.RemoteAddr
-	peerIP := peerAddr
-	if host, _, err := net.SplitHostPort(peerAddr); err == nil {
+	peerIP := r.RemoteAddr
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
 		peerIP = host
 	}
-	if isTrustedProxy(peerIP) {
-		if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-			ip := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0])
-			if parsed := net.ParseIP(ip); parsed != nil {
-				return ip
-			}
-		}
-		if xri := r.Header.Get("X-Real-IP"); xri != "" {
-			ip := strings.TrimSpace(xri)
-			if parsed := net.ParseIP(ip); parsed != nil {
-				return ip
-			}
-		}
-	}
-	if parsed := net.ParseIP(peerIP); parsed != nil {
-		return peerIP
+	resolved := resolveClientIP(peerIP, r.Header.Get("X-Forwarded-For"), r.Header.Get("X-Real-IP"))
+	if net.ParseIP(resolved) != nil {
+		return resolved
 	}
 	return ""
 }
@@ -216,30 +246,12 @@ func ClientIPFromHTTP(r *http.Request) string {
 // X-Real-IP) are only trusted when the direct peer is in TrustedProxies.
 // Falls back to the direct peer address.
 func clientIP(req connect.AnyRequest) string {
-	// Get the direct peer address first
 	peerAddr := req.Peer().Addr
 	peerIP := peerAddr
 	if host, _, err := net.SplitHostPort(peerAddr); err == nil {
 		peerIP = host
 	}
-
-	// Only trust proxy headers if the direct peer is a trusted proxy
-	if isTrustedProxy(peerIP) {
-		if xff := req.Header().Get("X-Forwarded-For"); xff != "" {
-			ip := strings.TrimSpace(strings.SplitN(xff, ",", 2)[0])
-			if parsed := net.ParseIP(ip); parsed != nil {
-				return ip
-			}
-		}
-		if xri := req.Header().Get("X-Real-IP"); xri != "" {
-			ip := strings.TrimSpace(xri)
-			if parsed := net.ParseIP(ip); parsed != nil {
-				return ip
-			}
-		}
-	}
-
-	return peerIP
+	return resolveClientIP(peerIP, req.Header().Get("X-Forwarded-For"), req.Header().Get("X-Real-IP"))
 }
 
 // RateLimiters bundles the per-procedure-family rate limiters the

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -251,7 +251,16 @@ func clientIP(req connect.AnyRequest) string {
 	if host, _, err := net.SplitHostPort(peerAddr); err == nil {
 		peerIP = host
 	}
-	return resolveClientIP(peerIP, req.Header().Get("X-Forwarded-For"), req.Header().Get("X-Real-IP"))
+	// Validate the resolved value exactly as ClientIPFromHTTP does, so the two
+	// paths cannot drift: a peer that isn't a parsable IP (non-TCP transport,
+	// unix socket) yields "" rather than a raw non-IP string. "" is also the
+	// safer limiter key — unidentifiable peers share one restrictive bucket
+	// instead of each getting a fresh one from an attacker-varied string.
+	resolved := resolveClientIP(peerIP, req.Header().Get("X-Forwarded-For"), req.Header().Get("X-Real-IP"))
+	if net.ParseIP(resolved) != nil {
+		return resolved
+	}
+	return ""
 }
 
 // RateLimiters bundles the per-procedure-family rate limiters the

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -931,4 +932,57 @@ func TestClientIPFromHTTP_TrustAttribution(t *testing.T) {
 			assert.Equal(t, tc.want, ClientIPFromHTTP(r))
 		})
 	}
+}
+
+// TestClientIP_ConnectPathResolution drives the Connect interceptor's clientIP
+// (the rate-limit resolver) end-to-end through an httptest server, so the
+// Connect path is covered independently of the shared resolveClientIP unit
+// table (exercised via the HTTP path). The handler echoes clientIP(req) back in
+// a header, so the assertion is on the resolved value directly — it would catch
+// a drift where clientIP read the wrong header or the peer address instead of
+// delegating to resolveClientIP. The loopback test peer is trusted so forwarded
+// headers are honoured.
+func TestClientIP_ConnectPathResolution(t *testing.T) {
+	t.Cleanup(func() { SetTrustedProxies(nil) })
+	// Trust the loopback test peer and any loopback tail hops in XFF.
+	SetTrustedProxies([]string{"127.0.0.0/8", "::1/128"})
+
+	jwtMgr := NewJWTManager(JWTConfig{Secret: []byte("test-secret"), AccessTokenExpiry: 15 * time.Minute})
+	interceptor := NewAuthInterceptor(testLogger, jwtMgr, RateLimiters{})
+
+	procedure := "/pm.v1.ControlService/Login" // public: no auth needed
+	mux := http.NewServeMux()
+	mux.Handle(procedure, connect.NewUnaryHandler(
+		procedure,
+		func(ctx context.Context, req *connect.Request[emptypb.Empty]) (*connect.Response[emptypb.Empty], error) {
+			resp := connect.NewResponse(&emptypb.Empty{})
+			resp.Header().Set("X-Resolved-IP", clientIP(req))
+			return resp, nil
+		},
+		connect.WithInterceptors(interceptor),
+	))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+	client := connect.NewClient[emptypb.Empty, emptypb.Empty](http.DefaultClient, srv.URL+procedure)
+
+	resolve := func(xff string) string {
+		req := connect.NewRequest(&emptypb.Empty{})
+		if xff != "" {
+			req.Header().Set("X-Forwarded-For", xff)
+		}
+		resp, err := client.CallUnary(context.Background(), req)
+		require.NoError(t, err)
+		return resp.Header().Get("X-Resolved-IP")
+	}
+
+	// Right-to-left: skip the trusted loopback tail hop and return the real
+	// client, NOT the spoofed leftmost entry (which first-hop selection would
+	// return).
+	assert.Equal(t, "203.0.113.10", resolve("9.9.9.9, 203.0.113.10, 127.0.0.1"))
+	// A single untrusted hop is returned as-is.
+	assert.Equal(t, "203.0.113.10", resolve("203.0.113.10"))
+	// No XFF + trusted peer → the loopback peer itself (a valid IP, not "").
+	peer := resolve("")
+	assert.NotEmpty(t, peer)
+	assert.NotNil(t, net.ParseIP(peer), "resolved peer must be a parsable IP, got %q", peer)
 }

--- a/internal/auth/interceptor_test.go
+++ b/internal/auth/interceptor_test.go
@@ -803,11 +803,43 @@ func TestClientIPFromHTTP_TrustAttribution(t *testing.T) {
 			want:       "198.51.100.5",
 		},
 		{
-			name:       "trusted /8 peer + XFF returns the first XFF hop",
+			// Right-to-left walk: the trailing trusted-proxy hop (10.9.9.9) is
+			// skipped and the first untrusted address (the spoofed left entry) is
+			// returned — here there is only one untrusted candidate.
+			name:       "trusted /8 peer + XFF: trailing trusted hop skipped, untrusted returned",
 			trusted:    []string{"10.0.0.0/8"},
 			remoteAddr: "10.1.2.3:1234",
 			xff:        spoofed + ", 10.9.9.9",
 			want:       spoofed,
+		},
+		{
+			// The distinguishing right-to-left case (AC6): attacker prepends a
+			// spoofed left entry, then the real client, then a trusted proxy hop.
+			// Leftmost-selection would return the spoof; right-to-left skips the
+			// trusted tail hop and returns the real client.
+			name:       "trusted peer + [spoof, client, trusted-proxy]: returns the client, not the spoof",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			xff:        spoofed + ", 198.51.100.20, 10.9.9.9",
+			want:       "198.51.100.20",
+		},
+		{
+			// Multiple trusted proxies at the tail are all skipped.
+			name:       "trusted peer + [client, proxy, proxy]: skips both trusted tail hops",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			xff:        "198.51.100.20, 10.9.9.9, 10.8.8.8",
+			want:       "198.51.100.20",
+		},
+		{
+			// Every XFF hop is a trusted proxy: the real client is farther
+			// upstream than any recorded address, so fall back to the direct peer
+			// rather than invent one.
+			name:       "trusted peer + all-trusted XFF chain falls back to the peer",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			xff:        "10.9.9.9, 10.8.8.8",
+			want:       "10.1.2.3",
 		},
 		{
 			name:       "trusted peer + X-Real-IP (no XFF) returns X-Real-IP",
@@ -817,12 +849,27 @@ func TestClientIPFromHTTP_TrustAttribution(t *testing.T) {
 			want:       "192.0.2.7",
 		},
 		{
-			name:       "trusted peer + malformed XFF falls through to X-Real-IP",
+			// XFF is present but malformed: X-Real-IP is consulted ONLY when XFF is
+			// absent, and a malformed hop stops the right-to-left walk — so this
+			// falls back to the direct peer, never to X-Real-IP or a farther-left
+			// (attacker-controllable) value.
+			name:       "trusted peer + malformed XFF falls back to the peer, not X-Real-IP",
 			trusted:    []string{"10.0.0.0/8"},
 			remoteAddr: "10.1.2.3:1234",
 			xff:        "not-an-ip",
 			xri:        "192.0.2.7",
-			want:       "192.0.2.7",
+			want:       "10.1.2.3",
+		},
+		{
+			// A malformed hop encountered before a trustworthy client is
+			// established (AC7): the trailing trusted hop is skipped, then the
+			// malformed middle hop aborts the walk to the direct peer instead of
+			// trusting the farther-left spoof.
+			name:       "trusted peer + malformed middle hop aborts to the peer (AC7)",
+			trusted:    []string{"10.0.0.0/8"},
+			remoteAddr: "10.1.2.3:1234",
+			xff:        spoofed + ", garbage, 10.9.9.9",
+			want:       "10.1.2.3",
 		},
 		{
 			name:       "trusted peer + malformed XFF + no X-Real-IP falls through to the peer",

--- a/internal/config/control_url.go
+++ b/internal/config/control_url.go
@@ -1,0 +1,51 @@
+package config
+
+import (
+	"errors"
+	"net/url"
+	"strings"
+)
+
+// ValidateControlURL validates a gateway control (InternalService) URL at
+// startup and returns its non-secret origin — scheme://host[:port] — for
+// logging (spec 29 AC8-9).
+//
+// The accepted shape is HTTPS with a non-empty host and no user-info, query,
+// or fragment: an InternalService base URL never legitimately carries any of
+// those, and each is a channel through which a credential could be smuggled
+// into startup logs. A path is permitted (Connect base URLs may have one) but
+// is stripped from the returned origin.
+//
+// On rejection the error names the offending component but never echoes the
+// raw URL, so a mistyped or injected credential-bearing value is not leaked to
+// logs. The origin is empty on error.
+func ValidateControlURL(raw string) (string, error) {
+	if raw == "" {
+		return "", errors.New("control URL is empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", errors.New("control URL is malformed")
+	}
+	if u.Scheme != "https" {
+		return "", errors.New("control URL must use the https scheme")
+	}
+	// u.Host is host[:port]; Hostname() strips the port. A space or other stray
+	// character in the authority means a malformed URL that url.Parse tolerated.
+	if u.Host == "" || u.Hostname() == "" {
+		return "", errors.New("control URL has no host")
+	}
+	if strings.ContainsAny(u.Host, " \t") {
+		return "", errors.New("control URL host is malformed")
+	}
+	if u.User != nil {
+		return "", errors.New("control URL must not contain user-info credentials")
+	}
+	if u.RawQuery != "" {
+		return "", errors.New("control URL must not contain a query string")
+	}
+	if u.Fragment != "" || u.RawFragment != "" {
+		return "", errors.New("control URL must not contain a fragment")
+	}
+	return u.Scheme + "://" + u.Host, nil
+}

--- a/internal/config/control_url_test.go
+++ b/internal/config/control_url_test.go
@@ -1,0 +1,83 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestValidateControlURL pins the gateway control-URL startup contract
+// (spec 29 AC8-9): accept only HTTPS URLs with a host and no user-info,
+// query, or fragment; on success return the bare scheme://host[:port]
+// origin; on failure never echo the raw (possibly credential-bearing)
+// value in the error.
+func TestValidateControlURL(t *testing.T) {
+	t.Run("accepted", func(t *testing.T) {
+		cases := []struct {
+			name       string
+			in         string
+			wantOrigin string
+		}{
+			{"host and port", "https://control:8082", "https://control:8082"},
+			{"host only", "https://control", "https://control"},
+			// A path is accepted for a Connect base URL, but the logged origin
+			// never contains it.
+			{"path allowed, stripped from origin", "https://control:8082/internal", "https://control:8082"},
+			{"ipv6 host", "https://[2001:db8::1]:8082", "https://[2001:db8::1]:8082"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				origin, err := ValidateControlURL(tc.in)
+				if err != nil {
+					t.Fatalf("ValidateControlURL(%q) unexpected error: %v", tc.in, err)
+				}
+				if origin != tc.wantOrigin {
+					t.Errorf("origin = %q, want %q", origin, tc.wantOrigin)
+				}
+				// The origin must never carry a path, query, fragment, or credential.
+				for _, forbidden := range []string{"/internal", "?", "#", "@"} {
+					if strings.Contains(origin, forbidden) {
+						t.Errorf("origin %q leaks forbidden component %q", origin, forbidden)
+					}
+				}
+			})
+		}
+	})
+
+	t.Run("rejected without echoing the raw value", func(t *testing.T) {
+		const secret = "s3cr3t-p4ss"
+		cases := []struct {
+			name string
+			in   string
+		}{
+			{"empty", ""},
+			{"malformed", "://nope"},
+			{"whitespace in host", "https://cont rol:8082"},
+			{"non-https http", "http://control:8082"},
+			{"non-https scheme", "ftp://control:8082"},
+			{"hostless", "https:///internal"},
+			{"user-info credential", "https://admin:" + secret + "@control:8082"},
+			{"query string", "https://control:8082?token=" + secret},
+			{"fragment", "https://control:8082#" + secret},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				origin, err := ValidateControlURL(tc.in)
+				if err == nil {
+					t.Fatalf("ValidateControlURL(%q) = %q, want error", tc.in, origin)
+				}
+				if origin != "" {
+					t.Errorf("origin = %q on error, want empty", origin)
+				}
+				// The error must name the offending component but never echo the
+				// raw URL or any secret it carried.
+				msg := err.Error()
+				if tc.in != "" && strings.Contains(msg, tc.in) {
+					t.Errorf("error %q echoes the raw URL %q", msg, tc.in)
+				}
+				if strings.Contains(msg, secret) {
+					t.Errorf("error %q leaks the embedded secret", msg)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
Closes #537. Implements three of the five spec 29 first-batch findings — the pure-Go, fully test-verifiable ones. Each is an independent defense-in-depth change committed separately.

## AC 5-7 — Right-to-left forwarded-IP resolution
`clientIP` (Connect interceptor) and its sibling `ClientIPFromHTTP` (SCIM auth) both selected the **leftmost** X-Forwarded-For entry, which a client behind a trusted proxy can spoof to poison per-IP rate-limit attribution. Extracted a single `resolveClientIP` walker used by both paths: walks XFF **right-to-left**, skipping trusted-proxy hops and returning the first untrusted address; a malformed hop or an all-trusted chain falls back to the direct peer; X-Real-IP is consulted only when XFF is absent. Both paths validate the resolved value with `net.ParseIP` so they cannot drift.

## AC 8-9 — Gateway control-URL validation
`GATEWAY_CONTROL_URL` was parsed only for `scheme==https` and then logged **raw** at startup (twice), so a mistyped/injected value carrying user-info/query/fragment credentials would land in logs. Added `config.ValidateControlURL`: HTTPS + host required; user-info/query/fragment rejected; the error names the bad component without echoing the raw value; success logs only `scheme://host[:port]`.

## AC 10-12 — Unknown-schema audit-redaction backstop
An audit event whose (stream,event) has no redaction schema was returned to the client verbatim, so a future/legacy raw-map append carrying a secret-looking key would leak it. When schema lookup finds nothing, recursively redact keys matching the narrow deny set derived from the codebase's **real** secret-field names (`password`/`passphrase`/`psk`, `private_key*`, `*_secret`/`*_hash`/`*_encrypted`/`*_enc`). The `*_encrypted`/`*_enc` suffixes specifically catch `client_secret_encrypted`/`secret_encrypted`/`private_key_enc`, which a `*_secret`/`*_hash`-only set misses. Re-marshals only when something changed, so non-secret objects stay byte-identical; schema-aware redaction is untouched.

## Deferred (not in this PR)
- **Task-envelope HMAC binding** (AC 1-4) — clean-break envelope requires a coordinated queue-drain deploy of control+gateway+indexer; needs a deploy window.
- **Traefik docker-socket-proxy** (AC 13-14) — changes the reference deployment's live ingress; can't be verified without a live Traefik.

Spec: `docs/content/06-specs/29-server-security-audit-hardening.md`. Full suite + `go vet ./...` green; TDD (red-before-green) for each change.