### PR TITLE
fix: close user-group existence oracle by scope-checking before lookup (spec 29 S10)

### DIFF
--- a/internal/api/scope_existence_oracle_test.go
+++ b/internal/api/scope_existence_oracle_test.go
@@ -1,0 +1,80 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestUserGroupHandlers_ExistenceOracleClosed pins spec 29 S10 for the
+// user-group mutation handlers: a scope-restricted caller must not be able to
+// distinguish an existing-but-out-of-scope group from a nonexistent one. Both
+// must return the SAME code (PermissionDenied) rather than
+// PermissionDenied-vs-NotFound.
+//
+// The fix reorders the scope check ahead of the existence lookup (the scope
+// gate reads the caller's grants from the auth context, not the DB), so an id
+// outside the caller's scope — whether it exists or not — is denied before any
+// lookup. This keeps the established WS3 scope-denial code (PermissionDenied)
+// while removing the existence oracle; before the fix the nonexistent id fell
+// through to the lookup and leaked NotFound.
+func TestUserGroupHandlers_ExistenceOracleClosed(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := api.NewUserGroupHandler(st, slog.Default())
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	ugInScope := testutil.CreateTestUserGroup(t, st, actor, "In Scope")
+	ugOutOfScope := testutil.CreateTestUserGroup(t, st, actor, "Out Of Scope") // exists, not in scope
+	nonexistent := testutil.NewID()                                            // valid ULID, no such group
+
+	// A caller scoped to ugInScope only.
+	scoped := func() context.Context {
+		return userGroupScopeGrants(
+			[]string{"UpdateUserGroup", "DeleteUserGroup", "RemoveUserFromGroup"},
+			[]string{ugInScope},
+		)
+	}
+
+	gates := []struct {
+		name   string
+		invoke func(ctx context.Context, groupID string) error
+	}{
+		{"UpdateUserGroup", func(ctx context.Context, id string) error {
+			_, err := h.UpdateUserGroup(ctx, connect.NewRequest(&pm.UpdateUserGroupRequest{GroupId: id, Name: "renamed"}))
+			return err
+		}},
+		{"DeleteUserGroup", func(ctx context.Context, id string) error {
+			_, err := h.DeleteUserGroup(ctx, connect.NewRequest(&pm.DeleteUserGroupRequest{Id: id}))
+			return err
+		}},
+		{"RemoveUserFromGroup", func(ctx context.Context, id string) error {
+			_, err := h.RemoveUserFromGroup(ctx, connect.NewRequest(&pm.RemoveUserFromGroupRequest{GroupId: id, UserId: testutil.NewID()}))
+			return err
+		}},
+	}
+
+	for _, g := range gates {
+		t.Run(g.name+" is uniform for out-of-scope existing vs nonexistent", func(t *testing.T) {
+			existErr := g.invoke(scoped(), ugOutOfScope)
+			require.Error(t, existErr)
+			missingErr := g.invoke(scoped(), nonexistent)
+			require.Error(t, missingErr)
+
+			// The oracle is closed only if BOTH return the same code.
+			assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(existErr),
+				"out-of-scope existing group should be PermissionDenied")
+			assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(missingErr),
+				"nonexistent group must NOT leak NotFound — an out-of-scope caller cannot tell it apart from an existing one")
+			assert.Equal(t, connect.CodeOf(existErr), connect.CodeOf(missingErr),
+				"existence oracle: out-of-scope existing and nonexistent must return the same code")
+		})
+	}
+}

--- a/internal/api/user_group_handler.go
+++ b/internal/api/user_group_handler.go
@@ -212,11 +212,12 @@ func (h *UserGroupHandler) UpdateUserGroup(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	_, err := h.store.Repos().UserGroup.Get(ctx, req.Msg.GroupId)
-	if err != nil {
-		return nil, handleGetError(ctx, err, ErrUserGroupNotFound, "user group not found")
-	}
-
+	// Authenticate and scope-check the group id BEFORE the existence lookup
+	// (spec 29 S10). The scope gate reads the caller's grants from the auth
+	// context, not the DB, so an id outside the caller's scope — whether it
+	// exists or not — is denied here uniformly with PermissionDenied. Looking up
+	// first would leak NotFound for a nonexistent id, letting a scoped caller
+	// distinguish it from an existing-but-out-of-scope group.
 	userCtx, err := requireAuth(ctx)
 	if err != nil {
 		return nil, err
@@ -224,6 +225,10 @@ func (h *UserGroupHandler) UpdateUserGroup(ctx context.Context, req *connect.Req
 
 	if err := auth.EnforceUserGroupScope(ctx, "UpdateUserGroup", req.Msg.GroupId); err != nil {
 		return nil, err
+	}
+
+	if _, err := h.store.Repos().UserGroup.Get(ctx, req.Msg.GroupId); err != nil {
+		return nil, handleGetError(ctx, err, ErrUserGroupNotFound, "user group not found")
 	}
 
 	if err := appendEvent(ctx, h.store, h.logger, store.Event{
@@ -312,8 +317,22 @@ func (h *UserGroupHandler) DeleteUserGroup(ctx context.Context, req *connect.Req
 		return nil, err
 	}
 
-	_, err := h.store.Repos().UserGroup.Get(ctx, req.Msg.Id)
+	// Authenticate and scope-check BEFORE any DB observation (spec 29 S10). The
+	// scope gate reads the caller's grants from the auth context, so an
+	// out-of-scope id is denied here uniformly — before the existence lookup
+	// (which would leak NotFound for a nonexistent id) and before the
+	// SCIM-managed probe (which would leak the group's SCIM-managed status to a
+	// caller with no scope over it).
+	userCtx, err := requireAuth(ctx)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceUserGroupScope(ctx, "DeleteUserGroup", req.Msg.Id); err != nil {
+		return nil, err
+	}
+
+	if _, err := h.store.Repos().UserGroup.Get(ctx, req.Msg.Id); err != nil {
 		return nil, handleGetError(ctx, err, ErrUserGroupNotFound, "user group not found")
 	}
 
@@ -326,15 +345,6 @@ func (h *UserGroupHandler) DeleteUserGroup(ctx context.Context, req *connect.Req
 	}
 	if isScimManaged {
 		return nil, apiErrorCtx(ctx, ErrSCIMManagedResource, connect.CodeFailedPrecondition, "cannot delete a SCIM-managed group — remove it from the identity provider instead")
-	}
-
-	userCtx, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := auth.EnforceUserGroupScope(ctx, "DeleteUserGroup", req.Msg.Id); err != nil {
-		return nil, err
 	}
 
 	appendDelete := func() error {
@@ -483,6 +493,21 @@ func (h *UserGroupHandler) RemoveUserFromGroup(ctx context.Context, req *connect
 		return nil, err
 	}
 
+	// Authenticate and scope-check BEFORE any DB observation (spec 29 S10). The
+	// scope gate reads the caller's grants from the auth context, so an
+	// out-of-scope id is denied here uniformly — before the existence lookup
+	// (which would leak NotFound for a nonexistent id), the dynamic-group probe
+	// (which would leak the group's dynamic status), and the membership probe.
+	// Removal only needs the group id-match — it cannot expand the caller's scope.
+	userCtx, err := requireAuth(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := auth.EnforceUserGroupScope(ctx, "RemoveUserFromGroup", req.Msg.GroupId); err != nil {
+		return nil, err
+	}
+
 	// Verify group exists and is not dynamic
 	group, err := h.store.Repos().UserGroup.Get(ctx, req.Msg.GroupId)
 	if err != nil {
@@ -491,19 +516,6 @@ func (h *UserGroupHandler) RemoveUserFromGroup(ctx context.Context, req *connect
 
 	if group.IsDynamic {
 		return nil, apiErrorCtx(ctx, ErrDynamicGroupManualModify, connect.CodeFailedPrecondition, "cannot manually modify members of a dynamic group")
-	}
-
-	// Authenticate and scope-check BEFORE the membership probe so an out-of-scope
-	// group is denied with PermissionDenied rather than leaking membership state
-	// (a non-member would otherwise surface as NotFound first). Removal only needs
-	// the group id-match — it cannot expand the caller's scope.
-	userCtx, err := requireAuth(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := auth.EnforceUserGroupScope(ctx, "RemoveUserFromGroup", req.Msg.GroupId); err != nil {
-		return nil, err
 	}
 
 	// Verify membership


### PR DESCRIPTION
Closes #539.

`UpdateUserGroup`/`DeleteUserGroup`/`RemoveUserFromGroup` looked the group up (→ NotFound if missing) **before** the scope gate (→ PermissionDenied if out of scope), so a scope-restricted caller could distinguish an existing out-of-scope group from a nonexistent one — and, for delete, observe the group's SCIM-managed status (via the FailedPrecondition it returned before the scope check).

The scope gate (`EnforceUserGroupScope`) resolves the caller's grants from the **auth context, not the DB**, so it can run first. Reordering it ahead of every DB observation denies an out-of-scope id — existing or not — uniformly with **PermissionDenied**, before any lookup. This keeps the established WS3 scope-denial code (existing scope tests stay green) while removing the oracle.

New regression test `TestUserGroupHandlers_ExistenceOracleClosed` drives all three handlers with a scoped caller against both an existing out-of-scope group and a nonexistent id, and asserts they return the **same** code (was PermissionDenied vs NotFound).

**Scope note:** the three execution/log load-then-scope handlers (`GetExecution`/`CancelExecution`/`GetDeviceLogResult`) need the loaded row to know the device before they can scope-check, so their only fix is remapping PermissionDenied→NotFound — a client-visible error-code change that collides with the WS3 scope-denial convention. Tracked separately for a maintainer decision, not in this PR.

Spec: `docs/content/06-specs/29-server-security-audit-hardening.md` (S10).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access control for user-group updates, deletions, and removals.
  * Prevented unauthorized requests from revealing whether a group exists or exposing its status.
  * Standardized responses for inaccessible and nonexistent groups to protect resource information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->