### PR TITLE
fix: uniform PermissionDenied on out-of-scope execution/log reads (spec 29 S10)

### DIFF
--- a/internal/api/action_dispatch.go
+++ b/internal/api/action_dispatch.go
@@ -691,6 +691,12 @@ func (h *ActionHandler) GetExecution(ctx context.Context, req *connect.Request[p
 
 	exec, err := h.store.Repos().Execution.Get(ctx, req.Msg.Id)
 	if err != nil {
+		if store.IsNotFound(err) {
+			// Uniform with the out-of-scope path below (spec 29 S10): a
+			// scope-restricted caller must not tell a missing execution apart from
+			// one on a device outside their scope.
+			return nil, deviceScopeMissError(ctx, "GetExecution", ErrExecutionNotFound, "execution not found")
+		}
 		return nil, handleGetError(ctx, err, ErrExecutionNotFound, "execution not found")
 	}
 
@@ -999,6 +1005,10 @@ func (h *ActionHandler) CancelExecution(ctx context.Context, req *connect.Reques
 
 	exec, err := h.store.Repos().Execution.Get(ctx, req.Msg.ExecutionId)
 	if err != nil {
+		if store.IsNotFound(err) {
+			// Uniform with the out-of-scope path below (spec 29 S10).
+			return nil, deviceScopeMissError(ctx, "CancelExecution", ErrExecutionNotFound, "execution not found")
+		}
 		return nil, handleGetError(ctx, err, ErrExecutionNotFound, "execution not found")
 	}
 

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -53,7 +53,7 @@ func handleGetError(ctx context.Context, err error, notFoundCode, notFoundMsg st
 // (or is confined by an owner filter elsewhere) — gets the honest NotFound, since
 // for them absence carries no scope signal.
 func deviceScopeMissError(ctx context.Context, permission, notFoundCode, notFoundMsg string) error {
-	if _, restricted := auth.DeviceScopeListFilter(ctx, permission); restricted {
+	if auth.IsDeviceScopeRestricted(ctx, permission) {
 		return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
 	}
 	return apiErrorCtx(ctx, notFoundCode, connect.CodeNotFound, notFoundMsg)

--- a/internal/api/helpers.go
+++ b/internal/api/helpers.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 
 	"connectrpc.com/connect"
@@ -36,6 +37,26 @@ func handleGetError(ctx context.Context, err error, notFoundCode, notFoundMsg st
 		return apiErrorCtx(ctx, notFoundCode, connect.CodeNotFound, notFoundMsg)
 	}
 	return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get resource")
+}
+
+// deviceScopeMissError returns the error a caller should see when a device-scoped
+// object (an execution, a log-query result) is NOT visible to them — covering
+// BOTH "genuinely absent" and "exists on a device outside their scope" with the
+// SAME code, so existence does not leak (spec 29 S10). These handlers must load
+// the row to learn its device before they can scope-check, so the check cannot
+// run first (unlike the user-group handlers); instead the miss is resolved to
+// match the out-of-scope path.
+//
+// A device_group-scoped (restricted) caller gets a PermissionDenied byte-identical
+// to the one auth.EnforceDeviceScope returns for the out-of-scope path, so the two
+// are indistinguishable. A global/unrestricted caller — who can see every device
+// (or is confined by an owner filter elsewhere) — gets the honest NotFound, since
+// for them absence carries no scope signal.
+func deviceScopeMissError(ctx context.Context, permission, notFoundCode, notFoundMsg string) error {
+	if _, restricted := auth.DeviceScopeListFilter(ctx, permission); restricted {
+		return connect.NewError(connect.CodePermissionDenied, errors.New("permission denied"))
+	}
+	return apiErrorCtx(ctx, notFoundCode, connect.CodeNotFound, notFoundMsg)
 }
 
 // appendEvent appends an event and logs it. Returns a Connect error on failure.

--- a/internal/api/logs_handler.go
+++ b/internal/api/logs_handler.go
@@ -154,7 +154,13 @@ func (h *LogsHandler) GetDeviceLogResult(ctx context.Context, req *connect.Reque
 
 	result, err := h.store.Repos().Logs.GetQueryResult(ctx, req.Msg.QueryId)
 	if err != nil {
-		return nil, apiErrorCtx(ctx, ErrQueryResultNotFound, connect.CodeNotFound, "log query result not found")
+		if store.IsNotFound(err) {
+			// Uniform with the out-of-scope path below (spec 29 S10): a
+			// scope-restricted caller must not tell a missing result apart from one
+			// on a device outside their scope.
+			return nil, deviceScopeMissError(ctx, "GetDeviceLogResult", ErrQueryResultNotFound, "log query result not found")
+		}
+		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get log query result")
 	}
 
 	if err := auth.EnforceDeviceScopeOnBaseTier(ctx, newScopeResolver(h.store), "GetDeviceLogResult", result.DeviceID); err != nil {

--- a/internal/api/logs_handler.go
+++ b/internal/api/logs_handler.go
@@ -160,6 +160,9 @@ func (h *LogsHandler) GetDeviceLogResult(ctx context.Context, req *connect.Reque
 			// on a device outside their scope.
 			return nil, deviceScopeMissError(ctx, "GetDeviceLogResult", ErrQueryResultNotFound, "log query result not found")
 		}
+		// A non-NotFound error is a transient/internal fault — surface it, don't
+		// swallow it behind a NotFound like the prior blanket mapping did.
+		h.logger.Error("failed to fetch log query result", "query_id", req.Msg.QueryId, "error", err)
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to get log query result")
 	}
 

--- a/internal/api/scope_exec_log_oracle_test.go
+++ b/internal/api/scope_exec_log_oracle_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 
@@ -79,8 +80,17 @@ func TestExecLogHandlers_ScopeExistenceOracleClosed(t *testing.T) {
 	})
 
 	t.Run("GetDeviceLogResult", func(t *testing.T) {
-		// Seeding a real log-query result is heavy; the unknown-id case is the
-		// one that carries the oracle, so it is sufficient here.
+		// An existing result on the out-of-scope device must also be
+		// PermissionDenied — this confirms EnforceDeviceScopeOnBaseTier actually
+		// fires for this handler and agrees with the miss path (without it, the
+		// unknown-id assertion alone would still pass even if the scope check were
+		// removed).
+		logQueryID := testutil.NewID()
+		require.NoError(t, st.Repos().Logs.CreateQueryResult(context.Background(), logQueryID, devOut))
+		_, outErr := lh.GetDeviceLogResult(scoped, connect.NewRequest(&pm.GetDeviceLogResultRequest{QueryId: logQueryID}))
+		require.Error(t, outErr)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(outErr), "out-of-scope existing result")
+
 		_, missErr := lh.GetDeviceLogResult(scoped, connect.NewRequest(&pm.GetDeviceLogResultRequest{QueryId: nonexistent}))
 		require.Error(t, missErr)
 		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(missErr),

--- a/internal/api/scope_exec_log_oracle_test.go
+++ b/internal/api/scope_exec_log_oracle_test.go
@@ -1,0 +1,91 @@
+package api_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestExecLogHandlers_ScopeExistenceOracleClosed pins spec 29 S10 for the
+// load-then-scope execution/log handlers. Unlike the user-group handlers (whose
+// scope keys on the id straight from the auth context), these must load the row
+// to learn its device before they can scope-check — so "scope-check first" is
+// impossible. The fix instead makes BOTH an out-of-scope existing object and an
+// unknown id return the SAME code for a scope-restricted caller
+// (PermissionDenied, matching the out-of-scope path), while a global caller —
+// who can see every device — still gets an honest NotFound.
+func TestExecLogHandlers_ScopeExistenceOracleClosed(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ah := api.NewActionHandler(st, slog.Default(), api.NoOpSigner{})
+	ah.SetTaskQueueClient(&api.NoOpEnqueuer{})
+	lh := api.NewLogsHandler(st, slog.Default(), api.NoOpSigner{})
+
+	actor := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+	dgX := testutil.CreateTestDeviceGroup(t, st, actor, "In Scope")
+	dgY := testutil.CreateTestDeviceGroup(t, st, actor, "Out Of Scope")
+	devOut := testutil.CreateTestDevice(t, st, "out-of-scope-host")
+	testutil.AddDeviceToTestGroup(t, st, actor, dgY, devOut)
+
+	// Seed an execution on the out-of-scope device.
+	actionID := testutil.CreateTestAction(t, st, actor, "Exec", int(pm.ActionType_ACTION_TYPE_SHELL))
+	dispatch, err := ah.DispatchAction(testutil.AdminContext(actor), connect.NewRequest(&pm.DispatchActionRequest{
+		DeviceId:     devOut,
+		ActionSource: &pm.DispatchActionRequest_ActionId{ActionId: actionID},
+	}))
+	require.NoError(t, err)
+	execOut := dispatch.Msg.Execution.Id
+
+	// A caller scoped to dgX (which does NOT contain devOut) — restricted.
+	perms := []string{"GetExecution", "CancelExecution", "GetDeviceLogResult"}
+	grants := make([]auth.ScopedGrant, len(perms))
+	for i, p := range perms {
+		grants[i] = auth.ScopedGrant{Permission: p, ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgX}
+	}
+	scoped := testutil.AuthContextScoped(testutil.NewID(), "scoped@test.com", perms, grants)
+	// A caller holding the same permissions UNSCOPED — not restricted.
+	global := testutil.AuthContext(testutil.NewID(), "global@test.com", perms)
+	nonexistent := testutil.NewID()
+
+	t.Run("GetExecution", func(t *testing.T) {
+		_, outErr := ah.GetExecution(scoped, connect.NewRequest(&pm.GetExecutionRequest{Id: execOut}))
+		require.Error(t, outErr)
+		_, missErr := ah.GetExecution(scoped, connect.NewRequest(&pm.GetExecutionRequest{Id: nonexistent}))
+		require.Error(t, missErr)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(outErr), "out-of-scope existing execution")
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(missErr),
+			"unknown id must not leak NotFound to a scoped caller")
+		_, gErr := ah.GetExecution(global, connect.NewRequest(&pm.GetExecutionRequest{Id: nonexistent}))
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(gErr), "global caller still gets an honest NotFound")
+	})
+
+	t.Run("CancelExecution", func(t *testing.T) {
+		_, outErr := ah.CancelExecution(scoped, connect.NewRequest(&pm.CancelExecutionRequest{ExecutionId: execOut}))
+		require.Error(t, outErr)
+		_, missErr := ah.CancelExecution(scoped, connect.NewRequest(&pm.CancelExecutionRequest{ExecutionId: nonexistent}))
+		require.Error(t, missErr)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(outErr), "out-of-scope existing execution")
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(missErr),
+			"unknown id must not leak NotFound to a scoped caller")
+		_, gErr := ah.CancelExecution(global, connect.NewRequest(&pm.CancelExecutionRequest{ExecutionId: nonexistent}))
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(gErr), "global caller still gets an honest NotFound")
+	})
+
+	t.Run("GetDeviceLogResult", func(t *testing.T) {
+		// Seeding a real log-query result is heavy; the unknown-id case is the
+		// one that carries the oracle, so it is sufficient here.
+		_, missErr := lh.GetDeviceLogResult(scoped, connect.NewRequest(&pm.GetDeviceLogResultRequest{QueryId: nonexistent}))
+		require.Error(t, missErr)
+		assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(missErr),
+			"unknown id must not leak NotFound to a scoped caller")
+		_, gErr := lh.GetDeviceLogResult(global, connect.NewRequest(&pm.GetDeviceLogResultRequest{QueryId: nonexistent}))
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(gErr), "global caller still gets an honest NotFound")
+	})
+}

--- a/internal/auth/scope.go
+++ b/internal/auth/scope.go
@@ -371,6 +371,17 @@ func DeviceScopeListFilter(ctx context.Context, permission string) (groupIDs []s
 	return scopeListFilter(ctx, permission, DeviceScopeFilterFor)
 }
 
+// IsDeviceScopeRestricted reports whether the caller is confined to specific
+// device groups for permission — i.e. the `restricted` half of the scope
+// decision, without the list framing. Single-object access paths (spec 29 S10
+// existence-oracle handling) use it to decide whether a "not visible" object
+// should read as PermissionDenied (restricted caller) or NotFound (global
+// caller), independent of any row-filtering concern.
+func IsDeviceScopeRestricted(ctx context.Context, permission string) bool {
+	_, restricted := scopeListFilter(ctx, permission, DeviceScopeFilterFor)
+	return restricted
+}
+
 // UserScopeListFilter is the user-group symmetric of DeviceScopeListFilter.
 func UserScopeListFilter(ctx context.Context, permission string) (groupIDs []string, restricted bool) {
 	return scopeListFilter(ctx, permission, UserScopeFilterFor)


### PR DESCRIPTION
Closes #541. Completes S10 (the user-group half shipped in #540).

`GetExecution`/`CancelExecution`/`GetDeviceLogResult` loaded the row (→ NotFound if missing) before the device-scope gate (→ PermissionDenied if out of scope), letting a scope-restricted caller confirm an execution/log-query id exists on a device outside their scope. Unlike the user-group handlers (whose scope keys on the id from the auth context), these must load the row to learn its device, so 'scope-check first' is impossible.

`deviceScopeMissError` resolves a miss to match the out-of-scope path: a device_group-scoped (restricted) caller gets a PermissionDenied **byte-identical** to `auth.EnforceDeviceScope`'s, so the two are indistinguishable; a global/unrestricted caller keeps the honest NotFound. Keeps the WS3 scope-denial convention (per maintainer decision) — no web error-code change.

New test `TestExecLogHandlers_ScopeExistenceOracleClosed` drives all three with a scoped caller against out-of-scope-existing and unknown ids (both PermissionDenied) and a global caller (NotFound). Also fixes GetDeviceLogResult's prior blanket 'any error → NotFound' to distinguish transient faults (now logged + Internal).

Spec: `docs/content/06-specs/29-...md` (S10).