### PR TITLE
fix: inbox worker requires agent-scheduled action to resolve to the device (spec 29 S5)

### DIFF
--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
 	"github.com/manchtools/power-manage/server/internal/gateway/registry"
+	"github.com/manchtools/power-manage/server/internal/resolution"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/taskqueue"
@@ -267,6 +268,36 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 		// retries of the same result don't create duplicates, but separate
 		// scheduled runs of the same action get unique IDs.
 		actionID = resultID
+
+		// spec 29 S5: an agent-scheduled result names its own action_id. Before
+		// minting an ExecutionCreated / compliance event from it, verify the
+		// action currently resolves (is assigned) to the reporting device —
+		// otherwise a compromised agent could forge execution and compliance
+		// records (including self-reported `compliant`) for actions it was never
+		// assigned. Device-origin binding already confines writes to this device's
+		// own streams; this closes the remaining gap (the action lookup below is
+		// existence-only). A since-unassigned action is safe to drop: unassignment
+		// drives the action to ABSENT and the agent rolls it back.
+		//
+		// The immediate (no grace/retry) drop is race-safe: projections are
+		// synchronous post-commit (store.RegisterEventListener fires before
+		// AppendEvent returns), so this read is read-your-writes consistent, and
+		// the agent only ever runs actions it was synced via the SAME resolution
+		// (ProxySyncActions → ResolveActionsForDevice). A legitimately-run action
+		// therefore always resolves here; the only thing that removes it is an
+		// explicit unassignment — exactly the case we mean to drop.
+		resolves, resErr := w.actionResolvesToDevice(ctx, actionID, deviceID)
+		if resErr != nil {
+			// Transient DB/resolution error — let Asynq retry rather than drop a
+			// possibly-legitimate result.
+			return fmt.Errorf("resolve action %s for device %s: %w", actionID, deviceID, resErr)
+		}
+		if !resolves {
+			logger.Warn("dropping agent-scheduled result: action does not resolve to the reporting device",
+				"action_id", actionID, "device_id", deviceID)
+			return nil
+		}
+
 		// Use CompletedAt (seconds+nanos) for per-run uniqueness; fall back to
 		// DurationMs+Status — stable across retries of the same result — when
 		// CompletedAt is absent. stableExecutionID frames + domain-separates the
@@ -466,6 +497,24 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 
 	logger.Info("execution result recorded", "event_type", eventType)
 	return nil
+}
+
+// actionResolvesToDevice reports whether actionID is currently assigned
+// (resolves) to deviceID, via the same resolution engine the sync path uses
+// (resolution.ResolveActionsForDevice) — so "assigned" here means exactly what
+// the agent is legitimately told to run. Used to gate agent-scheduled result
+// ingestion (spec 29 S5).
+func (w *InboxWorker) actionResolvesToDevice(ctx context.Context, actionID, deviceID string) (bool, error) {
+	resolved, err := resolution.ResolveActionsForDevice(ctx, w.store.Queries(), deviceID)
+	if err != nil {
+		return false, err
+	}
+	for _, a := range resolved {
+		if a.ID == actionID {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (w *InboxWorker) handleExecutionOutputChunk(ctx context.Context, t *asynq.Task) error {

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -1148,3 +1148,68 @@ func TestHandleTerminalAuditChunk_RejectsUnownedSession(t *testing.T) {
 	assert.Equal(t, []byte("ls -la\n"), row.Input, "the owning user's chunk must be appended")
 	assert.Equal(t, int32(1), row.ChunkCount)
 }
+
+// TestHandleExecutionResult_AgentScheduled_RequiresAssignment pins spec 29 S5.
+// An agent-scheduled result names its OWN action_id (not a server-dispatched
+// execution id), so the inbox worker must verify the action currently resolves
+// (is assigned) to the reporting device before minting an ExecutionCreated /
+// compliance event — otherwise a compromised agent could forge execution and
+// compliance records for actions it was never assigned. A since-unassigned
+// action is safe to drop: unassignment drives the action to ABSENT and the
+// agent rolls it back.
+func TestHandleExecutionResult_AgentScheduled_RequiresAssignment(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	mux := worker.NewMux()
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+
+	device := testutil.CreateTestDevice(t, st, "agent-sched-host")
+	assignedAction := testutil.CreateTestAction(t, st, adminID, "Assigned", int(pm.ActionType_ACTION_TYPE_SHELL))
+	unassignedAction := testutil.CreateTestAction(t, st, adminID, "Unassigned", int(pm.ActionType_ACTION_TYPE_SHELL))
+	// Only the assigned action resolves to the device. REQUIRED is the mode the
+	// offline scheduler acts on — the realistic agent-scheduled case.
+	testutil.CreateTestAssignment(t, st, adminID, "action", assignedAction, "device", device, int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
+
+	feed := func(actionID string) error {
+		// ActionId carries an ACTION id (not an execution id) → agent-scheduled path.
+		result := &pm.ActionResult{
+			ActionId:    &pm.ActionId{Value: actionID},
+			Status:      pm.ExecutionStatus_EXECUTION_STATUS_SUCCESS,
+			DurationMs:  100,
+			CompletedAt: timestamppb.Now(),
+			Output:      &pm.CommandOutput{Stdout: "ran", ExitCode: 0},
+		}
+		resultProto, err := proto.Marshal(result)
+		require.NoError(t, err)
+		task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
+			DeviceID:          device,
+			ActionResultProto: resultProto,
+		})
+		return mux.ProcessTask(context.Background(), task)
+	}
+
+	execActionIDs := func() []string {
+		rows, err := st.Queries().ListRecentExecutionsForDevice(context.Background(),
+			db.ListRecentExecutionsForDeviceParams{DeviceID: device, Limit: 100})
+		require.NoError(t, err)
+		var out []string
+		for _, r := range rows {
+			if r.ActionID != nil {
+				out = append(out, *r.ActionID)
+			}
+		}
+		return out
+	}
+
+	t.Run("unassigned action is dropped with no execution created", func(t *testing.T) {
+		require.NoError(t, feed(unassignedAction), "a dropped forgery is a benign no-op, not a retryable error")
+		assert.NotContains(t, execActionIDs(), unassignedAction,
+			"an unassigned agent-scheduled action must not mint an execution")
+	})
+
+	t.Run("assigned action still records its execution", func(t *testing.T) {
+		require.NoError(t, feed(assignedAction))
+		assert.Contains(t, execActionIDs(), assignedAction,
+			"a legitimately assigned action's result must still be recorded")
+	})
+}


### PR DESCRIPTION
Closes #543.

The agent-scheduled branch of `handleExecutionResult` (a result whose `action_id` is NOT a server-dispatched execution id) looked the action up for **existence only**, never checking it resolves to the reporting device. A compromised agent could therefore forge `ExecutionCreated`/`ExecutionCompleted`/`ComplianceResultUpdated` events — including a self-reported `compliant` — for any action id that exists in the org.

Fix: gate that path on `resolution.ResolveActionsForDevice` — the **same** call `ProxySyncActions` uses to sync the agent's action set — so a result is accepted only for an action currently assigned to the reporting device; otherwise it is dropped with a WARN.

**No legitimate results are lost.** The immediate drop is race-safe: projections are synchronous post-commit (`store.RegisterEventListener` fires before `AppendEvent` returns), so the read is read-your-writes consistent, and the agent only runs actions it was synced via the same resolution. The only thing that removes an action between run and result is an explicit unassignment — which drives the action to ABSENT and triggers the agent's rollback, so dropping its stale result is correct (confirmed with maintainer).

New test `TestHandleExecutionResult_AgentScheduled_RequiresAssignment`: an unassigned action's agent-scheduled result mints no execution; a REQUIRED-assigned action's result still records. Device-origin binding (existing) already blocks cross-device spoofing; this closes the same-device unassigned-action gap.

Spec: `docs/content/06-specs/29-...md` (S5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of agent-scheduled execution results.
  * Results are now recorded only when the associated action is assigned to the reporting device.
  * Invalid or unassigned results are safely ignored, while temporary validation errors can be retried.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->