### PR TITLE
fix: bound execution output read to prevent control memory-DoS (spec 29 S6)

### DIFF
--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -244,7 +244,11 @@ var maxOutputChunkRows int32 = 4096
 var maxLiveOutputBytes = 4 << 20 // 4 MiB
 
 func (h *ActionHandler) loadLiveOutput(ctx context.Context, executionID string) *pm.CommandOutput {
-	chunks, err := h.store.Repos().Execution.LoadOutputChunks(ctx, executionID, maxOutputChunkRows)
+	// Fetch one more than the cap so we can tell "exactly at the cap" (nothing
+	// dropped) from "over the cap" (output beyond the limit exists) — a plain
+	// LIMIT can't distinguish the two, which would mark a full-but-at-limit
+	// stream as truncated.
+	chunks, err := h.store.Repos().Execution.LoadOutputChunks(ctx, executionID, maxOutputChunkRows+1)
 	if err != nil {
 		// A real DB failure must not look like "no output yet" — surface it.
 		h.logger.ErrorContext(ctx, "failed to load execution output chunks", "execution_id", executionID, "error", err)
@@ -254,9 +258,15 @@ func (h *ActionHandler) loadLiveOutput(ctx context.Context, executionID string) 
 		return nil
 	}
 
+	truncated := false
+	if int32(len(chunks)) > maxOutputChunkRows {
+		// More chunks exist than we display; keep only the first cap-many.
+		truncated = true
+		chunks = chunks[:maxOutputChunkRows]
+	}
+
 	var stdout, stderr strings.Builder
 	total := 0
-	truncated := false
 	for _, chunk := range chunks {
 		// Parse the chunk data
 		var data struct {
@@ -281,12 +291,6 @@ func (h *ActionHandler) loadLiveOutput(ctx context.Context, executionID string) 
 		} else if data.Stream == "stderr" {
 			stderr.WriteString(data.Data)
 		}
-	}
-
-	// The SQL LIMIT is a hard row bound; hitting it also means output beyond it
-	// was dropped.
-	if int32(len(chunks)) >= maxOutputChunkRows {
-		truncated = true
 	}
 
 	// Only return if we have some output

--- a/internal/api/action_handler.go
+++ b/internal/api/action_handler.go
@@ -232,13 +232,31 @@ func stringToStatus(s string) pm.ExecutionStatus {
 
 // loadLiveOutput loads streaming output chunks from the event store and
 // aggregates them into a CommandOutput.
+// maxOutputChunkRows bounds how many OutputChunk rows loadLiveOutput fetches for
+// one execution (the SQL LIMIT), so a flood of chunks can't load an unbounded
+// slice into control memory (spec 29 S6). Package var for the test seam.
+var maxOutputChunkRows int32 = 4096
+
+// maxLiveOutputBytes caps the total stdout+stderr bytes loadLiveOutput
+// concatenates. Actions don't produce megabytes of output; past this the stream
+// is truncated with a marker rather than blowing up control memory. Package var
+// for the test seam.
+var maxLiveOutputBytes = 4 << 20 // 4 MiB
+
 func (h *ActionHandler) loadLiveOutput(ctx context.Context, executionID string) *pm.CommandOutput {
-	chunks, err := h.store.Repos().Execution.LoadOutputChunks(ctx, executionID)
-	if err != nil || len(chunks) == 0 {
+	chunks, err := h.store.Repos().Execution.LoadOutputChunks(ctx, executionID, maxOutputChunkRows)
+	if err != nil {
+		// A real DB failure must not look like "no output yet" — surface it.
+		h.logger.ErrorContext(ctx, "failed to load execution output chunks", "execution_id", executionID, "error", err)
+		return nil
+	}
+	if len(chunks) == 0 {
 		return nil
 	}
 
 	var stdout, stderr strings.Builder
+	total := 0
+	truncated := false
 	for _, chunk := range chunks {
 		// Parse the chunk data
 		var data struct {
@@ -249,6 +267,15 @@ func (h *ActionHandler) loadLiveOutput(ctx context.Context, executionID string) 
 			continue
 		}
 
+		// Stop concatenating once the cumulative output would exceed the budget,
+		// so a chunk flood can't grow the response without bound even within the
+		// row limit.
+		if total+len(data.Data) > maxLiveOutputBytes {
+			truncated = true
+			break
+		}
+		total += len(data.Data)
+
 		if data.Stream == "stdout" {
 			stdout.WriteString(data.Data)
 		} else if data.Stream == "stderr" {
@@ -256,9 +283,19 @@ func (h *ActionHandler) loadLiveOutput(ctx context.Context, executionID string) 
 		}
 	}
 
+	// The SQL LIMIT is a hard row bound; hitting it also means output beyond it
+	// was dropped.
+	if int32(len(chunks)) >= maxOutputChunkRows {
+		truncated = true
+	}
+
 	// Only return if we have some output
 	if stdout.Len() == 0 && stderr.Len() == 0 {
 		return nil
+	}
+
+	if truncated {
+		stderr.WriteString("\n[pm: output truncated — exceeded the per-execution display limit]")
 	}
 
 	return &pm.CommandOutput{

--- a/internal/api/output_cap_internal_test.go
+++ b/internal/api/output_cap_internal_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestLoadLiveOutput_BoundsFloodedOutput pins spec 29 S6: execution output is
+// bounded on read by BOTH a row LIMIT (how many OutputChunk rows are loaded into
+// memory) and a cumulative byte budget (how much is concatenated), so a chunk
+// flood on one execution can't exhaust control memory. Uses the package-var
+// seams to shrink the caps to test scale.
+func TestLoadLiveOutput_BoundsFloodedOutput(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	h := NewActionHandler(st, slog.Default(), NoOpSigner{})
+	h.SetTaskQueueClient(&NoOpEnqueuer{})
+	admin := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	ctx := testutil.AdminContext(admin)
+	device := testutil.CreateTestDevice(t, st, "output-host")
+
+	// seed creates an execution and appends n stdout OutputChunk events of `data`.
+	seed := func(n int, data string) string {
+		execID := testutil.NewID()
+		require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+			StreamType: "execution", StreamID: execID, EventType: "ExecutionCreated",
+			Data: map[string]any{
+				"device_id": device, "action_type": int(pm.ActionType_ACTION_TYPE_SHELL),
+				"desired_state": 0, "params": map[string]any{}, "timeout_seconds": 300,
+			},
+			ActorType: "user", ActorID: admin,
+		}))
+		for i := 0; i < n; i++ {
+			require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+				StreamType: "execution", StreamID: execID, EventType: "OutputChunk",
+				Data:      map[string]any{"stream": "stdout", "data": data, "sequence": i},
+				ActorType: "device", ActorID: device,
+			}))
+		}
+		return execID
+	}
+
+	liveOut := func(execID string) *pm.CommandOutput {
+		resp, err := h.GetExecution(ctx, connect.NewRequest(&pm.GetExecutionRequest{Id: execID}))
+		require.NoError(t, err)
+		return resp.Msg.Execution.LiveOutput
+	}
+
+	t.Run("row limit bounds the chunks read", func(t *testing.T) {
+		origRows, origBytes := maxOutputChunkRows, maxLiveOutputBytes
+		t.Cleanup(func() { maxOutputChunkRows, maxLiveOutputBytes = origRows, origBytes })
+		maxOutputChunkRows, maxLiveOutputBytes = 5, 1<<20 // large byte budget so only the row limit bites
+
+		out := liveOut(seed(12, "X"))
+		require.NotNil(t, out)
+		assert.Len(t, out.Stdout, 5, "only maxOutputChunkRows (5) chunks should be read, not all 12")
+		assert.Contains(t, out.Stderr, "truncated", "hitting the row limit must mark the output truncated")
+	})
+
+	t.Run("byte budget bounds the concatenation", func(t *testing.T) {
+		origRows, origBytes := maxOutputChunkRows, maxLiveOutputBytes
+		t.Cleanup(func() { maxOutputChunkRows, maxLiveOutputBytes = origRows, origBytes })
+		maxOutputChunkRows, maxLiveOutputBytes = 1000, 10 // large row limit so only the byte budget bites
+
+		out := liveOut(seed(20, "ABC")) // 60 bytes total, budget 10
+		require.NotNil(t, out)
+		assert.LessOrEqual(t, len(out.Stdout), 10, "concatenation must stop at the byte budget")
+		assert.Contains(t, out.Stderr, "truncated")
+	})
+
+	t.Run("output within the caps is returned in full, no truncation marker", func(t *testing.T) {
+		origRows, origBytes := maxOutputChunkRows, maxLiveOutputBytes
+		t.Cleanup(func() { maxOutputChunkRows, maxLiveOutputBytes = origRows, origBytes })
+		maxOutputChunkRows, maxLiveOutputBytes = 1000, 1<<20
+
+		out := liveOut(seed(3, "hello"))
+		require.NotNil(t, out)
+		assert.Equal(t, "hellohellohello", out.Stdout)
+		assert.NotContains(t, out.Stderr, "truncated", "output within the caps must not be marked truncated")
+	})
+}

--- a/internal/store/execution.go
+++ b/internal/store/execution.go
@@ -115,10 +115,11 @@ type ExecutionRepo interface {
 	// warm-up pagination.
 	CountForWarm(ctx context.Context) (int64, error)
 
-	// LoadOutputChunks loads every ExecutionOutputChunk event for
-	// the given execution stream ID, ordered by sequence. The
-	// chunks are stored on the event stream rather than as
-	// projection rows, hence the cross-shape (returns
-	// PersistedEvent rather than execution data).
-	LoadOutputChunks(ctx context.Context, executionID string) ([]PersistedEvent, error)
+	// LoadOutputChunks loads up to limit ExecutionOutputChunk events for
+	// the given execution stream ID, ordered by sequence. The limit bounds
+	// the rows read into memory so a chunk flood can't exhaust control
+	// memory (spec 29 S6). The chunks are stored on the event stream rather
+	// than as projection rows, hence the cross-shape (returns PersistedEvent
+	// rather than execution data).
+	LoadOutputChunks(ctx context.Context, executionID string, limit int32) ([]PersistedEvent, error)
 }

--- a/internal/store/generated/events.sql.go
+++ b/internal/store/generated/events.sql.go
@@ -496,11 +496,18 @@ WHERE stream_type = 'execution'
   AND stream_id = $1
   AND event_type = 'OutputChunk'
 ORDER BY stream_version
+LIMIT $2
 `
 
-// Load all output chunks for an execution, ordered by sequence
-func (q *Queries) LoadOutputChunks(ctx context.Context, streamID string) ([]Event, error) {
-	rows, err := q.db.Query(ctx, loadOutputChunks, streamID)
+type LoadOutputChunksParams struct {
+	StreamID string `json:"stream_id"`
+	Limit    int32  `json:"limit"`
+}
+
+// Load output chunks for an execution, ordered by sequence, bounded by $2 rows
+// so a chunk flood can't load an unbounded slice into control memory (spec 29 S6).
+func (q *Queries) LoadOutputChunks(ctx context.Context, arg LoadOutputChunksParams) ([]Event, error) {
+	rows, err := q.db.Query(ctx, loadOutputChunks, arg.StreamID, arg.Limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/postgres/execution.go
+++ b/internal/store/postgres/execution.go
@@ -120,8 +120,8 @@ func (e *Execution) CountForWarm(ctx context.Context) (int64, error) {
 	return n, nil
 }
 
-func (e *Execution) LoadOutputChunks(ctx context.Context, executionID string) ([]store.PersistedEvent, error) {
-	rows, err := e.q.LoadOutputChunks(ctx, executionID)
+func (e *Execution) LoadOutputChunks(ctx context.Context, executionID string, limit int32) ([]store.PersistedEvent, error) {
+	rows, err := e.q.LoadOutputChunks(ctx, generated.LoadOutputChunksParams{StreamID: executionID, Limit: limit})
 	if err != nil {
 		return nil, fmt.Errorf("execution: load output chunks: %w", err)
 	}

--- a/internal/store/queries/events.sql
+++ b/internal/store/queries/events.sql
@@ -71,12 +71,14 @@ WHERE ($1::TEXT = '' OR actor_id = $1)
   AND ($3::TEXT = '' OR event_type ILIKE '%' || replace(replace(replace($3, '!', '!!'), '%', '!%'), '_', '!_') || '%' ESCAPE '!');
 
 -- name: LoadOutputChunks :many
--- Load all output chunks for an execution, ordered by sequence
+-- Load output chunks for an execution, ordered by sequence, bounded by $2 rows
+-- so a chunk flood can't load an unbounded slice into control memory (spec 29 S6).
 SELECT * FROM events
 WHERE stream_type = 'execution'
   AND stream_id = $1
   AND event_type = 'OutputChunk'
-ORDER BY stream_version;
+ORDER BY stream_version
+LIMIT $2;
 
 -- name: ExportAuditEvents :many
 -- Keyset export feed for the audit-log export (spec 26). Same filter


### PR DESCRIPTION
Closes #545.

`LoadOutputChunks` had no LIMIT and `loadLiveOutput` concatenated every OutputChunk into two `strings.Builder`s, so an unbounded flood of chunks on one execution (each 64 KiB-capped, but unbounded in count) could exhaust control memory when the output is read (GetExecution).

Bounds the read in two layers:
- a SQL `LIMIT` on `LoadOutputChunks` caps the rows loaded into the slice (sqlc-regenerated);
- a cumulative byte budget in `loadLiveOutput` caps the concatenation, with a truncation marker.

Caps are package vars (4096 rows / 4 MiB) — generous, since actions don't produce MBs of output — and a test seam. Device-origin binding already scopes it to the reporting device's own executions.

Scope note: the read cap defuses the stated memory-DoS. Append-side disk growth is bounded per-chunk (64 KiB) + device-origin; a per-append count cap would be O(n²) and is out of scope.

Test `TestLoadLiveOutput_BoundsFloodedOutput` (internal, uses the cap seams): row limit bounds chunks read, byte budget bounds concatenation, within-caps output returns in full with no marker.