### PR TITLE
test: regression-test batch ID max=256 cap (spec 29 S7)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260710151251-40990896bb10
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260712093419-4aeac8b4d5b8
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260710151251-40990896bb10 h1:R6xSxbhIM1x2VOJnJ0PKHdESluv+EC/fovrKCAKqZIg=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260710151251-40990896bb10/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260712093419-4aeac8b4d5b8 h1:XSgHx2gJd6lkt6iYlkY7Bo49Dlf5xCltZeFqdc15VX4=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260712093419-4aeac8b4d5b8/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/batch_id_cap_test.go
+++ b/internal/api/batch_id_cap_test.go
@@ -20,10 +20,9 @@ import (
 // proves that), so rejection here is rejection at the real boundary.
 //
 // Each case builds an OTHERWISE-VALID request and varies only the capped field:
-// 256 passes, 257 is rejected — isolating the count cap as the cause. The three
-// cover the required-batch and omitempty variants across different messages; all
-// eight capped fields share the identical max=256,dive,ulid tag and the same
-// Validate path.
+// 256 passes, 257 is rejected — isolating the count cap as the cause. All eight
+// capped request fields are covered, so a cap accidentally dropped from any one
+// in a future SDK regen is caught here.
 func TestBatchIDFields_CappedAt256(t *testing.T) {
 	ulids := func(n int) []string {
 		out := make([]string, n)
@@ -34,20 +33,37 @@ func TestBatchIDFields_CappedAt256(t *testing.T) {
 	}
 	valid := testutil.NewID()
 
+	// All eight capped request fields, each built otherwise-valid (required
+	// anchors set to a valid ULID) so only the batch length varies.
 	cases := []struct {
 		name  string
 		build func(ids []string) any
 	}{
-		{"DispatchToMultipleRequest.device_ids (required,min=1,max=256)", func(ids []string) any {
+		{"DispatchToMultipleRequest.device_ids", func(ids []string) any {
 			return &pm.DispatchToMultipleRequest{
 				DeviceIds:    ids,
 				ActionSource: &pm.DispatchToMultipleRequest_ActionId{ActionId: valid},
 			}
 		}},
-		{"CreateUserRequest.role_ids (omitempty,max=256)", func(ids []string) any {
+		{"CreateUserRequest.role_ids", func(ids []string) any {
 			return &pm.CreateUserRequest{Email: "user@test.com", Password: "password123", RoleIds: ids}
 		}},
-		{"AssignRoleToUserGroupRequest.role_ids (omitempty,max=256)", func(ids []string) any {
+		{"AssignDeviceRequest.user_ids", func(ids []string) any {
+			return &pm.AssignDeviceRequest{DeviceId: valid, UserIds: ids}
+		}},
+		{"AssignDeviceRequest.group_ids", func(ids []string) any {
+			return &pm.AssignDeviceRequest{DeviceId: valid, GroupIds: ids}
+		}},
+		{"AddDeviceToGroupRequest.device_ids", func(ids []string) any {
+			return &pm.AddDeviceToGroupRequest{GroupId: valid, DeviceIds: ids}
+		}},
+		{"AssignRoleToUserRequest.role_ids", func(ids []string) any {
+			return &pm.AssignRoleToUserRequest{UserId: valid, RoleIds: ids}
+		}},
+		{"AddUserToGroupRequest.user_ids", func(ids []string) any {
+			return &pm.AddUserToGroupRequest{GroupId: valid, UserIds: ids}
+		}},
+		{"AssignRoleToUserGroupRequest.role_ids", func(ids []string) any {
 			return &pm.AssignRoleToUserGroupRequest{GroupId: valid, RoleIds: ids}
 		}},
 	}

--- a/internal/api/batch_id_cap_test.go
+++ b/internal/api/batch_id_cap_test.go
@@ -1,0 +1,65 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestBatchIDFields_CappedAt256 pins spec 29 S7: the repeated batch ID request
+// fields carry max=256 (via the SDK @gotags validate tag) so one request can't
+// drive unbounded O(N) work. api.Validate runs the same go-playground validator
+// every ControlService handler invokes (TestEveryControlRPCRunsValidateBeforeWork
+// proves that), so rejection here is rejection at the real boundary.
+//
+// Each case builds an OTHERWISE-VALID request and varies only the capped field:
+// 256 passes, 257 is rejected — isolating the count cap as the cause. The three
+// cover the required-batch and omitempty variants across different messages; all
+// eight capped fields share the identical max=256,dive,ulid tag and the same
+// Validate path.
+func TestBatchIDFields_CappedAt256(t *testing.T) {
+	ulids := func(n int) []string {
+		out := make([]string, n)
+		for i := range out {
+			out[i] = testutil.NewID()
+		}
+		return out
+	}
+	valid := testutil.NewID()
+
+	cases := []struct {
+		name  string
+		build func(ids []string) any
+	}{
+		{"DispatchToMultipleRequest.device_ids (required,min=1,max=256)", func(ids []string) any {
+			return &pm.DispatchToMultipleRequest{
+				DeviceIds:    ids,
+				ActionSource: &pm.DispatchToMultipleRequest_ActionId{ActionId: valid},
+			}
+		}},
+		{"CreateUserRequest.role_ids (omitempty,max=256)", func(ids []string) any {
+			return &pm.CreateUserRequest{Email: "user@test.com", Password: "password123", RoleIds: ids}
+		}},
+		{"AssignRoleToUserGroupRequest.role_ids (omitempty,max=256)", func(ids []string) any {
+			return &pm.AssignRoleToUserGroupRequest{GroupId: valid, RoleIds: ids}
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.NoError(t, api.Validate(context.Background(), tc.build(ulids(256))),
+				"a batch at the 256 cap must pass validation")
+
+			err := api.Validate(context.Background(), tc.build(ulids(257)))
+			require.Error(t, err, "a batch of 257 ids must be rejected by max=256")
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+		})
+	}
+}


### PR DESCRIPTION
Closes #546. Companion to manchtools/power-manage-sdk#316 (merged).

The repeated batch ID request fields now carry `max=256` in the SDK. Every ControlService handler already runs `api.Validate` (proven by `TestEveryControlRPCRunsValidateBeforeWork`), which runs the go-playground validator over those `@gotags` — so the cap is enforced at the request boundary with **no server code change**.

`TestBatchIDFields_CappedAt256` pins it: a 256-id batch validates, a 257-id batch is rejected (CodeInvalidArgument), across the required-batch (`DispatchToMultipleRequest`) and omitempty (`CreateUserRequest`, `AssignRoleToUserGroupRequest`) variants. All eight capped fields share the identical tag + Validate path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Power Manage SDK integration to a newer version.

* **Tests**
  * Added validation coverage confirming batch requests accept up to 256 IDs and reject larger batches with an invalid-argument error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->