### PR TITLE
fix: bind queued-task HMAC to version/direction/queue/type (spec 29 AC1-4)

### DIFF
--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -847,10 +847,17 @@ func TestInbox_RejectsCrossGatewayDeviceOrigin(t *testing.T) {
 			GatewayID:         claimedGateway,
 		})
 		require.NoError(t, err)
-		// Wrap exactly as the producer does so the mux's VerifyMiddleware
-		// admits the payload — the binding is the ONLY thing under test.
-		return asynq.NewTask(taskqueue.TypeExecutionResult, signer.Wrap(raw))
+		// Wrap exactly as the producer does (control:inbox queue, ExecutionResult
+		// type) so the mux's VerifyMiddleware admits the payload — the device→
+		// gateway binding is the ONLY thing under test here.
+		wrapped, err := signer.Wrap(taskqueue.ControlInboxQueue, taskqueue.TypeExecutionResult, raw)
+		require.NoError(t, err)
+		return asynq.NewTask(taskqueue.TypeExecutionResult, wrapped)
 	}
+
+	// inboxCtx carries the queue the VerifyMiddleware binds against (the real
+	// Asynq server would supply it).
+	inboxCtx := taskqueue.WithQueue(context.Background(), taskqueue.ControlInboxQueue)
 
 	seedVictimExecution := func(t *testing.T, st *store.Store, deviceID string) string {
 		t.Helper()
@@ -883,7 +890,7 @@ func TestInbox_RejectsCrossGatewayDeviceOrigin(t *testing.T) {
 		worker := control.NewInboxWorker(st, nil, nil, signer, slog.Default(), bindingRegistry(t, victim, liveGateway))
 		mux := worker.NewMux()
 
-		require.NoError(t, mux.ProcessTask(context.Background(),
+		require.NoError(t, mux.ProcessTask(inboxCtx,
 			signedExecResultTask(t, victim, execID, liveGateway)))
 
 		exec, err := st.Queries().GetExecutionByID(context.Background(), execID)
@@ -898,7 +905,7 @@ func TestInbox_RejectsCrossGatewayDeviceOrigin(t *testing.T) {
 		worker := control.NewInboxWorker(st, nil, nil, signer, slog.Default(), bindingRegistry(t, victim, liveGateway))
 		mux := worker.NewMux()
 
-		require.Error(t, mux.ProcessTask(context.Background(),
+		require.Error(t, mux.ProcessTask(inboxCtx,
 			signedExecResultTask(t, victim, execID, "")),
 			"an empty gateway_id must be rejected while the registry is enabled")
 
@@ -916,7 +923,7 @@ func TestInbox_RejectsCrossGatewayDeviceOrigin(t *testing.T) {
 		worker := control.NewInboxWorker(st, nil, nil, signer, slog.Default(), bindingRegistry(t, victim, liveGateway))
 		mux := worker.NewMux()
 
-		require.Error(t, mux.ProcessTask(context.Background(),
+		require.Error(t, mux.ProcessTask(inboxCtx,
 			signedExecResultTask(t, victim, execID, wrongGateway)),
 			"a gateway the device is not live on must not complete its execution")
 

--- a/internal/gateway/task_handlers_test.go
+++ b/internal/gateway/task_handlers_test.go
@@ -384,16 +384,19 @@ func TestGatewayMux_RejectsUnsignedTask(t *testing.T) {
 		return mux
 	}
 
-	// queue context so VerifyMiddleware's queueOf has a name.
+	// queue context so VerifyMiddleware's queueOf resolves the device queue the
+	// task is bound to (the real Asynq server would supply this).
+	deviceQueue := taskqueue.DeviceQueue("device-hmac")
 	ctxWithQueue := func() context.Context {
-		return context.Background()
+		return taskqueue.WithQueue(context.Background(), deviceQueue)
 	}
 
 	t.Run("correctly wrapped task reaches the handler", func(t *testing.T) {
 		sender := &recordingMessageSender{}
 		mux := newMux(sender)
-		wrapped := taskSigner.Wrap(innerPayload)
-		err := mux.ProcessTask(ctxWithQueue(), asynq.NewTask(taskqueue.TypeActionDispatch, wrapped))
+		wrapped, err := taskSigner.Wrap(deviceQueue, taskqueue.TypeActionDispatch, innerPayload)
+		require.NoError(t, err)
+		err = mux.ProcessTask(ctxWithQueue(), asynq.NewTask(taskqueue.TypeActionDispatch, wrapped))
 		require.NoError(t, err)
 		require.Len(t, sender.messages, 1, "a correctly HMAC-wrapped task must reach handleActionDispatch")
 	})
@@ -410,7 +413,8 @@ func TestGatewayMux_RejectsUnsignedTask(t *testing.T) {
 	t.Run("wrong-key task is rejected before the handler", func(t *testing.T) {
 		sender := &recordingMessageSender{}
 		mux := newMux(sender)
-		wrapped := wrongSigner.Wrap(innerPayload) // HMAC under the wrong key
+		wrapped, wErr := wrongSigner.Wrap(deviceQueue, taskqueue.TypeActionDispatch, innerPayload)
+		require.NoError(t, wErr) // HMAC under the wrong key
 		err := mux.ProcessTask(ctxWithQueue(), asynq.NewTask(taskqueue.TypeActionDispatch, wrapped))
 		require.Error(t, err)
 		assert.Empty(t, sender.messages, "wrong-key task must NOT reach the handler")
@@ -419,11 +423,12 @@ func TestGatewayMux_RejectsUnsignedTask(t *testing.T) {
 	t.Run("byte-tampered task is rejected before the handler", func(t *testing.T) {
 		sender := &recordingMessageSender{}
 		mux := newMux(sender)
-		wrapped := taskSigner.Wrap(innerPayload)
+		wrapped, err := taskSigner.Wrap(deviceQueue, taskqueue.TypeActionDispatch, innerPayload)
+		require.NoError(t, err)
 		// Flip a byte in the payload region (after the 32-byte HMAC prefix).
 		tampered := append([]byte(nil), wrapped...)
 		tampered[len(tampered)-1] ^= 0xff
-		err := mux.ProcessTask(ctxWithQueue(), asynq.NewTask(taskqueue.TypeActionDispatch, tampered))
+		err = mux.ProcessTask(ctxWithQueue(), asynq.NewTask(taskqueue.TypeActionDispatch, tampered))
 		require.Error(t, err)
 		assert.Empty(t, sender.messages, "byte-tampered task must NOT reach the handler")
 	})

--- a/internal/search/worker_test.go
+++ b/internal/search/worker_test.go
@@ -38,14 +38,19 @@ func newWorkerFixture(t *testing.T) *workerFixture {
 	mux := asynq.NewServeMux()
 	worker.RegisterHandlers(mux)
 
-	return &workerFixture{ctx: context.Background(), rdb: rdb, signer: signer, mux: mux}
+	// The queue seam supplies the queue name the mux's VerifyMiddleware binds
+	// against, which the real Asynq server would otherwise provide.
+	ctx := taskqueue.WithQueue(context.Background(), taskqueue.SearchQueue)
+	return &workerFixture{ctx: ctx, rdb: rdb, signer: signer, mux: mux}
 }
 
 func (f *workerFixture) signedTask(t *testing.T, taskType string, payload any) *asynq.Task {
 	t.Helper()
 	data, err := json.Marshal(payload)
 	require.NoError(t, err)
-	return asynq.NewTask(taskType, f.signer.Wrap(data), asynq.Queue(taskqueue.SearchQueue))
+	wrapped, err := f.signer.Wrap(taskqueue.SearchQueue, taskType, data)
+	require.NoError(t, err)
+	return asynq.NewTask(taskType, wrapped, asynq.Queue(taskqueue.SearchQueue))
 }
 
 func TestWorker_ReindexRequiresSignedTaskAndWritesHash(t *testing.T) {
@@ -113,9 +118,12 @@ func TestWorker_UnsignedTaskIsRejected(t *testing.T) {
 	data, err := json.Marshal(payload)
 	require.NoError(t, err)
 
+	// A raw (unsigned) payload has no version+HMAC prefix, so it is rejected —
+	// its leading byte is not the envelope version — and dead-lettered.
 	err = f.mux.ProcessTask(f.ctx, asynq.NewTask(taskqueue.TypeSearchReindex, data))
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "task signature")
+	assert.True(t, errors.Is(err, asynq.SkipRetry),
+		"an unsigned/raw task must be rejected and dead-lettered, not retry-loop; got %v", err)
 }
 
 // A task signed with a DIFFERENT key (forged, not merely absent) must be
@@ -149,8 +157,11 @@ func TestWorker_ForgedKeyTaskRejectedAndNoHSET(t *testing.T) {
 			f := newWorkerFixture(t)
 			data, err := json.Marshal(tc.payload)
 			require.NoError(t, err)
-			// Signed with the WRONG key.
-			task := asynq.NewTask(tc.taskType, forged.Wrap(data), asynq.Queue(taskqueue.SearchQueue))
+			// Signed with the WRONG key (correct queue/type, so it reaches
+			// verification and fails on the signature).
+			wrapped, err := forged.Wrap(taskqueue.SearchQueue, tc.taskType, data)
+			require.NoError(t, err)
+			task := asynq.NewTask(tc.taskType, wrapped, asynq.Queue(taskqueue.SearchQueue))
 
 			err = f.mux.ProcessTask(f.ctx, task)
 			require.Error(t, err)

--- a/internal/taskqueue/client.go
+++ b/internal/taskqueue/client.go
@@ -87,7 +87,10 @@ func (c *Client) EnqueueToDevice(deviceID, taskType string, payload any, opts ..
 	}
 
 	task := asynq.NewTask(taskType, data)
-	enqueueOpts := append([]asynq.Option{asynq.Queue(queue)}, opts...)
+	// Apply the signed queue LAST so a caller-supplied asynq.Queue option can't
+	// override it — the task must land on exactly the queue it was signed for,
+	// or the consumer's queue-bound HMAC check would (correctly) reject it.
+	enqueueOpts := append(append([]asynq.Option{}, opts...), asynq.Queue(queue))
 	_, err = c.client.Enqueue(task, enqueueOpts...)
 	if err != nil {
 		return fmt.Errorf("enqueue to device %s: %w", deviceID, err)

--- a/internal/taskqueue/client.go
+++ b/internal/taskqueue/client.go
@@ -78,12 +78,16 @@ func (c *Client) EnqueueToDevice(deviceID, taskType string, payload any, opts ..
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
-	// Wrap with HMAC prefix (audit F-02). c.signer is nil-safe — a
-	// disabled signer returns data unchanged.
-	data = c.signer.Wrap(data)
+	// Sign the envelope, binding it to this exact queue + task type (audit F-02;
+	// spec 29). c.signer is nil-safe — a disabled signer returns data unchanged.
+	queue := DeviceQueue(deviceID)
+	data, err = c.signer.Wrap(queue, taskType, data)
+	if err != nil {
+		return fmt.Errorf("sign task for %s: %w", queue, err)
+	}
 
 	task := asynq.NewTask(taskType, data)
-	enqueueOpts := append([]asynq.Option{asynq.Queue(DeviceQueue(deviceID))}, opts...)
+	enqueueOpts := append([]asynq.Option{asynq.Queue(queue)}, opts...)
 	_, err = c.client.Enqueue(task, enqueueOpts...)
 	if err != nil {
 		return fmt.Errorf("enqueue to device %s: %w", deviceID, err)
@@ -105,11 +109,14 @@ func (c *Client) EnqueueToControl(taskType string, payload any) error {
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
-	data = c.signer.Wrap(data)
-
 	queue := ControlInboxQueue
 	if taskType == TypeTerminalAuditChunk {
 		queue = ControlTerminalAuditQueue
+	}
+
+	data, err = c.signer.Wrap(queue, taskType, data)
+	if err != nil {
+		return fmt.Errorf("sign task for %s: %w", queue, err)
 	}
 
 	task := asynq.NewTask(taskType, data)
@@ -126,7 +133,10 @@ func (c *Client) EnqueueToSearch(taskType string, payload any) error {
 	if err != nil {
 		return fmt.Errorf("marshal payload: %w", err)
 	}
-	data = c.signer.Wrap(data)
+	data, err = c.signer.Wrap(SearchQueue, taskType, data)
+	if err != nil {
+		return fmt.Errorf("sign task for %s: %w", SearchQueue, err)
+	}
 
 	task := asynq.NewTask(taskType, data)
 	_, err = c.client.Enqueue(task, asynq.Queue(SearchQueue))

--- a/internal/taskqueue/client_test.go
+++ b/internal/taskqueue/client_test.go
@@ -44,6 +44,33 @@ func TestClient_EnqueueToDeviceSignsPayloadAndUsesDeviceQueue(t *testing.T) {
 	assert.Equal(t, payload.Limit, got.Limit)
 }
 
+// A caller-supplied asynq.Queue option must NOT override the signed device
+// queue — the task must land on exactly the queue its HMAC is bound to, or the
+// consumer would (correctly) reject it as a queue mismatch.
+func TestClient_EnqueueToDeviceIgnoresConflictingQueueOption(t *testing.T) {
+	mr := miniredis.RunT(t)
+	signer, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+	client := NewClientWithSigner(mr.Addr(), "", 0, signer)
+	t.Cleanup(func() { require.NoError(t, client.Close()) })
+
+	require.NoError(t, client.EnqueueToDevice("device-1", TypeOSQueryDispatch,
+		OSQueryDispatchPayload{QueryID: "q"}, asynq.Queue("attacker-chosen")))
+
+	inspector := asynq.NewInspector(asynq.RedisClientOpt{Addr: mr.Addr()})
+	t.Cleanup(func() { require.NoError(t, inspector.Close()) })
+
+	onSigned, err := inspector.ListPendingTasks(DeviceQueue("device-1"))
+	require.NoError(t, err)
+	require.Len(t, onSigned, 1, "the task must be enqueued to the signed device queue")
+
+	onOverride, err := inspector.ListPendingTasks("attacker-chosen")
+	if !errors.Is(err, asynq.ErrQueueNotFound) {
+		require.NoError(t, err)
+	}
+	assert.Empty(t, onOverride, "a caller-supplied queue option must not override the signed queue")
+}
+
 func TestClient_EnqueueToControlRoutesTerminalAuditToSerialQueue(t *testing.T) {
 	mr := miniredis.RunT(t)
 	signer, err := NewSigner(testKeyHex)

--- a/internal/taskqueue/client_test.go
+++ b/internal/taskqueue/client_test.go
@@ -31,8 +31,11 @@ func TestClient_EnqueueToDeviceSignsPayloadAndUsesDeviceQueue(t *testing.T) {
 	assert.Equal(t, TypeOSQueryDispatch, tasks[0].Type)
 	assert.NotEqual(t, []byte(`{"QueryID":"query-1"}`), tasks[0].Payload, "payload must be HMAC wrapped before it is stored in Valkey")
 
-	verified, err := signer.Verify(tasks[0].Payload)
+	// The stored task verifies ONLY under its actual queue + type (spec 29).
+	verified, err := signer.Verify(DeviceQueue("device-1"), tasks[0].Type, tasks[0].Payload)
 	require.NoError(t, err)
+	_, wrongQueueErr := signer.Verify(ControlInboxQueue, tasks[0].Type, tasks[0].Payload)
+	require.Error(t, wrongQueueErr, "a device task must not verify under the control-inbox queue/direction")
 	var got OSQueryDispatchPayload
 	require.NoError(t, json.Unmarshal(verified, &got))
 	assert.Equal(t, payload.QueryID, got.QueryID)
@@ -72,8 +75,10 @@ func TestClient_EnqueueToControlRoutesTerminalAuditToSerialQueue(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, auditTasks, 1)
 	assert.Equal(t, TypeTerminalAuditChunk, auditTasks[0].Type)
-	verified, err := signer.Verify(auditTasks[0].Payload)
+	verified, err := signer.Verify(ControlTerminalAuditQueue, auditTasks[0].Type, auditTasks[0].Payload)
 	require.NoError(t, err)
+	_, wrongQueueErr := signer.Verify(ControlInboxQueue, auditTasks[0].Type, auditTasks[0].Payload)
+	require.Error(t, wrongQueueErr, "a terminal-audit task must not verify under the control-inbox queue")
 	var got TerminalAuditChunkPayload
 	require.NoError(t, json.Unmarshal(verified, &got))
 	assert.Equal(t, "sess-1", got.SessionID)

--- a/internal/taskqueue/sign.go
+++ b/internal/taskqueue/sign.go
@@ -1,78 +1,114 @@
 package taskqueue
 
-// HMAC-SHA256 signed envelope for Asynq task payloads (audit F-02).
+// HMAC-SHA256 signed envelope for Asynq task payloads (audit F-02; hardened by
+// spec 29 to bind task metadata, not just payload bytes).
 //
-// Threat model: Valkey is a trust boundary for the control ↔ gateway
-// path. A Valkey compromise (CVE, weak password, network exposure,
-// misconfigured ACL) lets an attacker enqueue arbitrary tasks into
-// any device queue or the control inbox. Without signing, the gateway
-// dispatches those tasks to the agent's mTLS stream, and the agent
-// trusts them. For non-action paths (terminal input, osquery, log
-// queries) the agent has no other validation — a forged task arrives
-// as a real instruction. For action-dispatch, the CA-signed action
-// signature mitigates payload forgery but does not stop an attacker
-// from causing arbitrary side effects (re-dispatching a legitimate
-// action against the wrong device, replaying old tasks, etc.).
+// Threat model: Valkey is a trust boundary for the control ↔ gateway path. A
+// Valkey compromise (CVE, weak password, network exposure, misconfigured ACL)
+// lets an attacker enqueue arbitrary tasks into any device queue or the control
+// inbox. Without signing, the gateway dispatches those tasks to the agent's
+// mTLS stream, and the agent trusts them. For non-action paths (terminal input,
+// osquery, log queries) the agent has no other validation. For action-dispatch,
+// the CA-signed action signature mitigates payload forgery but does not stop an
+// attacker from causing arbitrary side effects.
 //
-// Format of a signed task envelope:
+// The original envelope signed ONLY the payload bytes, so a holder of a valid
+// signed task (or a queue writer) could REPLAY those bytes under a different
+// queue, task type, or direction — the consumer verified the payload and then
+// dispatched using the independently-supplied Asynq queue/type. Spec 29 binds
+// the HMAC to (version, direction, exact queue, task type, payload) so a signed
+// task is valid only in the exact position it was signed for.
 //
-//   [ 32 bytes HMAC-SHA256(key, payload) ][ payload bytes ]
+// Envelope format (clean-break v1 — there is intentionally NO payload-only
+// fallback; an old payload-only envelope fails the version check):
 //
-// Workers strip the 32-byte prefix, verify the HMAC in constant
-// time, and only then invoke their normal JSON-decoding handler.
-// Tampered or unsigned tasks are rejected with a non-retriable
-// asynq.SkipRetry error so they land in the dead queue for operator
-// inspection rather than burning retry slots.
+//   [ 1 byte version=1 ][ 32 bytes HMAC-SHA256 ][ payload bytes ]
 //
-// Key distribution: `PM_TASK_SIGNING_KEY` is a 32-byte (64 hex char)
-// shared secret that must be configured identically on every service
-// that participates in the Asynq fan-out (control, gateway, indexer).
-// Operators rotate it by setting two values in `.env` during the
-// rotation window and pointing every service at the new one in
-// lock-step — there is intentionally no support for "accept either
-// of two keys" because the rotation window is bounded by
-// queue-drain time (minutes), not by token lifetime (hours/days).
+// The HMAC preimage is a fixed domain tag followed by length-prefixed fields:
+//
+//   domainTag || u8(version) || lp(direction) || lp(queue) || lp(type) || lp(payload)
+//
+// where lp(x) = u32be(len(x)) || x. Direction is DERIVED from the queue class
+// (device:* → control→device, control:inbox → device→control, terminal-audit,
+// search → control→search), never caller-supplied, so a signed task cannot be
+// replayed across directions.
+//
+// Workers verify in constant time (hmac.Equal) and reject tampered, unsigned,
+// unknown-queue, unsupported-version, or truncated tasks with a non-retriable
+// asynq.SkipRetry error so they land in the dead queue for operator inspection
+// rather than burning retry slots.
+//
+// Key distribution: `PM_TASK_SIGNING_KEY` is a 32-byte (64 hex char) shared
+// secret configured identically on every service in the fan-out (control,
+// gateway, indexer). This is a clean-break format: drain pending queues (or stop
+// producers) before deploying, and deploy every service from the same release —
+// mixed old/new signers are intentionally unsupported.
 
 import (
+	"bytes"
 	"context"
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hibiken/asynq"
 )
 
-// signatureSize is the byte length of an HMAC-SHA256 prefix.
+// signatureSize is the byte length of an HMAC-SHA256 signature.
 const signatureSize = sha256.Size
 
-// ErrUnsignedTask is returned by Signer.Verify when the envelope is
-// shorter than the signature prefix, i.e. the producer didn't wrap
-// the payload. Surfaces in worker logs as "task too short" so
-// operators can tell unsigned-task-during-upgrade from key-mismatch.
+// envelopeVersion is the current envelope version byte. A clean break: a task
+// carrying any other leading byte (including a legacy payload-only envelope,
+// whose first byte is a random HMAC byte) is rejected.
+const envelopeVersion byte = 1
+
+// signDomainTag domain-separates the task HMAC from any other HMAC in the system
+// that might share the key material, and pins the format version.
+const signDomainTag = "power-manage:taskqueue:v1"
+
+// Queue-class directions bound into the HMAC preimage. Derived from the queue
+// name (not caller-supplied) so a signed task cannot be replayed across the
+// control↔device↔search boundaries.
+const (
+	dirControlToDevice = "c2d"
+	dirDeviceToControl = "d2c"
+	dirTerminalAudit   = "audit"
+	dirControlToSearch = "c2s"
+)
+
+// ErrUnsignedTask is returned when the envelope is shorter than version+signature,
+// i.e. the producer didn't wrap the payload (or it was truncated).
 var ErrUnsignedTask = errors.New("taskqueue: task is unsigned or truncated")
 
-// ErrSignatureMismatch is returned by Signer.Verify when the HMAC
-// over the payload does not match the prefix. Caused by either a
-// key mismatch between producer and consumer, or by a third party
-// tampering with the queue contents.
+// ErrSignatureMismatch is returned when the HMAC does not match — a key mismatch,
+// tampering, or a replay of a task signed for a different queue/type/direction.
 var ErrSignatureMismatch = errors.New("taskqueue: task signature mismatch")
 
-// Signer holds an HMAC key for sign + verify operations. Construct
-// once at boot from PM_TASK_SIGNING_KEY and pass through to both
-// Client (producer side) and the worker handler chain (consumer
-// side). nil-safe: a nil Signer means "signing disabled" — handlers
-// receive raw task payloads unchanged. nil should only ever appear
-// in test fixtures; production wiring rejects an empty key at boot.
+// ErrUnknownQueue is returned when a queue name maps to no known direction. It
+// fails closed: neither producer nor consumer will proceed for an unrecognized
+// queue class.
+var ErrUnknownQueue = errors.New("taskqueue: unknown queue class")
+
+// ErrUnsupportedVersion is returned when the envelope's leading version byte is
+// not the supported version — including a legacy payload-only envelope.
+var ErrUnsupportedVersion = errors.New("taskqueue: unsupported envelope version")
+
+// Signer holds an HMAC key for sign + verify. Construct once at boot from
+// PM_TASK_SIGNING_KEY and pass to both Client (producer) and the worker mux
+// chains (consumer). nil-safe: a nil Signer means "signing disabled" — Wrap
+// returns the payload unchanged and Verify accepts it. nil should only appear in
+// test fixtures; production boot rejects an empty key.
 type Signer struct {
 	key []byte
 }
 
-// NewSigner parses keyHex (32-byte HMAC key as 64 hex chars) and
-// returns a Signer. Empty string returns (nil, nil) so callers can
-// pass through "signing disabled" without an error — but production
-// boot code must treat that case as fatal.
+// NewSigner parses keyHex (32-byte HMAC key as 64 hex chars). Empty string
+// returns (nil, nil) so callers can pass through "signing disabled" without an
+// error — production boot must treat that as fatal.
 func NewSigner(keyHex string) (*Signer, error) {
 	if keyHex == "" {
 		return nil, nil
@@ -88,78 +124,148 @@ func NewSigner(keyHex string) (*Signer, error) {
 	return &Signer{key: key}, nil
 }
 
-// Wrap returns the signed envelope: HMAC prefix followed by the raw
-// payload bytes. Nil-safe — a nil Signer returns the payload unchanged
-// so tests that don't wire a signer continue to work.
-func (s *Signer) Wrap(payload []byte) []byte {
-	if s == nil {
-		return payload
+// directionForQueue maps a queue name to its bound direction. Returns ok=false
+// for an unrecognized queue class (fail closed).
+func directionForQueue(queue string) (string, bool) {
+	switch {
+	case strings.HasPrefix(queue, deviceQueuePrefix):
+		return dirControlToDevice, true
+	case queue == ControlInboxQueue:
+		return dirDeviceToControl, true
+	case queue == ControlTerminalAuditQueue:
+		return dirTerminalAudit, true
+	case queue == SearchQueue:
+		return dirControlToSearch, true
+	default:
+		return "", false
 	}
-	mac := hmac.New(sha256.New, s.key)
-	mac.Write(payload)
-	sig := mac.Sum(nil)
-	out := make([]byte, 0, len(sig)+len(payload))
-	out = append(out, sig...)
-	out = append(out, payload...)
-	return out
 }
 
-// Verify strips the signature prefix from envelope and returns the
-// inner payload bytes when the HMAC matches. Constant-time compare
-// via hmac.Equal — do not switch to bytes.Equal. Nil-safe.
-func (s *Signer) Verify(envelope []byte) ([]byte, error) {
+// mac computes HMAC-SHA256 over the domain-separated, length-prefixed preimage
+// binding version, direction, queue, task type, and payload.
+func (s *Signer) mac(version byte, direction, queue, taskType string, payload []byte) []byte {
+	var b bytes.Buffer
+	b.WriteString(signDomainTag)
+	b.WriteByte(version)
+	writeLenPrefixed(&b, []byte(direction))
+	writeLenPrefixed(&b, []byte(queue))
+	writeLenPrefixed(&b, []byte(taskType))
+	writeLenPrefixed(&b, payload)
+
+	m := hmac.New(sha256.New, s.key)
+	m.Write(b.Bytes())
+	return m.Sum(nil)
+}
+
+// writeLenPrefixed writes u32be(len(x)) || x so concatenated fields are
+// unambiguous (no field boundary can be shifted to forge a different tuple with
+// the same preimage bytes).
+func writeLenPrefixed(b *bytes.Buffer, x []byte) {
+	var l [4]byte
+	binary.BigEndian.PutUint32(l[:], uint32(len(x)))
+	b.Write(l[:])
+	b.Write(x)
+}
+
+// Wrap returns the signed envelope for a task destined for queue with taskType.
+// Nil-safe — a nil Signer returns the payload unchanged (signing disabled).
+// Returns ErrUnknownQueue for an unrecognized queue class so the producer fails
+// closed rather than emitting an unverifiable task.
+func (s *Signer) Wrap(queue, taskType string, payload []byte) ([]byte, error) {
+	if s == nil {
+		return payload, nil
+	}
+	direction, ok := directionForQueue(queue)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownQueue, queue)
+	}
+	sig := s.mac(envelopeVersion, direction, queue, taskType, payload)
+	out := make([]byte, 0, 1+len(sig)+len(payload))
+	out = append(out, envelopeVersion)
+	out = append(out, sig...)
+	out = append(out, payload...)
+	return out, nil
+}
+
+// Verify checks the envelope against queue+taskType and returns the inner
+// payload when the HMAC matches. Constant-time compare via hmac.Equal — do not
+// switch to bytes.Equal. Nil-safe. Fails closed on a short envelope, an
+// unsupported version (including a legacy payload-only envelope), an unknown
+// queue class, or a signature mismatch (which also covers a task replayed under
+// a different queue/type/direction).
+func (s *Signer) Verify(queue, taskType string, envelope []byte) ([]byte, error) {
 	if s == nil {
 		return envelope, nil
 	}
-	if len(envelope) < signatureSize {
+	if len(envelope) < 1+signatureSize {
 		return nil, ErrUnsignedTask
 	}
-	sig := envelope[:signatureSize]
-	payload := envelope[signatureSize:]
-	mac := hmac.New(sha256.New, s.key)
-	mac.Write(payload)
-	expected := mac.Sum(nil)
+	if version := envelope[0]; version != envelopeVersion {
+		return nil, fmt.Errorf("%w: %d", ErrUnsupportedVersion, version)
+	}
+	direction, ok := directionForQueue(queue)
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownQueue, queue)
+	}
+	sig := envelope[1 : 1+signatureSize]
+	payload := envelope[1+signatureSize:]
+	expected := s.mac(envelopeVersion, direction, queue, taskType, payload)
 	if !hmac.Equal(sig, expected) {
 		return nil, ErrSignatureMismatch
 	}
 	return payload, nil
 }
 
-// VerifyMiddleware returns an asynq middleware that verifies the
-// envelope HMAC and replaces the task's payload with the unwrapped
-// bytes before passing it down to the wrapped handler chain. Wrap
-// every mux registration with this in production wiring; tests that
-// don't sign can pass a nil Signer and the middleware is a no-op.
+// VerifyMiddleware returns an asynq middleware that verifies the envelope
+// against the task's actual queue (from ctx) and type before passing the
+// unwrapped payload to the handler chain. Wrap every mux registration with it in
+// production; a nil Signer makes it a no-op (tests only).
 //
-// Verification failures wrap asynq.SkipRetry so an attacker with
-// transient Valkey access can't burn retry slots by injecting
-// unsigned tasks — the task lands in the dead queue immediately
-// and surfaces as a single WARN line for the operator.
+// Verification failures wrap asynq.SkipRetry so an attacker with transient
+// Valkey access can't burn retry slots by injecting bad tasks — the task
+// dead-letters immediately and surfaces as a single WARN line.
 func (s *Signer) VerifyMiddleware() asynq.MiddlewareFunc {
 	return func(next asynq.Handler) asynq.Handler {
 		return asynq.HandlerFunc(func(ctx context.Context, t *asynq.Task) error {
 			if s == nil {
 				return next.ProcessTask(ctx, t)
 			}
-			payload, err := s.Verify(t.Payload())
+			queue := queueOf(ctx)
+			payload, err := s.Verify(queue, t.Type(), t.Payload())
 			if err != nil {
-				return fmt.Errorf("%w: %s/%s: %v",
-					asynq.SkipRetry, queueOf(ctx), t.Type(), err)
+				return fmt.Errorf("%w: %s/%s: %v", asynq.SkipRetry, queue, t.Type(), err)
 			}
-			// Replace the task's payload in-place so downstream
-			// handlers see the unwrapped bytes. asynq.NewTask copies
-			// the payload — we construct a fresh Task with the
-			// verified content so handlers don't have to know about
-			// signing.
-			verified := asynq.NewTask(t.Type(), payload, asynq.Queue(queueOf(ctx)))
+			// Rebuild the task with the verified (unwrapped) payload so downstream
+			// handlers don't have to know about signing, preserving the queue.
+			verified := asynq.NewTask(t.Type(), payload, asynq.Queue(queue))
 			return next.ProcessTask(ctx, verified)
 		})
 	}
 }
 
-// queueOf retrieves the task's queue name from the asynq context.
-// Returns "" if not present (which only happens in synthetic tests).
+// queueCtxKey carries the queue name for callers that invoke a handler chain
+// outside the Asynq server (which provides the queue via asynq.GetQueueName).
+type queueCtxKey struct{}
+
+// WithQueue returns a context carrying the queue a task is processed under. In
+// production the Asynq server supplies the queue through its own context; this
+// helper is for tests (and any non-Asynq caller) that drive a mux's
+// ProcessTask directly, where Asynq's queue context is absent. queueOf prefers
+// Asynq's value and only falls back to this one — production wiring runs through
+// the real server, so it never sets this key.
+func WithQueue(ctx context.Context, queue string) context.Context {
+	return context.WithValue(ctx, queueCtxKey{}, queue)
+}
+
+// queueOf retrieves the task's queue name: the Asynq server's value in
+// production, or the WithQueue fallback for direct-invocation tests. Returns ""
+// if neither is present; "" maps to no direction, so Verify fails closed.
 func queueOf(ctx context.Context) string {
-	q, _ := asynq.GetQueueName(ctx)
-	return q
+	if q, ok := asynq.GetQueueName(ctx); ok && q != "" {
+		return q
+	}
+	if q, ok := ctx.Value(queueCtxKey{}).(string); ok {
+		return q
+	}
+	return ""
 }

--- a/internal/taskqueue/sign_middleware_test.go
+++ b/internal/taskqueue/sign_middleware_test.go
@@ -1,0 +1,79 @@
+package taskqueue
+
+// Integration test for VerifyMiddleware: a real Asynq server + miniredis proves
+// that a task whose signed queue/type does NOT match the queue/type it is
+// actually processed under never reaches the downstream handler — it is
+// rejected by the middleware (SkipRetry) and archived instead (spec 29, AC2).
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyMiddleware_QueueOrTypeReplayNeverReachesHandler(t *testing.T) {
+	mr := miniredis.RunT(t)
+	signer, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+	redisOpt := asynq.RedisClientOpt{Addr: mr.Addr()}
+
+	delivered := make(chan string, 8)
+	mux := asynq.NewServeMux()
+	mux.Use(signer.VerifyMiddleware())
+	mux.HandleFunc(testType, func(ctx context.Context, task *asynq.Task) error {
+		delivered <- string(task.Payload())
+		return nil
+	})
+
+	aclient := asynq.NewClient(redisOpt)
+	t.Cleanup(func() { _ = aclient.Close() })
+
+	// 1. A valid task on its correct queue + type.
+	validEnv, err := signer.Wrap("device:dev-1", testType, []byte("valid"))
+	require.NoError(t, err)
+	_, err = aclient.Enqueue(asynq.NewTask(testType, validEnv), asynq.Queue("device:dev-1"))
+	require.NoError(t, err)
+
+	// 2. Queue replay: signed for device:dev-1, but enqueued (unchanged bytes)
+	//    onto the control-inbox queue.
+	queueReplay, err := signer.Wrap("device:dev-1", testType, []byte("queue-replay"))
+	require.NoError(t, err)
+	_, err = aclient.Enqueue(asynq.NewTask(testType, queueReplay), asynq.Queue(ControlInboxQueue))
+	require.NoError(t, err)
+
+	// 3. Type replay: signed for a different task type, but delivered as testType
+	//    (so it routes to the handler) on the correct queue.
+	typeReplay, err := signer.Wrap("device:dev-1", "some:other-type", []byte("type-replay"))
+	require.NoError(t, err)
+	_, err = aclient.Enqueue(asynq.NewTask(testType, typeReplay), asynq.Queue("device:dev-1"))
+	require.NoError(t, err)
+
+	srv := asynq.NewServer(redisOpt, asynq.Config{
+		Concurrency: 2,
+		Queues:      map[string]int{"device:dev-1": 1, ControlInboxQueue: 1},
+		LogLevel:    asynq.FatalLevel, // keep the test output quiet
+	})
+	require.NoError(t, srv.Start(mux))
+	t.Cleanup(srv.Shutdown)
+
+	// The valid task must be delivered; the two replays must not. Wait for the
+	// valid delivery, then give the replays ample time to be (wrongly) delivered
+	// if the binding were broken.
+	select {
+	case got := <-delivered:
+		require.Equal(t, "valid", got, "only the correctly-bound task may reach the handler")
+	case <-time.After(10 * time.Second):
+		t.Fatal("valid task was never delivered — server/handler wiring is broken")
+	}
+
+	select {
+	case got := <-delivered:
+		t.Fatalf("a replayed task reached the handler: %q — the queue/type binding is not enforced", got)
+	case <-time.After(1500 * time.Millisecond):
+		// No further delivery — the replays were rejected by the middleware.
+	}
+}

--- a/internal/taskqueue/sign_test.go
+++ b/internal/taskqueue/sign_test.go
@@ -1,20 +1,17 @@
 package taskqueue
 
-// Pure-Go tests for the Asynq task-envelope signer (audit F-02).
-//
-// The wire format is `[32 bytes HMAC-SHA256][payload]`. These tests
-// lock in:
-//   - parse-time validation of the hex key (wrong length, malformed
-//     hex, empty disables);
-//   - round-trip: a Wrapped payload Verifies cleanly back to the
-//     original bytes;
-//   - rejection: tampered prefix, tampered payload, truncated
-//     envelope, and unsigned envelope each return a typed error;
-//   - nil-safety: a nil Signer is a no-op for both Wrap and Verify
-//     so tests that don't care about signing don't need to plumb
-//     one in.
+// Pure-Go tests for the versioned, metadata-bound Asynq task-envelope signer
+// (audit F-02; spec 29). The wire format is
+// `[1 byte version][32 bytes HMAC-SHA256][payload]`, with the HMAC bound to
+// (version, direction, exact queue, task type, payload). These tests lock in the
+// key parsing, round-trip, and the full rejection matrix: tampered signature /
+// payload / version, replay under a different queue / direction / task type,
+// unknown queue class, truncated envelope, wrong key, and a legacy payload-only
+// envelope (which must NOT pass through any compatibility fallback).
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
 	"errors"
 	"strings"
 	"testing"
@@ -24,6 +21,14 @@ import (
 )
 
 const testKeyHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// A valid queue+type pair for round-trips: a device queue (control→device).
+const (
+	testQueue = "device:dev-1"
+	testType  = "action:dispatch"
+)
+
+func clone(b []byte) []byte { return append([]byte(nil), b...) }
 
 func TestNewSigner_ParsesValidKey(t *testing.T) {
 	s, err := NewSigner(testKeyHex)
@@ -39,12 +44,7 @@ func TestNewSigner_EmptyKeyReturnsNilNil(t *testing.T) {
 }
 
 func TestNewSigner_WrongLengthRejected(t *testing.T) {
-	cases := []string{
-		"00",
-		strings.Repeat("ab", 31), // 31 bytes
-		strings.Repeat("ab", 33), // 33 bytes
-	}
-	for _, k := range cases {
+	for _, k := range []string{"00", strings.Repeat("ab", 31), strings.Repeat("ab", 33)} {
 		t.Run(k[:min(8, len(k))], func(t *testing.T) {
 			_, err := NewSigner(k)
 			require.Error(t, err)
@@ -59,103 +59,175 @@ func TestNewSigner_MalformedHexRejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "valid hex")
 }
 
+// AC1: round-trip with known queue/type metadata returns the original payload.
 func TestSigner_WrapVerifyRoundTrip(t *testing.T) {
 	s, err := NewSigner(testKeyHex)
 	require.NoError(t, err)
 
-	cases := [][]byte{
+	for _, payload := range [][]byte{
 		[]byte(""),
 		[]byte("{}"),
 		[]byte(`{"device_id":"abc","action_type":1}`),
 		[]byte(strings.Repeat("payload bytes ", 100)),
-	}
-	for _, payload := range cases {
-		wrapped := s.Wrap(payload)
-		assert.Equal(t, signatureSize+len(payload), len(wrapped),
-			"wrapped envelope = 32-byte HMAC prefix + payload")
-		out, err := s.Verify(wrapped)
+	} {
+		env, err := s.Wrap(testQueue, testType, payload)
+		require.NoError(t, err)
+		assert.Equal(t, 1+signatureSize+len(payload), len(env), "envelope = version + 32-byte HMAC + payload")
+		assert.Equal(t, envelopeVersion, env[0])
+
+		out, err := s.Verify(testQueue, testType, env)
 		require.NoError(t, err)
 		assert.Equal(t, payload, out)
 	}
 }
 
-func TestSigner_VerifyRejectsTamperedSignature(t *testing.T) {
+// AC2: independently changing any bound field rejects the task.
+func TestSigner_VerifyRejectsEachTamperedOrReplayedField(t *testing.T) {
 	s, err := NewSigner(testKeyHex)
 	require.NoError(t, err)
-	wrapped := s.Wrap([]byte(`{"x":1}`))
-	wrapped[0] ^= 0xFF // flip the first byte of the HMAC
+	payload := []byte(`{"x":1}`)
+	env, err := s.Wrap(testQueue, testType, payload)
+	require.NoError(t, err)
 
-	_, err = s.Verify(wrapped)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrSignatureMismatch),
-		"tampered signature must return ErrSignatureMismatch")
+	cases := []struct {
+		name    string
+		verify  func() ([]byte, error)
+		wantErr error
+	}{
+		{"tampered signature", func() ([]byte, error) {
+			e := clone(env)
+			e[1] ^= 0xFF
+			return s.Verify(testQueue, testType, e)
+		}, ErrSignatureMismatch},
+		{"tampered payload", func() ([]byte, error) {
+			e := clone(env)
+			e[len(e)-1] ^= 0xFF
+			return s.Verify(testQueue, testType, e)
+		}, ErrSignatureMismatch},
+		{"tampered version", func() ([]byte, error) {
+			e := clone(env)
+			e[0] = envelopeVersion + 1
+			return s.Verify(testQueue, testType, e)
+		}, ErrUnsupportedVersion},
+		{"replayed under a different exact queue (cross-device)", func() ([]byte, error) {
+			return s.Verify("device:dev-2", testType, env)
+		}, ErrSignatureMismatch},
+		{"replayed under a different direction (control inbox)", func() ([]byte, error) {
+			return s.Verify(ControlInboxQueue, testType, env)
+		}, ErrSignatureMismatch},
+		{"replayed under a different task type", func() ([]byte, error) {
+			return s.Verify(testQueue, "other:type", env)
+		}, ErrSignatureMismatch},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.verify()
+			require.Error(t, err)
+			assert.Truef(t, errors.Is(err, tc.wantErr), "got %v, want %v", err, tc.wantErr)
+		})
+	}
 }
 
-func TestSigner_VerifyRejectsTamperedPayload(t *testing.T) {
+// AC3: an unknown queue class fails closed on both sides.
+func TestSigner_UnknownQueueFailsClosed(t *testing.T) {
 	s, err := NewSigner(testKeyHex)
 	require.NoError(t, err)
-	wrapped := s.Wrap([]byte(`{"x":1}`))
-	// Modify the last byte of the payload, leaving the HMAC intact.
-	wrapped[len(wrapped)-1] = '2'
 
-	_, err = s.Verify(wrapped)
+	_, err = s.Wrap("bogus:queue", testType, []byte("x"))
 	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrSignatureMismatch))
+	assert.True(t, errors.Is(err, ErrUnknownQueue), "producer must refuse an unknown queue class")
+
+	env, err := s.Wrap(testQueue, testType, []byte("x"))
+	require.NoError(t, err)
+	for _, q := range []string{"bogus:queue", ""} {
+		_, err = s.Verify(q, testType, env)
+		require.Error(t, err)
+		assert.Truef(t, errors.Is(err, ErrUnknownQueue), "consumer must fail closed on queue %q", q)
+	}
 }
 
-func TestSigner_VerifyRejectsTruncatedEnvelope(t *testing.T) {
+func TestSigner_VerifyRejectsTruncated(t *testing.T) {
 	s, err := NewSigner(testKeyHex)
 	require.NoError(t, err)
-	short := []byte{1, 2, 3}
-
-	_, err = s.Verify(short)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrUnsignedTask),
-		"envelopes shorter than the signature prefix are classified as unsigned")
-}
-
-func TestSigner_VerifyRejectsUnsignedEnvelope(t *testing.T) {
-	// An envelope produced by an older / misconfigured producer that
-	// didn't wrap: the bytes are pure JSON, no HMAC prefix. The
-	// recognizer treats the first 32 bytes as the HMAC, finds they
-	// don't verify, and returns SignatureMismatch.
-	s, err := NewSigner(testKeyHex)
-	require.NoError(t, err)
-	unsigned := []byte(strings.Repeat(`{"a":"b"} `, 5)) // 50 bytes — enough that the prefix is treated as a (bogus) HMAC
-
-	_, err = s.Verify(unsigned)
-	require.Error(t, err)
-	assert.True(t, errors.Is(err, ErrSignatureMismatch),
-		"an unsigned payload that's long enough to have a 'prefix' must fail the HMAC compare, not pass through")
+	for _, short := range [][]byte{{}, {envelopeVersion}, make([]byte, signatureSize)} { // all < 1+32
+		_, err := s.Verify(testQueue, testType, short)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrUnsignedTask), "envelopes shorter than version+signature are unsigned/truncated")
+	}
 }
 
 func TestSigner_VerifyRejectsKeyMismatch(t *testing.T) {
 	producer, err := NewSigner(testKeyHex)
 	require.NoError(t, err)
-	wrapped := producer.Wrap([]byte("hello"))
+	env, err := producer.Wrap(testQueue, testType, []byte("hello"))
+	require.NoError(t, err)
 
 	consumer, err := NewSigner(strings.Repeat("ff", 32))
 	require.NoError(t, err)
-	_, err = consumer.Verify(wrapped)
+	_, err = consumer.Verify(testQueue, testType, env)
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrSignatureMismatch))
+}
+
+// AC4: a legacy payload-only envelope ([32-byte HMAC][payload], no version byte)
+// must be rejected — there is no compatibility fallback.
+func TestSigner_RejectsLegacyPayloadOnlyEnvelope(t *testing.T) {
+	s, err := NewSigner(testKeyHex)
+	require.NoError(t, err)
+	payload := []byte(`{"x":1}`)
+
+	// Reconstruct the OLD scheme: HMAC over payload bytes only, no version byte.
+	m := hmac.New(sha256.New, s.key)
+	m.Write(payload)
+	legacy := append(m.Sum(nil), payload...) // [32-byte HMAC][payload]
+
+	_, err = s.Verify(testQueue, testType, legacy)
+	require.Error(t, err, "a legacy payload-only envelope must never verify")
+	// Rejected either as an unsupported version (its first byte is a random HMAC
+	// byte, almost never our version) or, in the 1/256 case it is, as a signature
+	// mismatch — never accepted.
+	assert.True(t, errors.Is(err, ErrUnsupportedVersion) || errors.Is(err, ErrSignatureMismatch))
 }
 
 func TestSigner_NilSafetyOnBothSides(t *testing.T) {
 	var s *Signer
 	payload := []byte(`{"x":1}`)
 
-	wrapped := s.Wrap(payload)
-	assert.Equal(t, payload, wrapped, "nil Signer Wrap is a passthrough")
+	env, err := s.Wrap(testQueue, testType, payload)
+	require.NoError(t, err)
+	assert.Equal(t, payload, env, "nil Signer Wrap is a passthrough")
 
-	out, err := s.Verify(payload)
+	out, err := s.Verify(testQueue, testType, payload)
 	require.NoError(t, err)
 	assert.Equal(t, payload, out, "nil Signer Verify is a passthrough")
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
+// TestDirectionForQueue pins that every real queue class maps to a direction and
+// that the classes are distinct, and that unrecognized names fail closed.
+func TestDirectionForQueue(t *testing.T) {
+	known := []struct {
+		queue string
+		dir   string
+	}{
+		{DeviceQueue("dev-1"), dirControlToDevice},
+		{DeviceQueue("dev-2"), dirControlToDevice},
+		{ControlInboxQueue, dirDeviceToControl},
+		{ControlTerminalAuditQueue, dirTerminalAudit},
+		{SearchQueue, dirControlToSearch},
 	}
-	return b
+	for _, k := range known {
+		d, ok := directionForQueue(k.queue)
+		require.Truef(t, ok, "queue %q should map to a direction", k.queue)
+		assert.Equal(t, k.dir, d)
+	}
+	// device→control, terminal-audit, and search are three DISTINCT directions
+	// so a task can't be replayed across them even at equal queue-name length.
+	assert.NotEqual(t, dirDeviceToControl, dirControlToDevice)
+	assert.NotEqual(t, dirTerminalAudit, dirDeviceToControl)
+	assert.NotEqual(t, dirControlToSearch, dirControlToDevice)
+
+	for _, bad := range []string{"", "bogus", "control:other", "device", "devices:x"} {
+		_, ok := directionForQueue(bad)
+		assert.Falsef(t, ok, "queue %q must be unknown (fail closed)", bad)
+	}
 }

--- a/internal/taskqueue/types.go
+++ b/internal/taskqueue/types.go
@@ -86,9 +86,14 @@ const (
 // SearchQueue is the Asynq queue name for search index update tasks.
 const SearchQueue = "search"
 
+// deviceQueuePrefix prefixes every per-device queue name. Single source shared
+// by DeviceQueue (producer) and the signer's directionForQueue (queue-class
+// direction binding).
+const deviceQueuePrefix = "device:"
+
 // DeviceQueue returns the Asynq queue name for a specific device.
 // Tasks enqueued to this queue are processed by the per-device Asynq server
 // running on the gateway that has the agent connected.
 func DeviceQueue(deviceID string) string {
-	return "device:" + deviceID
+	return deviceQueuePrefix + deviceID
 }


### PR DESCRIPTION
Closes #550. The last spec-29 first-batch finding.

## ⚠️ Deploy coordination required (clean break)
This is an intentionally **incompatible** envelope format. Before deploying:
1. **Drain pending Asynq queues** (or stop producers) — in-flight old-format tasks will be rejected.
2. Deploy **control + gateway + indexer from the same release** — mixed old/new signers are unsupported.

## What
The Asynq task envelope signed **only the payload bytes**, so a queue writer (compromised Valkey) or a holder of a valid signed task could **replay** it under a different queue, task type, or direction — the consumer verified the payload and then dispatched using the independently-supplied Asynq queue/type.

New clean-break v1 envelope: `[1-byte version][32-byte HMAC][payload]`, HMAC preimage =
`domainTag || u8(version) || lp(direction) || lp(queue) || lp(type) || lp(payload)` (`lp` = u32be-length-prefixed). **Direction is derived from the queue class** (device:* → control→device, control:inbox → device→control, terminal-audit, search) — never caller-supplied. There is **no payload-only fallback**: a legacy envelope fails the version-byte check.

- Producers (`EnqueueTo{Device,Control,Search}`) bind the exact queue + type and **fail closed** on an unknown queue; the signed queue is applied last so a caller option can't reroute it.
- `VerifyMiddleware` verifies against the task's **actual** queue (from the Asynq context) + type, dead-lettering (SkipRetry) on any mismatch.

## Tests
Full rejection matrix (tamper signature/payload/version; replay across queue/direction/type; unknown queue; truncated; wrong key; **legacy payload-only envelope rejected**), a **real Asynq-server** test proving a queue/type replay never reaches the handler, and client/miniredis tests asserting the stored task verifies only under its actual queue+type. `taskqueue.WithQueue` is a queue seam for direct `mux.ProcessTask` tests (production runs through the real server, which supplies the queue). All of taskqueue/control/gateway/search green; `go vet ./...` clean.