### PR TITLE
fix: refuse SCIM cross-provider email link of an already-owned user (spec 29 S14)

### DIFF
--- a/internal/scim/users_create.go
+++ b/internal/scim/users_create.go
@@ -116,6 +116,37 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 				writeError(w, http.StatusConflict, "email already belongs to a local account; cannot auto-link")
 				return
 			}
+
+			// S14 (spec 29): a passwordless user already OWNED by another identity
+			// provider must not be silently claimed by this one via email — a
+			// lower-trust IdP's SCIM token could otherwise seize a higher-trust
+			// IdP's passwordless SSO user (the HasPassword guard above only covers
+			// LOCAL accounts). Refuse unless the operator delegated identity to this
+			// provider (trust_email_assertions). Fail CLOSED if links can't be read.
+			//
+			// This read-then-append is not atomic, but the residual is narrow: it
+			// only affects two providers racing to create the FIRST link for the
+			// same brand-new email (→ a double-link), NOT the S14 threat of claiming
+			// an ALREADY-owned user — provider A's link is committed (projections
+			// are synchronous post-commit) before a later provider B reads here, so
+			// the sequential takeover is blocked.
+			if !provider.TrustEmailAssertions {
+				links, lerr := h.store.Queries().ListIdentityLinksForUser(ctx, existingUser.ID)
+				if lerr != nil {
+					h.logger.Error("SCIM: cannot read existing identity links; refusing auto-link",
+						"user_id", existingUser.ID, "provider_id", provider.ID, "error", lerr)
+					writeError(w, http.StatusInternalServerError, "failed to verify existing identity links")
+					return
+				}
+				for _, l := range links {
+					if l.ProviderID != provider.ID {
+						h.logger.Warn("SCIM: refusing to cross-link a user already owned by another identity provider",
+							"user_id", existingUser.ID, "provider_id", provider.ID, "existing_provider_id", l.ProviderID)
+						writeError(w, http.StatusConflict, "email already belongs to a user linked to another identity provider; cannot auto-link")
+						return
+					}
+				}
+			}
 			// User exists — create identity link
 			h.logger.Debug("SCIM createUser: linking existing user by email", "user_id", existingUser.ID, "email", email)
 			linkID := newULID()

--- a/internal/scim/users_link_test.go
+++ b/internal/scim/users_link_test.go
@@ -217,3 +217,53 @@ func TestReplaceUser_ExplicitEmptyNameClearsProfile(t *testing.T) {
 	assert.Empty(t, cleared.FamilyName, "explicit empty name object must clear family_name")
 	assert.Empty(t, cleared.DisplayName, "explicit empty name object must clear display_name")
 }
+
+// TestCreateUser_CrossProviderLink_RequiresTrust pins spec 29 S14: a passwordless
+// user already OWNED by one identity provider must not be silently claimed by a
+// SECOND provider via email — a lower-trust IdP's SCIM token could otherwise
+// seize a higher-trust IdP's passwordless SSO user. The HasPassword guard does
+// not cover this (the user is passwordless); the cross-provider guard does.
+func TestCreateUser_CrossProviderLink_RequiresTrust(t *testing.T) {
+	setup := func(t *testing.T) (env *scimTestEnv, email, userID, slugB, tokenB, providerB string) {
+		env = setupSCIM(t)
+		setProviderFlags(t, env, env.providerID, map[string]any{"auto_link_by_email": true})
+		email = "sso-" + testutil.NewID()[:6] + "@corp.com"
+		userID = createPasswordlessUser(t, env, email)
+		// Provider A legitimately claims the passwordless user (first link).
+		require.Equal(t, http.StatusCreated, postSCIMUser(t, env, email).Code)
+		require.True(t, providerOwnsUser(t, env, env.providerID, userID))
+		// A second provider appears.
+		slugB, tokenB, providerB = secondSCIMProvider(t, env)
+		return
+	}
+
+	postAsB := func(t *testing.T, env *scimTestEnv, slugB, tokenB, email string) *httptest.ResponseRecorder {
+		return scimReq(t, env, slugB, tokenB, http.MethodPost, "/Users", map[string]any{
+			"schemas":    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+			"userName":   email,
+			"externalId": "extB-" + testutil.NewID(),
+			"active":     true,
+		})
+	}
+
+	t.Run("second_provider_refused_without_trust", func(t *testing.T) {
+		env, email, userID, slugB, tokenB, providerB := setup(t)
+		setProviderFlags(t, env, providerB, map[string]any{"auto_link_by_email": true})
+
+		w := postAsB(t, env, slugB, tokenB, email)
+		assert.Equal(t, http.StatusConflict, w.Code,
+			"a user owned by another provider must not be cross-linked without trust opt-in: %s", w.Body.String())
+		assert.False(t, providerOwnsUser(t, env, providerB, userID),
+			"provider B must NOT gain a link to a user owned by provider A")
+	})
+
+	t.Run("second_provider_allowed_with_trust", func(t *testing.T) {
+		env, email, userID, slugB, tokenB, providerB := setup(t)
+		setProviderFlags(t, env, providerB, map[string]any{"auto_link_by_email": true, "trust_email_assertions": true})
+
+		w := postAsB(t, env, slugB, tokenB, email)
+		assert.Equal(t, http.StatusCreated, w.Code, "%s", w.Body.String())
+		assert.True(t, providerOwnsUser(t, env, providerB, userID),
+			"with trust_email_assertions provider B may cross-link")
+	})
+}


### PR DESCRIPTION
Closes #552. The `HasPassword` account-takeover guard only covers LOCAL accounts, so a **passwordless** user already owned by identity provider A (a higher-trust SSO IdP) could be silently claimed by provider B via a SCIM `POST /Users` by email — a lower-trust IdP's token seizing A's user. Extends the guard: if the matched user is already linked to a *different* provider, refuse unless `trust_email_assertions` is set; fail closed if links can't be read. Regression test across two providers (refused-without-trust / allowed-with-trust), red-checked. Per-provider tokens + `verifyProviderOwnership` bound the rest.

Note on the read-then-append (CR): the residual is a narrow concurrent-double-provision of a brand-new email, not the sequential takeover the guard closes (A's link is committed before a later B reads, projections being synchronous post-commit). A fully-atomic conditional invariant (multi-link is allowed under trust, so it's not a plain unique constraint) is disproportionate for this defense-in-depth guard; documented in-code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account linking safeguards for passwordless users.
  - Prevented cross-provider account linking unless email assertions are explicitly trusted.
  - Added clearer conflict and error handling when an account is already linked elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->