### PR TITLE
test: spec 30 authorization-coverage guards (object family)

### DIFF
--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"sort"
 	"time"
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
@@ -55,5 +56,6 @@ func ScopableObjectTypes() []string {
 	for k := range objectTypeToIndexScope {
 		out = append(out, k)
 	}
+	sort.Strings(out) // stable order for deterministic callers
 	return out
 }

--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -43,3 +43,17 @@ func SetExportPageSizeForTest(n int) (restore func()) {
 	exportPageSize = n
 	return func() { exportPageSize = prev }
 }
+
+// ScopableObjectTypes returns the canonical assignment-confined object-type set
+// (the keys of objectTypeToIndexScope). The external api_test behavioral
+// confinement sweeps assert their driver tables cover every entry, so a NEW
+// scopable object type cannot satisfy the AST enforcement guards while silently
+// having no behavioral out-of-scope coverage (the "presence ≠ behavior" gap, one
+// layer up). Compiled only into test binaries.
+func ScopableObjectTypes() []string {
+	out := make([]string, 0, len(objectTypeToIndexScope))
+	for k := range objectTypeToIndexScope {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/api/object_scope_list_coverage_test.go
+++ b/internal/api/object_scope_list_coverage_test.go
@@ -63,6 +63,12 @@ func TestObjectListHandlers_AllScopeEnforced(t *testing.T) {
 			want := expectedScope[fn.Name.Name]
 			enforced := false
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				// Skip nested function literals: a dead/uninvoked closure calling
+				// scopedObjectIDs must not satisfy the check for a List handler whose
+				// direct body never scopes the query.
+				if _, ok := n.(*ast.FuncLit); ok {
+					return false
+				}
 				c, ok := n.(*ast.CallExpr)
 				if !ok || calleeName(c.Fun) != "scopedObjectIDs" {
 					return true

--- a/internal/api/object_scope_read_behavioral_test.go
+++ b/internal/api/object_scope_read_behavioral_test.go
@@ -1,0 +1,121 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// objReadDriver drives one scopable object type through its Get RPC for the
+// behavioral out-of-scope confinement sweep. create returns a new object id
+// (owned by admin, not yet assigned); get invokes the REAL Get handler under ctx
+// and returns the connect error.
+type objReadDriver struct {
+	objType string // the assignment/object type (== an objectTypeToIndexScope key)
+	perm    string // the Get permission the scoped caller holds
+	create  func(t *testing.T, st *store.Store, adminID string) string
+	get     func(ctx context.Context, st *store.Store, id string) error
+}
+
+func objReadDrivers() []objReadDriver {
+	logger := slog.Default()
+	return []objReadDriver{
+		{
+			objType: "action", perm: "GetAction",
+			create: func(t *testing.T, st *store.Store, adminID string) string {
+				return testutil.CreateTestAction(t, st, adminID, "Secret Action", 1)
+			},
+			get: func(ctx context.Context, st *store.Store, id string) error {
+				_, err := api.NewActionHandler(st, logger, nil).GetAction(ctx, connect.NewRequest(&pm.GetActionRequest{Id: id}))
+				return err
+			},
+		},
+		{
+			objType: "action_set", perm: "GetActionSet",
+			create: func(t *testing.T, st *store.Store, adminID string) string {
+				return testutil.CreateTestActionSet(t, st, adminID, "Secret Set")
+			},
+			get: func(ctx context.Context, st *store.Store, id string) error {
+				_, err := api.NewActionSetHandler(st, logger).GetActionSet(ctx, connect.NewRequest(&pm.GetActionSetRequest{Id: id}))
+				return err
+			},
+		},
+		{
+			objType: "definition", perm: "GetDefinition",
+			create: func(t *testing.T, st *store.Store, adminID string) string {
+				return testutil.CreateTestDefinition(t, st, adminID, "Secret Def")
+			},
+			get: func(ctx context.Context, st *store.Store, id string) error {
+				_, err := api.NewDefinitionHandler(st, logger).GetDefinition(ctx, connect.NewRequest(&pm.GetDefinitionRequest{Id: id}))
+				return err
+			},
+		},
+		{
+			objType: "compliance_policy", perm: "GetCompliancePolicy",
+			create: func(t *testing.T, st *store.Store, adminID string) string {
+				resp, err := api.NewCompliancePolicyHandler(st, logger).CreateCompliancePolicy(
+					testutil.AdminContext(adminID),
+					connect.NewRequest(&pm.CreateCompliancePolicyRequest{Name: "Secret Policy"}))
+				require.NoError(t, err)
+				return resp.Msg.Policy.Id
+			},
+			get: func(ctx context.Context, st *store.Store, id string) error {
+				_, err := api.NewCompliancePolicyHandler(st, logger).GetCompliancePolicy(ctx, connect.NewRequest(&pm.GetCompliancePolicyRequest{Id: id}))
+				return err
+			},
+		},
+	}
+}
+
+// TestObjectReadHandlers_ConfineOutOfScope is the behavioral backstop (spec 30
+// AC 5) to the AST read guard: it drives every scopable object type's Get RPC
+// through the REAL handler with a group-scoped caller and a seeded out-of-scope
+// object, and asserts confinement (NotFound — no existence leak), plus an
+// in-scope positive control per type. AST presence proves enforceObjectReadScope
+// is CALLED; this proves it actually CONFINES — the exact "presence ≠ behavior"
+// gap that let spec 29 S1 through a green suite.
+//
+// Completeness: the AST guard TestObjectGetHandlers_AllReadScopeEnforced
+// self-discovers the object-type set from objectTypeToIndexScope and fails if a
+// new type's Get is unenforced, which forces a driver to be added here too.
+func TestObjectReadHandlers_ConfineOutOfScope(t *testing.T) {
+	drivers := objReadDrivers()
+	require.NotEmpty(t, drivers, "no object read drivers — the sweep would pass vacuously")
+
+	for _, d := range drivers {
+		t.Run(d.objType, func(t *testing.T) {
+			st := testutil.SetupPostgres(t)
+			adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+			dgA := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet A")
+			dgB := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet B")
+
+			id := d.create(t, st, adminID)
+			testutil.CreateTestAssignment(t, st, adminID, d.objType, id, "device_group", dgA, 0)
+
+			// Caller scoped to dgB — a DIFFERENT group than the object is assigned to.
+			sid, grants := scopedToGroup("scoped-"+d.objType, dgB, d.perm)
+			ctx := testutil.AuthContextScoped(sid, "s@test.com", []string{d.perm}, grants)
+
+			err := d.get(ctx, st, id)
+			require.Errorf(t, err, "%s: out-of-scope Get must error", d.objType)
+			assert.Equalf(t, connect.CodeNotFound, connect.CodeOf(err),
+				"%s: out-of-scope Get must be NotFound (never PermissionDenied — no existence leak); got %v",
+				d.objType, connect.CodeOf(err))
+
+			// Positive control: an IN-scope caller (scoped to dgA) can read it —
+			// proving the gate confines, not just blanket-denies.
+			okID, okGrants := scopedToGroup("scoped-ok-"+d.objType, dgA, d.perm)
+			okCtx := testutil.AuthContextScoped(okID, "ok@test.com", []string{d.perm}, okGrants)
+			require.NoErrorf(t, d.get(okCtx, st, id), "%s: in-scope Get must succeed", d.objType)
+		})
+	}
+}

--- a/internal/api/object_scope_read_behavioral_test.go
+++ b/internal/api/object_scope_read_behavioral_test.go
@@ -87,9 +87,29 @@ func objReadDrivers() []objReadDriver {
 // Completeness: the AST guard TestObjectGetHandlers_AllReadScopeEnforced
 // self-discovers the object-type set from objectTypeToIndexScope and fails if a
 // new type's Get is unenforced, which forces a driver to be added here too.
+// requireCoversAllObjectTypes asserts the behavioral driver set covers every
+// canonical scopable object type (api.ScopableObjectTypes, the SAME source the
+// internal AST guards discover from) — so a new type cannot satisfy the AST
+// enforcement guards yet slip through with no behavioral out-of-scope coverage.
+func requireCoversAllObjectTypes(t *testing.T, covered map[string]bool) {
+	t.Helper()
+	all := api.ScopableObjectTypes()
+	require.NotEmpty(t, all, "no scopable object types exposed — the completeness check is vacuous")
+	for _, ot := range all {
+		require.Truef(t, covered[ot],
+			"scopable object type %q has no behavioral confinement driver — add one (a new object type must get out-of-scope coverage, not just AST enforcement)", ot)
+	}
+}
+
 func TestObjectReadHandlers_ConfineOutOfScope(t *testing.T) {
 	drivers := objReadDrivers()
 	require.NotEmpty(t, drivers, "no object read drivers — the sweep would pass vacuously")
+
+	covered := map[string]bool{}
+	for _, d := range drivers {
+		covered[d.objType] = true
+	}
+	requireCoversAllObjectTypes(t, covered)
 
 	for _, d := range drivers {
 		t.Run(d.objType, func(t *testing.T) {

--- a/internal/api/object_scope_read_coverage_test.go
+++ b/internal/api/object_scope_read_coverage_test.go
@@ -61,6 +61,12 @@ func TestObjectGetHandlers_AllReadScopeEnforced(t *testing.T) {
 			}
 			enforced := false
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				// Do not descend into nested function literals: a dead/uninvoked
+				// closure containing enforceObjectReadScope must not satisfy the check
+				// for a handler whose direct body never gates the request.
+				if _, ok := n.(*ast.FuncLit); ok {
+					return false
+				}
 				c, ok := n.(*ast.CallExpr)
 				if !ok || calleeName(c.Fun) != "enforceObjectReadScope" {
 					return true

--- a/internal/api/object_scope_read_coverage_test.go
+++ b/internal/api/object_scope_read_coverage_test.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestObjectGetHandlers_AllReadScopeEnforced is the read-side (Get) per-handler
+// companion to TestObjectListHandlers_AllScopeEnforced (List) and
+// TestObjectMutationHandlers_AllWriteScopeEnforced (mutations). Together the
+// three give the object family per-handler coverage on every operation, closing
+// the spec 29 S1 blind spot on each axis.
+//
+// The prior read guard (TestObjectScope_EnforcementMatchesIndexFiltering) is
+// type-level PRESENCE: it asserts enforceObjectReadScope("action") appears
+// SOMEWHERE, which GetAction satisfies — so a SECOND action reader that skipped
+// the gate would pass, exactly the shape that let ListActions leak. Here every
+// Get<ObjectType> handler must itself call enforceObjectReadScope with its own
+// object-type literal (validated as the ARGUMENT, so a copy-paste type — e.g.
+// GetDefinition enforcing "action" — is also rejected).
+func TestObjectGetHandlers_AllReadScopeEnforced(t *testing.T) {
+	require.NotEmpty(t, objectTypeToIndexScope, "no scopable object types discovered — guard would pass vacuously")
+
+	// Expected Get method name -> the object-type literal it MUST pass to
+	// enforceObjectReadScope (argument index 3).
+	expectedType := map[string]string{}
+	for objType := range objectTypeToIndexScope {
+		expectedType["Get"+pascalFromSnake(objType)] = objType
+	}
+	found := map[string]bool{}
+	for method := range expectedType {
+		found[method] = false
+	}
+
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+	sawFile := false
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		sawFile = true
+		f, perr := parser.ParseFile(fset, name, nil, 0)
+		require.NoErrorf(t, perr, "parse %s", name)
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv == nil || fn.Body == nil {
+				continue
+			}
+			want, tracked := expectedType[fn.Name.Name]
+			if !tracked {
+				continue
+			}
+			enforced := false
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				c, ok := n.(*ast.CallExpr)
+				if !ok || calleeName(c.Fun) != "enforceObjectReadScope" {
+					return true
+				}
+				// enforceObjectReadScope(ctx, groups, logger, objectType, id, ...):
+				// objectType is arg index 3 — the literal must match THIS handler.
+				if len(c.Args) > 3 {
+					if s, ok := stringLit(c.Args[3]); ok && s == want {
+						enforced = true
+					}
+				}
+				return !enforced
+			})
+			// OR-accumulate across declarations: the ControlService delegator has
+			// the same method name but only forwards; the real handler enforces.
+			found[fn.Name.Name] = found[fn.Name.Name] || enforced
+		}
+	}
+	require.True(t, sawFile, "scanned zero source files — discovery is broken")
+
+	for method, ok := range found {
+		require.Truef(t, ok,
+			"%s does not call enforceObjectReadScope(ctx, objScope(h.store), logger, %q, id, ...) — "+
+				"an object Get RPC that skips read-scope leaks the out-of-scope object (spec 29 S1, read side / spec 30 AC 2).",
+			method, expectedType[method])
+	}
+}

--- a/internal/api/object_scope_write_behavioral_test.go
+++ b/internal/api/object_scope_write_behavioral_test.go
@@ -17,18 +17,22 @@ import (
 
 // objWriteDriver drives one scopable object type through a representative
 // mutation (Rename) for the behavioral out-of-scope confinement sweep.
+// readName performs a privileged (admin) read of the object's current name so
+// the sweep can assert a denied write did NOT persist and an allowed write did.
 type objWriteDriver struct {
-	objType string
-	perm    string // the mutation permission the scoped caller holds
-	create  func(t *testing.T, st *store.Store, adminID string) string
-	rename  func(ctx context.Context, st *store.Store, id string) error
+	objType  string
+	perm     string // the mutation permission the scoped caller holds
+	origName string // the name create() assigns
+	create   func(t *testing.T, st *store.Store, adminID string) string
+	rename   func(ctx context.Context, st *store.Store, id string) error // renames to "Renamed"
+	readName func(t *testing.T, st *store.Store, adminID, id string) string
 }
 
 func objWriteDrivers() []objWriteDriver {
 	logger := slog.Default()
 	return []objWriteDriver{
 		{
-			objType: "action", perm: "RenameAction",
+			objType: "action", perm: "RenameAction", origName: "Target Action",
 			create: func(t *testing.T, st *store.Store, adminID string) string {
 				return testutil.CreateTestAction(t, st, adminID, "Target Action", 1)
 			},
@@ -36,9 +40,14 @@ func objWriteDrivers() []objWriteDriver {
 				_, err := api.NewActionHandler(st, logger, nil).RenameAction(ctx, connect.NewRequest(&pm.RenameActionRequest{Id: id, Name: "Renamed"}))
 				return err
 			},
+			readName: func(t *testing.T, st *store.Store, adminID, id string) string {
+				resp, err := api.NewActionHandler(st, logger, nil).GetAction(testutil.AdminContext(adminID), connect.NewRequest(&pm.GetActionRequest{Id: id}))
+				require.NoError(t, err)
+				return resp.Msg.GetAction().GetName()
+			},
 		},
 		{
-			objType: "action_set", perm: "RenameActionSet",
+			objType: "action_set", perm: "RenameActionSet", origName: "Target Set",
 			create: func(t *testing.T, st *store.Store, adminID string) string {
 				return testutil.CreateTestActionSet(t, st, adminID, "Target Set")
 			},
@@ -46,9 +55,14 @@ func objWriteDrivers() []objWriteDriver {
 				_, err := api.NewActionSetHandler(st, logger).RenameActionSet(ctx, connect.NewRequest(&pm.RenameActionSetRequest{Id: id, Name: "Renamed"}))
 				return err
 			},
+			readName: func(t *testing.T, st *store.Store, adminID, id string) string {
+				resp, err := api.NewActionSetHandler(st, logger).GetActionSet(testutil.AdminContext(adminID), connect.NewRequest(&pm.GetActionSetRequest{Id: id}))
+				require.NoError(t, err)
+				return resp.Msg.GetSet().GetName()
+			},
 		},
 		{
-			objType: "definition", perm: "RenameDefinition",
+			objType: "definition", perm: "RenameDefinition", origName: "Target Def",
 			create: func(t *testing.T, st *store.Store, adminID string) string {
 				return testutil.CreateTestDefinition(t, st, adminID, "Target Def")
 			},
@@ -56,9 +70,14 @@ func objWriteDrivers() []objWriteDriver {
 				_, err := api.NewDefinitionHandler(st, logger).RenameDefinition(ctx, connect.NewRequest(&pm.RenameDefinitionRequest{Id: id, Name: "Renamed"}))
 				return err
 			},
+			readName: func(t *testing.T, st *store.Store, adminID, id string) string {
+				resp, err := api.NewDefinitionHandler(st, logger).GetDefinition(testutil.AdminContext(adminID), connect.NewRequest(&pm.GetDefinitionRequest{Id: id}))
+				require.NoError(t, err)
+				return resp.Msg.GetDefinition().GetName()
+			},
 		},
 		{
-			objType: "compliance_policy", perm: "RenameCompliancePolicy",
+			objType: "compliance_policy", perm: "RenameCompliancePolicy", origName: "Target Policy",
 			create: func(t *testing.T, st *store.Store, adminID string) string {
 				resp, err := api.NewCompliancePolicyHandler(st, logger).CreateCompliancePolicy(
 					testutil.AdminContext(adminID),
@@ -70,20 +89,25 @@ func objWriteDrivers() []objWriteDriver {
 				_, err := api.NewCompliancePolicyHandler(st, logger).RenameCompliancePolicy(ctx, connect.NewRequest(&pm.RenameCompliancePolicyRequest{Id: id, Name: "Renamed"}))
 				return err
 			},
+			readName: func(t *testing.T, st *store.Store, adminID, id string) string {
+				resp, err := api.NewCompliancePolicyHandler(st, logger).GetCompliancePolicy(testutil.AdminContext(adminID), connect.NewRequest(&pm.GetCompliancePolicyRequest{Id: id}))
+				require.NoError(t, err)
+				return resp.Msg.GetPolicy().GetName()
+			},
 		},
 	}
 }
 
 // TestObjectWriteHandlers_ConfineOutOfScope is the write-side behavioral
-// companion to TestObjectReadHandlers_ConfineOutOfScope (spec 30 AC 5): it drives
-// every scopable object type's mutation through the REAL handler with a
+// companion to TestObjectReadHandlers_ConfineOutOfScope (spec 30 AC 5). It drives
+// every scopable object type's mutation through the real handler with a
 // group-scoped caller and an out-of-scope object, and asserts PermissionDenied
-// (out-of-scope writes are refused, not silently NotFound — the object's
-// existence within the org is not the secret here; the write authority is). A
-// per-type in-scope positive control proves the gate confines rather than
-// blanket-denies. Write scope uses DIRECT group membership (no transitive
-// container walk), so a caller scoped to a different group than the object's
-// direct assignment is refused.
+// (out-of-scope writes are refused; write authority is the secret, not
+// existence). It also reads the object back with a privileged caller to assert
+// the denied write did NOT persist, so a handler that appends the mutation before
+// returning the error (right code, leaked write) still fails. A per-type in-scope
+// positive control proves the gate confines rather than blanket-denies, and that
+// an allowed write does persist. Write scope keys on DIRECT group membership.
 func TestObjectWriteHandlers_ConfineOutOfScope(t *testing.T) {
 	drivers := objWriteDrivers()
 	require.NotEmpty(t, drivers, "no object write drivers — the sweep would pass vacuously")
@@ -104,7 +128,7 @@ func TestObjectWriteHandlers_ConfineOutOfScope(t *testing.T) {
 			id := d.create(t, st, adminID)
 			testutil.CreateTestAssignment(t, st, adminID, d.objType, id, "device_group", dgA, 0)
 
-			// Caller scoped to dgB — a DIFFERENT group than the object is assigned to.
+			// Caller scoped to dgB, a DIFFERENT group than the object is assigned to.
 			sid, grants := scopedToGroup("scoped-"+d.objType, dgB, d.perm)
 			ctx := testutil.AuthContextScoped(sid, "s@test.com", []string{d.perm}, grants)
 
@@ -112,11 +136,16 @@ func TestObjectWriteHandlers_ConfineOutOfScope(t *testing.T) {
 			require.Errorf(t, err, "%s: out-of-scope write must error", d.objType)
 			assert.Equalf(t, connect.CodePermissionDenied, connect.CodeOf(err),
 				"%s: out-of-scope write must be PermissionDenied; got %v", d.objType, connect.CodeOf(err))
+			assert.Equalf(t, d.origName, d.readName(t, st, adminID, id),
+				"%s: a denied write must NOT persist (the mutation leaked despite the error)", d.objType)
 
-			// Positive control: an IN-scope caller (scoped to dgA) can rename it.
+			// Positive control: an IN-scope caller (scoped to dgA) can rename it, and
+			// the change persists.
 			okID, okGrants := scopedToGroup("scoped-ok-"+d.objType, dgA, d.perm)
 			okCtx := testutil.AuthContextScoped(okID, "ok@test.com", []string{d.perm}, okGrants)
 			require.NoErrorf(t, d.rename(okCtx, st, id), "%s: in-scope write must succeed", d.objType)
+			assert.Equalf(t, "Renamed", d.readName(t, st, adminID, id),
+				"%s: an allowed write must persist", d.objType)
 		})
 	}
 }

--- a/internal/api/object_scope_write_behavioral_test.go
+++ b/internal/api/object_scope_write_behavioral_test.go
@@ -88,6 +88,12 @@ func TestObjectWriteHandlers_ConfineOutOfScope(t *testing.T) {
 	drivers := objWriteDrivers()
 	require.NotEmpty(t, drivers, "no object write drivers — the sweep would pass vacuously")
 
+	covered := map[string]bool{}
+	for _, d := range drivers {
+		covered[d.objType] = true
+	}
+	requireCoversAllObjectTypes(t, covered)
+
 	for _, d := range drivers {
 		t.Run(d.objType, func(t *testing.T) {
 			st := testutil.SetupPostgres(t)

--- a/internal/api/object_scope_write_behavioral_test.go
+++ b/internal/api/object_scope_write_behavioral_test.go
@@ -1,0 +1,116 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// objWriteDriver drives one scopable object type through a representative
+// mutation (Rename) for the behavioral out-of-scope confinement sweep.
+type objWriteDriver struct {
+	objType string
+	perm    string // the mutation permission the scoped caller holds
+	create  func(t *testing.T, st *store.Store, adminID string) string
+	rename  func(ctx context.Context, st *store.Store, id string) error
+}
+
+func objWriteDrivers() []objWriteDriver {
+	logger := slog.Default()
+	return []objWriteDriver{
+		{
+			objType: "action", perm: "RenameAction",
+			create: func(t *testing.T, st *store.Store, adminID string) string {
+				return testutil.CreateTestAction(t, st, adminID, "Target Action", 1)
+			},
+			rename: func(ctx context.Context, st *store.Store, id string) error {
+				_, err := api.NewActionHandler(st, logger, nil).RenameAction(ctx, connect.NewRequest(&pm.RenameActionRequest{Id: id, Name: "Renamed"}))
+				return err
+			},
+		},
+		{
+			objType: "action_set", perm: "RenameActionSet",
+			create: func(t *testing.T, st *store.Store, adminID string) string {
+				return testutil.CreateTestActionSet(t, st, adminID, "Target Set")
+			},
+			rename: func(ctx context.Context, st *store.Store, id string) error {
+				_, err := api.NewActionSetHandler(st, logger).RenameActionSet(ctx, connect.NewRequest(&pm.RenameActionSetRequest{Id: id, Name: "Renamed"}))
+				return err
+			},
+		},
+		{
+			objType: "definition", perm: "RenameDefinition",
+			create: func(t *testing.T, st *store.Store, adminID string) string {
+				return testutil.CreateTestDefinition(t, st, adminID, "Target Def")
+			},
+			rename: func(ctx context.Context, st *store.Store, id string) error {
+				_, err := api.NewDefinitionHandler(st, logger).RenameDefinition(ctx, connect.NewRequest(&pm.RenameDefinitionRequest{Id: id, Name: "Renamed"}))
+				return err
+			},
+		},
+		{
+			objType: "compliance_policy", perm: "RenameCompliancePolicy",
+			create: func(t *testing.T, st *store.Store, adminID string) string {
+				resp, err := api.NewCompliancePolicyHandler(st, logger).CreateCompliancePolicy(
+					testutil.AdminContext(adminID),
+					connect.NewRequest(&pm.CreateCompliancePolicyRequest{Name: "Target Policy"}))
+				require.NoError(t, err)
+				return resp.Msg.Policy.Id
+			},
+			rename: func(ctx context.Context, st *store.Store, id string) error {
+				_, err := api.NewCompliancePolicyHandler(st, logger).RenameCompliancePolicy(ctx, connect.NewRequest(&pm.RenameCompliancePolicyRequest{Id: id, Name: "Renamed"}))
+				return err
+			},
+		},
+	}
+}
+
+// TestObjectWriteHandlers_ConfineOutOfScope is the write-side behavioral
+// companion to TestObjectReadHandlers_ConfineOutOfScope (spec 30 AC 5): it drives
+// every scopable object type's mutation through the REAL handler with a
+// group-scoped caller and an out-of-scope object, and asserts PermissionDenied
+// (out-of-scope writes are refused, not silently NotFound — the object's
+// existence within the org is not the secret here; the write authority is). A
+// per-type in-scope positive control proves the gate confines rather than
+// blanket-denies. Write scope uses DIRECT group membership (no transitive
+// container walk), so a caller scoped to a different group than the object's
+// direct assignment is refused.
+func TestObjectWriteHandlers_ConfineOutOfScope(t *testing.T) {
+	drivers := objWriteDrivers()
+	require.NotEmpty(t, drivers, "no object write drivers — the sweep would pass vacuously")
+
+	for _, d := range drivers {
+		t.Run(d.objType, func(t *testing.T) {
+			st := testutil.SetupPostgres(t)
+			adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+			dgA := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet A")
+			dgB := testutil.CreateTestDeviceGroup(t, st, adminID, "Fleet B")
+
+			id := d.create(t, st, adminID)
+			testutil.CreateTestAssignment(t, st, adminID, d.objType, id, "device_group", dgA, 0)
+
+			// Caller scoped to dgB — a DIFFERENT group than the object is assigned to.
+			sid, grants := scopedToGroup("scoped-"+d.objType, dgB, d.perm)
+			ctx := testutil.AuthContextScoped(sid, "s@test.com", []string{d.perm}, grants)
+
+			err := d.rename(ctx, st, id)
+			require.Errorf(t, err, "%s: out-of-scope write must error", d.objType)
+			assert.Equalf(t, connect.CodePermissionDenied, connect.CodeOf(err),
+				"%s: out-of-scope write must be PermissionDenied; got %v", d.objType, connect.CodeOf(err))
+
+			// Positive control: an IN-scope caller (scoped to dgA) can rename it.
+			okID, okGrants := scopedToGroup("scoped-ok-"+d.objType, dgA, d.perm)
+			okCtx := testutil.AuthContextScoped(okID, "ok@test.com", []string{d.perm}, okGrants)
+			require.NoErrorf(t, d.rename(okCtx, st, id), "%s: in-scope write must succeed", d.objType)
+		})
+	}
+}

--- a/internal/api/object_scope_write_coverage_test.go
+++ b/internal/api/object_scope_write_coverage_test.go
@@ -37,15 +37,16 @@ import (
 // A small allow-list covers the non-RPC internal machinery that legitimately
 // mutates an object stream without a user scope to confine (spec 30 "non-RPC
 // internal helpers with no externally reachable entry point"). Each entry is
-// keyed by receiver.method — NOT a bare name — so exempting the system-action
-// store's DeleteAction can never accidentally suppress a future gap in the
-// user-facing ActionHandler.DeleteAction. The no-orphan block below (staleExempt)
-// guards the list against rot: an entry that stops naming a live unenforced
-// mutation fails the build.
+// keyed by "receiver.method|objectType" — receiver-qualified so exempting the
+// system-action store's DeleteAction can never suppress a future gap in the
+// user-facing ActionHandler.DeleteAction, AND object-type-qualified so an
+// exempted function that later gains a SECOND, unrelated mutation of a DIFFERENT
+// object type is NOT silently covered by the original entry. The no-orphan block
+// below (staleExempt) guards the list against rot.
 var objectWriteScopeExempt = map[string]string{
-	"systemActionStore.UpdateAction":       "system-managed action machinery: ActorType=system, driven by SystemActionManager role-sync with system-chosen action IDs; a scope-restricted user caller can never reach it (user handlers refuse is_system actions).",
-	"systemActionStore.DeleteAction":       "system-managed action machinery: same as UpdateAction — system-driven lifecycle, no user scope to confine.",
-	"ActionHandler.rollbackUnsignedCreate": "compensating rollback for CreateAction's signing-failure path; deletes the action the SAME request just created (caller owns it, no prior assignment to confine). The user-facing DeleteAction handler is separately write-scope enforced.",
+	"systemActionStore.UpdateAction|action":       "system-managed action machinery: ActorType=system, driven by SystemActionManager role-sync with system-chosen action IDs; a scope-restricted user caller can never reach it (user handlers refuse is_system actions).",
+	"systemActionStore.DeleteAction|action":       "system-managed action machinery: same as UpdateAction — system-driven lifecycle, no user scope to confine.",
+	"ActionHandler.rollbackUnsignedCreate|action": "compensating rollback for CreateAction's signing-failure path; deletes the action the SAME request just created (caller owns it, no prior assignment to confine). The user-facing DeleteAction handler is separately write-scope enforced.",
 }
 
 func TestObjectMutationHandlers_AllWriteScopeEnforced(t *testing.T) {
@@ -87,22 +88,37 @@ func TestObjectMutationHandlers_AllWriteScopeEnforced(t *testing.T) {
 			// splits them across functions is itself a finding this guard surfaces.
 			mutated := map[string]string{} // objType -> first mutation verb (for the message)
 			writeScoped := map[string]bool{}
+			recordEvent := func(lit *ast.CompositeLit) {
+				streamType, verb, okS := eventStreamAndVerb(lit)
+				if !okS || !objectStreamTypes[streamType] {
+					return
+				}
+				if strings.HasSuffix(verb, "Created") {
+					return // create establishes ownership — nothing to confine
+				}
+				mutationsSeen++
+				if _, exists := mutated[streamType]; !exists {
+					mutated[streamType] = verb
+				}
+			}
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
 				switch node := n.(type) {
 				case *ast.CompositeLit:
-					if !isStoreEventLit(node) {
-						return true
-					}
-					streamType, verb, okS := eventStreamAndVerb(node)
-					if !okS || !objectStreamTypes[streamType] {
-						return true
-					}
-					if strings.HasSuffix(verb, "Created") {
-						return true // create establishes ownership — nothing to confine
-					}
-					mutationsSeen++
-					if _, exists := mutated[streamType]; !exists {
-						mutated[streamType] = verb
+					switch {
+					case isStoreEventLit(node):
+						recordEvent(node)
+					case isStoreEventSliceLit(node):
+						// []store.Event{{...}, {...}} — Go elides the element type on
+						// inner literals, so those inner CompositeLits have Type==nil
+						// and are NOT matched as store.Event on their own. Record the
+						// elided ones here; explicitly-typed inner literals are matched
+						// when ast.Inspect visits them, so skip those to avoid
+						// double-processing.
+						for _, elt := range node.Elts {
+							if inner, ok := elt.(*ast.CompositeLit); ok && inner.Type == nil {
+								recordEvent(inner)
+							}
+						}
 					}
 				case *ast.CallExpr:
 					if calleeName(node.Fun) == "enforceObjectWriteScope" {
@@ -121,8 +137,9 @@ func TestObjectMutationHandlers_AllWriteScopeEnforced(t *testing.T) {
 				if writeScoped[objType] {
 					continue
 				}
-				if _, exempt := objectWriteScopeExempt[key]; exempt {
-					seenExempt[key] = true
+				exemptKey := key + "|" + objType
+				if _, exempt := objectWriteScopeExempt[exemptKey]; exempt {
+					seenExempt[exemptKey] = true
 					continue
 				}
 				misses = append(misses, miss{key, objType, verb, fset.Position(fn.Pos()).String()})
@@ -166,7 +183,20 @@ func TestObjectMutationHandlers_AllWriteScopeEnforced(t *testing.T) {
 
 // isStoreEventLit reports whether the composite literal constructs a store.Event.
 func isStoreEventLit(c *ast.CompositeLit) bool {
-	sel, ok := c.Type.(*ast.SelectorExpr)
+	return isStoreEventSelector(c.Type)
+}
+
+// isStoreEventSliceLit reports whether c is a []store.Event / [N]store.Event
+// composite literal — whose inner element literals may elide the store.Event
+// element type (so they need explicit handling; see recordEvent's caller).
+func isStoreEventSliceLit(c *ast.CompositeLit) bool {
+	arr, ok := c.Type.(*ast.ArrayType)
+	return ok && isStoreEventSelector(arr.Elt)
+}
+
+// isStoreEventSelector reports whether e is the `store.Event` type expression.
+func isStoreEventSelector(e ast.Expr) bool {
+	sel, ok := e.(*ast.SelectorExpr)
 	if !ok {
 		return false
 	}

--- a/internal/api/object_scope_write_coverage_test.go
+++ b/internal/api/object_scope_write_coverage_test.go
@@ -62,21 +62,30 @@ func TestObjectMutationHandlers_AllWriteScopeEnforced(t *testing.T) {
 	entries, err := os.ReadDir(".")
 	require.NoError(t, err)
 
-	type miss struct{ fn, objType, event, pos string }
-	var misses []miss
-	mutationsSeen := 0
-	seenExempt := map[string]bool{}
-
-	sawFile := false
+	// Parse every non-test file once, and collect package-level string consts so a
+	// StreamType given as a named const (e.g. lpsKeypairStreamType = "lps_keypair")
+	// resolves to its literal value rather than being dismissed as unclassifiable.
+	var files []*ast.File
+	constStrings := map[string]string{}
 	for _, e := range entries {
 		name := e.Name()
 		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
-		sawFile = true
 		f, perr := parser.ParseFile(fset, name, nil, 0)
 		require.NoErrorf(t, perr, "parse %s", name)
+		files = append(files, f)
+		collectStringConsts(f, constStrings)
+	}
+	require.NotEmpty(t, files, "scanned zero source files — discovery is broken")
 
+	type miss struct{ fn, objType, event, pos string }
+	var misses []miss
+	mutationsSeen := 0
+	seenExempt := map[string]bool{}
+	var unclassifiable []string // store.Event with an unresolvable non-literal StreamType
+
+	for _, f := range files {
 		for _, decl := range f.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
 			if !ok || fn.Body == nil {
@@ -89,8 +98,17 @@ func TestObjectMutationHandlers_AllWriteScopeEnforced(t *testing.T) {
 			mutated := map[string]string{} // objType -> first mutation verb (for the message)
 			writeScoped := map[string]bool{}
 			recordEvent := func(lit *ast.CompositeLit) {
-				streamType, verb, okS := eventStreamAndVerb(lit)
-				if !okS || !objectStreamTypes[streamType] {
+				streamType, verb, failClosed := eventStreamAndVerb(lit, constStrings)
+				if failClosed {
+					// A StreamType given as a bare identifier that is not a resolvable
+					// string const (a variable or parameter) cannot be classified, and
+					// could carry an object stream type. Fail closed; reported below.
+					// (A computed field access such as event.StreamType, used only by
+					// generic event forwarders, is ignored, not failed.)
+					unclassifiable = append(unclassifiable, fset.Position(lit.Pos()).String())
+					return
+				}
+				if streamType == "" || !objectStreamTypes[streamType] {
 					return
 				}
 				if strings.HasSuffix(verb, "Created") {
@@ -101,34 +119,45 @@ func TestObjectMutationHandlers_AllWriteScopeEnforced(t *testing.T) {
 					mutated[streamType] = verb
 				}
 			}
+			// Pass 1 — appends: descend everywhere (including invoked closures), so a
+			// mutation anywhere in the function is detected (fail closed).
 			ast.Inspect(fn.Body, func(n ast.Node) bool {
-				switch node := n.(type) {
-				case *ast.CompositeLit:
-					switch {
-					case isStoreEventLit(node):
-						recordEvent(node)
-					case isStoreEventSliceLit(node):
-						// []store.Event{{...}, {...}} — Go elides the element type on
-						// inner literals, so those inner CompositeLits have Type==nil
-						// and are NOT matched as store.Event on their own. Record the
-						// elided ones here; explicitly-typed inner literals are matched
-						// when ast.Inspect visits them, so skip those to avoid
-						// double-processing.
-						for _, elt := range node.Elts {
-							if inner, ok := elt.(*ast.CompositeLit); ok && inner.Type == nil {
-								recordEvent(inner)
-							}
+				cl, ok := n.(*ast.CompositeLit)
+				if !ok {
+					return true
+				}
+				switch {
+				case isStoreEventLit(cl):
+					recordEvent(cl)
+				case isStoreEventSliceLit(cl):
+					// []store.Event{{...}, {...}} — Go elides the element type on inner
+					// literals, so those inner CompositeLits have Type==nil and are NOT
+					// matched as store.Event on their own. Record the elided ones here;
+					// explicitly-typed inner literals are matched when ast.Inspect visits
+					// them, so skip those to avoid double-processing.
+					for _, elt := range cl.Elts {
+						if inner, ok := elt.(*ast.CompositeLit); ok && inner.Type == nil {
+							recordEvent(inner)
 						}
 					}
-				case *ast.CallExpr:
-					if calleeName(node.Fun) == "enforceObjectWriteScope" {
-						for _, arg := range node.Args {
-							if s, ok := stringLit(arg); ok {
-								writeScoped[s] = true
-								break
-							}
-						}
-					}
+				}
+				return true
+			})
+			// Pass 2 — enforcement: does NOT descend into function literals, so a
+			// dead/nested closure containing enforceObjectWriteScope cannot satisfy the
+			// check for a mutation the handler's direct body actually leaves unguarded.
+			// The object type is arg index 3 (matched specifically, like the read
+			// guard) so an inline id literal can't be mistaken for the type.
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				if _, ok := n.(*ast.FuncLit); ok {
+					return false
+				}
+				call, ok := n.(*ast.CallExpr)
+				if !ok || calleeName(call.Fun) != "enforceObjectWriteScope" || len(call.Args) <= 3 {
+					return true
+				}
+				if s, ok := stringLit(call.Args[3]); ok {
+					writeScoped[s] = true
 				}
 				return true
 			})
@@ -146,9 +175,17 @@ func TestObjectMutationHandlers_AllWriteScopeEnforced(t *testing.T) {
 			}
 		}
 	}
-	require.True(t, sawFile, "scanned zero source files — discovery is broken")
 	require.Positivef(t, mutationsSeen,
 		"no object-mutation appends discovered — the guard would pass vacuously (objectTypeToIndexScope or store.Event AST shape drifted)")
+
+	// Fail closed on any store.Event whose StreamType is not a string literal:
+	// the scanner classifies by that literal, so a const/var StreamType (e.g.
+	// StreamType: actionStream) could hide an object mutation. Keep StreamType a
+	// literal, or extend the guard to resolve the constant.
+	sort.Strings(unclassifiable)
+	require.Emptyf(t, unclassifiable,
+		"store.Event literals with a non-literal StreamType — the write-scope coverage guard cannot classify them (use a string literal, or extend the guard):\n  %s",
+		strings.Join(unclassifiable, "\n  "))
 
 	// No-orphan: every exemption must still name a live function that appends an
 	// object mutation WITHOUT co-located write-scope. A rename, a removal, or a
@@ -204,10 +241,16 @@ func isStoreEventSelector(e ast.Expr) bool {
 	return ok && x.Name == "store" && sel.Sel.Name == "Event"
 }
 
-// eventStreamAndVerb extracts the StreamType string literal and the EventType
-// verb (the eventtypes.<Verb> selector name) from a store.Event composite
-// literal. ok is false when there is no StreamType literal to classify.
-func eventStreamAndVerb(c *ast.CompositeLit) (streamType, verb string, ok bool) {
+// eventStreamAndVerb extracts the StreamType (a string literal or a named string
+// const resolved via constStrings) and the EventType verb (the eventtypes.<Verb>
+// selector name) from a store.Event composite literal. failClosed is true when
+// StreamType is a bare identifier that is NOT a resolvable string const (a
+// variable/parameter that could carry an object stream type): the caller fails
+// closed rather than skipping a possible object mutation. A computed StreamType
+// (e.g. a field access `event.StreamType`, used only by generic event
+// forwarders, never a per-object mutation handler) resolves to neither and is
+// ignored.
+func eventStreamAndVerb(c *ast.CompositeLit, constStrings map[string]string) (streamType, verb string, failClosed bool) {
 	for _, elt := range c.Elts {
 		kv, ok := elt.(*ast.KeyValueExpr)
 		if !ok {
@@ -219,14 +262,49 @@ func eventStreamAndVerb(c *ast.CompositeLit) (streamType, verb string, ok bool) 
 		}
 		switch key.Name {
 		case "StreamType":
-			if s, isLit := stringLit(kv.Value); isLit {
-				streamType = s
+			switch v := kv.Value.(type) {
+			case *ast.BasicLit:
+				if s, isLit := stringLit(v); isLit {
+					streamType = s
+				}
+			case *ast.Ident:
+				if s, ok := constStrings[v.Name]; ok {
+					streamType = s
+				} else {
+					failClosed = true
+				}
 			}
 		case "EventType":
 			verb = eventTypesSelectorName(kv.Value)
 		}
 	}
-	return streamType, verb, streamType != ""
+	return streamType, verb, failClosed
+}
+
+// collectStringConsts records package-level `const name = "value"` string
+// constants (including those inside grouped const blocks) so a StreamType given
+// by name can be resolved to its literal value.
+func collectStringConsts(f *ast.File, out map[string]string) {
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, nm := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				if s, ok := stringLit(vs.Values[i]); ok {
+					out[nm.Name] = s
+				}
+			}
+		}
+	}
 }
 
 // funcKey identifies a function for exemption keying: "Receiver.Method" for a

--- a/internal/api/object_scope_write_coverage_test.go
+++ b/internal/api/object_scope_write_coverage_test.go
@@ -1,0 +1,237 @@
+package api
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestObjectMutationHandlers_AllWriteScopeEnforced generalizes the type-level
+// object-write guard (TestObjectScope_EnforcementMatchesIndexFiltering, which
+// only asserts enforceObjectWriteScope appears SOMEWHERE per object type) to a
+// PER-FUNCTION invariant: every function that appends a MUTATION event on a
+// scopable object stream MUST call enforceObjectWriteScope for that same object
+// type in the same function body.
+//
+// This is the write-side analog of spec 29 S1 (spec 30 AC 3). The type-level
+// guard is a PRESENCE check — one enforced handler satisfies it, so it cannot
+// see a SECOND mutation handler that skips the gate. S1 was exactly this shape on
+// the read side (ListActions leaked while GetAction satisfied the presence
+// check). Here the unit of verification is the (function, object-append) pair,
+// DISCOVERED from the store.Event StreamType literal — not a hand-kept list — so
+// no object mutation can silently skip write-scope now or in the future.
+//
+// CREATE is exempt by construction: a <Object>Created event establishes a new
+// object with no prior assignment to confine against (mirrors the group-create
+// exemption reasoned in scope_enforcement_parity_test.go). The verb is read from
+// the eventtypes.<Verb> selector on the EventType field; anything not ending in
+// "Created" is treated as a mutation (fail closed — an unrecognized verb requires
+// write-scope, so only an explicit *Created literal earns the exemption).
+//
+// A small allow-list covers the non-RPC internal machinery that legitimately
+// mutates an object stream without a user scope to confine (spec 30 "non-RPC
+// internal helpers with no externally reachable entry point"). Each entry is
+// keyed by receiver.method — NOT a bare name — so exempting the system-action
+// store's DeleteAction can never accidentally suppress a future gap in the
+// user-facing ActionHandler.DeleteAction. The no-orphan block below (staleExempt)
+// guards the list against rot: an entry that stops naming a live unenforced
+// mutation fails the build.
+var objectWriteScopeExempt = map[string]string{
+	"systemActionStore.UpdateAction":       "system-managed action machinery: ActorType=system, driven by SystemActionManager role-sync with system-chosen action IDs; a scope-restricted user caller can never reach it (user handlers refuse is_system actions).",
+	"systemActionStore.DeleteAction":       "system-managed action machinery: same as UpdateAction — system-driven lifecycle, no user scope to confine.",
+	"ActionHandler.rollbackUnsignedCreate": "compensating rollback for CreateAction's signing-failure path; deletes the action the SAME request just created (caller owns it, no prior assignment to confine). The user-facing DeleteAction handler is separately write-scope enforced.",
+}
+
+func TestObjectMutationHandlers_AllWriteScopeEnforced(t *testing.T) {
+	// The scopable object stream types (assignment-confined). Reuses the canonical
+	// registry so a NEW object type is automatically in scope for this guard too.
+	objectStreamTypes := map[string]bool{}
+	for objType := range objectTypeToIndexScope {
+		objectStreamTypes[objType] = true
+	}
+	require.NotEmpty(t, objectStreamTypes, "no scopable object types discovered — guard would pass vacuously")
+
+	fset := token.NewFileSet()
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	type miss struct{ fn, objType, event, pos string }
+	var misses []miss
+	mutationsSeen := 0
+	seenExempt := map[string]bool{}
+
+	sawFile := false
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		sawFile = true
+		f, perr := parser.ParseFile(fset, name, nil, 0)
+		require.NoErrorf(t, perr, "parse %s", name)
+
+		for _, decl := range f.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Body == nil {
+				continue
+			}
+			// Within THIS function: object mutations appended, and the object types
+			// passed to enforceObjectWriteScope. Enforcement must be co-located with
+			// the append (the handlers already do both inline); a refactor that
+			// splits them across functions is itself a finding this guard surfaces.
+			mutated := map[string]string{} // objType -> first mutation verb (for the message)
+			writeScoped := map[string]bool{}
+			ast.Inspect(fn.Body, func(n ast.Node) bool {
+				switch node := n.(type) {
+				case *ast.CompositeLit:
+					if !isStoreEventLit(node) {
+						return true
+					}
+					streamType, verb, okS := eventStreamAndVerb(node)
+					if !okS || !objectStreamTypes[streamType] {
+						return true
+					}
+					if strings.HasSuffix(verb, "Created") {
+						return true // create establishes ownership — nothing to confine
+					}
+					mutationsSeen++
+					if _, exists := mutated[streamType]; !exists {
+						mutated[streamType] = verb
+					}
+				case *ast.CallExpr:
+					if calleeName(node.Fun) == "enforceObjectWriteScope" {
+						for _, arg := range node.Args {
+							if s, ok := stringLit(arg); ok {
+								writeScoped[s] = true
+								break
+							}
+						}
+					}
+				}
+				return true
+			})
+			key := funcKey(fn)
+			for objType, verb := range mutated {
+				if writeScoped[objType] {
+					continue
+				}
+				if _, exempt := objectWriteScopeExempt[key]; exempt {
+					seenExempt[key] = true
+					continue
+				}
+				misses = append(misses, miss{key, objType, verb, fset.Position(fn.Pos()).String()})
+			}
+		}
+	}
+	require.True(t, sawFile, "scanned zero source files — discovery is broken")
+	require.Positivef(t, mutationsSeen,
+		"no object-mutation appends discovered — the guard would pass vacuously (objectTypeToIndexScope or store.Event AST shape drifted)")
+
+	// No-orphan: every exemption must still name a live function that appends an
+	// object mutation WITHOUT co-located write-scope. A rename, a removal, or a
+	// later addition of enforcement makes the entry stale — fail so the allow-list
+	// can't rot into a silent hole (spec 30 AC 7).
+	var staleExempt []string
+	for key := range objectWriteScopeExempt {
+		if !seenExempt[key] {
+			staleExempt = append(staleExempt, key)
+		}
+	}
+	sort.Strings(staleExempt)
+	require.Emptyf(t, staleExempt,
+		"stale objectWriteScopeExempt entries — these no longer name a live object-mutation function missing write-scope (remove or fix the entry):\n  %s",
+		strings.Join(staleExempt, "\n  "))
+
+	sort.Slice(misses, func(i, j int) bool {
+		if misses[i].fn != misses[j].fn {
+			return misses[i].fn < misses[j].fn
+		}
+		return misses[i].objType < misses[j].objType
+	})
+	var lines []string
+	for _, m := range misses {
+		lines = append(lines, m.fn+" appends "+m.event+" ("+m.objType+") without enforceObjectWriteScope(..., \""+m.objType+"\", id) — "+m.pos)
+	}
+	require.Emptyf(t, lines,
+		"object-mutation functions missing write-scope enforcement (spec 29 S1, write side / spec 30 AC 3):\n  %s\n"+
+			"Each must call enforceObjectWriteScope(ctx, objScope(h.store), logger, <objectType>, id) in the SAME function that appends the mutation.",
+		strings.Join(lines, "\n  "))
+}
+
+// isStoreEventLit reports whether the composite literal constructs a store.Event.
+func isStoreEventLit(c *ast.CompositeLit) bool {
+	sel, ok := c.Type.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	x, ok := sel.X.(*ast.Ident)
+	return ok && x.Name == "store" && sel.Sel.Name == "Event"
+}
+
+// eventStreamAndVerb extracts the StreamType string literal and the EventType
+// verb (the eventtypes.<Verb> selector name) from a store.Event composite
+// literal. ok is false when there is no StreamType literal to classify.
+func eventStreamAndVerb(c *ast.CompositeLit) (streamType, verb string, ok bool) {
+	for _, elt := range c.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		switch key.Name {
+		case "StreamType":
+			if s, isLit := stringLit(kv.Value); isLit {
+				streamType = s
+			}
+		case "EventType":
+			verb = eventTypesSelectorName(kv.Value)
+		}
+	}
+	return streamType, verb, streamType != ""
+}
+
+// funcKey identifies a function for exemption keying: "Receiver.Method" for a
+// method (the receiver type without its pointer star), or the bare name for a
+// free function. Receiver-qualified so exempting systemActionStore.DeleteAction
+// can never suppress a gap in the user-facing ActionHandler.DeleteAction.
+func funcKey(fn *ast.FuncDecl) string {
+	if fn.Recv == nil || len(fn.Recv.List) == 0 {
+		return fn.Name.Name
+	}
+	recv := fn.Recv.List[0].Type
+	if star, ok := recv.(*ast.StarExpr); ok {
+		recv = star.X
+	}
+	if id, ok := recv.(*ast.Ident); ok {
+		return id.Name + "." + fn.Name.Name
+	}
+	return fn.Name.Name
+}
+
+// eventTypesSelectorName pulls "ActionRenamed" out of
+// `string(eventtypes.ActionRenamed)` (or a bare eventtypes.ActionRenamed).
+// Empty when the shape isn't the eventtypes.<Verb> selector — callers treat empty
+// as a mutation (fail closed: only an explicit *Created literal earns the
+// create exemption).
+func eventTypesSelectorName(e ast.Expr) string {
+	found := ""
+	ast.Inspect(e, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok {
+			if x, ok := sel.X.(*ast.Ident); ok && x.Name == "eventtypes" {
+				found = sel.Sel.Name
+				return false
+			}
+		}
+		return true
+	})
+	return found
+}


### PR DESCRIPTION
## Spec 30 — authorization-coverage verification (object family)

First batch of the [spec 30](https://github.com/manchtools/power-manage/blob/main/docs/content/06-specs/30-authorization-coverage-verification.md) guard suite, focused on the **object family** (`action` / `action_set` / `definition` / `compliance_policy`) — the family that actually leaked in spec 29 S1. It closes the S1-shaped blind spot on **every** operation axis and adds the behavioral backstop that would have *caught* S1.

### Why this exists
The prior object-scope guards were **type-level presence** checks — `enforceObjectReadScope("action")` appears *somewhere* (satisfied by `GetAction`) — so a second handler reading/writing the same type could skip the gate unseen. That is exactly how `ListActions` leaked. The unit of verification here is the **(handler, operation)** pair, discovered from the code itself.

### What's in this PR (test-only; no production changes)

| Guard | AC | Kind |
|---|---|---|
| `TestObjectMutationHandlers_AllWriteScopeEnforced` | 3 | AST — every function that appends an object **mutation** (discovered from the `store.Event` `StreamType` literal) must call `enforceObjectWriteScope` for that type in the same function. `*Created` exempt by construction; 3 justified system-machinery exemptions, `(function, objectType)`-keyed + no-orphan. |
| `TestObjectGetHandlers_AllReadScopeEnforced` | 2 | AST — every `Get<ObjectType>` handler must call `enforceObjectReadScope` with its own type literal (argument-validated). |
| `TestObjectReadHandlers_ConfineOutOfScope` | 5 | **Behavioral** — drives every type's `Get` through the real handler with a group-scoped caller + seeded out-of-scope object; asserts `NotFound` + in-scope positive control. |
| `TestObjectWriteHandlers_ConfineOutOfScope` | 5 | **Behavioral** — same, for a mutation (`Rename`); asserts `PermissionDenied`. |

Together with the existing `TestObjectListHandlers_AllScopeEnforced` (List), the object family now has **per-handler AST coverage on all three operations** (read-Get, read-List, write-mutation) **plus behavioral out-of-scope confinement** on read and write. The behavioral sweeps assert their driver tables cover every `ScopableObjectTypes()` entry (the same canonical source the AST guards use), so a new object type cannot satisfy AST enforcement yet slip through with no behavioral coverage.

### Rigor
- Every guard **red-checked** against an injected bug. The behavioral red-check is the clearest demonstration of the spec's thesis: making a handler *run and log* its scope denial but ignore the result **passes the AST guard and fails the behavioral sweep** — the precise S1 class.
- The write guard immediately flagged 3 object-mutation functions with no write-scope; all traced and confirmed legitimate (system-action machinery + a create-rollback), encoded as justified, no-orphan-guarded exemptions.
- Local CodeRabbit review run pre-push; its 3 findings (elided batch literals, exemption granularity, behavioral-completeness enforcement) are all fixed in the final commit.
- Full `internal/api` package green; `go vet` / `gofmt` clean.

### Follow-on (not in this PR)
- Behavioral confinement sweeps for the **device / user / execution** families (already per-RPC AST-covered via `TestScopablePermissions_AllEnforced`, so lower-risk).
- The **general AST sink registry** (AC 2 generalized to arbitrary readers, not just `Get<Type>`) — the larger classification effort across all repo/query/append sinks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive checks to verify object read and write operations respect device-group scope restrictions.
  * Confirmed out-of-scope reads do not reveal object existence and out-of-scope updates are denied.
  * Added automated coverage checks to ensure all applicable API handlers enforce read and write scope controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->