### PR TITLE
test: spec 30 behavioral scope sweeps (device + user families)

### DIFF
--- a/internal/api/device_scope_behavioral_test.go
+++ b/internal/api/device_scope_behavioral_test.go
@@ -17,16 +17,19 @@ import (
 
 // deviceScopeDriver drives one device-targeted RPC for the behavioral
 // out-of-scope confinement sweep. The device family confines via
-// EnforceDeviceScope, which returns PermissionDenied uniformly for an
-// out-of-scope device (read and write alike, per the S10 decision; the device
-// family does not use the object family's NotFound existence oracle).
+// EnforceDeviceScopeOnBaseTier (which delegates to EnforceDeviceScope), returning
+// PermissionDenied uniformly for an out-of-scope device — read and write alike,
+// per the S10 decision; the device family does not use the object family's
+// NotFound existence oracle.
+//
+// For write RPCs, readState returns the mutable state (via a privileged read) so
+// the sweep can assert a denied call left it unchanged AND an allowed call
+// changed it to afterAllowed. nil readState marks a read RPC (nothing to mutate).
 type deviceScopeDriver struct {
-	rpc  string // the RPC name, which is also the permission key
-	call func(ctx context.Context, st *store.Store, deviceID string) error
-	// verifyDenied (write RPCs only) asserts, via a privileged read, that a denied
-	// out-of-scope call did NOT mutate the device — so a handler that mutates
-	// before returning PermissionDenied still fails. nil for read RPCs.
-	verifyDenied func(t *testing.T, st *store.Store, adminID, deviceID string)
+	rpc          string // the RPC name, which is also the permission key
+	call         func(ctx context.Context, st *store.Store, deviceID string) error
+	readState    func(t *testing.T, st *store.Store, adminID, deviceID string) any
+	afterAllowed any
 }
 
 func deviceScopeDrivers() []deviceScopeDriver {
@@ -55,11 +58,12 @@ func deviceScopeDrivers() []deviceScopeDriver {
 				_, err := dev(st).SetDeviceSyncInterval(ctx, connect.NewRequest(&pm.SetDeviceSyncIntervalRequest{Id: deviceID, SyncIntervalMinutes: 60}))
 				return err
 			},
-			verifyDenied: func(t *testing.T, st *store.Store, adminID, deviceID string) {
+			readState: func(t *testing.T, st *store.Store, adminID, deviceID string) any {
 				d, err := getDevice(st, adminID, deviceID)
 				require.NoError(t, err)
-				assert.NotEqual(t, int32(60), d.GetSyncIntervalMinutes(), "denied SetDeviceSyncInterval must not persist")
+				return d.GetSyncIntervalMinutes()
 			},
+			afterAllowed: int32(60),
 		},
 		{
 			rpc: "DeleteDevice",
@@ -67,10 +71,12 @@ func deviceScopeDrivers() []deviceScopeDriver {
 				_, err := dev(st).DeleteDevice(ctx, connect.NewRequest(&pm.DeleteDeviceRequest{Id: deviceID}))
 				return err
 			},
-			verifyDenied: func(t *testing.T, st *store.Store, adminID, deviceID string) {
+			// State is device existence: true until an allowed delete removes it.
+			readState: func(t *testing.T, st *store.Store, adminID, deviceID string) any {
 				_, err := getDevice(st, adminID, deviceID)
-				require.NoError(t, err, "denied DeleteDevice must not delete the device")
+				return err == nil
 			},
+			afterAllowed: false,
 		},
 	}
 }
@@ -78,11 +84,11 @@ func deviceScopeDrivers() []deviceScopeDriver {
 // TestDeviceScopeHandlers_ConfineOutOfScope drives representative SCOPABLE
 // (TargetDevice) device RPCs (read, interval write, delete) through the real
 // handler with a device-group-scoped caller and an out-of-scope device (a member
-// of a DIFFERENT group), asserting PermissionDenied. A per-RPC in-scope positive
-// control proves the gate confines to the caller's group rather than
-// blanket-denying. Org-tier device RPCs (SetDeviceLabel/AssignDevice, which are
-// TargetUnspecified in AllPermissions) are deliberately NOT device-group-scoped
-// and so are not part of this sweep.
+// of a DIFFERENT group), asserting PermissionDenied. For write RPCs it reads the
+// device back with a privileged caller to assert the denied call did NOT mutate
+// and the in-scope positive control DID. Org-tier device RPCs
+// (SetDeviceLabel/AssignDevice, which are TargetUnspecified in AllPermissions)
+// are deliberately NOT device-group-scoped and so are not part of this sweep.
 //
 // Per-RPC completeness for the device family is held by the AST permission guard
 // (TestScopablePermissions_AllEnforced): every TargetDevice permission, which is
@@ -101,18 +107,29 @@ func TestDeviceScopeHandlers_ConfineOutOfScope(t *testing.T) {
 			device := testutil.CreateTestDevice(t, st, "host-"+d.rpc)
 			testutil.AddDeviceToTestGroup(t, st, admin, dgA, device)
 
+			var before any
+			if d.readState != nil {
+				before = d.readState(t, st, admin, device)
+			}
+
 			// Caller scoped to dgB; the device is a member of dgA.
 			err := d.call(deviceScoped(testutil.NewID(), d.rpc, dgB), st, device)
 			require.Errorf(t, err, "%s: out-of-scope device op must error", d.rpc)
 			assert.Equalf(t, connect.CodePermissionDenied, connect.CodeOf(err),
 				"%s: out-of-scope device op must be PermissionDenied; got %v", d.rpc, connect.CodeOf(err))
-			if d.verifyDenied != nil {
-				d.verifyDenied(t, st, admin, device)
+			if d.readState != nil {
+				assert.Equalf(t, before, d.readState(t, st, admin, device),
+					"%s: a denied write must NOT persist", d.rpc)
 			}
 
-			// Positive control: a caller scoped to dgA (the device's group) succeeds.
+			// Positive control: a caller scoped to dgA (the device's group) succeeds
+			// and the write actually persists.
 			require.NoErrorf(t, d.call(deviceScoped(testutil.NewID(), d.rpc, dgA), st, device),
 				"%s: in-scope device op must succeed", d.rpc)
+			if d.readState != nil {
+				assert.Equalf(t, d.afterAllowed, d.readState(t, st, admin, device),
+					"%s: an allowed write must persist", d.rpc)
+			}
 		})
 	}
 }

--- a/internal/api/device_scope_behavioral_test.go
+++ b/internal/api/device_scope_behavioral_test.go
@@ -23,12 +23,23 @@ import (
 type deviceScopeDriver struct {
 	rpc  string // the RPC name, which is also the permission key
 	call func(ctx context.Context, st *store.Store, deviceID string) error
+	// verifyDenied (write RPCs only) asserts, via a privileged read, that a denied
+	// out-of-scope call did NOT mutate the device — so a handler that mutates
+	// before returning PermissionDenied still fails. nil for read RPCs.
+	verifyDenied func(t *testing.T, st *store.Store, adminID, deviceID string)
 }
 
 func deviceScopeDrivers() []deviceScopeDriver {
 	logger := slog.Default()
 	dev := func(st *store.Store) *api.DeviceHandler {
 		return api.NewDeviceHandler(st, nil, logger, api.NoOpSigner{})
+	}
+	getDevice := func(st *store.Store, adminID, id string) (*pm.Device, error) {
+		resp, err := dev(st).GetDevice(testutil.AdminContext(adminID), connect.NewRequest(&pm.GetDeviceRequest{Id: id}))
+		if err != nil {
+			return nil, err
+		}
+		return resp.Msg.GetDevice(), nil
 	}
 	return []deviceScopeDriver{
 		{
@@ -44,12 +55,21 @@ func deviceScopeDrivers() []deviceScopeDriver {
 				_, err := dev(st).SetDeviceSyncInterval(ctx, connect.NewRequest(&pm.SetDeviceSyncIntervalRequest{Id: deviceID, SyncIntervalMinutes: 60}))
 				return err
 			},
+			verifyDenied: func(t *testing.T, st *store.Store, adminID, deviceID string) {
+				d, err := getDevice(st, adminID, deviceID)
+				require.NoError(t, err)
+				assert.NotEqual(t, int32(60), d.GetSyncIntervalMinutes(), "denied SetDeviceSyncInterval must not persist")
+			},
 		},
 		{
 			rpc: "DeleteDevice",
 			call: func(ctx context.Context, st *store.Store, deviceID string) error {
 				_, err := dev(st).DeleteDevice(ctx, connect.NewRequest(&pm.DeleteDeviceRequest{Id: deviceID}))
 				return err
+			},
+			verifyDenied: func(t *testing.T, st *store.Store, adminID, deviceID string) {
+				_, err := getDevice(st, adminID, deviceID)
+				require.NoError(t, err, "denied DeleteDevice must not delete the device")
 			},
 		},
 	}
@@ -86,6 +106,9 @@ func TestDeviceScopeHandlers_ConfineOutOfScope(t *testing.T) {
 			require.Errorf(t, err, "%s: out-of-scope device op must error", d.rpc)
 			assert.Equalf(t, connect.CodePermissionDenied, connect.CodeOf(err),
 				"%s: out-of-scope device op must be PermissionDenied; got %v", d.rpc, connect.CodeOf(err))
+			if d.verifyDenied != nil {
+				d.verifyDenied(t, st, admin, device)
+			}
 
 			// Positive control: a caller scoped to dgA (the device's group) succeeds.
 			require.NoErrorf(t, d.call(deviceScoped(testutil.NewID(), d.rpc, dgA), st, device),

--- a/internal/api/device_scope_behavioral_test.go
+++ b/internal/api/device_scope_behavioral_test.go
@@ -1,0 +1,95 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// deviceScopeDriver drives one device-targeted RPC for the behavioral
+// out-of-scope confinement sweep. The device family confines via
+// EnforceDeviceScope, which returns PermissionDenied uniformly for an
+// out-of-scope device (read and write alike, per the S10 decision; the device
+// family does not use the object family's NotFound existence oracle).
+type deviceScopeDriver struct {
+	rpc  string // the RPC name, which is also the permission key
+	call func(ctx context.Context, st *store.Store, deviceID string) error
+}
+
+func deviceScopeDrivers() []deviceScopeDriver {
+	logger := slog.Default()
+	dev := func(st *store.Store) *api.DeviceHandler {
+		return api.NewDeviceHandler(st, nil, logger, api.NoOpSigner{})
+	}
+	return []deviceScopeDriver{
+		{
+			rpc: "GetDevice",
+			call: func(ctx context.Context, st *store.Store, deviceID string) error {
+				_, err := dev(st).GetDevice(ctx, connect.NewRequest(&pm.GetDeviceRequest{Id: deviceID}))
+				return err
+			},
+		},
+		{
+			rpc: "SetDeviceSyncInterval",
+			call: func(ctx context.Context, st *store.Store, deviceID string) error {
+				_, err := dev(st).SetDeviceSyncInterval(ctx, connect.NewRequest(&pm.SetDeviceSyncIntervalRequest{Id: deviceID, SyncIntervalMinutes: 60}))
+				return err
+			},
+		},
+		{
+			rpc: "DeleteDevice",
+			call: func(ctx context.Context, st *store.Store, deviceID string) error {
+				_, err := dev(st).DeleteDevice(ctx, connect.NewRequest(&pm.DeleteDeviceRequest{Id: deviceID}))
+				return err
+			},
+		},
+	}
+}
+
+// TestDeviceScopeHandlers_ConfineOutOfScope drives representative SCOPABLE
+// (TargetDevice) device RPCs (read, interval write, delete) through the real
+// handler with a device-group-scoped caller and an out-of-scope device (a member
+// of a DIFFERENT group), asserting PermissionDenied. A per-RPC in-scope positive
+// control proves the gate confines to the caller's group rather than
+// blanket-denying. Org-tier device RPCs (SetDeviceLabel/AssignDevice, which are
+// TargetUnspecified in AllPermissions) are deliberately NOT device-group-scoped
+// and so are not part of this sweep.
+//
+// Per-RPC completeness for the device family is held by the AST permission guard
+// (TestScopablePermissions_AllEnforced): every TargetDevice permission, which is
+// its RPC name, must be passed to a recognized scope enforcer. This sweep adds
+// the behavioral proof that the enforcer actually confines at runtime.
+func TestDeviceScopeHandlers_ConfineOutOfScope(t *testing.T) {
+	drivers := deviceScopeDrivers()
+	require.NotEmpty(t, drivers, "no device scope drivers — the sweep would pass vacuously")
+
+	for _, d := range drivers {
+		t.Run(d.rpc, func(t *testing.T) {
+			st := testutil.SetupPostgres(t)
+			admin := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+			dgA := testutil.CreateTestDeviceGroup(t, st, admin, "Fleet A")
+			dgB := testutil.CreateTestDeviceGroup(t, st, admin, "Fleet B")
+			device := testutil.CreateTestDevice(t, st, "host-"+d.rpc)
+			testutil.AddDeviceToTestGroup(t, st, admin, dgA, device)
+
+			// Caller scoped to dgB; the device is a member of dgA.
+			err := d.call(deviceScoped(testutil.NewID(), d.rpc, dgB), st, device)
+			require.Errorf(t, err, "%s: out-of-scope device op must error", d.rpc)
+			assert.Equalf(t, connect.CodePermissionDenied, connect.CodeOf(err),
+				"%s: out-of-scope device op must be PermissionDenied; got %v", d.rpc, connect.CodeOf(err))
+
+			// Positive control: a caller scoped to dgA (the device's group) succeeds.
+			require.NoErrorf(t, d.call(deviceScoped(testutil.NewID(), d.rpc, dgA), st, device),
+				"%s: in-scope device op must succeed", d.rpc)
+		})
+	}
+}

--- a/internal/api/user_scope_behavioral_test.go
+++ b/internal/api/user_scope_behavioral_test.go
@@ -1,0 +1,79 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// userScopeDriver drives one user-targeted RPC for the behavioral out-of-scope
+// confinement sweep. The user family confines via EnforceUserScopeOrSelf, which
+// returns PermissionDenied for a target that is neither in the caller's user
+// group nor the caller itself (the :self tier).
+type userScopeDriver struct {
+	rpc  string // the RPC name, which is also the permission key
+	call func(ctx context.Context, st *store.Store, targetUserID string) error
+}
+
+func userScopeDrivers() []userScopeDriver {
+	logger := slog.Default()
+	uh := func(st *store.Store) *api.UserHandler { return api.NewUserHandler(st, logger, nil) }
+	return []userScopeDriver{
+		{
+			rpc: "GetUser",
+			call: func(ctx context.Context, st *store.Store, targetUserID string) error {
+				_, err := uh(st).GetUser(ctx, connect.NewRequest(&pm.GetUserRequest{Id: targetUserID}))
+				return err
+			},
+		},
+		{
+			rpc: "SetUserDisabled",
+			call: func(ctx context.Context, st *store.Store, targetUserID string) error {
+				_, err := uh(st).SetUserDisabled(ctx, connect.NewRequest(&pm.SetUserDisabledRequest{Id: targetUserID, Disabled: true}))
+				return err
+			},
+		},
+	}
+}
+
+// TestUserScopeHandlers_ConfineOutOfScope drives scopable (TargetUser) user RPCs
+// through the real handler with a user-group-scoped caller and an out-of-scope
+// target user (a member of a DIFFERENT user group, and NOT the caller so the
+// :self tier does not apply), asserting PermissionDenied. A per-RPC in-scope
+// positive control proves the gate confines to the caller's group rather than
+// blanket-denying. Per-RPC completeness for the user family is held by the AST
+// permission guard (TestScopablePermissions_AllEnforced).
+func TestUserScopeHandlers_ConfineOutOfScope(t *testing.T) {
+	drivers := userScopeDrivers()
+	require.NotEmpty(t, drivers, "no user scope drivers — the sweep would pass vacuously")
+
+	for _, d := range drivers {
+		t.Run(d.rpc, func(t *testing.T) {
+			st := testutil.SetupPostgres(t)
+			admin := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+			ugA := testutil.CreateTestUserGroup(t, st, admin, "Team A")
+			ugB := testutil.CreateTestUserGroup(t, st, admin, "Team B")
+			target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
+			testutil.AddUserToTestGroup(t, st, admin, ugA, target)
+
+			// Caller scoped to ugB; target is a member of ugA and is not the caller.
+			err := d.call(userScoped(testutil.NewID(), d.rpc, ugB), st, target)
+			require.Errorf(t, err, "%s: out-of-scope user op must error", d.rpc)
+			assert.Equalf(t, connect.CodePermissionDenied, connect.CodeOf(err),
+				"%s: out-of-scope user op must be PermissionDenied; got %v", d.rpc, connect.CodeOf(err))
+
+			// Positive control: a caller scoped to ugA (the target's group) succeeds.
+			require.NoErrorf(t, d.call(userScoped(testutil.NewID(), d.rpc, ugA), st, target),
+				"%s: in-scope user op must succeed", d.rpc)
+		})
+	}
+}

--- a/internal/api/user_scope_behavioral_test.go
+++ b/internal/api/user_scope_behavioral_test.go
@@ -22,6 +22,9 @@ import (
 type userScopeDriver struct {
 	rpc  string // the RPC name, which is also the permission key
 	call func(ctx context.Context, st *store.Store, targetUserID string) error
+	// verifyDenied (write RPCs only) asserts, via a privileged read, that a denied
+	// out-of-scope call did NOT mutate the target user. nil for read RPCs.
+	verifyDenied func(t *testing.T, st *store.Store, adminID, targetUserID string)
 }
 
 func userScopeDrivers() []userScopeDriver {
@@ -40,6 +43,11 @@ func userScopeDrivers() []userScopeDriver {
 			call: func(ctx context.Context, st *store.Store, targetUserID string) error {
 				_, err := uh(st).SetUserDisabled(ctx, connect.NewRequest(&pm.SetUserDisabledRequest{Id: targetUserID, Disabled: true}))
 				return err
+			},
+			verifyDenied: func(t *testing.T, st *store.Store, adminID, targetUserID string) {
+				resp, err := uh(st).GetUser(testutil.AdminContext(adminID), connect.NewRequest(&pm.GetUserRequest{Id: targetUserID}))
+				require.NoError(t, err)
+				assert.False(t, resp.Msg.GetUser().GetDisabled(), "denied SetUserDisabled must not disable the user")
 			},
 		},
 	}
@@ -70,6 +78,9 @@ func TestUserScopeHandlers_ConfineOutOfScope(t *testing.T) {
 			require.Errorf(t, err, "%s: out-of-scope user op must error", d.rpc)
 			assert.Equalf(t, connect.CodePermissionDenied, connect.CodeOf(err),
 				"%s: out-of-scope user op must be PermissionDenied; got %v", d.rpc, connect.CodeOf(err))
+			if d.verifyDenied != nil {
+				d.verifyDenied(t, st, admin, target)
+			}
 
 			// Positive control: a caller scoped to ugA (the target's group) succeeds.
 			require.NoErrorf(t, d.call(userScoped(testutil.NewID(), d.rpc, ugA), st, target),

--- a/internal/api/user_scope_behavioral_test.go
+++ b/internal/api/user_scope_behavioral_test.go
@@ -19,12 +19,15 @@ import (
 // confinement sweep. The user family confines via EnforceUserScopeOrSelf, which
 // returns PermissionDenied for a target that is neither in the caller's user
 // group nor the caller itself (the :self tier).
+//
+// For write RPCs, readState returns the mutable state (via a privileged read) so
+// the sweep can assert a denied call left it unchanged AND an allowed call
+// changed it to afterAllowed. nil readState marks a read RPC.
 type userScopeDriver struct {
-	rpc  string // the RPC name, which is also the permission key
-	call func(ctx context.Context, st *store.Store, targetUserID string) error
-	// verifyDenied (write RPCs only) asserts, via a privileged read, that a denied
-	// out-of-scope call did NOT mutate the target user. nil for read RPCs.
-	verifyDenied func(t *testing.T, st *store.Store, adminID, targetUserID string)
+	rpc          string // the RPC name, which is also the permission key
+	call         func(ctx context.Context, st *store.Store, targetUserID string) error
+	readState    func(t *testing.T, st *store.Store, adminID, targetUserID string) any
+	afterAllowed any
 }
 
 func userScopeDrivers() []userScopeDriver {
@@ -44,11 +47,12 @@ func userScopeDrivers() []userScopeDriver {
 				_, err := uh(st).SetUserDisabled(ctx, connect.NewRequest(&pm.SetUserDisabledRequest{Id: targetUserID, Disabled: true}))
 				return err
 			},
-			verifyDenied: func(t *testing.T, st *store.Store, adminID, targetUserID string) {
+			readState: func(t *testing.T, st *store.Store, adminID, targetUserID string) any {
 				resp, err := uh(st).GetUser(testutil.AdminContext(adminID), connect.NewRequest(&pm.GetUserRequest{Id: targetUserID}))
 				require.NoError(t, err)
-				assert.False(t, resp.Msg.GetUser().GetDisabled(), "denied SetUserDisabled must not disable the user")
+				return resp.Msg.GetUser().GetDisabled()
 			},
+			afterAllowed: true,
 		},
 	}
 }
@@ -56,10 +60,10 @@ func userScopeDrivers() []userScopeDriver {
 // TestUserScopeHandlers_ConfineOutOfScope drives scopable (TargetUser) user RPCs
 // through the real handler with a user-group-scoped caller and an out-of-scope
 // target user (a member of a DIFFERENT user group, and NOT the caller so the
-// :self tier does not apply), asserting PermissionDenied. A per-RPC in-scope
-// positive control proves the gate confines to the caller's group rather than
-// blanket-denying. Per-RPC completeness for the user family is held by the AST
-// permission guard (TestScopablePermissions_AllEnforced).
+// :self tier does not apply), asserting PermissionDenied. For write RPCs it reads
+// the target back with a privileged caller to assert the denied call did NOT
+// mutate and the in-scope positive control DID. Per-RPC completeness for the user
+// family is held by the AST permission guard (TestScopablePermissions_AllEnforced).
 func TestUserScopeHandlers_ConfineOutOfScope(t *testing.T) {
 	drivers := userScopeDrivers()
 	require.NotEmpty(t, drivers, "no user scope drivers — the sweep would pass vacuously")
@@ -73,18 +77,29 @@ func TestUserScopeHandlers_ConfineOutOfScope(t *testing.T) {
 			target := testutil.CreateTestUser(t, st, testutil.NewID()+"@t.com", "pass", "admin")
 			testutil.AddUserToTestGroup(t, st, admin, ugA, target)
 
+			var before any
+			if d.readState != nil {
+				before = d.readState(t, st, admin, target)
+			}
+
 			// Caller scoped to ugB; target is a member of ugA and is not the caller.
 			err := d.call(userScoped(testutil.NewID(), d.rpc, ugB), st, target)
 			require.Errorf(t, err, "%s: out-of-scope user op must error", d.rpc)
 			assert.Equalf(t, connect.CodePermissionDenied, connect.CodeOf(err),
 				"%s: out-of-scope user op must be PermissionDenied; got %v", d.rpc, connect.CodeOf(err))
-			if d.verifyDenied != nil {
-				d.verifyDenied(t, st, admin, target)
+			if d.readState != nil {
+				assert.Equalf(t, before, d.readState(t, st, admin, target),
+					"%s: a denied write must NOT persist", d.rpc)
 			}
 
-			// Positive control: a caller scoped to ugA (the target's group) succeeds.
+			// Positive control: a caller scoped to ugA (the target's group) succeeds
+			// and the write actually persists.
 			require.NoErrorf(t, d.call(userScoped(testutil.NewID(), d.rpc, ugA), st, target),
 				"%s: in-scope user op must succeed", d.rpc)
+			if d.readState != nil {
+				assert.Equalf(t, d.afterAllowed, d.readState(t, st, admin, target),
+					"%s: an allowed write must persist", d.rpc)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Spec 30 — behavioral confinement sweeps for the device + user families

Follow-on to #554 (object family). Extends the behavioral "presence ≠ behavior" layer of spec 30 AC 5 to the **group-membership** scope families.

### What's in this PR (test-only; no production changes)

| Sweep | Family | Confinement asserted |
|---|---|---|
| `TestDeviceScopeHandlers_ConfineOutOfScope` | device (`TargetDevice`) | `GetDevice` / `SetDeviceSyncInterval` / `DeleteDevice` out-of-scope → **PermissionDenied** (the device family's uniform code, per S10), + in-scope positive control + denied-write non-persistence |
| `TestUserScopeHandlers_ConfineOutOfScope` | user (`TargetUser`) | `GetUser` / `SetUserDisabled` out-of-scope (target not in caller's group, not `:self`) → **PermissionDenied**, + positive control + non-persistence |

Each drives the **real handler** with a group-scoped caller and an out-of-scope target (member of a *different* group), and reads the target back with a privileged caller after a denied write to prove it did not mutate.

### Behavioral-confinement layer is now complete across all scopable families
- **objects** (action/action_set/definition/compliance_policy) — merged in #554.
- **device + user** — this PR.
- **execution** — already covered by the pre-existing `TestExecLogHandlers_ScopeExistenceOracleClosed` (GetExecution/CancelExecution/GetDeviceLogResult out-of-scope → PermissionDenied).

### An audit-discipline note
The device sweep initially flagged `SetDeviceLabel` as non-confining. Traced before reporting: `SetDeviceLabel`/`AssignDevice` are `TargetUnspecified` in `AllPermissions` — intentionally org-tier, not device-group-scopable. So not a gap; the sweep now covers only `TargetDevice` RPCs, and the finding validated the guard's discrimination.

### Follow-on (not in this PR)
The **general AST sink registry** — AC 2 generalized to arbitrary readers/writers across all repo/query/append sinks, catching a handler that reads/mutates a scopable resource with no recognized enforcement regardless of naming. That's the larger classification pass and is best done as its own focused PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added behavioral coverage confirming device-scoped operations reject requests targeting devices outside the caller’s permitted scope.
  * Added behavioral coverage confirming user-scoped operations reject requests targeting users outside the caller’s permitted scope.
  * Verified denied write operations do not modify protected data.
  * Added positive controls confirming permitted operations continue to succeed within the caller’s scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->