### PR TITLE
feat: control-plane HA — advisory-lock stale-expiry + OIDC replica-safety (spec 31 Part E)

### DIFF
--- a/cmd/control/periodic.go
+++ b/cmd/control/periodic.go
@@ -213,11 +213,20 @@ func startDynamicGroupWorker(ctx context.Context, st *store.Store, interval time
 	}, false)
 }
 
+// advisoryKeyStaleExpiry single-flights the stale-execution-expiry tick across
+// control replicas (spec 31 AC15), so exactly one replica emits ExecutionTimedOut
+// for a given stale execution per tick — matching the retention, inventory, and
+// dynamic-group workers. "stale" in ASCII/hex; distinct from advisoryKeyPrune,
+// advisoryKeyInventorySchedule, advisoryKeyAdminMutation, and the cert/dyngroup
+// namespaces so two unrelated workers never contend on the same key.
+const advisoryKeyStaleExpiry int64 = 0x7374616c65 // "stale"
+
 // startStaleExecutionExpiry launches a 1-minute ticker that lists
 // executions stuck in pending/dispatched past their deadline and emits
 // ExecutionTimedOut events for each. The 1-minute cadence is fixed —
 // there's no operator knob today and the prior inline goroutine in
-// main.go didn't expose one either; this is a straight extraction.
+// main.go didn't expose one either. Each tick runs under a cross-replica
+// advisory lock (AC15) so N replicas do not each emit a duplicate timeout.
 func startStaleExecutionExpiry(ctx context.Context, st *store.Store, logger *slog.Logger, now func() time.Time) {
 	go func() {
 		ticker := time.NewTicker(1 * time.Minute)
@@ -225,33 +234,49 @@ func startStaleExecutionExpiry(ctx context.Context, st *store.Store, logger *slo
 		for {
 			select {
 			case <-ticker.C:
-				stale, err := st.Repos().Execution.ListStale(ctx)
+				ran, err := expireStaleExecutions(ctx, st, logger, now)
 				if err != nil {
-					logger.Error("failed to list stale executions", "error", err)
-					continue
-				}
-				for _, exec := range stale {
-					errMsg := fmt.Sprintf("execution timed out: device did not respond (status was %s)", exec.Status)
-					completedAt := now().UTC().Format(time.RFC3339Nano)
-					if err := st.AppendEvent(ctx, store.Event{
-						StreamType: "execution",
-						StreamID:   exec.ID,
-						EventType:  string(eventtypes.ExecutionTimedOut),
-						Data: payloads.ExecutionTimedOut{
-							Error:       &errMsg,
-							CompletedAt: &completedAt,
-						},
-						ActorType: "system",
-						ActorID:   "expiry",
-					}); err != nil {
-						logger.Error("failed to expire stale execution", "error", err, "execution_id", exec.ID)
-					} else {
-						logger.Info("expired stale execution", "execution_id", exec.ID, "status", exec.Status, "device_id", exec.DeviceID)
-					}
+					logger.Error("failed to expire stale executions", "error", err)
+				} else if !ran {
+					logger.Debug("stale-execution expiry skipped — another replica holds the lock")
 				}
 			case <-ctx.Done():
 				return
 			}
 		}
 	}()
+}
+
+// expireStaleExecutions runs one stale-execution sweep under the cross-replica
+// advisory lock. Returns ran=false (no error) when another replica currently
+// holds the lock — the caller treats that as a clean skip. A per-execution
+// AppendEvent failure is logged and does NOT abort the remaining sweep (matching
+// the pre-lock behavior); only a ListStale failure aborts the tick.
+func expireStaleExecutions(ctx context.Context, st *store.Store, logger *slog.Logger, now func() time.Time) (ran bool, err error) {
+	return st.TryWithAdvisoryLock(ctx, advisoryKeyStaleExpiry, func() error {
+		stale, listErr := st.Repos().Execution.ListStale(ctx)
+		if listErr != nil {
+			return fmt.Errorf("list stale executions: %w", listErr)
+		}
+		for _, exec := range stale {
+			errMsg := fmt.Sprintf("execution timed out: device did not respond (status was %s)", exec.Status)
+			completedAt := now().UTC().Format(time.RFC3339Nano)
+			if appendErr := st.AppendEvent(ctx, store.Event{
+				StreamType: "execution",
+				StreamID:   exec.ID,
+				EventType:  string(eventtypes.ExecutionTimedOut),
+				Data: payloads.ExecutionTimedOut{
+					Error:       &errMsg,
+					CompletedAt: &completedAt,
+				},
+				ActorType: "system",
+				ActorID:   "expiry",
+			}); appendErr != nil {
+				logger.Error("failed to expire stale execution", "error", appendErr, "execution_id", exec.ID)
+			} else {
+				logger.Info("expired stale execution", "execution_id", exec.ID, "status", exec.Status, "device_id", exec.DeviceID)
+			}
+		}
+		return nil
+	})
 }

--- a/cmd/control/periodic_ha_test.go
+++ b/cmd/control/periodic_ha_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestExpireStaleExecutions_SingleFlight pins spec 31 AC15: the stale-execution
+// expiry sweep runs under a cross-replica advisory lock, so when another replica
+// holds it the sweep skips (ran=false) without error — exactly one replica emits
+// ExecutionTimedOut per tick.
+//
+// The "other replica" is simulated with a foreign session holding the lock via
+// pg_try_advisory_lock, NOT st.TryWithAdvisoryLock: the latter takes a
+// process-local mutex it holds across fn, so a second in-process caller would
+// block on that mutex rather than exercise the CROSS-replica Postgres-lock skip.
+func TestExpireStaleExecutions_SingleFlight(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	holder, err := st.TestingPool().Acquire(ctx)
+	require.NoError(t, err)
+	defer holder.Release()
+
+	var got bool
+	require.NoError(t, holder.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", advisoryKeyStaleExpiry).Scan(&got))
+	require.True(t, got, "the foreign session must acquire the stale-expiry lock")
+
+	ran, err := expireStaleExecutions(ctx, st, slog.Default(), time.Now)
+	require.NoError(t, err)
+	assert.False(t, ran, "a concurrent sweep must skip without error while another replica holds the lock")
+
+	require.NoError(t, holder.QueryRow(ctx, "SELECT pg_advisory_unlock($1)", advisoryKeyStaleExpiry).Scan(&got))
+
+	// With the lock free, the sweep acquires it and runs.
+	ran, err = expireStaleExecutions(ctx, st, slog.Default(), time.Now)
+	require.NoError(t, err)
+	assert.True(t, ran, "with the lock free, the sweep runs")
+}

--- a/docs/adr/0031-control-plane-ha.md
+++ b/docs/adr/0031-control-plane-ha.md
@@ -1,0 +1,92 @@
+# 0031 — Multi-instance control plane (HA) without leader election
+
+- Status: accepted
+- Date: 2026-07-12
+- Related: spec 31 (`06-specs/31-gateway-enrollment-and-control-ha.md`, Part E);
+  ADR 0029 (Postgres state is event-sourced — the idempotent-projection
+  contract this relies on); spec 29 (task-metadata HMAC — already assumes a
+  shared signing key across the fan-out); ADR 0025 (mTLS identity model).
+
+## Context
+
+Operators want to run N control replicas behind a load balancer for
+availability and horizontal read capacity. Control is a stateless request
+processor over shared Postgres + Valkey: all durable state is the event store
+and its projections, and every secret that authenticates or encrypts
+(`CONTROL_CA_KEY`, `CONTROL_JWT_SECRET`, `CONTROL_ENCRYPTION_KEY`,
+`PM_TASK_SIGNING_KEY`) is already externalized config. The question is whether
+running several replicas needs new coordination machinery (a leader, a lease, a
+consensus layer) or whether the existing primitives already make replicas
+fungible.
+
+Two hazards distinguish "stateless" from "actually replica-safe":
+
+1. **Duplicated periodic work.** Any replica running a timer that emits events
+   (retention prune, inventory scheduling, dynamic-group evaluation,
+   stale-execution expiry) would, with N replicas, emit N copies per tick.
+2. **Replica-local request state.** Any multi-step flow that stashes
+   intermediate state in a replica's memory breaks when the load balancer routes
+   the second step to a different replica. The OIDC authorization-code flow
+   (state + nonce + PKCE verifier created at login-start, read at callback) is
+   the one such flow.
+
+## Decision
+
+**Control replicas are fungible; no leader election.** The model is:
+
+1. **Shared crypto material, identical across replicas.** No key is minted
+   per-replica. All four secrets stay in config and must be byte-identical on
+   every replica. A per-replica CA/JWT/encryption key would fracture trust and
+   is explicitly rejected. (Giving each control replica its own mTLS identity
+   buys nothing — they share the CA key anyway — so control-instance enrollment
+   is out of scope; the generic gateway enroll RPC could serve it later if a
+   reason emerges.)
+
+2. **Idempotent projectors, one apply per append.** Projections are written by
+   synchronous post-commit Go listeners using `ON CONFLICT` / version-guarded
+   upserts (ADR 0029). Whichever replica handles the append runs the projector
+   once; the append's optimistic-concurrency version is the cross-replica
+   first-writer-wins. No cross-replica double-projection, no missed projection.
+
+3. **Periodic work single-flights on a Postgres advisory lock.** Every replica
+   runs every timer, but the tick body runs under
+   `store.TryWithAdvisoryLock(key, fn)` — a non-blocking `pg_try_advisory_lock`.
+   Exactly one replica acquires the lock per tick and does the work; the others
+   skip (`ran=false`) without error. This already covered retention
+   (`advisoryKeyPrune`), inventory scheduling (`advisoryKeyInventorySchedule`),
+   and dynamic-group evaluation. Spec 31 closes the **fourth**: the
+   stale-execution-expiry loop now runs under `advisoryKeyStaleExpiry`, so N
+   replicas emit at most one `ExecutionTimedOut` per stale execution per tick.
+
+4. **OIDC flow state lives in Postgres, never replica-local memory.**
+   `GetSSOLoginURL` persists `{state, nonce, code_verifier, redirect_uri}` to the
+   shared `auth_states` table; `SSOCallback` consumes it from that table. A flow
+   begun on replica A therefore completes on replica B, and `Consume` is
+   single-use so a replayed callback landing on a third replica finds nothing.
+   This was already the design; spec 31 adds a regression test that pins it.
+
+**Why no leader election.** A leader/lease adds a failure mode (split-brain,
+lease expiry, failover latency) to buy coordination the advisory locks already
+provide at per-task granularity — and finer: each periodic task single-flights
+independently, so a slow prune never blocks inventory scheduling. Consensus is
+warranted when replicas must agree on *shared mutable in-memory state*; control
+has none — the event store is the single source of truth and Postgres is the
+coordinator.
+
+## Consequences
+
+- **Deploy is trivial.** Scale control replicas behind an L7 load balancer
+  sharing one Postgres + one Valkey; set the four secrets identically. The
+  advisory-lock fix is safe to deploy on a single instance too — it just takes a
+  lock it never contends.
+- **Advisory-lock keys are a shared namespace.** New periodic work MUST pick a
+  distinct key constant (they are ad-hoc `int64` hex tags today); a collision
+  would make two unrelated tasks contend. Documented at each key's definition.
+- **Postgres is the coordination bottleneck.** Advisory locks and the event
+  store funnel through one primary. This is the intended tradeoff — correctness
+  and operational simplicity over write-scaling — and matches the existing
+  single-primary assumption. Read replicas / write-sharding are a separate,
+  future concern, not blocked by this decision.
+- **No per-replica observability of "who ran the tick."** The winning replica
+  logs the work; losers log a debug skip. Sufficient for now; a metric could be
+  added if operators need to see lock-winner distribution.

--- a/internal/api/sso_replica_safety_test.go
+++ b/internal/api/sso_replica_safety_test.go
@@ -1,0 +1,56 @@
+package api_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestSSOFlowState_IsReplicaSafe pins spec 31 AC16: the OIDC authorization-code
+// flow state (state / nonce / PKCE code_verifier / redirect) lives in the shared
+// Postgres store, never replica-local memory, so a flow begun on replica A
+// completes on replica B.
+//
+// GetSSOLoginURL persists via store.Repos().AuthState.Create and SSOCallback
+// reads via store.Repos().AuthState.Consume (see sso_handler.go). N control
+// replicas all connect to the same Postgres, represented here by one store: what
+// replica A writes, replica B reads. A single-use Consume also guards against a
+// replayed callback landing on a second replica.
+func TestSSOFlowState_IsReplicaSafe(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	enc := testutil.NewEncryptor(t)
+	actorID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	providerID := testutil.CreateTestIdentityProvider(t, st, enc, actorID, "Test IdP", "test-idp")
+
+	const state = "01JSTATEREPLICASAFE0000000"
+	// Replica A (GetSSOLoginURL) persists the flow state to the shared DB.
+	require.NoError(t, st.Repos().AuthState.Create(ctx, store.CreateAuthStateParams{
+		State:        state,
+		ProviderID:   providerID,
+		Nonce:        "nonce-value",
+		CodeVerifier: "pkce-code-verifier-value",
+		RedirectURI:  "https://app.example.com/auth/callback",
+		ExpiresAt:    time.Now().Add(10 * time.Minute),
+	}))
+
+	// Replica B (SSOCallback) consumes it from the same shared DB — proving the
+	// flow state is not held in replica A's memory.
+	got, err := st.Repos().AuthState.Consume(ctx, state)
+	require.NoError(t, err)
+	assert.Equal(t, "nonce-value", got.Nonce)
+	assert.Equal(t, "pkce-code-verifier-value", got.CodeVerifier)
+	assert.Equal(t, "https://app.example.com/auth/callback", got.RedirectURI)
+
+	// Consume is single-use: a replayed callback (e.g. retried against another
+	// replica) finds nothing.
+	_, err = st.Repos().AuthState.Consume(ctx, state)
+	require.Error(t, err, "a consumed state must not resolve a second time")
+	assert.True(t, store.IsNotFound(err), "a replayed/absent state must surface as not-found")
+}


### PR DESCRIPTION
## Summary

Spec 31 **Part E** — makes N control replicas safe to run behind a load balancer, no leader election.

- **Advisory-lock stale-expiry** (AC15): the stale-execution-expiry tick now runs under `TryWithAdvisoryLock(advisoryKeyStaleExpiry)`, so N replicas emit at most one `ExecutionTimedOut` per stale execution per tick — closing the **fourth** periodic loop (retention / inventory / dynamic-group already single-flight). Single-flight regression test via a foreign session holding the lock.
- **OIDC replica-safety** (AC16): a test pins that the OIDC flow state (state / nonce / PKCE verifier / redirect) is carried in the shared `auth_states` table, not replica-local memory, so a flow begun on replica A completes on replica B; single-use `Consume` guards a replayed callback.
- **ADR 0031**: multi-instance control plane without leader election (idempotent projectors + advisory-lock single-flight + DB-backed flow state; why no consensus layer).

## Validation
`go vet`, `gofmt`, `staticcheck` clean; both new tests green against real Postgres. No production behavior change for a single instance (it just takes a lock it never contends).

Refs manchtools/power-manage-server#556