### PR TITLE
fix(terminal): enumerate sessions unscoped in revocation path (H1)

### DIFF
--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -15,6 +15,21 @@ func (h *TerminalHandler) ScopedSessionsForTest(ctx context.Context, sessions []
 	return h.scopedSessions(ctx, sessions)
 }
 
+// SetGatewaySessionsForTest overrides the unscoped gateway session enumeration
+// seam so the H1 revocation regression test can inject a known session set
+// without standing up the gateway fan-out. Compiled only into test binaries.
+func (h *TerminalHandler) SetGatewaySessionsForTest(fn func(ctx context.Context) ([]*pm.TerminalSessionInfo, error)) {
+	h.gatewaySessions = fn
+}
+
+// SessionsForUserTest exposes the unexported unscoped per-user session
+// enumeration the internal revocation path uses (TerminateUserSessions), so the
+// H1 regression test can assert it selects a user's sessions even under a
+// user-less context — the exact case the scoped RPC filtered to zero (#391).
+func (h *TerminalHandler) SessionsForUserTest(ctx context.Context, userID string) ([]*pm.TerminalSessionInfo, error) {
+	return h.sessionsForUser(ctx, userID)
+}
+
 // SetRenewCertTestHook installs the test-only seam invoked between the
 // fingerprint check and certificate issuance in RenewCertificate, letting the
 // concurrency regression test widen the read→append window. Compiled only into

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -44,6 +44,15 @@ type TerminalHandler struct {
 	// return Unavailable.
 	internalHTTPClient *http.Client
 
+	// gatewaySessions enumerates every live terminal session across all
+	// gateways with NO caller-scope filtering. Defaults to fanOutSessions;
+	// overridden in tests. The scoped RPC (ListActiveTerminalSessions) layers
+	// scopedSessions on top of this; the internal revocation path
+	// (TerminateUserSessions) uses it raw so a system-initiated revocation sees
+	// every session (H1 / #391 — routing revocation through the scoped RPC under
+	// a user-less context silently filtered to zero and terminated nothing).
+	gatewaySessions func(ctx context.Context) ([]*pm.TerminalSessionInfo, error)
+
 	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
 }
 
@@ -64,7 +73,7 @@ func (h *TerminalHandler) SetInternalHTTPClient(c *http.Client) {
 // In production at least one of reg or fallbackURL must be supplied,
 // or every StartTerminal call returns Unavailable.
 func NewTerminalHandler(st *store.Store, tokenStore *terminal.TokenStore, reg *registry.Registry, fallbackURL string, logger *slog.Logger) *TerminalHandler {
-	return &TerminalHandler{
+	h := &TerminalHandler{
 		store:       st,
 		tokenStore:  tokenStore,
 		registry:    reg,
@@ -72,6 +81,8 @@ func NewTerminalHandler(st *store.Store, tokenStore *terminal.TokenStore, reg *r
 		logger:      logger,
 		now:         time.Now,
 	}
+	h.gatewaySessions = h.fanOutSessions
+	return h
 }
 
 // StartTerminal verifies the caller is authenticated, resolves the
@@ -501,6 +512,35 @@ func (h *TerminalHandler) ListActiveTerminalSessions(ctx context.Context, req *c
 		return nil, err
 	}
 
+	all, err := h.gatewaySessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Scope (#3): confine the merged list to sessions on devices in the caller's
+	// ListActiveTerminalSessions device-group scope. A global holder sees all.
+	// The internal revocation path (TerminateUserSessions) deliberately does NOT
+	// apply this — it enumerates via h.gatewaySessions directly (H1 / #391).
+	scoped, err := h.scopedSessions(ctx, all)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: enrich with user email / device hostname from DB for
+	// the admin view. For now the IDs are returned directly.
+
+	return connect.NewResponse(&pm.ListActiveTerminalSessionsResponse{
+		Sessions:   scoped,
+		TotalCount: int32(len(scoped)),
+	}), nil
+}
+
+// fanOutSessions is the real gateway fan-out backing h.gatewaySessions: it calls
+// GatewayService on every live gateway and merges their local session snapshots
+// with NO caller-scope filtering. The registry/internalHTTPClient wiring guard
+// lives here so both callers (the scoped RPC and the internal revocation path)
+// get the same Unavailable behaviour when the fan-out plumbing is unset.
+func (h *TerminalHandler) fanOutSessions(ctx context.Context) ([]*pm.TerminalSessionInfo, error) {
 	if h.registry == nil || h.internalHTTPClient == nil {
 		return nil, apiErrorCtx(ctx, ErrTerminalNotConfigured, connect.CodeUnavailable,
 			"terminal admin RPCs require a configured registry and internal HTTP client")
@@ -549,20 +589,7 @@ func (h *TerminalHandler) ListActiveTerminalSessions(ctx context.Context, req *c
 	}
 	wg.Wait()
 
-	// Scope (#3): confine the merged list to sessions on devices in the caller's
-	// ListActiveTerminalSessions device-group scope. A global holder sees all.
-	scoped, err := h.scopedSessions(ctx, all)
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: enrich with user email / device hostname from DB for
-	// the admin view. For now the IDs are returned directly.
-
-	return connect.NewResponse(&pm.ListActiveTerminalSessionsResponse{
-		Sessions:   scoped,
-		TotalCount: int32(len(scoped)),
-	}), nil
+	return all, nil
 }
 
 // scopedSessions filters a merged terminal-session list to those on devices
@@ -757,17 +784,19 @@ func (h *TerminalHandler) TerminateTerminalSession(ctx context.Context, req *con
 // TerminalRevocationListener) so it never blocks the disable/delete that
 // triggered it.
 func (h *TerminalHandler) TerminateUserSessions(ctx context.Context, userID string) {
-	listResp, err := h.ListActiveTerminalSessions(ctx, connect.NewRequest(&pm.ListActiveTerminalSessionsRequest{}))
+	sysCtx := auth.WithUser(ctx, &auth.UserContext{ID: "system", Email: "system@power-manage"})
+
+	// Enumerate UNSCOPED: this is a system-initiated revocation, not a scoped
+	// admin's list. Going through ListActiveTerminalSessions would apply
+	// scopedSessions, which under this user-less context fails closed to zero
+	// sessions — terminating nothing (H1 / #391).
+	targets, err := h.sessionsForUser(sysCtx, userID)
 	if err != nil {
 		h.logger.Error("revocation: failed to list terminal sessions", "user_id", userID, "error", err)
 		return
 	}
 
-	sysCtx := auth.WithUser(ctx, &auth.UserContext{ID: "system", Email: "system@power-manage"})
-	for _, s := range listResp.Msg.Sessions {
-		if s.UserId != userID {
-			continue
-		}
+	for _, s := range targets {
 		if _, err := h.TerminateTerminalSession(sysCtx, connect.NewRequest(&pm.TerminateTerminalSessionRequest{
 			SessionId: s.SessionId,
 			Reason:    "user access revoked",
@@ -779,6 +808,26 @@ func (h *TerminalHandler) TerminateUserSessions(ctx context.Context, userID stri
 				"user_id", userID, "session_id", s.SessionId)
 		}
 	}
+}
+
+// sessionsForUser returns the live terminal sessions belonging to userID across
+// all gateways, WITHOUT caller-scope filtering. The internal revocation path is
+// a system operation and must see every session regardless of any device-group
+// scope; routing it through the scoped ListActiveTerminalSessions RPC under a
+// user-less context silently filtered to zero and terminated nothing (H1 /
+// #391).
+func (h *TerminalHandler) sessionsForUser(ctx context.Context, userID string) ([]*pm.TerminalSessionInfo, error) {
+	all, err := h.gatewaySessions(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*pm.TerminalSessionInfo, 0, len(all))
+	for _, s := range all {
+		if s.UserId == userID {
+			out = append(out, s)
+		}
+	}
+	return out, nil
 }
 
 // GatewayBaseURL normalises the configured gateway URL into the

--- a/internal/api/terminal_revocation_enum_test.go
+++ b/internal/api/terminal_revocation_enum_test.go
@@ -1,0 +1,46 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+
+	"github.com/manchtools/power-manage/server/internal/api"
+)
+
+// TestTerminateUserSessions_EnumeratesUnscoped is the H1 (#391) regression: the
+// internal revocation path must enumerate live sessions UNSCOPED, so a
+// system-initiated revocation running under the listener's user-less background
+// context still finds the revoked user's sessions.
+//
+// Before the fix TerminateUserSessions listed via the scoped
+// ListActiveTerminalSessions RPC; under a context with no UserContext the scope
+// filter fails closed to zero rows, so the terminate loop never ran and NO live
+// session was closed — the immediate-revocation control was a silent no-op. This
+// test injects two live sessions and asserts the target user's session is
+// selected even under context.Background() (exactly the listener's bgCtx shape).
+func TestTerminateUserSessions_EnumeratesUnscoped(t *testing.T) {
+	h := api.NewTerminalHandler(nil, nil, nil, "", slog.Default())
+
+	// Two live sessions across the fleet — one per user. The internal
+	// revocation path must see BOTH regardless of caller scope.
+	h.SetGatewaySessionsForTest(func(context.Context) ([]*pm.TerminalSessionInfo, error) {
+		return []*pm.TerminalSessionInfo{
+			{SessionId: "sess-a", UserId: "user-A", DeviceId: "dev-1"},
+			{SessionId: "sess-b", UserId: "user-B", DeviceId: "dev-2"},
+		}, nil
+	})
+
+	// context.Background() has no UserContext — the same shape as the revocation
+	// listener's bgCtx. The scoped RPC would fail closed here; the internal path
+	// must not.
+	targets, err := h.SessionsForUserTest(context.Background(), "user-A")
+	require.NoError(t, err)
+	require.Len(t, targets, 1, "revocation must select the revoked user's session under a user-less context")
+	require.Equal(t, "sess-a", targets[0].SessionId)
+	require.Equal(t, "user-A", targets[0].UserId)
+}

--- a/internal/archtest/context_background_test.go
+++ b/internal/archtest/context_background_test.go
@@ -54,7 +54,7 @@ func TestNoContextBackgroundInRequestPaths(t *testing.T) {
 	allow := newAllowlist(map[string]string{
 		"internal/api/settings_handler.go :: runSettingsPropagation":                 "detached post-update settings fan-out; must outlive the RPC, bounded 5m, panic-recovered (WS16 #9)",
 		"internal/api/terminal_revocation_listener.go :: TerminalRevocationListener": "post-commit event-bus listener goroutine; not a request path, bounded by terminalRevocationCloseTimeout, panic-recovered",
-		"internal/gateway/registry/registry.go :: RegisterGateway":                   "background heartbeat-refresh + shutdown-cleanup goroutine with its own stop signal; each bounded 5s",
+		"internal/gateway/registry/registry.go :: heartbeat":                         "detached TTL-refresh goroutine + shutdown-cleanup closure, each with its own stop signal and a 5s WithTimeout bound; not a request path (shared by RegisterGateway/RegisterGatewayAlive/RegisterGatewayInternal)",
 	})
 
 	// Liveness probe: every context.Background()/context.TODO() seen


### PR DESCRIPTION
## H1 — Terminal revocation listener terminates nothing

`TerminateUserSessions` (internal/api/terminal_handler.go) is the sole mechanism that force-closes an **already-accepted**, root-capable terminal shell when a user is disabled / deleted / role-revoked (#391). It enumerated sessions by calling the **scoped** `ListActiveTerminalSessions` RPC under the revocation listener's user-less `bgCtx`.

With no `UserContext` in the context, `scopeListFilter` (internal/auth/scope.go) fails closed to zero rows → `scopedSessions` returns `nil` → the terminate loop never runs → **no live session is terminated**. The single-use enrollment token only blocks *new* sessions; a disabled/fired admin's open root shell stayed connected until it ended naturally. The bug was invisible in tests because the revocation-listener tests stub `TerminateUserSessions`.

## Fix
- Extract the gateway fan-out into an **unscoped** `fanOutSessions` (behind a `gatewaySessions` field seam). The registry/HTTP-client wiring guard moves there so both callers keep identical Unavailable behaviour.
- The RPC `ListActiveTerminalSessions` layers `scopedSessions` on top (caller scope preserved).
- The internal revocation path enumerates via `sessionsForUser` (unscoped) so a **system-initiated** revocation sees every session.

## Test (red-before-green)
`TestTerminateUserSessions_EnumeratesUnscoped` injects two live sessions and asserts the target user's session is selected under `context.Background()` (the listener's user-less context shape). Verified RED against the buggy scoped-RPC enumeration (0 selected), GREEN with the fix. Full `internal/api` suite passes.

Closes #562. Audit ref: SECURITY_AUDIT_2026_07_17 Part A / H1.