### PR TITLE
test(archtest): re-point context-root allowlist to registry heartbeat (unblock alpha3 CI)

### DIFF
--- a/internal/archtest/context_background_test.go
+++ b/internal/archtest/context_background_test.go
@@ -54,7 +54,7 @@ func TestNoContextBackgroundInRequestPaths(t *testing.T) {
 	allow := newAllowlist(map[string]string{
 		"internal/api/settings_handler.go :: runSettingsPropagation":                 "detached post-update settings fan-out; must outlive the RPC, bounded 5m, panic-recovered (WS16 #9)",
 		"internal/api/terminal_revocation_listener.go :: TerminalRevocationListener": "post-commit event-bus listener goroutine; not a request path, bounded by terminalRevocationCloseTimeout, panic-recovered",
-		"internal/gateway/registry/registry.go :: RegisterGateway":                   "background heartbeat-refresh + shutdown-cleanup goroutine with its own stop signal; each bounded 5s",
+		"internal/gateway/registry/registry.go :: heartbeat":                         "detached TTL-refresh goroutine + shutdown-cleanup closure, each with its own stop signal and a 5s WithTimeout bound; not a request path (shared by RegisterGateway/RegisterGatewayAlive/RegisterGatewayInternal)",
 	})
 
 	// Liveness probe: every context.Background()/context.TODO() seen


### PR DESCRIPTION
## Problem

The Unit Tests lane is red on **every** PR into `integration/alpha3` (e.g. #563). `TestNoContextBackgroundInRequestPaths` (internal/archtest) fails for two reasons, both from the spec 31/32 gateway-registry refactor:

1. The refactor extracted the detached TTL-refresh and shutdown-cleanup goroutines out of `RegisterGateway` into a shared `heartbeat` helper, carrying both `context.WithTimeout(context.Background(), 5*time.Second)` sites (registry.go:179, :195) with them. Those roots are now in `heartbeat`, which is **not** allowlisted → the guard flags them.
2. The old allowlist key `RegisterGateway` now matches **zero** context roots → `assertNoStale` fails (the escape-hatch-can't-rot-open invariant).

## Fix

Re-point the allowlist entry from `RegisterGateway` to `heartbeat`. Both roots are detached-by-design — a self-stopping refresh goroutine and a shutdown-cleanup closure, each with its own stop signal and bounded by a 5s `WithTimeout` — which is precisely the sanctioned "detached work that must outlive the RPC" category the guard documents. No production code changes; allowlist only.

```
go test ./internal/archtest/ -count=1   # ok
```

Unblocks #563 (H1) and the H2 fix once rebased onto this.