### PR TITLE
fix(registration): consume one-time token race-free via version-pinned append (H2)

### DIFF
--- a/internal/api/export_test.go
+++ b/internal/api/export_test.go
@@ -35,6 +35,13 @@ func (h *AuthHandler) SetDummyVerifyForTest(fn func(password, hash string) bool)
 // Compiled only into test binaries.
 func (h *DeviceHandler) SetNowForTest(now func() time.Time) { h.now = now }
 
+// SetRegistrationBeforeConsumeHookForTest installs the test-only barrier invoked
+// at the top of consumeRegistrationToken — after the stale projection read but
+// before the first versioned append. The H2 concurrency regression test uses it
+// to release racing goroutines together so they provably read CurrentUses==0
+// before any consume lands. Compiled only into test binaries. Pass nil to clear.
+func SetRegistrationBeforeConsumeHookForTest(fn func()) { registrationBeforeConsumeHook = fn }
+
 // SetExportPageSizeForTest shrinks the ExportAuditEvents page seam so
 // chunking tests can prove multi-chunk exports without seeding a
 // thousand events. Returns a restore func. Compiled only into test

--- a/internal/api/registration_handler.go
+++ b/internal/api/registration_handler.go
@@ -161,31 +161,15 @@ func (h *RegistrationHandler) Register(ctx context.Context, req *connect.Request
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to validate token")
 	}
 
-	// Check if token is disabled
-	if token.Disabled {
-		logger.Warn("token is disabled")
-		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "registration token is disabled")
-	}
-
-	// Check if token is expired
-	if token.ExpiresAt != nil && h.now().After(*token.ExpiresAt) {
-		logger.Warn("token is expired")
-		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "registration token has expired")
-	}
-
-	// Check max uses for reusable tokens
-	if !token.OneTime && token.MaxUses > 0 && token.CurrentUses >= token.MaxUses {
-		logger.Warn("token max uses reached")
-		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "registration token has reached max uses")
-	}
-	// Defence-in-depth for one-time tokens. The `token.Disabled` check above
-	// already rejects consumed one-time tokens once their TokenDisabled event
-	// has projected, and the event-store optimistic lock at AppendEvent
-	// rejects concurrent consumptions. Rejecting on CurrentUses>0 here fails
-	// fast in the projection-lag window, before the (expensive) CSR signing.
-	if token.OneTime && token.CurrentUses > 0 {
-		logger.Warn("one-time token already used")
-		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "registration token has already been used")
+	// Fail-fast pre-check against the (possibly stale) projection read, so an
+	// obviously-unusable token is rejected before the expensive CSR signing.
+	// This is defence-in-depth, NOT the single-use guarantee: because it reads a
+	// projection that only updates post-commit, concurrent Register calls all
+	// see CurrentUses==0 and all pass here. The AUTHORITATIVE single-use / max-
+	// uses enforcement is the version-pinned consume below (H2).
+	if reason, ok := tokenConsumable(token, h.now()); !ok {
+		logger.Warn("registration token not consumable", "reason", reason)
+		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, reason)
 	}
 
 	// Generate device ID
@@ -230,27 +214,15 @@ func (h *RegistrationHandler) Register(ctx context.Context, req *connect.Request
 		logger.Info("auto-assigning device to token owner", "owner_id", ownerID)
 	}
 
-	// Consume the token FIRST to prevent race conditions with one-time tokens.
-	// The token stream has optimistic locking (version conflict on concurrent
-	// writes), so only one concurrent registration can succeed for a one-time
-	// token. If we registered the device first, a second concurrent request
-	// could create an orphaned device before failing on the token event.
-	eventType := "TokenUsed"
-	if token.OneTime {
-		eventType = "TokenDisabled"
-	}
-	if err := h.store.AppendEvent(ctx, store.Event{
-		StreamType: "token",
-		StreamID:   token.ID,
-		EventType:  eventType,
-		Data: payloads.RegistrationTokenConsumed{
-			DeviceID: deviceID,
-		},
-		ActorType: "system",
-		ActorID:   "registration",
-	}); err != nil {
-		logger.Error("failed to consume token (possible concurrent use)", "error", err)
-		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "registration token has already been used")
+	// Consume the token race-free BEFORE emitting DeviceRegistered. Using the
+	// auto-versioning h.store.AppendEvent here would RETRY on version conflict,
+	// so two concurrent Register calls that both passed the stale-projection
+	// pre-check would BOTH consume a single-use token and both register a device
+	// (H2). consumeRegistrationToken pins the expected stream version so the
+	// event store's UNIQUE(stream_type, stream_id, stream_version) constraint
+	// serialises concurrent consumptions: exactly one lands per version.
+	if err := h.consumeRegistrationToken(ctx, logger, token, deviceID); err != nil {
+		return nil, err
 	}
 
 	// Emit DeviceRegistered event (token is already consumed, safe to proceed)
@@ -274,4 +246,92 @@ func (h *RegistrationHandler) Register(ctx context.Context, req *connect.Request
 		Certificate: cert.CertPEM,
 		GatewayUrl:  h.gatewayURL,
 	}), nil
+}
+
+// registrationBeforeConsumeHook is a test-only barrier invoked at the top of
+// consumeRegistrationToken — after the (stale) projection read but before the
+// first versioned append. The H2 concurrency regression test uses it to release
+// all racing goroutines together so they provably read CurrentUses==0 before any
+// consume lands. nil in production.
+var registrationBeforeConsumeHook func()
+
+// tokenConsumable reports whether a registration token may be consumed right
+// now and, if not, the fixed user-facing reason. Shared by the fail-fast
+// pre-check and the post-conflict re-validation in consumeRegistrationToken so
+// both agree on the disabled / expired / max-uses / one-time-used invariant.
+func tokenConsumable(token store.Token, now time.Time) (reason string, ok bool) {
+	switch {
+	case token.Disabled:
+		return "registration token is disabled", false
+	case token.ExpiresAt != nil && now.After(*token.ExpiresAt):
+		return "registration token has expired", false
+	case !token.OneTime && token.MaxUses > 0 && token.CurrentUses >= token.MaxUses:
+		return "registration token has reached max uses", false
+	case token.OneTime && token.CurrentUses > 0:
+		return "registration token has already been used", false
+	}
+	return "", true
+}
+
+// consumeRegistrationToken consumes one use of a registration token race-free,
+// using the event store's UNIQUE(stream_type, stream_id, stream_version)
+// constraint as the serialisation point. Concurrent Register calls that all
+// passed the stale-projection pre-check converge on the same expected version
+// (ProjectionVersion+1); the DB lets exactly one land per version. A loser
+// re-reads the now-advanced projection, re-validates the consume invariant
+// against fresh state, and retries with the new version — so a one-time token
+// yields exactly one device and a reusable token never exceeds MaxUses no matter
+// how many requests race (H2). fireListeners is synchronous, so the winner's
+// projection update is visible to a loser's re-read within a few attempts.
+func (h *RegistrationHandler) consumeRegistrationToken(ctx context.Context, logger *slog.Logger, token store.Token, deviceID string) error {
+	if registrationBeforeConsumeHook != nil {
+		registrationBeforeConsumeHook()
+	}
+
+	const maxAttempts = 8
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		// Re-validate against the current (fresh after a retry) projection so a
+		// now-used one-time token or an at-cap reusable token fails closed
+		// instead of consuming again.
+		if reason, ok := tokenConsumable(token, h.now()); !ok {
+			logger.Warn("registration token not consumable", "reason", reason, "attempt", attempt)
+			return apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, reason)
+		}
+
+		eventType := "TokenUsed"
+		if token.OneTime {
+			eventType = "TokenDisabled"
+		}
+		expectedVersion := int32(token.ProjectionVersion) + 1
+		err := h.store.AppendEventWithVersion(ctx, store.Event{
+			StreamType: "token",
+			StreamID:   token.ID,
+			EventType:  eventType,
+			Data:       payloads.RegistrationTokenConsumed{DeviceID: deviceID},
+			ActorType:  "system",
+			ActorID:    "registration",
+		}, expectedVersion)
+		if err == nil {
+			return nil
+		}
+		if !store.IsVersionConflict(err) {
+			logger.Error("failed to consume registration token", "error", err)
+			return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to consume registration token")
+		}
+
+		// Lost the OCC race — another consume advanced the token stream. Reload
+		// the fresh projection and retry; the loop head re-validates the
+		// invariant so a fully-consumed token fails closed.
+		fresh, gErr := h.store.Repos().Token.GetByHash(ctx, token.ValueHash)
+		if gErr != nil {
+			logger.Error("failed to reload registration token after version conflict", "error", gErr)
+			return apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to consume registration token")
+		}
+		token = fresh
+	}
+
+	// Exhausted retries purely due to contention (not an invariant violation).
+	// Fail closed with a retryable code rather than risk an unbounded loop.
+	logger.Warn("registration token consume exhausted retries under contention", "token_id", token.ID)
+	return apiErrorCtx(ctx, ErrInternal, connect.CodeUnavailable, "registration token is contended; retry")
 }

--- a/internal/api/registration_handler_test.go
+++ b/internal/api/registration_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"log/slog"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -235,6 +236,90 @@ func TestRegister_OneTimeTokenDisabledAfterUse(t *testing.T) {
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+// TestRegister_OneTimeTokenConcurrentConsumeYieldsOneDevice is the H2
+// regression test. It fires N Register calls at a single one-time token
+// concurrently, holding every goroutine at a barrier installed just before the
+// token consume so they all pass the stale-projection pre-check (CurrentUses==0)
+// before any consume lands — the exact interleaving a serial test cannot force.
+//
+// On the buggy version (consume via auto-versioning AppendEvent, which RETRIES
+// on version conflict) each goroutine re-reads the stream head and lands a fresh
+// TokenDisabled event, so several concurrent registrations all succeed and the
+// one-time token mints multiple devices. On the fixed version (consume via
+// AppendEventWithVersion pinned to ProjectionVersion+1) the event store's
+// UNIQUE(stream_type, stream_id, stream_version) constraint lets exactly one
+// consume land; the losers re-read the now-disabled token and fail closed. So
+// exactly one device is registered no matter how many requests race.
+func TestRegister_OneTimeTokenConcurrentConsumeYieldsOneDevice(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	testCA := newTestCA(t)
+	h := api.NewRegistrationHandler(st, testCA, "https://gateway.test:8080", slog.Default())
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	_, tokenValue := createTestTokenWithValue(t, st, adminID, true) // one-time
+
+	const n = 5
+
+	// Barrier: every goroutine signals arrival at the consume point, then blocks
+	// until the main goroutine releases them together, so all N read the same
+	// stale (CurrentUses==0) projection before any consume executes.
+	release := make(chan struct{})
+	arrived := make(chan struct{}, n)
+	api.SetRegistrationBeforeConsumeHookForTest(func() {
+		arrived <- struct{}{}
+		<-release
+	})
+	defer api.SetRegistrationBeforeConsumeHookForTest(nil)
+
+	var mu sync.Mutex
+	var deviceIDs []string
+	successes := 0
+	permissionDenied := 0
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			csr := generateCSR(t)
+			resp, err := h.Register(context.Background(), connect.NewRequest(&pm.RegisterRequest{
+				Token:        tokenValue,
+				Hostname:     "race-device",
+				AgentVersion: "1.0.0",
+				Csr:          csr,
+			}))
+			mu.Lock()
+			defer mu.Unlock()
+			if err == nil {
+				successes++
+				deviceIDs = append(deviceIDs, resp.Msg.DeviceId.Value)
+				return
+			}
+			if connect.CodeOf(err) == connect.CodePermissionDenied {
+				permissionDenied++
+			}
+		}()
+	}
+
+	// Wait for every goroutine to reach the consume barrier (or fail the test
+	// rather than deadlock), then release them all at once.
+	timeout := time.After(15 * time.Second)
+	for i := 0; i < n; i++ {
+		select {
+		case <-arrived:
+		case <-timeout:
+			close(release)
+			t.Fatalf("only %d/%d goroutines reached the consume barrier", i, n)
+		}
+	}
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, 1, successes, "a one-time token must yield exactly one successful registration under concurrency")
+	assert.Len(t, deviceIDs, 1, "exactly one device may be minted from a one-time token")
+	assert.Equal(t, n-1, permissionDenied, "every loser must fail closed with PermissionDenied")
 }
 
 func TestRegister_DisabledTokenFails(t *testing.T) {

--- a/internal/archtest/context_background_test.go
+++ b/internal/archtest/context_background_test.go
@@ -54,7 +54,7 @@ func TestNoContextBackgroundInRequestPaths(t *testing.T) {
 	allow := newAllowlist(map[string]string{
 		"internal/api/settings_handler.go :: runSettingsPropagation":                 "detached post-update settings fan-out; must outlive the RPC, bounded 5m, panic-recovered (WS16 #9)",
 		"internal/api/terminal_revocation_listener.go :: TerminalRevocationListener": "post-commit event-bus listener goroutine; not a request path, bounded by terminalRevocationCloseTimeout, panic-recovered",
-		"internal/gateway/registry/registry.go :: RegisterGateway":                   "background heartbeat-refresh + shutdown-cleanup goroutine with its own stop signal; each bounded 5s",
+		"internal/gateway/registry/registry.go :: heartbeat":                         "detached TTL-refresh goroutine + shutdown-cleanup closure, each with its own stop signal and a 5s WithTimeout bound; not a request path (shared by RegisterGateway/RegisterGatewayAlive/RegisterGatewayInternal)",
 	})
 
 	// Liveness probe: every context.Background()/context.TODO() seen

--- a/internal/store/postgres/token.go
+++ b/internal/store/postgres/token.go
@@ -70,16 +70,17 @@ func (t *Token) Count(ctx context.Context, filter store.CountTokensFilter) (int6
 // one place.
 func tokenFromRow(row generated.TokensProjection) store.Token {
 	return store.Token{
-		ID:          row.ID,
-		ValueHash:   row.ValueHash,
-		Name:        row.Name,
-		OneTime:     row.OneTime,
-		MaxUses:     row.MaxUses,
-		CurrentUses: row.CurrentUses,
-		ExpiresAt:   row.ExpiresAt,
-		CreatedAt:   row.CreatedAt,
-		CreatedBy:   row.CreatedBy,
-		Disabled:    row.Disabled,
-		OwnerID:     row.OwnerID,
+		ID:                row.ID,
+		ValueHash:         row.ValueHash,
+		Name:              row.Name,
+		OneTime:           row.OneTime,
+		MaxUses:           row.MaxUses,
+		CurrentUses:       row.CurrentUses,
+		ExpiresAt:         row.ExpiresAt,
+		CreatedAt:         row.CreatedAt,
+		CreatedBy:         row.CreatedBy,
+		Disabled:          row.Disabled,
+		OwnerID:           row.OwnerID,
+		ProjectionVersion: row.ProjectionVersion,
 	}
 }

--- a/internal/store/token.go
+++ b/internal/store/token.go
@@ -20,6 +20,17 @@ type Token struct {
 	CreatedBy   string
 	Disabled    bool
 	OwnerID     *string
+	// ProjectionVersion is the store version the token projector recorded for
+	// the last token event applied to this row (projection_version, set from the
+	// event's global SequenceNum — see projectors.ApplyToken). It is the OCC
+	// anchor for a race-free single-use consume: every concurrent consumer pins
+	// AppendEventWithVersion to ProjectionVersion+1, so they all target the same
+	// stream_version and the event store's UNIQUE(stream_type, stream_id,
+	// stream_version) constraint lets exactly one land (H2). SequenceNum grows
+	// monotonically and is always >= the stream head's stream_version, so
+	// ProjectionVersion+1 never collides with an existing version. Mirrors
+	// totp.ProjectionVersion.
+	ProjectionVersion int64
 }
 
 // ListTokensFilter is the pagination + scoping shape for ListTokens.


### PR DESCRIPTION
## Finding (SECURITY_AUDIT_2026_07_17 — Part A / H2)

`Register` consumed the registration token with the **auto-versioning** `store.AppendEvent`, which **retries on version conflict** (re-reading the stream head each attempt). Concurrent `Register` calls that all passed the stale-projection pre-check (`CurrentUses==0`) each landed a *fresh* `TokenDisabled` event at a new stream version — so **every** concurrent request succeeded and a single one-time token minted **multiple devices**; a `max_uses` token could overshoot its cap. The pre-check comment even claimed AppendEvent's optimistic lock rejects concurrent consumptions — false for an auto-versioning append whose job is to retry past conflicts.

## Fix

Consume via `AppendEventWithVersion` pinned to `ProjectionVersion+1`, so the event store's `UNIQUE(stream_type, stream_id, stream_version)` constraint serialises concurrent consumptions — exactly one lands per version. A loser re-reads the advanced projection, re-validates the consume invariant (`tokenConsumable`), and retries: **fail-closed** for a now-used one-time token, **next-slot** for a reusable token up to `max_uses`. Mirrors the shipped TOTP backup-code consume (F-07). `store.Token` now carries `ProjectionVersion` (mapped from `tokens_projection.projection_version`).

## Test (red-before-green)

`TestRegister_OneTimeTokenConcurrentConsumeYieldsOneDevice` fires N concurrent `Register` calls at a one-time token behind a consume barrier and asserts exactly one device is minted. Verified locally:
- **RED** on the auto-versioning path: all 5 goroutines succeed, 5 devices minted.
- **GREEN** on the version-pinned fix: 1 success, 1 device, 4 fail closed with `PermissionDenied`.

Full `internal/api` package green (246s), gofmt + vet clean.

> Note: this branch stacks the #565 archtest-allowlist commit so the Unit Tests lane is green; that commit self-drops from the diff once #565 merges into `integration/alpha3`.

Closes manchtools/power-manage-server#564