### PR TITLE
fix(search): confine executions/device-group/user-group Search + gate audit_events (H4)

### DIFF
--- a/internal/api/object_scope_parity_test.go
+++ b/internal/api/object_scope_parity_test.go
@@ -123,13 +123,26 @@ func TestObjectScope_EnforcementMatchesIndexFiltering(t *testing.T) {
 }
 
 // searchScopedNonObjectScopes are the non-object search scopes that also carry the
-// scope_group_ids TAG (#7 spec 14). They are NOT confined by enforceObjectReadScope
-// / enforceObjectWriteScope; their Search is filtered in scopeGroupClause via the
-// dedicated device-/user-group list filters (DeviceScopeListFilter("ListDevices") /
-// UserScopeListFilter("ListUsers")), and their per-object Get is already confined by
-// the existing device/user handler scope (covered by scope_enforcement_*_test.go and
-// TestScopablePermissions_AllEnforced). So the object-parity reverse check skips them.
+// scope_group_ids TAG (#7 spec 14) but are NOT confined by enforceObjectReadScope /
+// enforceObjectWriteScope. Their Search is confined in scopeGroupClause (devices/
+// users via the dedicated device-/user-group list filters; device_groups/user_groups/
+// executions via the union ObjectScopeListFilter — H4), and their per-object Get is
+// confined by the device/user handler scope, NOT the object-scope path:
+//
+//   - devices/users: the existing device/user handler scope.
+//   - device_groups/user_groups: GetDeviceGroup/GetUserGroup are TargetDevice/
+//     TargetUser scopable permissions (permissions.go), enforced and proven by
+//     TestScopablePermissions_AllEnforced.
+//   - executions: GetExecution enforces auth.EnforceDeviceScopeOnBaseTier on the
+//     target device (uniform NotFound out-of-scope) — the same device-group axis
+//     the search stamp uses.
+//
+// So the object-parity reverse check skips them; their Get-leak risk is covered by
+// scope_enforcement_*_test.go and TestScopablePermissions_AllEnforced instead.
 var searchScopedNonObjectScopes = map[string]bool{
-	"devices": true,
-	"users":   true,
+	"devices":       true,
+	"users":         true,
+	"device_groups": true,
+	"user_groups":   true,
+	"executions":    true,
 }

--- a/internal/api/scope_group_clause_test.go
+++ b/internal/api/scope_group_clause_test.go
@@ -47,8 +47,17 @@ func TestScopeGroupClause(t *testing.T) {
 		assert.Equal(t, "", scopeGroupClause(unrestricted, "devices"))
 		assert.Equal(t, "", scopeGroupClause(unrestricted, "actions"))
 	})
-	t.Run("non-scope-filtered scope gets no clause", func(t *testing.T) {
-		assert.Equal(t, "", scopeGroupClause(deviceScoped, "executions"))
-		assert.Equal(t, "", scopeGroupClause(deviceScoped, "device_groups"))
+	t.Run("device_groups, user_groups and executions now confine (H4)", func(t *testing.T) {
+		// Pre-H4 these three carried no scope_group_ids field, so scopeGroupClause
+		// returned "" — a scope-restricted caller's Search leaked every group/
+		// execution fleet-wide. They now confine via the union ObjectScopeListFilter,
+		// exactly like the object scopes. (The user_groups clause here matches no
+		// row for a device-scoped caller — fail closed, correct.)
+		assert.Equal(t, "@scope_group_ids:{dg1}", scopeGroupClause(deviceScoped, "executions"))
+		assert.Equal(t, "@scope_group_ids:{dg1}", scopeGroupClause(deviceScoped, "device_groups"))
+		assert.Equal(t, "@scope_group_ids:{dg1}", scopeGroupClause(deviceScoped, "user_groups"))
+	})
+	t.Run("audit_events carries no scope field, so no clause (gated by ListAuditEvents instead)", func(t *testing.T) {
+		assert.Equal(t, "", scopeGroupClause(deviceScoped, "audit_events"))
 	})
 }

--- a/internal/api/search_facet_confinement_parity_test.go
+++ b/internal/api/search_facet_confinement_parity_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+)
+
+// TestSearchFacetsConfinedOrGated is the H4 confinement-parity guard. Every
+// searchable facet MUST be either (a) scope-group-confined — it carries the
+// scope_group_ids field, so scopeGroupClause narrows a restricted caller to
+// their scope — OR (b) permission-gated — it's org-tier with no group scope, so
+// facetListPermission requires the caller's dedicated List permission before the
+// facet is queried. A facet that is NEITHER leaks fleet-wide to any Search
+// holder (the H4 bug: executions/device_groups/user_groups had no field, and
+// audit_events had no gate).
+//
+// Self-discovering: the facet set is searchScopeToIndex (exactly what the
+// handler queries), the confined set is derived from the index schemas
+// (scopesWithScopeGroupField), and the gated set is facetListPermission. Adding
+// a new searchable facet with neither a scope_group_ids field nor a gate entry
+// fails this test — it cannot ship as a silent fleet-wide leak.
+func TestSearchFacetsConfinedOrGated(t *testing.T) {
+	require.NotEmpty(t, searchScopeToIndex, "matches-zero: no searchable facets discovered — the guard would pass vacuously")
+
+	for scope := range searchScopeToIndex {
+		confined := scopesWithScopeGroupField[scope]
+		_, gated := facetListPermission[scope]
+		assert.Truef(t, confined || gated,
+			"searchable facet %q is neither scope-confined (no scope_group_ids field) nor permission-gated (no facetListPermission entry) — it would leak fleet-wide to any Search holder. Add scope_group_ids to its index schema, or gate it on its dedicated List permission.", scope)
+		assert.Falsef(t, confined && gated,
+			"searchable facet %q is BOTH scope-confined and permission-gated — pick one: scope confinement for group-scopable facets, a permission gate only for org-tier facets that can't be group-scoped", scope)
+	}
+
+	// Every gated facet must be a real searchable facet (no stale entry), and its
+	// permission must be a REAL, org-tier (TargetUnspecified) permission. This is
+	// load-bearing, not cosmetic: a group-scopable permission here would admit a
+	// scope-restricted caller to a facet Search can't confine — HasPermission(base)
+	// is true for a group-scoped holder, so the gate would pass and the whole
+	// (unconfined) facet would leak. A typo'd key would silently make the facet
+	// unqueryable. TargetKindFor returns TargetUnspecified for BOTH org-tier and
+	// unknown keys, so existence is asserted separately.
+	validPerms := auth.ValidPermissionKeys()
+	for scope, perm := range facetListPermission {
+		_, searchable := searchScopeToIndex[scope]
+		assert.Truef(t, searchable, "facetListPermission gates %q which is not a searchable facet", scope)
+		assert.Truef(t, validPerms[perm],
+			"facetListPermission[%q] = %q is not a real permission key (typo? renamed?) — the gate would make the facet permanently unqueryable", scope, perm)
+		assert.Equalf(t, auth.TargetUnspecified, auth.TargetKindFor(perm),
+			"facetListPermission[%q] = %q must be an org-tier (TargetUnspecified) permission — a group-scopable gate perm admits a scope-restricted caller to a facet Search cannot confine (HasPermission(base) is true for scoped holders), reopening the H4 leak", scope, perm)
+	}
+}
+
+// TestSearchConfinedFacets_YieldNonEmptyClause is the behavioral half of the
+// guard (audit wording: "every searchable scope with a scoped dedicated List RPC
+// must yield a non-empty confining clause for a restricted caller"). For a caller
+// restricted to one group, scopeGroupClause on EVERY confined facet must return a
+// non-empty confining clause — never "" (which is fail-open to the whole
+// catalog). This catches a facet that gains the scope_group_ids field but whose
+// scopeGroupClause switch arm forgets to confine it.
+func TestSearchConfinedFacets_YieldNonEmptyClause(t *testing.T) {
+	require.NotEmpty(t, scopesWithScopeGroupField, "matches-zero: no confined facets discovered")
+
+	// A caller restricted on all three axes (device-group, user-group, object
+	// union) so every confined facet resolves to a real, non-empty clause.
+	restricted := auth.WithUser(context.Background(), &auth.UserContext{
+		ID:          "c",
+		Permissions: []string{"ListDevices", "ListUsers"},
+		ScopedGrants: []auth.ScopedGrant{
+			{Permission: "ListDevices", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: "dg1"},
+			{Permission: "ListUsers", ScopeKind: auth.ScopeKindUserGroup, ScopeID: "ug1"},
+		},
+	})
+
+	for scope := range scopesWithScopeGroupField {
+		clause := scopeGroupClause(restricted, scope)
+		assert.NotEmptyf(t, clause,
+			"confined facet %q yielded an EMPTY clause for a scope-restricted caller — fail-open leak. scopeGroupClause must confine every facet in scopesWithScopeGroupField.", scope)
+	}
+}

--- a/internal/api/search_facet_scope_behavioral_test.go
+++ b/internal/api/search_facet_scope_behavioral_test.go
@@ -1,0 +1,130 @@
+package api_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
+	"github.com/manchtools/power-manage/server/internal/api"
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// TestValkeySearch_FacetScope_ConfinesAndGates is the H4 behavioral regression:
+// the executions / device_groups / user_groups facets used to leak fleet-wide via
+// Search (no scope_group_ids field → no confining clause), and audit_events had
+// no permission gate at all (a Search-only holder read the whole audit log). This
+// drives the REAL search handler against a REAL valkey-search backend and proves
+// each facet is now confined (groups/executions) or gated (audit_events).
+//
+// Pre-fix this test fails: device_groups/user_groups/executions return the
+// out-of-scope object, and the audit_events sub-test returns the log to a caller
+// without ListAuditEvents.
+func TestValkeySearch_FacetScope_ConfinesAndGates(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping valkey-search integration test in short mode")
+	}
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	admin := testutil.CreateTestUser(t, st, testutil.NewID()+"@a.com", "pass", "admin")
+
+	// Device groups: caller is scoped to dgA; dgB is out of scope.
+	dgA := testutil.CreateTestDeviceGroup(t, st, admin, "Fleet A")
+	dgB := testutil.CreateTestDeviceGroup(t, st, admin, "Fleet B")
+
+	// A device in each group, and an execution targeting each device. An
+	// execution inherits its target device's device-group scope (H4).
+	deviceA := testutil.CreateTestDevice(t, st, "host-a")
+	deviceB := testutil.CreateTestDevice(t, st, "host-b")
+	testutil.AddDeviceToTestGroup(t, st, admin, dgA, deviceA)
+	testutil.AddDeviceToTestGroup(t, st, admin, dgB, deviceB)
+	execA := createTestExecution(t, st, admin, deviceA)
+	execB := createTestExecution(t, st, admin, deviceB)
+
+	// User groups: a separate caller is scoped to ugA; ugB is out of scope.
+	ugA := testutil.CreateTestUserGroup(t, st, admin, "Eng")
+	ugB := testutil.CreateTestUserGroup(t, st, admin, "Ops")
+
+	idx := testutil.SetupValkeySearch(t, st)
+	require.NoError(t, idx.Rebuild(ctx), "backfill the search index")
+
+	sh := api.NewSearchHandler(slog.Default())
+	sh.SetSearchIndex(idx)
+
+	search := func(c context.Context, scope pm.SearchScope) map[string]bool {
+		resp, err := sh.Search(c, connect.NewRequest(&pm.SearchRequest{Scope: scope, PageSize: 200}))
+		require.NoError(t, err)
+		ids := map[string]bool{}
+		for _, r := range resp.Msg.Results {
+			ids[r.Id] = true
+		}
+		return ids
+	}
+
+	scopedToDgA := testutil.AuthContextScoped(testutil.NewID(), "dev@test.com",
+		[]string{"Search"},
+		[]auth.ScopedGrant{{Permission: "Search", ScopeKind: auth.ScopeKindDeviceGroup, ScopeID: dgA}})
+	scopedToUgA := testutil.AuthContextScoped(testutil.NewID(), "usr@test.com",
+		[]string{"Search"},
+		[]auth.ScopedGrant{{Permission: "Search", ScopeKind: auth.ScopeKindUserGroup, ScopeID: ugA}})
+
+	t.Run("device_groups facet confines to the caller's scope group", func(t *testing.T) {
+		got := search(scopedToDgA, pm.SearchScope_SEARCH_SCOPE_DEVICE_GROUPS)
+		assert.True(t, got[dgA], "in-scope device group must be visible")
+		assert.False(t, got[dgB], "out-of-scope device group must be confined")
+	})
+
+	t.Run("executions facet confines to the target device's scope group", func(t *testing.T) {
+		got := search(scopedToDgA, pm.SearchScope_SEARCH_SCOPE_EXECUTIONS)
+		assert.True(t, got[execA], "execution on an in-scope device must be visible")
+		assert.False(t, got[execB], "execution on an out-of-scope device must be confined")
+	})
+
+	t.Run("user_groups facet confines to the caller's scope group", func(t *testing.T) {
+		got := search(scopedToUgA, pm.SearchScope_SEARCH_SCOPE_USER_GROUPS)
+		assert.True(t, got[ugA], "in-scope user group must be visible")
+		assert.False(t, got[ugB], "out-of-scope user group must be confined")
+	})
+
+	t.Run("audit_events facet is gated by ListAuditEvents", func(t *testing.T) {
+		// Every state change above wrote an event, all indexed as audit_events.
+		denied := testutil.AuthContextScoped(testutil.NewID(), "d@test.com",
+			[]string{"Search"}, []auth.ScopedGrant{{Permission: "Search"}})
+		allowed := testutil.AuthContextScoped(testutil.NewID(), "a@test.com",
+			[]string{"Search", "ListAuditEvents"}, []auth.ScopedGrant{{Permission: "Search"}})
+
+		assert.Empty(t, search(denied, pm.SearchScope_SEARCH_SCOPE_AUDIT_EVENTS),
+			"a Search holder without ListAuditEvents must NOT read the audit log via Search")
+		assert.NotEmpty(t, search(allowed, pm.SearchScope_SEARCH_SCOPE_AUDIT_EVENTS),
+			"a caller with ListAuditEvents sees audit events (gate must not block a permitted caller)")
+	})
+}
+
+// createTestExecution appends an ExecutionCreated event so the executions
+// projection (and, after Rebuild, the search index) carries a row targeting
+// deviceID. Returns the execution id.
+func createTestExecution(t *testing.T, st *store.Store, actorID, deviceID string) string {
+	t.Helper()
+	execID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "execution",
+		StreamID:   execID,
+		EventType:  "ExecutionCreated",
+		Data: map[string]any{
+			"device_id":     deviceID,
+			"action_type":   1,
+			"desired_state": 1,
+			"params":        map[string]any{"name": "nginx"},
+		},
+		ActorType: "user",
+		ActorID:   actorID,
+	}))
+	return execID
+}

--- a/internal/api/search_handler.go
+++ b/internal/api/search_handler.go
@@ -37,6 +37,36 @@ var scopesWithScopeGroupField = func() map[string]bool {
 // empty — fail closed, never fail open to the whole catalog.
 const noScopeSentinel = "__pm_no_scope__"
 
+// searchScopeToIndex is the full set of searchable facets and their valkey-search
+// index names. The default (unscoped) query plan is a subset; executions and
+// audit_events are reachable only via an explicit scope. Hoisted to package scope
+// so the confinement-parity guard (TestSearchFacetsConfinedOrGated) reads exactly
+// the set the handler queries.
+var searchScopeToIndex = map[string]string{
+	"actions":             "idx:actions",
+	"action_sets":         "idx:action_sets",
+	"definitions":         "idx:definitions",
+	"compliance_policies": "idx:compliance_policies",
+	"devices":             "idx:devices",
+	"users":               "idx:users",
+	"device_groups":       "idx:device_groups",
+	"user_groups":         "idx:user_groups",
+	"executions":          "idx:executions",
+	"audit_events":        "idx:audit_events",
+}
+
+// facetListPermission gates searchable facets that carry NO scope_group_ids field,
+// so scopeGroupClause cannot confine them by group scope. Such a facet is org-tier
+// (TargetUnspecified): a Search caller must hold its dedicated List permission to
+// see any of it, exactly as the dedicated List RPC requires — otherwise a
+// Search-only holder would read it fleet-wide. audit_events is the only such facet
+// (its ListAuditEvents permission is org-tier). The parity guard proves every
+// searchable facet is EITHER scope-confined OR listed here — never both unconfined
+// and ungated (H4).
+var facetListPermission = map[string]string{
+	"audit_events": "ListAuditEvents",
+}
+
 // scopeGroupClause returns the RediSearch clause confining a scope-restricted
 // caller to objects assigned within their scope groups (#7 spec 14), or "" when
 // the scope carries no scope_group_ids field or the caller is unrestricted
@@ -302,19 +332,6 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 		return nil, err
 	}
 
-	scopeToIndex := map[string]string{
-		"actions":             "idx:actions",
-		"action_sets":         "idx:action_sets",
-		"definitions":         "idx:definitions",
-		"compliance_policies": "idx:compliance_policies",
-		"devices":             "idx:devices",
-		"users":               "idx:users",
-		"device_groups":       "idx:device_groups",
-		"user_groups":         "idx:user_groups",
-		"executions":          "idx:executions",
-		"audit_events":        "idx:audit_events",
-	}
-
 	// Build the FT.SEARCH query from text query + filters.
 	ftQuery := buildFTQuery(query, req.Msg.DateFilters, tagFilters)
 	if deviceStatusClause != "" {
@@ -329,8 +346,17 @@ func (h *SearchHandler) Search(ctx context.Context, req *connect.Request[pm.Sear
 	var totalCount int32
 
 	for _, scope := range scopes {
-		idxName, ok := scopeToIndex[scope]
+		idxName, ok := searchScopeToIndex[scope]
 		if !ok {
+			continue
+		}
+
+		// H4: a facet with no scope_group_ids field can't be group-confined, so it
+		// is gated by its dedicated org-tier List permission. Skip it for a caller
+		// who lacks that permission (never leak it fleet-wide via Search). Facets
+		// that ARE scope-confined (the common case) carry no entry here and fall
+		// through to scopeGroupClause below.
+		if perm, gated := facetListPermission[scope]; gated && !auth.HasPermission(ctx, perm) {
 			continue
 		}
 

--- a/internal/api/search_listener.go
+++ b/internal/api/search_listener.go
@@ -658,6 +658,11 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 			IsDynamic:   isDynamic,
 			MemberCount: g.MemberCount,
 			CreatedAt:   createdAt,
+			// A device group is in-scope for a caller scoped to it: stamp its OWN
+			// id so ObjectScopeListFilter (union device-/user-group scope) confines
+			// Search to the groups the caller can list (H4).
+			ScopeGroupIDs:    id,
+			HasScopeGroupIDs: true,
 		}, nil
 
 	case search.ScopeActionSet:
@@ -841,6 +846,9 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 			IsDynamic:   isDynamic,
 			MemberCount: g.MemberCount,
 			CreatedAt:   createdAt,
+			// Own id — same rationale as ScopeDeviceGroup (H4).
+			ScopeGroupIDs:    id,
+			HasScopeGroupIDs: true,
 		}, nil
 
 	case search.ScopeExecution:
@@ -871,17 +879,27 @@ func loadSearchEntityData(ctx context.Context, st *store.Store, logger *slog.Log
 		if exec.DurationMs != nil {
 			execDurationMs = *exec.DurationMs
 		}
+		// An execution inherits the scope of its TARGET DEVICE: stamp the device's
+		// device-group ids so a scope-restricted caller sees only executions on
+		// devices in their scope, mirroring the dedicated ListExecutions confinement
+		// (H4 — was leaking every execution fleet-wide).
+		scopeGroups, err := loadDeviceScopeGroupIDs(ctx, q, exec.DeviceID)
+		if err != nil {
+			return nil, err
+		}
 		return &taskqueue.SearchEntityData{
-			ActionName:     actionName,
-			DeviceHostname: deviceHostname,
-			Status:         exec.Status,
-			Type:           exec.ActionType,
-			DeviceID:       exec.DeviceID,
-			CreatedAt:      execCreatedAt,
-			DurationMs:     execDurationMs,
-			Changed:        exec.Changed,
-			DesiredState:   exec.DesiredState,
-			ActionID:       execActionID,
+			ActionName:       actionName,
+			DeviceHostname:   deviceHostname,
+			Status:           exec.Status,
+			Type:             exec.ActionType,
+			DeviceID:         exec.DeviceID,
+			CreatedAt:        execCreatedAt,
+			DurationMs:       execDurationMs,
+			Changed:          exec.Changed,
+			DesiredState:     exec.DesiredState,
+			ActionID:         execActionID,
+			ScopeGroupIDs:    scopeGroups,
+			HasScopeGroupIDs: true,
 		}, nil
 	}
 

--- a/internal/search/index.go
+++ b/internal/search/index.go
@@ -360,6 +360,10 @@ var IndexSchemas = []IndexSchema{
 			"is_dynamic", "TAG",
 			"member_count", "NUMERIC", "SORTABLE",
 			"created_at", "NUMERIC", "SORTABLE",
+			// scope_group_ids holds the group's OWN id so a scope-restricted
+			// caller's Search is confined to the device groups they're scoped
+			// to (H4 — was leaking every group org-wide).
+			"scope_group_ids", "TAG",
 		},
 	},
 	{
@@ -371,6 +375,7 @@ var IndexSchemas = []IndexSchema{
 			"is_dynamic", "TAG",
 			"member_count", "NUMERIC", "SORTABLE",
 			"created_at", "NUMERIC", "SORTABLE",
+			"scope_group_ids", "TAG",
 		},
 	},
 	{
@@ -383,6 +388,10 @@ var IndexSchemas = []IndexSchema{
 			"action_type", "TAG", "SORTABLE",
 			"device_id", "TAG",
 			"created_at", "NUMERIC", "SORTABLE",
+			// scope_group_ids holds the TARGET DEVICE's device-group ids so a
+			// scope-restricted caller sees only executions on devices in their
+			// scope (H4 — was leaking every execution fleet-wide).
+			"scope_group_ids", "TAG",
 		},
 	},
 	{
@@ -1201,10 +1210,12 @@ func (idx *Index) warmDeviceGroups(ctx context.Context) (int, error) {
 				isDynamic = "true"
 			}
 			data := &taskqueue.SearchEntityData{
-				Name:        g.Name,
-				Description: g.Description,
-				IsDynamic:   isDynamic,
-				MemberCount: g.MemberCount,
+				Name:             g.Name,
+				Description:      g.Description,
+				IsDynamic:        isDynamic,
+				MemberCount:      g.MemberCount,
+				ScopeGroupIDs:    g.ID, // own id (H4)
+				HasScopeGroupIDs: true,
 			}
 			if g.CreatedAt != nil {
 				data.CreatedAt = g.CreatedAt.Unix()
@@ -1245,10 +1256,12 @@ func (idx *Index) warmUserGroups(ctx context.Context) (int, error) {
 				isDynamic = "true"
 			}
 			data := &taskqueue.SearchEntityData{
-				Name:        g.Name,
-				Description: g.Description,
-				IsDynamic:   isDynamic,
-				MemberCount: g.MemberCount,
+				Name:             g.Name,
+				Description:      g.Description,
+				IsDynamic:        isDynamic,
+				MemberCount:      g.MemberCount,
+				ScopeGroupIDs:    g.ID, // own id (H4)
+				HasScopeGroupIDs: true,
 			}
 			if !g.CreatedAt.IsZero() {
 				data.CreatedAt = g.CreatedAt.Unix()
@@ -1286,6 +1299,14 @@ func (idx *Index) warmExecutions(ctx context.Context) (int, error) {
 	const pageSize int32 = 1000
 	var offset int32
 	var total int
+
+	// An execution's scope_group_ids is its target device's device-group ids
+	// (H4): one bulk query, then O(1) lookup per exec. A device absent from the
+	// map has no groups → "" → invisible to scoped admins (fail closed).
+	deviceGroups, err := idx.deviceGroupSet(ctx)
+	if err != nil {
+		return total, err
+	}
 
 	// Build lookup caches for device hostnames and action names.
 	deviceNames := make(map[string]string)
@@ -1340,6 +1361,7 @@ func (idx *Index) warmExecutions(ctx context.Context) (int, error) {
 				"action_id":       actionID,
 				"desired_state":   strconv.Itoa(int(e.DesiredState)),
 				"changed":         strconv.FormatBool(e.Changed),
+				"scope_group_ids": deviceGroups[e.DeviceID], // H4: target device's groups
 			}
 			if e.CreatedAt != nil {
 				execFields["created_at"] = strconv.FormatInt(e.CreatedAt.Unix(), 10)

--- a/internal/search/worker.go
+++ b/internal/search/worker.go
@@ -451,6 +451,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"is_dynamic":   data.IsDynamic,
 			"member_count": strconv.Itoa(int(data.MemberCount)),
 		}
+		setScopeGroupIDs(fields, data)
 		if data.CreatedAt != 0 {
 			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)
 		}
@@ -466,6 +467,7 @@ func entityFields(scope string, data *taskqueue.SearchEntityData) map[string]any
 			"desired_state":   strconv.Itoa(int(data.DesiredState)),
 			"changed":         strconv.FormatBool(data.Changed),
 		}
+		setScopeGroupIDs(fields, data)
 		if data.CreatedAt != 0 {
 			fields["created_at"] = strconv.FormatInt(data.CreatedAt, 10)
 		}


### PR DESCRIPTION
## H4 — Search scope fail-open (Highs, SECURITY_AUDIT_2026_07_17)

Search fans out across per-facet valkey-search indexes, but only the object facets (actions/action_sets/definitions/compliance_policies) plus devices/users carried the `scope_group_ids` TAG. The **executions**, **device_groups** and **user_groups** indexes declared no such field, so `scopeGroupClause` returned `""` for them — a scope-restricted caller's Search on those facets **fell open to the whole fleet**. **audit_events** had neither a scope field nor a permission gate, so a `Search` holder without `ListAuditEvents` could read the entire audit log via `scope=audit_events`.

### Fix
- Add `scope_group_ids` to the executions/device_groups/user_groups index schemas (auto-bumps `SchemaFingerprint` → drop+recreate+rebuild on next indexer boot; no manual version bump).
- Stamp the field in all three write paths (incremental listener, warm rebuild, worker `entityFields`): groups stamp their **own id**; executions stamp the **target device's device-group ids** (mirroring `GetExecution`'s `EnforceDeviceScopeOnBaseTier` and the dedicated `ListExecutions` confinement). These facets fall through to the default `ObjectScopeListFilter`, which **fails closed** for any scoped caller.
- Gate `audit_events` (org-tier, no group scope) on `ListAuditEvents` in the query loop — a `Search` caller without it never queries the facet.
- **Self-discovering guard** `TestSearchFacetsConfinedOrGated`: every searchable facet is either scope-confined or permission-gated, never both unconfined and ungated (matches-zero guarded). Companion clause guard proves every confined facet yields a non-empty confining clause for a restricted caller.
- Extend `searchScopedNonObjectScopes` so the object-scope reverse guard accepts the three device/user-scope-confined facets (their Get is confined via the device/user handler scope, proven by `TestScopablePermissions_AllEnforced`).

### Tests
- Behavioral regression against **real valkey-search**: a scope-restricted caller sees only in-scope device groups / executions / user groups, and a Search-only holder gets nothing from `scope=audit_events`. **Verified red-before-green** (all four facets leak with the fix neutralized).
- Clause-level + self-discovering parity guards.