### PR TITLE
fix: bind target_device_id into the four non-action stream-RPC dispatches (PMSEC-001)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260712190623-bbc6a78b889c
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260717205410-7a6ce34c9fcc
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8S
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260712190623-bbc6a78b889c h1:KeBTaHW9wdX3P1/Cfo63yitz58srsO8IOsFULu+VJxw=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260712190623-bbc6a78b889c/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260717205410-7a6ce34c9fcc h1:6DHBeJEgg7abtTi6IRhPsubZIC476NZfxR+qZ0XHLRM=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260717205410-7a6ce34c9fcc/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/device_handler.go
+++ b/internal/api/device_handler.go
@@ -1254,7 +1254,7 @@ func (h *DeviceHandler) RevokeLuksDeviceKey(ctx context.Context, req *connect.Re
 	// action_id before performing the destructive, irreversible slot-7 wipe
 	// (WS4), so a compromised gateway cannot forge or replay a revocation. A
 	// signing failure transitions the projection requested → failed.
-	revokePayload := taskqueue.RevokeLuksDeviceKeyPayload{ActionID: req.Msg.ActionId}
+	revokePayload := taskqueue.RevokeLuksDeviceKeyPayload{ActionID: req.Msg.ActionId, TargetDeviceID: req.Msg.DeviceId}
 	if signErr := signRevokeLuksDeviceKey(h.signer, &revokePayload); signErr != nil {
 		h.logger.Error("luks revocation signing failed; emitting LuksDeviceKeyRevocationFailed",
 			"device_id", req.Msg.DeviceId, "action_id", req.Msg.ActionId, "error", signErr)

--- a/internal/api/logs_handler.go
+++ b/internal/api/logs_handler.go
@@ -76,14 +76,15 @@ func (h *LogsHandler) QueryDeviceLogs(ctx context.Context, req *connect.Request[
 	// Fail closed on a signing error — expire the pending row rather than
 	// shipping an unsigned task the agent drops.
 	payload := taskqueue.LogQueryDispatchPayload{
-		QueryID:  queryID,
-		Lines:    msg.Lines,
-		Unit:     msg.Unit,
-		Since:    msg.Since,
-		Until:    msg.Until,
-		Priority: msg.Priority,
-		Grep:     msg.Grep,
-		Kernel:   msg.Kernel,
+		QueryID:        queryID,
+		Lines:          msg.Lines,
+		Unit:           msg.Unit,
+		Since:          msg.Since,
+		Until:          msg.Until,
+		Priority:       msg.Priority,
+		Grep:           msg.Grep,
+		Kernel:         msg.Kernel,
+		TargetDeviceID: msg.DeviceId,
 	}
 	if err := signLogQueryDispatch(h.signer, &payload); err != nil {
 		h.logger.Error("log query dispatch signing failed; marking result expired",

--- a/internal/api/osquery_handler.go
+++ b/internal/api/osquery_handler.go
@@ -91,11 +91,12 @@ func (h *OSQueryHandler) DispatchOSQuery(ctx context.Context, req *connect.Reque
 	// and returns an error rather than shipping an unsigned task the agent
 	// would drop.
 	payload := taskqueue.OSQueryDispatchPayload{
-		QueryID: queryID,
-		Table:   msg.Table,
-		Columns: msg.Columns,
-		Limit:   msg.Limit,
-		RawSQL:  msg.RawSql,
+		QueryID:        queryID,
+		Table:          msg.Table,
+		Columns:        msg.Columns,
+		Limit:          msg.Limit,
+		RawSQL:         msg.RawSql,
+		TargetDeviceID: msg.DeviceId,
 	}
 	if err := signOSQueryDispatch(h.signer, &payload); err != nil {
 		h.logger.Error("osquery dispatch signing failed; marking result expired",
@@ -295,7 +296,7 @@ func (h *OSQueryHandler) RefreshDeviceInventory(ctx context.Context, req *connec
 	// Build + sign the inventory request (WS4): a query_id makes it bindable,
 	// and the agent verifies the CA signature before running osquery as root.
 	// Fail closed on a signing error.
-	payload := taskqueue.InventoryRequestPayload{QueryID: ulid.Make().String()}
+	payload := taskqueue.InventoryRequestPayload{QueryID: ulid.Make().String(), TargetDeviceID: msg.DeviceId}
 	if err := taskqueue.SignInventoryRequest(h.signer, &payload); err != nil {
 		h.logger.Error("inventory request signing failed",
 			"device_id", msg.DeviceId, "error", err)

--- a/internal/api/stream_dispatch_signing_test.go
+++ b/internal/api/stream_dispatch_signing_test.go
@@ -67,11 +67,23 @@ func TestDispatchOSQuery_SignsCanonicalUnderDomain(t *testing.T) {
 	call := lastDeviceCall(t, queue, taskqueue.TypeOSQueryDispatch)
 	payload := payloadAs[taskqueue.OSQueryDispatchPayload](t, call)
 	require.NotEmpty(t, payload.Signature, "osquery dispatch must be signed")
+	require.Equal(t, deviceID, payload.TargetDeviceID,
+		"dispatch must bind the target device inside the signed bytes (PMSEC-001) — an empty target signs a message the agent will reject")
 
 	canonical, err := verify.OSQueryCanonical(payload.ToProto())
 	require.NoError(t, err)
 	require.NoError(t, verifier.VerifyDomain(verify.OSQuerySignatureDomain, canonical, payload.Signature),
 		"enqueued osquery must verify under the osquery domain")
+
+	// Cross-device replay (PMSEC-001): retargeting the signed message to another
+	// device must break verification — a compromised gateway cannot replay this
+	// device's signed query onto a different served device.
+	retargeted := payload.ToProto()
+	retargeted.TargetDeviceId = testutil.CreateTestDevice(t, st, "osq-other-host")
+	retargetedCanon, err := verify.OSQueryCanonical(retargeted)
+	require.NoError(t, err)
+	require.Error(t, verifier.VerifyDomain(verify.OSQuerySignatureDomain, retargetedCanon, payload.Signature),
+		"retargeting target_device_id must break verification")
 
 	// Domain disjointness: the same bytes/signature must NOT verify under a
 	// sibling domain (no cross-surface replay).
@@ -161,6 +173,8 @@ func TestQueryDeviceLogs_SignsCanonicalUnderDomain(t *testing.T) {
 	call := lastDeviceCall(t, queue, taskqueue.TypeLogQueryDispatch)
 	payload := payloadAs[taskqueue.LogQueryDispatchPayload](t, call)
 	require.NotEmpty(t, payload.Signature, "log query dispatch must be signed")
+	require.Equal(t, deviceID, payload.TargetDeviceID,
+		"log query dispatch must bind the target device inside the signed bytes (PMSEC-001)")
 
 	canonical, err := verify.LogQueryCanonical(payload.ToProto())
 	require.NoError(t, err)
@@ -197,6 +211,8 @@ func TestRefreshDeviceInventory_SignsCanonicalUnderDomain(t *testing.T) {
 	payload := payloadAs[taskqueue.InventoryRequestPayload](t, call)
 	require.NotEmpty(t, payload.QueryID, "inventory request must carry a query_id to be bindable")
 	require.NotEmpty(t, payload.Signature, "inventory request must be signed")
+	require.Equal(t, deviceID, payload.TargetDeviceID,
+		"inventory request must bind the target device inside the signed bytes (PMSEC-001)")
 
 	canonical, err := verify.RequestInventoryCanonical(payload.ToProto())
 	require.NoError(t, err)
@@ -234,6 +250,8 @@ func TestRevokeLuksDeviceKey_SignsCanonicalUnderDomain(t *testing.T) {
 	payload := payloadAs[taskqueue.RevokeLuksDeviceKeyPayload](t, call)
 	require.Equal(t, actionID, payload.ActionID)
 	require.NotEmpty(t, payload.Signature, "LUKS revoke dispatch must be signed")
+	require.Equal(t, deviceID, payload.TargetDeviceID,
+		"LUKS revoke must bind the target device inside the signed bytes (PMSEC-001) — the most destructive cross-device replay to close")
 
 	canonical, err := verify.RevokeLuksDeviceKeyCanonical(payload.ToProto())
 	require.NoError(t, err)

--- a/internal/inventorysched/inventorysched.go
+++ b/internal/inventorysched/inventorysched.go
@@ -162,7 +162,7 @@ func (w *Worker) runLocked(ctx context.Context) (RunResult, error) {
 
 	deadline := now.Add(Tick - enqueueDeadlineSlack)
 	for _, deviceID := range ids {
-		payload := taskqueue.InventoryRequestPayload{QueryID: ulid.Make().String()}
+		payload := taskqueue.InventoryRequestPayload{QueryID: ulid.Make().String(), TargetDeviceID: deviceID}
 		if err := taskqueue.SignInventoryRequest(w.signer, &payload); err != nil {
 			// Signing failure is systemic (nil signer / broken key):
 			// abort the cycle fail-closed instead of log-spamming one

--- a/internal/inventorysched/inventorysched_test.go
+++ b/internal/inventorysched/inventorysched_test.go
@@ -126,6 +126,8 @@ func TestRunOnce_StaleConnectedDeviceGetsOneSignedRequest(t *testing.T) {
 	assert.Equal(t, taskqueue.TypeInventoryRequest, call.taskType)
 	assert.NotEmpty(t, call.payload.QueryID, "request must carry a bindable query_id")
 	assert.NotEmpty(t, call.payload.Signature, "request must be CA-signed (WS4)")
+	assert.Equal(t, stale, call.payload.TargetDeviceID,
+		"scheduled request must bind the target device inside the signed bytes (PMSEC-001)")
 	assert.Equal(t, 2, call.opts, "MaxRetry + sub-tick Deadline")
 }
 

--- a/internal/taskqueue/payloads.go
+++ b/internal/taskqueue/payloads.go
@@ -36,12 +36,18 @@ type ActionDispatchPayload struct {
 // verify.OSQuerySignatureDomain (WS4). The control server computes it; the
 // gateway copies it onto the wire OSQuery verbatim and NEVER originates it.
 type OSQueryDispatchPayload struct {
-	QueryID   string   `json:"query_id"`
-	Table     string   `json:"table"`
-	Columns   []string `json:"columns,omitempty"`
-	Limit     int32    `json:"limit,omitempty"`
-	RawSQL    string   `json:"raw_sql,omitempty"`
-	Signature []byte   `json:"signature,omitempty"`
+	QueryID string   `json:"query_id"`
+	Table   string   `json:"table"`
+	Columns []string `json:"columns,omitempty"`
+	Limit   int32    `json:"limit,omitempty"`
+	RawSQL  string   `json:"raw_sql,omitempty"`
+	// TargetDeviceID is the device this query is authorized to run on. It is
+	// bound INSIDE the signed canonical bytes (PMSEC-001) so a compromised
+	// gateway cannot replay one device's signed query onto another; the agent
+	// verifies target == self. The control server sets it to the dispatch
+	// target before signing.
+	TargetDeviceID string `json:"target_device_id"`
+	Signature      []byte `json:"signature,omitempty"`
 }
 
 // ToProto builds the wire OSQuery from the payload (signature excluded). It is
@@ -51,11 +57,12 @@ type OSQueryDispatchPayload struct {
 // byte-for-byte the bytes the server signed, with no field-mapping drift.
 func (p OSQueryDispatchPayload) ToProto() *pm.OSQuery {
 	return &pm.OSQuery{
-		QueryId: p.QueryID,
-		Table:   p.Table,
-		Columns: p.Columns,
-		Limit:   p.Limit,
-		RawSql:  p.RawSQL,
+		QueryId:        p.QueryID,
+		Table:          p.Table,
+		Columns:        p.Columns,
+		Limit:          p.Limit,
+		RawSql:         p.RawSQL,
+		TargetDeviceId: p.TargetDeviceID,
 	}
 }
 
@@ -65,15 +72,18 @@ func (p OSQueryDispatchPayload) ToProto() *pm.OSQuery {
 // the CA signature over ToProto()'s canonical bytes under
 // verify.InventorySignatureDomain (WS4).
 type InventoryRequestPayload struct {
-	QueryID   string `json:"query_id"`
-	Signature []byte `json:"signature,omitempty"`
+	QueryID string `json:"query_id"`
+	// TargetDeviceID binds the collection request to one device inside the
+	// signed canonical bytes (PMSEC-001); the agent verifies target == self.
+	TargetDeviceID string `json:"target_device_id"`
+	Signature      []byte `json:"signature,omitempty"`
 }
 
 // ToProto builds the wire RequestInventory (signature excluded). Shared
 // construction site for sign (control) and send (gateway) — see
 // OSQueryDispatchPayload.ToProto.
 func (p InventoryRequestPayload) ToProto() *pm.RequestInventory {
-	return &pm.RequestInventory{QueryId: p.QueryID}
+	return &pm.RequestInventory{QueryId: p.QueryID, TargetDeviceId: p.TargetDeviceID}
 }
 
 // RevokeLuksDeviceKeyPayload is the payload for TypeRevokeLuksDeviceKey tasks.
@@ -82,14 +92,19 @@ func (p InventoryRequestPayload) ToProto() *pm.RequestInventory {
 // verify.LuksRevokeSignatureDomain (WS4) — binding action_id so a compromised
 // gateway cannot forge or replay the destructive slot-7 wipe.
 type RevokeLuksDeviceKeyPayload struct {
-	ActionID  string `json:"action_id"`
-	Signature []byte `json:"signature,omitempty"`
+	ActionID string `json:"action_id"`
+	// TargetDeviceID binds the destructive slot-7 wipe to one device inside the
+	// signed canonical bytes (PMSEC-001); the agent verifies target == self so a
+	// compromised gateway cannot replay a validly-signed revocation onto another
+	// served device.
+	TargetDeviceID string `json:"target_device_id"`
+	Signature      []byte `json:"signature,omitempty"`
 }
 
 // ToProto builds the wire RevokeLuksDeviceKey (signature excluded). Shared
 // construction site for sign (control) and send (gateway).
 func (p RevokeLuksDeviceKeyPayload) ToProto() *pm.RevokeLuksDeviceKey {
-	return &pm.RevokeLuksDeviceKey{ActionId: p.ActionID}
+	return &pm.RevokeLuksDeviceKey{ActionId: p.ActionID, TargetDeviceId: p.TargetDeviceID}
 }
 
 // LogQueryDispatchPayload is the payload for TypeLogQueryDispatch tasks.
@@ -97,15 +112,18 @@ func (p RevokeLuksDeviceKeyPayload) ToProto() *pm.RevokeLuksDeviceKey {
 // Signature is the CA signature over ToProto()'s canonical bytes under
 // verify.LogQuerySignatureDomain (WS4).
 type LogQueryDispatchPayload struct {
-	QueryID   string `json:"query_id"`
-	Lines     int32  `json:"lines,omitempty"`
-	Unit      string `json:"unit,omitempty"`
-	Since     string `json:"since,omitempty"`
-	Until     string `json:"until,omitempty"`
-	Priority  string `json:"priority,omitempty"`
-	Grep      string `json:"grep,omitempty"`
-	Kernel    bool   `json:"kernel,omitempty"`
-	Signature []byte `json:"signature,omitempty"`
+	QueryID  string `json:"query_id"`
+	Lines    int32  `json:"lines,omitempty"`
+	Unit     string `json:"unit,omitempty"`
+	Since    string `json:"since,omitempty"`
+	Until    string `json:"until,omitempty"`
+	Priority string `json:"priority,omitempty"`
+	Grep     string `json:"grep,omitempty"`
+	Kernel   bool   `json:"kernel,omitempty"`
+	// TargetDeviceID binds the log read to one device inside the signed
+	// canonical bytes (PMSEC-001); the agent verifies target == self.
+	TargetDeviceID string `json:"target_device_id"`
+	Signature      []byte `json:"signature,omitempty"`
 }
 
 // ToProto builds the wire LogQuery (signature excluded). Shared construction
@@ -114,14 +132,15 @@ type LogQueryDispatchPayload struct {
 // gateway, so the canonical bytes match on both sides.
 func (p LogQueryDispatchPayload) ToProto() *pm.LogQuery {
 	return &pm.LogQuery{
-		QueryId:  p.QueryID,
-		Lines:    p.Lines,
-		Unit:     p.Unit,
-		Since:    p.Since,
-		Until:    p.Until,
-		Priority: p.Priority,
-		Grep:     p.Grep,
-		Kernel:   p.Kernel,
+		QueryId:        p.QueryID,
+		Lines:          p.Lines,
+		Unit:           p.Unit,
+		Since:          p.Since,
+		Until:          p.Until,
+		Priority:       p.Priority,
+		Grep:           p.Grep,
+		Kernel:         p.Kernel,
+		TargetDeviceId: p.TargetDeviceID,
 	}
 }
 


### PR DESCRIPTION
## Summary

Security fix (audit finding **H3 / PMSEC-001**), server half. The four non-action stream-RPC surfaces — `OSQuery`, `LogQuery`, `RevokeLuksDeviceKey`, `RequestInventory` — are CA-signed per-surface (WS4), but their signed canonical bytes bound only the request *content* (`query_id`, `table`, `action_id`…), never the **target device**. A compromised gateway relaying for multiple devices could capture one device's validly-signed message and replay it onto another device that trusts the same CA — most severely a cross-device replay of the destructive, irreversible **LUKS slot-7 wipe**.

The action envelope already closed this exact class with `SignedActionEnvelope.target_device_id`. These four sibling surfaces were the gap. This brings them to parity — no new signing machinery.

## Change

- Add `TargetDeviceID` to the four payload structs; `ToProto()` forwards it into the wire message. The sdk canonical encoder auto-binds every field but `signature`, so the new field is covered by the **existing** signing site — no signing-code change.
- Populate it at all **five** dispatch sites with the target device: `DispatchOSQuery`, `QueryDeviceLogs`, `RefreshDeviceInventory`, `RevokeLuksDeviceKey`, and the inventory scheduler.
- Bump the sdk pin to the merged proto (manchtools/power-manage-sdk#325).

The gateway relays `payload.ToProto()` + signature verbatim (unchanged — it is the untrusted relay). The agent enforces `target == self` (companion PR in the agent repo).

## Tests (regression)

`stream_dispatch_signing_test.go` + `inventorysched_test.go`:
- Each dispatch asserts `payload.TargetDeviceID == <target device>` (the populate step).
- Retargeting the signed OSQuery message breaks verification (cross-device replay closed).

**Red-verified** by neutralizing a populate site (empty target → assertion fails for the right reason).

Depends on manchtools/power-manage-sdk#325 (merged).
