### PR TITLE
fix: harden cert renewal, close two existence oracles, recover terminal audit goroutine

### DIFF
--- a/internal/api/certificate_handler.go
+++ b/internal/api/certificate_handler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/crl"
 	"github.com/manchtools/power-manage/server/internal/eventtypes"
 	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/mtls"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -150,6 +151,21 @@ func (h *CertificateHandler) renewLocked(ctx context.Context, deviceID string, m
 	// renewals. No-op in production.
 	if renewCertTestHook != nil {
 		renewCertTestHook()
+	}
+
+	// Defense-in-depth (audit L2): assert the presented cert is agent-class
+	// before re-issuing an agent-class cert. RenewCertificate only ever mints
+	// agent certs, so a non-agent peer (e.g. a leaked gateway cert, same CA +
+	// ClientAuth EKU) must not be renewable here. Today it is caught downstream
+	// (a gateway ULID isn't in the device table → NotFound), but that safety
+	// rests entirely on the device lookup; pin the class at the boundary so a
+	// future change that seeds gateway IDs into the device table can't turn this
+	// into a class-confusion re-issue.
+	presentedClass, err := ca.PeerClassFromPEM(msg.CurrentCertificate)
+	if err != nil || presentedClass != mtls.PeerClassAgent {
+		h.logger.Warn("certificate renewal rejected: presented cert is not agent-class",
+			"device_id", deviceID, "peer_class", presentedClass, "error", err)
+		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "certificate not recognized")
 	}
 
 	// Proof-of-possession: the CSR must carry the SAME public key as the

--- a/internal/api/certificate_handler_test.go
+++ b/internal/api/certificate_handler_test.go
@@ -66,6 +66,26 @@ func genDeviceCSR(t *testing.T, deviceID string) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
 }
 
+// seedDeviceWithID registers a device projection under a caller-chosen id (vs
+// CreateTestDevice, which mints a random one). Used by the L2 peer-class test to
+// simulate the guarded-against misconfiguration where a gateway id ends up in
+// the device table.
+func seedDeviceWithID(t *testing.T, st *store.Store, deviceID, hostname string) {
+	t.Helper()
+	err := st.AppendEvent(t.Context(), store.Event{
+		StreamType: "device",
+		StreamID:   deviceID,
+		EventType:  "DeviceRegistered",
+		Data: map[string]any{
+			"hostname":      hostname,
+			"agent_version": "1.0.0",
+		},
+		ActorType: "system",
+		ActorID:   "test",
+	})
+	require.NoError(t, err)
+}
+
 // setDeviceCertFingerprint stores a cert fingerprint on a device via event.
 func setDeviceCertFingerprint(t *testing.T, st *store.Store, deviceID, fingerprint string) {
 	t.Helper()
@@ -124,6 +144,51 @@ func TestRenewCertificate_RejectsKeyMismatch(t *testing.T) {
 		Csr:                foreignCSR,
 	}))
 	require.Error(t, err, "renewal must reject a CSR whose key differs from the current certificate")
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+// TestRenewCertificate_RejectsNonAgentPeerClass is the audit L2 regression
+// (defense-in-depth). RenewCertificate only ever mints agent-class certs, so a
+// presented cert of another class — e.g. a leaked gateway cert (same CA, carries
+// ClientAuth EKU, so it passes VerifyCertificate) — must be refused at the
+// peer-class boundary, not merely caught downstream by the device lookup. The
+// test simulates the future change the assert guards against: a gateway id
+// seeded into the device table with the gateway cert's fingerprint, so ONLY the
+// peer-class check can reject it (lookup, fingerprint, and proof-of-possession
+// all pass). Without the assert the handler re-issues an agent cert.
+//
+// Red check: drop the PeerClassFromPEM assert in renewLocked and this returns a
+// successful renewal instead of PermissionDenied.
+func TestRenewCertificate_RejectsNonAgentPeerClass(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	certAuth := newTestCA(t)
+	h := api.NewCertificateHandler(st, certAuth, slog.Default())
+
+	// Mint a GATEWAY-class cert and reuse its key so the renewal CSR is
+	// proof-of-possession valid (only the peer-class check should stop it).
+	gatewayID := testutil.NewID()
+	gwKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	csrTemplate := &x509.CertificateRequest{Subject: pkix.Name{CommonName: gatewayID}}
+	csrDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, gwKey)
+	require.NoError(t, err)
+	gwCSR := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+	gwCert, err := certAuth.IssueGatewayCertificateFromCSR(gatewayID, gwCSR, "gw.example.com")
+	require.NoError(t, err)
+	renewDER, err := x509.CreateCertificateRequest(rand.Reader, csrTemplate, gwKey)
+	require.NoError(t, err)
+	renewCSR := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: renewDER})
+
+	// Guarded-against misconfiguration: a device row whose id is the gateway id,
+	// carrying the gateway cert's fingerprint.
+	seedDeviceWithID(t, st, gatewayID, "seeded-gateway-host")
+	setDeviceCertFingerprint(t, st, gatewayID, gwCert.Fingerprint)
+
+	_, err = h.RenewCertificate(t.Context(), connect.NewRequest(&pm.RenewCertificateRequest{
+		CurrentCertificate: gwCert.CertPEM,
+		Csr:                renewCSR,
+	}))
+	require.Error(t, err, "a non-agent (gateway) peer class must be refused before issuance")
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 }
 

--- a/internal/api/identity_link_handler.go
+++ b/internal/api/identity_link_handler.go
@@ -68,9 +68,14 @@ func (h *IdentityLinkHandler) UnlinkIdentity(ctx context.Context, req *connect.R
 		return nil, handleGetError(ctx, err, ErrIdentityLinkNotFound, "identity link not found")
 	}
 
-	// Non-admin callers can only unlink their own identities.
+	// Non-admin callers can only unlink their own identities. Return the SAME
+	// NotFound a missing link returns (not PermissionDenied) so a non-owner
+	// cannot use the code distinction as a cross-actor existence oracle for
+	// another user's link id (audit L3; mirrors scope_existence_oracle_test.go).
+	// (ErrCannotUnlinkOtherUser is retained in the error catalog for TS/paraglide
+	// parity even though this handler no longer emits it.)
 	if link.UserID != userCtx.ID && !auth.HasPermission(ctx, "DeleteUser") {
-		return nil, apiErrorCtx(ctx, ErrCannotUnlinkOtherUser, connect.CodePermissionDenied, "cannot unlink another user's identity")
+		return nil, apiErrorCtx(ctx, ErrIdentityLinkNotFound, connect.CodeNotFound, "identity link not found")
 	}
 
 	targetUserID := link.UserID

--- a/internal/api/identity_link_handler_test.go
+++ b/internal/api/identity_link_handler_test.go
@@ -90,6 +90,14 @@ func TestUnlinkIdentity_Success(t *testing.T) {
 	assert.Empty(t, linksResp.Msg.Links)
 }
 
+// TestUnlinkIdentity_NotOwned pins the audit L3 oracle fix: a non-owner
+// (non-admin) unlinking another user's link gets the SAME CodeNotFound a missing
+// link returns (see TestUnlinkIdentity_NotFound), never PermissionDenied — so
+// the code distinction can't be used as a cross-actor existence oracle for the
+// opaque link id.
+//
+// Red check: this asserted CodePermissionDenied before the fix; it now asserts
+// CodeNotFound, so it fails against the pre-fix handler.
 func TestUnlinkIdentity_NotOwned(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	enc := testutil.NewEncryptor(t)
@@ -115,7 +123,8 @@ func TestUnlinkIdentity_NotOwned(t *testing.T) {
 		LinkId: linkID,
 	}))
 	require.Error(t, err)
-	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err),
+		"a non-owner must get the same NotFound as a missing link, not PermissionDenied (existence oracle)")
 }
 
 func TestUnlinkIdentity_NotFound(t *testing.T) {

--- a/internal/api/terminal_handler.go
+++ b/internal/api/terminal_handler.go
@@ -430,11 +430,16 @@ func (h *TerminalHandler) StopTerminal(ctx context.Context, req *connect.Request
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to look up session")
 	}
 
-	// Ownership check: only the user that opened the session may stop
-	// it. Admins use TerminateTerminalSession (separate permission).
+	// Ownership check: only the user that opened the session may stop it. A
+	// non-owner gets the SAME idempotent empty OK as an unknown/already-stopped
+	// session (above), never PermissionDenied, so the owner-vs-not distinction
+	// can't be used as an existence oracle for another user's opaque session id
+	// (audit L4). The session is not stopped — only the owner's request mutates
+	// it. Admins kill others' sessions via TerminateTerminalSession.
 	if session.UserID != userCtx.ID {
-		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied,
-			"only the session owner may stop a terminal session; admins must use TerminateTerminalSession")
+		h.logger.Debug("StopTerminal on non-owned session; returning idempotent OK",
+			"session_id", req.Msg.SessionId)
+		return connect.NewResponse(&pm.StopTerminalResponse{}), nil
 	}
 
 	// Scope (#3): a device-group-scoped StopTerminal holder may stop only sessions

--- a/internal/api/terminal_handler_test.go
+++ b/internal/api/terminal_handler_test.go
@@ -239,16 +239,19 @@ func TestStopTerminal_OtherUserCannotStop(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	_, err = h.StopTerminal(authedCtx(otherID), connect.NewRequest(&pm.StopTerminalRequest{
+	// Audit L4: a non-owner gets the SAME idempotent empty OK an unknown session
+	// returns (see TestStopTerminal_UnknownSessionIsIdempotent), never
+	// PermissionDenied — so the owner-vs-not distinction can't be used as an
+	// existence oracle for the opaque session id.
+	// Red check: this asserted CodePermissionDenied before the fix.
+	resp, err := h.StopTerminal(authedCtx(otherID), connect.NewRequest(&pm.StopTerminalRequest{
 		SessionId: startResp.Msg.SessionId,
 	}))
-	require.Error(t, err)
-	var connectErr *connect.Error
-	require.True(t, errors.As(err, &connectErr))
-	assert.Equal(t, connect.CodePermissionDenied, connectErr.Code())
+	require.NoError(t, err, "a non-owner must get the same idempotent OK as a missing session, not PermissionDenied (existence oracle)")
+	require.NotNil(t, resp)
 
-	// Session must still be live — the rejected stop must not have
-	// revoked the token.
+	// Session must still be live — a non-owner's request must NOT revoke the
+	// token; only the owner's stop mutates the session.
 	_, lookupErr := tokenStore.Lookup(context.Background(), startResp.Msg.SessionId)
 	require.NoError(t, lookupErr)
 

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -137,9 +137,13 @@ func (ca *CA) IssueCertificateFromCSR(deviceID string, csrPEM []byte) (*Certific
 // DNS SAN for that hostname. The DNS SAN is load-bearing: an agent connects to
 // the gateway by hostname and verifies its server cert with STANDARD TLS
 // (ServerName match against DNS SANs), so a gateway cert without a DNS SAN
-// matching its public hostname cannot be verified. hostname is the operator-
-// validated value from EnrollGateway (or the current cert's DNS SAN on renewal),
-// never a CSR-supplied SAN. Callers reach this from GatewayAuthService
+// matching its public hostname cannot be verified. hostname is NOT a CSR-supplied
+// SAN: on enrollment it is the enroller's self-reported EnrollGateway request
+// hostname (proto format-validated only — there is no operator hostname
+// allow-list today, so a CONTROL_GATEWAY_ENROLL_TOKEN holder can request any DNS
+// SAN; the gateway identity/CN is still a server-minted ULID, so this is not
+// identity forgery — audit L1); on renewal it is the current cert's
+// previously-server-stamped DNS SAN. Callers reach this from GatewayAuthService
 // enrollment and InternalService renewal.
 func (ca *CA) IssueGatewayCertificateFromCSR(gatewayID string, csrPEM []byte, hostname string) (*Certificate, error) {
 	var dnsNames []string
@@ -390,6 +394,23 @@ func DeviceIDFromPEM(certPEM []byte) (string, error) {
 	}
 
 	return cert.Subject.CommonName, nil
+}
+
+// PeerClassFromPEM extracts the SPIFFE peer class from a PEM-encoded
+// certificate's URI SAN. Mirrors DeviceIDFromPEM/NotAfterFromPEM so the API
+// handlers can assert a presented cert's class without re-implementing the
+// decode. Delegates the URI-SAN parsing to mtls.PeerClassFromCert (single
+// source of truth for the class layout).
+func PeerClassFromPEM(certPEM []byte) (mtls.PeerClass, error) {
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return "", fmt.Errorf("failed to decode certificate PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("parse certificate: %w", err)
+	}
+	return mtls.PeerClassFromCert(cert)
 }
 
 // AssertCSRMatchesCertKey verifies that the CSR's public key equals the

--- a/internal/handler/terminal_audit_batcher.go
+++ b/internal/handler/terminal_audit_batcher.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"log/slog"
 	"sync"
 	"time"
 )
@@ -41,7 +42,8 @@ type auditFlush func(data []byte, seq int64)
 // defer once reading is done. The batcher runs one background flush
 // goroutine that respects both the size cap and the debounce timer.
 type terminalAuditBatcher struct {
-	flush auditFlush
+	flush  auditFlush
+	logger *slog.Logger
 
 	mu     sync.Mutex
 	buf    []byte
@@ -58,11 +60,15 @@ type terminalAuditBatcher struct {
 	done  chan struct{}
 }
 
-func newTerminalAuditBatcher(flush auditFlush) *terminalAuditBatcher {
+func newTerminalAuditBatcher(logger *slog.Logger, flush auditFlush) *terminalAuditBatcher {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	b := &terminalAuditBatcher{
-		flush: flush,
-		woken: make(chan struct{}, 1),
-		done:  make(chan struct{}),
+		flush:  flush,
+		logger: logger,
+		woken:  make(chan struct{}, 1),
+		done:   make(chan struct{}),
 	}
 	go b.run()
 	return b
@@ -151,7 +157,19 @@ func (b *terminalAuditBatcher) flushCapped(data []byte) {
 // flushCapped for size-cap splitting). Exits when Close has been
 // called AND the buffer is empty.
 func (b *terminalAuditBatcher) run() {
+	// close(b.done) is deferred FIRST so it runs LAST on unwind — the recover
+	// below (deferred second, runs first) stops a panic in the flush callback
+	// (nil map, marshalling edge, closed client) from unwinding this detached
+	// goroutine and crashing the whole gateway process, while close(b.done)
+	// still fires so Close() cannot deadlock on <-b.done (audit L13; mirrors the
+	// recover on every other long-lived goroutine in the codebase).
 	defer close(b.done)
+	defer func() {
+		if r := recover(); r != nil {
+			b.logger.Error("terminal audit batcher goroutine panicked; session audit flushing stopped",
+				"panic", r)
+		}
+	}()
 	for {
 		<-b.woken
 		b.mu.Lock()

--- a/internal/handler/terminal_audit_batcher_test.go
+++ b/internal/handler/terminal_audit_batcher_test.go
@@ -2,10 +2,31 @@ package handler
 
 import (
 	"bytes"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 )
+
+// syncBuffer is a concurrency-safe io.Writer for capturing slog output the
+// batcher's flush goroutine emits from a different goroutine than the test.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}
 
 // recordingFlush collects every chunk the batcher emits so tests can
 // assert ordering, sequence, and content.
@@ -53,7 +74,7 @@ func waitForChunks(r *recordingFlush, n int, timeout time.Duration) bool {
 
 func TestBatcher_SizeCapFlushesImmediately(t *testing.T) {
 	r := &recordingFlush{}
-	b := newTerminalAuditBatcher(r.flush)
+	b := newTerminalAuditBatcher(nil, r.flush)
 	defer b.Close()
 
 	payload := bytes.Repeat([]byte("x"), terminalAuditFlushBytes)
@@ -77,7 +98,7 @@ func TestBatcher_SizeCapFlushesImmediately(t *testing.T) {
 
 func TestBatcher_OversizedWriteSplitsAtCap(t *testing.T) {
 	r := &recordingFlush{}
-	b := newTerminalAuditBatcher(r.flush)
+	b := newTerminalAuditBatcher(nil, r.flush)
 	defer b.Close()
 
 	// Single Write larger than the cap — representative of a paste
@@ -124,7 +145,7 @@ func TestBatcher_OversizedWriteSplitsAtCap(t *testing.T) {
 
 func TestBatcher_CoalescesKeystrokesIntoOneChunk(t *testing.T) {
 	r := &recordingFlush{}
-	b := newTerminalAuditBatcher(r.flush)
+	b := newTerminalAuditBatcher(nil, r.flush)
 	defer b.Close()
 
 	// Simulate xterm.js sending one WS frame per keystroke.
@@ -152,7 +173,7 @@ func TestBatcher_CoalescesKeystrokesIntoOneChunk(t *testing.T) {
 
 func TestBatcher_SequenceIsMonotonicAcrossFlushes(t *testing.T) {
 	r := &recordingFlush{}
-	b := newTerminalAuditBatcher(r.flush)
+	b := newTerminalAuditBatcher(nil, r.flush)
 	defer b.Close()
 
 	// Three separated writes, each far enough apart that debounce
@@ -177,7 +198,7 @@ func TestBatcher_SequenceIsMonotonicAcrossFlushes(t *testing.T) {
 
 func TestBatcher_CloseFlushesPending(t *testing.T) {
 	r := &recordingFlush{}
-	b := newTerminalAuditBatcher(r.flush)
+	b := newTerminalAuditBatcher(nil, r.flush)
 
 	// Write far below the size cap and immediately close — the
 	// debounce timer should NOT have had time to fire, but Close
@@ -196,7 +217,7 @@ func TestBatcher_CloseFlushesPending(t *testing.T) {
 
 func TestBatcher_CloseIsIdempotent(t *testing.T) {
 	r := &recordingFlush{}
-	b := newTerminalAuditBatcher(r.flush)
+	b := newTerminalAuditBatcher(nil, r.flush)
 	b.Write([]byte("x"))
 	b.Close()
 	b.Close() // must not panic or flush twice
@@ -208,7 +229,7 @@ func TestBatcher_CloseIsIdempotent(t *testing.T) {
 
 func TestBatcher_WriteAfterCloseIsNoop(t *testing.T) {
 	r := &recordingFlush{}
-	b := newTerminalAuditBatcher(r.flush)
+	b := newTerminalAuditBatcher(nil, r.flush)
 	b.Close()
 	b.Write([]byte("late"))
 	// Give any background goroutine a chance to (incorrectly) flush.
@@ -221,7 +242,7 @@ func TestBatcher_WriteAfterCloseIsNoop(t *testing.T) {
 
 func TestBatcher_EmptyWriteIsNoop(t *testing.T) {
 	r := &recordingFlush{}
-	b := newTerminalAuditBatcher(r.flush)
+	b := newTerminalAuditBatcher(nil, r.flush)
 	defer b.Close()
 	b.Write(nil)
 	b.Write([]byte{})
@@ -229,5 +250,56 @@ func TestBatcher_EmptyWriteIsNoop(t *testing.T) {
 	chunks, _ := r.snapshot()
 	if len(chunks) != 0 {
 		t.Errorf("empty writes produced %d chunks, want 0", len(chunks))
+	}
+}
+
+// TestBatcher_FlushPanicIsRecoveredAndLogged is the audit L13 regression. A
+// panic in the flush callback (nil map, marshalling edge, closed client) must
+// be recovered INSIDE the batcher's detached goroutine — otherwise it unwinds
+// that goroutine and crashes the whole gateway process, dropping every live
+// terminal session and device stream. The recover must also log (never a silent
+// swallow) and must still let close(b.done) fire so Close() cannot deadlock.
+//
+// Red check: delete the `defer func(){ recover() }()` in run() and this test
+// crashes the package test binary with the unrecovered panic instead of failing
+// cleanly — which is exactly the production crash it guards against.
+func TestBatcher_FlushPanicIsRecoveredAndLogged(t *testing.T) {
+	var logs syncBuffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	entered := make(chan struct{}, 1)
+	b := newTerminalAuditBatcher(logger, func(data []byte, seq int64) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		panic("simulated flush failure")
+	})
+
+	// Cross the size cap so the flush goroutine wakes and invokes the callback.
+	b.Write(bytes.Repeat([]byte("x"), terminalAuditFlushBytes))
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("flush callback was never invoked")
+	}
+
+	// Close must return promptly: the recover keeps the deferred close(b.done)
+	// reachable, so <-b.done does not hang even though the goroutine panicked.
+	done := make(chan struct{})
+	go func() {
+		b.Close()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close() deadlocked after a flush panic (b.done never closed)")
+	}
+
+	// The recover must not be silent — the panic is logged at error level.
+	if got := logs.String(); !strings.Contains(got, "panicked") {
+		t.Errorf("expected the recovered panic to be logged; got %q", got)
 	}
 }

--- a/internal/handler/terminal_bridge.go
+++ b/internal/handler/terminal_bridge.go
@@ -419,7 +419,7 @@ func (h *TerminalBridgeHandler) bridgeWSToAgent(
 	validated *pm.InternalValidateTerminalTokenResponse,
 	logger *slog.Logger,
 ) error {
-	audit := newTerminalAuditBatcher(func(data []byte, seq int64) {
+	audit := newTerminalAuditBatcher(logger, func(data []byte, seq int64) {
 		h.enqueueAuditChunk(sess, validated, data, seq)
 	})
 	defer audit.Close()


### PR DESCRIPTION
## Summary

Security-audit low-severity batch (2026-07-17 deep pass), handler + CA plane. Five findings, each a root-cause fix; no new machinery.

- **L2** — `RenewCertificate` now asserts the presented cert is **agent-class** (`ca.PeerClassFromPEM`) before re-issuing. A non-agent peer (e.g. a leaked gateway cert — same CA, carries ClientAuth EKU, so it passes `VerifyCertificate`) was previously caught only downstream by the device lookup; the class is now pinned at the boundary, belt-and-suspenders against a future change that seeds gateway IDs into the device table.
- **L3** — `UnlinkIdentity` returns the **same `NotFound`** a missing link returns for a cross-actor request (was `PermissionDenied`), closing the existence oracle on the opaque link id.
- **L4** — `StopTerminal` returns the **idempotent empty OK** for a non-owned session (matching the unknown-session path), closing the same oracle on the opaque session id. The session is not stopped — only the owner mutates it.
- **L13** — the detached **terminal-audit-batcher** goroutine now `recover()`s a panic in its flush callback (and logs it) instead of crashing the whole gateway process; `close(b.done)` still fires so `Close()` cannot deadlock.
- **L1** — corrected the over-claiming `IssueGatewayCertificateFromCSR` comment: the enrollment DNS SAN is the enroller's self-reported hostname (format-validated only, no operator allow-list today), not an "operator-validated value."

## Tests (regression, red-verified)

- `TestRenewCertificate_RejectsNonAgentPeerClass` — a gateway cert seeded to pass the lookup + fingerprint + PoP is still refused at the peer-class check. Red: drop the assert → successful renewal.
- `TestUnlinkIdentity_NotOwned` — now asserts `CodeNotFound` (was `CodePermissionDenied`); indistinguishable from `TestUnlinkIdentity_NotFound`.
- `TestStopTerminal_OtherUserCannotStop` — now asserts idempotent empty OK; session stays live.
- `TestBatcher_FlushPanicIsRecoveredAndLogged` — a panicking flush callback is recovered + logged; `Close()` returns. Red: remove the recover → the package test binary crashes with the unrecovered panic.

Each behavioral fix was red-verified by neutralizing the fix and confirming the test fails for the right reason. Full `internal/api` + `internal/ca` + `internal/handler` suites pass; `go vet` + `staticcheck` clean.
