### PR TITLE
fix: cap compliance detection output, guard deleted-device inbox writes, drop dead event-store code

### DIFF
--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -474,12 +474,12 @@ func (w *InboxWorker) handleExecutionResult(ctx context.Context, t *asynq.Task) 
 				isCompliance, _ = params["isCompliance"].(bool)
 			}
 			if isCompliance {
-				complianceData := map[string]any{
-					"device_id":        deviceID,
-					"action_id":        actionID,
-					"action_name":      cachedAction.Name,
-					"compliant":        result.Compliant,
-					"detection_output": commandOutputToMap(result.DetectionOutput),
+				complianceData := payloads.ComplianceResultUpdated{
+					DeviceID:        deviceID,
+					ActionID:        actionID,
+					ActionName:      cachedAction.Name,
+					Compliant:       result.Compliant,
+					DetectionOutput: payloads.RawCommandOutput(commandOutputPayload(result.DetectionOutput)),
 				}
 				if err := w.store.AppendEvent(ctx, store.Event{
 					StreamType: "compliance",
@@ -662,6 +662,35 @@ func (w *InboxWorker) handleInventoryUpdate(ctx context.Context, t *asynq.Task) 
 		return err
 	}
 
+	// Skip processing for deleted or unknown devices. A just-deleted
+	// device's inventory must not repopulate projections or influence
+	// dynamic device-group membership (which drives action assignment),
+	// leaving orphan rows behind the deletion.
+	//
+	// ponytail: a best-effort filter, deliberately NOT atomic with the write
+	// below — same posture as the sibling handleDeviceHello/handleDeviceHeartbeat
+	// guards. A DeviceDeleted committing in the tiny window after this check
+	// only lets a stale inventory row through, which is benign: DeviceDeleted
+	// does not cascade-delete inventory (applyDeviceDeleted soft-deletes the
+	// device + wipes assignments/memberships but leaves inventory), and dynamic
+	// device-group evaluation excludes soft-deleted devices, so no action is
+	// assigned to a dead device. Row-locking every inbox handler to close a
+	// sub-millisecond race with no security effect isn't worth the complexity
+	// or the divergence from the siblings.
+	deleted, err := w.store.Repos().Device.IsDeleted(ctx, payload.DeviceID)
+	if err != nil {
+		if store.IsNotFound(err) {
+			w.logger.Debug("ignoring inventory update from unknown device", "device_id", payload.DeviceID)
+			return nil
+		}
+		w.logger.Error("failed to check device deletion status", "device_id", payload.DeviceID, "error", err)
+		return err
+	}
+	if deleted {
+		w.logger.Debug("ignoring inventory update from deleted device", "device_id", payload.DeviceID)
+		return nil
+	}
+
 	w.logger.Info("received device inventory",
 		"device_id", payload.DeviceID,
 		"tables", len(payload.Tables),
@@ -721,6 +750,25 @@ func (w *InboxWorker) handleSecurityAlert(ctx context.Context, t *asynq.Task) er
 
 	if err := w.verifyDeviceGatewayBinding(ctx, payload.DeviceID, payload.GatewayID); err != nil {
 		return err
+	}
+
+	// Skip processing for deleted or unknown devices — do not append a
+	// new alert event onto a deleted device's stream. Best-effort like the
+	// inventory guard above (see its note); the residual TOCTOU is benign —
+	// worst case one extra durable event on an already-dead stream, with no
+	// projection resurrection.
+	deleted, err := w.store.Repos().Device.IsDeleted(ctx, payload.DeviceID)
+	if err != nil {
+		if store.IsNotFound(err) {
+			w.logger.Debug("ignoring security alert from unknown device", "device_id", payload.DeviceID)
+			return nil
+		}
+		w.logger.Error("failed to check device deletion status", "device_id", payload.DeviceID, "error", err)
+		return err
+	}
+	if deleted {
+		w.logger.Debug("ignoring security alert from deleted device", "device_id", payload.DeviceID)
+		return nil
 	}
 
 	w.logger.Warn("received security alert from device",
@@ -1003,21 +1051,6 @@ func (w *InboxWorker) dispatchPendingActions(ctx context.Context, deviceID strin
 		return fmt.Errorf("%d dispatch(es) failed, first: %w", len(enqueueErrs), enqueueErrs[0])
 	}
 	return nil
-}
-
-// commandOutputToMap converts a CommandOutput proto to a map for event
-// data. Returns nil if the output is nil. Used by emit sites that
-// still construct payloads as map[string]any (the compliance event
-// shape, for now).
-func commandOutputToMap(o *pm.CommandOutput) map[string]any {
-	if o == nil {
-		return nil
-	}
-	return map[string]any{
-		"stdout":    o.Stdout,
-		"stderr":    o.Stderr,
-		"exit_code": o.ExitCode,
-	}
 }
 
 // maxCommandOutputBytes is the per-stream ceiling enforced on

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"log/slog"
 	"math/big"
+	"strings"
 	"testing"
 	"time"
 
@@ -155,6 +156,103 @@ func TestHandleSecurityAlert(t *testing.T) {
 	assert.True(t, found, "SecurityAlert event should be stored")
 }
 
+// TestHandleSecurityAlert_DeletedDevice pins the deleted-device guard: an
+// alert arriving after the device is deleted must be dropped, not appended
+// onto the dead stream. Without the guard the handler resurrects the stream
+// with an orphan SecurityAlert event.
+func TestHandleSecurityAlert_DeletedDevice(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	mux := worker.NewMux()
+
+	deviceID := testutil.CreateTestDevice(t, st, "deleted-alert-host")
+	err := st.AppendEvent(context.Background(), store.Event{
+		StreamType: "device",
+		StreamID:   deviceID,
+		EventType:  "DeviceDeleted",
+		Data:       map[string]any{},
+		ActorType:  "system",
+		ActorID:    "test",
+	})
+	require.NoError(t, err)
+
+	task := newTask(t, taskqueue.TypeSecurityAlert, taskqueue.SecurityAlertPayload{
+		DeviceID:  deviceID,
+		AlertType: "tamper_detected",
+		Message:   "Agent binary modified",
+	})
+
+	// Should succeed silently (skip deleted device).
+	require.NoError(t, mux.ProcessTask(context.Background(), task))
+
+	events, err := st.Queries().LoadStream(context.Background(), db.LoadStreamParams{
+		StreamType: "device",
+		StreamID:   deviceID,
+	})
+	require.NoError(t, err)
+	for _, e := range events {
+		assert.NotEqual(t, "SecurityAlert", e.EventType,
+			"no SecurityAlert event may be appended to a deleted device's stream")
+	}
+}
+
+func TestHandleInventoryUpdate(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	mux := worker.NewMux()
+
+	deviceID := testutil.CreateTestDevice(t, st, "inventory-host")
+
+	task := newTask(t, taskqueue.TypeInventoryUpdate, taskqueue.InventoryUpdatePayload{
+		DeviceID: deviceID,
+		Tables: []taskqueue.InventoryTable{
+			{TableName: "packages", RowsJSON: []byte(`[{"name":"vim","version":"9.0"}]`)},
+		},
+	})
+
+	require.NoError(t, mux.ProcessTask(context.Background(), task))
+
+	rows, err := st.Queries().GetDeviceInventory(context.Background(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, rows, 1, "a live device's inventory table must be upserted")
+	assert.Equal(t, "packages", rows[0].TableName)
+}
+
+// TestHandleInventoryUpdate_DeletedDevice pins the deleted-device guard: an
+// inventory push arriving after deletion must not repopulate inventory rows
+// (which feed dynamic device-group membership → action assignment). Without
+// the guard the Upsert leaves orphan inventory behind the deletion.
+func TestHandleInventoryUpdate_DeletedDevice(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	mux := worker.NewMux()
+
+	deviceID := testutil.CreateTestDevice(t, st, "deleted-inventory-host")
+	err := st.AppendEvent(context.Background(), store.Event{
+		StreamType: "device",
+		StreamID:   deviceID,
+		EventType:  "DeviceDeleted",
+		Data:       map[string]any{},
+		ActorType:  "system",
+		ActorID:    "test",
+	})
+	require.NoError(t, err)
+
+	task := newTask(t, taskqueue.TypeInventoryUpdate, taskqueue.InventoryUpdatePayload{
+		DeviceID: deviceID,
+		Tables: []taskqueue.InventoryTable{
+			{TableName: "packages", RowsJSON: []byte(`[{"name":"vim","version":"9.0"}]`)},
+		},
+	})
+
+	// Should succeed silently (skip deleted device).
+	require.NoError(t, mux.ProcessTask(context.Background(), task))
+
+	rows, err := st.Queries().GetDeviceInventory(context.Background(), deviceID)
+	require.NoError(t, err)
+	assert.Empty(t, rows, "a deleted device's inventory must not be repopulated")
+}
+
 func TestHandleExecutionResult_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
@@ -212,6 +310,117 @@ func TestHandleExecutionResult_Success(t *testing.T) {
 	exec, err := st.Queries().GetExecutionByID(context.Background(), executionID)
 	require.NoError(t, err)
 	assert.Equal(t, "success", exec.Status)
+}
+
+// TestHandleExecutionResult_ComplianceDetectionOutputIsTruncated pins the L5
+// fix: the compliance emit path must cap the detection output at
+// maxCommandOutputBytes (audit F-33) like every other output path. Before the
+// fix the compliance branch built its event via commandOutputToMap, which
+// wrote stdout/stderr verbatim — a compromised or buggy agent could push an
+// unbounded blob into events.data on this one path. The test also proves the
+// typed ComplianceResultUpdated emit is decoded correctly by the projector
+// (parity: the projection row carries the action_name and compliant flag).
+func TestHandleExecutionResult_ComplianceDetectionOutputIsTruncated(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	mux := worker.NewMux()
+
+	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
+	deviceID := testutil.CreateTestDevice(t, st, "compliance-host")
+
+	// Compliance action: params carry isCompliance=true so the execution-result
+	// handler emits a ComplianceResultUpdated carrying the detection output.
+	actionID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "action",
+		StreamID:   actionID,
+		EventType:  "ActionCreated",
+		Data: map[string]any{
+			"name":            "compliance-check",
+			"action_type":     int(pm.ActionType_ACTION_TYPE_SHELL),
+			"desired_state":   0,
+			"params":          map[string]any{"isCompliance": true},
+			"timeout_seconds": 300,
+		},
+		ActorType: "user",
+		ActorID:   adminID,
+	}))
+
+	executionID := testutil.NewID()
+	require.NoError(t, st.AppendEvent(context.Background(), store.Event{
+		StreamType: "execution",
+		StreamID:   executionID,
+		EventType:  "ExecutionCreated",
+		Data: map[string]any{
+			"device_id":       deviceID,
+			"action_id":       actionID,
+			"action_type":     int(pm.ActionType_ACTION_TYPE_SHELL),
+			"desired_state":   0,
+			"params":          map[string]any{},
+			"timeout_seconds": 300,
+			"executed_at":     time.Now().Format(time.RFC3339Nano),
+		},
+		ActorType: "user",
+		ActorID:   adminID,
+	}))
+
+	// Detection output well over the 1 MiB per-stream cap.
+	const cap1MiB = 1024 * 1024
+	oversized := strings.Repeat("x", cap1MiB+50_000)
+	result := &pm.ActionResult{
+		ActionId:    &pm.ActionId{Value: executionID},
+		Status:      pm.ExecutionStatus_EXECUTION_STATUS_SUCCESS,
+		CompletedAt: timestamppb.Now(),
+		Compliant:   false,
+		DetectionOutput: &pm.CommandOutput{
+			Stdout:   oversized,
+			ExitCode: 1,
+		},
+	}
+	resultProto, err := proto.Marshal(result)
+	require.NoError(t, err)
+	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
+		DeviceID:          deviceID,
+		ActionResultProto: resultProto,
+	})
+	require.NoError(t, mux.ProcessTask(context.Background(), task))
+
+	// The emitted ComplianceResultUpdated event's detection_output must be
+	// truncated to the cap — the whole point of the fix.
+	events, err := st.Queries().LoadStream(context.Background(), db.LoadStreamParams{
+		StreamType: "compliance",
+		StreamID:   deviceID + "_" + actionID,
+	})
+	require.NoError(t, err)
+	var found bool
+	for _, e := range events {
+		if e.EventType != "ComplianceResultUpdated" {
+			continue
+		}
+		found = true
+		var data struct {
+			DetectionOutput struct {
+				Stdout string `json:"stdout"`
+			} `json:"detection_output"`
+		}
+		require.NoError(t, json.Unmarshal(e.Data, &data))
+		assert.LessOrEqual(t, len(data.DetectionOutput.Stdout), cap1MiB,
+			"compliance detection_output stdout must be capped at 1 MiB")
+		assert.Less(t, len(data.DetectionOutput.Stdout), len(oversized),
+			"oversized detection output must actually be shortened")
+		assert.Contains(t, data.DetectionOutput.Stdout, "truncated by control server",
+			"the truncation marker must be present so the UI can tell head-only from full")
+	}
+	require.True(t, found, "a ComplianceResultUpdated event must be emitted for a compliance action")
+
+	// Parity: the typed emit is decoded by the real projector into a row with
+	// the correct action_name + compliant flag (proves the wire keys match the
+	// projector's decoder, not just that the event serialized).
+	results, err := st.Queries().GetDeviceComplianceResults(context.Background(), deviceID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, "compliance-check", results[0].ActionName)
+	assert.False(t, results[0].Compliant)
 }
 
 // TestHandleExecutionResult_RejectsCrossDeviceSpoof pins the fix for

--- a/internal/eventtypes/payloads/compliance.go
+++ b/internal/eventtypes/payloads/compliance.go
@@ -1,0 +1,27 @@
+package payloads
+
+import "encoding/json"
+
+// ComplianceResultUpdated is the wire shape for the ComplianceResultUpdated
+// event the inbox worker emits on the "compliance" stream when a compliance
+// action's detection output comes back from a device.
+//
+// DetectionOutput rides as a JSONB blob in the same {stdout,stderr,exit_code}
+// shape as the execution events, produced by RawCommandOutput. The emit site
+// funnels it through commandOutputPayload, which caps each stream at
+// maxCommandOutputBytes (audit F-33) — the legacy commandOutputToMap emit
+// this replaced wrote the detection output verbatim, so a compromised or
+// buggy agent could push an unbounded blob into events.data on this path.
+//
+// Field presence matches the historical map[string]any emit exactly:
+// device_id / action_id / action_name / compliant are always written;
+// detection_output is dropped only when the CommandOutput is nil (which the
+// emit guard already precludes). The projector's decoder
+// (complianceResultUpdatedRaw) reads these same keys.
+type ComplianceResultUpdated struct {
+	DeviceID        string          `json:"device_id"`
+	ActionID        string          `json:"action_id"`
+	ActionName      string          `json:"action_name"`
+	Compliant       bool            `json:"compliant"`
+	DetectionOutput json.RawMessage `json:"detection_output,omitempty"`
+}

--- a/internal/projectors/wire.go
+++ b/internal/projectors/wire.go
@@ -124,21 +124,21 @@ func WireAll(st *store.Store, logger *slog.Logger) {
 	// Phase 2 port under tracker #136 (action_set, assignment,
 	// user_group, device_group, compliance_policy, compliance,
 	// action+definition, execution, device, user). With UserListener
-	// landed, every domain projector lives in Go — the cleanup
-	// migration can drop project_event() and the dispatcher trigger.
+	// landed, every domain projector lives in Go; migration 041 dropped
+	// project_event() and the PL/pgSQL dispatcher trigger.
 	// One ActionListener handles both the action and definition stream
 	// types because DefinitionCreated dispatches across two
 	// projections — synthesise an actions_projection row (when
 	// payload carries `action_type`) OR insert a definitions_projection
 	// row (otherwise) — and splitting would race the two branches.
 
-	// Rebuild appliers (manchtools/power-manage-server#125). Only
-	// the ported projectors that own a rebuildTarget in
-	// store.AllRebuildTargets need this wiring — RebuildAll
-	// dispatches everything else through the legacy PL/pgSQL
-	// Function. Of the 11 #107 ports, three own rebuild targets:
-	// roles, tokens, user_selections. The Phase 2 ports add four
-	// more (action_sets, assignments, user_groups, device_groups).
+	// Rebuild appliers (manchtools/power-manage-server#125). Every
+	// rebuildTarget in store.AllRebuildTargets MUST be wired here:
+	// RebuildAll hard-errors on a listed target with no registered
+	// applier (there is no PL/pgSQL fallback — migration 041 dropped
+	// it). Of the 11 #107 ports, three own rebuild targets: roles,
+	// tokens, user_selections. The Phase 2 ports add four more
+	// (action_sets, assignments, user_groups, device_groups).
 	st.RegisterRebuildApply("roles", ApplyRole)
 	st.RegisterRebuildApply("tokens", ApplyToken)
 	st.RegisterRebuildApply("user_selections", ApplyUserSelection)

--- a/internal/store/rebuild.go
+++ b/internal/store/rebuild.go
@@ -460,11 +460,11 @@ var ErrSkipEvent = errors.New("projector: event skipped (unprojectable)")
 // rebuilds during incident response — operators must be able to run
 // it and either succeed completely or no-op completely.
 //
-// The replay invokes the existing project_<stream>_event() PL/pgSQL
-// projector for each event matching the target's stream types. As
-// projectors are ported to Go (#96–#106), the per-target Function
-// field gets swapped to a Go dispatcher and this same RebuildAll
-// keeps working without operator-facing changes.
+// The replay dispatches each event matching the target's stream types
+// through the target's registered Go applier (see runOneTarget). Every
+// projector is Go-ported and the PL/pgSQL projector dispatcher was
+// dropped (migration 041), so a target with no registered applier is a
+// hard error rather than a silent no-op.
 func (s *Store) RebuildAll(ctx context.Context, targetNames ...string) (RebuildResult, error) {
 	targets, err := selectTargets(targetNames)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -70,10 +70,11 @@ type EventListener func(ctx context.Context, ev PersistedEvent)
 // successful no-ops (event type the projector doesn't care about)
 // must return nil.
 //
-// Wired in projectors.WireAll for every Go-ported projector that
-// owns an entry in AllRebuildTargets. RebuildAll falls back to the
-// PL/pgSQL Function dispatch when no applier is registered for the
-// target — preserves operator behaviour for not-yet-ported targets.
+// Wired in projectors.WireAll for every Go-ported projector that owns
+// an entry in AllRebuildTargets. Every rebuild target MUST have a
+// registered applier: RebuildAll hard-errors on a target with none (the
+// PL/pgSQL projector dispatch was dropped in migration 041), so a
+// drifted WireAll wiring fails loudly instead of silently no-op'ing.
 //
 // Refs manchtools/power-manage-server#125.
 type RebuildApply func(ctx context.Context, q *Queries, ev PersistedEvent) error
@@ -93,13 +94,12 @@ type Store struct {
 	// key; switch to a per-key map if a second hot key is added.
 	advisoryMu sync.Mutex
 
-	// listenersMu guards listeners + OnEventAppended +
-	// rebuildAppliers. Documented usage is "register at boot, then
-	// start serving", but Go's race detector won't catch a future
-	// caller that registers after AppendEvent is in flight
-	// (concurrent slice append + range read is a data race). RWMutex
-	// is cheap on the hot read path (fireListeners holds RLock) and
-	// lets boot code register without extra ceremony.
+	// listenersMu guards listeners + rebuildAppliers. Documented usage
+	// is "register at boot, then start serving", but Go's race detector
+	// won't catch a future caller that registers after AppendEvent is in
+	// flight (concurrent slice append + range read is a data race).
+	// RWMutex is cheap on the hot read path (fireListeners holds RLock)
+	// and lets boot code register without extra ceremony.
 	listenersMu sync.RWMutex
 
 	// listeners are invoked after every successful AppendEvent /
@@ -117,14 +117,6 @@ type Store struct {
 	// guarded by listenersMu (same boot-once-then-read posture as
 	// listeners). See manchtools/power-manage-server#125.
 	rebuildAppliers map[string]RebuildApply
-
-	// OnEventAppended is preserved for backwards compatibility with
-	// the search-indexing wiring at cmd/control/main.go. Setting it
-	// is equivalent to RegisterEventListener; do not read from it
-	// outside this file. Guarded by listenersMu — callers that
-	// reassign at runtime should go through RegisterEventListener
-	// instead. (rc11 review round 4: search-indexer wiring migrated.)
-	OnEventAppended func(ctx context.Context, ev PersistedEvent)
 
 	// logger is used by fireListeners to log panic recoveries through
 	// the standard logging pipeline instead of os.Stderr. Optional;
@@ -300,9 +292,8 @@ func (s *Store) HasRebuildApply(name string) bool {
 	return ok
 }
 
-// fireListeners invokes both the legacy OnEventAppended callback (if
-// set) and every RegisterEventListener entry. Centralised so the two
-// AppendEvent variants stay in sync.
+// fireListeners invokes every RegisterEventListener entry. Centralised
+// so the two AppendEvent variants stay in sync.
 //
 // Each listener is wrapped in defer/recover so a panic in one cannot
 // fail AppendEvent — the event is already committed, and listeners
@@ -332,7 +323,6 @@ func (s *Store) fireListeners(ctx context.Context, row PersistedEvent) {
 	// SetLogger doesn't race with the panic-recovery read inside
 	// the closure below.
 	s.listenersMu.RLock()
-	onEvent := s.OnEventAppended
 	listeners := s.listeners
 	logger := s.logger
 	s.listenersMu.RUnlock()
@@ -354,9 +344,6 @@ func (s *Store) fireListeners(ctx context.Context, row PersistedEvent) {
 		fn()
 	}
 
-	if onEvent != nil {
-		safe("OnEventAppended", func() { onEvent(ctx, row) })
-	}
 	for _, l := range listeners {
 		safe("RegisterEventListener", func() { l(ctx, row) })
 	}


### PR DESCRIPTION
Security-audit low-severity batch — event-store + `control:inbox` plane. Sibling of #569 (handler/CA plane).

## Findings addressed

**L5 — compliance detection output bypassed the 1 MiB output cap.** The `ComplianceResultUpdated` emit built its event via `commandOutputToMap`, which wrote `stdout`/`stderr` verbatim — the one output path that skipped the `truncateOutputStream` cap every other execution path enforces (audit F-33). A compromised or buggy agent could push an unbounded blob into `events.data` on this path. Now emits a typed `payloads.ComplianceResultUpdated` routed through `commandOutputPayload` (truncating), wire-identical keys to the old map so the projector decoder is unchanged; `commandOutputToMap` deleted.

**L6 — `handleInventoryUpdate` / `handleSecurityAlert` lacked the deleted-device guard** their `handleDeviceHello` / `handleDeviceHeartbeat` siblings already have. A momentarily-connected just-deleted agent (or a signing-key holder) could repopulate inventory — which feeds dynamic device-group membership → action assignment — or append alert events onto a dead stream. Both now short-circuit for deleted/unknown devices. The guard is a best-effort filter (non-atomic with the write, same as the siblings); the residual TOCTOU is documented in-code and benign (`DeviceDeleted` doesn't cascade-delete inventory, and dyn-group eval excludes soft-deleted devices).

**L8 — stale PL/pgSQL-fallback comments** in `store.go` / `rebuild.go` / `wire.go` claimed `RebuildAll` falls back to a PL/pgSQL dispatcher for un-ported targets. That dispatcher was dropped in migration 041; a rebuild target with no registered Go applier now **hard-errors** (`runOneTarget`). Comments corrected to match.

**L9 — dead `OnEventAppended` field** on `Store`: never assigned anywhere (the search-indexer wiring migrated to `RegisterEventListener`). Removed the field, its snapshot in `fireListeners`, and the dead fire branch.

## Testing
- L5: `TestHandleExecutionResult_ComplianceDetectionOutputIsTruncated` — drives a real compliance action through `handleExecutionResult` with a >1 MiB detection output, asserts the persisted event is truncated + carries the marker, and (parity) that the projector decodes the typed emit into a correct projection row.
- L6: `TestHandleInventoryUpdate_DeletedDevice`, `TestHandleSecurityAlert_DeletedDevice` (+ positive `TestHandleInventoryUpdate`).
- All three behavioral tests verified **red before green** (fail on the pre-fix code for the right reason, pass after).
- `go vet` / `staticcheck` / `gofmt` / `docref check` / affected-package `go test` all green locally.