### PR TITLE
fix: schedule projection-drift detection; document per-replica rate-limit scope (audit M1/M2/M3/L12)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -238,6 +238,12 @@ func main() {
 
 	startStaleExecutionExpiry(ctx, st, logger, time.Now)
 
+	// M1: scheduled projection-drift detection. A post-commit projector
+	// apply that fails after the event commits drifts silently; this tick
+	// surfaces it at ERROR so an operator can rebuild before retention prunes
+	// the source events (remediation stays operator-driven — see the worker).
+	startProjectionDriftCheck(ctx, st, logger)
+
 	// Spec 19 audit-log retention: rolling snapshot + prune of the event
 	// log. Config was validated at parse time (fatal on violation); the
 	// archive store and worker construction are fatal too — a destructive
@@ -392,6 +398,11 @@ func main() {
 	// patterns within seconds. Login + VerifyLoginTOTP + SSOCallback
 	// share one limiter — they're all auth-attempt vectors that a
 	// defender treats as one logical "attempt" per IP.
+	//
+	// These ceilings are process-local / PER REPLICA — under multi-replica
+	// control HA the effective limit is roughly limit×replicas. Size them for
+	// that budget; see the replica-scope note on auth.RateLimiters (L12, audit
+	// 2026-07-17).
 	rateLimiters := auth.RateLimiters{
 		Login:       auth.NewRateLimiter(10, 1*time.Minute), // credential-spray defense
 		Refresh:     auth.NewRateLimiter(60, 1*time.Minute), // legitimate refreshes are frequent

--- a/cmd/control/periodic.go
+++ b/cmd/control/periodic.go
@@ -247,6 +247,170 @@ func startStaleExecutionExpiry(ctx context.Context, st *store.Store, logger *slo
 	}()
 }
 
+// advisoryKeyProjectionDrift serializes the projection-drift scan across control
+// replicas: TryWithAdvisoryLock ensures no two replicas run the (read-only) scan
+// concurrently — bounding peak DB load and matching the retention, inventory,
+// dynamic-group, and stale-expiry workers' lock discipline. It does NOT make the
+// scan cluster-wide once-per-window: each replica owns its ticker, so with offset
+// ticks each may still run its own scan within a window. Unlike stale-expiry
+// (whose emitted state transition makes a later replica's re-run a no-op), this
+// scan is read-only, so like the per-replica rate limiters (audit M2/M3/L12) it
+// is deliberately per-replica — under ADR-0031 HA its cheap indexed reads and,
+// under real drift, its identical ERROR logs scale with replica count. Accepted
+// for a read-only alert: the signal is correct however many replicas emit it, and
+// a shared-store next-run lease (the exactly-once upgrade) is deliberately NOT
+// taken here, consistent with the M2/M3/L12 per-replica decision.
+// "drft" in ASCII/hex; distinct from every other advisory key so two unrelated
+// workers never contend on the same lock.
+const advisoryKeyProjectionDrift int64 = 0x64726674 // "drft"
+
+// projectionDriftCheckInterval is the fixed cadence of the drift-reconcile
+// tick. No operator knob today (like the stale-expiry cadence): 15 min is
+// frequent enough to surface a silently-dropped projection write well before
+// the far slower retention prune could delete the source events, without adding
+// meaningful load (the scan is a handful of indexed aggregate queries).
+const projectionDriftCheckInterval = 15 * time.Minute
+
+// driftRecheckGrace is how long a suspected-drift target must stay behind
+// before the tick alerts. A committed event is visible in the events table the
+// instant its transaction commits, but its post-commit projector apply runs
+// just after and takes a few milliseconds; a single scan reading the events and
+// projection tables independently can catch that in-flight window and read a
+// healthy projection as "behind" (false positive). Genuine drift — a projector
+// that stopped applying — is permanent, so a second scan after this grace still
+// sees it while transient apply-lag has cleared. Kept well above worst-case
+// apply latency yet trivial against the 15-min cadence.
+const driftRecheckGrace = 5 * time.Second
+
+// startProjectionDriftCheck launches the M1 drift-reconcile tick: every
+// projectionDriftCheckInterval it runs one advisory-lock single-flighted
+// ComputeProjectionDrift scan and logs an ERROR for every projection that has
+// fallen behind the event log. This is the scheduled counterpart to the
+// operator-manual `control doctor` drift check — a post-commit projector apply
+// that fails after the event commits (DB blip, ctx cancel mid-dispatch) drifts
+// silently and permanently, and without this tick stays invisible until someone
+// runs doctor.
+//
+// Detection only: remediation stays operator-driven (`control doctor` + the
+// cascade-safe rebuild tool). The drift heuristic has an accepted sampled-type
+// blind spot (see store.ComputeProjectionDrift), so an unattended TRUNCATE+replay
+// on a false-positive verdict is a worse failure mode than the drift it would
+// "fix"; the ERROR log is the actionable signal an operator acts on.
+//
+// The first scan runs immediately on boot to catch drift left by a crash during
+// the previous run.
+func startProjectionDriftCheck(ctx context.Context, st *store.Store, logger *slog.Logger) {
+	go runPeriodic(ctx, projectionDriftCheckInterval, func() {
+		// A panic in one scan must not crash the control server — recover,
+		// log, and let the next tick retry (WS15 posture: background jobs are
+		// isolated, not load-bearing).
+		defer func() {
+			if r := recover(); r != nil {
+				logger.Error("projection-drift check panicked", "panic", r)
+			}
+		}()
+		tickCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+		ran, drifted, err := runProjectionDriftCheck(tickCtx, st, logger, driftRecheckGrace)
+		if err != nil {
+			logger.Error("projection-drift check failed", "error", err)
+			return
+		}
+		if !ran {
+			logger.Debug("projection-drift check skipped — another replica holds the lock")
+			return
+		}
+		if len(drifted) == 0 {
+			logger.Debug("projection-drift check clean — every projection is current")
+		}
+	}, true)
+}
+
+// runProjectionDriftCheck runs one drift scan under the cross-replica advisory
+// lock, alerting only on drift that PERSISTS across a grace-separated recheck
+// (see driftRecheckGrace / rescreenDrift), so a projection caught mid-apply is
+// not mistaken for a stopped one. Returns ran=false (no error) when another
+// replica holds the lock — the caller treats that as a clean skip. When it ran,
+// drifted lists every persistently-Behind target (empty when clean); each is
+// also logged at ERROR here so the alert fires even for callers that ignore the
+// slice. Only a ComputeProjectionDrift failure returns an error.
+func runProjectionDriftCheck(ctx context.Context, st *store.Store, logger *slog.Logger, grace time.Duration) (ran bool, drifted []store.TargetDrift, err error) {
+	ran, err = st.TryWithAdvisoryLock(ctx, advisoryKeyProjectionDrift, func() error {
+		confirmed, screenErr := rescreenDrift(ctx, st.ComputeProjectionDrift, grace)
+		if screenErr != nil {
+			return screenErr
+		}
+		drifted = confirmed
+		for _, d := range confirmed {
+			// Remediation is deliberately investigate-first, not "rebuild": a
+			// rebuild TRUNCATEs then replays, refuses once history has been
+			// pruned (store.ErrHistoryPruned), and cascade-widens to FK-child
+			// targets — a heavy, operator-judgment recovery, never a reflexive
+			// fix for an alert. A stopped projector is usually a control-process
+			// fault to diagnose first.
+			logger.Error("projection drift detected — a projection has stopped applying events it should",
+				"target", d.Target,
+				"lagging_table", d.LaggingTable,
+				"lagging_max", d.LaggingMax,
+				"stream_max", d.StreamMax,
+				"remediation", "diagnose this target's projector apply failure in the control logs; recovery is a targeted rebuild from un-pruned history via `control doctor` — a heavy operation, not a routine fix, and impossible once retention has pruned the source events")
+		}
+		return nil
+	})
+	return ran, drifted, err
+}
+
+// rescreenDrift returns only the targets that are Behind in TWO scans separated
+// by grace. compute is the drift probe (store.ComputeProjectionDrift in
+// production; a deterministic fake in tests). The first scan is the cheap common
+// path: with nothing behind it returns immediately, no wait and no re-scan. When
+// something is behind it waits grace — long enough for any in-flight post-commit
+// apply to finish — and re-scans; a target still Behind in both is a genuinely
+// stopped projector, while transient apply-lag has cleared by the second read.
+// Intersection is by target name. ctx cancellation during the grace aborts with
+// the ctx error.
+//
+// Only the two-scan intersection gates the alert, deliberately NOT a "high-water
+// did not advance" refinement: a target's high-water can advance on a co-owned
+// sibling table (e.g. users owns users_projection + user_roles_projection) while
+// the stalled table stays frozen, so gating on forward progress would MISS a
+// partial stall. A false negative on an integrity alert is worse than the
+// negligible residual false positive of a projector so overloaded it is mid-apply
+// in both scans — itself a real signal worth surfacing.
+func rescreenDrift(ctx context.Context, compute func(context.Context) ([]store.TargetDrift, error), grace time.Duration) ([]store.TargetDrift, error) {
+	first, err := compute(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("compute projection drift: %w", err)
+	}
+	firstBehind := map[string]bool{}
+	for _, d := range first {
+		if d.Drifted() {
+			firstBehind[d.Target] = true
+		}
+	}
+	if len(firstBehind) == 0 {
+		return nil, nil // clean on the first scan — no recheck needed
+	}
+
+	select {
+	case <-time.After(grace):
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	second, err := compute(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("recompute projection drift: %w", err)
+	}
+	var confirmed []store.TargetDrift
+	for _, d := range second {
+		if d.Drifted() && firstBehind[d.Target] {
+			confirmed = append(confirmed, d)
+		}
+	}
+	return confirmed, nil
+}
+
 // expireStaleExecutions runs one stale-execution sweep under the cross-replica
 // advisory lock. Returns ran=false (no error) when another replica currently
 // holds the lock — the caller treats that as a clean skip. A per-execution

--- a/cmd/control/periodic_drift_test.go
+++ b/cmd/control/periodic_drift_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
+)
+
+// testDriftGrace is a near-zero recheck grace for the DB-backed tests: the
+// induced drift is permanent (a raw event the projectors never applied), so the
+// recheck sees it in both scans regardless of grace — a tiny grace just keeps
+// the test fast. The false-positive suppression itself is proven deterministically
+// by the rescreenDrift unit tests below.
+const testDriftGrace = time.Millisecond
+
+// TestRunProjectionDriftCheck_DetectsDrift pins M1 (TG4): the scheduled
+// drift-reconcile tick runs the scan under the advisory lock and reports a
+// projection that has silently stopped applying events it should. A healthy
+// store reports ran=true with no drift; after a raw event is injected past a
+// projection's high-water (a direct INSERT fires no post-commit listener, the
+// exact silent-drop this worker exists to surface), the same tick reports the
+// lagging target.
+func TestRunProjectionDriftCheck_DetectsDrift(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	testutil.CreateTestUser(t, st, "drift-tick-"+testutil.NewID()[:8]+"@test.com", "pass", "admin")
+	testutil.CreateTestDevice(t, st, "drift-tick-host-"+testutil.NewID()[:6])
+
+	// Healthy: the live listeners kept every projection current, so the tick
+	// runs (lock free) and finds nothing.
+	ran, drifted, err := runProjectionDriftCheck(ctx, st, slog.Default(), testDriftGrace)
+	require.NoError(t, err)
+	require.True(t, ran, "with the lock free the drift check must run")
+	assert.Empty(t, drifted, "a healthy store has no drifted projections")
+
+	// Induce drift on the user stream: a raw event the projectors never
+	// applied. Its type is UserCreatedWithRoles — one the users projection has
+	// demonstrably applied before — so it is a real silently-dropped write, not
+	// a co-tenant event of a shared stream. Mirrors the store-level
+	// observability_test drift induction.
+	_, err = st.TestingPool().Exec(ctx, `
+		INSERT INTO events (id, stream_type, stream_id, stream_version, event_type, data, metadata, actor_type, actor_id)
+		VALUES ($1, 'user', $2, 1, 'UserCreatedWithRoles', '{}', '{}', 'system', 'drift-tick-test')`,
+		testutil.NewID(), "ghost-"+testutil.NewID()[:8])
+	require.NoError(t, err)
+
+	ran, drifted, err = runProjectionDriftCheck(ctx, st, slog.Default(), testDriftGrace)
+	require.NoError(t, err)
+	require.True(t, ran)
+	require.NotEmpty(t, drifted, "the injected unapplied event must surface as drift")
+
+	var users *store.TargetDrift
+	for i := range drifted {
+		if drifted[i].Target == "users" {
+			users = &drifted[i]
+		}
+		assert.True(t, drifted[i].Drifted(), "every returned target must actually be Behind")
+	}
+	require.NotNil(t, users, "the users projection must be reported as drifted")
+	assert.NotEmpty(t, users.LaggingTable, "a drifted target names the lagging table")
+}
+
+// TestRunProjectionDriftCheck_SingleFlight pins the cross-replica single-flight
+// (M1): the scan runs under advisoryKeyProjectionDrift, so when another replica
+// holds the lock the tick skips (ran=false) without error — exactly one replica
+// scans per tick.
+//
+// The "other replica" is a foreign session holding the lock via
+// pg_try_advisory_lock, NOT st.TryWithAdvisoryLock (which takes a process-local
+// mutex across fn, so a second in-process caller would block on the mutex rather
+// than exercise the CROSS-replica Postgres-lock skip).
+func TestRunProjectionDriftCheck_SingleFlight(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	holder, err := st.TestingPool().Acquire(ctx)
+	require.NoError(t, err)
+	defer holder.Release()
+
+	var got bool
+	require.NoError(t, holder.QueryRow(ctx, "SELECT pg_try_advisory_lock($1)", advisoryKeyProjectionDrift).Scan(&got))
+	require.True(t, got, "the foreign session must acquire the drift-check lock")
+
+	ran, drifted, err := runProjectionDriftCheck(ctx, st, slog.Default(), testDriftGrace)
+	require.NoError(t, err)
+	assert.False(t, ran, "a concurrent scan must skip without error while another replica holds the lock")
+	assert.Empty(t, drifted, "a skipped scan reports no drift")
+
+	require.NoError(t, holder.QueryRow(ctx, "SELECT pg_advisory_unlock($1)", advisoryKeyProjectionDrift).Scan(&got))
+
+	// With the lock free, the scan acquires it and runs.
+	ran, _, err = runProjectionDriftCheck(ctx, st, slog.Default(), testDriftGrace)
+	require.NoError(t, err)
+	assert.True(t, ran, "with the lock free, the scan runs")
+}
+
+// behindTarget builds a Behind TargetDrift for the rescreen unit tests.
+func behindTarget(name string) store.TargetDrift {
+	return store.TargetDrift{Target: name, Behind: true, LaggingTable: name + "_projection", LaggingMax: 1}
+}
+
+// scriptedDrift returns a compute func that yields the supplied per-call results
+// in order; the last entry repeats if called more than len(results) times.
+func scriptedDrift(results ...[]store.TargetDrift) func(context.Context) ([]store.TargetDrift, error) {
+	call := 0
+	return func(context.Context) ([]store.TargetDrift, error) {
+		r := results[call]
+		if call < len(results)-1 {
+			call++
+		}
+		return r, nil
+	}
+}
+
+// TestRescreenDrift_TransientNotReported is the regression test for the
+// post-commit apply race: a committed event is visible before its projector
+// apply finishes, so a single scan can read a healthy projection as behind. The
+// first scan sees "users" behind (mid-apply); by the grace recheck it has caught
+// up. The tick must NOT alert — the recheck separates transient apply-lag from a
+// stopped projector. (Fails on the pre-fix single-scan implementation.)
+func TestRescreenDrift_TransientNotReported(t *testing.T) {
+	compute := scriptedDrift(
+		[]store.TargetDrift{behindTarget("users")}, // first scan: mid-apply
+		nil, // recheck: caught up
+	)
+	confirmed, err := rescreenDrift(context.Background(), compute, time.Millisecond)
+	require.NoError(t, err)
+	assert.Empty(t, confirmed, "transient drift that clears by the recheck must not be reported")
+}
+
+// TestRescreenDrift_PersistentReported pins the true-positive: a projection
+// behind in BOTH scans is a genuinely stopped projector and is reported.
+func TestRescreenDrift_PersistentReported(t *testing.T) {
+	compute := scriptedDrift(
+		[]store.TargetDrift{behindTarget("users")},
+		[]store.TargetDrift{behindTarget("users")},
+	)
+	confirmed, err := rescreenDrift(context.Background(), compute, time.Millisecond)
+	require.NoError(t, err)
+	require.Len(t, confirmed, 1)
+	assert.Equal(t, "users", confirmed[0].Target)
+}
+
+// TestRescreenDrift_CleanFirstScanSkipsRecheck pins the fast path: a clean first
+// scan returns immediately without re-scanning. The call-count assertion detects
+// an unexpected recheck directly (calls would be 2), so the short grace is used —
+// a regressed fast path fails promptly instead of stalling CI.
+func TestRescreenDrift_CleanFirstScanSkipsRecheck(t *testing.T) {
+	calls := 0
+	compute := func(context.Context) ([]store.TargetDrift, error) {
+		calls++
+		return nil, nil
+	}
+	confirmed, err := rescreenDrift(context.Background(), compute, testDriftGrace)
+	require.NoError(t, err)
+	assert.Empty(t, confirmed)
+	assert.Equal(t, 1, calls, "a clean first scan must skip the grace wait and the recheck")
+}
+
+// TestRescreenDrift_NewDriftInSecondScanNotReported pins the intersection
+// direction: drift that appears only in the recheck (e.g. itself a fresh
+// mid-apply) is not yet corroborated, so it is not reported — only drift present
+// in BOTH scans alerts.
+func TestRescreenDrift_NewDriftInSecondScanNotReported(t *testing.T) {
+	compute := scriptedDrift(
+		[]store.TargetDrift{behindTarget("users")},
+		[]store.TargetDrift{behindTarget("users"), behindTarget("devices")},
+	)
+	confirmed, err := rescreenDrift(context.Background(), compute, time.Millisecond)
+	require.NoError(t, err)
+	require.Len(t, confirmed, 1)
+	assert.Equal(t, "users", confirmed[0].Target, "only drift present in both scans is reported")
+}

--- a/internal/api/auth_handler.go
+++ b/internal/api/auth_handler.go
@@ -23,6 +23,20 @@ import (
 // The interceptor's IP limiter is bypassable by rotating IPs, so a targeted
 // admin needs an account-keyed ceiling too. Only FAILURES are counted, so a
 // legitimate user's normal/successful logins never accrue toward it.
+//
+// Replica scope (M2, audit 2026-07-17): this ceiling is a PROCESS-LOCAL
+// in-memory counter (auth.RateLimiter), so it is enforced PER REPLICA. On the
+// default single-instance compose deployment (compose.yml notes control does not
+// scale horizontally) that is exactly loginAccountFailLimit per account. Under
+// the multi-replica control-plane HA that ADR 0031 enables, an attacker whose
+// requests load-balance across N replicas gets up to loginAccountFailLimit×N
+// failed attempts per window per account. This is a deliberate design choice —
+// the SSO auth-state and refresh-token single-use were made DB-backed and
+// replica-safe, but the brute-force *ceilings* were intentionally left
+// per-replica rather than adding a shared-store round-trip to every login. If
+// you run N replicas, size loginAccountFailLimit for the per-replica budget you
+// want (effective ceiling ≈ loginAccountFailLimit×N), or front control with a
+// sticky/global rate limit at the load balancer.
 const (
 	loginAccountFailLimit  = 10
 	loginAccountFailWindow = 15 * time.Minute

--- a/internal/api/totp_handler.go
+++ b/internal/api/totp_handler.go
@@ -45,9 +45,24 @@ type TOTPHandler struct {
 	// for a given challenge is admitted and every later one (even with a valid
 	// code) is rejected. Without it the challenge JWT is replayable for its full
 	// 5-min life — unlimited TOTP guesses per single password step.
+	//
+	// Replica scope (M3, audit 2026-07-17): both this consumer and
+	// totpAccountLimiter below are PROCESS-LOCAL in-memory windows, so single-use
+	// and the per-account failure ceiling are enforced PER REPLICA. On the default
+	// single-instance compose deployment the challenge is worth exactly one guess.
+	// Under multi-replica control HA (ADR 0031) the same challenge JWT replayed
+	// once to each of N replicas passes each replica's fresh consumer — up to N
+	// TOTP guesses per challenge instead of one. Deliberately left per-replica
+	// (not DB-backed like refresh-token JTIs) because compensating controls make
+	// this impractical to exploit: the 6-digit space, ~30s code rotation, the
+	// attacker already holding the password, and small real replica counts. If you
+	// run many replicas and want a strict global single-use, persist/consume the
+	// challenge JTI in the shared store. Keep the two windows in mind together —
+	// a per-replica consumer with a per-replica failure ceiling multiply.
 	challengeConsumer *auth.RateLimiter
 	// totpAccountLimiter throttles FAILED TOTP login attempts per account
-	// (keyed by user ID), independent of source IP.
+	// (keyed by user ID), independent of source IP. Process-local / per-replica —
+	// see the replica-scope note on challengeConsumer above.
 	totpAccountLimiter *auth.RateLimiter
 }
 

--- a/internal/auth/interceptor.go
+++ b/internal/auth/interceptor.go
@@ -286,6 +286,20 @@ func ClientIP(req connect.AnyRequest) string { return clientIP(req) }
 //   - RenewCertificate                      → RenewCert
 //   - GetCertificateRevocationList          → GetCRL
 //   - ListAuthMethods                       → AuthMethods
+//
+// Replica scope (L12, audit 2026-07-17): every limiter here is a PROCESS-LOCAL
+// in-memory window, so each ceiling is enforced PER REPLICA. On the default
+// single-instance compose deployment that is the exact configured limit. Under
+// multi-replica control HA (ADR 0031) an attacker whose requests load-balance
+// across N replicas gets up to N× the configured throughput against a single
+// IP / user / enumeration oracle. This is a deliberate design choice — these
+// ceilings bound DoS and enumeration (not a credential check, unlike the
+// DB-backed SSO state and refresh single-use), so the per-replica multiplier is
+// accepted rather than paying a shared-store round-trip on every request. If you
+// run N replicas, size the limits for the per-replica budget (effective ceiling
+// ≈ limit×N) or enforce a global ceiling at the load balancer / API gateway. A
+// shared-store token bucket is the upgrade path if strict global ceilings are
+// ever required.
 type RateLimiters struct {
 	Login     *RateLimiter
 	Refresh   *RateLimiter

--- a/internal/store/observability.go
+++ b/internal/store/observability.go
@@ -245,6 +245,16 @@ func ComputeProjectionDrift(ctx context.Context, pool *pgxpool.Pool) ([]TargetDr
 	return out, nil
 }
 
+// ComputeProjectionDrift is the production accessor for the periodic
+// drift-reconcile worker (M1), which holds a *Store and not a raw pool.
+// The free function above takes a pool so the doctor probe (its own pool)
+// and store tests (TestingPool) can call it without a full Store; this
+// method wraps it over the store's own unexported pool so production code
+// never has to reach for TestingPool (which is deliberately test-only).
+func (s *Store) ComputeProjectionDrift(ctx context.Context) ([]TargetDrift, error) {
+	return ComputeProjectionDrift(ctx, s.pool)
+}
+
 // tablesWithProjectionVersion returns the set of public base tables that
 // have a projection_version column.
 func tablesWithProjectionVersion(ctx context.Context, pool *pgxpool.Pool) (map[string]bool, error) {


### PR DESCRIPTION
## Audit remediation: M1 (projection-drift alerting) + M2/M3/L12 (per-replica rate-limit scope)

Closes the remaining server-only findings from the 2026-07-17 security audit.

### M1 — scheduled projection-drift detection (`cmd/control/periodic.go`)
A post-commit projector apply that fails after the event commits (DB blip, ctx
cancel mid-dispatch) drifts silently and permanently, invisible until an operator
runs `control doctor`. This adds a 15-minute, advisory-lock single-flighted tick
(`startProjectionDriftCheck`) that runs `ComputeProjectionDrift` and logs an ERROR
per lagging projection — the scheduled counterpart to the manual doctor check.

- New `Store.ComputeProjectionDrift` production seam (`internal/store/observability.go`)
  so the worker reaches the probe without the test-only `TestingPool`.
- **Detection only, no auto-rebuild** — the drift heuristic has an accepted
  sampled-type blind spot, so an unattended TRUNCATE+replay on a false positive is
  a worse failure mode than the drift it would "fix".
- **Grace-separated recheck** (`rescreenDrift`): a committed event is visible before
  its post-commit apply finishes, so a single scan can read a healthy projection
  mid-apply as "behind". The tick alerts only on drift that persists across a
  `driftRecheckGrace` (5s) recheck — transient apply-lag clears; a stopped projector
  stays behind. The clean common case pays neither the wait nor a second scan.
- **Remediation hint is investigate-first, not "rebuild"** — a rebuild TRUNCATEs then
  replays, refuses once history is pruned, and cascade-widens to FK-child targets:
  an operator-judgment recovery, never a reflexive alert fix.

### M2 / M3 / L12 — document per-replica rate-limit scope
Per ADR-0031 HA (N control replicas), the in-memory login limiter
(`auth_handler.go`), single-use TOTP login challenge (`totp_handler.go`), and the
general per-user/IP limiters (`auth/interceptor.go`) are process-local: the effective
ceiling is limit×N. Documented as a deliberate, sized-accordingly choice at each site
(not backed by a shared store — that is the future upgrade path).

### Tests
- `periodic_drift_test.go`: DB-backed `TestRunProjectionDriftCheck_DetectsDrift`
  (ghost event past a projection high-water surfaces as drift) and `_SingleFlight`
  (foreign session holds the advisory lock → tick skips).
- Deterministic `rescreenDrift` unit tests: transient-not-reported (the regression
  test — RED on the pre-recheck single-scan version), persistent-reported,
  clean-first-scan-skips-recheck (fast path), and new-drift-in-second-scan-not-reported
  (intersection direction).

Gates: `go vet`, `gofmt`, full `cmd/control` package tests, `docref check` — all green.
