### PR TITLE
fix(mtls): remove NoopRevocationChecker fail-open opt-out (audit L11)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -550,15 +550,17 @@ func main() {
 	// peer-class URI, are admitted.
 	// Revocation gate on the internal listener (WS12 #2): a revoked gateway
 	// cert must not be able to call the credential-bearing proxy RPCs. With
-	// Valkey the loaded CRL cache backs it; a no-Valkey dev control server has
-	// no CRL, so it gets the explicit, WARN-logged NoopRevocationChecker rather
-	// than a silent nil (which would fail closed and break the dev path).
+	// Valkey the loaded CRL cache backs it. Without a CRL (a no-Valkey control
+	// server) internalRevocation stays nil, which RequirePeerClassNotRevoked
+	// treats as FAIL-CLOSED — every gateway call to this listener is rejected
+	// (403) until a real CRL is loaded. There is no permissive opt-out: a
+	// gateway needs Valkey to function at all, so a no-Valkey control has no
+	// legitimate InternalService caller to admit (audit L11).
 	var internalRevocation mtls.RevocationChecker
 	if valkey != nil && valkey.CRLCache != nil {
 		internalRevocation = valkey.CRLCache
 	} else {
-		logger.Warn("InternalService mTLS listener running WITHOUT certificate revocation (no Valkey CRL configured) — dev only")
-		internalRevocation = mtls.NoopRevocationChecker{}
+		logger.Warn("InternalService mTLS listener has no certificate revocation list (no Valkey CRL configured) — every gateway call to it will be rejected (fail-closed)")
 	}
 	internalMux := http.NewServeMux()
 	// WithPeerCert (inside the class/revocation gate) injects the authenticated

--- a/docs/adr/0016-crl-fail-closed.md
+++ b/docs/adr/0016-crl-fail-closed.md
@@ -71,3 +71,15 @@ in `handler` was removed. `mtls` cannot import `handler` or `ca` (both import
   not addressed here. It has since been **fixed** by serializing
   `RenewCertificate` per device under an advisory lock — see ADR 0023 and
   `manchtools/power-manage-server#441`.
+
+## Update (2026-07-18, audit L11)
+
+The `NoopRevocationChecker` dev opt-out described above (Decision → "Fail-closed
+until loaded" and "One RevocationChecker") has been **removed**. It was the one
+path by which a no-CRL deployment ran fail-*open*. This strengthens — does not
+reverse — the fail-closed decision: the no-CRL path now uses a **bare nil**
+checker, which `RequirePeerClassNotRevoked` / `MTLSMiddleware` already treat as
+fail-closed (403). A control server with no Valkey/CRL therefore rejects every
+gateway call to its internal listener until a real list loads, and there is no
+longer any typed opt-out to disable revocation. See `internal/mtls/peer_class.go`
+(`RevocationChecker`) and `cmd/control/main.go` (internal-listener wiring).

--- a/internal/api/gateway_handler.go
+++ b/internal/api/gateway_handler.go
@@ -28,9 +28,9 @@ type GatewayHandler struct {
 	store  *store.Store
 	logger *slog.Logger
 	// crl is the Valkey-backed revocation list. nil when no Valkey is
-	// configured (dev): GetCRL then returns an empty list (matching the
-	// internal listener's NoopRevocationChecker dev posture) and revocation
-	// returns Unavailable (it cannot take effect without a CRL).
+	// configured (dev): GetCRL then returns an empty list and revocation
+	// returns Unavailable (it cannot take effect without a CRL — and the
+	// internal listener fails closed on every gateway call in that state).
 	crl *crl.Store
 	// liveness reports which gateway_ids are actually live right now (Valkey
 	// registry heartbeat), so ListGateways reflects real liveness rather than

--- a/internal/handler/agent.go
+++ b/internal/handler/agent.go
@@ -146,8 +146,8 @@ func (h *AgentHandler) SetTerminalSessions(reg *connection.TerminalSessionRegist
 // MTLSMiddleware gates the gateway's AgentService listener. The revocation
 // checker is mtls.RevocationChecker (the gateway's *crl.Cache satisfies it); a
 // nil or not-yet-loaded checker fails CLOSED — see mtls.RevocationChecker and
-// the fail-closed block below. The only no-CRL path is an explicit
-// mtls.NoopRevocationChecker, logged at WARN by the caller.
+// the fail-closed block below. There is no permissive opt-out: without a loaded
+// CRL every call is rejected (the gateway refuses to boot without one).
 func MTLSMiddleware(next http.Handler, revocation mtls.RevocationChecker, logger *slog.Logger) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Skip TLS check for health endpoints
@@ -205,9 +205,8 @@ func MTLSMiddleware(next http.Handler, revocation mtls.RevocationChecker, logger
 		// same leaf the peer-class check used, so it's non-nil here.
 		//
 		// A nil checker or one whose list has not loaded means we CANNOT prove
-		// this cert is unrevoked → reject, never admit. Running without real
-		// revocation data requires an explicit NoopRevocationChecker (Loaded()
-		// true), which the caller logs at WARN — a bare nil is never tolerated.
+		// this cert is unrevoked → reject, never admit. There is no opt-out from
+		// this gate — a deployment without a loaded CRL rejects every call here.
 		if revocation == nil || !revocation.Loaded() {
 			logger.Warn("mTLS rejected: certificate revocation unavailable (fail-closed)",
 				"device_id", deviceID,

--- a/internal/handler/agent_middleware_test.go
+++ b/internal/handler/agent_middleware_test.go
@@ -285,10 +285,10 @@ func TestMTLSMiddleware_AgentClassReachesInnerWithDeviceIDInContext(t *testing.T
 	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		gotDeviceID, gotOK = DeviceIDFromContext(r.Context())
 	})
-	// Explicit NoopRevocationChecker (the typed dev opt-out) — a bare nil now
-	// fails closed (see TestMTLSMiddleware_NilRevocationChecker), so the happy
-	// path must pass an explicit loaded checker.
-	mw := MTLSMiddleware(inner, mtls.NoopRevocationChecker{}, newTestLogger())
+	// A loaded checker with nothing revoked — the happy path must pass an
+	// explicit loaded checker because a bare nil now fails closed (see
+	// TestMTLSMiddleware_NilRevocationChecker).
+	mw := MTLSMiddleware(inner, fakeRevocation{revoked: false}, newTestLogger())
 
 	req := httptest.NewRequest(http.MethodGet, "/api", nil)
 	agent := mtls.PeerClassAgent
@@ -457,9 +457,11 @@ func TestMTLSMiddleware_NotLoadedCacheFailsClosed(t *testing.T) {
 	assert.True(t, called)
 }
 
-// TestMTLSMiddleware_NilRevocationChecker pins WS12 #4: a bare nil checker fails
-// closed; only the explicit, typed NoopRevocationChecker admits without a real
-// CRL. RED today (a nil checker is silently skipped → admits).
+// TestMTLSMiddleware_NilRevocationChecker pins WS12 #4 / audit L11: a nil checker
+// fails closed (403), never silently admits. With NoopRevocationChecker removed
+// there is no opt-out — a deployment without a CRL rejects every call here, and a
+// loaded-but-empty CRL (which admits non-revoked) is covered by
+// TestMTLSMiddleware_RevokedCertRejected.
 func TestMTLSMiddleware_NilRevocationChecker(t *testing.T) {
 	agent := mtls.PeerClassAgent
 	inner := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
@@ -470,16 +472,5 @@ func TestMTLSMiddleware_NilRevocationChecker(t *testing.T) {
 	reqNil.TLS = fakeTLSStateWithPeerClass(t, "device-1", &agent)
 	recNil := httptest.NewRecorder()
 	mwNil.ServeHTTP(recNil, reqNil)
-	assert.Equal(t, http.StatusForbidden, recNil.Code, "a bare nil checker must fail closed, never silently admit")
-
-	// explicit NoopRevocationChecker → admits non-revoked (typed dev opt-out).
-	called := false
-	innerOK := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) { called = true })
-	mwNoop := MTLSMiddleware(innerOK, mtls.NoopRevocationChecker{}, newTestLogger())
-	reqNoop := httptest.NewRequest(http.MethodGet, "/api", nil)
-	reqNoop.TLS = fakeTLSStateWithPeerClass(t, "device-1", &agent)
-	recNoop := httptest.NewRecorder()
-	mwNoop.ServeHTTP(recNoop, reqNoop)
-	assert.Equal(t, http.StatusOK, recNoop.Code, "the explicit NoopRevocationChecker is the dev opt-out and admits non-revoked")
-	assert.True(t, called)
+	assert.Equal(t, http.StatusForbidden, recNil.Code, "a nil checker must fail closed, never silently admit")
 }

--- a/internal/mtls/peer_class.go
+++ b/internal/mtls/peer_class.go
@@ -172,26 +172,14 @@ func RequirePeerClass(logger *slog.Logger, allowed ...PeerClass) func(http.Handl
 // import cycle.
 //
 // A nil checker, or one whose Loaded() is false, is treated as FAIL-CLOSED:
-// without a loaded list we cannot prove the cert is unrevoked, so we reject. The
-// only no-CRL path is an explicit NoopRevocationChecker, which the caller logs
-// at WARN — never a bare nil.
+// without a loaded list we cannot prove the cert is unrevoked, so we reject.
+// There is deliberately NO opt-out: a deployment with no CRL (e.g. a no-Valkey
+// control server) passes a nil checker and every gateway call fails closed at
+// the listener until a real CRL is loaded.
 type RevocationChecker interface {
 	IsRevoked(fingerprint string) bool
 	Loaded() bool
 }
-
-// NoopRevocationChecker is the explicit, typed dev-only opt-out from the
-// revocation gate: nothing revoked, always loaded. Use it ONLY where there is
-// genuinely no CRL (a no-Valkey dev control server) and log at WARN where wired.
-// It is deliberately distinct from a bare nil (which fails closed) so disabling
-// revocation is a visible, intentional choice in the code.
-type NoopRevocationChecker struct{}
-
-// IsRevoked always returns false.
-func (NoopRevocationChecker) IsRevoked(string) bool { return false }
-
-// Loaded always returns true.
-func (NoopRevocationChecker) Loaded() bool { return true }
 
 // fingerprintFromCert returns hex(sha256(cert.Raw)), matching
 // ca.FingerprintFromCert. Reimplemented here (rather than imported) because ca
@@ -214,8 +202,8 @@ func fingerprintFromCert(cert *x509.Certificate) string {
 // RequirePeerClass.
 //
 // Revocation is ADDITIVE: a wrong-class cert is still rejected first by the
-// peer-class check. A nil/unloaded checker fails closed (403) — pass an explicit
-// NoopRevocationChecker (logged at WARN) to run without a CRL.
+// peer-class check. A nil/unloaded checker fails closed (403): a deployment
+// without a CRL rejects every gateway call here until a real list is loaded.
 func RequirePeerClassNotRevoked(logger *slog.Logger, revocation RevocationChecker, allowed ...PeerClass) func(http.Handler) http.Handler {
 	peerClass := RequirePeerClass(logger, allowed...)
 	return func(next http.Handler) http.Handler {


### PR DESCRIPTION
## Audit L11 — remove the `NoopRevocationChecker` fail-open opt-out

The InternalService mTLS listener's revocation gate fell back to
`mtls.NoopRevocationChecker{}` (IsRevoked always false, Loaded always true)
whenever no CRL was configured — the single path by which a no-Valkey control
server ran **fail-open** on the credential-bearing proxy RPCs (`ProxyGetLuksKey`,
`ProxyStoreLpsPasswords`, …).

Per the audit decision ("why not just remove it?"), the type is deleted entirely.
The no-CRL case now leaves `internalRevocation` as a bare `nil`, which
`RequirePeerClassNotRevoked` (and the agent-side `MTLSMiddleware`) **already treat
as fail-closed** — a nil/unloaded checker returns 403 before any `IsRevoked` call.
So a control server without a CRL rejects every gateway call to its internal
listener until a real list loads, and there is no longer any typed opt-out.

This is safe because a gateway requires Valkey to function at all (Asynq task
queue, action dispatch), so a no-Valkey control server has no legitimate
InternalService caller to admit — the previously-"kept alive" dev path served
nothing real.

### Changes
- Delete `NoopRevocationChecker` + its methods (`internal/mtls/peer_class.go`).
- `cmd/control/main.go`: no-CRL branch now leaves the checker nil (fail-closed) and
  WARN-logs that gateway calls will be rejected.
- Doc-comment updates in `gateway_handler.go`, `agent.go`.
- `agent_middleware_test.go`: the two `NoopRevocationChecker{}` sites use the
  existing `fakeRevocation{}` (loaded, nothing revoked); `TestMTLSMiddleware_NilRevocationChecker`
  keeps only the nil→fail-closed assertion.
- ADR 0016: dated amendment noting the opt-out's removal (decision strengthened, not reversed).

### Regression coverage
The now-load-bearing invariant — no-CRL → fail-closed — is already pinned green:
`peer_class_test.go` (`TestRequirePeerClassNotRevoked_RejectsRevokedFingerprint`:
unloaded and nil → 403 on the internal listener) and
`agent_middleware_test.go` (`TestMTLSMiddleware_NilRevocationChecker`: nil → 403).
Removing the permissive type means nothing can re-open the path.

Gates: `go vet`, `gofmt`, `internal/mtls` + `internal/handler` tests, `docref check` — all green.
