### PR TITLE
fix(scim): fail closed on SCIM append errors (audit L7)

### DIFF
--- a/internal/scim/atomic_append_test.go
+++ b/internal/scim/atomic_append_test.go
@@ -120,3 +120,94 @@ func TestReplaceUser_PartialFailureRollsBackEmail(t *testing.T) {
 	assert.Equal(t, before.Email, after.Email,
 		"email change must roll back when the profile update in the same PUT fails")
 }
+
+// Audit L7 — createUser is now atomic across its UserCreatedWithRoles +
+// IdentityLinked appends. Forcing the identity-link append to fail must leave
+// NO orphan user row: otherwise the IdP's next POST misses the externalID dedup
+// (no link projection) and, with auto-link off, mints a DUPLICATE user under a
+// fresh ULID. Pre-fix (sequential appends) the user row committed before the
+// link append failed.
+func TestCreateUser_IdentityLinkFailureLeavesNoOrphan(t *testing.T) {
+	env := setupSCIM(t)
+	ctx := context.Background()
+
+	countDEKs := func() int {
+		var n int
+		require.NoError(t, env.st.TestingPool().QueryRow(ctx, "SELECT count(*) FROM user_encryption_keys").Scan(&n))
+		return n
+	}
+
+	email := strings.ToLower("orphan-"+testutil.NewID()[:8]) + "@example.com"
+	body := map[string]any{
+		"schemas":    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+		"userName":   email,
+		"externalId": "ext-" + testutil.NewID()[:8],
+		"active":     true,
+	}
+
+	deksBefore := countDEKs()
+
+	// Fail the identity-link append (2nd event in the create batch).
+	env.st.TestingSetInsertHook(func(streamType, eventType string) error {
+		if eventType == string(eventtypes.IdentityLinked) {
+			return errors.New("synthetic identity-link append failure")
+		}
+		return nil
+	})
+
+	w := env.request("POST", "/Users", body)
+	require.Equal(t, http.StatusInternalServerError, w.Code, "identity-link failure must surface as 500: %s", w.Body.String())
+
+	_, err := env.st.Repos().User.GetByEmail(ctx, email)
+	assert.True(t, store.IsNotFound(err),
+		"no orphan user may exist after a failed create — user and identity link are all-or-nothing")
+
+	// The DEK minted before the batch must not leak: it is shredded on rollback,
+	// so a persistent create failure can't accumulate a wrapped key per retry.
+	assert.Equal(t, deksBefore, countDEKs(),
+		"orphaned user DEK must be shredded when the create batch rolls back")
+
+	// A subsequent clean sync creates the user exactly once.
+	env.st.TestingSetInsertHook(nil)
+
+	w = env.request("POST", "/Users", body)
+	require.Equal(t, http.StatusCreated, w.Code, "clean sync must create the user: %s", w.Body.String())
+
+	created, err := env.st.Repos().User.GetByEmail(ctx, email)
+	require.NoError(t, err, "clean sync must create the user")
+	assert.Equal(t, email, created.Email)
+}
+
+// Audit L7 — a SCIM re-POST of an already-linked user syncs via syncUserFromSCIM,
+// whose appends previously went through the SWALLOWING appendEvent helper: an
+// append failure was logged and dropped, and the handler still returned 200 while
+// the projection silently diverged from what the IdP believed it provisioned. The
+// identity-link sync append must now fail the request closed so the IdP retries.
+func TestCreateUser_RepostSyncFailureFailsClosed(t *testing.T) {
+	env := setupSCIM(t)
+
+	email := strings.ToLower("resync-"+testutil.NewID()[:8]) + "@example.com"
+	body := map[string]any{
+		"schemas":    []string{"urn:ietf:params:scim:schemas:core:2.0:User"},
+		"userName":   email,
+		"externalId": "ext-" + testutil.NewID()[:8],
+		"active":     true,
+	}
+
+	// Clean create establishes the linked user.
+	w := env.request("POST", "/Users", body)
+	require.Equal(t, http.StatusCreated, w.Code, "%s", w.Body.String())
+
+	// Re-POST hits the idempotent externalID branch → syncUserFromSCIM →
+	// syncIdentityLink emits IdentityLinkLoginUpdated on every sync. Force it.
+	env.st.TestingSetInsertHook(func(streamType, eventType string) error {
+		if eventType == string(eventtypes.IdentityLinkLoginUpdated) {
+			return errors.New("synthetic identity-link-sync append failure")
+		}
+		return nil
+	})
+
+	w = env.request("POST", "/Users", body)
+	require.Equal(t, http.StatusInternalServerError, w.Code,
+		"a swallowed sync append must now fail the request closed, not return 200: %s", w.Body.String())
+}

--- a/internal/scim/groups_create.go
+++ b/internal/scim/groups_create.go
@@ -55,48 +55,64 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 		// Already exists — update display name if changed and return existing resource.
 		h.logger.Debug("SCIM createGroup: group already exists, syncing", "scim_group_id", scimGroupID, "user_group_id", existing.UserGroupID)
 		// This makes POST idempotent, which handles SCIM clients that re-POST on every sync.
+		// The mapping-rename and user_group-rename commit atomically (audit L7):
+		// the change guard reads the *mapping's* name, so a partial apply would
+		// let the retry see equal names, skip, and leave the user_group name stale
+		// forever. AppendEvents makes both land or neither.
 		if existing.SCIMDisplayName != scimGroup.DisplayName {
-			h.appendEvent(ctx, store.Event{
-				StreamType: "scim_group_mapping",
-				StreamID:   existing.ID,
-				EventType:  string(eventtypes.SCIMGroupMappingUpdated),
-				Data: payloads.SCIMGroupMappingUpdated{
-					ProviderID:      provider.ID,
-					SCIMGroupID:     scimGroupID,
-					SCIMDisplayName: &scimGroup.DisplayName,
+			if err := h.store.AppendEvents(ctx, []store.Event{
+				{
+					StreamType: "scim_group_mapping",
+					StreamID:   existing.ID,
+					EventType:  string(eventtypes.SCIMGroupMappingUpdated),
+					Data: payloads.SCIMGroupMappingUpdated{
+						ProviderID:      provider.ID,
+						SCIMGroupID:     scimGroupID,
+						SCIMDisplayName: &scimGroup.DisplayName,
+					},
+					ActorType: "scim",
+					ActorID:   provider.ID,
 				},
-				ActorType: "scim",
-				ActorID:   provider.ID,
-			})
-			h.appendEvent(ctx, store.Event{
-				StreamType: "user_group",
-				StreamID:   existing.UserGroupID,
-				EventType:  string(eventtypes.UserGroupUpdated),
-				// nil Description = preserve the existing one (SCIM
-				// only renames; the description is server-owned).
-				Data: payloads.UserGroupUpdated{
-					Name: scimGroup.DisplayName,
+				{
+					StreamType: "user_group",
+					StreamID:   existing.UserGroupID,
+					EventType:  string(eventtypes.UserGroupUpdated),
+					// nil Description = preserve the existing one (SCIM
+					// only renames; the description is server-owned).
+					Data: payloads.UserGroupUpdated{
+						Name: scimGroup.DisplayName,
+					},
+					ActorType: "scim",
+					ActorID:   provider.ID,
 				},
-				ActorType: "scim",
-				ActorID:   provider.ID,
-			})
+			}); err != nil {
+				h.logger.Error("failed to rename SCIM group", "error", err)
+				writeError(w, http.StatusInternalServerError, "failed to update group")
+				return
+			}
 		}
 
 		// Reconcile members if the field was present in the JSON body.
 		// nil means the field was omitted (don't touch members).
 		// Empty slice means explicitly empty (remove all members).
 		if scimGroup.Members != nil {
-			h.reconcileGroupMembers(ctx, provider, existing.UserGroupID, scimGroup.Members)
+			if err := h.reconcileGroupMembers(ctx, provider, existing.UserGroupID, scimGroup.Members); err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to update group members")
+				return
+			}
 		}
 
 		group, err := h.buildGroupResource(ctx, provider.ID, existing, baseURL)
 		if err != nil {
 			// User group referenced by mapping no longer exists.
 			// Remove the orphaned mapping and fall through to create
-			// a fresh group+mapping pair below.
+			// a fresh group+mapping pair below. Fail closed on the unmap
+			// (audit L7): swallowing it and falling through would create a
+			// SECOND mapping for the same scim_group_id alongside the stale
+			// one — two mappings for one SCIM group.
 			h.logger.Warn("orphaned SCIM group mapping, removing and recreating",
 				"mapping_id", existing.ID, "user_group_id", existing.UserGroupID, "error", err)
-			h.appendEvent(ctx, store.Event{
+			if err := h.appendEvent(ctx, store.Event{
 				StreamType: "scim_group_mapping",
 				StreamID:   existing.ID,
 				EventType:  string(eventtypes.SCIMGroupUnmapped),
@@ -106,7 +122,10 @@ func (h *Handler) createGroup(w http.ResponseWriter, r *http.Request) {
 				},
 				ActorType: "scim",
 				ActorID:   provider.ID,
-			})
+			}); err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to remove orphaned group mapping")
+				return
+			}
 			// Fall through to create a new group below
 		} else {
 			writeJSON(w, http.StatusOK, group)

--- a/internal/scim/groups_helpers.go
+++ b/internal/scim/groups_helpers.go
@@ -36,13 +36,16 @@ func (h *Handler) mayAddMemberToGroup(ctx context.Context, providerID, groupID, 
 // reconcileGroupMembers diff's the requested member set against the
 // current member set and emits per-user UserGroupMemberAdded /
 // UserGroupMemberRemoved events. Idempotent — calling with the same
-// member set twice produces no second-round events.
-func (h *Handler) reconcileGroupMembers(ctx context.Context, provider store.IdentityProvider, groupID string, requestedMembers []SCIMMember) {
+// member set twice produces no second-round events. Fails closed (audit
+// L7): a list or append failure is returned so the caller answers 500 and
+// the IdP retries; the per-member appends are ON CONFLICT-idempotent, so a
+// retry after a partial apply converges without duplicating membership.
+func (h *Handler) reconcileGroupMembers(ctx context.Context, provider store.IdentityProvider, groupID string, requestedMembers []SCIMMember) error {
 	h.logger.Debug("SCIM reconcileGroupMembers", "group_id", groupID, "requested_count", len(requestedMembers))
 	currentMemberIDs, err := h.store.Repos().UserGroup.ListMemberIDs(ctx, groupID)
 	if err != nil {
 		h.logger.Error("failed to list current group members for reconciliation", "error", err)
-		return
+		return err
 	}
 
 	currentSet := make(map[string]bool, len(currentMemberIDs))
@@ -66,7 +69,7 @@ func (h *Handler) reconcileGroupMembers(ctx context.Context, provider store.Iden
 			}
 			h.logger.Debug("SCIM adding member to group", "group_id", groupID, "user_id", userID)
 			streamID := groupID + ":" + userID
-			h.appendEvent(ctx, store.Event{
+			if err := h.appendEvent(ctx, store.Event{
 				StreamType: "user_group",
 				StreamID:   streamID,
 				EventType:  string(eventtypes.UserGroupMemberAdded),
@@ -76,7 +79,9 @@ func (h *Handler) reconcileGroupMembers(ctx context.Context, provider store.Iden
 				},
 				ActorType: "scim",
 				ActorID:   provider.ID,
-			})
+			}); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -85,7 +90,7 @@ func (h *Handler) reconcileGroupMembers(ctx context.Context, provider store.Iden
 		if !requestedSet[userID] {
 			h.logger.Debug("SCIM removing member from group", "group_id", groupID, "user_id", userID)
 			streamID := groupID + ":" + userID
-			h.appendEvent(ctx, store.Event{
+			if err := h.appendEvent(ctx, store.Event{
 				StreamType: "user_group",
 				StreamID:   streamID,
 				EventType:  string(eventtypes.UserGroupMemberRemoved),
@@ -95,9 +100,12 @@ func (h *Handler) reconcileGroupMembers(ctx context.Context, provider store.Iden
 				},
 				ActorType: "scim",
 				ActorID:   provider.ID,
-			})
+			}); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 // buildGroupResource constructs a SCIMGroup from a mapping and its associated user group.

--- a/internal/scim/groups_mutate.go
+++ b/internal/scim/groups_mutate.go
@@ -52,33 +52,42 @@ func (h *Handler) replaceGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Update display name if changed
+	// Update display name if changed. The mapping-rename and user_group-rename
+	// commit atomically (audit L7): the change guard reads the *mapping's* name,
+	// so a partial apply (mapping renamed, user_group not) would let the retry
+	// see equal names, skip the rename, and leave the user_group name stale
+	// forever. AppendEvents makes both land or neither.
 	if scimGroup.DisplayName != "" && scimGroup.DisplayName != mapping.SCIMDisplayName {
-		h.appendEvent(ctx, store.Event{
-			StreamType: "scim_group_mapping",
-			StreamID:   mapping.ID,
-			EventType:  string(eventtypes.SCIMGroupMappingUpdated),
-			Data: payloads.SCIMGroupMappingUpdated{
-				ProviderID:      provider.ID,
-				SCIMGroupID:     mapping.SCIMGroupID,
-				SCIMDisplayName: &scimGroup.DisplayName,
+		if err := h.store.AppendEvents(ctx, []store.Event{
+			{
+				StreamType: "scim_group_mapping",
+				StreamID:   mapping.ID,
+				EventType:  string(eventtypes.SCIMGroupMappingUpdated),
+				Data: payloads.SCIMGroupMappingUpdated{
+					ProviderID:      provider.ID,
+					SCIMGroupID:     mapping.SCIMGroupID,
+					SCIMDisplayName: &scimGroup.DisplayName,
+				},
+				ActorType: "scim",
+				ActorID:   provider.ID,
 			},
-			ActorType: "scim",
-			ActorID:   provider.ID,
-		})
-
-		h.appendEvent(ctx, store.Event{
-			StreamType: "user_group",
-			StreamID:   groupID,
-			EventType:  string(eventtypes.UserGroupUpdated),
-			// nil Description = preserve the existing one (SCIM
-			// only renames; the description is server-owned).
-			Data: payloads.UserGroupUpdated{
-				Name: scimGroup.DisplayName,
+			{
+				StreamType: "user_group",
+				StreamID:   groupID,
+				EventType:  string(eventtypes.UserGroupUpdated),
+				// nil Description = preserve the existing one (SCIM
+				// only renames; the description is server-owned).
+				Data: payloads.UserGroupUpdated{
+					Name: scimGroup.DisplayName,
+				},
+				ActorType: "scim",
+				ActorID:   provider.ID,
 			},
-			ActorType: "scim",
-			ActorID:   provider.ID,
-		})
+		}); err != nil {
+			h.logger.Error("failed to rename SCIM group", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to update group")
+			return
+		}
 	}
 
 	// Reconcile members if the field was present in the JSON body.
@@ -86,7 +95,10 @@ func (h *Handler) replaceGroup(w http.ResponseWriter, r *http.Request) {
 	// Empty slice means explicitly empty (remove all members).
 	// SCIM is treated as the source of truth for group membership.
 	if scimGroup.Members != nil {
-		h.reconcileGroupMembers(ctx, provider, groupID, scimGroup.Members)
+		if err := h.reconcileGroupMembers(ctx, provider, groupID, scimGroup.Members); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to update group members")
+			return
+		}
 	}
 
 	// Read back and return
@@ -151,16 +163,22 @@ func (h *Handler) patchGroup(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, fmt.Sprintf("unsupported patch op: %s", op.Op))
 			return
 		}
+		var opErr error
 		switch op.Op.Normalize() {
 		case SCIMPatchOpAdd:
-			h.handleGroupPatchAdd(ctx, provider, groupID, op)
+			opErr = h.handleGroupPatchAdd(ctx, provider, groupID, op)
 		case SCIMPatchOpRemove:
-			h.handleGroupPatchRemove(ctx, provider, groupID, op)
+			opErr = h.handleGroupPatchRemove(ctx, provider, groupID, op)
 		case SCIMPatchOpReplace:
-			h.handleGroupPatchReplace(ctx, provider, groupID, mapping, op)
+			opErr = h.handleGroupPatchReplace(ctx, provider, groupID, mapping, op)
 		default:
 			// Unreachable: IsValid above guards this switch.
 			writeError(w, http.StatusBadRequest, fmt.Sprintf("unsupported patch op: %s", op.Op))
+			return
+		}
+		if opErr != nil {
+			h.logger.Error("failed to apply SCIM group patch op", "op", op.Op, "path", op.Path, "error", opErr)
+			writeError(w, http.StatusInternalServerError, "failed to apply patch operation")
 			return
 		}
 	}
@@ -181,11 +199,13 @@ func (h *Handler) patchGroup(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, group)
 }
 
-// handleGroupPatchAdd processes an "add" patch operation on a group.
-func (h *Handler) handleGroupPatchAdd(ctx context.Context, provider store.IdentityProvider, groupID string, op SCIMPatchOp) {
+// handleGroupPatchAdd processes an "add" patch operation on a group. Fails
+// closed (audit L7); per-member appends are ON CONFLICT-idempotent so a retry
+// after a partial apply converges.
+func (h *Handler) handleGroupPatchAdd(ctx context.Context, provider store.IdentityProvider, groupID string, op SCIMPatchOp) error {
 	path := strings.ToLower(op.Path)
 	if path != "members" && path != "" {
-		return
+		return nil
 	}
 
 	members := extractMembers(op.Value)
@@ -194,7 +214,7 @@ func (h *Handler) handleGroupPatchAdd(ctx context.Context, provider store.Identi
 			continue
 		}
 		streamID := groupID + ":" + userID
-		h.appendEvent(ctx, store.Event{
+		if err := h.appendEvent(ctx, store.Event{
 			StreamType: "user_group",
 			StreamID:   streamID,
 			EventType:  string(eventtypes.UserGroupMemberAdded),
@@ -204,12 +224,16 @@ func (h *Handler) handleGroupPatchAdd(ctx context.Context, provider store.Identi
 			},
 			ActorType: "scim",
 			ActorID:   provider.ID,
-		})
+		}); err != nil {
+			return err
+		}
 	}
+	return nil
 }
 
-// handleGroupPatchRemove processes a "remove" patch operation on a group.
-func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider store.IdentityProvider, groupID string, op SCIMPatchOp) {
+// handleGroupPatchRemove processes a "remove" patch operation on a group. Fails
+// closed (audit L7); per-member removals are idempotent so a retry converges.
+func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider store.IdentityProvider, groupID string, op SCIMPatchOp) error {
 	path := strings.ToLower(op.Path)
 
 	// Handle path like: members[value eq "userId"]
@@ -218,7 +242,7 @@ func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider store.Ide
 		userID := extractUserIDFromMemberFilter(op.Path)
 		if userID != "" {
 			streamID := groupID + ":" + userID
-			h.appendEvent(ctx, store.Event{
+			return h.appendEvent(ctx, store.Event{
 				StreamType: "user_group",
 				StreamID:   streamID,
 				EventType:  string(eventtypes.UserGroupMemberRemoved),
@@ -230,7 +254,7 @@ func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider store.Ide
 				ActorID:   provider.ID,
 			})
 		}
-		return
+		return nil
 	}
 
 	// Handle path "members" with value containing member list
@@ -238,7 +262,7 @@ func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider store.Ide
 		members := extractMembers(op.Value)
 		for _, userID := range members {
 			streamID := groupID + ":" + userID
-			h.appendEvent(ctx, store.Event{
+			if err := h.appendEvent(ctx, store.Event{
 				StreamType: "user_group",
 				StreamID:   streamID,
 				EventType:  string(eventtypes.UserGroupMemberRemoved),
@@ -248,45 +272,52 @@ func (h *Handler) handleGroupPatchRemove(ctx context.Context, provider store.Ide
 				},
 				ActorType: "scim",
 				ActorID:   provider.ID,
-			})
+			}); err != nil {
+				return err
+			}
 		}
 	}
+	return nil
 }
 
 // handleGroupPatchReplace processes a "replace" patch operation on a group.
-func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.IdentityProvider, groupID string, mapping store.SCIMGroupMapping, op SCIMPatchOp) {
+// Fails closed (audit L7). The displayname rename commits its mapping+user_group
+// events atomically via AppendEvents (same reason as replaceGroup); the member
+// add/remove appends are ON CONFLICT-idempotent so a retry converges.
+func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.IdentityProvider, groupID string, mapping store.SCIMGroupMapping, op SCIMPatchOp) error {
 	path := strings.ToLower(op.Path)
 
 	switch path {
 	case "displayname":
 		name, ok := op.Value.(string)
 		if !ok || name == "" {
-			return
+			return nil
 		}
 
-		h.appendEvent(ctx, store.Event{
-			StreamType: "scim_group_mapping",
-			StreamID:   mapping.ID,
-			EventType:  string(eventtypes.SCIMGroupMappingUpdated),
-			Data: payloads.SCIMGroupMappingUpdated{
-				ProviderID:      provider.ID,
-				SCIMGroupID:     mapping.SCIMGroupID,
-				SCIMDisplayName: &name,
+		return h.store.AppendEvents(ctx, []store.Event{
+			{
+				StreamType: "scim_group_mapping",
+				StreamID:   mapping.ID,
+				EventType:  string(eventtypes.SCIMGroupMappingUpdated),
+				Data: payloads.SCIMGroupMappingUpdated{
+					ProviderID:      provider.ID,
+					SCIMGroupID:     mapping.SCIMGroupID,
+					SCIMDisplayName: &name,
+				},
+				ActorType: "scim",
+				ActorID:   provider.ID,
 			},
-			ActorType: "scim",
-			ActorID:   provider.ID,
-		})
-
-		h.appendEvent(ctx, store.Event{
-			StreamType: "user_group",
-			StreamID:   groupID,
-			EventType:  string(eventtypes.UserGroupUpdated),
-			// nil Description = preserve (SCIM only renames).
-			Data: payloads.UserGroupUpdated{
-				Name: name,
+			{
+				StreamType: "user_group",
+				StreamID:   groupID,
+				EventType:  string(eventtypes.UserGroupUpdated),
+				// nil Description = preserve (SCIM only renames).
+				Data: payloads.UserGroupUpdated{
+					Name: name,
+				},
+				ActorType: "scim",
+				ActorID:   provider.ID,
 			},
-			ActorType: "scim",
-			ActorID:   provider.ID,
 		})
 
 	case "members":
@@ -300,7 +331,7 @@ func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.Id
 		currentMemberIDs, err := h.store.Repos().UserGroup.ListMemberIDs(ctx, groupID)
 		if err != nil {
 			h.logger.Error("failed to list group members for patch replace", "group_id", groupID, "error", err)
-			return
+			return err
 		}
 
 		currentSet := make(map[string]bool, len(currentMemberIDs))
@@ -316,7 +347,7 @@ func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.Id
 				}
 				h.logger.Debug("SCIM adding member to group", "group_id", groupID, "user_id", userID)
 				streamID := groupID + ":" + userID
-				h.appendEvent(ctx, store.Event{
+				if err := h.appendEvent(ctx, store.Event{
 					StreamType: "user_group",
 					StreamID:   streamID,
 					EventType:  string(eventtypes.UserGroupMemberAdded),
@@ -326,7 +357,9 @@ func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.Id
 					},
 					ActorType: "scim",
 					ActorID:   provider.ID,
-				})
+				}); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -335,7 +368,7 @@ func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.Id
 			if !requestedSet[userID] {
 				h.logger.Debug("SCIM removing member from group", "group_id", groupID, "user_id", userID)
 				streamID := groupID + ":" + userID
-				h.appendEvent(ctx, store.Event{
+				if err := h.appendEvent(ctx, store.Event{
 					StreamType: "user_group",
 					StreamID:   streamID,
 					EventType:  string(eventtypes.UserGroupMemberRemoved),
@@ -345,8 +378,11 @@ func (h *Handler) handleGroupPatchReplace(ctx context.Context, provider store.Id
 					},
 					ActorType: "scim",
 					ActorID:   provider.ID,
-				})
+				}); err != nil {
+					return err
+				}
 			}
 		}
 	}
+	return nil
 }

--- a/internal/scim/handler.go
+++ b/internal/scim/handler.go
@@ -10,12 +10,18 @@ import (
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
-// appendEvent appends an event and logs any error.
-// Use this for best-effort event appends where failure should be logged but not fatal.
-func (h *Handler) appendEvent(ctx context.Context, event store.Event) {
+// appendEvent appends an event, logs the event context on failure, and
+// returns the error so callers fail closed. SCIM must never report success
+// (200/201) on a swallowed append — the projection would silently diverge
+// from what the IdP believes it provisioned, and the IdP, having seen a 2xx,
+// never retries (audit L7). Callers propagate the error to an HTTP 500 so the
+// IdP retries and the projection converges.
+func (h *Handler) appendEvent(ctx context.Context, event store.Event) error {
 	if err := h.store.AppendEvent(ctx, event); err != nil {
 		h.logger.Error("failed to append event", "event_type", event.EventType, "stream_type", event.StreamType, "error", err)
+		return err
 	}
+	return nil
 }
 
 // contextKey is a private type for context keys in this package.

--- a/internal/scim/users_create.go
+++ b/internal/scim/users_create.go
@@ -66,7 +66,10 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 			// (source of truth) and return existing resource. Using 200 instead
 			// of 409 makes POST idempotent for SCIM clients that re-POST on
 			// every sync cycle.
-			h.syncUserFromSCIM(ctx, provider, existing.ID, email, scimUser.Active, scimUser.Name)
+			if err := h.syncUserFromSCIM(ctx, provider, existing.ID, email, scimUser.Active, scimUser.Name); err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to sync user")
+				return
+			}
 			user, err := h.store.Repos().User.Get(ctx, existing.ID)
 			if err != nil {
 				writeJSON(w, http.StatusOK, findExternalIDUserRowToSCIM(existing, baseURL))
@@ -90,7 +93,10 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 		})
 		if err == nil {
 			// Already linked — sync data from SCIM (source of truth) and return
-			h.syncUserFromSCIM(ctx, provider, existing.ID, email, scimUser.Active, scimUser.Name)
+			if err := h.syncUserFromSCIM(ctx, provider, existing.ID, email, scimUser.Active, scimUser.Name); err != nil {
+				writeError(w, http.StatusInternalServerError, "failed to sync user")
+				return
+			}
 			user, readErr := h.store.Repos().User.Get(ctx, existing.ID)
 			if readErr != nil {
 				writeJSON(w, http.StatusOK, findUserRowToSCIM(existing, baseURL))
@@ -183,68 +189,65 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = h.store.AppendEvent(ctx, store.Event{
-		StreamType: "user",
-		StreamID:   userID,
-		EventType:  string(eventtypes.UserCreatedWithRoles),
-		// Pointers always set (possibly to ""): SCIM asserts every
-		// field, mirroring the legacy always-present map keys.
-		Data: payloads.UserCreatedWithRoles{
-			Email:         &email,
-			DisplayName:   ptr(formatExternalName(scimUser.Name)),
-			GivenName:     ptr(safeNameField(scimUser.Name, "given")),
-			FamilyName:    ptr(safeNameField(scimUser.Name, "family")),
-			LinuxUsername: &linuxUsername,
-			LinuxUID:      &linuxUID,
-			RoleIDs:       roleIDs,
+	// Create the user as one atomic unit (audit L7): the UserCreatedWithRoles,
+	// IdentityLinked, and any auto-enable events either all commit or none do.
+	// A mid-sequence failure on independent appends left an orphan user with no
+	// identity link; the IdP's next POST then missed the externalID-keyed dedup
+	// and — with auto-link off — minted a *duplicate* user under a fresh ULID.
+	// Batching makes a failed create roll back fully, so the IdP's retry is
+	// clean. Array order = apply order (user first, then its link/settings).
+	events := []store.Event{
+		{
+			StreamType: "user",
+			StreamID:   userID,
+			EventType:  string(eventtypes.UserCreatedWithRoles),
+			// Pointers always set (possibly to ""): SCIM asserts every
+			// field, mirroring the legacy always-present map keys.
+			Data: payloads.UserCreatedWithRoles{
+				Email:         &email,
+				DisplayName:   ptr(formatExternalName(scimUser.Name)),
+				GivenName:     ptr(safeNameField(scimUser.Name, "given")),
+				FamilyName:    ptr(safeNameField(scimUser.Name, "family")),
+				LinuxUsername: &linuxUsername,
+				LinuxUID:      &linuxUID,
+				RoleIDs:       roleIDs,
+			},
+			ActorType: "scim",
+			ActorID:   provider.ID,
 		},
-		ActorType: "scim",
-		ActorID:   provider.ID,
-	})
-	if err != nil {
-		h.logger.Error("failed to create user via SCIM", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to create user")
-		return
+		{
+			StreamType: "identity_provider",
+			StreamID:   newULID(),
+			EventType:  string(eventtypes.IdentityLinked),
+			Data: payloads.IdentityLinked{
+				UserID:        userID,
+				ProviderID:    provider.ID,
+				ExternalID:    externalID,
+				ExternalEmail: email,
+				ExternalName:  formatExternalName(scimUser.Name),
+			},
+			ActorType: "scim",
+			ActorID:   provider.ID,
+		},
 	}
 
-	// Create identity link
-	linkID := newULID()
-	err = h.store.AppendEvent(ctx, store.Event{
-		StreamType: "identity_provider",
-		StreamID:   linkID,
-		EventType:  string(eventtypes.IdentityLinked),
-		Data: payloads.IdentityLinked{
-			UserID:        userID,
-			ProviderID:    provider.ID,
-			ExternalID:    externalID,
-			ExternalEmail: email,
-			ExternalName:  formatExternalName(scimUser.Name),
-		},
-		ActorType: "scim",
-		ActorID:   provider.ID,
-	})
-	if err != nil {
-		h.logger.Error("failed to create identity link via SCIM", "error", err)
-		writeError(w, http.StatusInternalServerError, "failed to link user")
-		return
-	}
-
-	// Auto-enable provisioning/SSH if global server settings are on
+	// Auto-enable provisioning/SSH if global server settings are on. These join
+	// the same atomic batch — a settings read failure only skips the auto-enable
+	// (not fatal: the user is still created), but a failed append rolls the whole
+	// create back so the IdP retries rather than leaving a half-provisioned user.
 	if settings, err := h.store.Queries().GetServerSettings(ctx); err == nil {
 		if settings.UserProvisioningEnabled {
-			if err := h.store.AppendEvent(ctx, store.Event{
+			events = append(events, store.Event{
 				StreamType: "user",
 				StreamID:   userID,
 				EventType:  string(eventtypes.UserProvisioningSettingsUpdated),
 				Data:       payloads.UserProvisioningSettingsUpdated{UserProvisioningEnabled: ptr(true)},
 				ActorType:  "system",
 				ActorID:    "scim",
-			}); err != nil {
-				h.logger.Warn("failed to auto-enable provisioning for SCIM user", "user_id", userID, "error", err)
-			}
+			})
 		}
 		if settings.SshAccessForAll {
-			if err := h.store.AppendEvent(ctx, store.Event{
+			events = append(events, store.Event{
 				StreamType: "user",
 				StreamID:   userID,
 				EventType:  string(eventtypes.UserSshSettingsUpdated),
@@ -255,12 +258,25 @@ func (h *Handler) createUser(w http.ResponseWriter, r *http.Request) {
 				},
 				ActorType: "system",
 				ActorID:   "scim",
-			}); err != nil {
-				h.logger.Warn("failed to auto-enable SSH for SCIM user", "user_id", userID, "error", err)
-			}
+			})
 		}
 	} else {
 		h.logger.Warn("failed to check server settings for SCIM user defaults", "error", err)
+	}
+
+	if err := h.store.AppendEvents(ctx, events); err != nil {
+		h.logger.Error("failed to create user via SCIM", "error", err)
+		// The DEK minted above is now orphaned — its user rolled back with the
+		// batch. Best-effort shred it so a persistent create failure can't leak a
+		// wrapped key on every IdP retry (each retry mints a fresh userID). The
+		// key sealed nothing (the batch never committed), so this destroys an
+		// inert row. ponytail: bounded cleanup; the full fix is minting the DEK
+		// inside the event transaction, which needs the minter to join AppendEvents.
+		if _, serr := h.store.Repos().UserEncryptionKey.Shred(ctx, userID); serr != nil {
+			h.logger.Warn("failed to shred orphaned user DEK after SCIM create rollback", "user_id", userID, "error", serr)
+		}
+		writeError(w, http.StatusInternalServerError, "failed to create user")
+		return
 	}
 
 	// Read back created user

--- a/internal/scim/users_helpers.go
+++ b/internal/scim/users_helpers.go
@@ -36,46 +36,55 @@ func newULID() string {
 func ptr[T any](v T) *T { return &v }
 
 // syncUserFromSCIM syncs email, active status, profile, and identity link data from SCIM.
-// SCIM is treated as the source of truth — any differences are overwritten.
-func (h *Handler) syncUserFromSCIM(ctx context.Context, provider store.IdentityProvider, userID, email string, active *bool, name *SCIMName) {
+// SCIM is treated as the source of truth — any differences are overwritten. Fails
+// closed (audit L7): a read or append failure is returned so the caller answers
+// 500 and the IdP retries. The per-difference appends are idempotent (each is
+// gated on "changed"), so a retry converges without duplicating state.
+func (h *Handler) syncUserFromSCIM(ctx context.Context, provider store.IdentityProvider, userID, email string, active *bool, name *SCIMName) error {
 	user, err := h.store.Repos().User.Get(ctx, userID)
 	if err != nil {
 		h.logger.Error("failed to get user for SCIM sync", "user_id", userID, "error", err)
-		return
+		return err
 	}
 
 	// Sync email
 	if email != "" && email != user.Email {
-		h.appendEvent(ctx, store.Event{
+		if err := h.appendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
 			EventType:  string(eventtypes.UserEmailChanged),
 			Data:       payloads.UserEmailChanged{Email: &email},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	// Sync active status (nil = not provided, default to true per SCIM RFC 7643)
 	isActive := active == nil || *active
 	if !isActive && !user.Disabled {
-		h.appendEvent(ctx, store.Event{
+		if err := h.appendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
 			EventType:  string(eventtypes.UserDisabled),
 			Data:       payloads.UserDisabled{},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
-		})
+		}); err != nil {
+			return err
+		}
 	} else if isActive && user.Disabled {
-		h.appendEvent(ctx, store.Event{
+		if err := h.appendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
 			EventType:  string(eventtypes.UserEnabled),
 			Data:       payloads.UserEnabled{},
 			ActorType:  "scim",
 			ActorID:    provider.ID,
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	// Sync profile fields (display_name, given_name, family_name)
@@ -87,7 +96,7 @@ func (h *Handler) syncUserFromSCIM(ctx context.Context, provider store.IdentityP
 	// clears the profile ("" overwrite), while an omitted one preserves
 	// it. The old any-non-empty gate made an explicit clear impossible.
 	if name != nil {
-		h.appendEvent(ctx, store.Event{
+		if err := h.appendEvent(ctx, store.Event{
 			StreamType: "user",
 			StreamID:   userID,
 			EventType:  string(eventtypes.UserProfileUpdated),
@@ -101,26 +110,29 @@ func (h *Handler) syncUserFromSCIM(ctx context.Context, provider store.IdentityP
 			},
 			ActorType: "scim",
 			ActorID:   provider.ID,
-		})
+		}); err != nil {
+			return err
+		}
 	}
 
 	// Sync identity link (external_email + external_name)
-	h.syncIdentityLink(ctx, provider, userID, email, name)
+	return h.syncIdentityLink(ctx, provider, userID, email, name)
 }
 
 // syncIdentityLink updates the identity link's external_email and external_name
-// to reflect the latest data from the SCIM provider (source of truth).
-func (h *Handler) syncIdentityLink(ctx context.Context, provider store.IdentityProvider, userID, email string, name *SCIMName) {
+// to reflect the latest data from the SCIM provider (source of truth). Fails
+// closed (audit L7).
+func (h *Handler) syncIdentityLink(ctx context.Context, provider store.IdentityProvider, userID, email string, name *SCIMName) error {
 	link, err := h.store.Queries().GetIdentityLinkByProviderAndUser(ctx, db.GetIdentityLinkByProviderAndUserParams{
 		ProviderID: provider.ID,
 		UserID:     userID,
 	})
 	if err != nil {
 		h.logger.Error("failed to get identity link for SCIM sync", "user_id", userID, "provider_id", provider.ID, "error", err)
-		return
+		return err
 	}
 
-	h.appendEvent(ctx, store.Event{
+	return h.appendEvent(ctx, store.Event{
 		StreamType: "identity_provider",
 		StreamID:   link.ID,
 		EventType:  string(eventtypes.IdentityLinkLoginUpdated),

--- a/internal/scim/users_mutate.go
+++ b/internal/scim/users_mutate.go
@@ -143,7 +143,10 @@ func (h *Handler) replaceUser(w http.ResponseWriter, r *http.Request) {
 	if effectiveEmail == "" {
 		effectiveEmail = existingUser.Email
 	}
-	h.syncIdentityLink(ctx, provider, userID, effectiveEmail, scimUser.Name)
+	if err := h.syncIdentityLink(ctx, provider, userID, effectiveEmail, scimUser.Name); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to sync identity link")
+		return
+	}
 
 	// Read back updated user
 	user, err := h.store.Repos().User.Get(ctx, userID)
@@ -242,7 +245,10 @@ func (h *Handler) patchUser(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to read user")
 		return
 	}
-	h.syncIdentityLink(ctx, provider, userID, patchedUser.Email, extractNameFromPatchOps(patch.Operations))
+	if err := h.syncIdentityLink(ctx, provider, userID, patchedUser.Email, extractNameFromPatchOps(patch.Operations)); err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to sync identity link")
+		return
+	}
 
 	// Look up external ID
 	externalID := ""


### PR DESCRIPTION
## Audit L7 — SCIM sync-path append errors were swallowed while the client was told success

The `appendEvent` helper logged and dropped every event-append failure, so SCIM sync paths returned 200/201 while the projection silently diverged from what the IdP believed it provisioned. Having seen a 2xx, the IdP never retried, so the divergence was permanent.

### Fail-closed
`appendEvent` now returns its error. All 13 swallow sites and the helper chains (`syncUserFromSCIM`, `syncIdentityLink`, `reconcileGroupMembers`, `handleGroupPatch{Add,Remove,Replace}`) propagate it to an HTTP 500 so the IdP retries and the projection converges.

### Underlying issues fixed (not layered over)
- **`createUser` atomicity** — the new-user path now commits `UserCreatedWithRoles` + `IdentityLinked` (+ auto-enable events) via `AppendEvents`. Previously a mid-sequence failure committed the user before the link, leaving an orphan the IdP's next POST duplicated under a fresh ULID (auto-link off). The DEK minted before the batch is **best-effort shredded on rollback** so a persistent failure can't leak a wrapped key per retry.
- **Group-rename atomicity** — the three rename pairs (`replaceGroup`, `patchGroup` replace, `createGroup` re-POST) batch their mapping + user_group events. The change guard reads the *mapping's* display name, so a partial apply would make the retry see equal names, skip the rename, and leave the user_group name **stale forever** (non-convergent). The orphaned-mapping unmap also fails closed instead of falling through to create a duplicate mapping.

Idempotent multi-append paths (member reconcile/add/remove) stay per-append fail-closed — each append is `ON CONFLICT`-idempotent, so a retry after a partial apply converges.

### Tests
Red-before-green regression tests in `atomic_append_test.go`: the swallow (re-POST sync now 500s, not 200), `createUser` atomicity (no orphan user), and DEK-shred-on-rollback. Each verified RED against a scoped neutralization of its fix.

### Reviewer note
A CodeRabbit "major" on the orphaned-mapping ordering in `groups_create.go` was **refuted**: its "returns 500 before cleanup" premise is wrong — `fireListeners` is post-commit and never propagates a projector-vs-missing-group mismatch to `AppendEvents`. That residual is pre-existing, identical before/after this diff, and out of the L7 swallow scope.