### PR TITLE
fix(valkey): confine gateway CRL to read-only + scope indexer ACL (spec 32 A1/A2)

### DIFF
--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -167,6 +167,23 @@ DANGEROUS_OUT="$(compose exec -T -e REDISCLI_AUTH="$VALKEY_CONTROL_PASSWORD" val
 [[ "$DANGEROUS_OUT" == *NOPERM* ]] || { red "FAIL: pm-control can run FLUSHALL"; exit 1; }
 green "pm-control found an indexed search document; unrelated keys + dangerous commands remain denied"
 
+# 5b. Least-privilege confinement of the OTHER writers (spec 32 A1/A2). The
+# gateway reads the CRL but must never write it (else a compromised gateway
+# un-revokes a device fleet-wide); the indexer owns the search namespaces but
+# must not reach the CRL, gateway/device routes, or traefik KV.
+CRL_READ="$(compose exec -T -e REDISCLI_AUTH="$VALKEY_GATEWAY_PASSWORD" valkey \
+  valkey-cli "${VALKEY_TLS_ARGS[@]}" --user pm-gateway ZRANGE pm:crl:revoked 0 -1 2>&1 || true)"
+[[ "$CRL_READ" != *NOPERM* ]] || { red "FAIL: pm-gateway cannot READ pm:crl:revoked"; printf '%s\n' "$CRL_READ"; exit 1; }
+CRL_WRITE="$(compose exec -T -e REDISCLI_AUTH="$VALKEY_GATEWAY_PASSWORD" valkey \
+  valkey-cli "${VALKEY_TLS_ARGS[@]}" --user pm-gateway ZADD pm:crl:revoked 1 smoke-probe 2>&1 || true)"
+[[ "$CRL_WRITE" == *NOPERM* ]] || { red "FAIL: pm-gateway can WRITE pm:crl:revoked (spec 32 A1)"; printf '%s\n' "$CRL_WRITE"; exit 1; }
+for k in pm:crl:revoked pm:gateway:smoke-probe pm:device:smoke-probe traefik/smoke-probe; do
+  IX_WRITE="$(compose exec -T -e REDISCLI_AUTH="$VALKEY_INDEXER_PASSWORD" valkey \
+    valkey-cli "${VALKEY_TLS_ARGS[@]}" --user pm-indexer SET "$k" v 2>&1 || true)"
+  [[ "$IX_WRITE" == *NOPERM* ]] || { red "FAIL: pm-indexer can write $k outside its namespace (spec 32 A2)"; printf '%s\n' "$IX_WRITE"; exit 1; }
+done
+green "pm-gateway CRL is read-only; pm-indexer is confined to its search namespaces"
+
 # 6. Traefik: start it (not gated — no DNS/LE here) so its Valkey ACL path runs.
 compose up -d traefik >>up.log 2>&1 || true
 sleep 8   # let control/indexer subscribe to asynq:cancel + traefik connect

--- a/deploy/valkey.conf.template
+++ b/deploy/valkey.conf.template
@@ -60,14 +60,19 @@ user default off
 user pm-control on >__VALKEY_CONTROL_PASSWORD__ ~asynq:* ~pm:* ~traefik/* ~idx:* ~search:* ~reverse:* ~members:* &asynq:* +@all -@dangerous
 
 # gateway — Asynq consumer/producer, publishes its own routes + registry, reads
-# the CRL. Confined to the gateway/device/crl namespaces + traefik route KV +
-# the Asynq cancellation channel.
-user pm-gateway on >__VALKEY_GATEWAY_PASSWORD__ ~asynq:* ~pm:gateway:* ~pm:device:* ~pm:crl:* ~traefik/* &asynq:* +@all -@dangerous
+# the CRL. Confined to the gateway/device namespaces + traefik route KV + the
+# Asynq cancellation channel. The CRL is READ-ONLY (%R): revocation is a
+# control-plane authority; a compromised gateway must not be able to ZADD/ZREM
+# pm:crl:revoked and un-revoke a device fleet-wide.
+user pm-gateway on >__VALKEY_GATEWAY_PASSWORD__ ~asynq:* ~pm:gateway:* ~pm:device:* %R~pm:crl:* ~traefik/* &asynq:* +@all -@dangerous
 
-# indexer — search-index consumer + FT index owner. valkey-search FT.* commands
-# span the keyspace, so keys are broad, but destructive commands are denied and
-# it holds no pm:secret material. Asynq Server → the cancellation channel.
-user pm-indexer on >__VALKEY_INDEXER_PASSWORD__ ~* &asynq:* +@all -@dangerous
+# indexer — search-index consumer + FT index owner. Owns the search keyspace:
+# idx:* index names, search:* HASH documents, reverse:*/members:* relationship
+# sets, plus its own pm:indexer:* bookkeeping and the asynq:* task keys it
+# consumes. Confined to those namespaces (not ~*) so a compromised indexer
+# cannot reach pm:secret, the CRL, gateway/device routes, or traefik KV.
+# Asynq Server → the cancellation channel.
+user pm-indexer on >__VALKEY_INDEXER_PASSWORD__ ~asynq:* ~idx:* ~search:* ~reverse:* ~members:* ~pm:indexer:* &asynq:* +@all -@dangerous
 
 # traefik — internet-facing + Docker-socket-exposed, so the smallest KEY surface:
 # READ-ONLY discovery on traefik/* only (writes + the queues + CRL are denied —

--- a/internal/datastore/valkey_tls_integration_test.go
+++ b/internal/datastore/valkey_tls_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -105,5 +106,131 @@ func TestValkeyMutualTLS_AndACL_Integration(t *testing.T) {
 	}
 	if err := scoped.FlushAll(cctx).Err(); err == nil || !strings.Contains(err.Error(), "NOPERM") {
 		t.Errorf("pmscoped must be denied FLUSHALL (@dangerous) with NOPERM, got: %v", err)
+	}
+}
+
+// templateACLUsers renders the real per-service ACL `user` lines from the deploy
+// template with test passwords substituted. Reading the live template (rather
+// than hardcoding grants) keeps the confinement test tracking production: a
+// widened grant in valkey.conf.template surfaces here.
+func templateACLUsers(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile("../../deploy/valkey.conf.template")
+	if err != nil {
+		t.Fatalf("read valkey.conf.template: %v", err)
+	}
+	repl := strings.NewReplacer(
+		"__VALKEY_CONTROL_PASSWORD__", "ctlpw",
+		"__VALKEY_GATEWAY_PASSWORD__", "gwpw",
+		"__VALKEY_INDEXER_PASSWORD__", "ixpw",
+		"__VALKEY_TRAEFIK_PASSWORD__", "trfpw",
+	)
+	var b strings.Builder
+	for _, line := range strings.Split(string(raw), "\n") {
+		if strings.HasPrefix(line, "user ") {
+			b.WriteString(repl.Replace(line))
+			b.WriteByte('\n')
+		}
+	}
+	if b.Len() == 0 {
+		t.Fatal("no ACL user lines found in valkey.conf.template (matches-zero guard)")
+	}
+	return b.String()
+}
+
+// TestValkeyProductionACL_NamespaceConfinement_Integration exercises the actual
+// per-service ACL users from valkey.conf.template (spec 32 AC 4), not a synthetic
+// stand-in. It proves the two confinement invariants the 2026-07-18 audit found
+// broken:
+//
+//   - pm-gateway may READ the CRL but must NOT write it (a compromised gateway
+//     ZREM-ing its own fingerprint would defeat revocation fleet-wide).
+//   - pm-indexer is confined to its search namespaces and cannot reach
+//     traefik/pm:gateway/pm:crl (a full-keyspace grant re-opens the same blast
+//     radius the spec exists to close).
+func TestValkeyProductionACL_NamespaceConfinement_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test (real Valkey container)")
+	}
+	certAuth := buildTestCA(t)
+	caPEM, srvCertPEM, srvKeyPEM, cliCertPEM, cliKeyPEM := caIssuedPKI(t, certAuth, "valkey-client")
+
+	valkeyConf := "port 0\n" +
+		"tls-port 6379\n" +
+		"tls-cert-file /certs/server.crt\n" +
+		"tls-key-file /certs/server.key\n" +
+		"tls-ca-cert-file /certs/ca.crt\n" +
+		"tls-auth-clients yes\n" +
+		"save \"\"\n" +
+		templateACLUsers(t)
+
+	ctx := context.Background()
+	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Image:        "valkey/valkey-bundle:9.1.0",
+			ExposedPorts: []string{"6379/tcp"},
+			Cmd:          []string{"valkey-server", "/etc/valkey/valkey.conf"},
+			Files: []testcontainers.ContainerFile{
+				{Reader: bytes.NewReader([]byte(valkeyConf)), ContainerFilePath: "/etc/valkey/valkey.conf", FileMode: 0o644},
+				{Reader: bytes.NewReader(srvCertPEM), ContainerFilePath: "/certs/server.crt", FileMode: 0o644},
+				{Reader: bytes.NewReader(srvKeyPEM), ContainerFilePath: "/certs/server.key", FileMode: 0o644},
+				{Reader: bytes.NewReader(caPEM), ContainerFilePath: "/certs/ca.crt", FileMode: 0o644},
+			},
+			WaitingFor: wait.ForLog("Ready to accept connections").WithStartupTimeout(60 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("start tls valkey: %v", err)
+	}
+	t.Cleanup(func() { _ = container.Terminate(ctx) })
+
+	port, err := container.MappedPort(ctx, "6379")
+	if err != nil {
+		t.Fatalf("port: %v", err)
+	}
+	addr := fmt.Sprintf("localhost:%s", port.Port())
+
+	clientTLS, err := datastore.ValkeyClientTLS(cliCertPEM, cliKeyPEM, caPEM)
+	if err != nil {
+		t.Fatalf("ValkeyClientTLS: %v", err)
+	}
+	cctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	// pm-gateway: reads the CRL and writes its own namespaces, but never writes
+	// the CRL (A1 — revocation-defeat guard).
+	gw := redis.NewClient(&redis.Options{Addr: addr, Username: "pm-gateway", Password: "gwpw", Protocol: 2, TLSConfig: clientTLS})
+	defer gw.Close()
+	if err := gw.ZRange(cctx, "pm:crl:revoked", 0, -1).Err(); err != nil {
+		t.Errorf("pm-gateway must be able to READ pm:crl:revoked: %v", err)
+	}
+	if err := gw.Set(cctx, "pm:gateway:probe", "v", 0).Err(); err != nil {
+		t.Errorf("pm-gateway must write its own pm:gateway:* namespace: %v", err)
+	}
+	if err := gw.ZAdd(cctx, "pm:crl:revoked", redis.Z{Score: 1, Member: "fp"}).Err(); err == nil || !strings.Contains(err.Error(), "NOPERM") {
+		t.Errorf("pm-gateway must be denied ZADD pm:crl:revoked with NOPERM (spec 32 A1), got: %v", err)
+	}
+	if err := gw.ZRem(cctx, "pm:crl:revoked", "fp").Err(); err == nil || !strings.Contains(err.Error(), "NOPERM") {
+		t.Errorf("pm-gateway must be denied ZREM pm:crl:revoked with NOPERM (spec 32 A1), got: %v", err)
+	}
+
+	// pm-indexer: confined to its search namespaces; cannot reach other keyspaces
+	// (A2 — the ~* grant re-opens the full blast radius).
+	ix := redis.NewClient(&redis.Options{Addr: addr, Username: "pm-indexer", Password: "ixpw", Protocol: 2, TLSConfig: clientTLS})
+	defer ix.Close()
+	if err := ix.Set(cctx, "idx:probe", "v", 0).Err(); err != nil {
+		t.Errorf("pm-indexer must write its own idx:* namespace: %v", err)
+	}
+	if err := ix.Set(cctx, "search:device:probe", "v", 0).Err(); err != nil {
+		t.Errorf("pm-indexer must write its own search:* namespace: %v", err)
+	}
+	for _, k := range []string{"traefik/probe", "pm:gateway:probe", "pm:device:probe"} {
+		if err := ix.Set(cctx, k, "v", 0).Err(); err == nil || !strings.Contains(err.Error(), "NOPERM") {
+			t.Errorf("pm-indexer must be denied write to %q with NOPERM (spec 32 A2), got: %v", k, err)
+		}
+	}
+	if err := ix.ZAdd(cctx, "pm:crl:revoked", redis.Z{Score: 1, Member: "fp"}).Err(); err == nil || !strings.Contains(err.Error(), "NOPERM") {
+		t.Errorf("pm-indexer must be denied ZADD pm:crl:revoked with NOPERM (spec 32 A2), got: %v", err)
 	}
 }


### PR DESCRIPTION
## Spec 32 audit — datastore ACL least-privilege holes (A1, A2)

The 2026-07-18 spec audit found the per-service Valkey ACL, though otherwise
minimal, re-opened two namespaces the model exists to confine:

### A1 — gateway could write the CRL (revocation defeat)
`user pm-gateway … ~pm:crl:*` granted **read-write** on `pm:crl:revoked`. The
gateway only ever *reads* the CRL to fail-closed on revoked agents; write access
means a compromised gateway can `ZADD`/`ZREM pm:crl:revoked` and un-revoke a
device **fleet-wide**. Revocation is a control-plane authority.

**Fix:** `~pm:crl:*` → `%R~pm:crl:*` (read-only).

### A2 — indexer held the entire keyspace (`~*`)
`user pm-indexer … ~*` gave the search indexer read-write on *everything* —
`pm:secret:*`, the CRL, gateway/device routes, traefik KV. The old comment
justified this as "valkey-search FT.* commands span the keyspace"; verified
against `internal/search/index.go` + `cmd/indexer`, the indexer only touches
`asynq:*`, `idx:*`, `search:*`, `reverse:*`, `members:*`, and its own
`pm:indexer:*` bookkeeping.

**Fix:** `~*` → `~asynq:* ~idx:* ~search:* ~reverse:* ~members:* ~pm:indexer:*`.

## Tests
- `TestValkeyProductionACL_NamespaceConfinement_Integration` renders the
  production ACL from the template and asserts the denials against a real Valkey
  container (added RED-first: it failed on the old ACL because the writes
  succeeded, passes now that they NOPERM).
- Equivalent NOPERM guards added to `deploy/smoke-test.sh` (5b).
- **Full deployment E2E gate run locally and green** — all services healthy
  under the confined ACL, indexer still creates FT indexes and indexes documents
  that control finds via `FT.SEARCH`, no NOPERM/TLS errors in any service log.