### PR TITLE
feat(erasure): AC 36 doctor safety-net + auto-reconcile for dropped user teardown (spec 19)

### DIFF
--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -104,7 +104,7 @@ Flags:
 - `--env-file <path>` — also inspect this `.env` (default `.env`, silently skipped if absent). Values in the file take precedence over the process environment — it is the operator's stored config, the source of truth for what was configured.
 <!-- docref: end -->
 
-<!-- docref: begin src=internal/doctor/registry.go#DefaultChecks:dd5d9b84 -->
+<!-- docref: begin src=internal/doctor/registry.go#DefaultChecks:bc2ea180 -->
 It reports placeholder/weak secrets, mandatory at-rest encryption key, a
 credentialed CORS wildcard, an internal mTLS listener bound to all interfaces, a
 floating `IMAGE_TAG`, certificate file permissions and approaching expiry,
@@ -113,7 +113,9 @@ and indexer liveness (reconcile heartbeat), remote-terminal (TTY) routing and
 config consistency (Valkey keyspace notifications, web-listener and TTY-host
 config), a bootstrap admin still on the default email, the per-user
 encryption-key invariants that crypto-shred erasure depends on (every live
-user's DEK unwraps; no erased user retains one), projection drift (a
+user's DEK unwraps; no erased user retains one), erased-user teardown (no
+erased user still has a live system account action provisioned on devices),
+projection drift (a
 projection that has stopped applying events, caught before retention prunes
 the source events), and the audit-log retention posture (event count, oldest
 event age, configured window, last prune — plus a critical finding when

--- a/internal/api/system_actions.go
+++ b/internal/api/system_actions.go
@@ -98,6 +98,50 @@ func (m *SystemActionManager) SyncAllUsersSystemActions(ctx context.Context) err
 		m.logger.Error("failed to reconcile scoped TerminalAdmin actions during sync sweep", "error", err)
 	}
 
+	// Spec 19 AC 36: tear down any erased user whose account teardown was
+	// dropped (queue down at delete time), so the OS account is removed from
+	// devices instead of persisting. Embedded here, like the TerminalAdmin
+	// reconciles, so it rides the same periodic cadence + best-effort shape.
+	if err := m.ReconcileErasedUserTeardown(ctx); err != nil {
+		m.logger.Error("failed to reconcile erased-user teardown during sync sweep", "error", err)
+	}
+
+	return nil
+}
+
+// ReconcileErasedUserTeardown re-runs account teardown for erased (is_deleted)
+// users whose system USER action is still live and PRESENT — the incomplete
+// teardown spec 19 AC 36's doctor check reports. DeleteUser's teardown is
+// best-effort (logged, never fails the delete so erasure always completes); if
+// it was dropped, this sweep converges the dropped case to the succeeded case:
+// the same CleanupDeletedUserActions the delete handler runs, reconstructed from
+// the (redacted) projection — only the user id and the system-action ids are
+// needed, none of which is PII, so this works after the DEK shred.
+//
+// Best-effort per user (one failure does not abort the sweep) and idempotent: a
+// torn-down action drops out of the next scan. Runs on every replica like the
+// TerminalAdmin reconciles; a duplicate ActionDeleted/UserSystemActionLinked is
+// a harmless no-op / version-conflict, not a correctness problem.
+func (m *SystemActionManager) ReconcileErasedUserTeardown(ctx context.Context) error {
+	orphans, err := m.store.ErasedUsersStillProvisioned(ctx)
+	if err != nil {
+		return fmt.Errorf("list erased users still provisioned: %w", err)
+	}
+	for _, o := range orphans {
+		// CleanupDeletedUserActions reads only these fields — no PII.
+		user := store.User{
+			ID:                 o.UserID,
+			SystemUserActionID: o.SystemUserActionID,
+			SystemSshActionID:  o.SystemSshActionID,
+			SystemTtyActionID:  o.SystemTtyActionID,
+		}
+		if err := m.CleanupDeletedUserActions(ctx, user); err != nil {
+			m.logger.Error("failed to reconcile teardown for erased user", "user_id", o.UserID, "error", err)
+			continue
+		}
+		m.logger.Warn("reconciled dropped teardown for erased user — OS account removal re-dispatched",
+			"user_id", o.UserID, "system_user_action_id", o.SystemUserActionID)
+	}
 	return nil
 }
 

--- a/internal/api/system_actions_manager_test.go
+++ b/internal/api/system_actions_manager_test.go
@@ -178,6 +178,55 @@ func TestCleanupDeletedUserActions_RemovesAllSystemActions(t *testing.T) {
 }
 
 // =============================================================================
+// ReconcileErasedUserTeardown — spec 19 AC 36 auto-remediation
+// =============================================================================
+
+// TestReconcileErasedUserTeardown_TearsDownDroppedTeardown proves the sweep
+// converges a DROPPED teardown (erased user whose delete never ran
+// CleanupDeletedUserActions) to the succeeded state: the live PRESENT system
+// USER action is removed and the link cleared. A cleanly torn-down erased user
+// and a live user are left untouched.
+func TestReconcileErasedUserTeardown_TearsDownDroppedTeardown(t *testing.T) {
+	m, st := newManagerForTest(t)
+	ctx := context.Background()
+	enableGlobalProvisioning(t, st)
+
+	// Orphan: provisioned, then erased WITHOUT running teardown (drop).
+	orphan := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, orphan, "orphan")
+	require.NoError(t, m.SyncUserSystemActions(ctx, orphan))
+	before, err := st.Repos().User.Get(ctx, orphan)
+	require.NoError(t, err)
+	require.NotEmpty(t, before.SystemUserActionID, "precondition: orphan has a live system action")
+	_, err = st.TestingPool().Exec(ctx, `UPDATE users_projection SET is_deleted = true WHERE id = $1`, orphan)
+	require.NoError(t, err)
+
+	// Live control: a normal provisioned user must survive the sweep.
+	live := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "viewer")
+	setLinuxUsername(t, st, live, "liveuser")
+	require.NoError(t, m.SyncUserSystemActions(ctx, live))
+	liveBefore, err := st.Repos().User.Get(ctx, live)
+	require.NoError(t, err)
+	require.NotEmpty(t, liveBefore.SystemUserActionID)
+
+	require.NoError(t, m.ReconcileErasedUserTeardown(ctx))
+
+	// Orphan's action link is cleared → teardown was re-run.
+	orphans, err := st.ErasedUsersStillProvisioned(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, orphans, "the sweep drained every erased-user orphan")
+
+	// Idempotent: a second run over the now-clean state is a no-op, no error.
+	require.NoError(t, m.ReconcileErasedUserTeardown(ctx))
+
+	// The live user is untouched (its is_deleted is false, so it was never an orphan).
+	liveAfter, err := st.Repos().User.Get(ctx, live)
+	require.NoError(t, err)
+	assert.Equal(t, liveBefore.SystemUserActionID, liveAfter.SystemUserActionID,
+		"a live user's system action must NOT be torn down by the erasure sweep")
+}
+
+// =============================================================================
 // SyncUserSystemActions — provisioning disabled cleans up prior action
 // =============================================================================
 

--- a/internal/doctor/check_erasure.go
+++ b/internal/doctor/check_erasure.go
@@ -1,0 +1,52 @@
+package doctor
+
+import (
+	"context"
+	"fmt"
+)
+
+// ErasureProvisioningCheck is the spec 19 AC 36 safety net: it flags an erased
+// (is_deleted) user whose OS account teardown was incomplete — their system
+// USER action is still live (not deleted) and PRESENT, so the account persists
+// on already-provisioned devices. Deletion crypto-shreds the DEK and redacts the
+// projection, but the account teardown rides on a best-effort
+// CleanupDeletedUserActions call (user_handler.go — logged, never fails the
+// delete so erasure always completes). If that teardown was dropped (queue down,
+// gateway offline), the user's OS account can persist on devices with the
+// projection already redacted and no other alarm — a GDPR/NIS2 gap. This check
+// is that alarm; the reconcile sweep (control periodic worker) is the auto-fix.
+//
+// A lingering user_provisioning_enabled flag is intentionally not flagged:
+// SyncUserSystemActions fail-closes on is_deleted (AC 32), so an erased user can
+// never re-acquire a provisioning action, and nothing clears the flag on delete
+// — treating it as a finding would fire on every erased user a
+// provisioning-for-all deployment ever had.
+//
+// Read-only: the check reports; reconciliation is the sweep's / operator's job.
+type ErasureProvisioningCheck struct{}
+
+func (ErasureProvisioningCheck) ID() string { return "erasure_provisioning" }
+
+func (c ErasureProvisioningCheck) Run(ctx context.Context, env *Env) ([]Finding, error) {
+	if skip, proceed := dbReady(ctx, c, env); !proceed {
+		return skip, nil
+	}
+
+	orphans, err := env.DB.ErasedUsersStillProvisioned(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list erased users still provisioned: %w", err)
+	}
+	if len(orphans) == 0 {
+		return []Finding{ok(c.ID(),
+			"no erased user retains a live OS account (teardown completed for every deleted user)")}, nil
+	}
+
+	ids := make([]string, len(orphans))
+	for i, o := range orphans {
+		ids[i] = o.UserID
+	}
+	return []Finding{crit(c.ID(),
+		fmt.Sprintf("%d erased user(s) still have a live PRESENT system USER action — their OS account persists on devices (incomplete teardown): %s",
+			len(orphans), sample(ids)),
+		"the reconcile sweep re-runs teardown automatically; if it is disabled, re-run the user teardown so the system USER action is removed and the account is deleted from devices — until then the erased account lives on managed hosts")}, nil
+}

--- a/internal/doctor/check_erasure_test.go
+++ b/internal/doctor/check_erasure_test.go
@@ -1,0 +1,36 @@
+package doctor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+func TestErasureProvisioningCheck_CleanIsOK(t *testing.T) {
+	env := testEnv(nil)
+	env.DB = fakeDB{} // no orphans
+	fs := run1(t, ErasureProvisioningCheck{}, env)
+	assert.Equal(t, SeverityOK, worst(fs), "no erased user retains a live account")
+}
+
+func TestErasureProvisioningCheck_LiveActionIsCritical(t *testing.T) {
+	env := testEnv(nil)
+	env.DB = fakeDB{orphans: []store.ErasedProvisioning{
+		{UserID: "erased-1", SystemUserActionID: "act-1"},
+	}}
+	fs := run1(t, ErasureProvisioningCheck{}, env)
+	require.Equal(t, SeverityCritical, worst(fs))
+	txt := findingText(fs)
+	assert.Contains(t, txt, "live PRESENT system USER action",
+		"AC 36: a lingering PRESENT system USER action is the flagged gap")
+	assert.Contains(t, txt, "persists on devices", "and the finding names the real exposure")
+}
+
+func TestErasureProvisioningCheck_DBDownSkips(t *testing.T) {
+	env := testEnv(nil) // DB nil → dbReady returns a skip, not a false pass
+	fs := run1(t, ErasureProvisioningCheck{}, env)
+	assert.NotEqual(t, SeverityCritical, worst(fs), "a down DB skips rather than false-flags")
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -30,6 +30,8 @@ type fakeDB struct {
 	driftErr    error
 	posture     store.RetentionPosture
 	postureErr  error
+	orphans     []store.ErasedProvisioning
+	orphanErr   error
 }
 
 func (f fakeDB) Ping(context.Context) error { return f.pingErr }
@@ -47,6 +49,9 @@ func (f fakeDB) ProjectionDrift(context.Context) ([]store.TargetDrift, error) {
 }
 func (f fakeDB) RetentionPosture(context.Context) (store.RetentionPosture, error) {
 	return f.posture, f.postureErr
+}
+func (f fakeDB) ErasedUsersStillProvisioned(context.Context) ([]store.ErasedProvisioning, error) {
+	return f.orphans, f.orphanErr
 }
 
 type fakeCache struct {

--- a/internal/doctor/env.go
+++ b/internal/doctor/env.go
@@ -150,6 +150,9 @@ type DBProbe interface {
 	// DeletedUsersWithDEK returns erased users that still hold a DEK row — the
 	// resurrected-shredded-key anomaly (spec 19 AC 31).
 	DeletedUsersWithDEK(ctx context.Context) ([]string, error)
+	// ErasedUsersStillProvisioned returns erased users whose OS provisioning
+	// outlived their erasure — incomplete teardown (spec 19 AC 36).
+	ErasedUsersStillProvisioned(ctx context.Context) ([]store.ErasedProvisioning, error)
 	// ProjectionDrift compares each rebuild target's projection high-water
 	// against the events it should have applied (spec 19 AC 31a).
 	ProjectionDrift(ctx context.Context) ([]store.TargetDrift, error)

--- a/internal/doctor/probe.go
+++ b/internal/doctor/probe.go
@@ -55,6 +55,10 @@ func (p *PGProbe) DeletedUsersWithDEK(ctx context.Context) ([]string, error) {
 	return store.DeletedUsersWithDEK(ctx, p.pool)
 }
 
+func (p *PGProbe) ErasedUsersStillProvisioned(ctx context.Context) ([]store.ErasedProvisioning, error) {
+	return store.ErasedUsersStillProvisioned(ctx, p.pool)
+}
+
 func (p *PGProbe) ProjectionDrift(ctx context.Context) ([]store.TargetDrift, error) {
 	return store.ComputeProjectionDrift(ctx, p.pool)
 }

--- a/internal/doctor/registry.go
+++ b/internal/doctor/registry.go
@@ -20,5 +20,6 @@ func DefaultChecks() []Check {
 		DEKInvariantCheck{},
 		ProjectionDriftCheck{},
 		RetentionPostureCheck{},
+		ErasureProvisioningCheck{},
 	}
 }

--- a/internal/store/observability.go
+++ b/internal/store/observability.go
@@ -85,6 +85,61 @@ func DeletedUsersWithDEK(ctx context.Context, pool *pgxpool.Pool) ([]string, err
 	return out, rows.Err()
 }
 
+// ErasedProvisioning names an erased (is_deleted) user whose account teardown
+// was incomplete — their system USER action is still live and PRESENT, so the
+// OS account persists on already-provisioned devices (spec 19 AC 36). The three
+// linked system-action ids are carried so the reconcile sweep can re-run the
+// same teardown DeleteUser would have.
+//
+// A lingering user_provisioning_enabled flag is deliberately NOT a signal here:
+// SyncUserSystemActions fail-closes on is_deleted (AC 32), so an erased user can
+// never re-acquire a provisioning action regardless of that flag. It is cosmetic
+// (nothing clears it on delete), and flagging it would fire on every erased user
+// a provisioning-for-all deployment ever had — alarm fatigue, not a real gap.
+type ErasedProvisioning struct {
+	UserID             string
+	SystemUserActionID string
+	SystemSshActionID  string
+	SystemTtyActionID  string
+}
+
+// ErasedUsersStillProvisioned returns erased users whose OS account teardown was
+// dropped: their system USER action is still live (not deleted) and PRESENT, so
+// the account persists on managed devices (spec 19 AC 36 doctor safety net /
+// reconcile source). is_deleted (the durable projection flag) is used rather
+// than the UserDeleted event so the check still holds after that event has
+// itself been pruned. Read-only.
+func ErasedUsersStillProvisioned(ctx context.Context, pool *pgxpool.Pool) ([]ErasedProvisioning, error) {
+	// DESIRED_STATE_PRESENT is 0 (sdk pm.v1). A PRESENT, non-deleted action
+	// referenced by system_user_action_id means the account was never torn
+	// down. The empty-string default of system_user_action_id matches no
+	// action id, so the EXISTS is naturally false for a cleanly-torn-down user.
+	rows, err := pool.Query(ctx, `
+		SELECT u.id, u.system_user_action_id, u.system_ssh_action_id, u.system_tty_action_id
+		FROM users_projection u
+		WHERE u.is_deleted
+		  AND EXISTS (
+		      SELECT 1 FROM actions_projection a
+		      WHERE a.id = u.system_user_action_id
+		        AND NOT a.is_deleted
+		        AND a.desired_state = 0
+		  )
+		ORDER BY u.id`)
+	if err != nil {
+		return nil, fmt.Errorf("observability: list erased users still provisioned: %w", err)
+	}
+	defer rows.Close()
+	var out []ErasedProvisioning
+	for rows.Next() {
+		var e ErasedProvisioning
+		if err := rows.Scan(&e.UserID, &e.SystemUserActionID, &e.SystemSshActionID, &e.SystemTtyActionID); err != nil {
+			return nil, fmt.Errorf("observability: scan erased user provisioning: %w", err)
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
 // RetentionPosture is the read-only snapshot `control doctor` reports for
 // AC 29: how big/old the live event log is and when retention last acted.
 type RetentionPosture struct {
@@ -253,6 +308,14 @@ func ComputeProjectionDrift(ctx context.Context, pool *pgxpool.Pool) ([]TargetDr
 // never has to reach for TestingPool (which is deliberately test-only).
 func (s *Store) ComputeProjectionDrift(ctx context.Context) ([]TargetDrift, error) {
 	return ComputeProjectionDrift(ctx, s.pool)
+}
+
+// ErasedUsersStillProvisioned is the production accessor for the erasure
+// reconcile sweep (spec 19 AC 36), which holds a *Store and not a raw pool. The
+// free function above takes a pool so the doctor probe and store tests can call
+// it without a full Store; this method wraps it over the store's own pool.
+func (s *Store) ErasedUsersStillProvisioned(ctx context.Context) ([]ErasedProvisioning, error) {
+	return ErasedUsersStillProvisioned(ctx, s.pool)
 }
 
 // tablesWithProjectionVersion returns the set of public base tables that

--- a/internal/store/observability_test.go
+++ b/internal/store/observability_test.go
@@ -72,6 +72,75 @@ func TestDeletedUsersWithDEK(t *testing.T) {
 	assert.NotContains(t, ids, live, "a live user is not a deletion anomaly")
 }
 
+// TestErasedUsersStillProvisioned pins the AC 36 safety-net data source: an
+// erased user whose OS account teardown was dropped — their system USER action
+// is still live and PRESENT — is reported (with its linked action ids for the
+// sweep), while a cleanly-torn-down erased user, a deleted action, and a live
+// user are not. A lingering provisioning flag alone is NOT a signal (AC 32).
+func TestErasedUsersStillProvisioned(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+	pool := st.TestingPool()
+
+	erase := func(id string) {
+		_, err := pool.Exec(ctx, `UPDATE users_projection SET is_deleted = true WHERE id = $1`, id)
+		require.NoError(t, err)
+	}
+	// seedUserAction inserts a system action with a chosen desired_state /
+	// deleted flag and links it as the user's system USER action.
+	seedUserAction := func(userID string, desiredState int, deleted bool) string {
+		actID := testutil.NewID()
+		_, err := pool.Exec(ctx,
+			`INSERT INTO actions_projection (id, name, action_type, is_system, is_deleted, desired_state)
+			 VALUES ($1, $2, 0, true, $3, $4)`,
+			actID, "sys-user-"+actID[:6], deleted, desiredState)
+		require.NoError(t, err)
+		_, err = pool.Exec(ctx,
+			`UPDATE users_projection SET system_user_action_id = $2 WHERE id = $1`, userID, actID)
+		require.NoError(t, err)
+		return actID
+	}
+
+	// Clean teardown: erased, system action set ABSENT.
+	clean := testutil.CreateTestUser(t, st, "clean-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	seedUserAction(clean, 1 /*ABSENT*/, false)
+	erase(clean)
+
+	// Provisioning flag left set but no live action — cosmetic, must NOT flag.
+	provOn := testutil.CreateTestUser(t, st, "provon-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	_, err := pool.Exec(ctx, `UPDATE users_projection SET user_provisioning_enabled = true WHERE id = $1`, provOn)
+	require.NoError(t, err)
+	erase(provOn)
+
+	// Live PRESENT system USER action still targeting an erased user — the gap.
+	livePresent := testutil.CreateTestUser(t, st, "livep-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	liveActID := seedUserAction(livePresent, 0 /*PRESENT*/, false)
+	erase(livePresent)
+
+	// A deleted action is not "live" even if PRESENT → must NOT flag.
+	deletedAction := testutil.CreateTestUser(t, st, "delact-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	seedUserAction(deletedAction, 0 /*PRESENT*/, true /*deleted*/)
+	erase(deletedAction)
+
+	// A LIVE (non-erased) user with a PRESENT action is not an erasure anomaly.
+	liveUser := testutil.CreateTestUser(t, st, "liveu-"+testutil.NewID()[:8]+"@test.com", "pass", "user")
+	seedUserAction(liveUser, 0 /*PRESENT*/, false)
+
+	orphans, err := store.ErasedUsersStillProvisioned(ctx, pool)
+	require.NoError(t, err)
+
+	byID := map[string]store.ErasedProvisioning{}
+	for _, o := range orphans {
+		byID[o.UserID] = o
+	}
+	assert.Contains(t, byID, livePresent, "erased user with a live PRESENT system USER action is flagged")
+	assert.Equal(t, liveActID, byID[livePresent].SystemUserActionID, "carries the action id for the sweep")
+	assert.NotContains(t, byID, clean, "a cleanly torn-down erased user is not flagged")
+	assert.NotContains(t, byID, provOn, "a lingering provisioning flag alone is not a signal (AC 32 closes it)")
+	assert.NotContains(t, byID, deletedAction, "a deleted (not live) system action does not flag")
+	assert.NotContains(t, byID, liveUser, "a live user is not an erasure anomaly")
+}
+
 // TestComputeProjectionDrift pins AC 31a: a projection whose tail is
 // behind the newest event in its streams is reported as drifted, while a
 // healthy projection is not.


### PR DESCRIPTION
## Spec 19 AC 36 — the erased-account-persists gap

`DeleteUser` crypto-shreds the DEK and redacts the projection, but the OS-account
teardown rides on a **best-effort** `CleanupDeletedUserActions` call — logged,
never fails the delete (so erasure always completes). If that teardown is dropped
(Asynq/Valkey down, gateway offline), the erased user's Linux account **persists
on devices** with the projection already redacted and no other alarm: a
GDPR/NIS2 gap the audit rated Medium.

## Fix — report *and* remediation
- **`erasure_provisioning` doctor check** flags any `is_deleted` user whose system
  USER action is still live (not deleted) and PRESENT — the real "account
  persists" exposure. Backed by the read-only `ErasedUsersStillProvisioned` store
  query.
- **`ReconcileErasedUserTeardown`**, embedded in the periodic
  `SyncAllUsersSystemActions` sweep next to the TerminalAdmin reconciles, re-runs
  the exact teardown the delete handler would have — reconstructed from the
  redacted projection (only the user id + system-action ids, no PII) — converging
  a dropped teardown to the succeeded state. Best-effort per user, idempotent,
  multi-replica-safe (same shape as the existing reconciles).

## Withdrawn sub-finding
The original finding also named a lingering `user_provisioning_enabled` flag. On
tracing it, AC 32's fail-closed provisioning choke point (`SyncUserSystemActions`
refuses `is_deleted` users) already makes a stale flag harmless, and nothing
clears it on delete — so flagging it would fire on **every** erased user a
provisioning-for-all deployment ever had (alarm fatigue) while protecting against
nothing. Dropped as a signal; documented in the spec amendment
(power-manage-docs `3064604`).

## Tests
- Real-Postgres store test, red-verified via the PRESENT/ABSENT discriminator.
- Manager-level sweep test: a dropped teardown is reconciled, a live user is
  untouched — red-verified by neutralizing the teardown call.
- Doctor unit tests for the finding + the DB-down skip; the self-discovering
  completeness guard covers the new check.