### PR TITLE
spec 19 audit follow-ups: AC 13 uniform-NotFound, AC 14 rollback test, ADR 0033

### DIFF
--- a/docs/adr/0033-audit-retention-crypto-shred-erasure.md
+++ b/docs/adr/0033-audit-retention-crypto-shred-erasure.md
@@ -1,0 +1,103 @@
+# 0033 — Audit-log retention window + crypto-shred erasure contract
+
+- Status: accepted
+- Date: 2026-07-18
+- Related: spec 19 (docs repo, `06-specs/19-audit-retention-and-erasure.md`);
+  ADR 0029 (all Postgres state is event-sourced or classified — **amended** by
+  this ADR: `user_encryption_keys` is the sole durable-non-recoverable,
+  non-event-sourced exception); ADR 0030 (single AAD at-rest format — the DEK
+  wraps under its `enc:v1:` envelope); ADR 0001 (AES key rotation — the DEK
+  envelope enables cheap KEK rotation for PII).
+
+## Context
+
+Spec 19 introduced two things the event-sourcing contract (ADR 0029) had no
+place for:
+
+1. **A right-to-erasure that survives an append-only log.** The events table is
+   immutable by design (ADR 0026/0029: it is both the system of record and the
+   audit log, and replay must reproduce state 1:1). PII written into an event
+   payload can therefore never be deleted or overwritten. GDPR erasure demands
+   the opposite. Hard-deleting events, or holding PII out of the log in a
+   separate deletable store, would each break the replay guarantee.
+2. **A bounded audit-retention window with off-box archival.** An unbounded
+   event log grows without limit and keeps audit records past any lawful
+   retention period; pruning old events must not silently discard them, and the
+   pruned data must remain independently auditable.
+
+Spec 19's References section names an ADR for this contract but the number it
+reserved (0030) was taken by the unrelated single-AAD-format ADR (spec 20).
+This ADR is the record spec 19 always intended; it is written now to close that
+gap and to record the ADR-0029 amendment explicitly rather than only in prose.
+
+## Decision
+
+**Crypto-shred is the erasure mechanism.** Every user is minted one random
+32-byte data-encryption key (DEK) at creation. PII-tagged event-payload fields
+(`pii:"true"`) are sealed under the *subject* user's DEK before append (format
+tag `pii:v1:`, distinct from the `enc:v1:` at-rest secret format); projectors
+unseal at projection-build time. Deleting the user destroys the one
+`user_encryption_keys` row, which makes every copy of that person's PII — live
+log, cold archives, and any future rebuild — permanently unreadable at once,
+without ever mutating the append-only log.
+
+- **Fail-closed sealing (spec 19 AC 6).** A sealing error aborts the append. The
+  log is immutable, so plaintext PII written once is unerasable forever; refusing
+  the write is always cheaper than an un-shreddable leak.
+- **Atomic shred (spec 19 AC 7/14).** The `UserDeleted` append and the DEK-row
+  delete happen in ONE transaction (`AppendUserDeletionWithShred`) — all or
+  nothing. A failed shred rolls the deletion back; there is no half-erased state.
+- **Redaction on missing DEK.** A projector that finds a sealed PII value with no
+  DEK projects the redaction sentinel — a shredded user's projection is
+  indistinguishable from one that was never populated.
+
+**`user_encryption_keys` is the sole durable-non-recoverable exception (amends
+ADR 0029).** It is classified as by-design non-event-sourced operational state
+with a unique justification: it *cannot* be event-sourced (that would make the
+key un-destroyable, defeating erasure) and *cannot* be regenerated (random key
+material). It is therefore **jointly authoritative with `events`**: the recovery
+contract is that both must be backed up and restored together. A rebuild from
+the event log alone completes, but reproduces every user's PII as the redaction
+sentinel — indistinguishable from mass erasure. The event log is no longer a
+self-sufficient source of truth for PII.
+
+**Retention is a bounded window with sealed off-box archival.** A scheduled,
+advisory-lock-single-flighted prune worker archives events older than the
+configured window to an integrity-sealed `ArchiveStore` before deleting them
+from `events`; tampering with any archived byte is detectable and an archive can
+be replayed out-of-band for audit without the live system. Retention that is
+enabled but misconfigured is a fail-closed boot refusal (a restart would
+otherwise silently keep or drop the wrong events).
+
+**Enforcement / runtime alarm.** `control doctor` is the safety net, not a
+projector: it checks the per-user key invariants crypto-shred depends on (every
+live user's DEK unwraps; no erased user retains one), erased-user teardown, and
+the retention posture — flagging drift before a prune makes it unrecoverable.
+
+## Alternatives considered
+
+- **Hard-delete events for an erased user.** Rejected — it breaks the replay
+  guarantee (ADR 0029) and destroys the audit trail of everything that user did,
+  not just their PII. Crypto-shred erases the *identity* while leaving the
+  pseudonymised audit history (actor ULID with no way back to the person) intact.
+- **Hold PII in a separate deletable table, keyed from events.** Rejected — two
+  systems of record for one fact, and the join key (ULID) plus any denormalised
+  copy in the log would still leak. The DEK envelope keeps PII *in* the log but
+  cryptographically gated by one deletable row.
+- **Event-source the DEK.** Rejected — an event-sourced key is reproducible from
+  the log, so it could never be truly destroyed. The one non-event-sourced row is
+  the point.
+
+## Consequences
+
+- `user_encryption_keys` is the single most backup-critical table in the system;
+  losing it is mass erasure. This is stated in the operator recovery docs and
+  guarded at runtime by doctor's dual key-invariant check.
+- Erasure is O(1) (destroy one row) regardless of how much PII the user
+  accumulated across the log and archives.
+- Pseudonymisation, not anonymisation: an erased user's actor ULID remains in the
+  audit history with the person-mapping severed. Sufficiency depends on the legal
+  basis — the accepted residual-risk posture, recorded in spec 19's Security
+  section.
+- Retention pruning is irreversible for the live system once the sealed archive
+  is the only copy; the archive seal is what keeps it auditable.

--- a/internal/api/shred_delete_handler_test.go
+++ b/internal/api/shred_delete_handler_test.go
@@ -43,10 +43,12 @@ func TestDeleteUser_ShredsDEK(t *testing.T) {
 	assert.False(t, hasDEKRepo(t, st, victim), "DeleteUser must crypto-shred the DEK (AC 7/8)")
 }
 
-// TestDeleteUser_IdempotentAndNoOracle pins AC 13: deleting an
-// already-deleted (still visible to the caller) user is idempotent OK;
-// deleting an absent id returns NotFound (no existence oracle).
-func TestDeleteUser_IdempotentAndNoOracle(t *testing.T) {
+// TestDeleteUser_UniformNotFound pins AC 13: the delete response is uniform
+// NotFound across absent, out-of-scope, and already-erased targets — none of
+// them confirms a ULID ever existed. An already-deleted target resolves the
+// same way as an absent one because GetUserByID filters is_deleted = false, so
+// the delete flow is never re-entered (no idempotent-OK path).
+func TestDeleteUser_UniformNotFound(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 
 	adminID := testutil.CreateTestUser(t, st, "adm2-"+testutil.NewID()[:8]+"@test.com", "pass", "admin")
@@ -57,6 +59,18 @@ func TestDeleteUser_IdempotentAndNoOracle(t *testing.T) {
 		connect.NewRequest(&pm.DeleteUserRequest{Id: testutil.NewID()}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err), "absent target must be NotFound (no oracle)")
+
+	// Already-deleted target that the admin could see → NotFound too (uniform).
+	victimID := testutil.CreateTestUser(t, st, "victim-"+testutil.NewID()[:8]+"@test.com", "pass", "viewer")
+	_, err = h.DeleteUser(testutil.AdminContext(adminID),
+		connect.NewRequest(&pm.DeleteUserRequest{Id: victimID}))
+	require.NoError(t, err, "first delete of a visible user succeeds")
+
+	_, err = h.DeleteUser(testutil.AdminContext(adminID),
+		connect.NewRequest(&pm.DeleteUserRequest{Id: victimID}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err),
+		"repeat delete of an already-erased user must be NotFound — indistinguishable from absent (no oracle)")
 }
 
 // TestReAddSameEmailAfterErase_MintsFreshDEK pins AC 15: after erasing

--- a/internal/store/generated/user_encryption_keys.sql.go
+++ b/internal/store/generated/user_encryption_keys.sql.go
@@ -58,7 +58,7 @@ type InsertUserEncryptionKeyParams struct {
 	WrappedDek string `json:"wrapped_dek"`
 }
 
-// Per-user DEK envelope (spec 19 / ADR 0030). The wrapped_dek is the
+// Per-user DEK envelope (spec 19 / ADR 0033). The wrapped_dek is the
 // KEK-wrapped data-encryption key every PII field of the user's events
 // is sealed under; deleting the row IS the erasure ("crypto-shred").
 // ON CONFLICT DO NOTHING: minting is first-write-wins so a re-provision

--- a/internal/store/postgres/user_encryption_key.go
+++ b/internal/store/postgres/user_encryption_key.go
@@ -10,7 +10,7 @@ import (
 
 // UserEncryptionKey implements store.UserEncryptionKeyRepo against
 // user_encryption_keys — the crypto-shred key material (spec 19 /
-// ADR 0030).
+// ADR 0033).
 type UserEncryptionKey struct {
 	q *generated.Queries
 }

--- a/internal/store/queries/user_encryption_keys.sql
+++ b/internal/store/queries/user_encryption_keys.sql
@@ -1,4 +1,4 @@
--- Per-user DEK envelope (spec 19 / ADR 0030). The wrapped_dek is the
+-- Per-user DEK envelope (spec 19 / ADR 0033). The wrapped_dek is the
 -- KEK-wrapped data-encryption key every PII field of the user's events
 -- is sealed under; deleting the row IS the erasure ("crypto-shred").
 

--- a/internal/store/shred.go
+++ b/internal/store/shred.go
@@ -25,10 +25,13 @@ import (
 // AppendEvent does, so the UserDeleted projector (soft-delete +
 // PII-column redaction) runs on the durable event.
 //
-// Idempotent (AC 13): re-running for an already-deleted user still
-// appends a UserDeleted event (harmless — the projector's
-// projection_version guard no-ops the stale replay) and the DEK delete
-// reports zero rows without error, so the DEK stays absent.
+// Idempotent at the store level (defense in depth): re-running for an
+// already-deleted user still appends a UserDeleted event (harmless — the
+// projector's projection_version guard no-ops the stale replay) and the DEK
+// delete reports zero rows without error, so the DEK stays absent. The API
+// handler never re-enters this flow for an erased user — GetUserByID filters
+// is_deleted, so a repeat delete is uniform NotFound (AC 13); this
+// idempotency backs the SCIM path and any direct store caller.
 func (s *Store) AppendUserDeletionWithShred(ctx context.Context, event Event) error {
 	if event.StreamType != "user" {
 		return fmt.Errorf("shred flow: event must be on the user stream, got %q", event.StreamType)
@@ -88,6 +91,11 @@ func (s *Store) AppendUserDeletionWithShred(ctx context.Context, event Event) er
 			}
 			// THE crypto-shred, in the SAME transaction (AC 7/14). A
 			// failure here rolls the UserDeleted append back too.
+			if s.beforeDEKShred != nil {
+				if herr := s.beforeDEKShred(event.StreamID); herr != nil {
+					return fmt.Errorf("shred DEK (test hook): %w", herr)
+				}
+			}
 			if _, derr := q.DeleteUserEncryptionKey(ctx, event.StreamID); derr != nil {
 				return fmt.Errorf("shred DEK: %w", derr)
 			}

--- a/internal/store/shred_test.go
+++ b/internal/store/shred_test.go
@@ -2,6 +2,7 @@ package store_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,9 +78,11 @@ func TestAppendUserDeletionWithShred_FiresProjector(t *testing.T) {
 	assert.True(t, store.IsNotFound(err), "deleted user must not resolve by email")
 }
 
-// TestAppendUserDeletionWithShred_Idempotent pins AC 13: re-running for
-// an already-deleted user is a no-op success — DEK stays absent, no
-// duplicate/orphaned writes.
+// TestAppendUserDeletionWithShred_Idempotent pins the store-level
+// idempotency (defense in depth): re-running for an already-deleted user is a
+// no-op success — DEK stays absent, no duplicate/orphaned writes. The API
+// handler never re-enters this flow for an erased user (it returns uniform
+// NotFound, AC 13); this idempotency backs the SCIM path and direct callers.
 func TestAppendUserDeletionWithShred_Idempotent(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	ctx := context.Background()
@@ -89,5 +92,37 @@ func TestAppendUserDeletionWithShred_Idempotent(t *testing.T) {
 	require.NoError(t, st.AppendUserDeletionWithShred(ctx, userDeletedEvent(userID)),
 		"a second shred of an already-erased user is a no-op success")
 
+	assert.False(t, hasDEK(t, st, userID))
+}
+
+// TestAppendUserDeletionWithShred_DEKShredFailureRollsBack pins AC 14: if the
+// DEK delete fails, the whole transaction rolls back — the already-appended
+// UserDeleted event does NOT survive and the projection stays unredacted
+// (no half-erased state). The failure is injected AT the shred step (after
+// the append) so the rollback of a committed-in-tx append is what's proven.
+func TestAppendUserDeletionWithShred_DEKShredFailureRollsBack(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	ctx := context.Background()
+
+	email := "rollback-" + testutil.NewID()[:8] + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "pass", "user")
+	require.True(t, hasDEK(t, st, userID), "precondition: user has a DEK")
+
+	st.TestingSetDEKShredHook(func(string) error { return errors.New("injected DEK-delete failure") })
+
+	err := st.AppendUserDeletionWithShred(ctx, userDeletedEvent(userID))
+	require.Error(t, err, "a DEK-shred failure must surface as an error")
+
+	assert.Equal(t, 0, countUserEvents(t, st, userID, "UserDeleted"),
+		"AC 14: no UserDeleted event may survive a rolled-back shred")
+	assert.True(t, hasDEK(t, st, userID),
+		"AC 14: the DEK must still be present — nothing was destroyed")
+	_, gerr := st.Repos().User.GetByEmail(ctx, email)
+	require.NoError(t, gerr, "AC 14: the projection stays unredacted — the user still resolves")
+
+	// Clear the seam: a normal shred now succeeds, proving the hook was the
+	// only thing blocking (the flow itself is healthy).
+	st.TestingSetDEKShredHook(nil)
+	require.NoError(t, st.AppendUserDeletionWithShred(ctx, userDeletedEvent(userID)))
 	assert.False(t, hasDEK(t, st, userID))
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -159,6 +159,13 @@ type Store struct {
 	// TestingSetInsertHook; always nil in production, so the per-insert
 	// nil check is the only cost the write path pays.
 	beforeInsert func(streamType, eventType string) error
+
+	// beforeDEKShred, when non-nil, is consulted in
+	// AppendUserDeletionWithShred AFTER the UserDeleted append but BEFORE
+	// the DEK delete, so a test can fail the shred step specifically and
+	// assert the already-appended UserDeleted rolls back (spec 19 AC 14).
+	// TEST-ONLY, set via TestingSetDEKShredHook; always nil in production.
+	beforeDEKShred func(userID string) error
 }
 
 // PIISealer seals the PII fields of an event's typed payload under the
@@ -917,4 +924,14 @@ func (s *Store) appendBatchTx(ctx context.Context, prepared []preparedEvent) ([]
 // package and a concrete *Store gives it no other seam.
 func (s *Store) TestingSetInsertHook(fn func(streamType, eventType string) error) {
 	s.beforeInsert = fn
+}
+
+// TestingSetDEKShredHook installs a test-only failure seam consulted in
+// AppendUserDeletionWithShred between the UserDeleted append and the DEK
+// delete. Returning a non-nil error from fn fails the shred step, letting a
+// test assert the all-or-nothing rollback (spec 19 AC 14): no UserDeleted
+// event survives and the projection stays unredacted. Pass nil to clear.
+// Same posture as TestingSetInsertHook — production code must not call this.
+func (s *Store) TestingSetDEKShredHook(fn func(userID string) error) {
+	s.beforeDEKShred = fn
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -139,7 +139,7 @@ type Store struct {
 
 	// piiSealer, when set, transforms every event BEFORE its payload is
 	// marshalled: PII-tagged fields are sealed under the subject user's
-	// DEK (spec 19 / ADR 0030). FAIL-CLOSED contract (AC 6): a sealing
+	// DEK (spec 19 / ADR 0033). FAIL-CLOSED contract (AC 6): a sealing
 	// error aborts the append — the log is immutable, so plaintext PII
 	// written once is unerasable forever; an error is always cheaper.
 	// Wired via SetPIISealer from boot code / the test fixture,

--- a/internal/store/user_encryption_key.go
+++ b/internal/store/user_encryption_key.go
@@ -6,7 +6,8 @@ import (
 )
 
 // UserEncryptionKey is one user's KEK-wrapped data-encryption key
-// (spec 19 / ADR 0030). The wrapped form is the ONLY persisted form;
+// (spec 19 / ADR 0033; wrapped under the ADR 0030 enc:v1 format). The
+// wrapped form is the ONLY persisted form;
 // the plaintext DEK exists in memory only, inside internal/crypto.
 type UserEncryptionKey struct {
 	UserID     string


### PR DESCRIPTION
Spec-19 audit follow-ups from the 2026-07-18 spec audit (WS-F). Base: `integration/alpha3`.

## AC 13 — uniform-NotFound (test + spec)
Spec 19 AC 13 claimed a repeat delete of an *already-deleted, still-visible* user is idempotent-OK. Shipped `DeleteUser` calls `GetUserByID`, which filters `is_deleted = false`, so it actually returns **NotFound** — the stronger anti-oracle behavior (absent / out-of-scope / already-erased all resolve identically). Amended the spec (docs main) to the shipped behavior and renamed/extended the handler test to pin the already-deleted → NotFound case. No production code change.

## AC 14 — DEK-shred rollback now tested
The all-or-nothing `UserDeleted`-append + DEK-delete guarantee had no failure-injection test. Added a `beforeDEKShred` test-only seam (mirrors `beforeInsert`; one nil-check in production) consulted between the append and the DEK delete, and a test that injects a shred failure and asserts the append rolled back (no `UserDeleted` event, DEK intact, projection unredacted). Red-verified by relocating the hook post-commit → the event survives and the DEK is gone (test fails for the right reason).

## ADR 0033 — the missing erasure ADR
Spec 19's References named "ADR 0030 (new) — retention + crypto-shred erasure contract (amends ADR 0029)", but number 0030 was taken by spec 20's single-AAD-format ADR, so the erasure ADR was never written. Added `docs/adr/0033-audit-retention-crypto-shred-erasure.md` and repointed the stale `ADR 0030` references (store comments, the sqlc source comment + regenerated file, and spec 19 in docs) at 0033. The DEK *wrapping format* is still correctly attributed to ADR 0030.

## Verification
- `go build` · `go vet` · `staticcheck` clean on changed packages.
- `internal/store` + `internal/api` suites green (real Postgres).
- `docref check` green (server tree).
- sqlc regenerated via `make sqlc-generate` (pinned image) — only the ADR comment changed, no schema drift.
