### PR TITLE
fix(rebuild): wire the PII opener so emergency projection rebuild/restore works

### DIFF
--- a/cmd/control/rebuild.go
+++ b/cmd/control/rebuild.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/manchtools/power-manage/server/internal/archive"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/doctor"
+	"github.com/manchtools/power-manage/server/internal/pii"
 	"github.com/manchtools/power-manage/server/internal/projectors"
 	"github.com/manchtools/power-manage/server/internal/retention"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -85,6 +87,31 @@ func runRebuildProjections(args []string) int {
 	st.SetLogger(logger)
 	st.SetRepos(postgres.NewRepos(st.Queries()))
 	projectors.WireAll(st, logger)
+
+	// Spec 19 / ADR 0033: the users projection (and any PII-bearing stream)
+	// replays sealed `pii:v1:` fields, so the rebuild MUST wire the same PII
+	// opener that boot wires — WireAll does NOT. Without it, openSealedPII
+	// refuses to project ciphertext and the entire rebuild rolls back, so the
+	// emergency-recovery command fails on any real deployment (all of which
+	// have users with PII). The KEK is mandatory (same posture as control
+	// boot); a rebuild cannot decrypt PII without it. Resolved from the same
+	// merged env as the DSN, so a key kept only in `.env` is honoured.
+	encKey := vars["CONTROL_ENCRYPTION_KEY"]
+	if encKey == "" {
+		fmt.Fprintln(os.Stderr, "rebuild-projections: CONTROL_ENCRYPTION_KEY is not set (env or --env-file) — required to decrypt sealed PII during replay")
+		return 2
+	}
+	encryptor, err := crypto.NewEncryptor(encKey)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "rebuild-projections: initialize encryptor: %v\n", err)
+		return 2
+	}
+	piiOpener, err := pii.NewOpener(encryptor, st.Repos().UserEncryptionKey)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "rebuild-projections: initialize PII opener: %v\n", err)
+		return 2
+	}
+	projectors.SetPIIOpener(piiOpener)
 
 	var res store.RebuildResult
 	if *archiveDir != "" {

--- a/cmd/control/rebuild_test.go
+++ b/cmd/control/rebuild_test.go
@@ -1,12 +1,19 @@
 package main
 
 import (
+	"context"
 	"io"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/eventtypes"
+	"github.com/manchtools/power-manage/server/internal/eventtypes/payloads"
+	"github.com/manchtools/power-manage/server/internal/projectors"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testutil"
 )
 
 // The store layer carries the behavioral coverage for the rebuild
@@ -23,6 +30,93 @@ func TestRunRebuildProjections_NoDatabaseURLIsCouldNotRun(t *testing.T) {
 func TestRunRebuildProjections_HelpIsSuccess(t *testing.T) {
 	code := runRebuildProjections([]string{"-h"})
 	assert.Equal(t, 0, code, "-h is a successful help request, not a failure")
+}
+
+// TestRunRebuildProjections_RebuildsPIIBearingProjection is the happy-path
+// smoke the audit flagged as missing — and it caught a real bug: the rebuild
+// CLI must wire the spec-19 PII opener (WireAll does NOT), or replaying any
+// user event that carries sealed PII fails with "no PII opener is wired" and
+// the whole emergency rebuild rolls back. Seeds a user with a GENUINELY sealed
+// PII field (a typed UserProfileUpdated — the factory's own map event is
+// deliberately plaintext), TRUNCATE-and-replays the users projection through
+// the real runRebuildProjections, and asserts exit 0 with the field DECRYPTED
+// (not the redaction sentinel — proving the opener decrypted rather than the
+// projector redacting an "unreadable" value).
+func TestRunRebuildProjections_RebuildsPIIBearingProjection(t *testing.T) {
+	st, dsn := testutil.SetupPostgresWithDSN(t)
+	ctx := context.Background()
+
+	email := "rebuild-happy-" + testutil.NewID()[:8] + "@test.com"
+	userID := testutil.CreateTestUser(t, st, email, "pass", "viewer")
+
+	// A typed profile event seals given_name under the user's DEK (the factory
+	// creation event stores an unsealed map, so it alone would not exercise the
+	// opener). Mirrors the production UpdateUserProfile emit.
+	const sealedGivenName = "Alice-Sealed"
+	gn := sealedGivenName
+	require.NoError(t, st.AppendEvent(ctx, store.Event{
+		StreamType: "user",
+		StreamID:   userID,
+		EventType:  string(eventtypes.UserProfileUpdated),
+		Data:       payloads.UserProfileUpdated{GivenName: &gn},
+		ActorType:  "system",
+		ActorID:    "test",
+	}))
+	// Prove the event is genuinely sealed AT REST — otherwise a regression that
+	// silently stopped sealing would leave given_name in plaintext, the rebuild
+	// would never need the opener, and this whole test would pass vacuously.
+	require.Contains(t, storedEventData(t, st, userID, eventtypes.UserProfileUpdated), "pii:v1:",
+		"precondition: the given_name must be sealed (pii:v1:) in the stored event")
+	require.NotContains(t, storedEventData(t, st, userID, eventtypes.UserProfileUpdated), sealedGivenName,
+		"precondition: the plaintext given_name must NOT appear in the stored event")
+	require.Equal(t, sealedGivenName, projectedGivenName(t, st, userID),
+		"precondition: the live projector decrypted the sealed given_name")
+
+	// Simulate a FRESH CLI process: boot never ran, so the package-global PII
+	// opener is unset. (SetupPostgresWithDSN wired it to seed the user above;
+	// without this reset the leaked global would let the rebuild succeed even
+	// if the CLI forgot to wire its own opener — masking the very bug this
+	// test exists to catch.) Restore to the unwired default on teardown so no
+	// later serial test inherits this test's (torn-down) store opener.
+	projectors.SetPIIOpener(nil)
+	t.Cleanup(func() { projectors.SetPIIOpener(nil) })
+
+	// The CLI opens its OWN store from these; --env-file points nowhere so the
+	// process env is authoritative. The KEK MUST match the one the seed data
+	// was sealed under, or the DEK unwrap fails.
+	t.Setenv("CONTROL_DATABASE_URL", dsn)
+	t.Setenv("CONTROL_ENCRYPTION_KEY", testutil.TestKEKHex)
+
+	code := runRebuildProjections([]string{"--env-file", "/nonexistent/never.env", "users"})
+	require.Equal(t, 0, code, "rebuilding the PII-bearing users projection must succeed (exit 0)")
+
+	assert.Equal(t, sealedGivenName, projectedGivenName(t, st, userID),
+		"given_name must be decrypted through the CLI-wired opener, not redacted to the sentinel")
+}
+
+// projectedGivenName reads users_projection.given_name directly, so the
+// assertion does not depend on the repo struct's field surface.
+func projectedGivenName(t *testing.T, st *store.Store, userID string) string {
+	t.Helper()
+	var gn *string
+	require.NoError(t, st.TestingPool().QueryRow(context.Background(),
+		`SELECT given_name FROM users_projection WHERE id = $1`, userID).Scan(&gn))
+	if gn == nil {
+		return ""
+	}
+	return *gn
+}
+
+// storedEventData returns the raw JSON payload of the user's event of the given
+// type, so a test can assert the at-rest sealed representation rather than
+// trusting the projection round-trip.
+func storedEventData(t *testing.T, st *store.Store, userID string, eventType eventtypes.EventType) string {
+	t.Helper()
+	var data string
+	require.NoError(t, st.TestingPool().QueryRow(context.Background(),
+		`SELECT data::text FROM events WHERE stream_id = $1 AND event_type = $2`,
+		userID, string(eventType)).Scan(&data))
+	return data
 }
 
 func TestRunRebuildProjections_ArchiveDirWithTargetsIsCouldNotRun(t *testing.T) {

--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -165,7 +165,7 @@ docker compose exec control control rebuild-projections users devices
 ```
 <!-- docref: end -->
 
-<!-- docref: begin src=cmd/control/rebuild.go#runRebuildProjections:3f101b6f -->
+<!-- docref: begin src=cmd/control/rebuild.go#runRebuildProjections:583ca0ac -->
 The command prints the resolved target list before touching anything. A
 partial selection is widened automatically when a selected table's
 `TRUNCATE ... CASCADE` would wipe tables owned by other targets — a
@@ -175,6 +175,11 @@ payloads) separately. Everything runs in a single transaction (one
 consistent snapshot): a failure rolls back to the pre-rebuild state.
 After a successful rebuild the system-role permissions are re-reconciled
 from the code registry, so no Control restart is needed.
+
+Because replay decrypts each user's sealed PII, the rebuild needs
+`CONTROL_ENCRYPTION_KEY` (the same key Control boots with, read from the
+environment or `--env-file`); without it the command exits `2` rather than
+risk projecting redacted PII over good data.
 
 Once audit-log retention has pruned history, a plain rebuild **refuses to
 run** — the surviving live log no longer contains events up to the prune

--- a/internal/testutil/factories_idp.go
+++ b/internal/testutil/factories_idp.go
@@ -17,11 +17,16 @@ import (
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
+// TestKEKHex is the fixed 32-byte (64 hex char) KEK every test fixture seals
+// under. Exported so tests that drive a CLI/boot path opening its own
+// encryptor from CONTROL_ENCRYPTION_KEY can hand it the SAME key the seed data
+// was sealed with (otherwise the DEK unwrap fails and PII reads as sentinel).
+const TestKEKHex = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
 // NewEncryptor creates an Encryptor with a test key.
 func NewEncryptor(t *testing.T) *crypto.Encryptor {
 	t.Helper()
-	// 32-byte hex key (64 hex chars)
-	enc, err := crypto.NewEncryptor("0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	enc, err := crypto.NewEncryptor(TestKEKHex)
 	if err != nil {
 		t.Fatalf("create test encryptor: %v", err)
 	}

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -148,7 +148,7 @@ func databaseURL(base *url.URL, dbName string) string {
 // Store; callers decide whether to wire projectors. maxConns caps the pgx pool
 // size (0 = pgx default); a small cap is used to exercise pool-pressure paths
 // such as the advisory-lock deadlock guard.
-func setupTestStore(t *testing.T, maxConns int) *store.Store {
+func setupTestStore(t *testing.T, maxConns int) (*store.Store, string) {
 	t.Helper()
 	sharedOnce.Do(initShared)
 	if sharedErr != nil {
@@ -201,7 +201,7 @@ func setupTestStore(t *testing.T, maxConns int) *store.Store {
 	}
 	t.Cleanup(func() { st.Close() })
 	st.SetRepos(pgrepo.NewRepos(st.Queries()))
-	return st
+	return st, connStr
 }
 
 // SetupPostgres returns a connected Store backed by a fresh per-test database
@@ -209,7 +209,7 @@ func setupTestStore(t *testing.T, maxConns int) *store.Store {
 // completes.
 func SetupPostgres(t *testing.T) *store.Store {
 	t.Helper()
-	st := setupTestStore(t, 0)
+	st, _ := setupTestStore(t, 0)
 
 	// Wire the same Go-side projector listeners that production boot wires in
 	// cmd/control/main.go. Without this, handlers emit events but the
@@ -275,7 +275,22 @@ func MintTestUserDEK(t *testing.T, st *store.Store, userID string) {
 // tests that read projection state.
 func SetupPostgresWithoutProjectors(t *testing.T) *store.Store {
 	t.Helper()
-	return setupTestStore(t, 0)
+	st, _ := setupTestStore(t, 0)
+	return st
+}
+
+// SetupPostgresWithDSN is SetupPostgres plus the raw connection string for the
+// per-test database. Use it for the handful of tests that drive a CLI/boot
+// path which opens its OWN store from CONTROL_DATABASE_URL (e.g.
+// runRebuildProjections) rather than receiving an already-connected *Store.
+// The returned DSN points at the same template-cloned database, so seed via
+// the returned store and the CLI sees the same rows.
+func SetupPostgresWithDSN(t *testing.T) (*store.Store, string) {
+	t.Helper()
+	st, dsn := setupTestStore(t, 0)
+	projectors.WireAll(st, nil)
+	WirePIIEnvelope(t, st)
+	return st, dsn
 }
 
 // SetupPostgresPool returns a connected Store (with projectors wired) whose pgx
@@ -284,7 +299,7 @@ func SetupPostgresWithoutProjectors(t *testing.T) *store.Store {
 // pool size.
 func SetupPostgresPool(t *testing.T, maxConns int) *store.Store {
 	t.Helper()
-	st := setupTestStore(t, maxConns)
+	st, _ := setupTestStore(t, maxConns)
 	projectors.WireAll(st, nil)
 	return st
 }


### PR DESCRIPTION
Fixes a latent bug in the emergency projection-rebuild/restore command, found while adding the happy-path test the spec-21 audit flagged as missing. Base: `integration/alpha3`.

## The bug
`runRebuildProjections` calls `projectors.WireAll` but never `projectors.SetPIIOpener` — boot (`main.go`) wires the opener as a *separate* step. `rebuild-projections` is its own process/subcommand that `os.Exit`s before boot runs, so it executed with a **nil package-global PII opener**.

Replaying any user event that carries sealed PII (`pii:v1:` fields — every real deployment has users) then hits `openSealedPII`'s fail-closed guard:

```
projector: UserProfileUpdated carries sealed PII but no PII opener is wired
(SetPIIOpener at boot) — refusing to project ciphertext
```

…which fails the rebuild transaction and rolls everything back. The disaster-recovery path ADR 0029 rests on (and the spec-19 AC 21 archive restore) was **unusable on any populated database**. It fails closed — no silent PII loss — but the command simply never succeeds.

## The fix
Wire the PII opener in `runRebuildProjections`, resolved from the same merged env as the DSN (so a KEK kept only in `.env` is honoured). The KEK is mandatory — same posture as control boot; a rebuild cannot decrypt PII without it. Covers both the normal rebuild and the `--archive-dir` restore path (wired before the branch).

## Regression test (spec-21 gap)
`TestRunRebuildProjections_RebuildsPIIBearingProjection` seeds a user with a **genuinely sealed** `given_name` (a typed `UserProfileUpdated` — the factory's own creation event is deliberately plaintext), asserts the payload is sealed *at rest* (`pii:v1:`, no plaintext), resets the package-global opener to simulate a fresh CLI process, then drives the real `runRebuildProjections` and asserts exit 0 with `given_name` decrypted. Red-verified: fails with the exact "no PII opener is wired" error on the pre-fix code.

New test infra: `testutil.SetupPostgresWithDSN` (returns the per-test DSN for CLI/boot paths that open their own store) and the exported `testutil.TestKEKHex`.

## Sibling sweep
The only other store-opening subcommand, `doctor`, reads projections (no event replay) so needs no opener. `setup`'s `WireAll` runs inside the boot flow that already wires the opener. `rebuild-projections` was the sole affected path.

## Verification
`go build` · `go vet ./...` · `staticcheck` clean · `cmd/control` + `internal/store` suites green · local CodeRabbit review addressed (opener teardown restore + at-rest seal assertion).
