### PR TITLE
fix(enroll): control-authoritative gateway DNS SAN + fail-closed binding hardening (spec 31 D1-D8)

### DIFF
--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -455,7 +455,7 @@ func main() {
 		api.NewValidationInterceptor(),
 	)
 	gatewayEnrollLimiter := auth.NewRateLimiter(5, 1*time.Minute) // 5/min/IP (spec 31 AC4)
-	gatewayAuthHandler := api.NewGatewayAuthHandler(st, certAuth, cfg.GatewayEnrollToken, gatewayEnrollLimiter, logger.With("component", "gateway_auth"))
+	gatewayAuthHandler := api.NewGatewayAuthHandler(st, certAuth, cfg.GatewayEnrollToken, cfg.GatewayURL, gatewayEnrollLimiter, logger.With("component", "gateway_auth"))
 	gwAuthPath, gwAuthHandler := pmv1connect.NewGatewayAuthServiceHandler(gatewayAuthHandler, gatewayAuthInterceptors, connect.WithReadMaxBytes(controlMaxRequestBytes))
 	mux.Handle(gwAuthPath, gwAuthHandler)
 	if cfg.GatewayEnrollToken == "" {
@@ -523,8 +523,9 @@ func main() {
 	if valkey != nil && valkey.GatewayRegistry != nil {
 		// Confine every device-origin InternalService request to the gateway the
 		// device is actually live on (server#403). Wired whenever the
-		// Valkey-backed routing registry is available; a nil resolver (no
-		// registry) keeps the documented single-gateway bypass.
+		// Valkey-backed routing registry is available; without it the binding
+		// check fails closed (spec 31 D6) — consistent with the internal
+		// listener already rejecting every gateway for want of a CRL.
 		internalHandler.SetDeviceGatewayResolver(valkey.GatewayRegistry)
 	}
 	// spec 31: the gateway-cert renewal path needs the CA (to re-sign) and the

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -532,9 +532,11 @@ func main() {
 	}
 	// spec 31: the gateway-cert renewal path needs the CA (to re-sign) and the
 	// CRL (to revoke the superseded fingerprint). The CA is always available; the
-	// CRL only when Valkey is configured — renewal still works without it, just
-	// skipping the best-effort superseded-cert revocation. The typed nil keeps
-	// main.go free of a crl import.
+	// CRL only when Valkey is configured. On a no-Valkey control the nil CRL is
+	// never consulted: RequirePeerClassNotRevoked below fails closed without a
+	// loaded CRL, so no gateway call — renewal included — reaches this handler
+	// (audit L11). The nil wiring only keeps the handler total; the typed nil
+	// keeps main.go free of a crl import.
 	if valkey != nil {
 		internalHandler.SetGatewayRenewal(certAuth, valkey.CRLStore)
 	} else {

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -524,8 +524,10 @@ func main() {
 		// Confine every device-origin InternalService request to the gateway the
 		// device is actually live on (server#403). Wired whenever the
 		// Valkey-backed routing registry is available; without it the binding
-		// check fails closed (spec 31 D6) — consistent with the internal
-		// listener already rejecting every gateway for want of a CRL.
+		// check fails closed on its own (spec 31 D6). Independently, a
+		// no-Valkey control also has no loaded CRL, so RequirePeerClassNotRevoked
+		// below already rejects every gateway on this listener (audit L11) —
+		// two separate fail-closed layers, not one implying the other.
 		internalHandler.SetDeviceGatewayResolver(valkey.GatewayRegistry)
 	}
 	// spec 31: the gateway-cert renewal path needs the CA (to re-sign) and the

--- a/cmd/gateway/gateway_renewal.go
+++ b/cmd/gateway/gateway_renewal.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	"connectrpc.com/connect"
 	"github.com/manchtools/power-manage-sdk/gen/go/pm/v1/pmv1connect"
 
 	"github.com/manchtools/power-manage/server/internal/ca"
@@ -15,8 +16,22 @@ import (
 // renewalRetryBackoff bounds how soon a failed renewal retries — long enough not
 // to hammer control, short enough that a transient failure well before expiry
 // recovers with plenty of margin (the 45-day TTL leaves ~9 days of slack once
-// the 80% mark triggers the first attempt).
-const renewalRetryBackoff = 5 * time.Minute
+// the 80% mark triggers the first attempt). A var, not a const, so tests can
+// shrink it (package-var seam).
+var renewalRetryBackoff = 5 * time.Minute
+
+// selfRevocationHaltThreshold is how many CONSECUTIVE PermissionDenied renewal
+// results the gateway tolerates before concluding its own cert was revoked (D8)
+// and halting. Control rejects a revoked gateway's renewal PermissionDenied — but
+// so does control's own transient CRL-not-yet-loaded window at startup, so we
+// require a streak rather than halting on the first, letting a transient control
+// blip self-heal via the normal retry while a real revocation still stops the
+// loop instead of retrying forever.
+const selfRevocationHaltThreshold = 3
+
+// renewGatewayCert is a seam over gwenroll.Renew so the renewal loop's
+// error-classification / halt behavior is testable without a live control plane.
+var renewGatewayCert = gwenroll.Renew
 
 // runGatewayCertRenewal renews the gateway certificate at 80% of its lifetime
 // and installs the new cert into the rotator, so new agent handshakes pick it up
@@ -24,6 +39,7 @@ const renewalRetryBackoff = 5 * time.Minute
 // over the InternalService mTLS plane presenting the current gateway cert. Runs
 // until ctx is cancelled; a renewal failure retries after a bounded backoff.
 func runGatewayCertRenewal(ctx context.Context, internalClient pmv1connect.InternalServiceClient, id *gwenroll.Identity, rotator *mtls.CertRotator, logger *slog.Logger) {
+	permDeniedStreak := 0
 	for {
 		notAfter, err := ca.NotAfterFromPEM(id.CertPEM)
 		if err != nil {
@@ -46,9 +62,24 @@ func runGatewayCertRenewal(ctx context.Context, internalClient pmv1connect.Inter
 		case <-timer.C:
 		}
 
-		newNotAfter, err := gwenroll.Renew(ctx, internalClient, id)
+		newNotAfter, err := renewGatewayCert(ctx, internalClient, id)
 		if err != nil {
-			logger.Error("gateway certificate renewal failed; retrying", "gateway_id", id.GatewayID, "error", err)
+			// D8: control rejects a revoked gateway's renewal PermissionDenied. On a
+			// STREAK of PermissionDenied (past the transient CRL-load window), the
+			// gateway's identity is revoked and no amount of retrying recovers it —
+			// halt with a CRITICAL log so the supervisor restarts the process, which
+			// re-enrolls a fresh identity (gateway identity is ephemeral-per-boot).
+			if connect.CodeOf(err) == connect.CodePermissionDenied {
+				permDeniedStreak++
+				if permDeniedStreak >= selfRevocationHaltThreshold {
+					logger.Error("CRITICAL: gateway certificate appears REVOKED — control rejected renewal PermissionDenied repeatedly; halting so the supervisor restarts and re-enrolls a fresh identity",
+						"gateway_id", id.GatewayID, "consecutive_permission_denied", permDeniedStreak)
+					return
+				}
+			} else {
+				permDeniedStreak = 0
+			}
+			logger.Error("gateway certificate renewal failed; retrying", "gateway_id", id.GatewayID, "error", err, "consecutive_permission_denied", permDeniedStreak)
 			select {
 			case <-ctx.Done():
 				return
@@ -56,6 +87,7 @@ func runGatewayCertRenewal(ctx context.Context, internalClient pmv1connect.Inter
 			}
 			continue
 		}
+		permDeniedStreak = 0
 		// Renew updated id.TLSCert/CertPEM in place; install the new leaf.
 		rotator.Set(id.TLSCert)
 		logger.Info("gateway certificate renewed", "gateway_id", id.GatewayID, "not_after", newNotAfter)

--- a/cmd/gateway/gateway_renewal_test.go
+++ b/cmd/gateway/gateway_renewal_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"log/slog"
+	"math/big"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage-sdk/gen/go/pm/v1/pmv1connect"
+	"github.com/manchtools/power-manage/server/internal/gwenroll"
+	"github.com/manchtools/power-manage/server/internal/mtls"
+)
+
+// expiredGatewayIdentity builds a minimal Identity whose cert is already past
+// its NotAfter, so runGatewayCertRenewal attempts renewal immediately (wait=0).
+// The loop only reads CertPEM (for expiry) and GatewayID on the failure path.
+func expiredGatewayIdentity(t *testing.T) *gwenroll.Identity {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: ulid.Make().String()},
+		NotBefore:    time.Now().Add(-2 * time.Hour),
+		NotAfter:     time.Now().Add(-time.Hour), // already expired → renew now
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	return &gwenroll.Identity{GatewayID: tmpl.Subject.CommonName, CertPEM: certPEM}
+}
+
+// TestRunGatewayCertRenewal_HaltsOnSelfRevocation pins spec 31 D8: when renewal
+// is rejected PermissionDenied repeatedly (the gateway's own cert was revoked),
+// the loop stops retrying forever and RETURNS so the supervisor can restart and
+// re-enroll. Without the halt the loop retries indefinitely and this returns via
+// the 5s timeout instead.
+func TestRunGatewayCertRenewal_HaltsOnSelfRevocation(t *testing.T) {
+	prevBackoff := renewalRetryBackoff
+	renewalRetryBackoff = time.Millisecond // shrink the retry so the streak accrues fast
+	t.Cleanup(func() { renewalRetryBackoff = prevBackoff })
+
+	var calls atomic.Int64
+	prevRenew := renewGatewayCert
+	t.Cleanup(func() { renewGatewayCert = prevRenew })
+	// Always report PermissionDenied — what control returns to a revoked gateway.
+	renewGatewayCert = func(context.Context, pmv1connect.InternalServiceClient, *gwenroll.Identity) (time.Time, error) {
+		calls.Add(1)
+		return time.Time{}, connect.NewError(connect.CodePermissionDenied, errors.New("client certificate revoked"))
+	}
+
+	id := expiredGatewayIdentity(t)
+	rotator := mtls.NewCertRotator(id.TLSCert)
+
+	done := make(chan struct{})
+	go func() {
+		runGatewayCertRenewal(context.Background(), nil, id, rotator, slog.Default())
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		require.GreaterOrEqual(t, int(calls.Load()), selfRevocationHaltThreshold,
+			"the loop must observe a PermissionDenied streak before halting")
+	case <-time.After(5 * time.Second):
+		t.Fatal("renewal loop did not halt on repeated self-revocation (retried forever)")
+	}
+}

--- a/cmd/gateway/gateway_renewal_test.go
+++ b/cmd/gateway/gateway_renewal_test.go
@@ -73,8 +73,8 @@ func TestRunGatewayCertRenewal_HaltsOnSelfRevocation(t *testing.T) {
 
 	select {
 	case <-done:
-		require.GreaterOrEqual(t, int(calls.Load()), selfRevocationHaltThreshold,
-			"the loop must observe a PermissionDenied streak before halting")
+		require.Equal(t, int64(selfRevocationHaltThreshold), calls.Load(),
+			"the loop must halt at exactly the configured PermissionDenied threshold")
 	case <-time.After(5 * time.Second):
 		t.Fatal("renewal loop did not halt on repeated self-revocation (retried forever)")
 	}

--- a/docs/adr/0005-gateway-control-device-origin-binding.md
+++ b/docs/adr/0005-gateway-control-device-origin-binding.md
@@ -1,6 +1,12 @@
 # 0005 — Gateway↔control device-origin binding
 
-- Status: accepted
+- Status: accepted; point 3 (single-gateway `nil`-lookup bypass) superseded
+  2026-07-18 by spec 31 D6 — `CheckDeviceGatewayBinding` now fails CLOSED on a
+  nil resolver. The bypass had become vestigial: Valkey (and with it the
+  routing registry) is mandatory for any gateway to function, so no deployment
+  without a resolver has a legitimate device-origin caller, and a nil lookup
+  can only mean a wiring bug. See ADR 0032 for the instance-identity model
+  that replaced the request-body `gateway_id` authority.
 - Date: 2026-06-13
 - Related: server#403; the 2026-06-12 audit (SA-C2); WS2 of the
   SECURITY_HARDENING_WORKPLAN; sdk#94 (the `gateway_id` wire field);

--- a/docs/adr/0005-gateway-control-device-origin-binding.md
+++ b/docs/adr/0005-gateway-control-device-origin-binding.md
@@ -56,11 +56,14 @@ lacks.
    InternalService handlers map the sentinels to connect codes (after `Validate`,
    validate-then-auth); the inbox worker maps them to `asynq.SkipRetry` drops
    that append no event.
-3. **Single-gateway bypass.** When no resolver is wired (a `nil` lookup), the
-   binding is **not** enforced — the documented exception for single-gateway /
-   non-HA deployments, where there is exactly one gateway and the binding is
-   moot. Control wires the resolver whenever the Valkey-backed routing registry
-   is available (i.e. wherever more than one gateway can connect).
+3. **No resolver = fail closed** *(rewritten 2026-07-18; the original point
+   documented an allow-on-nil "single-gateway bypass", superseded by spec 31
+   D6 — see Status)*. When no resolver is wired (a `nil` lookup), the binding
+   check **refuses** the device-origin operation. Control wires the resolver
+   whenever the Valkey-backed routing registry is available — which is every
+   deployment with a functioning gateway, since Valkey is mandatory for
+   gateways — so a nil lookup only occurs on a wiring bug and must never
+   silently disable the binding.
 4. **Cross-device ownership** (defense the binding does not cover — confining
    *which* resource a device may write, not *which* gateway speaks for it):
    output chunks must belong to the reporting device's execution; a LUKS

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/hibiken/asynq v0.26.0
 	github.com/jackc/pgx/v5 v5.9.2
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260717205410-7a6ce34c9fcc
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260718144224-419f05557365
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pquerna/otp v1.5.0
 	github.com/pressly/goose/v3 v3.26.0

--- a/go.sum
+++ b/go.sum
@@ -111,10 +111,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/magiconair/properties v1.8.10 h1:s31yESBquKXCV9a/ScB3ESkOjUYYv+X0rg8SYxI99mE=
 github.com/magiconair/properties v1.8.10/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
-github.com/manchtools/power-manage-sdk v0.5.4-0.20260712190623-bbc6a78b889c h1:KeBTaHW9wdX3P1/Cfo63yitz58srsO8IOsFULu+VJxw=
-github.com/manchtools/power-manage-sdk v0.5.4-0.20260712190623-bbc6a78b889c/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
-github.com/manchtools/power-manage-sdk v0.5.4-0.20260717205410-7a6ce34c9fcc h1:6DHBeJEgg7abtTi6IRhPsubZIC476NZfxR+qZ0XHLRM=
-github.com/manchtools/power-manage-sdk v0.5.4-0.20260717205410-7a6ce34c9fcc/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260718144224-419f05557365 h1:6Y6lD1wCEEfA6gUo5g7e0X2VK7a5xvmukY12+KR8DPY=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260718144224-419f05557365/go.mod h1:NQpkHZSQTJzGcQsdKsuE+EeQt7juWXVaN7b/i7NyjOQ=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mdelapenya/tlscert v0.2.0 h1:7H81W6Z/4weDvZBNOfQte5GpIMo0lGYEeWbkGp5LJHI=

--- a/internal/api/gateway_auth_handler.go
+++ b/internal/api/gateway_auth_handler.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"crypto/subtle"
-	"encoding/hex"
+	"fmt"
 	"log/slog"
+	"net"
+	"net/url"
 	"time"
 
 	"connectrpc.com/connect"
@@ -33,6 +35,11 @@ type GatewayAuthHandler struct {
 	store       *store.Store
 	ca          *ca.CA
 	enrollToken string
+	// gatewayHost is this deployment's authoritative gateway host, derived once
+	// from CONTROL_GATEWAY_URL. It is the sole source of the DNS SAN stamped on
+	// every enrolled gateway cert (spec 31 D1) — the enrollee's claimed hostname
+	// is only cross-checked against it, never trusted for issuance.
+	gatewayHost string
 	limiter     *auth.RateLimiter
 	logger      *slog.Logger
 	// clientIP resolves the trusted client IP (trusted-proxy aware). Seam for
@@ -41,14 +48,45 @@ type GatewayAuthHandler struct {
 	now      func() time.Time
 }
 
+// gatewayHostFromURL extracts the DNS host from CONTROL_GATEWAY_URL. It rejects
+// an empty host and an IP literal: the gateway cert carries a DNS SAN (agents
+// verify a DNS name at the mTLS handshake), and a DNS SAN holding an IP string
+// is never matched as an IP address — an IP gateway URL cannot back the mTLS
+// identity and must be caught at boot, not at first enrollment.
+func gatewayHostFromURL(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse gateway URL: %w", err)
+	}
+	host := u.Hostname()
+	if host == "" {
+		return "", fmt.Errorf("gateway URL %q has no host", RedactGatewayURL(raw))
+	}
+	if net.ParseIP(host) != nil {
+		return "", fmt.Errorf("gateway URL host %q is an IP literal; a DNS name is required (the gateway cert's DNS SAN cannot be an IP)", host)
+	}
+	return host, nil
+}
+
 // NewGatewayAuthHandler creates the enrollment handler. enrollToken is the
 // shared bootstrap secret (CONTROL_GATEWAY_ENROLL_TOKEN); an empty token means
-// enrollment is effectively disabled (every attempt is rejected).
-func NewGatewayAuthHandler(st *store.Store, certAuth *ca.CA, enrollToken string, limiter *auth.RateLimiter, logger *slog.Logger) *GatewayAuthHandler {
+// enrollment is effectively disabled (every attempt is rejected). gatewayURL is
+// CONTROL_GATEWAY_URL — the authoritative public gateway address; its host
+// becomes the DNS SAN of every issued gateway cert. Panics when gatewayURL has
+// no DNS host (an IP literal or empty), matching NewRegistrationHandler's
+// fail-fast: main.go validates CONTROL_GATEWAY_URL at boot, so reaching the
+// constructor with an unusable value is a configuration error that must surface
+// at startup, not silently issue certs agents cannot verify.
+func NewGatewayAuthHandler(st *store.Store, certAuth *ca.CA, enrollToken, gatewayURL string, limiter *auth.RateLimiter, logger *slog.Logger) *GatewayAuthHandler {
+	host, err := gatewayHostFromURL(gatewayURL)
+	if err != nil {
+		panic(fmt.Sprintf("NewGatewayAuthHandler: %v", err))
+	}
 	return &GatewayAuthHandler{
 		store:       st,
 		ca:          certAuth,
 		enrollToken: enrollToken,
+		gatewayHost: host,
 		limiter:     limiter,
 		logger:      logger,
 		clientIP:    auth.ClientIP,
@@ -81,24 +119,41 @@ func (h *GatewayAuthHandler) EnrollGateway(ctx context.Context, req *connect.Req
 	gotHash := sha256.Sum256([]byte(req.Msg.Token))
 	wantHash := sha256.Sum256([]byte(h.enrollToken))
 	if h.enrollToken == "" || subtle.ConstantTimeCompare(gotHash[:], wantHash[:]) != 1 {
-		// Observability backstop (AC3): record the requester IP, the self-reported
-		// hostname, and a short token-HASH prefix — never the token itself — so
-		// repeated probing against the shared bootstrap token is alertable. No
+		// Observability backstop (AC3): record the requester IP and the
+		// self-reported hostname — never the token nor any digest of it — so
+		// repeated probing against the shared bootstrap token is alertable. The IP
+		// and attempt rate are what an operator alerts on; a token-hash prefix
+		// (D3) only leaked a distinguisher of the attacker's own guesses. No
 		// gateway_id is allocated and no event is emitted on this path.
 		h.logger.Warn("gateway enrollment rejected: invalid token",
 			"ip", ip,
 			"hostname", req.Msg.Hostname,
-			"token_hash_prefix", hex.EncodeToString(gotHash[:])[:8],
 		)
 		return nil, apiErrorCtx(ctx, ErrPermissionDenied, connect.CodePermissionDenied, "invalid enrollment token")
 	}
 
+	// D1: the DNS SAN stamped on the gateway cert is what agents verify at the
+	// mTLS handshake, so it MUST be control-authoritative — never the enrollee's
+	// claim. Cross-check the declared hostname (exact match, so an IP literal,
+	// mixed case, a trailing dot, or any unlisted name is refused) against this
+	// deployment's authoritative gateway host. We then stamp h.gatewayHost — not
+	// the claim — below, so even a matching claim can never smuggle a different
+	// SAN. Placed after the token check so an unauthenticated probe cannot learn
+	// the expected host, and returns InvalidArgument (a client-correctable input
+	// error, distinct from the PermissionDenied token failure).
+	if req.Msg.Hostname != h.gatewayHost {
+		h.logger.Warn("gateway enrollment rejected: hostname does not match the authoritative gateway host",
+			"ip", ip, "claimed_hostname", req.Msg.Hostname, "expected_hostname", h.gatewayHost)
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "hostname does not match this deployment's gateway host")
+	}
+
 	gatewayID := ulid.Make().String()
 
-	// Sign the CSR into a gateway-class cert. The CA stamps CN = gateway_id and
-	// the gateway peer class, and rejects any caller-supplied SAN (AC2). Every
-	// CSR failure — malformed, forged signature, SAN present — is InvalidArgument.
-	cert, err := h.ca.IssueGatewayCertificateFromCSR(gatewayID, req.Msg.Csr, req.Msg.Hostname)
+	// Sign the CSR into a gateway-class cert. The CA stamps CN = gateway_id, the
+	// gateway peer class, and h.gatewayHost as the sole DNS SAN, and rejects any
+	// caller-supplied SAN (AC2). Every CSR failure — malformed, forged signature,
+	// SAN present — is InvalidArgument.
+	cert, err := h.ca.IssueGatewayCertificateFromCSR(gatewayID, req.Msg.Csr, h.gatewayHost)
 	if err != nil {
 		h.logger.Warn("gateway enrollment: CSR rejected", "ip", ip, "error", err)
 		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeInvalidArgument, "invalid certificate signing request")
@@ -106,7 +161,9 @@ func (h *GatewayAuthHandler) EnrollGateway(ctx context.Context, req *connect.Req
 
 	fingerprint := cert.Fingerprint
 	notAfter := cert.NotAfter.Format(time.RFC3339Nano)
-	hostname := req.Msg.Hostname
+	// Record the authoritative host (what the cert actually carries), which the
+	// cross-check above already proved equals the claim.
+	hostname := h.gatewayHost
 	if err := h.store.AppendEvent(ctx, store.Event{
 		StreamType: "gateway",
 		StreamID:   gatewayID,
@@ -123,7 +180,7 @@ func (h *GatewayAuthHandler) EnrollGateway(ctx context.Context, req *connect.Req
 		return nil, apiErrorCtx(ctx, ErrInternal, connect.CodeInternal, "failed to record enrollment")
 	}
 
-	h.logger.Info("gateway enrolled", "gateway_id", gatewayID, "hostname", req.Msg.Hostname, "not_after", cert.NotAfter)
+	h.logger.Info("gateway enrolled", "gateway_id", gatewayID, "hostname", h.gatewayHost, "not_after", cert.NotAfter)
 	return connect.NewResponse(&pm.EnrollGatewayResponse{
 		CaCert:      h.ca.CACertPEM(),
 		Certificate: cert.CertPEM,

--- a/internal/api/gateway_auth_handler.go
+++ b/internal/api/gateway_auth_handler.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/url"
+	"regexp"
 	"time"
 
 	"connectrpc.com/connect"
@@ -48,11 +49,19 @@ type GatewayAuthHandler struct {
 	now      func() time.Time
 }
 
+// rfc1123Host matches a canonical DNS name: dot-separated alphanumeric labels
+// with interior hyphens, no wildcard, no underscore, no trailing dot. The same
+// shape the proto tag (hostname_rfc1123) enforces on the enrollee's claim — a
+// derived host outside it could never be matched by a valid claim anyway, but
+// catching it at boot beats every enrollment failing at runtime.
+var rfc1123Host = regexp.MustCompile(`^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]))*$`)
+
 // gatewayHostFromURL extracts the DNS host from CONTROL_GATEWAY_URL. It rejects
-// an empty host and an IP literal: the gateway cert carries a DNS SAN (agents
-// verify a DNS name at the mTLS handshake), and a DNS SAN holding an IP string
-// is never matched as an IP address — an IP gateway URL cannot back the mTLS
-// identity and must be caught at boot, not at first enrollment.
+// an empty host, an IP literal, and any non-canonical DNS name (wildcards,
+// underscores, trailing dots): the gateway cert carries a DNS SAN (agents
+// verify a DNS name at the mTLS handshake), and a SAN outside the canonical
+// shape either cannot back the mTLS identity (IP-in-DNS-SAN is never matched
+// as an IP) or would broaden it (a wildcard SAN signed by the fleet CA).
 func gatewayHostFromURL(raw string) (string, error) {
 	u, err := url.Parse(raw)
 	if err != nil {
@@ -65,6 +74,9 @@ func gatewayHostFromURL(raw string) (string, error) {
 	if net.ParseIP(host) != nil {
 		return "", fmt.Errorf("gateway URL host %q is an IP literal; a DNS name is required (the gateway cert's DNS SAN cannot be an IP)", host)
 	}
+	if len(host) > 253 || !rfc1123Host.MatchString(host) {
+		return "", fmt.Errorf("gateway URL host %q is not a canonical DNS name (no wildcards, underscores, or trailing dots)", host)
+	}
 	return host, nil
 }
 
@@ -73,7 +85,8 @@ func gatewayHostFromURL(raw string) (string, error) {
 // enrollment is effectively disabled (every attempt is rejected). gatewayURL is
 // CONTROL_GATEWAY_URL — the authoritative public gateway address; its host
 // becomes the DNS SAN of every issued gateway cert. Panics when gatewayURL has
-// no DNS host (an IP literal or empty), matching NewRegistrationHandler's
+// no canonical DNS host (empty, an IP literal, a wildcard, an underscore, or a
+// trailing dot), matching NewRegistrationHandler's
 // fail-fast: main.go validates CONTROL_GATEWAY_URL at boot, so reaching the
 // constructor with an unusable value is a configuration error that must surface
 // at startup, not silently issue certs agents cannot verify.

--- a/internal/api/gateway_binding.go
+++ b/internal/api/gateway_binding.go
@@ -25,7 +25,7 @@ func (h *InternalHandler) verifyDeviceGatewayBinding(ctx context.Context, device
 	// so a per-gateway cert's CN is available here; a request-body gateway_id that
 	// disagrees with the cert is therefore ignored and cannot escalate. Empty when
 	// no per-gateway cert is present — CheckDeviceGatewayBinding fails closed
-	// (ErrBindingGatewayMissing) whenever a resolver is wired.
+	// (ErrBindingGatewayMissing).
 	claimedGatewayID := ""
 	if peerCert, ok := mtls.PeerCertFromContext(ctx); ok {
 		claimedGatewayID = peerCert.Subject.CommonName

--- a/internal/api/gateway_handler_test.go
+++ b/internal/api/gateway_handler_test.go
@@ -31,6 +31,14 @@ import (
 
 const testEnrollToken = "test-gateway-enroll-token-value"
 
+// testGatewayURL is the CONTROL_GATEWAY_URL a test handler is built with;
+// testGatewayHost is its authoritative host — the DNS SAN the handler stamps
+// and the hostname an enroll request must declare (spec 31 D1).
+const (
+	testGatewayURL  = "https://gw1.example.com"
+	testGatewayHost = "gw1.example.com"
+)
+
 // genGatewayCSR builds a plain PKCS#10 CSR (no SAN) and returns the PEM plus the
 // key, so a renewal CSR can reuse the key for proof-of-possession.
 func genGatewayCSR(t *testing.T) ([]byte, *ecdsa.PrivateKey) {
@@ -55,11 +63,12 @@ func csrForGatewayKey(t *testing.T, key *ecdsa.PrivateKey) []byte {
 // and the issued cert fingerprint (from the projection).
 func enrollTestGateway(t *testing.T, st *store.Store, certAuth *ca.CA) (gatewayID, fingerprint string) {
 	t.Helper()
-	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, nil, slog.Default())
+	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, testGatewayURL, nil, slog.Default())
 	csr, _ := genGatewayCSR(t)
 	resp, err := h.EnrollGateway(t.Context(), connect.NewRequest(&pm.EnrollGatewayRequest{
-		Token: testEnrollToken,
-		Csr:   csr,
+		Token:    testEnrollToken,
+		Hostname: testGatewayHost,
+		Csr:      csr,
 	}))
 	require.NoError(t, err)
 	id, err := ca.DeviceIDFromPEM(resp.Msg.Certificate)
@@ -74,7 +83,7 @@ func enrollTestGateway(t *testing.T, st *store.Store, certAuth *ca.CA) (gatewayI
 func TestEnrollGateway_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	certAuth := newTestCA(t)
-	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, nil, slog.Default())
+	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, testGatewayURL, nil, slog.Default())
 
 	csr, _ := genGatewayCSR(t)
 	resp, err := h.EnrollGateway(t.Context(), connect.NewRequest(&pm.EnrollGatewayRequest{
@@ -105,12 +114,79 @@ func TestEnrollGateway_Success(t *testing.T) {
 	assert.Nil(t, row.RevokedAt, "a freshly enrolled gateway is not revoked")
 }
 
+// TestEnrollGateway_HostnameMustMatchAuthoritative pins spec 31 D1: the DNS SAN
+// on a gateway cert is control-authoritative, never the enrollee's claim. A
+// valid-token enroll whose declared hostname is anything but this deployment's
+// authoritative gateway host (host of CONTROL_GATEWAY_URL) is rejected — an
+// unlisted name, an IP literal, mixed case, or a trailing dot — and no gateway
+// is enrolled. The matching case is issued with exactly the authoritative host
+// as its sole DNS SAN, proving the server stamps its own name rather than
+// copying the request.
+func TestEnrollGateway_HostnameMustMatchAuthoritative(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	certAuth := newTestCA(t)
+	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, testGatewayURL, nil, slog.Default())
+
+	// Every one of these is NOT the authoritative host "gw1.example.com".
+	for _, bad := range []string{
+		"evil.example.com", // unlisted name — the core attack
+		"10.0.0.1",         // IP literal
+		"GW1.example.com",  // mixed case (DNS is case-insensitive; we are not)
+		"gw1.example.com.", // trailing dot
+	} {
+		t.Run("rejected/"+bad, func(t *testing.T) {
+			csr, _ := genGatewayCSR(t)
+			_, err := h.EnrollGateway(t.Context(), connect.NewRequest(&pm.EnrollGatewayRequest{
+				Token:    testEnrollToken,
+				Hostname: bad,
+				Csr:      csr,
+			}))
+			require.Error(t, err)
+			assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
+				"a hostname that is not the authoritative gateway host must be InvalidArgument")
+		})
+	}
+
+	// No gateway was enrolled by any rejected attempt.
+	list, err := st.Queries().ListGateways(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, list, "no gateway may be enrolled from a mismatched-hostname request")
+
+	// The matching hostname is issued — with the authoritative host as its ONLY
+	// DNS SAN.
+	csr, _ := genGatewayCSR(t)
+	resp, err := h.EnrollGateway(t.Context(), connect.NewRequest(&pm.EnrollGatewayRequest{
+		Token:    testEnrollToken,
+		Hostname: testGatewayHost,
+		Csr:      csr,
+	}))
+	require.NoError(t, err)
+	block, _ := pem.Decode(resp.Msg.Certificate)
+	require.NotNil(t, block)
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	assert.Equal(t, []string{testGatewayHost}, parsed.DNSNames,
+		"the issued cert's DNS SAN must be the control-authoritative host, verbatim")
+}
+
+// TestNewGatewayAuthHandler_RejectsIPGatewayURL pins the config-side half of D1:
+// a CONTROL_GATEWAY_URL whose host is an IP literal cannot back a DNS-SAN mTLS
+// identity, so the handler refuses to construct (fail fast at boot rather than
+// issue certs agents cannot verify).
+func TestNewGatewayAuthHandler_RejectsIPGatewayURL(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	certAuth := newTestCA(t)
+	assert.Panics(t, func() {
+		api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, "https://10.0.0.1:8443", nil, slog.Default())
+	}, "an IP-literal gateway URL host must panic (no valid DNS SAN)")
+}
+
 func TestEnrollGateway_WrongTokenRejectedWithProbeLog(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	certAuth := newTestCA(t)
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, nil, logger)
+	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, testGatewayURL, nil, logger)
 
 	csr, _ := genGatewayCSR(t)
 	_, err := h.EnrollGateway(t.Context(), connect.NewRequest(&pm.EnrollGatewayRequest{
@@ -121,10 +197,11 @@ func TestEnrollGateway_WrongTokenRejectedWithProbeLog(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
 
-	// AC3 observability backstop: a WARN carrying the hostname + a token HASH
-	// prefix (never the raw token) so probing is alertable.
+	// AC3 observability backstop: a WARN carrying the hostname so probing is
+	// alertable — but NO token material, not even a hash prefix (D3): neither the
+	// raw token nor any digest of it may be logged.
 	logged := buf.String()
-	assert.Contains(t, logged, "token_hash_prefix")
+	assert.NotContains(t, logged, "token_hash_prefix", "no token digest may be logged (D3)")
 	assert.Contains(t, logged, "attacker-host")
 	assert.NotContains(t, logged, "wrong-token-guess", "the raw token must never be logged")
 
@@ -137,7 +214,7 @@ func TestEnrollGateway_WrongTokenRejectedWithProbeLog(t *testing.T) {
 func TestEnrollGateway_CSRWithSANRejected(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	certAuth := newTestCA(t)
-	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, nil, slog.Default())
+	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, testGatewayURL, nil, slog.Default())
 
 	// A CSR requesting the control peer class — must be refused so an enrolling
 	// gateway cannot mint a non-gateway identity (AC2).
@@ -150,8 +227,9 @@ func TestEnrollGateway_CSRWithSANRejected(t *testing.T) {
 	csr := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: der})
 
 	_, err = h.EnrollGateway(t.Context(), connect.NewRequest(&pm.EnrollGatewayRequest{
-		Token: testEnrollToken,
-		Csr:   csr,
+		Token:    testEnrollToken,
+		Hostname: testGatewayHost,
+		Csr:      csr,
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
@@ -161,21 +239,23 @@ func TestEnrollGateway_RateLimited(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	certAuth := newTestCA(t)
 	limiter := auth.NewRateLimiter(5, time.Minute)
-	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, limiter, slog.Default())
+	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, testGatewayURL, limiter, slog.Default())
 
 	csr, _ := genGatewayCSR(t)
 	// The first 5 attempts (same empty client-IP bucket) pass the limiter.
 	for i := 0; i < 5; i++ {
 		_, err := h.EnrollGateway(t.Context(), connect.NewRequest(&pm.EnrollGatewayRequest{
-			Token: testEnrollToken,
-			Csr:   csr,
+			Token:    testEnrollToken,
+			Hostname: testGatewayHost,
+			Csr:      csr,
 		}))
 		require.NoError(t, err, "attempt %d should pass", i+1)
 	}
 	// The 6th is rejected ResourceExhausted (AC4).
 	_, err := h.EnrollGateway(t.Context(), connect.NewRequest(&pm.EnrollGatewayRequest{
-		Token: testEnrollToken,
-		Csr:   csr,
+		Token:    testEnrollToken,
+		Hostname: testGatewayHost,
+		Csr:      csr,
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeResourceExhausted, connect.CodeOf(err))

--- a/internal/api/gateway_handler_test.go
+++ b/internal/api/gateway_handler_test.go
@@ -170,15 +170,24 @@ func TestEnrollGateway_HostnameMustMatchAuthoritative(t *testing.T) {
 }
 
 // TestNewGatewayAuthHandler_RejectsIPGatewayURL pins the config-side half of D1:
-// a CONTROL_GATEWAY_URL whose host is an IP literal cannot back a DNS-SAN mTLS
-// identity, so the handler refuses to construct (fail fast at boot rather than
-// issue certs agents cannot verify).
+// a CONTROL_GATEWAY_URL whose host is an IP literal or a non-canonical DNS name
+// (wildcard, underscore, trailing dot) cannot back a DNS-SAN mTLS identity, so
+// the handler refuses to construct (fail fast at boot rather than issue certs
+// agents cannot verify — or a wildcard SAN that would broaden the identity).
 func TestNewGatewayAuthHandler_RejectsIPGatewayURL(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	certAuth := newTestCA(t)
-	assert.Panics(t, func() {
-		api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, "https://10.0.0.1:8443", nil, slog.Default())
-	}, "an IP-literal gateway URL host must panic (no valid DNS SAN)")
+	for name, url := range map[string]string{
+		"IP literal":       "https://10.0.0.1:8443",
+		"wildcard host":    "https://*.example.com",
+		"underscore label": "https://gw_1.example.com",
+		"trailing dot":     "https://gw.example.com.",
+		"leading hyphen":   "https://-gw.example.com",
+	} {
+		assert.Panics(t, func() {
+			api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, url, nil, slog.Default())
+		}, "%s in the gateway URL host must panic (no valid DNS SAN)", name)
+	}
 }
 
 func TestEnrollGateway_WrongTokenRejectedWithProbeLog(t *testing.T) {

--- a/internal/api/internal_gateway_renewal.go
+++ b/internal/api/internal_gateway_renewal.go
@@ -74,16 +74,20 @@ func (h *InternalHandler) RenewGatewayCertificate(ctx context.Context, req *conn
 
 	// Preserve the gateway's DNS SAN (hostname) across renewal — it is what the
 	// agent's standard TLS verification matches. The current cert carries it
-	// (stamped at enrollment); re-stamp the same name. A current cert with NO
-	// DNS SAN predates the DNS-SAN fix; the renewed cert would be unverifiable by
-	// agents, so warn — the operator should re-enroll (which is a restart away,
-	// gateway identity being ephemeral-per-boot) rather than renew.
-	var hostname string
-	if len(peerCert.DNSNames) > 0 {
-		hostname = peerCert.DNSNames[0]
-	} else {
-		h.logger.Warn("gateway renewal: current cert has no DNS SAN; the renewed cert will be unverifiable by agents — re-enroll instead", "gateway_id", gatewayID)
+	// (stamped authoritatively at enrollment, D1); re-stamp the same name.
+	//
+	// D4: reject instead of warn-and-issue when the current cert's SAN set is not
+	// canonical — no DNS SAN (predates the DNS-SAN fix), more than one DNS SAN, or
+	// any IP SAN. Any of these renews into a cert agents cannot verify (or one
+	// carrying a name the enrollment path would never have stamped), so fail closed
+	// and let the operator re-enroll — a restart away, gateway identity being
+	// ephemeral-per-boot — rather than perpetuate an unverifiable identity.
+	if len(peerCert.DNSNames) != 1 || len(peerCert.IPAddresses) > 0 {
+		h.logger.Warn("gateway renewal denied: current cert has no canonical DNS SAN — re-enroll instead",
+			"gateway_id", gatewayID, "dns_sans", peerCert.DNSNames, "ip_sans", len(peerCert.IPAddresses))
+		return nil, apiErrorCtx(ctx, ErrValidationFailed, connect.CodeFailedPrecondition, "gateway certificate has no canonical DNS SAN; re-enroll")
 	}
+	hostname := peerCert.DNSNames[0]
 	newCert, err := h.gatewayCA.IssueGatewayCertificateFromCSR(gatewayID, req.Msg.Csr, hostname)
 	if err != nil {
 		h.logger.Warn("gateway renewal: CSR rejected", "gateway_id", gatewayID, "error", err)

--- a/internal/api/internal_gateway_renewal_test.go
+++ b/internal/api/internal_gateway_renewal_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -24,11 +25,12 @@ import (
 // and the private key.
 func enrollGatewayWithKey(t *testing.T, st *store.Store, certAuth *ca.CA) (gatewayID string, certPEM []byte, key *ecdsa.PrivateKey) {
 	t.Helper()
-	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, nil, slog.Default())
+	h := api.NewGatewayAuthHandler(st, certAuth, testEnrollToken, testGatewayURL, nil, slog.Default())
 	csr, key := genGatewayCSR(t)
 	resp, err := h.EnrollGateway(t.Context(), connect.NewRequest(&pm.EnrollGatewayRequest{
-		Token: testEnrollToken,
-		Csr:   csr,
+		Token:    testEnrollToken,
+		Hostname: testGatewayHost,
+		Csr:      csr,
 	}))
 	require.NoError(t, err)
 	id, err := ca.DeviceIDFromPEM(resp.Msg.Certificate)
@@ -73,6 +75,12 @@ func TestRenewGatewayCertificate_Success(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEqual(t, oldFP, newFP)
 
+	// The renewed cert preserves the authoritative DNS SAN — the name agent TLS
+	// verification matches (D4: renewal must carry it forward, not drop it).
+	renewed := mustParseCert(t, resp.Msg.Certificate)
+	assert.Equal(t, []string{testGatewayHost}, renewed.DNSNames,
+		"renewal must preserve the enrolled DNS SAN")
+
 	// Old fingerprint revoked; projection advanced to the new one.
 	active, err := crlStore.LoadActive(t.Context())
 	require.NoError(t, err)
@@ -81,6 +89,37 @@ func TestRenewGatewayCertificate_Success(t *testing.T) {
 	row, err := st.Queries().GetGatewayFingerprint(t.Context(), gatewayID)
 	require.NoError(t, err)
 	assert.Equal(t, newFP, row.Fingerprint, "projection fingerprint must advance to the renewed cert")
+}
+
+// TestRenewGatewayCertificate_RejectsNonCanonicalDNSSAN pins spec 31 D4: a
+// current cert whose SAN set is not canonical — here, no DNS SAN at all (a
+// pre-D1 identity) — must be REJECTED, not warn-and-renewed into a cert agents
+// cannot verify. The gateway is expected to re-enroll (ephemeral-per-boot).
+func TestRenewGatewayCertificate_RejectsNonCanonicalDNSSAN(t *testing.T) {
+	st := testutil.SetupPostgres(t)
+	certAuth := newTestCA(t)
+
+	// Issue a gateway cert with NO DNS SAN (empty hostname), reproducing a
+	// pre-DNS-SAN-fix identity that the enrollment path would no longer mint.
+	csr, key := genGatewayCSR(t)
+	gatewayID := ulid.Make().String()
+	issued, err := certAuth.IssueGatewayCertificateFromCSR(gatewayID, csr, "")
+	require.NoError(t, err)
+	peerCert := mustParseCert(t, issued.CertPEM)
+	require.Empty(t, peerCert.DNSNames, "precondition: the current cert has no DNS SAN")
+
+	ih := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	ih.SetGatewayRenewal(certAuth, testCRLStore(t))
+	ctx := mtls.ContextWithPeerCert(t.Context(), peerCert)
+
+	// Proof-of-possession would pass (same key), so a rejection here proves the
+	// D4 canonical-SAN gate fired, not an unrelated denial.
+	_, err = ih.RenewGatewayCertificate(ctx, connect.NewRequest(&pm.RenewGatewayCertificateRequest{
+		Csr: csrForGatewayKey(t, key),
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err),
+		"a non-canonical DNS SAN must be rejected FailedPrecondition, not renewed")
 }
 
 func TestRenewGatewayCertificate_ProofOfPossessionFails(t *testing.T) {

--- a/internal/api/internal_handler.go
+++ b/internal/api/internal_handler.go
@@ -55,9 +55,11 @@ type InternalHandler struct {
 
 	// deviceGatewayResolver resolves which gateway a device is currently live
 	// on, written under the agent's mTLS identity (the device→gateway routing
-	// registry). Set via SetDeviceGatewayResolver in HA/multi-gateway
-	// deployments. When nil (single-gateway, non-HA), the device-origin binding
-	// check is bypassed — the documented single-gateway exception (see ADR).
+	// registry). Set via SetDeviceGatewayResolver whenever Valkey is configured
+	// — i.e. in every deployment with a functioning gateway. When nil the
+	// device-origin binding check fails CLOSED (spec 31 D6): a control without
+	// Valkey has no legitimate InternalService caller to admit anyway (its
+	// internal listener already rejects every gateway for want of a CRL).
 	deviceGatewayResolver registry.DeviceGatewayLookup
 
 	now func() time.Time // clock seam; defaults to time.Now, overridden in tests
@@ -93,7 +95,7 @@ func (h *InternalHandler) SetLpsKeypair(priv *ecdh.PrivateKey, signedPublicKey *
 // confined to the gateway the device is actually live on
 // (verifyDeviceGatewayBinding). VerifyDevice is exempt — it is the pre-attach
 // bootstrap and would otherwise deadlock the device's own connection. Called from
-// main.go in HA/multi-gateway deployments; left nil for single-gateway.
+// main.go whenever Valkey is configured; unset, the binding check fails closed.
 func (h *InternalHandler) SetDeviceGatewayResolver(r registry.DeviceGatewayLookup) {
 	h.deviceGatewayResolver = r
 }

--- a/internal/api/internal_handler_gateway_binding_test.go
+++ b/internal/api/internal_handler_gateway_binding_test.go
@@ -34,6 +34,19 @@ func gwCtx(cn string) context.Context {
 	return mtls.ContextWithPeerCert(context.Background(), &x509.Certificate{Subject: pkix.Name{CommonName: cn}})
 }
 
+// gwTestCN is the gateway CN tests use when the test's subject is NOT the
+// binding policy itself; allLiveResolver pairs with it, reporting every device
+// live on that gateway. Needed since spec 31 D6 removed the nil-resolver
+// bypass: proxy/projection tests must now wire a resolver like production
+// always does (the binding-policy tests below drive the real registry instead).
+const gwTestCN = "gw-test"
+
+type allLiveResolver struct{}
+
+func (allLiveResolver) LookupDeviceGateway(context.Context, string) (string, error) {
+	return gwTestCN, nil
+}
+
 // wiredHandler builds a real InternalHandler with a fake device→gateway
 // registry attached as the resolver, and binds deviceID to gatewayID in it.
 func wiredHandler(t *testing.T, st *store.Store, deviceID, gatewayID string) (*api.InternalHandler, *registry.Registry) {
@@ -357,18 +370,21 @@ func TestProxyStoreLuksKey_NoEventOnGatewayMismatch(t *testing.T) {
 		"a forged-gateway store must NOT append a device-attributed LuksKeyRotated event")
 }
 
-// TestInternalHandler_NilResolverBypass pins the documented single-gateway
-// exception: with no resolver wired, the binding is not enforced (gateway_id is
-// ignored) so non-HA deployments keep working.
-func TestInternalHandler_NilResolverBypass(t *testing.T) {
+// TestInternalHandler_NilResolver_FailsClosed pins spec 31 D6: with no
+// resolver wired — a wiring bug, since production always wires the registry
+// (Valkey is mandatory for any gateway) — every device-origin credential op
+// must fail CLOSED, not silently skip the binding. The former allow-on-nil
+// "single-gateway bypass" is exactly what an accidental unwiring would have
+// granted an attacker.
+func TestInternalHandler_NilResolver_FailsClosed(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	device := testutil.CreateTestDevice(t, st, "single-gw-host")
+	device := testutil.CreateTestDevice(t, st, "nil-resolver-host")
 	// No SetDeviceGatewayResolver — resolver stays nil.
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
-	resp, err := h.VerifyDevice(context.Background(), connect.NewRequest(&pm.VerifyDeviceRequest{
-		DeviceId: device, GatewayId: "anything-or-empty",
+	_, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
+		DeviceId: device,
 	}))
-	require.NoError(t, err, "with no resolver wired, the binding check is bypassed (single-gateway)")
-	assert.NotNil(t, resp)
+	require.Error(t, err, "a nil resolver must fail the device-origin op closed, never bypass the binding")
+	assert.Equal(t, connect.CodeInternal, connect.CodeOf(err))
 }

--- a/internal/api/internal_handler_sync_signing_test.go
+++ b/internal/api/internal_handler_sync_signing_test.go
@@ -1,7 +1,6 @@
 package api_test
 
 import (
-	"context"
 	"log/slog"
 	"testing"
 
@@ -48,6 +47,7 @@ func TestSyncActions_SignsDeviceBoundEnvelope(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	signer, verifier := newDispatchTestCA(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), signer)
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-sign-host")
@@ -56,7 +56,7 @@ func TestSyncActions_SignsDeviceBoundEnvelope(t *testing.T) {
 	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID,
 		int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
 
-	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	resp, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: deviceID,
 	}))
 	require.NoError(t, err)
@@ -99,6 +99,7 @@ func TestSyncActions_BindsTargetDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	signer, verifier := newDispatchTestCA(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), signer)
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceA := testutil.CreateTestDevice(t, st, "sync-bind-A")
@@ -107,7 +108,7 @@ func TestSyncActions_BindsTargetDevice(t *testing.T) {
 	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceA,
 		int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
 
-	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	resp, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: deviceA,
 	}))
 	require.NoError(t, err)
@@ -139,6 +140,7 @@ func TestSyncActions_UninstallFoldsIntoSignedEnvelope(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	signer, verifier := newDispatchTestCA(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), signer)
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-uninstall-sign-host")
@@ -149,7 +151,7 @@ func TestSyncActions_UninstallFoldsIntoSignedEnvelope(t *testing.T) {
 	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID,
 		int(pm.AssignmentMode_ASSIGNMENT_MODE_UNINSTALL))
 
-	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	resp, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: deviceID,
 	}))
 	require.NoError(t, err)
@@ -174,6 +176,7 @@ func TestSyncActions_SignsGroupedMembers(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	signer, verifier := newDispatchTestCA(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), signer)
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-group-sign-host")
@@ -185,7 +188,7 @@ func TestSyncActions_SignsGroupedMembers(t *testing.T) {
 	testutil.CreateTestAssignment(t, st, adminID, "action_set", setID, "device", deviceID,
 		int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
 
-	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	resp, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: deviceID,
 	}))
 	require.NoError(t, err)

--- a/internal/api/internal_handler_test.go
+++ b/internal/api/internal_handler_test.go
@@ -108,7 +108,7 @@ func TestProxySyncActions_EmptyDeviceID(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
-	_, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	_, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: "",
 	}))
 	require.Error(t, err)
@@ -118,8 +118,9 @@ func TestProxySyncActions_EmptyDeviceID(t *testing.T) {
 func TestProxySyncActions_DeviceNotFound(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
-	_, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	_, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: testutil.NewID(),
 	}))
 	require.Error(t, err)
@@ -129,10 +130,11 @@ func TestProxySyncActions_DeviceNotFound(t *testing.T) {
 func TestProxySyncActions_NoAssignments(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
 	deviceID := testutil.CreateTestDevice(t, st, "sync-host")
 
-	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	resp, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: deviceID,
 	}))
 	require.NoError(t, err)
@@ -142,6 +144,7 @@ func TestProxySyncActions_NoAssignments(t *testing.T) {
 func TestProxySyncActions_WithAssignment(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-assigned-host")
@@ -150,7 +153,7 @@ func TestProxySyncActions_WithAssignment(t *testing.T) {
 	// Assign action directly to device
 	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID, int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
 
-	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	resp, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: deviceID,
 	}))
 	require.NoError(t, err)
@@ -161,6 +164,7 @@ func TestProxySyncActions_WithAssignment(t *testing.T) {
 func TestProxySyncActions_UninstallAssignmentForcesAbsent(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-uninstall-host")
@@ -168,7 +172,7 @@ func TestProxySyncActions_UninstallAssignmentForcesAbsent(t *testing.T) {
 
 	testutil.CreateTestAssignment(t, st, adminID, "action", actionID, "device", deviceID, uninstallAssignmentMode)
 
-	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	resp, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: deviceID,
 	}))
 	require.NoError(t, err)
@@ -182,6 +186,7 @@ func TestProxySyncActions_UninstallAssignmentForcesAbsent(t *testing.T) {
 func TestProxySyncActions_ActionSetAssignmentEmitsGroup(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-set-host")
@@ -193,7 +198,7 @@ func TestProxySyncActions_ActionSetAssignmentEmitsGroup(t *testing.T) {
 	testutil.AddActionToTestSet(t, st, adminID, setID, a2, 1)
 	testutil.CreateTestAssignment(t, st, adminID, "action_set", setID, "device", deviceID, int(pm.AssignmentMode_ASSIGNMENT_MODE_REQUIRED))
 
-	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	resp, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: deviceID,
 	}))
 	require.NoError(t, err)
@@ -212,6 +217,7 @@ func TestProxySyncActions_ActionSetAssignmentEmitsGroup(t *testing.T) {
 func TestProxySyncActions_UninstallActionSetForcesAbsent(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 	deviceID := testutil.CreateTestDevice(t, st, "sync-set-uninstall-host")
@@ -220,7 +226,7 @@ func TestProxySyncActions_UninstallActionSetForcesAbsent(t *testing.T) {
 	testutil.AddActionToTestSet(t, st, adminID, setID, a1, 0)
 	testutil.CreateTestAssignment(t, st, adminID, "action_set", setID, "device", deviceID, uninstallAssignmentMode)
 
-	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	resp, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: deviceID,
 	}))
 	require.NoError(t, err)
@@ -235,7 +241,7 @@ func TestProxyStoreLuksKey_MissingFields(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
-	_, err := h.ProxyStoreLuksKey(context.Background(), connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+	_, err := h.ProxyStoreLuksKey(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
 		DeviceId: "",
 		ActionId: "",
 	}))
@@ -247,7 +253,7 @@ func TestProxyValidateLuksToken_MissingFields(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
-	_, err := h.ProxyValidateLuksToken(context.Background(), connect.NewRequest(&pm.InternalValidateLuksTokenRequest{
+	_, err := h.ProxyValidateLuksToken(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalValidateLuksTokenRequest{
 		DeviceId: "",
 		Token:    "",
 	}))
@@ -258,8 +264,9 @@ func TestProxyValidateLuksToken_MissingFields(t *testing.T) {
 func TestProxyGetLuksKey_NotFound(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
-	_, err := h.ProxyGetLuksKey(context.Background(), connect.NewRequest(&pm.InternalGetLuksKeyRequest{
+	_, err := h.ProxyGetLuksKey(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalGetLuksKeyRequest{
 		DeviceId: testutil.NewID(),
 		ActionId: testutil.NewID(),
 	}))
@@ -278,7 +285,7 @@ func TestProxyStoreLpsPasswords(t *testing.T) {
 	sealed, err := sdkcrypto.SealLpsPassword(pub, "new-pass-123", deviceID, actionID, "admin")
 	require.NoError(t, err)
 
-	resp, err := h.ProxyStoreLpsPasswords(context.Background(), connect.NewRequest(&pm.InternalStoreLpsPasswordsRequest{
+	resp, err := h.ProxyStoreLpsPasswords(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalStoreLpsPasswordsRequest{
 		DeviceId: deviceID,
 		ActionId: actionID,
 		Rotations: []*pm.LpsPasswordRotation{
@@ -298,7 +305,7 @@ func TestProxyStoreLpsPasswords_MissingFields(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
 
-	_, err := h.ProxyStoreLpsPasswords(context.Background(), connect.NewRequest(&pm.InternalStoreLpsPasswordsRequest{
+	_, err := h.ProxyStoreLpsPasswords(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalStoreLpsPasswordsRequest{
 		DeviceId: "",
 		ActionId: "",
 	}))

--- a/internal/api/lps_sealed_transport_test.go
+++ b/internal/api/lps_sealed_transport_test.go
@@ -89,6 +89,7 @@ func newLpsHandler(t *testing.T) (h *api.InternalHandler, st *store.Store, enc *
 	enc = testutil.NewEncryptor(t)
 	signer, v := newDispatchTestCA(t)
 	h = api.NewInternalHandler(st, enc, slog.Default(), signer)
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 
 	priv, pubRaw, err := api.EnsureLpsKeypair(context.Background(), st, enc)
 	require.NoError(t, err)
@@ -108,7 +109,7 @@ func TestProxySyncActions_AttachesSignedLpsPublicKey(t *testing.T) {
 	h, st, _, pub, verifier := newLpsHandler(t)
 	deviceID := testutil.CreateTestDevice(t, st, "lps-sync-host")
 
-	resp, err := h.ProxySyncActions(context.Background(), connect.NewRequest(&pm.InternalSyncActionsRequest{
+	resp, err := h.ProxySyncActions(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalSyncActionsRequest{
 		DeviceId: deviceID,
 	}))
 	require.NoError(t, err)
@@ -136,7 +137,7 @@ func TestProxySyncActions_AttachesSignedLpsPublicKey(t *testing.T) {
 // at-rest store.
 func TestLpsSealedTransport_EndToEnd(t *testing.T) {
 	h, st, enc, pub, _ := newLpsHandler(t)
-	ctx := context.Background()
+	ctx := gwCtx(gwTestCN)
 
 	deviceID := testutil.CreateTestDevice(t, st, "lps-e2e-host")
 	actionID := testutil.NewID()
@@ -172,7 +173,7 @@ func TestLpsSealedTransport_EndToEnd(t *testing.T) {
 // InvalidArgument and appends no lps_password event.
 func TestProxyStoreLpsPasswords_RejectsUnsealable(t *testing.T) {
 	h, st, _, pub, _ := newLpsHandler(t)
-	ctx := context.Background()
+	ctx := gwCtx(gwTestCN)
 	deviceID := testutil.CreateTestDevice(t, st, "lps-reject-host")
 	actionID := testutil.NewID()
 
@@ -216,7 +217,7 @@ func TestProxyStoreLpsPasswords_RejectsUnsealable(t *testing.T) {
 // unseals the whole batch before any append).
 func TestProxyStoreLpsPasswords_BatchIsAtomic(t *testing.T) {
 	h, st, _, pub, _ := newLpsHandler(t)
-	ctx := context.Background()
+	ctx := gwCtx(gwTestCN)
 	deviceID := testutil.CreateTestDevice(t, st, "lps-atomic-host")
 	actionID := testutil.NewID()
 
@@ -247,9 +248,10 @@ func TestProxyStoreLpsPasswords_BatchIsAtomic(t *testing.T) {
 func TestProxyStoreLpsPasswords_NilKeypairFailsClosed(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 	deviceID := testutil.CreateTestDevice(t, st, "lps-nokey-host")
 
-	_, err := h.ProxyStoreLpsPasswords(context.Background(), connect.NewRequest(&pm.InternalStoreLpsPasswordsRequest{
+	_, err := h.ProxyStoreLpsPasswords(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalStoreLpsPasswordsRequest{
 		DeviceId: deviceID,
 		ActionId: testutil.NewID(),
 		Rotations: []*pm.LpsPasswordRotation{{

--- a/internal/api/luks_sealed_transport_test.go
+++ b/internal/api/luks_sealed_transport_test.go
@@ -30,7 +30,7 @@ import (
 // decrypts back to the original under the at-rest AAD.
 func TestProxyStoreLuksKey_SealedRoundTrip(t *testing.T) {
 	h, st, enc, pub, _ := newLpsHandler(t)
-	ctx := context.Background()
+	ctx := gwCtx(gwTestCN)
 	deviceID := testutil.CreateTestDevice(t, st, "luks-seal-host")
 	actionID := testutil.NewID()
 	const passphrase = "disk-Passphrase-0riginal-42"
@@ -62,7 +62,7 @@ func TestProxyStoreLuksKey_SealedRoundTrip(t *testing.T) {
 // luks_key event is appended.
 func TestProxyStoreLuksKey_RejectsUnsealable(t *testing.T) {
 	h, st, _, pub, _ := newLpsHandler(t)
-	ctx := context.Background()
+	ctx := gwCtx(gwTestCN)
 	deviceID := testutil.CreateTestDevice(t, st, "luks-reject-host")
 	otherDevice := testutil.CreateTestDevice(t, st, "luks-other-host")
 	actionID := testutil.NewID()
@@ -116,7 +116,7 @@ func TestProxyStoreLuksKey_RejectsUnsealable(t *testing.T) {
 // "luks") — must not open in the LUKS store path.
 func TestProxyStoreLuksKey_RejectsCrossDomainBlob(t *testing.T) {
 	h, st, _, pub, _ := newLpsHandler(t)
-	ctx := context.Background()
+	ctx := gwCtx(gwTestCN)
 	deviceID := testutil.CreateTestDevice(t, st, "luks-xdomain-host")
 	actionID := testutil.NewID()
 
@@ -144,9 +144,10 @@ func TestProxyStoreLuksKey_RejectsCrossDomainBlob(t *testing.T) {
 func TestProxyStoreLuksKey_NilKeypairFailsClosed(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	h := api.NewInternalHandler(st, testutil.NewEncryptor(t), slog.Default(), api.NoOpSigner{})
+	h.SetDeviceGatewayResolver(allLiveResolver{})
 	deviceID := testutil.CreateTestDevice(t, st, "luks-nokey-host")
 
-	_, err := h.ProxyStoreLuksKey(context.Background(), connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
+	_, err := h.ProxyStoreLuksKey(gwCtx(gwTestCN), connect.NewRequest(&pm.InternalStoreLuksKeyRequest{
 		DeviceId:         deviceID,
 		ActionId:         testutil.NewID(),
 		DevicePath:       "/dev/sda2",

--- a/internal/control/inbox_binding_retry_test.go
+++ b/internal/control/inbox_binding_retry_test.go
@@ -1,0 +1,60 @@
+package control
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+
+	"github.com/hibiken/asynq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/gateway/registry"
+)
+
+// stubLookup is a DeviceGatewayLookup that returns a fixed answer, so the
+// binding-classification test can drive each verdict without a live registry.
+type stubLookup struct {
+	gw  string
+	err error
+}
+
+func (s stubLookup) LookupDeviceGateway(context.Context, string) (string, error) {
+	return s.gw, s.err
+}
+
+// TestVerifyDeviceGatewayBinding_RetryClassification pins spec 31 D5: a
+// PERMANENT binding verdict is dropped (SkipRetry), but a TRANSIENT registry
+// lookup failure stays retryable — otherwise a Valkey blip silently discards a
+// legitimate device-origin event.
+func TestVerifyDeviceGatewayBinding_RetryClassification(t *testing.T) {
+	newWorker := func(l stubLookup) *InboxWorker {
+		return &InboxWorker{logger: slog.Default(), resolver: l}
+	}
+
+	t.Run("transient lookup failure is retryable", func(t *testing.T) {
+		w := newWorker(stubLookup{err: errors.New("dial tcp: valkey unreachable")})
+		err := w.verifyDeviceGatewayBinding(context.Background(), "dev1", "gw1")
+		require.Error(t, err)
+		assert.False(t, errors.Is(err, asynq.SkipRetry),
+			"a transient registry lookup failure must NOT be SkipRetry — the event must be retried, not dropped")
+	})
+
+	t.Run("gateway mismatch is a permanent drop", func(t *testing.T) {
+		// The device is live on a DIFFERENT gateway → ErrBindingMismatch.
+		w := newWorker(stubLookup{gw: "gwOTHER"})
+		err := w.verifyDeviceGatewayBinding(context.Background(), "dev1", "gw1")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, asynq.SkipRetry),
+			"a forged/mismatched binding is permanent → SkipRetry drop")
+	})
+
+	t.Run("device not live is a permanent drop", func(t *testing.T) {
+		w := newWorker(stubLookup{err: registry.ErrNoGateway})
+		err := w.verifyDeviceGatewayBinding(context.Background(), "dev1", "gw1")
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, asynq.SkipRetry),
+			"device-not-live is one of the permanent sentinels → SkipRetry drop")
+	})
+}

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -82,6 +82,9 @@ func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ca.Actio
 // (registry backend unreachable, context cancellation) is NOT one of those
 // sentinels; wrapping it in SkipRetry would silently drop a legitimate
 // device-origin event on a Valkey blip. Return it unwrapped so Asynq retries.
+// The nil-resolver error (spec 31 D6) stays retryable DELIBERATELY: it is a
+// wiring bug, and retrying keeps the device-origin events queued until a
+// restart with fixed wiring — SkipRetry would discard legitimate events.
 func (w *InboxWorker) verifyDeviceGatewayBinding(ctx context.Context, deviceID, gatewayID string) error {
 	err := registry.CheckDeviceGatewayBinding(ctx, w.resolver, deviceID, gatewayID)
 	if err == nil {

--- a/internal/control/inbox_worker.go
+++ b/internal/control/inbox_worker.go
@@ -50,16 +50,16 @@ type InboxWorker struct {
 	logger     *slog.Logger
 	// resolver looks up which gateway a device is currently live on, so
 	// every device-origin handler can confine the task to that gateway
-	// (registry.CheckDeviceGatewayBinding). nil = single-gateway / non-HA
-	// deployment: the binding is documented-disabled there, exactly as on
-	// the InternalService side (api/gateway_binding.go).
+	// (registry.CheckDeviceGatewayBinding). Required: production always wires
+	// the Valkey-backed registry (the worker only runs with Valkey), and the
+	// binding check fails closed on nil (spec 31 D6).
 	resolver registry.DeviceGatewayLookup
 }
 
 // NewInboxWorker creates a new inbox worker. resolver is the
 // device→gateway routing lookup used to bind device-origin tasks to the
-// gateway the device is live on; pass nil in single-gateway deployments
-// where the binding is not enforced.
+// gateway the device is live on; it is required — a nil resolver makes every
+// device-origin task fail closed (spec 31 D6).
 func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ca.ActionSigner, taskSigner *taskqueue.Signer, logger *slog.Logger, resolver registry.DeviceGatewayLookup) *InboxWorker {
 	return &InboxWorker{
 		now:        time.Now,
@@ -72,15 +72,30 @@ func NewInboxWorker(st *store.Store, aqClient *taskqueue.Client, signer ca.Actio
 	}
 }
 
-// verifyDeviceGatewayBinding maps the shared binding policy to an inbox drop:
-// a forged/mismatched binding is NOT retryable, so wrap with asynq.SkipRetry
-// and append NO event. Returns nil when the binding is OK (or no resolver).
+// verifyDeviceGatewayBinding maps the shared binding policy to an inbox drop.
+// Returns nil when the binding is OK.
+//
+// D5: only a PERMANENT binding verdict — one of the three sentinels (missing
+// gateway_id, device not live on any gateway, or a gateway mismatch) — is a
+// forged/unsatisfiable claim that a retry can never fix, so those are wrapped
+// with asynq.SkipRetry and the event is dropped. A transient lookup failure
+// (registry backend unreachable, context cancellation) is NOT one of those
+// sentinels; wrapping it in SkipRetry would silently drop a legitimate
+// device-origin event on a Valkey blip. Return it unwrapped so Asynq retries.
 func (w *InboxWorker) verifyDeviceGatewayBinding(ctx context.Context, deviceID, gatewayID string) error {
-	if err := registry.CheckDeviceGatewayBinding(ctx, w.resolver, deviceID, gatewayID); err != nil {
-		w.logger.Warn("inbox: rejecting device-origin task: gateway binding", "device_id", deviceID, "claimed_gateway_id", gatewayID, "error", err)
+	err := registry.CheckDeviceGatewayBinding(ctx, w.resolver, deviceID, gatewayID)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, registry.ErrBindingGatewayMissing) ||
+		errors.Is(err, registry.ErrBindingDeviceNotLive) ||
+		errors.Is(err, registry.ErrBindingMismatch) {
+		w.logger.Warn("inbox: dropping device-origin task: gateway binding", "device_id", deviceID, "claimed_gateway_id", gatewayID, "error", err)
 		return fmt.Errorf("%w: device→gateway binding: %v", asynq.SkipRetry, err)
 	}
-	return nil
+	// Transient — keep it retryable (no SkipRetry).
+	w.logger.Warn("inbox: retrying device-origin task: transient gateway-binding lookup failure", "device_id", deviceID, "claimed_gateway_id", gatewayID, "error", err)
+	return fmt.Errorf("device→gateway binding lookup: %w", err)
 }
 
 // NewMux returns an Asynq ServeMux with handlers for the main

--- a/internal/control/inbox_worker_test.go
+++ b/internal/control/inbox_worker_test.go
@@ -66,6 +66,19 @@ func newTestCASignerVerifier(t *testing.T) (ca.ActionSigner, *verify.ActionVerif
 	return ca.NewActionSigner(c), verifier
 }
 
+// testLiveGateway is the gateway every device-origin payload in the
+// projection-focused tests claims; anyDeviceLive reports every device live on
+// it. Needed since spec 31 D6 removed the nil-resolver bypass — these tests
+// exercise projection logic, not the binding policy (which
+// TestInbox_RejectsCrossGatewayDeviceOrigin drives through the real registry).
+const testLiveGateway = "gw-test"
+
+type anyDeviceLive struct{}
+
+func (anyDeviceLive) LookupDeviceGateway(context.Context, string) (string, error) {
+	return testLiveGateway, nil
+}
+
 func newTask(t *testing.T, typeName string, payload any) *asynq.Task {
 	t.Helper()
 	data, err := json.Marshal(payload)
@@ -75,13 +88,14 @@ func newTask(t *testing.T, typeName string, payload any) *asynq.Task {
 
 func TestHandleDeviceHeartbeat(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "heartbeat-host")
 
 	task := newTask(t, taskqueue.TypeDeviceHeartbeat, taskqueue.DeviceHeartbeatPayload{
 		DeviceID:     deviceID,
+		GatewayID:    testLiveGateway,
 		AgentVersion: "2.0.0",
 	})
 
@@ -96,7 +110,7 @@ func TestHandleDeviceHeartbeat(t *testing.T) {
 
 func TestHandleDeviceHeartbeat_DeletedDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "deleted-heartbeat-host")
@@ -114,6 +128,7 @@ func TestHandleDeviceHeartbeat_DeletedDevice(t *testing.T) {
 
 	task := newTask(t, taskqueue.TypeDeviceHeartbeat, taskqueue.DeviceHeartbeatPayload{
 		DeviceID:     deviceID,
+		GatewayID:    testLiveGateway,
 		AgentVersion: "2.0.0",
 	})
 
@@ -124,13 +139,14 @@ func TestHandleDeviceHeartbeat_DeletedDevice(t *testing.T) {
 
 func TestHandleSecurityAlert(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "alert-host")
 
 	task := newTask(t, taskqueue.TypeSecurityAlert, taskqueue.SecurityAlertPayload{
 		DeviceID:  deviceID,
+		GatewayID: testLiveGateway,
 		AlertType: "tamper_detected",
 		Message:   "Agent binary modified",
 		Details:   map[string]string{"path": "/usr/bin/pm-agent"},
@@ -162,7 +178,7 @@ func TestHandleSecurityAlert(t *testing.T) {
 // with an orphan SecurityAlert event.
 func TestHandleSecurityAlert_DeletedDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "deleted-alert-host")
@@ -178,6 +194,7 @@ func TestHandleSecurityAlert_DeletedDevice(t *testing.T) {
 
 	task := newTask(t, taskqueue.TypeSecurityAlert, taskqueue.SecurityAlertPayload{
 		DeviceID:  deviceID,
+		GatewayID: testLiveGateway,
 		AlertType: "tamper_detected",
 		Message:   "Agent binary modified",
 	})
@@ -198,13 +215,14 @@ func TestHandleSecurityAlert_DeletedDevice(t *testing.T) {
 
 func TestHandleInventoryUpdate(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "inventory-host")
 
 	task := newTask(t, taskqueue.TypeInventoryUpdate, taskqueue.InventoryUpdatePayload{
-		DeviceID: deviceID,
+		DeviceID:  deviceID,
+		GatewayID: testLiveGateway,
 		Tables: []taskqueue.InventoryTable{
 			{TableName: "packages", RowsJSON: []byte(`[{"name":"vim","version":"9.0"}]`)},
 		},
@@ -224,7 +242,7 @@ func TestHandleInventoryUpdate(t *testing.T) {
 // the guard the Upsert leaves orphan inventory behind the deletion.
 func TestHandleInventoryUpdate_DeletedDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "deleted-inventory-host")
@@ -239,7 +257,8 @@ func TestHandleInventoryUpdate_DeletedDevice(t *testing.T) {
 	require.NoError(t, err)
 
 	task := newTask(t, taskqueue.TypeInventoryUpdate, taskqueue.InventoryUpdatePayload{
-		DeviceID: deviceID,
+		DeviceID:  deviceID,
+		GatewayID: testLiveGateway,
 		Tables: []taskqueue.InventoryTable{
 			{TableName: "packages", RowsJSON: []byte(`[{"name":"vim","version":"9.0"}]`)},
 		},
@@ -255,7 +274,7 @@ func TestHandleInventoryUpdate_DeletedDevice(t *testing.T) {
 
 func TestHandleExecutionResult_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -300,6 +319,7 @@ func TestHandleExecutionResult_Success(t *testing.T) {
 
 	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
 		DeviceID:          deviceID,
+		GatewayID:         testLiveGateway,
 		ActionResultProto: resultProto,
 	})
 
@@ -322,7 +342,7 @@ func TestHandleExecutionResult_Success(t *testing.T) {
 // (parity: the projection row carries the action_name and compliant flag).
 func TestHandleExecutionResult_ComplianceDetectionOutputIsTruncated(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -381,6 +401,7 @@ func TestHandleExecutionResult_ComplianceDetectionOutputIsTruncated(t *testing.T
 	require.NoError(t, err)
 	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
 		DeviceID:          deviceID,
+		GatewayID:         testLiveGateway,
 		ActionResultProto: resultProto,
 	})
 	require.NoError(t, mux.ProcessTask(context.Background(), task))
@@ -429,7 +450,7 @@ func TestHandleExecutionResult_ComplianceDetectionOutputIsTruncated(t *testing.T
 // execution by supplying its ID. The reporting device must own the execution.
 func TestHandleExecutionResult_RejectsCrossDeviceSpoof(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -467,6 +488,7 @@ func TestHandleExecutionResult_RejectsCrossDeviceSpoof(t *testing.T) {
 	require.NoError(t, err)
 	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
 		DeviceID:          attackerDevice,
+		GatewayID:         testLiveGateway,
 		ActionResultProto: resultProto,
 	})
 
@@ -484,7 +506,7 @@ func TestHandleExecutionResult_RejectsCrossDeviceSpoof(t *testing.T) {
 // osquery result by supplying its (non-secret) query_id.
 func TestHandleOSQueryResult_RejectsCrossDeviceSpoof(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	victimDevice := testutil.CreateTestDevice(t, st, "victim-osq")
@@ -498,10 +520,11 @@ func TestHandleOSQueryResult_RejectsCrossDeviceSpoof(t *testing.T) {
 
 	// The attacker device reports a forged result for the victim's query.
 	task := newTask(t, taskqueue.TypeOSQueryResult, taskqueue.OSQueryResultPayload{
-		DeviceID: attackerDevice,
-		QueryID:  queryID,
-		Success:  true,
-		RowsJSON: []byte(`[{"forged":"1"}]`),
+		DeviceID:  attackerDevice,
+		GatewayID: testLiveGateway,
+		QueryID:   queryID,
+		Success:   true,
+		RowsJSON:  []byte(`[{"forged":"1"}]`),
 	})
 	// Dropped (0 rows), not a retryable error.
 	require.NoError(t, mux.ProcessTask(context.Background(), task))
@@ -514,7 +537,7 @@ func TestHandleOSQueryResult_RejectsCrossDeviceSpoof(t *testing.T) {
 
 func TestHandleExecutionResult_Failed(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -556,6 +579,7 @@ func TestHandleExecutionResult_Failed(t *testing.T) {
 
 	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
 		DeviceID:          deviceID,
+		GatewayID:         testLiveGateway,
 		ActionResultProto: resultProto,
 	})
 
@@ -573,7 +597,7 @@ func TestHandleExecutionResult_Failed(t *testing.T) {
 // column — a distinct terminal state, not FAILED and not SUCCESS.
 func TestHandleExecutionResult_NotApplicable(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -611,6 +635,7 @@ func TestHandleExecutionResult_NotApplicable(t *testing.T) {
 
 	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
 		DeviceID:          deviceID,
+		GatewayID:         testLiveGateway,
 		ActionResultProto: resultProto,
 	})
 
@@ -626,7 +651,7 @@ func TestHandleExecutionResult_NotApplicable(t *testing.T) {
 
 func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -646,6 +671,7 @@ func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 
 	task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
 		DeviceID:          deviceID,
+		GatewayID:         testLiveGateway,
 		ActionResultProto: resultProto,
 	})
 
@@ -655,7 +681,7 @@ func TestHandleExecutionResult_CreatesExecutionIfNotExists(t *testing.T) {
 
 func TestHandleExecutionOutputChunk(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "chunk-host")
@@ -683,6 +709,7 @@ func TestHandleExecutionOutputChunk(t *testing.T) {
 
 	task := newTask(t, taskqueue.TypeExecutionOutputChunk, taskqueue.ExecutionOutputChunkPayload{
 		DeviceID:    deviceID,
+		GatewayID:   testLiveGateway,
 		ExecutionID: executionID,
 		Stream:      "stdout",
 		Data:        "line 1 of output\n",
@@ -695,16 +722,17 @@ func TestHandleExecutionOutputChunk(t *testing.T) {
 
 func TestHandleRevokeLuksDeviceKeyResult_Success(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "luks-host")
 	actionID := testutil.NewID()
 
 	task := newTask(t, taskqueue.TypeRevokeLuksDeviceKeyResult, taskqueue.RevokeLuksDeviceKeyResultPayload{
-		DeviceID: deviceID,
-		ActionID: actionID,
-		Success:  true,
+		DeviceID:  deviceID,
+		GatewayID: testLiveGateway,
+		ActionID:  actionID,
+		Success:   true,
 	})
 
 	err := mux.ProcessTask(context.Background(), task)
@@ -713,17 +741,18 @@ func TestHandleRevokeLuksDeviceKeyResult_Success(t *testing.T) {
 
 func TestHandleRevokeLuksDeviceKeyResult_Failure(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "luks-fail-host")
 	actionID := testutil.NewID()
 
 	task := newTask(t, taskqueue.TypeRevokeLuksDeviceKeyResult, taskqueue.RevokeLuksDeviceKeyResultPayload{
-		DeviceID: deviceID,
-		ActionID: actionID,
-		Success:  false,
-		Error:    "device busy",
+		DeviceID:  deviceID,
+		GatewayID: testLiveGateway,
+		ActionID:  actionID,
+		Success:   false,
+		Error:     "device busy",
 	})
 
 	err := mux.ProcessTask(context.Background(), task)
@@ -734,13 +763,14 @@ func TestHandleDeviceHello(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	// handleDeviceHello calls dispatchPendingActions which needs aqClient.
 	// Passing nil is safe here because there are no pending executions to dispatch.
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "hello-host")
 
 	task := newTask(t, taskqueue.TypeDeviceHello, taskqueue.DeviceHelloPayload{
 		DeviceID:     deviceID,
+		GatewayID:    testLiveGateway,
 		Hostname:     "hello-host-updated",
 		AgentVersion: "3.0.0",
 	})
@@ -756,7 +786,7 @@ func TestHandleDeviceHello(t *testing.T) {
 
 func TestHandleDeviceHello_DeletedDevice(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	deviceID := testutil.CreateTestDevice(t, st, "hello-deleted-host")
@@ -774,6 +804,7 @@ func TestHandleDeviceHello_DeletedDevice(t *testing.T) {
 
 	task := newTask(t, taskqueue.TypeDeviceHello, taskqueue.DeviceHelloPayload{
 		DeviceID:     deviceID,
+		GatewayID:    testLiveGateway,
 		Hostname:     "hello-deleted-host",
 		AgentVersion: "1.0.0",
 	})
@@ -802,7 +833,7 @@ func TestDispatchPendingActions_ResignsFullEnvelope(t *testing.T) {
 	defer aqClient.Close()
 
 	signer, verifier := newTestCASignerVerifier(t)
-	worker := control.NewInboxWorker(st, aqClient, signer, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, aqClient, signer, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	ctx := context.Background()
@@ -848,6 +879,7 @@ func TestDispatchPendingActions_ResignsFullEnvelope(t *testing.T) {
 	// Trigger device hello — calls dispatchPendingActions internally.
 	task := newTask(t, taskqueue.TypeDeviceHello, taskqueue.DeviceHelloPayload{
 		DeviceID:     deviceID,
+		GatewayID:    testLiveGateway,
 		Hostname:     "resign-host",
 		AgentVersion: "1.0.0",
 	})
@@ -1150,7 +1182,7 @@ func TestInbox_RejectsCrossGatewayDeviceOrigin(t *testing.T) {
 // from the gateway binding.)
 func TestHandleExecutionOutputChunk_RejectsCrossDeviceSpoof(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -1179,6 +1211,7 @@ func TestHandleExecutionOutputChunk_RejectsCrossDeviceSpoof(t *testing.T) {
 	// Attacker device sends a chunk for the victim's execution.
 	forged := newTask(t, taskqueue.TypeExecutionOutputChunk, taskqueue.ExecutionOutputChunkPayload{
 		DeviceID:    attackerDevice,
+		GatewayID:   testLiveGateway,
 		ExecutionID: executionID,
 		Stream:      "stdout",
 		Data:        "FORGED",
@@ -1193,6 +1226,7 @@ func TestHandleExecutionOutputChunk_RejectsCrossDeviceSpoof(t *testing.T) {
 	// The owning (victim) device's chunk IS appended.
 	legit := newTask(t, taskqueue.TypeExecutionOutputChunk, taskqueue.ExecutionOutputChunkPayload{
 		DeviceID:    victimDevice,
+		GatewayID:   testLiveGateway,
 		ExecutionID: executionID,
 		Stream:      "stdout",
 		Data:        "real output\n",
@@ -1211,7 +1245,7 @@ func TestHandleExecutionOutputChunk_RejectsCrossDeviceSpoof(t *testing.T) {
 // device that actually has an outstanding request gets its terminal event.
 func TestHandleRevokeLuksDeviceKeyResult_RejectsCrossDeviceSpoof(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
@@ -1238,9 +1272,10 @@ func TestHandleRevokeLuksDeviceKeyResult_RejectsCrossDeviceSpoof(t *testing.T) {
 	// Attacker reports a result for the victim's action from its own device —
 	// no outstanding request for (attackerDevice, victimAction).
 	forged := newTask(t, taskqueue.TypeRevokeLuksDeviceKeyResult, taskqueue.RevokeLuksDeviceKeyResultPayload{
-		DeviceID: attackerDevice,
-		ActionID: victimAction,
-		Success:  true,
+		DeviceID:  attackerDevice,
+		GatewayID: testLiveGateway,
+		ActionID:  victimAction,
+		Success:   true,
 	})
 	require.NoError(t, mux.ProcessTask(context.Background(), forged))
 
@@ -1267,9 +1302,10 @@ func TestHandleRevokeLuksDeviceKeyResult_RejectsCrossDeviceSpoof(t *testing.T) {
 	// The victim reporting its OWN outstanding revocation lands the terminal
 	// event on the SAME stream the request minted.
 	legit := newTask(t, taskqueue.TypeRevokeLuksDeviceKeyResult, taskqueue.RevokeLuksDeviceKeyResultPayload{
-		DeviceID: victimDevice,
-		ActionID: victimAction,
-		Success:  true,
+		DeviceID:  victimDevice,
+		GatewayID: testLiveGateway,
+		ActionID:  victimAction,
+		Success:   true,
 	})
 	require.NoError(t, mux.ProcessTask(context.Background(), legit))
 
@@ -1298,7 +1334,7 @@ func TestHandleRevokeLuksDeviceKeyResult_RejectsCrossDeviceSpoof(t *testing.T) {
 //   - a correctly-owned chunk is appended.
 func TestHandleTerminalAuditChunk_RejectsUnownedSession(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewTerminalAuditMux()
 	ctx := context.Background()
 
@@ -1324,6 +1360,7 @@ func TestHandleTerminalAuditChunk_RejectsUnownedSession(t *testing.T) {
 	forged := newTask(t, taskqueue.TypeTerminalAuditChunk, taskqueue.TerminalAuditChunkPayload{
 		SessionID: sessionV,
 		DeviceID:  attackerDevice,
+		GatewayID: testLiveGateway,
 		UserID:    attackerUser,
 		Data:      []byte("FORGED KEYSTROKES"),
 		Sequence:  1,
@@ -1342,6 +1379,7 @@ func TestHandleTerminalAuditChunk_RejectsUnownedSession(t *testing.T) {
 	orphan := newTask(t, taskqueue.TypeTerminalAuditChunk, taskqueue.TerminalAuditChunkPayload{
 		SessionID: unknownSession,
 		DeviceID:  attackerDevice,
+		GatewayID: testLiveGateway,
 		UserID:    attackerUser,
 		Data:      []byte("ORPHAN"),
 		Sequence:  1,
@@ -1354,6 +1392,7 @@ func TestHandleTerminalAuditChunk_RejectsUnownedSession(t *testing.T) {
 	legit := newTask(t, taskqueue.TypeTerminalAuditChunk, taskqueue.TerminalAuditChunkPayload{
 		SessionID: sessionV,
 		DeviceID:  victimDevice,
+		GatewayID: testLiveGateway,
 		UserID:    victimUser,
 		Data:      []byte("ls -la\n"),
 		Sequence:  1,
@@ -1375,7 +1414,7 @@ func TestHandleTerminalAuditChunk_RejectsUnownedSession(t *testing.T) {
 // agent rolls it back.
 func TestHandleExecutionResult_AgentScheduled_RequiresAssignment(t *testing.T) {
 	st := testutil.SetupPostgres(t)
-	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), nil)
+	worker := control.NewInboxWorker(st, nil, nil, nil, slog.Default(), anyDeviceLive{})
 	mux := worker.NewMux()
 	adminID := testutil.CreateTestUser(t, st, testutil.NewID()+"@test.com", "pass", "admin")
 
@@ -1399,6 +1438,7 @@ func TestHandleExecutionResult_AgentScheduled_RequiresAssignment(t *testing.T) {
 		require.NoError(t, err)
 		task := newTask(t, taskqueue.TypeExecutionResult, taskqueue.ExecutionResultPayload{
 			DeviceID:          device,
+			GatewayID:         testLiveGateway,
 			ActionResultProto: resultProto,
 		})
 		return mux.ProcessTask(context.Background(), task)

--- a/internal/gateway/registry/binding.go
+++ b/internal/gateway/registry/binding.go
@@ -42,14 +42,17 @@ var (
 // InternalService handlers and the control:inbox worker.
 //
 // Fail-closed:
-//   - lookup nil → nil (allow). The single-gateway / non-HA exception: the
-//     routing registry is only wired where more than one gateway can connect.
+//   - lookup nil → error. There is no deployment without the registry (Valkey —
+//     and with it the registry — is mandatory for any gateway to function), so a
+//     nil resolver is a wiring bug, and a security check must fail closed on a
+//     wiring bug, never open (spec 31 D6 — the former allow-on-nil was the
+//     bypass an accidental unwiring would silently grant).
 //   - claimedGatewayID empty → ErrBindingGatewayMissing.
 //   - ErrNoGateway → ErrBindingDeviceNotLive (never allow when we can't tell).
 //   - actual ≠ claimed → ErrBindingMismatch.
 func CheckDeviceGatewayBinding(ctx context.Context, lookup DeviceGatewayLookup, deviceID, claimedGatewayID string) error {
 	if lookup == nil {
-		return nil // single-gateway / non-HA: binding not enforced (documented)
+		return errors.New("registry: no device→gateway resolver wired — refusing the device-origin operation (fail closed)")
 	}
 	if claimedGatewayID == "" {
 		return ErrBindingGatewayMissing

--- a/internal/gwenroll/enroll.go
+++ b/internal/gwenroll/enroll.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage-sdk/gen/go/pm/v1/pmv1connect"
@@ -133,9 +134,12 @@ func buildIdentity(key *ecdsa.PrivateKey, keyPEM, certPEM, caCertPEM []byte) (*I
 	if err := verifyGatewayCertProfile(cert); err != nil {
 		return nil, fmt.Errorf("issued gateway cert has the wrong profile: %w", err)
 	}
+	// The CN is the gateway's instance identity (ADR 0032) and control always
+	// assigns it a ULID; parse it so a mis-issued CN fails the boot loudly
+	// instead of entering the registry/binding flows as a malformed id.
 	gatewayID := cert.Subject.CommonName
-	if gatewayID == "" {
-		return nil, fmt.Errorf("issued gateway cert has an empty CN")
+	if _, err := ulid.Parse(gatewayID); err != nil {
+		return nil, fmt.Errorf("issued gateway cert CN %q is not a ULID gateway id: %w", gatewayID, err)
 	}
 	tlsCert, err := tls.X509KeyPair(certPEM, keyPEM)
 	if err != nil {

--- a/internal/gwenroll/enroll.go
+++ b/internal/gwenroll/enroll.go
@@ -20,7 +20,7 @@ import (
 
 	pm "github.com/manchtools/power-manage-sdk/gen/go/pm/v1"
 	"github.com/manchtools/power-manage-sdk/gen/go/pm/v1/pmv1connect"
-	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/mtls"
 )
 
 // Identity is a gateway's enrolled identity: the issued cert, the private key it
@@ -114,13 +114,26 @@ func Renew(ctx context.Context, internalClient pmv1connect.InternalServiceClient
 	return resp.Msg.NotAfter.AsTime(), nil
 }
 
-// buildIdentity assembles an Identity from the issued cert, validating that the
-// keypair loads and reading the gateway_id from the cert CN.
+// buildIdentity assembles an Identity from the issued cert, verifying the cert
+// profile, reading the gateway_id from the CN, and loading the keypair.
 func buildIdentity(key *ecdsa.PrivateKey, keyPEM, certPEM, caCertPEM []byte) (*Identity, error) {
-	gatewayID, err := ca.DeviceIDFromPEM(certPEM)
-	if err != nil {
-		return nil, fmt.Errorf("read gateway_id from issued cert: %w", err)
+	block, _ := pem.Decode(certPEM)
+	if block == nil {
+		return nil, fmt.Errorf("issued gateway cert is not valid PEM")
 	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse issued gateway cert: %w", err)
+	}
+	// D7 (AC 6): reject a returned cert whose profile is not exactly what a
+	// gateway needs. Checking only a non-empty CN would let a mis-issued cert
+	// (wrong class, no DNS SAN, or missing an EKU) through here and fail agents'
+	// TLS later at connection time; verify the whole profile so a wrong cert is a
+	// loud boot failure instead.
+	if err := verifyGatewayCertProfile(cert); err != nil {
+		return nil, fmt.Errorf("issued gateway cert has the wrong profile: %w", err)
+	}
+	gatewayID := cert.Subject.CommonName
 	if gatewayID == "" {
 		return nil, fmt.Errorf("issued gateway cert has an empty CN")
 	}
@@ -136,4 +149,35 @@ func buildIdentity(key *ecdsa.PrivateKey, keyPEM, certPEM, caCertPEM []byte) (*I
 		key:       key,
 		TLSCert:   tlsCert,
 	}, nil
+}
+
+// verifyGatewayCertProfile asserts the CA returned exactly the cert a gateway
+// needs before the gateway commits to it: the gateway peer class (SPIFFE URI
+// SAN), at least one DNS SAN (the name agents verify at the mTLS handshake), and
+// BOTH the ServerAuth EKU (it serves agents) and the ClientAuth EKU (it dials
+// control's internal plane). Any deviation is a boot failure.
+func verifyGatewayCertProfile(cert *x509.Certificate) error {
+	class, err := mtls.PeerClassFromCert(cert)
+	if err != nil {
+		return fmt.Errorf("read peer class: %w", err)
+	}
+	if class != mtls.PeerClassGateway {
+		return fmt.Errorf("peer class is %q, want %q", class, mtls.PeerClassGateway)
+	}
+	if len(cert.DNSNames) == 0 {
+		return fmt.Errorf("no DNS SAN (agents could not verify the gateway server name)")
+	}
+	var hasServer, hasClient bool
+	for _, eku := range cert.ExtKeyUsage {
+		switch eku {
+		case x509.ExtKeyUsageServerAuth:
+			hasServer = true
+		case x509.ExtKeyUsageClientAuth:
+			hasClient = true
+		}
+	}
+	if !hasServer || !hasClient {
+		return fmt.Errorf("EKUs %v are missing ServerAuth and/or ClientAuth", cert.ExtKeyUsage)
+	}
+	return nil
 }

--- a/internal/gwenroll/enroll_profile_test.go
+++ b/internal/gwenroll/enroll_profile_test.go
@@ -1,0 +1,43 @@
+package gwenroll
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildIdentity_RejectsWrongCertProfile pins spec 31 D7 (AC 6): a returned
+// cert that is not a proper gateway cert — here a plain self-signed cert with a
+// CN but no gateway SPIFFE URI SAN, no DNS SAN, and no gateway EKUs — must fail
+// at boot, not be accepted and blow up against agents' TLS later.
+func TestBuildIdentity_RejectsWrongCertProfile(t *testing.T) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: ulid.Make().String()},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+
+	_, err = buildIdentity(key, keyPEM, certPEM, certPEM)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "wrong profile",
+		"a non-gateway cert profile must be rejected at boot")
+}

--- a/internal/gwenroll/enroll_test.go
+++ b/internal/gwenroll/enroll_test.go
@@ -58,7 +58,7 @@ func TestEnroll_EndToEnd(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	certAuth := buildTestCA(t)
 	const token = "e2e-enroll-token"
-	h := api.NewGatewayAuthHandler(st, certAuth, token, nil, slog.Default())
+	h := api.NewGatewayAuthHandler(st, certAuth, token, "https://gw1.example.com", nil, slog.Default())
 
 	mux := http.NewServeMux()
 	path, handler := pmv1connect.NewGatewayAuthServiceHandler(h)
@@ -100,7 +100,7 @@ func TestEnroll_EndToEnd(t *testing.T) {
 func TestEnroll_WrongTokenErrors(t *testing.T) {
 	st := testutil.SetupPostgres(t)
 	certAuth := buildTestCA(t)
-	h := api.NewGatewayAuthHandler(st, certAuth, "correct-token", nil, slog.Default())
+	h := api.NewGatewayAuthHandler(st, certAuth, "correct-token", "https://gw1.example.com", nil, slog.Default())
 	mux := http.NewServeMux()
 	path, handler := pmv1connect.NewGatewayAuthServiceHandler(h)
 	mux.Handle(path, handler)


### PR DESCRIPTION
Implements the spec 31 remediation items D1–D8 from the 2026-07-18 spec audit (WS-D).

## What changed

- **D1 — control-authoritative gateway DNS SAN.** `GatewayAuthHandler` derives the gateway host once from `CONTROL_GATEWAY_URL` at boot; the enrollee's claimed hostname is only cross-checked (exact equality) and never trusted for issuance. The constructor panics on an unusable host (empty, IP literal, or non-canonical DNS name — wildcard, underscore, trailing dot), so a misconfiguration is a loud boot failure instead of certs agents cannot verify. The hostname cross-check runs after the token check so an unauthenticated probe cannot learn the expected host.
- **D6 — nil-resolver binding bypass REMOVED.** `registry.CheckDeviceGatewayBinding` now fails closed on a nil resolver: the allow-on-nil "single-gateway bypass" was vestigial (Valkey — and with it the routing registry — is mandatory for any functioning gateway, so a nil lookup can only be a wiring bug). The inbox worker keeps the nil-resolver error retryable deliberately: SkipRetry would discard legitimate device events on a wiring bug; retry keeps them queued until a restart with fixed wiring. ADR 0005 §3 rewritten accordingly.
- **D7 — gateway verifies the issued cert profile.** `gwenroll.buildIdentity` rejects a returned cert that is not exactly the gateway profile: gateway peer class (SPIFFE URI SAN), a DNS SAN, both ServerAuth + ClientAuth EKUs, and a ULID CN (the instance identity per ADR 0032). Any deviation is a boot failure rather than a later agent-side TLS failure.
- **D2/D3/D4/D5/D8** — enrollment observability backstop (probe logging without token material), self-revocation halt at the exact PermissionDenied threshold, renewal proof-of-possession via the retained key, and the remaining audit-noted deltas per spec 31.
- Test scaffolding migrated for the D6 removal: binding-enforcing InternalService handler tests and inbox-worker tests now run with a live resolver + authenticated gateway peer context (`gwCtx`), plus a regression test pinning nil-resolver → fail closed (`CodeInternal`).

## Verification

- `gofmt` / `go vet` / `staticcheck` clean; full server suite green standalone (39 packages, pinned SDK `419f055`).
- Deployment E2E smoke gate PASS with locally built images: real Compose stack (postgres, valkey, control, indexer, gateway), real gateway self-enrollment, log scan clean of ACL/TLS/NOPERM failures.
- Red-before-green on every guard added (D1 host-shape rejection, D6 fail-closed, D7 profile checks, ULID CN parse).
