### PR TITLE
fix(datastore): close spec-32 audit remainder — doctor posture, creds withholding, placeholder ACL secrets, ADR 0034

### DIFF
--- a/cmd/control/doctor.go
+++ b/cmd/control/doctor.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"flag"
 	"fmt"
@@ -68,25 +71,21 @@ func runDoctor(args []string) int {
 		valkeyDB = n
 	}
 	// spec 32: probe Valkey the same way the live server connects — as the ACL
-	// user over mutual TLS. A partial/absent cert set yields a nil tlsCfg (plain-
-	// text probe); we log the reason so an incomplete config isn't a silent
-	// false "unreachable". Inside the control container the cert env is set, so
-	// the probe authenticates and reports accurately.
+	// user over mutual TLS. A partial cert set errors (logged below); an entirely
+	// absent one yields nil WITHOUT an error. Both mean a plaintext probe, so
+	// valkeyProbeCreds withholds the ACL credentials on any nil tlsCfg — they
+	// must never cross an unencrypted socket. The posture finding in the report
+	// surfaces the plaintext configuration as a Warning.
 	valkeyTLS, err := datastore.ValkeyClientTLSFromFiles(vars["CONTROL_VALKEY_TLS_CERT"], vars["CONTROL_VALKEY_TLS_KEY"], vars["CONTROL_VALKEY_TLS_CA"])
-	valkeyUser, valkeyPass := vars["CONTROL_VALKEY_USERNAME"], vars["CONTROL_VALKEY_PASSWORD"]
 	if err != nil {
-		// A nil tlsCfg means the probe would connect WITHOUT TLS — sending the
-		// ACL password in the clear. Drop the credentials so a doctor run with an
-		// incomplete cert set (e.g. outside the control container, against a
-		// remote datastore) can't leak them onto an unencrypted socket. The probe
-		// then fails at the datastores check, which is the accurate verdict.
 		fmt.Fprintf(os.Stderr, "doctor: valkey mTLS config incomplete, probing without TLS and without ACL credentials: %v\n", err)
-		valkeyUser, valkeyPass = "", ""
 	}
+	valkeyUser, valkeyPass := valkeyProbeCreds(valkeyTLS, vars["CONTROL_VALKEY_USERNAME"], vars["CONTROL_VALKEY_PASSWORD"])
 	if cache, err := doctor.NewValkeyProbe(vars["CONTROL_VALKEY_ADDR"], valkeyUser, valkeyPass, valkeyDB, valkeyTLS); err == nil {
 		env.Cache = cache
 		defer cache.Close()
 	}
+	env.Posture = datastorePosture(vars, valkeyTLS)
 
 	report := doctor.Run(ctx, env, doctor.DefaultChecks())
 
@@ -99,6 +98,72 @@ func runDoctor(args []string) int {
 		doctor.RenderHuman(os.Stdout, report)
 	}
 	return report.ExitCode()
+}
+
+// valkeyProbeCreds returns the ACL credentials the probe may use. A nil TLS
+// config — cert set absent OR incomplete — means a plaintext dial, so the
+// credentials are withheld: they must never cross an unencrypted socket.
+func valkeyProbeCreds(tlsCfg *tls.Config, user, pass string) (string, string) {
+	if tlsCfg == nil {
+		return "", ""
+	}
+	return user, pass
+}
+
+// datastorePosture derives the spec-32 auth posture the doctor reports. Safe
+// fields only (users, modes, cert CNs) — never credentials or raw DSNs.
+func datastorePosture(vars map[string]string, valkeyTLS *tls.Config) *doctor.DatastorePosture {
+	p := &doctor.DatastorePosture{
+		ValkeyUser:   vars["CONTROL_VALKEY_USERNAME"],
+		ValkeyMTLS:   valkeyTLS != nil,
+		ValkeyCertCN: clientCertCN(valkeyTLS),
+	}
+	dsn := vars["CONTROL_DATABASE_URL"]
+	sslmode, sslcert := datastore.PostgresTLSPosture(dsn)
+	if datastore.RequirePostgresTLS(dsn) == nil {
+		p.PostgresMTLS = true
+		p.PostgresCertCN = pemCertCN(sslcert)
+	} else if sslmode == "verify-full" {
+		p.PostgresDetail = "verify-full without complete client-cert material"
+	} else {
+		p.PostgresDetail = fmt.Sprintf("sslmode=%q", sslmode)
+	}
+	return p
+}
+
+// clientCertCN returns the CN of cfg's client certificate. Best-effort display
+// value: "" (posture shown as unknown) on a nil config or unparseable cert —
+// the mTLS on/off verdict is carried separately, so no error is swallowed.
+func clientCertCN(cfg *tls.Config) string {
+	if cfg == nil || len(cfg.Certificates) == 0 || len(cfg.Certificates[0].Certificate) == 0 {
+		return ""
+	}
+	leaf, err := x509.ParseCertificate(cfg.Certificates[0].Certificate[0])
+	if err != nil {
+		return ""
+	}
+	return leaf.Subject.CommonName
+}
+
+// pemCertCN reads a PEM certificate file and returns its CN. Same best-effort
+// display contract as clientCertCN.
+func pemCertCN(path string) string {
+	if path == "" {
+		return ""
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		return ""
+	}
+	leaf, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return ""
+	}
+	return leaf.Subject.CommonName
 }
 
 // resolveCertPaths returns the cert/key files to inspect. A path is included when

--- a/cmd/control/doctor_test.go
+++ b/cmd/control/doctor_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,4 +22,19 @@ func TestRunDoctor_RejectsExtraArgs(t *testing.T) {
 func TestRunDoctor_RejectsNonNumericValkeyDB(t *testing.T) {
 	t.Setenv("CONTROL_VALKEY_DB", "not-a-number")
 	assert.Equal(t, 2, runDoctor([]string{"--env-file=/nonexistent"}))
+}
+
+// spec 32 audit: a nil TLS config means the probe would dial plaintext — the ACL
+// credentials must be withheld in EVERY nil case, including TLS vars entirely
+// absent (which yields nil WITHOUT an error), not only the partial-set error path.
+func TestValkeyProbeCreds_NilTLSDropsCredentials(t *testing.T) {
+	user, pass := valkeyProbeCreds(nil, "pm-control", "secret")
+	assert.Empty(t, user)
+	assert.Empty(t, pass)
+}
+
+func TestValkeyProbeCreds_TLSKeepsCredentials(t *testing.T) {
+	user, pass := valkeyProbeCreds(&tls.Config{}, "pm-control", "secret")
+	assert.Equal(t, "pm-control", user)
+	assert.Equal(t, "secret", pass)
 }

--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -97,7 +97,7 @@ docker compose exec control control doctor --json   # machine-readable
 ```
 <!-- docref: end -->
 
-<!-- docref: begin src=cmd/control/doctor.go#runDoctor:9b9d0319 -->
+<!-- docref: begin src=cmd/control/doctor.go#runDoctor:da6dac8d -->
 Flags:
 
 - `--json` — emit a JSON report (`{summary, findings, exec_errors, exit_code}`) for CI/monitoring.

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -355,7 +355,10 @@ generate_datastore_certs() {
 ensure_acl_passwords() {
     local var generated
     for var in VALKEY_CONTROL_PASSWORD VALKEY_GATEWAY_PASSWORD VALKEY_INDEXER_PASSWORD VALKEY_TRAEFIK_PASSWORD; do
-        if [[ -z "${!var:-}" ]]; then
+        # A CHANGE_ME* placeholder is not a credential — treat it as missing and
+        # regenerate, or it would be rendered into valkey.conf as the real ACL
+        # password (spec 32 AC 8 rejects placeholders).
+        if [[ -z "${!var:-}" || "${!var}" == CHANGE_ME* ]]; then
             generated="$(openssl rand -hex 24)"
             write_env_var "$var" "$generated"
             printf -v "$var" '%s' "$generated"

--- a/deploy/setup_test.sh
+++ b/deploy/setup_test.sh
@@ -196,6 +196,41 @@ EOF
         && grep -qE '^ADMIN_EMAIL=admin@example\.com$' "$SCRIPT_DIR/.env"
 }
 
+# ----- ensure_acl_passwords (spec 32 AC 8) -----
+
+case_acl_passwords_regenerates_placeholder() {
+    # A CHANGE_ME* placeholder is NOT a credential — it must be treated as
+    # missing and regenerated, in .env AND the shell (spec 32 audit finding).
+    cat > "$SCRIPT_DIR/.env" <<EOF
+VALKEY_CONTROL_PASSWORD=CHANGE_ME_PLEASE
+EOF
+    VALKEY_CONTROL_PASSWORD="CHANGE_ME_PLEASE"
+    VALKEY_GATEWAY_PASSWORD="" VALKEY_INDEXER_PASSWORD="" VALKEY_TRAEFIK_PASSWORD=""
+    ensure_acl_passwords
+    [[ "$VALKEY_CONTROL_PASSWORD" != CHANGE_ME* && -n "$VALKEY_CONTROL_PASSWORD" ]] \
+        && ! grep -q 'CHANGE_ME' "$SCRIPT_DIR/.env" \
+        && grep -qE '^VALKEY_CONTROL_PASSWORD=[0-9a-f]{48}$' "$SCRIPT_DIR/.env"
+}
+
+case_acl_passwords_keeps_real_value() {
+    : > "$SCRIPT_DIR/.env"
+    VALKEY_CONTROL_PASSWORD="realsecretvalue"
+    VALKEY_GATEWAY_PASSWORD="" VALKEY_INDEXER_PASSWORD="" VALKEY_TRAEFIK_PASSWORD=""
+    ensure_acl_passwords
+    [[ "$VALKEY_CONTROL_PASSWORD" == "realsecretvalue" ]]
+}
+
+case_acl_passwords_mints_all_missing() {
+    : > "$SCRIPT_DIR/.env"
+    VALKEY_CONTROL_PASSWORD="" VALKEY_GATEWAY_PASSWORD="" VALKEY_INDEXER_PASSWORD="" VALKEY_TRAEFIK_PASSWORD=""
+    ensure_acl_passwords
+    local var
+    for var in VALKEY_CONTROL_PASSWORD VALKEY_GATEWAY_PASSWORD VALKEY_INDEXER_PASSWORD VALKEY_TRAEFIK_PASSWORD; do
+        [[ -n "${!var}" ]] || return 1
+        grep -qE "^${var}=[0-9a-f]{48}\$" "$SCRIPT_DIR/.env" || return 1
+    done
+}
+
 # ----- run -----
 
 run_case "write_env_var: adds missing key"          case_write_env_var_adds_missing_key
@@ -210,6 +245,9 @@ run_case "parent_domain: dotted hostname"           case_parent_domain_with_dot
 run_case "parent_domain: single label returns empty" case_parent_domain_single_label
 run_case "parent_domain: deep subdomain"            case_parent_domain_deep_subdomain
 run_case "disable terminals clears all three vars"  case_disable_terminals_clears_all_three_vars
+run_case "acl passwords: CHANGE_ME* regenerated"    case_acl_passwords_regenerates_placeholder
+run_case "acl passwords: real value untouched"      case_acl_passwords_keeps_real_value
+run_case "acl passwords: mints all four missing"    case_acl_passwords_mints_all_missing
 
 # Meta: make sure the FAIL counting + final non-zero exit path actually
 # work. The previous cut had set-e + ( ... ) + $? which silently killed

--- a/docs/adr/0034-datastore-authentication.md
+++ b/docs/adr/0034-datastore-authentication.md
@@ -1,0 +1,67 @@
+# 0034 — Datastore authentication: per-service ACLs + mutual TLS
+
+- Status: accepted
+- Date: 2026-07-19
+- Related: spec 32 (docs repo, `06-specs/32-datastore-auth-hardening.md`);
+  ADR 0031 (control-plane HA — the topology that makes cleartext untenable);
+  ADR 0032 (gateway instance identity — the CA identity model this reuses);
+  spec 29 task-HMAC (the compensating control for the shared Asynq keyspace);
+  `04-security/08-deployment-hardening.md` (docs repo — Traefik/Docker-socket,
+  the other half of the Traefik threat).
+
+## Context
+
+Both datastores were protected by a single shared password each and ran
+cleartext on the wire: one Valkey `requirepass` shared by control, gateway,
+indexer, and the internet-facing Traefik (full keyspace for every holder — CRL
+poisoning, route rewrite, queue deletion); Postgres password auth with
+`sslmode=disable`. On a single host with no published ports that is contained;
+the spec-31 HA topology spreads components across hosts, so shared-credential +
+cleartext becomes real exposure. Spec 31's CA already issues per-component
+certificates, so there is no reason to phase a weaker tier first.
+
+## Decision
+
+1. **Mutual TLS is the only posture, both datastores.** Valkey: `port 0`,
+   `tls-port`, `tls-auth-clients yes`. Postgres: `hostssl … cert
+   clientcert=verify-full`, cert `CN` → DB role, passwords dropped. All four
+   binaries fail closed at boot without their client cert
+   (`datastore.RequirePostgresTLS`, non-nil Valkey TLS config). No plaintext
+   fallback exists.
+2. **Per-service Valkey ACL users**, each with its own crypto-strong secret
+   behind the cert-gated transport: `pm-control` (broad, minus `@dangerous`),
+   `pm-gateway` (own namespaces, **CRL read-only** — `%R~pm:crl:*`, so a
+   compromised gateway cannot un-revoke certificates), `pm-indexer` (confined
+   to `asynq:*` + the search-index namespaces, no `pm:*`/`traefik/*`),
+   `pm-traefik` (**read-only `traefik/*`**, the smallest surface for the
+   internet-facing component). Destructive/admin commands are denied to all.
+3. **Postgres role model unchanged**: control is the owner (migrations + trust
+   root), `pm_indexer` stays `SELECT`-only. Secret-bearing columns are AES-GCM
+   encrypted at rest, so the indexer's broad `SELECT` yields ciphertext only.
+4. **Provisioning is self-contained in `setup.sh`**: it issues the datastore
+   server certs and per-component client certs from the deployment CA, mints
+   the four ACL secrets (regenerating empty *or* `CHANGE_ME*` placeholder
+   values), and renders `valkey.conf`. Container images that drop privileges
+   (valkey-bundle uid 999, postgres uid 70) cannot read root-owned `0600`
+   keys, so the compose entrypoints copy the key to `/tmp` and `chown` it to
+   the runtime user before exec — a deliberate, deployment-tested pattern.
+5. **`control doctor` reports posture, never secrets**: ACL user, mTLS on/off,
+   client-cert CNs; a plaintext configuration is a Warning. When the TLS
+   config is absent or incomplete the probe withholds the ACL credentials
+   entirely rather than sending them over a cleartext dial.
+
+## Consequences
+
+- **Breaking, coordinated deploy change**: certs and ACL users must exist
+  before services restart; existing deploys re-run `setup.sh` first. A service
+  without its client cert does not boot — by design.
+- **ACL scopes are maintained allow-lists.** A legitimate new key namespace
+  surfaces as `NOPERM`; the fix is widening that one user's grant narrowly
+  (as done for control's search-prefix grant), never reverting to `~*`.
+- **Accepted residual**: the three task-queue participants share Asynq's
+  `asynq:*` bookkeeping keyspace — per-queue key isolation is not achievable
+  in Asynq. Cross-queue tampering within that shared keyspace is compensated
+  by the spec-29 task-HMAC (forgery-proof payloads), and the deployment E2E
+  smoke test asserts the `NOPERM` boundaries that *are* enforceable.
+- **Rotation is operator-driven**: re-run `setup.sh` (mint/replace secrets,
+  reissue certs) + rolling restart. No auto-rotation.

--- a/docs/adr/0034-datastore-authentication.md
+++ b/docs/adr/0034-datastore-authentication.md
@@ -63,5 +63,9 @@ certificates, so there is no reason to phase a weaker tier first.
   in Asynq. Cross-queue tampering within that shared keyspace is compensated
   by the spec-29 task-HMAC (forgery-proof payloads), and the deployment E2E
   smoke test asserts the `NOPERM` boundaries that *are* enforceable.
-- **Rotation is operator-driven**: re-run `setup.sh` (mint/replace secrets,
-  reissue certs) + rolling restart. No auto-rotation.
+- **Rotation is operator-driven, and a plain `setup.sh` re-run does NOT
+  rotate**: set values are deliberately preserved (idempotent upgrades). To
+  rotate an ACL secret, clear its `VALKEY_*_PASSWORD` line in `.env` (or set
+  it to `CHANGE_ME`), re-run `setup.sh` (mints a fresh secret, re-renders
+  `valkey.conf`), and restart Valkey plus the affected service. Certificate
+  rotation follows the same pattern via the CA. No auto-rotation.

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -71,6 +71,18 @@ func ValkeyClientTLSFromFiles(certPath, keyPath, caPath string) (*tls.Config, er
 	return ValkeyClientTLS(certPEM, keyPEM, caPEM)
 }
 
+// PostgresTLSPosture reports the DSN's TLS posture for doctor display: the
+// effective sslmode and the client-cert path. Safe fields only — never a
+// credential, never the raw DSN (whose parse errors can embed the password).
+// An unparseable DSN yields ("", ""): posture unknown, reported as such.
+func PostgresTLSPosture(connString string) (sslmode, sslcert string) {
+	params, err := dsnParams(connString)
+	if err != nil {
+		return "", ""
+	}
+	return params["sslmode"], params["sslcert"]
+}
+
 // RequirePostgresTLS returns an error unless connString is configured for mutual
 // TLS: sslmode=verify-full with the client-cert material (sslrootcert/sslcert/
 // sslkey) present. A sslmode=disable or absent DSN, or verify-full without the

--- a/internal/datastore/datastore.go
+++ b/internal/datastore/datastore.go
@@ -111,7 +111,11 @@ func RequirePostgresTLS(connString string) error {
 // userinfo are ignored (and never returned).
 func dsnParams(connString string) (map[string]string, error) {
 	out := map[string]string{}
-	if strings.Contains(connString, "://") {
+	// libpq recognizes a URI by exactly these two scheme prefixes; anything else
+	// is keyword/value form. A substring "://" check would mis-route a keyword
+	// DSN whose quoted value contains a URL (e.g. password='https://…') through
+	// URL parsing and destroy its real parameters.
+	if strings.HasPrefix(connString, "postgres://") || strings.HasPrefix(connString, "postgresql://") {
 		u, err := url.Parse(connString)
 		if err != nil {
 			return nil, fmt.Errorf("datastore: parse DSN: %w", err)
@@ -130,7 +134,11 @@ func dsnParams(connString string) (map[string]string, error) {
 	// spurious `sslmode=verify-full` token that overwrites the real sslmode and
 	// tricks RequirePostgresTLS into accepting a plaintext DSN — defeating the
 	// fail-closed guarantee this file exists to provide.
-	for _, kv := range splitKeywordDSN(connString) {
+	toks, err := splitKeywordDSN(connString)
+	if err != nil {
+		return nil, err
+	}
+	for _, kv := range toks {
 		if i := strings.IndexByte(kv, '='); i > 0 {
 			out[strings.TrimSpace(kv[:i])] = kv[i+1:]
 		}
@@ -142,7 +150,9 @@ func dsnParams(connString string) (map[string]string, error) {
 // single-quote quoting and backslash escapes (per libpq's documented rules) so
 // whitespace inside a quoted value does not split it. Quote characters are
 // consumed (not emitted); a backslash escapes the next character literally.
-func splitKeywordDSN(s string) []string {
+// An unterminated quote or trailing escape is an error, as in libpq — a
+// half-tokenized DSN must fail closed, never yield guessed parameters.
+func splitKeywordDSN(s string) ([]string, error) {
 	var toks []string
 	var cur strings.Builder
 	inQuote, esc, started := false, false, false
@@ -172,6 +182,12 @@ func splitKeywordDSN(s string) []string {
 			started = true
 		}
 	}
+	if inQuote {
+		return nil, errors.New("datastore: keyword DSN has an unterminated quoted value")
+	}
+	if esc {
+		return nil, errors.New("datastore: keyword DSN ends in a dangling backslash escape")
+	}
 	flush()
-	return toks
+	return toks, nil
 }

--- a/internal/datastore/datastore_test.go
+++ b/internal/datastore/datastore_test.go
@@ -82,6 +82,19 @@ func TestPostgresTLSPosture(t *testing.T) {
 	if sslmode != "" || sslcert != "" {
 		t.Errorf("unparseable DSN must yield unknowns, got (%q, %q)", sslmode, sslcert)
 	}
+	// libpq treats only postgres://- or postgresql://-prefixed strings as URIs;
+	// a keyword DSN whose quoted value merely CONTAINS "://" must stay keyword-
+	// parsed, not be mis-routed through URL parsing (cr 2026-07-19).
+	sslmode, sslcert = PostgresTLSPosture("host=h sslmode=verify-full sslcert=/c/pg.crt password='https://x'")
+	if sslmode != "verify-full" || sslcert != "/c/pg.crt" {
+		t.Errorf("keyword DSN with :// inside a quoted value mis-parsed: got (%q, %q)", sslmode, sslcert)
+	}
+	// An unterminated quote is unparseable — posture must be unknown, not a
+	// half-tokenized guess.
+	sslmode, sslcert = PostgresTLSPosture("host=h sslmode=verify-full password='oops")
+	if sslmode != "" || sslcert != "" {
+		t.Errorf("unterminated quote must yield unknowns, got (%q, %q)", sslmode, sslcert)
+	}
 }
 
 func TestRequirePostgresTLS(t *testing.T) {
@@ -102,6 +115,15 @@ func TestRequirePostgresTLS(t *testing.T) {
 		// that overwrites it (a bare strings.Fields split would wrongly accept).
 		{"keyword quoted value cannot forge sslmode",
 			"host=h dbname=db sslmode=disable sslrootcert=/c/ca.crt sslcert=/c/pg.crt sslkey=/c/pg.key application_name='x sslmode=verify-full'",
+			false},
+		// A valid keyword DSN must not be mis-routed through URL parsing just
+		// because a quoted value contains "://" (cr 2026-07-19).
+		{"keyword value containing :// stays keyword-parsed",
+			"host=h dbname=db sslmode=verify-full sslrootcert=/c/ca.crt sslcert=/c/pg.crt sslkey=/c/pg.key password='https://not-a-uri'",
+			true},
+		// libpq errors on an unterminated quoted value; so do we (fail closed).
+		{"unterminated quote rejected",
+			"host=h dbname=db sslmode=verify-full sslrootcert=/c/ca.crt sslcert=/c/pg.crt sslkey=/c/pg.key application_name='oops",
 			false},
 	}
 	for _, tc := range cases {

--- a/internal/datastore/datastore_test.go
+++ b/internal/datastore/datastore_test.go
@@ -70,6 +70,20 @@ func TestValkeyClientTLS_RejectsBadMaterial(t *testing.T) {
 	}
 }
 
+// PostgresTLSPosture feeds doctor's posture report: safe display fields only,
+// and an unparseable DSN must yield unknowns, never an error string that could
+// carry the DSN (and its password).
+func TestPostgresTLSPosture(t *testing.T) {
+	sslmode, sslcert := PostgresTLSPosture("postgres://u:p@h:5432/db?sslmode=verify-full&sslcert=/c/pg.crt")
+	if sslmode != "verify-full" || sslcert != "/c/pg.crt" {
+		t.Errorf("got (%q, %q), want (verify-full, /c/pg.crt)", sslmode, sslcert)
+	}
+	sslmode, sslcert = PostgresTLSPosture("postgres://u:p@h:5432 bad\x00dsn://")
+	if sslmode != "" || sslcert != "" {
+		t.Errorf("unparseable DSN must yield unknowns, got (%q, %q)", sslmode, sslcert)
+	}
+}
+
 func TestRequirePostgresTLS(t *testing.T) {
 	const certs = "&sslrootcert=/c/ca.crt&sslcert=/c/pg.crt&sslkey=/c/pg.key"
 	cases := []struct {

--- a/internal/doctor/check_live.go
+++ b/internal/doctor/check_live.go
@@ -35,6 +35,22 @@ func (c DatastoresCheck) Run(ctx context.Context, env *Env) ([]Finding, error) {
 	} else {
 		findings = append(findings, ok(c.ID(), "Valkey reachable"))
 	}
+	// spec 32: report the auth/transport posture. mTLS is the only supported
+	// posture, so a plaintext configuration is a Warning, never a silent pass.
+	if p := env.Posture; p != nil {
+		if p.ValkeyMTLS {
+			findings = append(findings, ok(c.ID(), fmt.Sprintf("Valkey auth posture: ACL user %q, mTLS on (client cert CN %q)", p.ValkeyUser, p.ValkeyCertCN)))
+		} else {
+			findings = append(findings, warn(c.ID(), "Valkey mTLS is not configured — probe dialed plaintext with ACL credentials withheld",
+				"set CONTROL_VALKEY_TLS_CERT/_KEY/_CA; spec 32 supports no plaintext posture"))
+		}
+		if p.PostgresMTLS {
+			findings = append(findings, ok(c.ID(), fmt.Sprintf("Postgres auth posture: mTLS on (verify-full, client cert CN %q)", p.PostgresCertCN)))
+		} else {
+			findings = append(findings, warn(c.ID(), fmt.Sprintf("Postgres mutual TLS is not configured (%s)", p.PostgresDetail),
+				"set sslmode=verify-full with sslrootcert/sslcert/sslkey in CONTROL_DATABASE_URL; spec 32 supports no plaintext posture"))
+		}
+	}
 	return findings, nil
 }
 

--- a/internal/doctor/checks_test.go
+++ b/internal/doctor/checks_test.go
@@ -205,6 +205,53 @@ func TestDatastoresCheck(t *testing.T) {
 	t.Run("nil handles → critical", func(t *testing.T) {
 		assert.Equal(t, SeverityCritical, worst(run1(t, DatastoresCheck{}, testEnv(nil))))
 	})
+	// spec 32: doctor reports the datastore auth posture (ACL user, mTLS on/off,
+	// client-cert CN) — never secrets. mTLS is the only supported posture, so a
+	// plaintext configuration is a Warning, not a silent omission.
+	t.Run("posture mTLS on both → ok, reports user and CN", func(t *testing.T) {
+		env := testEnv(nil)
+		env.DB, env.Cache = fakeDB{}, fakeCache{}
+		env.Posture = &DatastorePosture{
+			ValkeyUser: "pm-control", ValkeyMTLS: true, ValkeyCertCN: "powermanage",
+			PostgresMTLS: true, PostgresCertCN: "powermanage",
+		}
+		findings := run1(t, DatastoresCheck{}, env)
+		assert.Equal(t, SeverityOK, worst(findings))
+		var joined string
+		for _, f := range findings {
+			joined += f.Message + " "
+		}
+		assert.Contains(t, joined, "pm-control")
+		assert.Contains(t, joined, "powermanage")
+		assert.Contains(t, joined, "mTLS")
+	})
+	t.Run("posture valkey plaintext → warning", func(t *testing.T) {
+		env := testEnv(nil)
+		env.DB, env.Cache = fakeDB{}, fakeCache{}
+		env.Posture = &DatastorePosture{ValkeyUser: "pm-control", PostgresMTLS: true}
+		assert.Equal(t, SeverityWarning, worst(run1(t, DatastoresCheck{}, env)))
+	})
+	t.Run("posture postgres plaintext → warning with detail", func(t *testing.T) {
+		env := testEnv(nil)
+		env.DB, env.Cache = fakeDB{}, fakeCache{}
+		env.Posture = &DatastorePosture{
+			ValkeyMTLS: true, ValkeyCertCN: "powermanage",
+			PostgresDetail: `sslmode="disable"`,
+		}
+		findings := run1(t, DatastoresCheck{}, env)
+		assert.Equal(t, SeverityWarning, worst(findings))
+		var joined string
+		for _, f := range findings {
+			joined += f.Message + " "
+		}
+		assert.Contains(t, joined, "disable")
+	})
+	t.Run("nil posture → reachability findings only", func(t *testing.T) {
+		env := testEnv(nil)
+		env.DB, env.Cache = fakeDB{}, fakeCache{}
+		findings := run1(t, DatastoresCheck{}, env)
+		assert.Len(t, findings, 2)
+	})
 }
 
 func TestQueuesCheck(t *testing.T) {

--- a/internal/doctor/env.go
+++ b/internal/doctor/env.go
@@ -33,7 +33,24 @@ type Env struct {
 	// can report "no .env file found" rather than a false pass).
 	FromEnvFile bool
 
+	// Posture is the config-derived datastore auth posture (spec 32), computed by
+	// the subcommand; nil when not computed (pure-config tests). Report-only.
+	Posture *DatastorePosture
+
 	Now func() time.Time
+}
+
+// DatastorePosture is what the doctor REPORTS about datastore authentication
+// (spec 32): the ACL user, whether mutual TLS is configured, and the client-cert
+// CNs. It never carries secrets — CNs and mode names only.
+type DatastorePosture struct {
+	ValkeyUser   string // CONTROL_VALKEY_USERNAME ("" = none configured)
+	ValkeyMTLS   bool   // client cert, key, and CA all configured
+	ValkeyCertCN string // CN of the Valkey client cert ("" when unknown)
+
+	PostgresMTLS   bool   // DSN passes RequirePostgresTLS (verify-full + cert material)
+	PostgresCertCN string // CN of the Postgres client cert ("" when unknown)
+	PostgresDetail string // safe reason PostgresMTLS is false (sslmode etc.), "" when true
 }
 
 // timeNow is the package clock seam (WS0): runtime code never calls time.Now()


### PR DESCRIPTION
Closes the four remaining spec-32 audit items (2026-07-18 audit section; the High/Medium ACL findings were already fixed in #575):

- **doctor credential withholding**: the ACL password is now withheld on ANY nil TLS config — the all-empty cert set returned nil WITHOUT an error and probed plaintext WITH the password (audit Low). Seam `valkeyProbeCreds`, red-checked.
- **doctor posture reporting** (missing deliverable): the datastores check now reports ACL user, mTLS on/off, and client-cert CNs — never secrets, never raw DSNs (URL-parse errors can embed the DSN password, so posture is built from safe fields only). Plaintext posture = Warning.
- **setup.sh placeholder rejection** (audit Low, AC 8): `ensure_acl_passwords` regenerates `CHANGE_ME*` values instead of rendering them into valkey.conf. Covered by three new `setup_test.sh` cases, red-checked.
- **ADR 0034** (missing deliverable): datastore authentication — per-service ACL model, mTLS-only transport, uid-drop key handling, shared-Asynq residual, accurate rotation procedure.

cr round folded in: libpq-exact DSN form detection (`postgres://`/`postgresql://` prefixes, not a `://` substring), fail-closed keyword tokenizer (unterminated quote/dangling escape now error), rotation docs corrected (a plain setup.sh re-run preserves set values and rotates nothing).

Verification: full server suite green (39 pkgs), staticcheck/vet/gofmt clean, docref green, setup_test.sh green, **deployment smoke gate PASS** (real compose stack, mTLS + ACL assertions, log scan clean).

The docs-repo half (deployment-hardening datastore section + spec 32 audit-status update) lands on docs main alongside this PR.