### PR TITLE
Harden credential custody, audit evidence, and CA rotation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,6 +70,14 @@ jobs, and background writers.
 Audit streams are hash-chained and periodically anchored off-host. Retention
 archives and verifies a prefix before deletion.
 
+<!-- docref: begin src=cmd/control/config.go#validateArchiveIsolation:ae89185b,cmd/control/devauth_stub.go#archiveIsolationRelaxed:8de98d35 -->
+Off-host is enforced, not advised. Control compares the filesystem holding the
+archive path with the one holding the database and refuses to start when they
+match. No configuration variable relaxes it; the only build that tolerates a
+shared filesystem is the same one that mints administrator sessions without an
+identity provider.
+<!-- docref: end -->
+
 ### Dispatch
 
 Control commits a complete delivery before send. The agent durably records
@@ -84,7 +92,12 @@ silent replay of non-idempotent effects.
 - Restrict the PROXY-protocol listener to the isolated Traefik network.
 - Protect CA, JWT, sealing, database, and at-rest encryption keys with strict
   filesystem or deployment-secret permissions.
-<!-- docref: begin src=deploy/backup.sh#@sqlite-backup:99bc90ed,cmd/control/backup_status.go#runBackupStatus:41ed4e6c -->
+<!-- docref: begin src=cmd/control/config.go#validateArchiveIsolation:ae89185b,cmd/control/devauth_stub.go#archiveIsolationRelaxed:8de98d35,deploy/backup.sh#@sqlite-backup:99bc90ed,cmd/control/backup_status.go#runBackupStatus:41ed4e6c -->
+- Give `POWER_MANAGE_BACKUP_PATH` its own filesystem, separate from the one
+  holding the database: it carries the audit chain's tamper-evidence, and
+  control refuses to start when the two share a mount. `deploy/setup.sh` makes
+  the same check before it renders a configuration, so a deployment installed
+  from this tree either has that storage or does not install.
 - Run `deploy/backup.sh` from a host timer and replicate the
   `POWER_MANAGE_BACKUP_PATH` directory off-host: it contains verified bounded
   SQLite backups, audit anchors, and archived prefixes. Back up artifacts too,

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,15 +67,16 @@ unaudited telemetry writer. Shared boundaries and exact-set tests enforce
 coverage for RPCs, sensitive reads, rejected authentication, SCIM, enrollment,
 jobs, and background writers.
 
-Audit streams are hash-chained and periodically anchored off-host. Retention
-archives and verifies a prefix before deletion.
+Audit streams are hash-chained and periodically anchored in the configured
+archive. Retention archives and verifies a prefix before deletion.
 
-<!-- docref: begin src=cmd/control/config.go#validateArchiveIsolation:ae89185b,cmd/control/devauth_stub.go#archiveIsolationRelaxed:8de98d35 -->
-Off-host is enforced, not advised. Control compares the filesystem holding the
-archive path with the one holding the database and refuses to start when they
-match. No configuration variable relaxes it; the only build that tolerates a
-shared filesystem is the same one that mints administrator sessions without an
-identity provider.
+<!-- docref: begin src=cmd/control/config.go#validateArchiveIsolation:b9894a73,cmd/control/devauth_stub.go#archiveIsolationRelaxed:8de98d35 -->
+Filesystem separation is enforced. Control compares the filesystem holding
+the archive path with the one holding the database and refuses to start when
+they match. Off-host replication remains an operator requirement. No
+configuration variable relaxes the filesystem check; the only build that
+tolerates a shared filesystem is the same one that mints administrator
+sessions without an identity provider.
 <!-- docref: end -->
 
 ### Dispatch
@@ -92,7 +93,7 @@ silent replay of non-idempotent effects.
 - Restrict the PROXY-protocol listener to the isolated Traefik network.
 - Protect CA, JWT, sealing, database, and at-rest encryption keys with strict
   filesystem or deployment-secret permissions.
-<!-- docref: begin src=cmd/control/config.go#validateArchiveIsolation:ae89185b,cmd/control/devauth_stub.go#archiveIsolationRelaxed:8de98d35,deploy/backup.sh#@sqlite-backup:99bc90ed,cmd/control/backup_status.go#runBackupStatus:41ed4e6c -->
+<!-- docref: begin src=cmd/control/config.go#validateArchiveIsolation:b9894a73,cmd/control/devauth_stub.go#archiveIsolationRelaxed:8de98d35,deploy/backup.sh#@sqlite-backup:99bc90ed,cmd/control/backup_status.go#runBackupStatus:41ed4e6c -->
 - Give `POWER_MANAGE_BACKUP_PATH` its own filesystem, separate from the one
   holding the database: it carries the audit chain's tamper-evidence, and
   control refuses to start when the two share a mount. `deploy/setup.sh` makes

--- a/cmd/control/README.md
+++ b/cmd/control/README.md
@@ -77,6 +77,14 @@ search semantics. PostgreSQL is removed and guarded against return.
 
 ## Development
 
+<!-- docref: begin src=cmd/control/devauth.go#wrapDevAuth:f04e68b9,cmd/control/devauth.go#devAuthEnabled:4a7b3325 -->
+The development session endpoint is available only in a `devauth` build run
+with `PM_DEV_AUTH=1` and a `PM_DEV_AUTH_TOKEN` of at least 32 bytes. Start Vite
+with the same token; its local proxy injects the token into `/dev/session`
+requests without exposing it to browser code. Requests without the matching
+token are refused even when the proxy's connection to control is loopback.
+<!-- docref: end -->
+
 ```bash
 go build ./cmd/control
 go test ./...

--- a/cmd/control/README.md
+++ b/cmd/control/README.md
@@ -27,7 +27,7 @@ Control must fail readiness when the schema is not current, required keys or CA
 material are unusable, artifact paths are not writable, or the agent listener
 cannot enforce revocation.
 
-<!-- docref: begin src=cmd/control/main.go#parseCommand:9ba09808,cmd/control/config.go#configEnvironment:30e9356f,cmd/control/config.go#readEnvironment:88fc4d61,cmd/control/config.go#parseList:02da4e62 -->
+<!-- docref: begin src=cmd/control/main.go#parseCommand:9ba09808,cmd/control/config.go#configEnvironment:f192d94c,cmd/control/config.go#readEnvironment:88fc4d61,cmd/control/config.go#parseList:02da4e62 -->
 Configuration is entirely environmental: every option is its own documented
 `POWER_MANAGE_`-prefixed variable. There is no configuration file and no
 `-config` flag, and the only accepted arguments are the `bootstrap-admin` and
@@ -38,6 +38,13 @@ variable and its type selects the parser — and startup fails closed on any
 process by name instead of silently leaving its option at the default. List
 options are comma-separated and reject an empty entry; malformed booleans and
 durations name their variable and fail startup.
+<!-- docref: end -->
+
+<!-- docref: begin src=cmd/control/main.go#run:065ded94,internal/ca/ca.go#CA.SetTrustBundle:3b932aea -->
+`POWER_MANAGE_CA_TRUST_BUNDLE_FILE` optionally names the startup-only PEM trust
+bundle used for agent-client certificate verification. It must contain the
+active CA from `POWER_MANAGE_CA_CERT_FILE`; changing either file requires a
+control restart.
 <!-- docref: end -->
 
 <!-- docref: begin src=cmd/control/config.go#loadSecret:b9678c7e,cmd/control/config.go#readSecretFile:60ffa83b,cmd/control/config.go#loadEd25519PrivateKey:3cc11345 -->

--- a/cmd/control/README.md
+++ b/cmd/control/README.md
@@ -80,9 +80,10 @@ search semantics. PostgreSQL is removed and guarded against return.
 <!-- docref: begin src=cmd/control/devauth.go#wrapDevAuth:f04e68b9,cmd/control/devauth.go#devAuthEnabled:4a7b3325 -->
 The development session endpoint is available only in a `devauth` build run
 with `PM_DEV_AUTH=1` and a `PM_DEV_AUTH_TOKEN` of at least 32 bytes. Start Vite
-with the same token; its local proxy injects the token into `/dev/session`
-requests without exposing it to browser code. Requests without the matching
-token are refused even when the proxy's connection to control is loopback.
+with the same token; its loopback-only proxy injects the token and forwards the
+original client address into `/dev/session` without exposing the token to
+browser code. Control requires both proxy and original client hops to be
+loopback and refuses requests without the matching token.
 <!-- docref: end -->
 
 ```bash

--- a/cmd/control/config.go
+++ b/cmd/control/config.go
@@ -384,7 +384,7 @@ func validateDatabasePath(path string) error {
 // evidence the moment one actor can write to the database and the archive at
 // once: the same root, the same disk failure, or the same ransomware pass
 // takes the record and its proof together. Documentation states that the
-// chain's head is anchored off-host, and an operator has to be able to say
+// chain's head is anchored separately, and an operator has to be able to say
 // that to an auditor, so it is a boot condition rather than a recommendation.
 //
 // Comparison is by filesystem, which is what a mount boundary actually is.
@@ -393,12 +393,16 @@ func validateDatabasePath(path string) error {
 // credentials, immutable object storage — is the operator's to provide, and
 // this refuses the one case the process can prove is wrong on its own.
 func validateArchiveIsolation(databasePath, archivePath string) error {
-	// The database file need not exist yet, so its filesystem is its
-	// directory's.
-	databaseDirectory := filepath.Dir(databasePath)
-	databaseFilesystem, err := filesystemIDOf(databaseDirectory)
+	databaseProbe := databasePath
+	if _, err := os.Stat(databasePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("database_path %q: %w", databasePath, err)
+		}
+		databaseProbe = filepath.Dir(databasePath)
+	}
+	databaseFilesystem, err := filesystemIDOf(databaseProbe)
 	if err != nil {
-		return fmt.Errorf("database_path %q: %w", databaseDirectory, err)
+		return fmt.Errorf("database_path %q: %w", databaseProbe, err)
 	}
 	archiveFilesystem, err := filesystemIDOf(archivePath)
 	if err != nil {
@@ -408,11 +412,11 @@ func validateArchiveIsolation(databasePath, archivePath string) error {
 		return nil
 	}
 	return fmt.Errorf(
-		"backup_path %q is on the same filesystem as the database at %q: the audit archive holds the off-host "+
+		"backup_path %q is on the same filesystem as the database at %q: the audit archive holds separately stored "+
 			"evidence for that database and must be a separate mount, ideally remote storage under different "+
 			"credentials, so that losing or tampering with one cannot silently take the other with it; mount a "+
 			"distinct filesystem and point POWER_MANAGE_BACKUP_PATH at it",
-		archivePath, databaseDirectory)
+		archivePath, databaseProbe)
 }
 
 func validateWritableDirectory(name, path string) error {

--- a/cmd/control/config.go
+++ b/cmd/control/config.go
@@ -35,6 +35,12 @@ const (
 // already exist in the surrounding shell.
 var configEnviron = os.Environ
 
+// filesystemIDOf reports which filesystem holds a path. It is a package
+// variable for the same reason configEnviron is: creating a second real
+// filesystem needs root, so a test cannot otherwise exercise the accepting
+// side of the separation check the loader enforces below.
+var filesystemIDOf = filesystemDeviceID
+
 // configEnvironment declares every recognized option exactly once: the tag
 // names its variable and the field type selects its parser. The recognized set
 // is derived from these declarations rather than from a second list.
@@ -324,6 +330,12 @@ func validateConfig(cfg *Config) error {
 	if err := validateWritableDirectory("backup_path", cfg.BackupPath); err != nil {
 		return err
 	}
+	if err := validateArchiveIsolation(cfg.DatabasePath, cfg.BackupPath); err != nil {
+		if !archiveIsolationRelaxed() {
+			return err
+		}
+		fmt.Fprintln(os.Stderr, "control: DEVELOPMENT BUILD, audit archive separation not enforced:", err)
+	}
 	if _, err := webhook.New(cfg.WebhookURL); err != nil {
 		return err
 	}
@@ -359,6 +371,45 @@ func validateDatabasePath(path string) error {
 		return fmt.Errorf("database_path %q: %w", path, err)
 	}
 	return validateWritableDirectory("database_path parent", filepath.Dir(path))
+}
+
+// validateArchiveIsolation refuses to start control when the audit archive
+// shares a filesystem with the database it is evidence for.
+//
+// The archive holds the anchors that authenticate the audit chain's head and
+// the prefixes retention deleted live rows in exchange for. Both stop being
+// evidence the moment one actor can write to the database and the archive at
+// once: the same root, the same disk failure, or the same ransomware pass
+// takes the record and its proof together. Documentation states that the
+// chain's head is anchored off-host, and an operator has to be able to say
+// that to an auditor, so it is a boot condition rather than a recommendation.
+//
+// Comparison is by filesystem, which is what a mount boundary actually is.
+// It is a floor, not a guarantee of remoteness: a second local disk passes
+// while sharing a machine. Anything stronger — a different host, different
+// credentials, immutable object storage — is the operator's to provide, and
+// this refuses the one case the process can prove is wrong on its own.
+func validateArchiveIsolation(databasePath, archivePath string) error {
+	// The database file need not exist yet, so its filesystem is its
+	// directory's.
+	databaseDirectory := filepath.Dir(databasePath)
+	databaseFilesystem, err := filesystemIDOf(databaseDirectory)
+	if err != nil {
+		return fmt.Errorf("database_path %q: %w", databaseDirectory, err)
+	}
+	archiveFilesystem, err := filesystemIDOf(archivePath)
+	if err != nil {
+		return fmt.Errorf("backup_path %q: %w", archivePath, err)
+	}
+	if databaseFilesystem != archiveFilesystem {
+		return nil
+	}
+	return fmt.Errorf(
+		"backup_path %q is on the same filesystem as the database at %q: the audit archive holds the off-host "+
+			"evidence for that database and must be a separate mount, ideally remote storage under different "+
+			"credentials, so that losing or tampering with one cannot silently take the other with it; mount a "+
+			"distinct filesystem and point POWER_MANAGE_BACKUP_PATH at it",
+		archivePath, databaseDirectory)
 }
 
 func validateWritableDirectory(name, path string) error {

--- a/cmd/control/config.go
+++ b/cmd/control/config.go
@@ -66,6 +66,7 @@ type configEnvironment struct {
 	WebhookURL            string        `env:"POWER_MANAGE_WEBHOOK_URL"`
 	CACertFile            string        `env:"POWER_MANAGE_CA_CERT_FILE"`
 	CAKeyFile             string        `env:"POWER_MANAGE_CA_KEY_FILE"`
+	CATrustBundleFile     string        `env:"POWER_MANAGE_CA_TRUST_BUNDLE_FILE"`
 	AgentTLSCertFile      string        `env:"POWER_MANAGE_AGENT_TLS_CERT_FILE"`
 	AgentTLSKeyFile       string        `env:"POWER_MANAGE_AGENT_TLS_KEY_FILE"`
 	PublicTLSCertFile     string        `env:"POWER_MANAGE_PUBLIC_TLS_CERT_FILE"`
@@ -100,6 +101,7 @@ type Config struct {
 	WebhookURL          string
 	CACertFile          string
 	CAKeyFile           string
+	CATrustBundleFile   string
 	AgentTLSCertFile    string
 	AgentTLSKeyFile     string
 	PublicTLSCertFile   string
@@ -154,6 +156,7 @@ func loadConfig() (*Config, error) {
 		WebhookURL:        document.WebhookURL,
 		CACertFile:        document.CACertFile,
 		CAKeyFile:         document.CAKeyFile,
+		CATrustBundleFile: document.CATrustBundleFile,
 		AgentTLSCertFile:  document.AgentTLSCertFile,
 		AgentTLSKeyFile:   document.AgentTLSKeyFile,
 		PublicTLSCertFile: document.PublicTLSCertFile,

--- a/cmd/control/config_test.go
+++ b/cmd/control/config_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -488,6 +489,30 @@ func TestLoadConfigAcceptsAnArchiveOnADistinctFilesystem(t *testing.T) {
 	cfg, err := loadConfig()
 	require.NoError(t, err)
 	assert.Equal(t, fixture.values["POWER_MANAGE_BACKUP_PATH"], cfg.BackupPath)
+}
+
+func TestArchiveIsolationProbesAnExistingDatabaseFile(t *testing.T) {
+	directory := t.TempDir()
+	database := filepath.Join(directory, "control.db")
+	archive := filepath.Join(directory, "archive")
+	require.NoError(t, os.WriteFile(database, []byte("sqlite"), 0o600))
+	require.NoError(t, os.Mkdir(archive, 0o700))
+
+	real := filesystemIDOf
+	filesystemIDOf = func(path string) (uint64, error) {
+		switch path {
+		case database:
+			return 1, nil
+		case archive, directory:
+			return 2, nil
+		default:
+			return 0, fmt.Errorf("unexpected probe %q", path)
+		}
+	}
+	t.Cleanup(func() { filesystemIDOf = real })
+
+	require.NoError(t, validateArchiveIsolation(database, archive),
+		"a bind-mounted database file can be isolated even when its parent is not")
 }
 
 // TestFilesystemDeviceIDIdentifiesOneMount pins what that decision rests on.

--- a/cmd/control/config_test.go
+++ b/cmd/control/config_test.go
@@ -45,6 +45,11 @@ func newEnvironmentFixture(t *testing.T) environmentFixture {
 	backupPath := filepath.Join(directory, "backups")
 	require.NoError(t, os.Mkdir(artifactPath, 0o700))
 	require.NoError(t, os.Mkdir(backupPath, 0o700))
+	// A configuration that loads successfully now needs the audit archive on
+	// its own mount, which a test cannot create without root — so the fixture
+	// models one. Cases that are about the separation itself put the real
+	// probe back with useRealFilesystemProbe.
+	modelSeparateFilesystems(t, backupPath)
 
 	return environmentFixture{
 		sessionKey: sessionKey,
@@ -83,6 +88,31 @@ func setEnvironment(t *testing.T, values map[string]string) {
 	previous := configEnviron
 	configEnviron = func() []string { return entries }
 	t.Cleanup(func() { configEnviron = previous })
+}
+
+// modelSeparateFilesystems makes archivePath report a filesystem of its own
+// while every other path keeps its real identifier, so a stat failure still
+// surfaces instead of being masked by the model.
+func modelSeparateFilesystems(t *testing.T, archivePath string) {
+	t.Helper()
+	real := filesystemIDOf
+	filesystemIDOf = func(path string) (uint64, error) {
+		id, err := real(path)
+		if err != nil || path != archivePath {
+			return id, err
+		}
+		return id + 1, nil
+	}
+	t.Cleanup(func() { filesystemIDOf = real })
+}
+
+// useRealFilesystemProbe undoes the fixture's model for cases that must be
+// judged against the kernel's answer.
+func useRealFilesystemProbe(t *testing.T) {
+	t.Helper()
+	modelled := filesystemIDOf
+	filesystemIDOf = filesystemDeviceID
+	t.Cleanup(func() { filesystemIDOf = modelled })
 }
 
 func TestLoadConfigResolvesEveryOptionFromTheEnvironment(t *testing.T) {
@@ -424,6 +454,59 @@ func TestParseCommandAcceptsSubcommandsAndRejectsEverythingElse(t *testing.T) {
 		assert.EqualError(t, err, message, "%v must be rejected", args)
 		assert.Empty(t, command)
 	}
+}
+
+// TestLoadConfigRefusesAnArchiveOnTheDatabaseFilesystem holds the enforced
+// half of "the audit chain's head is anchored off-host": an archive sharing a
+// mount with the database it is evidence for is not off-host, and whoever can
+// rewrite one can rewrite both. This case uses the REAL filesystem probe —
+// two directories under one temp dir genuinely are one mount — so it fails if
+// the check is removed, weakened, or made to depend only on the test seam.
+func TestLoadConfigRefusesAnArchiveOnTheDatabaseFilesystem(t *testing.T) {
+	fixture := newEnvironmentFixture(t)
+	useRealFilesystemProbe(t)
+	setEnvironment(t, fixture.values)
+
+	cfg, err := loadConfig()
+	require.Error(t, err)
+	assert.Nil(t, cfg)
+	assert.ErrorContains(t, err, fixture.values["POWER_MANAGE_BACKUP_PATH"])
+	assert.ErrorContains(t, err, filepath.Dir(fixture.values["POWER_MANAGE_DATABASE_PATH"]))
+	assert.ErrorContains(t, err, "same filesystem")
+	assert.ErrorContains(t, err, "separate mount",
+		"the operator must be told what to do, not only that something is wrong")
+}
+
+// TestLoadConfigAcceptsAnArchiveOnADistinctFilesystem is the positive control:
+// the refusal above must be about the shared mount and nothing else.
+func TestLoadConfigAcceptsAnArchiveOnADistinctFilesystem(t *testing.T) {
+	fixture := newEnvironmentFixture(t)
+	setEnvironment(t, fixture.values)
+
+	cfg, err := loadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, fixture.values["POWER_MANAGE_BACKUP_PATH"], cfg.BackupPath)
+}
+
+// TestFilesystemDeviceIDIdentifiesOneMount pins what that decision rests on.
+// A probe that failed open — reporting distinct identifiers for one mount, or
+// swallowing a stat error — would make the refusal above unreachable in
+// production while the seam-driven cases stayed green.
+func TestFilesystemDeviceIDIdentifiesOneMount(t *testing.T) {
+	directory := t.TempDir()
+	first := filepath.Join(directory, "first")
+	second := filepath.Join(directory, "second")
+	require.NoError(t, os.Mkdir(first, 0o700))
+	require.NoError(t, os.Mkdir(second, 0o700))
+
+	firstID, err := filesystemDeviceID(first)
+	require.NoError(t, err)
+	secondID, err := filesystemDeviceID(second)
+	require.NoError(t, err)
+	assert.Equal(t, firstID, secondID, "two directories in one temp dir share a filesystem")
+
+	_, err = filesystemDeviceID(filepath.Join(directory, "absent"))
+	assert.Error(t, err, "an unstattable path must fail closed rather than read as a distinct mount")
 }
 
 func TestValidateConfigRequiresWritableDataDirectories(t *testing.T) {

--- a/cmd/control/config_test.go
+++ b/cmd/control/config_test.go
@@ -122,6 +122,7 @@ func TestLoadConfigResolvesEveryOptionFromTheEnvironment(t *testing.T) {
 	fixture.values["POWER_MANAGE_CORS_ALLOW_ALL"] = "true"
 	fixture.values["POWER_MANAGE_HEARTBEAT_INTERVAL"] = "45s"
 	fixture.values["POWER_MANAGE_LOG_LEVEL"] = "debug"
+	fixture.values["POWER_MANAGE_CA_TRUST_BUNDLE_FILE"] = "/certs/ca-bundle.crt"
 	setEnvironment(t, fixture.values)
 
 	cfg, err := loadConfig()
@@ -136,6 +137,7 @@ func TestLoadConfigResolvesEveryOptionFromTheEnvironment(t *testing.T) {
 	assert.Equal(t, fixture.values["POWER_MANAGE_DATABASE_PATH"], cfg.DatabasePath)
 	assert.Equal(t, "/certs/ca.crt", cfg.CACertFile)
 	assert.Equal(t, "/certs/ca.key", cfg.CAKeyFile)
+	assert.Equal(t, "/certs/ca-bundle.crt", cfg.CATrustBundleFile)
 	assert.Equal(t, "/certs/control.crt", cfg.AgentTLSCertFile)
 	assert.Equal(t, "/certs/control.key", cfg.AgentTLSKeyFile)
 

--- a/cmd/control/devauth.go
+++ b/cmd/control/devauth.go
@@ -50,6 +50,19 @@ type devSessionResponse struct {
 	DisplayName  string `json:"displayName"`
 }
 
+// archiveIsolationRelaxed downgrades the audit archive's separate-filesystem
+// requirement to a warning on a development workstation, where the database
+// and the archive are two directories on one disk and mounting a second
+// filesystem needs root.
+//
+// It rides the two gates this file already establishes rather than adding a
+// third: a release binary compiles the !devauth stub, which returns false and
+// has no way to be told otherwise, and a devauth binary still enforces the
+// requirement unless PM_DEV_AUTH=1 is set. A build in which this can return
+// true is a build that also mints administrator sessions without an identity
+// provider, so it can never be mistaken for a deployable one.
+func archiveIsolationRelaxed() bool { return os.Getenv(devAuthEnv) == "1" }
+
 // wrapDevAuth mounts POST /dev/session in front of next when this devauth
 // build is run with PM_DEV_AUTH=1. Without the flag it returns
 // next unchanged, so the route does not exist. Production builds never

--- a/cmd/control/devauth.go
+++ b/cmd/control/devauth.go
@@ -16,6 +16,7 @@ import (
 	"encoding/json"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"time"
@@ -76,10 +77,15 @@ func wrapDevAuth(next http.Handler, st *store.Store, jwtMgr *auth.JWTManager, ke
 
 	mux := http.NewServeMux()
 	mux.HandleFunc(devSessionPath, func(w http.ResponseWriter, r *http.Request) {
-		// The web calls this cross-origin (dev UI on :5173 → control on
-		// :8081), so honour the preflight and echo the caller's origin.
-		// Dev-only: this permissiveness never ships to a real deployment.
+		if !devRequestIsLocal(r) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
 		if origin := r.Header.Get("Origin"); origin != "" {
+			if !devOriginAllowed(origin) {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
 			w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
@@ -106,6 +112,20 @@ func wrapDevAuth(next http.Handler, st *store.Store, jwtMgr *auth.JWTManager, ke
 	})
 	mux.Handle("/", next)
 	return mux
+}
+
+func devRequestIsLocal(r *http.Request) bool {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	return err == nil && net.ParseIP(host).IsLoopback()
+}
+
+func devOriginAllowed(origin string) bool {
+	switch origin {
+	case "https://localhost:5173", "https://127.0.0.1:5173", "https://[::1]:5173", "https://pm.localhost:5173":
+		return true
+	default:
+		return false
+	}
 }
 
 // devMintAdminSession idempotently provisions the fixed admin and returns
@@ -146,6 +166,12 @@ func devMintAdminSession(ctx context.Context, st *store.Store, jwtMgr *auth.JWTM
 	if err != nil {
 		return nil, err
 	}
+	if _, err := st.RecordOperation(ctx, devAuditOperation(), store.AuditEffect{
+		ResourceType: "session", ResourceID: userID,
+		Action: "DEV_ISSUE", Outcome: store.EffectApplied,
+	}); err != nil {
+		return nil, err
+	}
 	return &devSessionResponse{
 		AccessToken:  tokens.AccessToken,
 		RefreshToken: tokens.RefreshToken,
@@ -172,14 +198,7 @@ func devEnsureAdmin(ctx context.Context, st *store.Store, kek *pmcrypto.Encrypto
 	}
 
 	userID := ulid.Make().String()
-	op := store.AuditOperation{
-		Class:                store.ClassBackgroundWriter,
-		ActorType:            auth.AnonymousActorType,
-		Origin:               auth.ControlRPCOrigin,
-		RequestDescriptor:    devSessionPath,
-		AuthorizationOutcome: store.AuthorizationNotApplicable,
-		Result:               store.ResultSuccess,
-	}
+	op := devAuditOperation()
 	_, err := st.WithAudit(ctx, op, func(ctx context.Context, tx *store.Tx, rec *store.AuditRecorder) error {
 		wrapped, err := pmcrypto.GenerateWrappedDEK(kek, userID)
 		if err != nil {
@@ -233,16 +252,21 @@ func devEnsureAdmin(ctx context.Context, st *store.Store, kek *pmcrypto.Encrypto
 			Action:       "GRANT",
 			Outcome:      store.EffectApplied,
 		})
-		rec.Effect(store.AuditEffect{
-			ResourceType: "session",
-			ResourceID:   userID,
-			Action:       "DEV_ISSUE",
-			Outcome:      store.EffectApplied,
-		})
 		return nil
 	})
 	if err != nil {
 		return "", err
 	}
 	return userID, nil
+}
+
+func devAuditOperation() store.AuditOperation {
+	return store.AuditOperation{
+		Class:                store.ClassBackgroundWriter,
+		ActorType:            auth.AnonymousActorType,
+		Origin:               auth.ControlRPCOrigin,
+		RequestDescriptor:    devSessionPath,
+		AuthorizationOutcome: store.AuthorizationNotApplicable,
+		Result:               store.ResultSuccess,
+	}
 }

--- a/cmd/control/devauth.go
+++ b/cmd/control/devauth.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -133,7 +134,29 @@ func wrapDevAuth(next http.Handler, st *store.Store, jwtMgr *auth.JWTManager, ke
 
 func devRequestIsLocal(r *http.Request) bool {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	return err == nil && net.ParseIP(host).IsLoopback()
+	if err != nil || !net.ParseIP(host).IsLoopback() {
+		return false
+	}
+
+	// The Vite proxy terminates the browser connection, so RemoteAddr proves
+	// only that the proxy is local. xfwd records the original client hop; require
+	// every address in that chain to be loopback so a remotely reachable proxy
+	// cannot turn its own backend connection into local-client evidence.
+	forwarded := r.Header.Values("X-Forwarded-For")
+	if len(forwarded) == 0 || r.Header.Get("Forwarded") != "" {
+		return false
+	}
+	for _, value := range forwarded {
+		for _, address := range strings.Split(value, ",") {
+			if !net.ParseIP(strings.TrimSpace(address)).IsLoopback() {
+				return false
+			}
+		}
+	}
+	if realIP := r.Header.Get("X-Real-IP"); realIP != "" && !net.ParseIP(strings.TrimSpace(realIP)).IsLoopback() {
+		return false
+	}
+	return true
 }
 
 func devOriginAllowed(origin string) bool {

--- a/cmd/control/devauth.go
+++ b/cmd/control/devauth.go
@@ -1,18 +1,20 @@
 //go:build devauth
 
 // Development-only authentication bypass. Target design §5.2: a build
-// compiled with the `devauth` tag AND run with PM_DEV_AUTH=1
+// compiled with the `devauth` tag AND run with PM_DEV_AUTH=1 plus a
+// PM_DEV_AUTH_TOKEN
 // exposes POST /dev/session, which provisions one fixed local
 // administrator and mints an ordinary session for it so the web UI can be
-// exercised without an identity provider. Both gates are mandatory: a
+// exercised without an identity provider. All three gates are mandatory: a
 // release build omits this file entirely (the !devauth stub replaces it),
-// and a devauth build still refuses unless the environment flag is set.
+// and a devauth build still refuses unless both runtime gates are set.
 // The minted session is an ordinary signed session subject to the same
 // validation, revocation and expiry as an OIDC login.
 package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -30,8 +32,10 @@ import (
 )
 
 const (
-	devAuthEnv     = "PM_DEV_AUTH"
-	devSessionPath = "/dev/session"
+	devAuthEnv         = "PM_DEV_AUTH"
+	devAuthTokenEnv    = "PM_DEV_AUTH_TOKEN"
+	devAuthTokenHeader = "X-Power-Manage-Dev-Auth"
+	devSessionPath     = "/dev/session"
 	// devAdminEmail is the fixed local administrator. Lookup by this
 	// address keeps provisioning idempotent across restarts and repeat
 	// logins.
@@ -56,20 +60,29 @@ type devSessionResponse struct {
 // and the archive are two directories on one disk and mounting a second
 // filesystem needs root.
 //
-// It rides the two gates this file already establishes rather than adding a
-// third: a release binary compiles the !devauth stub, which returns false and
-// has no way to be told otherwise, and a devauth binary still enforces the
-// requirement unless PM_DEV_AUTH=1 is set. A build in which this can return
+// It rides the same gates as the session endpoint: a release binary compiles
+// the !devauth stub, which returns false and has no way to be told otherwise,
+// and a devauth binary still enforces the requirement unless PM_DEV_AUTH=1 and
+// a sufficiently long PM_DEV_AUTH_TOKEN are set. A build in which this can return
 // true is a build that also mints administrator sessions without an identity
 // provider, so it can never be mistaken for a deployable one.
-func archiveIsolationRelaxed() bool { return os.Getenv(devAuthEnv) == "1" }
+func archiveIsolationRelaxed() bool { return devAuthEnabled() }
+
+func devAuthEnabled() bool {
+	return os.Getenv(devAuthEnv) == "1" && len(os.Getenv(devAuthTokenEnv)) >= 32
+}
 
 // wrapDevAuth mounts POST /dev/session in front of next when this devauth
-// build is run with PM_DEV_AUTH=1. Without the flag it returns
+// build is run with PM_DEV_AUTH=1 and a development token. Without them it returns
 // next unchanged, so the route does not exist. Production builds never
 // reach here — they compile the !devauth stub instead.
 func wrapDevAuth(next http.Handler, st *store.Store, jwtMgr *auth.JWTManager, kek *pmcrypto.Encryptor, logger *slog.Logger) http.Handler {
 	if os.Getenv(devAuthEnv) != "1" {
+		return next
+	}
+	token := os.Getenv(devAuthTokenEnv)
+	if len(token) < 32 {
+		logger.Error("development auth bypass disabled: PM_DEV_AUTH_TOKEN must contain at least 32 bytes")
 		return next
 	}
 	logger.Warn("DEVELOPMENT AUTH BYPASS ACTIVE — POST /dev/session mints an administrator session without an identity provider; never run a devauth build in production",
@@ -78,6 +91,10 @@ func wrapDevAuth(next http.Handler, st *store.Store, jwtMgr *auth.JWTManager, ke
 	mux := http.NewServeMux()
 	mux.HandleFunc(devSessionPath, func(w http.ResponseWriter, r *http.Request) {
 		if !devRequestIsLocal(r) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+		if subtle.ConstantTimeCompare([]byte(r.Header.Get(devAuthTokenHeader)), []byte(token)) != 1 {
 			http.Error(w, "forbidden", http.StatusForbidden)
 			return
 		}
@@ -183,8 +200,8 @@ func devMintAdminSession(ctx context.Context, st *store.Store, jwtMgr *auth.JWTM
 }
 
 // devEnsureAdmin returns the fixed admin's id, provisioning it on first
-// use. Provision + role grant + the session-issue effect land in one
-// audited transaction, mirroring OIDC JIT.
+// use. Provision + role grant land in one audited transaction, mirroring
+// OIDC JIT; devMintAdminSession records each subsequent session issue.
 //
 // ponytail: check-then-create races on the unique email constraint, which
 // a second concurrent InsertUser would reject. That is fine for a

--- a/cmd/control/devauth.go
+++ b/cmd/control/devauth.go
@@ -1,0 +1,235 @@
+//go:build devauth
+
+// Development-only authentication bypass. Target design §5.2: a build
+// compiled with the `devauth` tag AND run with PM_DEV_AUTH=1
+// exposes POST /dev/session, which provisions one fixed local
+// administrator and mints an ordinary session for it so the web UI can be
+// exercised without an identity provider. Both gates are mandatory: a
+// release build omits this file entirely (the !devauth stub replaces it),
+// and a devauth build still refuses unless the environment flag is set.
+// The minted session is an ordinary signed session subject to the same
+// validation, revocation and expiry as an OIDC login.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+const (
+	devAuthEnv     = "PM_DEV_AUTH"
+	devSessionPath = "/dev/session"
+	// devAdminEmail is the fixed local administrator. Lookup by this
+	// address keeps provisioning idempotent across restarts and repeat
+	// logins.
+	devAdminEmail       = "dev-admin@localhost"
+	devAdminDisplayName = "Dev Admin"
+	devAdminLinuxName   = "devadmin"
+)
+
+// devSessionResponse is the JSON the web dev bypass consumes. It carries a
+// real access/refresh pair; the web stores it exactly like an SSO login.
+type devSessionResponse struct {
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken"`
+	ExpiresAt    string `json:"expiresAt"`
+	UserID       string `json:"userId"`
+	Email        string `json:"email"`
+	DisplayName  string `json:"displayName"`
+}
+
+// wrapDevAuth mounts POST /dev/session in front of next when this devauth
+// build is run with PM_DEV_AUTH=1. Without the flag it returns
+// next unchanged, so the route does not exist. Production builds never
+// reach here — they compile the !devauth stub instead.
+func wrapDevAuth(next http.Handler, st *store.Store, jwtMgr *auth.JWTManager, kek *pmcrypto.Encryptor, logger *slog.Logger) http.Handler {
+	if os.Getenv(devAuthEnv) != "1" {
+		return next
+	}
+	logger.Warn("DEVELOPMENT AUTH BYPASS ACTIVE — POST /dev/session mints an administrator session without an identity provider; never run a devauth build in production",
+		"endpoint", devSessionPath)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(devSessionPath, func(w http.ResponseWriter, r *http.Request) {
+		// The web calls this cross-origin (dev UI on :5173 → control on
+		// :8081), so honour the preflight and echo the caller's origin.
+		// Dev-only: this permissiveness never ships to a real deployment.
+		if origin := r.Header.Get("Origin"); origin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Vary", "Origin")
+			w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		}
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		resp, err := devMintAdminSession(r.Context(), st, jwtMgr, kek, time.Now())
+		if err != nil {
+			logger.Error("dev auth: mint admin session failed", "error", err)
+			http.Error(w, "dev session failed", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			logger.Error("dev auth: encode response failed", "error", err)
+		}
+	})
+	mux.Handle("/", next)
+	return mux
+}
+
+// devMintAdminSession idempotently provisions the fixed admin and returns
+// an ordinary session for it. The authority is read from the database and
+// baked into the access token exactly as the OIDC callback does, so the
+// resulting session is indistinguishable downstream from a real login.
+func devMintAdminSession(ctx context.Context, st *store.Store, jwtMgr *auth.JWTManager, kek *pmcrypto.Encryptor, now time.Time) (*devSessionResponse, error) {
+	userID, err := devEnsureAdmin(ctx, st, kek, now)
+	if err != nil {
+		return nil, err
+	}
+
+	permissions, err := st.ListUserPermissions(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	grantRows, err := st.ListUserScopedGrants(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	grants := make([]auth.ScopedGrant, 0, len(grantRows))
+	for _, g := range grantRows {
+		sg := auth.ScopedGrant{Permission: g.Permission}
+		if g.ScopeKind != nil {
+			sg.ScopeKind = *g.ScopeKind
+		}
+		if g.ScopeID != nil {
+			sg.ScopeID = *g.ScopeID
+		}
+		grants = append(grants, sg)
+	}
+	sessionState, err := st.GetUserSessionState(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	tokens, err := jwtMgr.GenerateTokens(userID, devAdminEmail, permissions, grants, sessionState.SessionVersion)
+	if err != nil {
+		return nil, err
+	}
+	return &devSessionResponse{
+		AccessToken:  tokens.AccessToken,
+		RefreshToken: tokens.RefreshToken,
+		ExpiresAt:    tokens.ExpiresAt.UTC().Format(time.RFC3339),
+		UserID:       userID,
+		Email:        devAdminEmail,
+		DisplayName:  devAdminDisplayName,
+	}, nil
+}
+
+// devEnsureAdmin returns the fixed admin's id, provisioning it on first
+// use. Provision + role grant + the session-issue effect land in one
+// audited transaction, mirroring OIDC JIT.
+//
+// ponytail: check-then-create races on the unique email constraint, which
+// a second concurrent InsertUser would reject. That is fine for a
+// single-operator dev tool; if it ever matters, catch the violation and
+// re-read instead.
+func devEnsureAdmin(ctx context.Context, st *store.Store, kek *pmcrypto.Encryptor, now time.Time) (string, error) {
+	if existing, err := st.GetUserByEmail(ctx, devAdminEmail); err == nil {
+		return existing.ID, nil
+	} else if !store.IsNotFound(err) {
+		return "", err
+	}
+
+	userID := ulid.Make().String()
+	op := store.AuditOperation{
+		Class:                store.ClassBackgroundWriter,
+		ActorType:            auth.AnonymousActorType,
+		Origin:               auth.ControlRPCOrigin,
+		RequestDescriptor:    devSessionPath,
+		AuthorizationOutcome: store.AuthorizationNotApplicable,
+		Result:               store.ResultSuccess,
+	}
+	_, err := st.WithAudit(ctx, op, func(ctx context.Context, tx *store.Tx, rec *store.AuditRecorder) error {
+		wrapped, err := pmcrypto.GenerateWrappedDEK(kek, userID)
+		if err != nil {
+			return err
+		}
+		if _, err := tx.InsertUserEncryptionKey(ctx, db.InsertUserEncryptionKeyParams{
+			UserID:     userID,
+			WrappedDek: wrapped,
+		}); err != nil {
+			return err
+		}
+		linuxUID, err := tx.GetNextLinuxUID(ctx)
+		if err != nil {
+			return err
+		}
+		if linuxUID > 2147483647 {
+			return errors.New("assign linux uid: int32 range exhausted")
+		}
+		createdAt := now.UTC()
+		if _, err := tx.InsertUser(ctx, db.InsertUserParams{
+			ID:                 userID,
+			Email:              devAdminEmail,
+			DisplayName:        devAdminDisplayName,
+			LinuxUsername:      devAdminLinuxName,
+			LinuxUid:           int32(linuxUID),
+			ProvisioningSource: store.UserProvisioningSourceOIDCJIT,
+			CreatedAt:          &createdAt,
+		}); err != nil {
+			return err
+		}
+		rec.Effect(store.AuditEffect{
+			ResourceType: "user",
+			ResourceID:   userID,
+			Action:       "PROVISION",
+			Outcome:      store.EffectApplied,
+		})
+
+		grantID := ulid.Make().String()
+		if _, err := tx.InsertUserRoleGrant(ctx, db.InsertUserRoleGrantParams{
+			GrantID:    grantID,
+			UserID:     userID,
+			RoleID:     auth.AdminRoleID,
+			AssignedAt: createdAt,
+			AssignedBy: "dev-auth",
+		}); err != nil {
+			return err
+		}
+		rec.Effect(store.AuditEffect{
+			ResourceType: "user_role",
+			ResourceID:   grantID,
+			Action:       "GRANT",
+			Outcome:      store.EffectApplied,
+		})
+		rec.Effect(store.AuditEffect{
+			ResourceType: "session",
+			ResourceID:   userID,
+			Action:       "DEV_ISSUE",
+			Outcome:      store.EffectApplied,
+		})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return userID, nil
+}

--- a/cmd/control/devauth_stub.go
+++ b/cmd/control/devauth_stub.go
@@ -1,0 +1,20 @@
+//go:build !devauth
+
+package main
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// wrapDevAuth is a no-op in production builds: the development auth bypass
+// (POST /dev/session) exists only in binaries compiled with the `devauth`
+// build tag. Keeping the signature identical lets main.go wire it
+// unconditionally while the real handler is physically absent here.
+func wrapDevAuth(next http.Handler, _ *store.Store, _ *auth.JWTManager, _ *pmcrypto.Encryptor, _ *slog.Logger) http.Handler {
+	return next
+}

--- a/cmd/control/devauth_stub.go
+++ b/cmd/control/devauth_stub.go
@@ -18,3 +18,11 @@ import (
 func wrapDevAuth(next http.Handler, _ *store.Store, _ *auth.JWTManager, _ *pmcrypto.Encryptor, _ *slog.Logger) http.Handler {
 	return next
 }
+
+// archiveIsolationRelaxed is false in every production build: the audit
+// archive must be on its own filesystem, and a shipped binary offers no way
+// to say otherwise. There is deliberately no configuration variable for it —
+// an option to skip a verification is the thing an attacker looks for first,
+// and the workstation case is served by the same build tag that already gates
+// the development sign-in.
+func archiveIsolationRelaxed() bool { return false }

--- a/cmd/control/devauth_test.go
+++ b/cmd/control/devauth_test.go
@@ -63,6 +63,41 @@ func TestDevAuthDisabledWithoutEnv(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, rec.Code, "/dev/session must not exist without PM_DEV_AUTH=1")
 }
 
+// TestArchiveIsolationRelaxationFollowsTheDevAuthFlag holds the escape hatch's
+// only reason to exist: it rides the same two gates as the sign-in bypass and
+// adds no third way to turn a verification off. A devauth binary run without
+// PM_DEV_AUTH=1 still demands the audit archive's own filesystem, and the
+// !devauth stub cannot relax it at all.
+func TestArchiveIsolationRelaxationFollowsTheDevAuthFlag(t *testing.T) {
+	t.Setenv(devAuthEnv, "")
+	assert.False(t, archiveIsolationRelaxed(), "the build tag alone must not relax the requirement")
+
+	t.Setenv(devAuthEnv, "yes")
+	assert.False(t, archiveIsolationRelaxed(), "only the exact flag value relaxes it")
+
+	t.Setenv(devAuthEnv, "1")
+	assert.True(t, archiveIsolationRelaxed(), "a workstation with one disk must still be able to run control")
+}
+
+// TestLoadConfigToleratesOneDiskInADevAuthBuild drives the relaxation through
+// the real loader with the real filesystem probe, so the branch is exercised
+// where it is actually reached rather than only where it is declared.
+func TestLoadConfigToleratesOneDiskInADevAuthBuild(t *testing.T) {
+	fixture := newEnvironmentFixture(t)
+	useRealFilesystemProbe(t)
+	setEnvironment(t, fixture.values)
+
+	t.Setenv(devAuthEnv, "")
+	cfg, err := loadConfig()
+	require.Error(t, err, "a devauth build without the flag still enforces the separation")
+	require.Nil(t, cfg)
+
+	t.Setenv(devAuthEnv, "1")
+	cfg, err = loadConfig()
+	require.NoError(t, err)
+	assert.Equal(t, fixture.values["POWER_MANAGE_BACKUP_PATH"], cfg.BackupPath)
+}
+
 // AC (c) + (d): with the flag set, POST /dev/session idempotently provisions
 // the fixed admin and returns an access token that authenticates AS an
 // administrator (carries the reconciled admin permission set).

--- a/cmd/control/devauth_test.go
+++ b/cmd/control/devauth_test.go
@@ -1,0 +1,117 @@
+//go:build devauth
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/auth"
+	"github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// devTestKEK is a 32-byte KEK in hex; the dev admin's DEK is minted under it.
+const devTestKEK = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+
+func devTestDeps(t *testing.T) (*store.Store, *auth.JWTManager, *crypto.Encryptor) {
+	t.Helper()
+	ctx := context.Background()
+	st, err := store.New(ctx, filepath.Join(t.TempDir(), "control.db"))
+	require.NoError(t, err)
+	t.Cleanup(st.Close)
+	require.NoError(t, auth.ReconcileSystemRoles(ctx, st, time.Now(), slog.New(slog.NewTextHandler(io.Discard, nil))))
+
+	_, priv, err := auth.GenerateSessionKey()
+	require.NoError(t, err)
+	jwtMgr, err := auth.NewJWTManager(auth.JWTConfig{PrivateKey: priv})
+	require.NoError(t, err)
+
+	kek, err := crypto.NewEncryptor(devTestKEK)
+	require.NoError(t, err)
+	return st, jwtMgr, kek
+}
+
+// base404 stands in for the real control handler: anything the dev wrapper
+// does not intercept falls through to it.
+func base404() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+}
+
+// AC (b): with the devauth build but PM_DEV_AUTH unset, the route
+// does not exist — the wrapper returns the base handler unchanged.
+func TestDevAuthDisabledWithoutEnv(t *testing.T) {
+	t.Setenv(devAuthEnv, "")
+	st, jwtMgr, kek := devTestDeps(t)
+	h := wrapDevAuth(base404(), st, jwtMgr, kek, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, devSessionPath, nil))
+	assert.Equal(t, http.StatusNotFound, rec.Code, "/dev/session must not exist without PM_DEV_AUTH=1")
+}
+
+// AC (c) + (d): with the flag set, POST /dev/session idempotently provisions
+// the fixed admin and returns an access token that authenticates AS an
+// administrator (carries the reconciled admin permission set).
+func TestDevAuthMintsAdminSession(t *testing.T) {
+	t.Setenv(devAuthEnv, "1")
+	st, jwtMgr, kek := devTestDeps(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	h := wrapDevAuth(base404(), st, jwtMgr, kek, logger)
+
+	post := func() devSessionResponse {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, devSessionPath, nil))
+		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+		var resp devSessionResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		return resp
+	}
+
+	first := post()
+	require.NotEmpty(t, first.AccessToken)
+	require.NotEmpty(t, first.RefreshToken)
+	assert.Equal(t, devAdminEmail, first.Email)
+	require.NotEmpty(t, first.UserID)
+
+	// The minted access token validates and carries administrator authority.
+	claims, err := jwtMgr.ValidateToken(first.AccessToken, auth.TokenTypeAccess)
+	require.NoError(t, err)
+	assert.Equal(t, first.UserID, claims.UserID)
+
+	dbPerms, err := st.ListUserPermissions(context.Background(), first.UserID)
+	require.NoError(t, err)
+	require.NotEmpty(t, dbPerms, "provisioned dev user must hold the admin role's permissions")
+	assert.Contains(t, dbPerms, "AssignRoleToUser", "dev user must be an administrator")
+	assert.ElementsMatch(t, dbPerms, claims.Permissions, "access token authority must match the DB")
+
+	// Second login is idempotent: the same subject, not a duplicate.
+	second := post()
+	assert.Equal(t, first.UserID, second.UserID)
+
+	users, err := st.ListUsers(context.Background(), "", 100)
+	require.NoError(t, err)
+	var adminCount int
+	emails := make([]string, 0, len(users))
+	for _, u := range users {
+		emails = append(emails, u.Email)
+		if u.Email == devAdminEmail {
+			adminCount++
+		}
+	}
+	sort.Strings(emails)
+	assert.Equal(t, 1, adminCount, "dev admin must be provisioned exactly once, saw %v", emails)
+}

--- a/cmd/control/devauth_test.go
+++ b/cmd/control/devauth_test.go
@@ -118,6 +118,7 @@ func TestDevAuthMintsAdminSession(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, devSessionPath, nil)
 		req.RemoteAddr = "127.0.0.1:1234"
+		req.Header.Set("X-Forwarded-For", "127.0.0.1")
 		req.Header.Set(devAuthTokenHeader, devTestAuthToken)
 		h.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
@@ -174,20 +175,32 @@ func TestDevAuthOnlyAcceptsLocalRequestsFromKnownDevOrigins(t *testing.T) {
 	h := wrapDevAuth(base404(), st, jwtMgr, kek, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	for name, test := range map[string]struct {
-		remote string
-		origin string
-		token  string
-		want   int
+		remote    string
+		forwarded string
+		realIP    string
+		origin    string
+		token     string
+		want      int
 	}{
-		"remote caller":     {"203.0.113.10:1234", "", devTestAuthToken, http.StatusForbidden},
-		"unknown origin":    {"127.0.0.1:1234", "https://evil.example", devTestAuthToken, http.StatusForbidden},
-		"wrong proxy token": {"127.0.0.1:1234", "https://localhost:5173", "wrong", http.StatusForbidden},
-		"localhost origin":  {"127.0.0.1:1234", "https://localhost:5173", devTestAuthToken, http.StatusNoContent},
-		"local no origin":   {"[::1]:1234", "", devTestAuthToken, http.StatusNoContent},
+		"remote proxy peer":        {"203.0.113.10:1234", "127.0.0.1", "", "", devTestAuthToken, http.StatusForbidden},
+		"missing original client":  {"127.0.0.1:1234", "", "", "", devTestAuthToken, http.StatusForbidden},
+		"remote original client":   {"127.0.0.1:1234", "203.0.113.10", "", "", devTestAuthToken, http.StatusForbidden},
+		"spoofed forwarded prefix": {"127.0.0.1:1234", "127.0.0.1, 203.0.113.10", "", "", devTestAuthToken, http.StatusForbidden},
+		"remote real IP":           {"127.0.0.1:1234", "127.0.0.1", "203.0.113.10", "", devTestAuthToken, http.StatusForbidden},
+		"unknown origin":           {"127.0.0.1:1234", "127.0.0.1", "", "https://evil.example", devTestAuthToken, http.StatusForbidden},
+		"wrong proxy token":        {"127.0.0.1:1234", "127.0.0.1", "", "https://localhost:5173", "wrong", http.StatusForbidden},
+		"localhost origin":         {"127.0.0.1:1234", "127.0.0.1", "", "https://localhost:5173", devTestAuthToken, http.StatusNoContent},
+		"local no origin":          {"[::1]:1234", "::1", "", "", devTestAuthToken, http.StatusNoContent},
 	} {
 		t.Run(name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodOptions, devSessionPath, nil)
 			req.RemoteAddr = test.remote
+			if test.forwarded != "" {
+				req.Header.Set("X-Forwarded-For", test.forwarded)
+			}
+			if test.realIP != "" {
+				req.Header.Set("X-Real-IP", test.realIP)
+			}
 			if test.origin != "" {
 				req.Header.Set("Origin", test.origin)
 			}

--- a/cmd/control/devauth_test.go
+++ b/cmd/control/devauth_test.go
@@ -109,7 +109,9 @@ func TestDevAuthMintsAdminSession(t *testing.T) {
 
 	post := func() devSessionResponse {
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, devSessionPath, nil))
+		req := httptest.NewRequest(http.MethodPost, devSessionPath, nil)
+		req.RemoteAddr = "127.0.0.1:1234"
+		h.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 		var resp devSessionResponse
 		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
@@ -121,6 +123,9 @@ func TestDevAuthMintsAdminSession(t *testing.T) {
 	require.NotEmpty(t, first.RefreshToken)
 	assert.Equal(t, devAdminEmail, first.Email)
 	require.NotEmpty(t, first.UserID)
+	issued, err := st.CountAuditEventRows(context.Background(), store.AuditEventFilter{EventType: "DEV_ISSUE"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), issued)
 
 	// The minted access token validates and carries administrator authority.
 	claims, err := jwtMgr.ValidateToken(first.AccessToken, auth.TokenTypeAccess)
@@ -136,6 +141,9 @@ func TestDevAuthMintsAdminSession(t *testing.T) {
 	// Second login is idempotent: the same subject, not a duplicate.
 	second := post()
 	assert.Equal(t, first.UserID, second.UserID)
+	issued, err = st.CountAuditEventRows(context.Background(), store.AuditEventFilter{EventType: "DEV_ISSUE"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), issued, "every minted session needs its own audit evidence")
 
 	users, err := st.ListUsers(context.Background(), "", 100)
 	require.NoError(t, err)
@@ -149,4 +157,37 @@ func TestDevAuthMintsAdminSession(t *testing.T) {
 	}
 	sort.Strings(emails)
 	assert.Equal(t, 1, adminCount, "dev admin must be provisioned exactly once, saw %v", emails)
+}
+
+func TestDevAuthOnlyAcceptsLocalRequestsFromKnownDevOrigins(t *testing.T) {
+	t.Setenv(devAuthEnv, "1")
+	st, jwtMgr, kek := devTestDeps(t)
+	h := wrapDevAuth(base404(), st, jwtMgr, kek, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+	for name, test := range map[string]struct {
+		remote string
+		origin string
+		want   int
+	}{
+		"remote caller":    {"203.0.113.10:1234", "", http.StatusForbidden},
+		"unknown origin":   {"127.0.0.1:1234", "https://evil.example", http.StatusForbidden},
+		"localhost origin": {"127.0.0.1:1234", "https://localhost:5173", http.StatusNoContent},
+		"local no origin":  {"[::1]:1234", "", http.StatusNoContent},
+	} {
+		t.Run(name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodOptions, devSessionPath, nil)
+			req.RemoteAddr = test.remote
+			if test.origin != "" {
+				req.Header.Set("Origin", test.origin)
+			}
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+			assert.Equal(t, test.want, rec.Code)
+			if test.want == http.StatusNoContent && test.origin != "" {
+				assert.Equal(t, test.origin, rec.Header().Get("Access-Control-Allow-Origin"))
+			} else {
+				assert.Empty(t, rec.Header().Get("Access-Control-Allow-Origin"))
+			}
+		})
+	}
 }

--- a/cmd/control/devauth_test.go
+++ b/cmd/control/devauth_test.go
@@ -24,6 +24,7 @@ import (
 
 // devTestKEK is a 32-byte KEK in hex; the dev admin's DEK is minted under it.
 const devTestKEK = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+const devTestAuthToken = "0123456789abcdef0123456789abcdef"
 
 func devTestDeps(t *testing.T) (*store.Store, *auth.JWTManager, *crypto.Encryptor) {
 	t.Helper()
@@ -64,19 +65,23 @@ func TestDevAuthDisabledWithoutEnv(t *testing.T) {
 }
 
 // TestArchiveIsolationRelaxationFollowsTheDevAuthFlag holds the escape hatch's
-// only reason to exist: it rides the same two gates as the sign-in bypass and
-// adds no third way to turn a verification off. A devauth binary run without
-// PM_DEV_AUTH=1 still demands the audit archive's own filesystem, and the
+// only reason to exist: it rides the same gates as the sign-in bypass and adds
+// no separate way to turn a verification off. A devauth binary run without
+// its runtime gates still demands the audit archive's own filesystem, and the
 // !devauth stub cannot relax it at all.
 func TestArchiveIsolationRelaxationFollowsTheDevAuthFlag(t *testing.T) {
 	t.Setenv(devAuthEnv, "")
+	t.Setenv(devAuthTokenEnv, "")
 	assert.False(t, archiveIsolationRelaxed(), "the build tag alone must not relax the requirement")
 
 	t.Setenv(devAuthEnv, "yes")
 	assert.False(t, archiveIsolationRelaxed(), "only the exact flag value relaxes it")
 
 	t.Setenv(devAuthEnv, "1")
-	assert.True(t, archiveIsolationRelaxed(), "a workstation with one disk must still be able to run control")
+	assert.False(t, archiveIsolationRelaxed(), "the bypass token is an independent gate")
+
+	t.Setenv(devAuthTokenEnv, devTestAuthToken)
+	assert.True(t, archiveIsolationRelaxed(), "a fully gated workstation with one disk must still be able to run control")
 }
 
 // TestLoadConfigToleratesOneDiskInADevAuthBuild drives the relaxation through
@@ -93,6 +98,7 @@ func TestLoadConfigToleratesOneDiskInADevAuthBuild(t *testing.T) {
 	require.Nil(t, cfg)
 
 	t.Setenv(devAuthEnv, "1")
+	t.Setenv(devAuthTokenEnv, devTestAuthToken)
 	cfg, err = loadConfig()
 	require.NoError(t, err)
 	assert.Equal(t, fixture.values["POWER_MANAGE_BACKUP_PATH"], cfg.BackupPath)
@@ -103,6 +109,7 @@ func TestLoadConfigToleratesOneDiskInADevAuthBuild(t *testing.T) {
 // administrator (carries the reconciled admin permission set).
 func TestDevAuthMintsAdminSession(t *testing.T) {
 	t.Setenv(devAuthEnv, "1")
+	t.Setenv(devAuthTokenEnv, devTestAuthToken)
 	st, jwtMgr, kek := devTestDeps(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := wrapDevAuth(base404(), st, jwtMgr, kek, logger)
@@ -111,6 +118,7 @@ func TestDevAuthMintsAdminSession(t *testing.T) {
 		rec := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodPost, devSessionPath, nil)
 		req.RemoteAddr = "127.0.0.1:1234"
+		req.Header.Set(devAuthTokenHeader, devTestAuthToken)
 		h.ServeHTTP(rec, req)
 		require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
 		var resp devSessionResponse
@@ -161,18 +169,21 @@ func TestDevAuthMintsAdminSession(t *testing.T) {
 
 func TestDevAuthOnlyAcceptsLocalRequestsFromKnownDevOrigins(t *testing.T) {
 	t.Setenv(devAuthEnv, "1")
+	t.Setenv(devAuthTokenEnv, devTestAuthToken)
 	st, jwtMgr, kek := devTestDeps(t)
 	h := wrapDevAuth(base404(), st, jwtMgr, kek, slog.New(slog.NewTextHandler(io.Discard, nil)))
 
 	for name, test := range map[string]struct {
 		remote string
 		origin string
+		token  string
 		want   int
 	}{
-		"remote caller":    {"203.0.113.10:1234", "", http.StatusForbidden},
-		"unknown origin":   {"127.0.0.1:1234", "https://evil.example", http.StatusForbidden},
-		"localhost origin": {"127.0.0.1:1234", "https://localhost:5173", http.StatusNoContent},
-		"local no origin":  {"[::1]:1234", "", http.StatusNoContent},
+		"remote caller":     {"203.0.113.10:1234", "", devTestAuthToken, http.StatusForbidden},
+		"unknown origin":    {"127.0.0.1:1234", "https://evil.example", devTestAuthToken, http.StatusForbidden},
+		"wrong proxy token": {"127.0.0.1:1234", "https://localhost:5173", "wrong", http.StatusForbidden},
+		"localhost origin":  {"127.0.0.1:1234", "https://localhost:5173", devTestAuthToken, http.StatusNoContent},
+		"local no origin":   {"[::1]:1234", "", devTestAuthToken, http.StatusNoContent},
 	} {
 		t.Run(name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodOptions, devSessionPath, nil)
@@ -180,6 +191,7 @@ func TestDevAuthOnlyAcceptsLocalRequestsFromKnownDevOrigins(t *testing.T) {
 			if test.origin != "" {
 				req.Header.Set("Origin", test.origin)
 			}
+			req.Header.Set(devAuthTokenHeader, test.token)
 			rec := httptest.NewRecorder()
 			h.ServeHTTP(rec, req)
 			assert.Equal(t, test.want, rec.Code)
@@ -190,4 +202,16 @@ func TestDevAuthOnlyAcceptsLocalRequestsFromKnownDevOrigins(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDevAuthRouteStaysAbsentWithoutAConfiguredToken(t *testing.T) {
+	t.Setenv(devAuthEnv, "1")
+	t.Setenv(devAuthTokenEnv, "short")
+	st, jwtMgr, kek := devTestDeps(t)
+	h := wrapDevAuth(base404(), st, jwtMgr, kek, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	req := httptest.NewRequest(http.MethodPost, devSessionPath, nil)
+	req.RemoteAddr = "127.0.0.1:1234"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
 }

--- a/cmd/control/filesystem_id_linux.go
+++ b/cmd/control/filesystem_id_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// filesystemDeviceID reports the kernel's device identifier for the filesystem
+// holding path. Two paths reporting the same identifier are on the same mount,
+// which is the condition the audit archive must not be in.
+//
+// It fails closed: a path that cannot be stat'ed, or whose stat carries no
+// device identifier, yields an error rather than an identifier that would
+// compare unequal to everything and quietly satisfy the separation check.
+func filesystemDeviceID(path string) (uint64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	raw, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("%q: the filesystem identifier is unavailable", path)
+	}
+	return uint64(raw.Dev), nil
+}

--- a/cmd/control/filesystem_id_other.go
+++ b/cmd/control/filesystem_id_other.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package main
+
+import "errors"
+
+// filesystemDeviceID has no portable implementation: control ships only as a
+// Linux service, and the separation between the database and the audit archive
+// is a property that must be proven rather than assumed. A build for any other
+// platform therefore refuses every configuration instead of admitting one whose
+// archive may sit on the database's own mount.
+func filesystemDeviceID(string) (uint64, error) {
+	return 0, errors.New("the filesystem identifier is unavailable on this platform")
+}

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -138,7 +138,13 @@ func run(cfg *Config, logger *slog.Logger) error {
 		},
 	})
 	defer runtime.Close()
-	publicServer, err := buildPublicServer(cfg, runtime.PublicHandler)
+	// wrapDevAuth is a no-op unless this binary was compiled with the
+	// `devauth` build tag and run with PM_DEV_AUTH=1; only then
+	// does it mount the local development sign-in endpoint (target design
+	// §5.2). Production builds compile the stub, so the wrap returns the
+	// handler unchanged.
+	publicHandler := wrapDevAuth(runtime.PublicHandler, st, jwt, atRest, logger)
+	publicServer, err := buildPublicServer(cfg, publicHandler)
 	if err != nil {
 		return err
 	}

--- a/cmd/control/main.go
+++ b/cmd/control/main.go
@@ -86,6 +86,15 @@ func run(cfg *Config, logger *slog.Logger) error {
 	if err != nil {
 		return fmt.Errorf("load certificate authority: %w", err)
 	}
+	if cfg.CATrustBundleFile != "" {
+		bundle, err := os.ReadFile(cfg.CATrustBundleFile)
+		if err != nil {
+			return fmt.Errorf("read CA trust bundle: %w", err)
+		}
+		if err := certificateAuthority.SetTrustBundle(bundle); err != nil {
+			return fmt.Errorf("load CA trust bundle: %w", err)
+		}
+	}
 	jwt, err := auth.NewJWTManager(auth.JWTConfig{PrivateKey: cfg.SessionSigningKey})
 	if err != nil {
 		return fmt.Errorf("load session signer: %w", err)

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -1,3 +1,16 @@
+# Before ./setup.sh, give the audit archive storage of its own: data/backups
+# must be on a different filesystem from the SQLite database under data/control.
+# Mount a second disk, an NFS or NAS export, or any remote-backed volume there,
+# or point that path at it:
+#
+#     mkdir -p data && ln -s /srv/power-manage-archive data/backups
+#
+# This is a requirement, not a recommendation. The archive holds the anchors and
+# archived chain prefixes that prove the audit log was not rewritten, so control
+# compares the two filesystems at startup and refuses to run when they match.
+# Nothing in this file or in config/control.env turns that off, and setup.sh
+# refuses to render a colliding configuration in the first place.
+
 # Public browser/API hostname. Traefik obtains its certificate with ACME.
 CONTROL_DOMAIN=manage.example.com
 

--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -18,12 +18,12 @@ configuration.
 
 ### Storage for the audit archive
 
-<!-- docref: begin src=deploy/setup.sh#@archive-isolation:b4ebb270,cmd/control/config.go#validateArchiveIsolation:ae89185b,cmd/control/devauth_stub.go#archiveIsolationRelaxed:8de98d35 -->
+<!-- docref: begin src=deploy/setup.sh#@archive-isolation:b4ebb270,cmd/control/config.go#validateArchiveIsolation:b9894a73,cmd/control/devauth_stub.go#archiveIsolationRelaxed:8de98d35 -->
 `data/backups` must be on a different filesystem from the SQLite database under
 `data/control`. Mount a second disk, an NFS or NAS export, or any
 remote-backed volume there:
 
-```
+```bash
 mkdir -p data && ln -s /srv/power-manage-archive data/backups
 ```
 
@@ -50,7 +50,7 @@ into `config/control.env`, and that file is where ordinary settings such as the
 log level or the retention windows are edited. `setup.sh` re-renders it on
 every run, including through `./deploy.sh`, so re-apply local edits afterwards.
 
-<!-- docref: begin src=deploy/setup.sh#@generated-material:6418f71a -->
+<!-- docref: begin src=deploy/setup.sh#@generated-material:6bc71f80 -->
 `setup.sh` creates the internal Ed25519 CA, the control certificate, the
 encryption, session and sealing keys, and `config/control.env` with a 90-day
 audit-retention policy and the SQLite `POWER_MANAGE_DATABASE_PATH`. It first

--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -11,9 +11,38 @@ authoritative system design is
 ## Prepare
 
 Copy `.env.example` to `.env`, set the three required public values
-(`CONTROL_DOMAIN`, `AGENT_DOMAIN`, and `ACME_EMAIL`), then run `./setup.sh`.
-`.env` carries only those values and `IMAGE_TAG`; it is Compose's own
-environment file, not control's configuration.
+(`CONTROL_DOMAIN`, `AGENT_DOMAIN`, and `ACME_EMAIL`), then give the audit
+archive its own storage and run `./setup.sh`. `.env` carries only those values
+and `IMAGE_TAG`; it is Compose's own environment file, not control's
+configuration.
+
+### Storage for the audit archive
+
+<!-- docref: begin src=deploy/setup.sh#@archive-isolation:b4ebb270,cmd/control/config.go#validateArchiveIsolation:ae89185b,cmd/control/devauth_stub.go#archiveIsolationRelaxed:8de98d35 -->
+`data/backups` must be on a different filesystem from the SQLite database under
+`data/control`. Mount a second disk, an NFS or NAS export, or any
+remote-backed volume there:
+
+```
+mkdir -p data && ln -s /srv/power-manage-archive data/backups
+```
+
+A symlink works as well as a mount point: Compose bind-mounts whatever the path
+resolves to, so control sees that storage rather than the deploy tree's
+filesystem. If a previous run already created the empty directory, `rmdir
+data/backups` before linking.
+
+This is a requirement, not a recommendation. The archive holds the anchors and
+archived chain prefixes that prove the audit log was not rewritten, so control
+compares the two filesystems at startup and refuses to run when they match —
+there is no configuration variable that turns the check off. `setup.sh` applies
+the same comparison first, naming both paths, so a deployment that cannot boot
+is never rendered in the first place.
+<!-- docref: end -->
+
+`install.sh` runs `setup.sh` for you and therefore stops at the same point.
+Provide the archive storage under the install directory it created, then run
+`./setup.sh && ./deploy.sh` there.
 
 Control is configured entirely by `POWER_MANAGE_`-prefixed environment
 variables and reads no configuration file. `setup.sh` renders every one of them
@@ -21,14 +50,16 @@ into `config/control.env`, and that file is where ordinary settings such as the
 log level or the retention windows are edited. `setup.sh` re-renders it on
 every run, including through `./deploy.sh`, so re-apply local edits afterwards.
 
-<!-- docref: begin src=deploy/setup.sh#@generated-material:e174bfa7 -->
+<!-- docref: begin src=deploy/setup.sh#@generated-material:2e53db95 -->
 `setup.sh` creates the internal Ed25519 CA, the control certificate, the
 encryption, session and sealing keys, and `config/control.env` with a 90-day
-audit-retention policy and the SQLite `POWER_MANAGE_DATABASE_PATH`. Existing
-complete keypairs are retained, which permits a pre-provisioned CA. Partial or
-unusable material fails closed. Generated secret files and `config/control.env`
-are mode 0600, verified before the script reports success, and no secret value
-is ever printed.
+audit-retention policy and the SQLite `POWER_MANAGE_DATABASE_PATH`. It first
+refuses, before generating any key material, when `data/backups` shares a
+filesystem with `data/control`, because control refuses to start on such a
+configuration. Existing complete keypairs are retained, which permits a
+pre-provisioned CA. Partial or unusable material fails closed. Generated secret
+files and `config/control.env` are mode 0600, verified before the script
+reports success, and no secret value is ever printed.
 <!-- docref: end -->
 
 <!-- docref: begin src=deploy/traefik/dynamic/routes.yml#@agent-route:2b16b515,cmd/control/httpserver.go#serveAgent:0543d07f,cmd/control/httpserver.go#buildAgentServer:ccd04d34,internal/agentstream/identity.go#MTLSMiddleware:f1b23680 -->
@@ -68,16 +99,21 @@ administrator.
 Use `./deploy.sh` for an update, `docker compose logs -f control` for logs, and
 `docker compose down` to stop the stack.
 
-Artifacts and backups live under `data/artifacts` and `data/backups`. The
-SQLite database lives under `data/control`; ACME state lives under
-`data/traefik`.
+Artifacts live under `data/artifacts`, and the audit archive and SQLite backups
+under `data/backups` — the separate storage prepared above. The SQLite database
+lives under `data/control`; ACME state lives under `data/traefik`. Never
+consolidate `data/backups` back onto the database's filesystem: control will
+refuse to start after the next restart.
 
-<!-- docref: begin src=internal/maintenance/service.go#Service.RetainAudit:c0aefcae,cmd/control/config.go#Config.AuditRetention:0e4ab606 -->
+<!-- docref: begin src=internal/maintenance/service.go#Service.RetainAudit:8584f810,cmd/control/config.go#Config.AuditRetention:0e4ab606 -->
 Control writes integrity-sealed audit anchors and archive-before-delete chain
-prefixes to `POWER_MANAGE_BACKUP_PATH`; `POWER_MANAGE_AUDIT_RETENTION` defaults
-to 90 days. Mount or
-replicate that path off-host, and back up the database, artifacts, `certs`, and
-`secrets` as one deployment unit.
+prefixes to `POWER_MANAGE_BACKUP_PATH`, and re-verifies every archived prefix
+against its recorded checkpoint digest before retention deletes anything more;
+`POWER_MANAGE_AUDIT_RETENTION` defaults to 90 days. That path must be a
+filesystem of its own, which control enforces at startup; replicating it
+off-host is the stronger form of the same property and remains yours to
+arrange. Back up the database, artifacts, `certs`, and `secrets` as one
+deployment unit.
 <!-- docref: end -->
 
 <!-- docref: begin src=cmd/control/config.go#Config.WebhookURL:341af9cf,internal/maintenance/service.go#Service.InspectSecurity:223fcf91,internal/maintenance/service.go#Service.InspectBackup:d8c2e6fd -->

--- a/deploy/QUICKSTART.md
+++ b/deploy/QUICKSTART.md
@@ -1,6 +1,6 @@
 # Power Manage server quickstart
 
-<!-- docref: begin src=deploy/compose.yml#@deployment-services:a9ac8ed8 -->
+<!-- docref: begin src=deploy/compose.yml#@deployment-services:1f0b2637 -->
 The stack has exactly two services: Traefik and one control process with an
 embedded SQLite database. Compose gives control no arguments and passes it the
 rendered `config/control.env` as the container's environment file. The
@@ -50,7 +50,7 @@ into `config/control.env`, and that file is where ordinary settings such as the
 log level or the retention windows are edited. `setup.sh` re-renders it on
 every run, including through `./deploy.sh`, so re-apply local edits afterwards.
 
-<!-- docref: begin src=deploy/setup.sh#@generated-material:2e53db95 -->
+<!-- docref: begin src=deploy/setup.sh#@generated-material:6418f71a -->
 `setup.sh` creates the internal Ed25519 CA, the control certificate, the
 encryption, session and sealing keys, and `config/control.env` with a 90-day
 audit-retention policy and the SQLite `POWER_MANAGE_DATABASE_PATH`. It first
@@ -69,7 +69,7 @@ protocol v2 on an isolated network; control itself authenticates the device
 certificate and checks revocation.
 <!-- docref: end -->
 
-<!-- docref: begin src=deploy/traefik/dynamic/routes.yml#@public-backend-tls:965c0116,deploy/traefik/traefik.yml#@safe-access-log:e383937a -->
+<!-- docref: begin src=deploy/traefik/dynamic/routes.yml#@public-backend-tls:873710ea,deploy/traefik/traefik.yml#@safe-access-log:e383937a -->
 Traefik also authenticates control's internal TLS certificate against the
 deployment CA, so browser/API traffic stays encrypted after public TLS
 termination. Its JSON access log omits the URI-bearing `RequestPath` and

--- a/deploy/compose.yml
+++ b/deploy/compose.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./traefik/traefik.yml:/etc/traefik/traefik.yml:ro,z
       - ./traefik/dynamic:/etc/traefik/dynamic:ro,z
-      - ./certs/ca.crt:/run/certs/ca.crt:ro,z
+      - ./certs/ca-trust-bundle.crt:/run/certs/ca-trust-bundle.crt:ro,z
       - ./data/traefik:/letsencrypt:z
     networks:
       internal:
@@ -30,6 +30,7 @@ services:
     volumes:
       - ./certs/ca.crt:/run/certs/ca.crt:ro,z
       - ./certs/ca.key:/run/certs/ca.key:ro,z
+      - ./certs/ca-trust-bundle.crt:/run/certs/ca-trust-bundle.crt:ro,z
       - ./certs/control.crt:/run/certs/control.crt:ro,z
       - ./certs/control.key:/run/certs/control.key:ro,z
       - ./secrets/encryption.key:/run/secrets/encryption.key:ro,z

--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -16,7 +16,23 @@ docker compose version >/dev/null 2>&1 || fail "the Docker Compose plugin is req
 [[ -n "${CONTROL_DOMAIN:-}" ]] || fail "set CONTROL_DOMAIN"
 [[ -n "${AGENT_DOMAIN:-}" ]] || fail "set AGENT_DOMAIN"
 [[ -n "${ACME_EMAIL:-}" ]] || fail "set ACME_EMAIL"
-[[ ! -e "$INSTALL_DIR" ]] || fail "$INSTALL_DIR already exists; update it with deploy.sh instead"
+
+# setup.sh checks the audit archive's filesystem before it generates any key
+# material, so an install that stopped there leaves the directory tree and
+# nothing in it. Refusing that tree would strand the operator with a half-made
+# installation they cannot finish here. Refuse once generated material exists,
+# which is what "already installed" means and is the state deploy.sh is for.
+#
+# Discovering the material rather than naming it keeps this attached to
+# setup.sh: anything it writes into these three directories blocks a re-run,
+# and nothing here ever deletes or rewrites what it finds. data/ is
+# deliberately not consulted — the archive storage the operator was told to
+# provide lives there, and so does the Traefik ACME file setup.sh touches
+# before the archive check.
+existing_material="$(find "$INSTALL_DIR/certs" "$INSTALL_DIR/secrets" "$INSTALL_DIR/config" \
+    -mindepth 1 -print -quit 2>/dev/null || true)"
+[[ -z "$existing_material" ]] \
+    || fail "$INSTALL_DIR is already installed ($existing_material exists); update it with deploy.sh instead"
 
 temporary_directory="$(mktemp -d)"
 trap 'rm -rf "$temporary_directory"' EXIT

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -45,6 +45,52 @@ require_pair() {
     return 1
 }
 
+# docref: begin archive-isolation
+# filesystem_of reports the kernel device identifier of the filesystem holding
+# a path. `-L` dereferences, matching control's own os.Stat, so an operator may
+# either mount storage at the path or point a symlink at it; without it a
+# symlink would report the deploy tree's filesystem and this check would reject
+# a correct deployment.
+filesystem_of() {
+    stat -L -c '%d' "$1"
+}
+
+# The audit archive must not sit on the filesystem holding the database it is
+# evidence for. Control compares the same two device identifiers at startup and
+# refuses to boot when they match; there is no variable that relaxes it, so an
+# installer that rendered a colliding pair would simply ship a deployment that
+# never starts.
+#
+# Checking the host directories decides the container's verdict: compose.yml
+# bind-mounts these two into control, and a bind mount reports the device of the
+# filesystem it came from.
+ensure_archive_isolation() {
+    local database="$DATA_DIR/control" archive="$DATA_DIR/backups"
+    [[ "$(filesystem_of "$database")" == "$(filesystem_of "$archive")" ]] || return 0
+    fail "$(printf '%s\n' \
+        "the audit archive would share a filesystem with the database, and control refuses to start that way:" \
+        "" \
+        "    database  $database" \
+        "    archive   $archive" \
+        "" \
+        "The archive holds the anchors and archived chain prefixes that prove the audit log was not" \
+        "rewritten, so it must not be destroyed or altered by whatever reaches the database: one bad" \
+        "root, one failed disk, or one ransomware pass must not take the record and its proof together." \
+        "" \
+        "Give it separate storage - a second disk, an NFS or NAS export, or any remote-backed volume -" \
+        "and either mount that storage at" \
+        "" \
+        "    $archive" \
+        "" \
+        "or point that path at it:" \
+        "" \
+        "    rmdir $archive && ln -s /path/on/that/storage $archive" \
+        "" \
+        "then run this script again. This cannot be skipped: control applies the same check to" \
+        "POWER_MANAGE_BACKUP_PATH at startup and no configuration variable turns it off.")"
+}
+# docref: end archive-isolation
+
 validate_key_pair() {
     local certificate="$1" key="$2" description="$3"
     openssl x509 -in "$certificate" -noout >/dev/null
@@ -190,6 +236,11 @@ main() {
     chmod 600 "$SCRIPT_DIR/.env"
     touch "$DATA_DIR/traefik/acme.json"
     chmod 600 "$DATA_DIR/traefik/acme.json"
+
+    # Before any key material is generated, so a deployment that cannot start
+    # leaves nothing behind but the empty directory tree the operator has to
+    # mount their archive storage onto.
+    ensure_archive_isolation
 
     ensure_ca
     ensure_certificates

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -154,6 +154,9 @@ certificate_covers_host() {
 ensure_certificates() {
     if [[ ! -f "$CERTS_DIR/ca-trust-bundle.crt" ]]; then
         cp "$CERTS_DIR/ca.crt" "$CERTS_DIR/ca-trust-bundle.crt"
+    elif ! openssl verify -CAfile "$CERTS_DIR/ca-trust-bundle.crt" "$CERTS_DIR/ca.crt" >/dev/null 2>&1; then
+        printf '\n' >> "$CERTS_DIR/ca-trust-bundle.crt"
+        cat "$CERTS_DIR/ca.crt" >> "$CERTS_DIR/ca-trust-bundle.crt"
     fi
     ensure_certificate control "/CN=$AGENT_DOMAIN/O=Power Manage" \
         "subjectAltName=DNS:$AGENT_DOMAIN,DNS:control,DNS:localhost\nextendedKeyUsage=serverAuth\nkeyUsage=digitalSignature"

--- a/deploy/setup.sh
+++ b/deploy/setup.sh
@@ -152,6 +152,9 @@ certificate_covers_host() {
 }
 
 ensure_certificates() {
+    if [[ ! -f "$CERTS_DIR/ca-trust-bundle.crt" ]]; then
+        cp "$CERTS_DIR/ca.crt" "$CERTS_DIR/ca-trust-bundle.crt"
+    fi
     ensure_certificate control "/CN=$AGENT_DOMAIN/O=Power Manage" \
         "subjectAltName=DNS:$AGENT_DOMAIN,DNS:control,DNS:localhost\nextendedKeyUsage=serverAuth\nkeyUsage=digitalSignature"
     certificate_covers_host "$CERTS_DIR/control.crt" "$AGENT_DOMAIN" \
@@ -202,6 +205,7 @@ POWER_MANAGE_BACKUP_MAX_LAG=26h
 POWER_MANAGE_WEBHOOK_URL=
 POWER_MANAGE_CA_CERT_FILE=/run/certs/ca.crt
 POWER_MANAGE_CA_KEY_FILE=/run/certs/ca.key
+POWER_MANAGE_CA_TRUST_BUNDLE_FILE=/run/certs/ca-trust-bundle.crt
 POWER_MANAGE_AGENT_TLS_CERT_FILE=/run/certs/control.crt
 POWER_MANAGE_AGENT_TLS_KEY_FILE=/run/certs/control.key
 POWER_MANAGE_PUBLIC_TLS_CERT_FILE=/run/certs/control.crt

--- a/deploy/setup_test.sh
+++ b/deploy/setup_test.sh
@@ -290,6 +290,22 @@ test_backend_name_missing_fails() {
     ! run_setup "$directory" >/dev/null 2>&1
 }
 
+test_ca_rotation_preserves_old_and_active_trust() {
+    local directory="$1"
+    new_fixture "$directory" manage.example.test agents.example.test
+    run_setup "$directory" >/dev/null
+    cp "$directory/certs/ca.crt" "$directory/old-ca.crt"
+    rm -f "$directory/certs/ca.crt" "$directory/certs/ca.key" \
+        "$directory/certs/control.crt" "$directory/certs/control.key"
+
+    run_setup "$directory" >/dev/null
+
+    openssl verify -CAfile "$directory/certs/ca-trust-bundle.crt" \
+        "$directory/old-ca.crt" >/dev/null
+    openssl verify -CAfile "$directory/certs/ca-trust-bundle.crt" \
+        "$directory/certs/ca.crt" >/dev/null
+}
+
 # The archive storage every fixture is given lives here, on a filesystem that
 # is not the one holding the fixtures themselves.
 ARCHIVE_ROOT="$(mktemp -d /dev/shm/pm-setup-test-XXXXXX)"
@@ -299,7 +315,8 @@ fixture_three="$(mktemp -d)"
 fixture_four="$(mktemp -d)"
 fixture_five="$(mktemp -d)"
 fixture_six="$(mktemp -d)"
-trap 'rm -rf "$ARCHIVE_ROOT" "$fixture_one" "$fixture_two" "$fixture_three" "$fixture_four" "$fixture_five" "$fixture_six"' EXIT
+fixture_seven="$(mktemp -d)"
+trap 'rm -rf "$ARCHIVE_ROOT" "$fixture_one" "$fixture_two" "$fixture_three" "$fixture_four" "$fixture_five" "$fixture_six" "$fixture_seven"' EXIT
 
 test_secure_idempotent_setup "$fixture_one"
 printf 'PASS secure and idempotent setup\n'
@@ -313,3 +330,5 @@ test_shared_filesystem_archive_fails "$fixture_five"
 printf 'PASS shared-filesystem audit archive rejected\n'
 test_backend_name_missing_fails "$fixture_six"
 printf 'PASS internal backend name required\n'
+test_ca_rotation_preserves_old_and_active_trust "$fixture_seven"
+printf 'PASS CA rotation trust bundle preserved\n'

--- a/deploy/setup_test.sh
+++ b/deploy/setup_test.sh
@@ -37,6 +37,9 @@ CONTROL_ENV_VARIABLES=(
     POWER_MANAGE_SEALING_KEY_FILE
 )
 
+# Every fixture models a deployment that can actually start, archive storage
+# included. Without it setup.sh would stop at the archive check and each
+# negative test below would pass for a reason it does not name.
 new_fixture() {
     local directory="$1" control_domain="$2" agent_domain="$3"
     mkdir -p "$directory"
@@ -45,6 +48,25 @@ CONTROL_DOMAIN=$control_domain
 AGENT_DOMAIN=$agent_domain
 ACME_EMAIL=admin@example.test
 EOF
+    link_archive_filesystem "$directory"
+}
+
+# Control refuses to boot when the audit archive shares a filesystem with the
+# database, so a fixture needs a second real filesystem rather than a stubbed
+# comparison. /dev/shm is a tmpfs on every Linux and is always a different
+# mount from the one holding a mktemp directory; the assertion proves that for
+# this machine instead of assuming it. The symlink is one of the two
+# arrangements setup.sh accepts, and Docker resolves it the same way when it
+# binds the directory into the container.
+link_archive_filesystem() {
+    local directory="$1" archive
+    archive="$(mktemp -d "$ARCHIVE_ROOT/XXXXXX")"
+    mkdir -p "$directory/data"
+    ln -s "$archive" "$directory/data/backups"
+    [[ "$(stat -L -c '%d' "$directory/data/backups")" != "$(stat -L -c '%d' "$directory")" ]] || {
+        printf 'fixture cannot model two filesystems: %s and %s share one\n' "$archive" "$directory" >&2
+        return 1
+    }
 }
 
 # The rendered file is consumed verbatim by Compose as an env file, so assert
@@ -67,6 +89,58 @@ assert_env_variable_set() {
     [[ "$expected" == "$actual" ]] || {
         printf 'unexpected control.env variables:\n%s\n' \
             "$(diff <(printf '%s\n' "$expected") <(printf '%s\n' "$actual") || true)" >&2
+        return 1
+    }
+}
+
+# The value of one rendered variable. A name rendered zero times, or twice,
+# fails here rather than yielding an empty string the caller would compare.
+env_value() {
+    local file="$1" name="$2" matches value
+    matches="$(grep -c "^$name=" "$file" || true)"
+    [[ "$matches" == 1 ]] || {
+        printf '%s is set %s times in %s, want once\n' "$name" "$matches" "$file" >&2
+        return 1
+    }
+    value="$(sed -n "s|^$name=||p" "$file")"
+    [[ -n "$value" ]] || {
+        printf '%s is empty in %s\n' "$name" "$file" >&2
+        return 1
+    }
+    printf '%s\n' "$value"
+}
+
+# The host directory Compose bind-mounts onto a container path. Reading it out
+# of compose.yml keeps the assertion attached to the deployment: a mount that
+# moves, disappears, or is declared twice fails here instead of leaving the
+# filesystem comparison below testing a path nothing is mounted on.
+host_mount_for() {
+    local container_path="$1" directory="$2" matches source
+    matches="$(grep -cE "^ +- \./[^:]+:${container_path}:" "$DEPLOY_DIR/compose.yml" || true)"
+    [[ "$matches" == 1 ]] || {
+        printf 'compose.yml bind-mounts %s %s times, want once\n' "$container_path" "$matches" >&2
+        return 1
+    }
+    source="$(sed -nE "s|^ +- \./([^:]+):${container_path}:.*$|\1|p" "$DEPLOY_DIR/compose.yml")"
+    printf '%s\n' "$directory/$source"
+}
+
+# The rendered configuration must never place the audit archive on the
+# filesystem holding the database, because control refuses to start when it
+# does. Both paths are read back out of the rendered file and translated
+# through compose.yml's bind mounts, so moving either one in setup.sh, or
+# remounting it in compose.yml, stays covered instead of escaping a hardcoded
+# pair.
+assert_archive_isolated() {
+    local config="$1" directory="$2"
+    local database_path archive_path database archive
+    database_path="$(env_value "$config" POWER_MANAGE_DATABASE_PATH)"
+    archive_path="$(env_value "$config" POWER_MANAGE_BACKUP_PATH)"
+    database="$(host_mount_for "$(dirname "$database_path")" "$directory")"
+    archive="$(host_mount_for "$archive_path" "$directory")"
+    [[ "$(stat -L -c '%d' "$database")" != "$(stat -L -c '%d' "$archive")" ]] || {
+        printf 'rendered config puts the audit archive on the database filesystem: %s and %s\n' \
+            "$database" "$archive" >&2
         return 1
     }
 }
@@ -134,6 +208,7 @@ test_secure_idempotent_setup() {
     assert_env_line "$config" 'POWER_MANAGE_ENCRYPTION_KEY_FILE=/run/secrets/encryption.key'
     assert_env_line "$config" 'POWER_MANAGE_SESSION_SIGNING_KEY_FILE=/run/secrets/session-signing.pem'
     assert_env_line "$config" 'POWER_MANAGE_SEALING_KEY_FILE=/run/secrets/sealing.key'
+    assert_archive_isolated "$config" "$directory"
 
     if grep -R -iEq 'valkey|asynq|indexer|password_auth|postgres|database_url' "$directory/config"; then
         return 1
@@ -175,6 +250,28 @@ test_example_values_fail() {
     ! run_setup "$directory" >/dev/null 2>&1
 }
 
+# Removing the fixture's separate storage leaves the deploy tree as it looks
+# before an operator provides any: database and archive on one filesystem,
+# which is the configuration control refuses to boot.
+test_shared_filesystem_archive_fails() {
+    local directory="$1" output
+    new_fixture "$directory" manage.example.test agents.example.test
+    rm -f "$directory/data/backups"
+
+    if output="$(run_setup "$directory" 2>&1)"; then
+        printf 'setup.sh rendered a configuration control refuses to start\n' >&2
+        return 1
+    fi
+    # An operator reading only this message has to know which two paths
+    # collided, so both are named.
+    grep -Fq -- "$directory/data/control" <<<"$output"
+    grep -Fq -- "$directory/data/backups" <<<"$output"
+    # The point of the check: a configuration that cannot boot never reaches
+    # the disk, and no key material is generated for it either.
+    [[ ! -e "$directory/config/control.env" ]]
+    [[ ! -e "$directory/certs/ca.key" ]]
+}
+
 test_backend_name_missing_fails() {
     local directory="$1"
     new_fixture "$directory" manage.example.test agents.example.test
@@ -190,12 +287,16 @@ test_backend_name_missing_fails() {
     ! run_setup "$directory" >/dev/null 2>&1
 }
 
+# The archive storage every fixture is given lives here, on a filesystem that
+# is not the one holding the fixtures themselves.
+ARCHIVE_ROOT="$(mktemp -d /dev/shm/pm-setup-test-XXXXXX)"
 fixture_one="$(mktemp -d)"
 fixture_two="$(mktemp -d)"
 fixture_three="$(mktemp -d)"
 fixture_four="$(mktemp -d)"
 fixture_five="$(mktemp -d)"
-trap 'rm -rf "$fixture_one" "$fixture_two" "$fixture_three" "$fixture_four" "$fixture_five"' EXIT
+fixture_six="$(mktemp -d)"
+trap 'rm -rf "$ARCHIVE_ROOT" "$fixture_one" "$fixture_two" "$fixture_three" "$fixture_four" "$fixture_five" "$fixture_six"' EXIT
 
 test_secure_idempotent_setup "$fixture_one"
 printf 'PASS secure and idempotent setup\n'
@@ -205,5 +306,7 @@ test_partial_ca_fails "$fixture_three"
 printf 'PASS partial CA rejected\n'
 test_example_values_fail "$fixture_four"
 printf 'PASS example values rejected\n'
-test_backend_name_missing_fails "$fixture_five"
+test_shared_filesystem_archive_fails "$fixture_five"
+printf 'PASS shared-filesystem audit archive rejected\n'
+test_backend_name_missing_fails "$fixture_six"
 printf 'PASS internal backend name required\n'

--- a/deploy/setup_test.sh
+++ b/deploy/setup_test.sh
@@ -28,6 +28,7 @@ CONTROL_ENV_VARIABLES=(
     POWER_MANAGE_WEBHOOK_URL
     POWER_MANAGE_CA_CERT_FILE
     POWER_MANAGE_CA_KEY_FILE
+    POWER_MANAGE_CA_TRUST_BUNDLE_FILE
     POWER_MANAGE_AGENT_TLS_CERT_FILE
     POWER_MANAGE_AGENT_TLS_KEY_FILE
     POWER_MANAGE_PUBLIC_TLS_CERT_FILE
@@ -201,6 +202,7 @@ test_secure_idempotent_setup() {
     assert_env_line "$config" 'POWER_MANAGE_WEBHOOK_URL='
     assert_env_line "$config" 'POWER_MANAGE_CA_CERT_FILE=/run/certs/ca.crt'
     assert_env_line "$config" 'POWER_MANAGE_CA_KEY_FILE=/run/certs/ca.key'
+    assert_env_line "$config" 'POWER_MANAGE_CA_TRUST_BUNDLE_FILE=/run/certs/ca-trust-bundle.crt'
     assert_env_line "$config" 'POWER_MANAGE_AGENT_TLS_CERT_FILE=/run/certs/control.crt'
     assert_env_line "$config" 'POWER_MANAGE_AGENT_TLS_KEY_FILE=/run/certs/control.key'
     assert_env_line "$config" 'POWER_MANAGE_PUBLIC_TLS_CERT_FILE=/run/certs/control.crt'
@@ -208,6 +210,7 @@ test_secure_idempotent_setup() {
     assert_env_line "$config" 'POWER_MANAGE_ENCRYPTION_KEY_FILE=/run/secrets/encryption.key'
     assert_env_line "$config" 'POWER_MANAGE_SESSION_SIGNING_KEY_FILE=/run/secrets/session-signing.pem'
     assert_env_line "$config" 'POWER_MANAGE_SEALING_KEY_FILE=/run/secrets/sealing.key'
+    cmp -s "$directory/certs/ca.crt" "$directory/certs/ca-trust-bundle.crt"
     assert_archive_isolated "$config" "$directory"
 
     if grep -R -iEq 'valkey|asynq|indexer|password_auth|postgres|database_url' "$directory/config"; then

--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -92,6 +92,7 @@ provision_archive_storage() {
     }
     ARCHIVE_DIR="$(mktemp -d /dev/shm/pm-smoke-archive-XXXXXX)"
     mkdir -p "$WORK_DIR/data"
+    rm -rf -- "$WORK_DIR/data/backups"
     ln -s "$ARCHIVE_DIR" "$WORK_DIR/data/backups"
 }
 

--- a/deploy/smoke-test.sh
+++ b/deploy/smoke-test.sh
@@ -4,11 +4,18 @@ set -euo pipefail
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WORK_DIR="$(mktemp -d)"
+ARCHIVE_DIR=""
 PROJECT_NAME="pm-smoke-$$"
 PUBLISHED_IMAGE_TAG="${IMAGE_TAG:-}"
 REQUESTED_IMAGE_TAG="${PUBLISHED_IMAGE_TAG:-smoke-$$}"
 CONTROL_IMAGE="ghcr.io/manchtools/power-manage-control:$REQUESTED_IMAGE_TAG"
 BUILT_IMAGE=""
+
+# The archive has to hold control's audit anchors and archived chain prefixes
+# plus the one SQLite backup this run takes and verifies. Below this a tmpfs
+# fails partway through with ENOSPC inside a health check, which says nothing
+# about the release under test.
+ARCHIVE_MINIMUM_KIB=16384
 
 # Compose substitutes from the process environment before any env file, and CI
 # exports IMAGE_TAG as an empty string, which resolves compose.yml's
@@ -21,6 +28,16 @@ compose() {
         --env-file "$WORK_DIR/.env" "$@"
 }
 
+# Control and backup.sh write into the state and archive directories as root,
+# and the host user running this script cannot unlink what they leave in the
+# directories root creates underneath. Empty those from a container instead.
+remove_root_owned_content() {
+    local directory="$1"
+    [[ -d "$directory" ]] || return 0
+    docker run --rm -v "$directory:/target" docker.io/library/alpine:3.23 \
+        find /target -mindepth 1 -delete >/dev/null 2>&1 || true
+}
+
 cleanup() {
     local status=$?
     trap - EXIT
@@ -29,8 +46,14 @@ cleanup() {
         compose logs --no-color >&2 || true
     fi
     compose down --remove-orphans >/dev/null 2>&1 || true
-    docker run --rm -v "$WORK_DIR:/work" docker.io/library/alpine:3.23 \
-        sh -c 'rm -rf /work/data/control' >/dev/null 2>&1 || true
+    remove_root_owned_content "$WORK_DIR/data/control"
+    # The archive is a filesystem of its own outside $WORK_DIR, so it needs a
+    # mount of its own: reached through $WORK_DIR it is only a symlink, and
+    # what that symlink names does not exist inside the container.
+    if [[ -n "$ARCHIVE_DIR" ]]; then
+        remove_root_owned_content "$ARCHIVE_DIR"
+        rmdir "$ARCHIVE_DIR" 2>/dev/null || true
+    fi
     if [[ -n "$BUILT_IMAGE" ]]; then
         docker image rm "$BUILT_IMAGE" >/dev/null 2>&1 || true
     fi
@@ -39,7 +62,95 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Control refuses to boot when the audit archive shares a filesystem with the
+# database, and setup.sh refuses to render such a configuration, so this
+# deployment needs two filesystems rather than the single $WORK_DIR. /dev/shm
+# is a tmpfs on every Linux and is always a different mount from the one behind
+# mktemp; the archive lives there and data/backups points at it. A symlink is
+# one of the two arrangements setup.sh accepts, and Docker resolves it the same
+# way when it binds the directory into control.
+#
+# There is deliberately no fallback to $WORK_DIR. Falling back would render a
+# deployment that cannot start and reduce this release gate to a --wait timeout
+# with nothing naming the cause.
+provision_archive_storage() {
+    local available
+    [[ -d /dev/shm && -w /dev/shm ]] || {
+        printf 'the audit archive needs a filesystem separate from %s, and /dev/shm is not writable\n' \
+            "$WORK_DIR" >&2
+        exit 1
+    }
+    available="$(df -Pk /dev/shm | awk 'NR == 2 { print $4 }')"
+    [[ "$available" =~ ^[0-9]+$ ]] || {
+        printf 'cannot read the free space on /dev/shm, which has to hold the audit archive\n' >&2
+        exit 1
+    }
+    (( available >= ARCHIVE_MINIMUM_KIB )) || {
+        printf '/dev/shm has %s KiB free; the audit archive needs at least %s KiB\n' \
+            "$available" "$ARCHIVE_MINIMUM_KIB" >&2
+        exit 1
+    }
+    ARCHIVE_DIR="$(mktemp -d /dev/shm/pm-smoke-archive-XXXXXX)"
+    mkdir -p "$WORK_DIR/data"
+    ln -s "$ARCHIVE_DIR" "$WORK_DIR/data/backups"
+}
+
+# The value of one variable in the rendered configuration. A name rendered zero
+# times, or twice, fails here rather than yielding an empty string the caller
+# would go on to compare.
+control_env_value() {
+    local name="$1" matches value
+    matches="$(grep -c "^$name=" "$WORK_DIR/config/control.env" || true)"
+    [[ "$matches" == 1 ]] || {
+        printf '%s is set %s times in the rendered control.env, want once\n' "$name" "$matches" >&2
+        return 1
+    }
+    value="$(sed -n "s|^$name=||p" "$WORK_DIR/config/control.env")"
+    [[ -n "$value" ]] || {
+        printf '%s is empty in the rendered control.env\n' "$name" >&2
+        return 1
+    }
+    printf '%s\n' "$value"
+}
+
+# The host path Compose will bind onto a container path, read from the resolved
+# configuration rather than from compose.yml's text, so it is the mount control
+# actually gets. A container path bound zero times, or more than once, fails
+# here instead of leaving the comparison below testing nothing.
+host_mount_for() {
+    local target="$1"
+    compose config | awk -v target="$target" '
+        $1 == "-" { source = "" }
+        $1 == "source:" { source = $2 }
+        $1 == "target:" && $2 == target && source != "" { print source; matches++ }
+        END { exit matches == 1 ? 0 : 1 }
+    ' || {
+        printf 'compose does not bind exactly one host path onto %s\n' "$target" >&2
+        return 1
+    }
+}
+
+# Control compares these two filesystems at startup and refuses to run when
+# they match, so a colliding pair would spend the whole of `compose up --wait`
+# on a container that was never going to become healthy. Both paths are derived
+# from the rendered configuration and the resolved mounts, so a path that moves
+# in setup.sh or is remounted in compose.yml stays covered instead of escaping
+# a hardcoded pair.
+assert_archive_isolated() {
+    local database_path archive_path database archive
+    database_path="$(control_env_value POWER_MANAGE_DATABASE_PATH)"
+    archive_path="$(control_env_value POWER_MANAGE_BACKUP_PATH)"
+    database="$(host_mount_for "$(dirname "$database_path")")"
+    archive="$(host_mount_for "$archive_path")"
+    [[ "$(stat -L -c '%d' "$database")" != "$(stat -L -c '%d' "$archive")" ]] || {
+        printf 'the audit archive shares a filesystem with the database and control will not start:\n    database %s\n    archive  %s\n' \
+            "$database" "$archive" >&2
+        return 1
+    }
+}
+
 cp -R "$SOURCE_DIR/." "$WORK_DIR/"
+provision_archive_storage
 if [[ -z "$PUBLISHED_IMAGE_TAG" ]]; then
     CGO_ENABLED=0 go -C "$SOURCE_DIR/.." build -o "$WORK_DIR/control" ./cmd/control
     docker build --build-arg BINARY=control -f "$SOURCE_DIR/Containerfile.control" \
@@ -55,6 +166,7 @@ EOF
 
 cd "$WORK_DIR"
 bash ./setup.sh >/dev/null
+assert_archive_isolated
 
 mapfile -t services < <(compose config --services | sort)
 [[ "${services[*]}" == "control traefik" ]] || {
@@ -148,4 +260,4 @@ direct_status="$(docker run --rm --network "container:$control_id" --user 0:0 \
     exit 1
 }
 
-printf 'PASS: two services, verified SQLite backup, FTS5, exact RPC surface, authenticated backend TLS, query-safe logs, and isolated agent route\n'
+printf 'PASS: two services, isolated audit archive, verified SQLite backup, FTS5, exact RPC surface, authenticated backend TLS, query-safe logs, and isolated agent route\n'

--- a/deploy/traefik/dynamic/routes.yml
+++ b/deploy/traefik/dynamic/routes.yml
@@ -4,7 +4,7 @@ http:
     control-tls:
       serverName: control
       rootCAs:
-        - /run/certs/ca.crt
+        - /run/certs/ca-trust-bundle.crt
       minVersion: VersionTLS13
       maxVersion: VersionTLS13
   routers:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260808113503-541746be378a
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260808120009-f761803c4049
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pires/go-proxyproto v0.15.0
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260802194823-693bde8f143e
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260808110728-454da2db9398
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pires/go-proxyproto v0.15.0
 	github.com/stretchr/testify v1.11.1

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-playground/validator/v10 v10.30.1
 	github.com/golang-jwt/jwt/v5 v5.3.1
-	github.com/manchtools/power-manage-sdk v0.5.4-0.20260808110728-454da2db9398
+	github.com/manchtools/power-manage-sdk v0.5.4-0.20260808113503-541746be378a
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/pires/go-proxyproto v0.15.0
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/manchtools/power-manage-sdk v0.5.4-0.20260808110728-454da2db9398 h1:R
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260808110728-454da2db9398/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260808113503-541746be378a h1:ECPBJnTqmf9R9lTqFmN/kLOyEhcDQPCOhL3Kx/Jrvqg=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260808113503-541746be378a/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260808120009-f761803c4049 h1:lNnjYE+Z4zPK5sLFyl4OciiqNNsO52XAunocWQv3kPw=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260808120009-f761803c4049/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/manchtools/power-manage-sdk v0.5.4-0.20260802115029-dd7fcf8895f9 h1:h
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260802115029-dd7fcf8895f9/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260802194823-693bde8f143e h1:yJz1QGOnW3F/5qLEYRqrIjgNh2Lm26hls9srsg2N4eI=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260802194823-693bde8f143e/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260808110728-454da2db9398 h1:RsaVRpxRlC6HCPYu/MJB5T149tHioEms5b+V4UPYiyk=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260808110728-454da2db9398/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/manchtools/power-manage-sdk v0.5.4-0.20260802194823-693bde8f143e h1:y
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260802194823-693bde8f143e/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260808110728-454da2db9398 h1:RsaVRpxRlC6HCPYu/MJB5T149tHioEms5b+V4UPYiyk=
 github.com/manchtools/power-manage-sdk v0.5.4-0.20260808110728-454da2db9398/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260808113503-541746be378a h1:ECPBJnTqmf9R9lTqFmN/kLOyEhcDQPCOhL3Kx/Jrvqg=
+github.com/manchtools/power-manage-sdk v0.5.4-0.20260808113503-541746be378a/go.mod h1:tjwQAdTEB5Dl1iL9mBP5sMcnJczXyFvxSkiNyg+E8lE=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=

--- a/internal/actionparams/actionparams.go
+++ b/internal/actionparams/actionparams.go
@@ -62,6 +62,15 @@ func MarshalActionParams(msg proto.Message) ([]byte, error) {
 	return marshalOptions.Marshal(msg)
 }
 
+// UnmarshalActionParams decodes one stored params object into the caller's
+// concrete contract message while rejecting unknown fields.
+func UnmarshalActionParams(raw []byte, msg proto.Message) error {
+	if msg == nil {
+		return fmt.Errorf("actionparams.UnmarshalActionParams: nil message")
+	}
+	return unmarshalOpts.Unmarshal(raw, msg)
+}
+
 // isNoParamsActionType reports whether an action type legitimately carries no
 // params oneof (so reaching the switch default is expected, not an error).
 // REBOOT and SYNC are instant actions with no parameters; UNSPECIFIED is the
@@ -93,4 +102,11 @@ func PopulateAction(action *pm.Action, actionType int32, paramsJSON []byte) erro
 // responses). Fail-closed identically to PopulateAction.
 func PopulateManagedAction(action *pm.ManagedAction, actionType pm.ActionType, paramsJSON []byte) error {
 	return populateParamsOneof(action, actionType, paramsJSON)
+}
+
+// PopulateUpdateActionParams deserializes stored authoring params into the
+// API input shape. Encryption and WiFi deliberately differ from their sealed
+// agent-wire shapes, so persisted authoring validation uses this carrier.
+func PopulateUpdateActionParams(request *pm.UpdateActionParamsRequest, actionType pm.ActionType, paramsJSON []byte) error {
+	return populateParamsOneof(request, actionType, paramsJSON)
 }

--- a/internal/actionparams/registry.go
+++ b/internal/actionparams/registry.go
@@ -10,9 +10,10 @@ import (
 
 // paramsOneofName is the name of the params oneof shared — identically — by
 // every message that carries action parameters: Action, ManagedAction,
-// CreateActionRequest, UpdateActionParamsRequest. The field
-// names and wrapped message types are the same across all four; only the
-// generated Go wrapper type differs. That shared shape is what lets one
+// CreateActionRequest, UpdateActionParamsRequest. The field names are the same
+// across all four; the credential-bearing Encryption/WiFi message types differ
+// deliberately between write input, safe read view, and sealed agent wire.
+// That shared oneof shape is what lets one
 // reflection helper replace the per-message switch tables.
 const paramsOneofName protoreflect.Name = "params"
 

--- a/internal/actionparams/registry_test.go
+++ b/internal/actionparams/registry_test.go
@@ -39,7 +39,11 @@ func TestEveryActionTypeUsesOneParamsRegistry(t *testing.T) {
 			managedParams := ExtractParamsMsg(managed)
 			require.NotNil(t, actionParams)
 			require.NotNil(t, managedParams)
-			assert.Equal(t, proto.MessageName(actionParams), proto.MessageName(managedParams))
+			if actionType == pm.ActionType_ACTION_TYPE_ENCRYPTION || actionType == pm.ActionType_ACTION_TYPE_WIFI {
+				assert.NotEqual(t, proto.MessageName(actionParams), proto.MessageName(managedParams))
+			} else {
+				assert.Equal(t, proto.MessageName(actionParams), proto.MessageName(managedParams))
+			}
 			assert.True(t, ParamsMatchType(action, actionType))
 		})
 	}

--- a/internal/agentstream/audit_evidence_test.go
+++ b/internal/agentstream/audit_evidence_test.go
@@ -1,0 +1,165 @@
+package agentstream
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"testing"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testdb"
+)
+
+// CHARTER — agent-originated audit evidence.
+//
+// Both writers on this file's path record an operation and a single effect
+// through the real store. They are the only durable trace of a device that
+// reported tampering or that flooded the single-writer control plane, so a
+// test that stops at "the function returned" proves nothing: the assertions
+// below read the committed rows back.
+
+// auditFixture opens one real SQLite file and a raw handle onto the same
+// database, so a test can read the rows the audited write actually committed.
+func auditFixture(t *testing.T) (*store.Store, *testdb.DB) {
+	t.Helper()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "power-manage.db")
+	st, err := store.New(ctx, path)
+	require.NoError(t, err, "initialize SQLite")
+	t.Cleanup(st.Close)
+	raw, err := testdb.Open(ctx, path)
+	require.NoError(t, err, "open raw SQLite handle")
+	t.Cleanup(raw.Close)
+	return st, raw
+}
+
+// auditHandler is the smallest Handler that can reach the audit writers: the
+// real store plus a discarding logger. The frame-drop budget is left nil so
+// every call records rather than being throttled by the test's own repetition.
+func auditHandler(st *store.Store) *Handler {
+	return &Handler{store: st, logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+}
+
+// countRows returns the number of rows the query matches.
+func countRows(t *testing.T, raw *testdb.DB, query string, args ...any) int {
+	t.Helper()
+	var count int
+	require.NoError(t, raw.QueryRow(context.Background(), query, args...).Scan(&count))
+	return count
+}
+
+func TestRecordSecurityAlertCommitsOperationAndEffect(t *testing.T) {
+	st, raw := auditFixture(t)
+	handler := auditHandler(st)
+	deviceID := ulid.Make().String()
+
+	// The longest alert name in the enum: 47 characters, which is what makes
+	// the discriminator's column choice load-bearing.
+	alert := &pmv1.SecurityAlert{
+		Type:    pmv1.SecurityAlertType_SECURITY_ALERT_TYPE_SERVER_REASSIGNMENT_ATTEMPT,
+		Message: "control endpoint was rewritten under the agent",
+	}
+	require.NoError(t, handler.recordSecurityAlert(context.Background(), deviceID, alert))
+
+	const descriptor = "powermanage.v1.AgentService.Stream/SecurityAlert"
+	assert.Equal(t, 1, countRows(t, raw,
+		`SELECT COUNT(*) FROM audit_operations WHERE request_descriptor = $1 AND actor_id = $2`,
+		descriptor, deviceID), "the alert must leave exactly one operation row")
+	assert.Equal(t, 1, countRows(t, raw, `
+		SELECT COUNT(*) FROM audit_effects e
+		JOIN audit_operations o ON o.operation_id = e.operation_id
+		WHERE o.request_descriptor = $1 AND e.resource_id = $2
+		  AND e.resource_type = 'device' AND e.action = 'SECURITY_ALERT'`,
+		descriptor, deviceID), "the alert must leave exactly one effect row")
+
+	// The alert TYPE is the whole point of the record; losing it would leave
+	// an indistinguishable "something happened" row.
+	var resultCode string
+	require.NoError(t, raw.QueryRow(context.Background(),
+		`SELECT result_code FROM audit_operations WHERE request_descriptor = $1 AND actor_id = $2`,
+		descriptor, deviceID).Scan(&resultCode))
+	assert.Equal(t, alert.Type.String(), resultCode,
+		"the alert type must survive in a column the schema accepts")
+
+	// after_ref names another ROW. A discriminator there is rejected by the
+	// schema, which is what silently rolled the whole operation back.
+	assert.Equal(t, 0, countRows(t, raw, `
+		SELECT COUNT(*) FROM audit_effects e
+		JOIN audit_operations o ON o.operation_id = e.operation_id
+		WHERE o.request_descriptor = $1 AND e.after_ref IS NOT NULL`, descriptor),
+		"a reference column must not carry a discriminator")
+}
+
+func TestRecordFrameDropCommitsOperationAndEffect(t *testing.T) {
+	st, raw := auditFixture(t)
+	handler := auditHandler(st)
+	deviceID := ulid.Make().String()
+
+	message := &pmv1.AgentMessage{
+		Id: ulid.Make().String(), Payload: &pmv1.AgentMessage_Heartbeat{Heartbeat: &pmv1.Heartbeat{}},
+	}
+	handler.recordFrameDrop(context.Background(), deviceID, message)
+
+	const descriptor = "powermanage.v1.AgentService.Stream/FrameRateLimit/telemetry"
+	assert.Equal(t, 1, countRows(t, raw,
+		`SELECT COUNT(*) FROM audit_operations WHERE request_descriptor = $1 AND actor_id = $2`,
+		descriptor, deviceID), "a throttled frame must leave exactly one operation row")
+	assert.Equal(t, 1, countRows(t, raw, `
+		SELECT COUNT(*) FROM audit_effects e
+		JOIN audit_operations o ON o.operation_id = e.operation_id
+		WHERE o.request_descriptor = $1 AND e.resource_id = $2
+		  AND e.resource_type = 'device' AND e.action = 'FRAME_RATE_LIMIT'
+		  AND e.outcome = 'REJECTED'`,
+		descriptor, deviceID), "a throttled frame must leave exactly one effect row")
+
+	var resultCode, outcome string
+	require.NoError(t, raw.QueryRow(context.Background(),
+		`SELECT result_code, authorization_outcome FROM audit_operations
+		 WHERE request_descriptor = $1 AND actor_id = $2`,
+		descriptor, deviceID).Scan(&resultCode, &outcome))
+	assert.Equal(t, "RATE_LIMITED.telemetry", resultCode,
+		"the dropped frame's class must survive in a column the schema accepts")
+	assert.Equal(t, string(store.AuthorizationDenied), outcome)
+
+	assert.Equal(t, 0, countRows(t, raw, `
+		SELECT COUNT(*) FROM audit_effects e
+		JOIN audit_operations o ON o.operation_id = e.operation_id
+		WHERE o.request_descriptor = $1 AND e.after_ref IS NOT NULL`, descriptor),
+		"a reference column must not carry a discriminator")
+}
+
+// The guard that keeps the next call site from repeating either defect:
+// before_ref and after_ref name other rows, and the store refuses anything
+// else BEFORE it opens a transaction, so the failure is loud instead of a
+// silent rollback that takes the whole operation with it.
+func TestAuditEffectReferenceColumnsRejectNonULIDsBeforeAnyWrite(t *testing.T) {
+	st, raw := auditFixture(t)
+	deviceID := ulid.Make().String()
+	discriminator := "SECURITY_ALERT_TYPE_SERVER_REASSIGNMENT_ATTEMPT"
+
+	for name, effect := range map[string]store.AuditEffect{
+		"after_ref": {
+			ResourceType: "device", ResourceID: deviceID, Action: "SECURITY_ALERT",
+			Outcome: store.EffectApplied, AfterRef: &discriminator,
+		},
+		"before_ref": {
+			ResourceType: "device", ResourceID: deviceID, Action: "SECURITY_ALERT",
+			Outcome: store.EffectApplied, BeforeRef: &discriminator,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			before := countRows(t, raw, `SELECT COUNT(*) FROM audit_operations`)
+			_, err := st.RecordOperation(context.Background(),
+				agentOperation(deviceID, "SecurityAlert"), effect)
+			require.ErrorIs(t, err, store.ErrAuditEffectInvalid)
+			assert.Equal(t, before, countRows(t, raw, `SELECT COUNT(*) FROM audit_operations`),
+				"a refused effect must perform no database work at all")
+		})
+	}
+}

--- a/internal/agentstream/frame_authorization_test.go
+++ b/internal/agentstream/frame_authorization_test.go
@@ -1,0 +1,137 @@
+package agentstream
+
+import (
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/delivery"
+	"github.com/manchtools/power-manage/server/internal/execution"
+)
+
+// The classification itself, error by error. Continuing on a rejection is the
+// default, so these cases pin the two directions independently: a benign
+// rejection that ended the stream and a cross-actor claim that did not would
+// both look identical from a single-direction test.
+func TestFrameNotAuthorizedSeparatesRejectionFromCrossActorClaims(t *testing.T) {
+	terminating := map[string]error{
+		"foreign terminal session": errForeignTerminalSession,
+		"another device's execution": fmt.Errorf("apply action result: %w",
+			execution.ErrWrongDevice),
+		"another delivery's occurrence": execution.ErrWrongDelivery,
+		"another action's occurrence":   execution.ErrWrongAction,
+		"another device's delivery":     delivery.ErrWrongDevice,
+		"another manifest":              delivery.ErrWrongManifest,
+		"unauthenticated":               connect.NewError(connect.CodeUnauthenticated, errors.New("no identity")),
+		"permission denied":             connect.NewError(connect.CodePermissionDenied, errors.New("denied")),
+	}
+	for name, err := range terminating {
+		t.Run("terminates/"+name, func(t *testing.T) {
+			assert.True(t, frameNotAuthorized(err))
+		})
+	}
+
+	surviving := map[string]error{
+		"malformed result":     execution.ErrInvalidInput,
+		"stale transition":     execution.ErrInvalidTransition,
+		"conflicting replay":   execution.ErrConflictingReplay,
+		"malformed delivery":   delivery.ErrInvalidInput,
+		"stale delivery epoch": delivery.ErrStaleEpoch,
+		"unsupported frame":    errors.New("unsupported agent frame"),
+		"internal":             connect.NewError(connect.CodeInternal, errors.New("boom")),
+		"not found":            connect.NewError(connect.CodeNotFound, errors.New("gone")),
+	}
+	for name, err := range surviving {
+		t.Run("continues/"+name, func(t *testing.T) {
+			assert.False(t, frameNotAuthorized(err))
+		})
+	}
+}
+
+// The guard that keeps the classification honest as the sinks grow.
+//
+// frameNotAuthorized defaults to "keep the stream", which is the right
+// default for a rejection and exactly the wrong one for a claim on another
+// actor's rows. A new ErrWrong… sentinel in either sink would therefore be
+// silently downgraded to a logged warning. This discovers those sentinels
+// from source instead of restating them, so the list cannot go stale.
+func TestFrameAuthorizationClassificationCoversEveryCrossActorSentinel(t *testing.T) {
+	classifier := functionSource(t, "handler.go", "frameNotAuthorized")
+
+	discovered := 0
+	for _, pkg := range []string{"execution", "delivery"} {
+		for _, sentinel := range crossActorSentinels(t, filepath.Join("..", pkg)) {
+			discovered++
+			assert.Contains(t, classifier, pkg+"."+sentinel,
+				"%s.%s names a claim on another actor's rows and must end the stream", pkg, sentinel)
+		}
+	}
+	require.NotZero(t, discovered,
+		"the sweep found no cross-actor sentinels — it is matching nothing and proves nothing")
+}
+
+// crossActorSentinels returns the ErrWrong… package-level error variables
+// declared in dir. That prefix is the codebase's existing name for "the
+// caller named a record that is not theirs".
+func crossActorSentinels(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") ||
+			strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), filepath.Join(dir, entry.Name()), nil, 0)
+		require.NoError(t, err)
+		for _, decl := range file.Decls {
+			general, ok := decl.(*ast.GenDecl)
+			if !ok || general.Tok != token.VAR {
+				continue
+			}
+			for _, spec := range general.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, name := range value.Names {
+					if strings.HasPrefix(name.Name, "ErrWrong") {
+						names = append(names, name.Name)
+					}
+				}
+			}
+		}
+	}
+	return names
+}
+
+// functionSource returns the source text of one top-level function.
+func functionSource(t *testing.T, path, name string) string {
+	t.Helper()
+	source, err := os.ReadFile(path)
+	require.NoError(t, err)
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, source, 0)
+	require.NoError(t, err)
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != name || fn.Recv != nil {
+			continue
+		}
+		return string(source[fset.Position(fn.Pos()).Offset:fset.Position(fn.End()).Offset])
+	}
+	t.Fatalf("%s declares no function %s", path, name)
+	return ""
+}

--- a/internal/agentstream/handler.go
+++ b/internal/agentstream/handler.go
@@ -22,6 +22,7 @@ import (
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/connection"
 	"github.com/manchtools/power-manage/server/internal/delivery"
+	"github.com/manchtools/power-manage/server/internal/execution"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 )
@@ -264,7 +265,11 @@ func (h *Handler) Stream(ctx context.Context, stream *connect.BidiStream[pmv1.Ag
 			if err := h.handleAgentMessage(ctx, agent, received.message); err != nil {
 				h.logger.Warn("apply agent frame", "device_id", deviceID,
 					"frame", fmt.Sprintf("%T", received.message.Payload), "error", err)
-				return connect.NewError(connect.CodeFailedPrecondition, errors.New("agent frame was not accepted"))
+				if frameNotAuthorized(err) {
+					return connect.NewError(connect.CodePermissionDenied,
+						errors.New("agent frame claimed a resource it does not own"))
+				}
+				continue
 			}
 		}
 	}
@@ -279,11 +284,14 @@ func (h *Handler) recordFrameDrop(ctx context.Context, deviceID string, message 
 	op.AuthorizationOutcome = store.AuthorizationDenied
 	op.AuthorizationDetail = "device_frame_budget"
 	op.Result = store.ResultRejected
-	op.ResultCode = "RATE_LIMITED"
-	classRef := string(class)
+	// The dropped frame's class rides the result code. It is not a row
+	// reference, so it must not go in an effect's after_ref: that column
+	// only accepts a ULID and the rejected INSERT rolls the operation row
+	// back with it, leaving an abusive device no durable trace at all.
+	op.ResultCode = "RATE_LIMITED." + string(class)
 	_, err := h.store.RecordOperation(ctx, op, store.AuditEffect{
 		ResourceType: "device", ResourceID: deviceID, Action: "FRAME_RATE_LIMIT",
-		Outcome: store.EffectRejected, AfterRef: &classRef,
+		Outcome: store.EffectRejected,
 	})
 	if err != nil {
 		h.logger.Error("record agent frame rate limit", "device_id", deviceID, "class", class, "error", err)
@@ -403,13 +411,51 @@ func (h *Handler) sendResponse(agent *connection.Agent, messageID string, respon
 	return agent.Send(message)
 }
 
+// errForeignTerminalSession is the terminal path's cross-device claim. It is
+// a sentinel rather than an inline error so frameNotAuthorized can recognise
+// it without matching on message text.
+var errForeignTerminalSession = errors.New("terminal session belongs to another device")
+
+// frameNotAuthorized reports whether a per-frame application error is the
+// device claiming a resource that is not its own. Only those end the
+// connection.
+//
+// Everything else — malformed input, a stale transition, an already-applied
+// replay — is dropped and the stream continues. The agent's outbox is
+// durable: a frame control refuses is re-sent on every reconnect, so ending
+// the connection turns one bad frame into a permanent reconnect loop and
+// discards every other frame the device was about to report. Defaulting to
+// "keep the stream" is what makes a new sink's rejection safe by
+// construction; a new cross-actor sentinel must be added here, and
+// TestFrameAuthorizationClassificationCoversEveryCrossActorSentinel fails
+// until it is.
+func frameNotAuthorized(err error) bool {
+	switch {
+	case errors.Is(err, errForeignTerminalSession),
+		errors.Is(err, execution.ErrWrongDevice),
+		errors.Is(err, execution.ErrWrongDelivery),
+		errors.Is(err, execution.ErrWrongAction),
+		errors.Is(err, delivery.ErrWrongDevice),
+		errors.Is(err, delivery.ErrWrongManifest):
+		return true
+	}
+	var connectErr *connect.Error
+	if errors.As(err, &connectErr) {
+		switch connectErr.Code() {
+		case connect.CodeUnauthenticated, connect.CodePermissionDenied:
+			return true
+		}
+	}
+	return false
+}
+
 func (h *Handler) routeTerminal(deviceID, sessionID string, message *pmv1.AgentMessage) error {
 	session := h.terminalSessions.Get(sessionID)
 	if session == nil {
 		return nil
 	}
 	if session.DeviceID != deviceID {
-		return errors.New("terminal session belongs to another device")
+		return errForeignTerminalSession
 	}
 	h.terminalSessions.RouteAgentMessage(sessionID, message)
 	return nil
@@ -457,10 +503,15 @@ func (h *Handler) recordSecurityAlert(ctx context.Context, deviceID string, aler
 	if alert == nil || alert.Type == pmv1.SecurityAlertType_SECURITY_ALERT_TYPE_UNSPECIFIED {
 		return errors.New("invalid security alert")
 	}
-	alertType := alert.Type.String()
-	_, err := h.store.RecordOperation(ctx, agentOperation(deviceID, "SecurityAlert"), store.AuditEffect{
+	op := agentOperation(deviceID, "SecurityAlert")
+	// The alert type is the record's whole content. It rides the result
+	// code because that column takes 64 characters of the shape an enum
+	// name has; the effect's action column stops at 32 and the longest
+	// alert name is 47, and a reference column takes a ULID or nothing.
+	op.ResultCode = alert.Type.String()
+	_, err := h.store.RecordOperation(ctx, op, store.AuditEffect{
 		ResourceType: "device", ResourceID: deviceID, Action: "SECURITY_ALERT",
-		Outcome: store.EffectApplied, AfterRef: &alertType,
+		Outcome: store.EffectApplied,
 	})
 	return err
 }

--- a/internal/agentstream/stream_frame_rejection_test.go
+++ b/internal/agentstream/stream_frame_rejection_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
@@ -156,7 +155,10 @@ func newStreamFixture(t *testing.T) *streamFixture {
 	mux.Handle(procedure, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		connectHandler.ServeHTTP(w, r.WithContext(WithDeviceID(r.Context(), f.own.deviceID)))
 	}))
-	server := httptest.NewServer(h2c.NewHandler(mux, &http2.Server{}))
+	server := httptest.NewUnstartedServer(mux)
+	server.Config.Protocols = new(http.Protocols)
+	server.Config.Protocols.SetUnencryptedHTTP2(true)
+	server.Start()
 	t.Cleanup(server.Close)
 
 	httpClient := &http.Client{Transport: &http2.Transport{

--- a/internal/agentstream/stream_frame_rejection_test.go
+++ b/internal/agentstream/stream_frame_rejection_test.go
@@ -1,0 +1,272 @@
+package agentstream
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
+	"github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1/powermanagev1connect"
+	"github.com/manchtools/power-manage/server/internal/connection"
+	"github.com/manchtools/power-manage/server/internal/delivery"
+	"github.com/manchtools/power-manage/server/internal/execution"
+	"github.com/manchtools/power-manage/server/internal/store"
+	"github.com/manchtools/power-manage/server/internal/testdb"
+)
+
+// CHARTER — one rejected frame must not cost the connection.
+//
+// The agent's outbox is durable: a frame control refuses is re-sent on every
+// reconnect. Ending the stream on an application-level rejection therefore
+// turns one bad frame into a permanent reconnect loop, and every other frame
+// the agent was about to report is lost with it. Only a claim the device is
+// not entitled to make ends the connection.
+
+type fakeSecrets struct{}
+
+func (fakeSecrets) ValidateLuksToken(context.Context, string, *pmv1.ValidateLuksTokenRequest) (*pmv1.ValidateLuksTokenResponse, error) {
+	return &pmv1.ValidateLuksTokenResponse{}, nil
+}
+
+func (fakeSecrets) GetLuksKey(context.Context, string, *pmv1.GetLuksKeyRequest) (*pmv1.GetLuksKeyResponse, error) {
+	return &pmv1.GetLuksKeyResponse{}, nil
+}
+
+func (fakeSecrets) StoreLuksKey(context.Context, string, *pmv1.StoreLuksKeyRequest) (*pmv1.StoreLuksKeyResponse, error) {
+	return &pmv1.StoreLuksKeyResponse{}, nil
+}
+
+func (fakeSecrets) StoreLpsPasswords(context.Context, string, *pmv1.StoreLpsPasswordsRequest) (*pmv1.StoreLpsPasswordsResponse, error) {
+	return &pmv1.StoreLpsPasswordsResponse{}, nil
+}
+
+type fakeSync struct{}
+
+func (fakeSync) Sync(context.Context, string) (*pmv1.SyncState, error) {
+	return &pmv1.SyncState{SyncIntervalMinutes: 30}, nil
+}
+
+type fakeWaker struct{}
+
+func (fakeWaker) WakeDevice(context.Context, string) error { return nil }
+
+// seededExecution is one device with one acknowledged delivery holding one
+// pending occurrence — the state an agent is in when it reports a result.
+type seededExecution struct {
+	deviceID   string
+	deliveryID string
+	occurrence string
+	actionID   string
+}
+
+func seedExecution(t *testing.T, raw *testdb.DB, at time.Time) seededExecution {
+	t.Helper()
+	ctx := context.Background()
+	seeded := seededExecution{
+		deviceID: ulid.Make().String(), deliveryID: ulid.Make().String(),
+		occurrence: ulid.Make().String(), actionID: ulid.Make().String(),
+	}
+	_, err := raw.Exec(ctx, `
+		INSERT INTO devices (id, hostname, agent_version, agent_sealing_public_key, registered_at)
+		VALUES ($1, $2, 'v1', $3, $4)`,
+		seeded.deviceID, "host-"+seeded.deviceID, bytes.Repeat([]byte{1}, 32), at)
+	require.NoError(t, err)
+	manifest, err := protojson.Marshal(&pmv1.Manifest{
+		ManifestId: ulid.Make().String(),
+		Occurrences: []*pmv1.ManifestOccurrence{{
+			OccurrenceId: seeded.occurrence,
+			Action: &pmv1.Action{
+				Id: &pmv1.ActionId{Value: seeded.actionID}, Type: pmv1.ActionType_ACTION_TYPE_ENCRYPTION,
+			},
+		}},
+	})
+	require.NoError(t, err)
+	_, err = raw.Exec(ctx, `
+		INSERT INTO deliveries (
+			delivery_id, device_id, manifest_id, manifest, state, pushed_at, acked_receipt_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $6)`,
+		seeded.deliveryID, seeded.deviceID, ulid.Make().String(), manifest, delivery.StateAckedReceipt, at)
+	require.NoError(t, err)
+	_, err = raw.Exec(ctx, `
+		INSERT INTO executions (
+			id, delivery_id, device_id, action_type, desired_state, params,
+			timeout_seconds, status, created_at, created_by_type, created_by_id
+		) VALUES ($1, $2, $3, 1, 0, '{}', 300, 'pending', $4, 'user', $5)`,
+		seeded.occurrence, seeded.deliveryID, seeded.deviceID, at, ulid.Make().String())
+	require.NoError(t, err)
+	return seeded
+}
+
+// streamFixture is one live AgentService stream over h2c, terminated by the
+// real handler with the real execution sink behind it. The fake sink used by
+// the routing tests never errors, so it cannot show what an error costs.
+type streamFixture struct {
+	store   *store.Store
+	client  powermanagev1connect.AgentServiceClient
+	own     seededExecution
+	foreign seededExecution
+}
+
+func newStreamFixture(t *testing.T) *streamFixture {
+	t.Helper()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "power-manage.db")
+	st, err := store.New(ctx, path)
+	require.NoError(t, err)
+	t.Cleanup(st.Close)
+	raw, err := testdb.Open(ctx, path)
+	require.NoError(t, err)
+	t.Cleanup(raw.Close)
+
+	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
+	f := &streamFixture{store: st, own: seedExecution(t, raw, now), foreign: seedExecution(t, raw, now)}
+
+	handler := New(Config{
+		Store: st, Manager: connection.NewManager(),
+		Deliveries:    &fakeDeliveryState{},
+		Executions:    execution.New(execution.Config{Store: st, Now: func() time.Time { return now }}),
+		DeviceResults: &fakeDeviceResults{},
+		Secrets:       fakeSecrets{}, Sync: fakeSync{}, Waker: fakeWaker{},
+		TerminalSessions: connection.NewTerminalSessionRegistry(),
+		Logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Now:              func() time.Time { return now },
+	})
+	t.Cleanup(handler.Close)
+
+	procedure, connectHandler := powermanagev1connect.NewAgentServiceHandler(handler)
+	mux := http.NewServeMux()
+	// Stands in for MTLSMiddleware: the transport is already authenticated by
+	// the time a frame reaches Stream, so the identity is bound here directly.
+	mux.Handle(procedure, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connectHandler.ServeHTTP(w, r.WithContext(WithDeviceID(r.Context(), f.own.deviceID)))
+	}))
+	server := httptest.NewServer(h2c.NewHandler(mux, &http2.Server{}))
+	t.Cleanup(server.Close)
+
+	httpClient := &http.Client{Transport: &http2.Transport{
+		AllowHTTP: true,
+		DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, addr)
+		},
+	}}
+	f.client = powermanagev1connect.NewAgentServiceClient(httpClient, server.URL, connect.WithGRPC())
+	return f
+}
+
+// open completes the handshake and returns a stream ready for result frames.
+func (f *streamFixture) open(t *testing.T, ctx context.Context) *connect.BidiStreamForClient[pmv1.AgentMessage, pmv1.ServerMessage] {
+	t.Helper()
+	stream := f.client.Stream(ctx)
+	t.Cleanup(func() { _ = stream.CloseRequest() })
+	require.NoError(t, stream.Send(&pmv1.AgentMessage{
+		Id: ulid.Make().String(),
+		Payload: &pmv1.AgentMessage_Hello{Hello: &pmv1.Hello{
+			DeviceId: &pmv1.DeviceId{Value: f.own.deviceID}, AgentVersion: "v1", Hostname: "device",
+		}},
+	}))
+	welcome, err := stream.Receive()
+	require.NoError(t, err)
+	require.NotNil(t, welcome.GetWelcome())
+	return stream
+}
+
+// luksResult is the frame the agent's LUKS success path actually produces.
+func luksResult(seeded seededExecution, metadata map[string]string) *pmv1.AgentMessage {
+	return &pmv1.AgentMessage{
+		Id: ulid.Make().String(),
+		Payload: &pmv1.AgentMessage_ActionResult{ActionResult: &pmv1.ActionResult{
+			ActionId: &pmv1.ActionId{Value: seeded.actionID}, Status: pmv1.ExecutionStatus_EXECUTION_STATUS_SUCCESS,
+			DeliveryId: seeded.deliveryID, OccurrenceId: seeded.occurrence, Changed: true,
+			Output:   &pmv1.CommandOutput{Stdout: "LUKS: ownership taken, managed passphrase set\n"},
+			Metadata: metadata,
+		}},
+	}
+}
+
+func syncRequest() *pmv1.AgentMessage {
+	return &pmv1.AgentMessage{
+		Id: ulid.Make().String(), Payload: &pmv1.AgentMessage_SyncRequest{SyncRequest: &pmv1.SyncRequest{}},
+	}
+}
+
+// A rejected LUKS result is the concrete case: the agent stamps
+// luks.device_path onto every setup success and the server refuses any
+// non-empty metadata. Before the fix this one frame closed the stream, so the
+// result was either lost outright or replayed on every reconnect forever.
+func TestStreamSurvivesRejectedActionResult(t *testing.T) {
+	f := newStreamFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stream := f.open(t, ctx)
+
+	require.NoError(t, stream.Send(luksResult(f.own, map[string]string{"luks.device_path": "/dev/sda2"})))
+
+	// The connection must still be usable: a request frame sent after the
+	// refused one still gets its answer.
+	require.NoError(t, stream.Send(syncRequest()))
+	response, err := stream.Receive()
+	require.NoError(t, err, "a rejected application frame must not end the stream")
+	require.NotNil(t, response.GetSyncState())
+
+	// The rejection is real — the result did not land.
+	row, err := f.store.GetExecution(ctx, f.own.occurrence)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", row.Status, "a frame the server refused must not be recorded as applied")
+}
+
+// The counterpart: a frame claiming another device's execution is an
+// authorization failure, and that still ends the connection.
+func TestStreamTerminatesOnCrossDeviceClaim(t *testing.T) {
+	f := newStreamFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stream := f.open(t, ctx)
+
+	// No follow-up frame here: the connection is expected to be gone, so a
+	// second Send would race the teardown. Receive is the deterministic
+	// observation point — it carries the code the handler returned.
+	require.NoError(t, stream.Send(luksResult(f.foreign, nil)))
+
+	_, err := stream.Receive()
+	require.Error(t, err, "a cross-device claim must end the connection")
+	assert.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+
+	row, err := f.store.GetExecution(context.Background(), f.foreign.occurrence)
+	require.NoError(t, err)
+	assert.Equal(t, "pending", row.Status, "another device's execution must be untouched")
+}
+
+// And the frame the server does accept still commits, so the two branches
+// above distinguish rejection from acceptance, not from a broken sink.
+func TestStreamAppliesCleanActionResult(t *testing.T) {
+	f := newStreamFixture(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	stream := f.open(t, ctx)
+
+	require.NoError(t, stream.Send(luksResult(f.own, nil)))
+	require.NoError(t, stream.Send(syncRequest()))
+	response, err := stream.Receive()
+	require.NoError(t, err)
+	require.NotNil(t, response.GetSyncState())
+
+	row, err := f.store.GetExecution(ctx, f.own.occurrence)
+	require.NoError(t, err)
+	assert.Equal(t, "success", row.Status)
+}

--- a/internal/architecture/compliance_writer_test.go
+++ b/internal/architecture/compliance_writer_test.go
@@ -1,0 +1,107 @@
+package architecture_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// Compliance reporting once had a read path, RPCs and permissions but no
+// writer: its projector was deleted with the event-sourced architecture and
+// nothing replaced it. The tests passed because they inserted the rows
+// themselves, so a device that ran a check and failed it reported UNKNOWN
+// forever. This guard keeps both halves of that failure impossible: compliance
+// state may only be created by the generated query layer, and the ingestion
+// path must still call it.
+func TestComplianceStateHasOneWriter(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate test source")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+	generated := filepath.Join(root, "internal", "store", "generated")
+
+	// Creating compliance state anywhere else means a fixture manufacturing a
+	// row production never produces. Corrupting an existing row is a different
+	// thing and stays available to rejection-path tests.
+	forbidden := []string{
+		"INSERT INTO compliance_results",
+		"INSERT INTO compliance_policy_evaluation",
+		"compliance_status =",
+	}
+	// The writers themselves, and the call that has to reach them.
+	writers := []string{
+		"UpsertDeviceComplianceResult",
+		"UpsertCompliancePolicyEvaluation",
+		"RefreshDeviceComplianceStatus",
+	}
+
+	declared := make(map[string]bool, len(writers))
+	called := make(map[string]bool, len(writers))
+	scanned := 0
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			name := entry.Name()
+			if name == "vendor" || name == "testdata" ||
+				(path != root && (strings.HasPrefix(name, "_") || strings.HasPrefix(name, "."))) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		source, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		text := string(source)
+		inGenerated := strings.HasPrefix(path, generated+string(filepath.Separator))
+		if inGenerated {
+			for _, writer := range writers {
+				if strings.Contains(text, "func (q *Queries) "+writer+"(") {
+					declared[writer] = true
+				}
+			}
+			return nil
+		}
+		scanned++
+		if path == file {
+			return nil
+		}
+		for _, statement := range forbidden {
+			if strings.Contains(text, statement) {
+				t.Errorf("compliance state is written outside the generated query layer: %q in %s", statement, path)
+			}
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		for _, writer := range writers {
+			if strings.Contains(text, "."+writer+"(ctx,") {
+				called[writer] = true
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scanned == 0 {
+		t.Fatal("matches-zero guard: inspected no Go files outside the generated query layer")
+	}
+	for _, writer := range writers {
+		if !declared[writer] {
+			t.Errorf("compliance writer %s no longer exists in the generated query layer", writer)
+		}
+		if !called[writer] {
+			t.Errorf("compliance writer %s exists but no production code calls it", writer)
+		}
+	}
+}

--- a/internal/architecture/deploy_test.go
+++ b/internal/architecture/deploy_test.go
@@ -66,7 +66,7 @@ func TestDeploymentIsTheTwoServiceTarget(t *testing.T) {
 	for _, required := range []string{
 		"passthrough: true", "proxyProtocol:", "version: 2", "172.30.0.3:8082",
 		"https://control:8081", "serversTransport: control-tls", "serverName: control",
-		"rootCAs:", "/run/certs/ca.crt", "minVersion: VersionTLS13", "maxVersion: VersionTLS13",
+		"rootCAs:", "/run/certs/ca-trust-bundle.crt", "minVersion: VersionTLS13", "maxVersion: VersionTLS13",
 	} {
 		if !strings.Contains(routes, required) {
 			t.Errorf("static route configuration is missing %q", required)

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -32,10 +32,16 @@ type Config struct {
 	FilesystemPath string // required when Backend == BackendFilesystem
 }
 
-// ArchiveInfo describes one stored artifact. SHA256 is the integrity
-// seal computed while the bytes stream in. Retention records that digest in
-// the immutable audit checkpoint, so the archived object remains identifiable
-// after its live prefix has been deleted.
+// ArchiveInfo describes one stored artifact.
+//
+// From Put, SHA256 is computed while the bytes stream in, and retention
+// records that digest in the immutable audit checkpoint so the archived object
+// remains identifiable after its live prefix has been deleted.
+//
+// From List, SHA256 is whatever the archive says about itself, read back from
+// storage the artifact shares. It identifies an object; it does not
+// authenticate one. Verify takes the digest to compare against as an argument
+// for that reason.
 type ArchiveInfo struct {
 	Ref    string
 	Size   int64

--- a/internal/archive/archive_test.go
+++ b/internal/archive/archive_test.go
@@ -81,7 +81,9 @@ func TestFilesystem_PutIsAtomic_NoPartialOnGet(t *testing.T) {
 	}
 }
 
-func TestFilesystem_TamperDetected(t *testing.T) {
+// TestFilesystem_CorruptionDetected covers the accident, not the attack: a
+// storage fault flips bytes in the artifact and leaves everything else alone.
+func TestFilesystem_CorruptionDetected(t *testing.T) {
 	dir := t.TempDir()
 	st, err := archive.New(archive.Config{Backend: archive.BackendFilesystem, FilesystemPath: dir})
 	require.NoError(t, err)
@@ -90,8 +92,13 @@ func TestFilesystem_TamperDetected(t *testing.T) {
 	info, err := st.Put(ctx, "sealed-1", strings.NewReader("the original sealed contents"))
 	require.NoError(t, err)
 
+	// Put's digest is computed from the bytes as they stream in, so it is
+	// what retention records durably in audit_chain_checkpoints.
+	want := sha256.Sum256([]byte("the original sealed contents"))
+	require.Equal(t, hex.EncodeToString(want[:]), info.SHA256)
+
 	// Verify passes on the pristine artifact.
-	require.NoError(t, archive.Verify(ctx, st, "sealed-1"))
+	require.NoError(t, archive.Verify(ctx, st, "sealed-1", info.SHA256))
 
 	// Flip a byte in the stored archive file.
 	target := filepath.Join(dir, "sealed-1")
@@ -104,15 +111,98 @@ func TestFilesystem_TamperDetected(t *testing.T) {
 	raw[len(raw)/2] ^= 0xFF
 	require.NoError(t, os.WriteFile(target, raw, 0o600))
 
-	// The seal now fails — tampering with any archived byte is detected.
-	err = archive.Verify(ctx, st, "sealed-1")
-	require.Error(t, err, "a flipped byte must break the integrity seal")
+	assert.Error(t, archive.Verify(ctx, st, "sealed-1", info.SHA256),
+		"a flipped byte must not rehash to the digest retention recorded")
+}
 
-	// The reported sha is the hash of the untampered original (recorded
-	// out of band by the retention checkpoint), so a re-hash of the flipped
-	// bytes mismatches it — the seal is what the checkpoint pins.
-	want := sha256.Sum256([]byte("the original sealed contents"))
-	assert.Equal(t, hex.EncodeToString(want[:]), info.SHA256)
+// TestFilesystem_TamperDetectedAgainstTheDurableDigest is the case the archive
+// exists for. The sidecar sits in the same directory as the artifact under the
+// same permissions, so whoever can rewrite one can rewrite both — comparing
+// them proves only that the attacker was consistent. Verification must rest on
+// the digest recorded outside the archive, in the append-only
+// audit_chain_checkpoints.archive_digest that authorised deleting the live rows.
+func TestFilesystem_TamperDetectedAgainstTheDurableDigest(t *testing.T) {
+	dir := t.TempDir()
+	st, err := archive.New(archive.Config{Backend: archive.BackendFilesystem, FilesystemPath: dir})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	info, err := st.Put(ctx, "sealed-1", strings.NewReader("the original sealed contents"))
+	require.NoError(t, err)
+	durable := info.SHA256 // the value retention writes to the checkpoint row
+
+	// Rewrite the artifact AND its sidecar together, consistently: the
+	// archive mount is now internally coherent and describes a document that
+	// was never archived.
+	forged := []byte("the contents an attacker would rather the auditor read")
+	forgedSum := sha256.Sum256(forged)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sealed-1"), forged, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "sealed-1.sha256"),
+		[]byte(hex.EncodeToString(forgedSum[:])), 0o600))
+
+	require.NotEqual(t, durable, hex.EncodeToString(forgedSum[:]),
+		"matches-zero guard: the forged bytes must actually differ from the archived ones")
+	assert.Error(t, archive.Verify(ctx, st, "sealed-1", durable),
+		"a consistently rewritten artifact and sidecar must still fail against the durable digest")
+
+	// Control: read the expected value back out of the archive, exactly as
+	// the defective version did, and the forgery verifies. The mount is
+	// internally coherent, so only a digest held outside it can expose the
+	// substitution — which is why Verify takes one as an argument.
+	sidecar := readSidecar(t, dir, "sealed-1")
+	require.Equal(t, hex.EncodeToString(forgedSum[:]), sidecar,
+		"the attacker's sidecar describes the attacker's artifact")
+	require.NoError(t, archive.Verify(ctx, st, "sealed-1", sidecar),
+		"a self-referential comparison cannot detect a consistent forgery")
+
+	// The sidecar List reports is that same attacker-controlled claim, so
+	// sourcing the expected digest from List is the same defect.
+	infos, err := st.List(ctx)
+	require.NoError(t, err)
+	var listed string
+	for _, info := range infos {
+		if info.Ref == "sealed-1" {
+			listed = info.SHA256
+		}
+	}
+	require.Equal(t, sidecar, listed, "List reports the archive's own claim about the artifact")
+}
+
+// readSidecar returns the digest the archive stores beside an artifact.
+func readSidecar(t *testing.T, dir, ref string) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(dir, ref+".sha256"))
+	require.NoError(t, err)
+	return strings.TrimSpace(string(raw))
+}
+
+// TestVerify_RefusesWithoutADurableDigest keeps the check from degrading into
+// a no-op: a caller with nothing durable to compare against has performed no
+// verification, and must be told so rather than handed a nil error.
+func TestVerify_RefusesWithoutADurableDigest(t *testing.T) {
+	dir := t.TempDir()
+	st, err := archive.New(archive.Config{Backend: archive.BackendFilesystem, FilesystemPath: dir})
+	require.NoError(t, err)
+	ctx := context.Background()
+
+	info, err := st.Put(ctx, "sealed-1", strings.NewReader("the original sealed contents"))
+	require.NoError(t, err)
+
+	unusable := map[string]string{
+		"empty":           "",
+		"truncated":       info.SHA256[:32],
+		"over-long":       info.SHA256 + "00",
+		"not hexadecimal": strings.Repeat("z", 64),
+	}
+	require.NotEmpty(t, unusable, "matches-zero guard: the unusable-digest table is empty")
+	for name, expected := range unusable {
+		assert.Error(t, archive.Verify(ctx, st, "sealed-1", expected),
+			"%s: an unusable digest is not a verification", name)
+	}
+
+	// The pristine artifact still verifies, so the refusals above are about
+	// the digest and not about the artifact.
+	assert.NoError(t, archive.Verify(ctx, st, "sealed-1", info.SHA256))
 }
 
 func TestFilesystem_List(t *testing.T) {

--- a/internal/archive/fs.go
+++ b/internal/archive/fs.go
@@ -1,6 +1,7 @@
 package archive
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -12,9 +13,12 @@ import (
 	"strings"
 )
 
-// sealSuffix names the sidecar holding an artifact's integrity seal
-// (the hex sha256 of the data file). Kept beside the artifact so the
-// archive is self-verifying offline without the live system.
+// sealSuffix names the sidecar holding an artifact's digest (the hex
+// sha256 of the data file). It makes the archive self-DESCRIBING offline
+// — an operator can see what each object claims to be without the live
+// system. It is not evidence: it lives in the same directory under the
+// same permissions as the artifact, so anyone able to rewrite one can
+// rewrite both. Verify deliberately ignores it (see Verify).
 const sealSuffix = ".sha256"
 
 // probePrefix names the writability-probe temp files newFilesystem
@@ -192,10 +196,12 @@ func (f *filesystem) List(ctx context.Context) ([]ArchiveInfo, error) {
 		if err != nil {
 			return nil, fmt.Errorf("archive: stat %s: %w", name, err)
 		}
-		// An unreadable/missing seal marks THAT entry (SHA256 == "")
+		// An unreadable/missing sidecar marks THAT entry (SHA256 == "")
 		// rather than failing the whole List — during an incident an
-		// operator most needs to see what IS safely archived. Verify is
-		// the authoritative per-artifact integrity check.
+		// operator most needs to see what IS archived. The reported
+		// digest is the artifact's own claim about itself and proves
+		// nothing; Verify against a durable digest is the integrity
+		// check.
 		seal, err := os.ReadFile(filepath.Join(f.dir, name+sealSuffix))
 		if err != nil {
 			out = append(out, ArchiveInfo{Ref: name, Size: info.Size(), SHA256: ""})
@@ -207,27 +213,29 @@ func (f *filesystem) List(ctx context.Context) ([]ArchiveInfo, error) {
 }
 
 // Verify recomputes an artifact's hash from its stored bytes and
-// compares it to its seal — tamper detection independent of the live
-// system. A mismatch, a missing artifact, or a missing seal is
-// an error.
-func Verify(ctx context.Context, store ArchiveStore, ref string) error {
+// compares it with expected — a digest the CALLER must hold from
+// evidence outside the archive: the append-only
+// audit_chain_checkpoints.archive_digest for a retained prefix, or the
+// value Put returned while the bytes streamed through.
+//
+// The colocated sidecar is deliberately not consulted. Reading the
+// expected value out of the same directory as the artifact makes the
+// comparison self-referential: an attacker who rewrites the artifact
+// rewrites the sidecar in the same breath and verification reports
+// success, which is precisely the outcome an audit archive exists to
+// make impossible. Tamper-evidence is only evidence when the two sides
+// of the comparison sit in different trust domains.
+//
+// An expected digest that is absent or unusable is an error, not a
+// skipped check: with nothing durable to compare against there is no
+// verification to report.
+func Verify(ctx context.Context, store ArchiveStore, ref, expected string) error {
 	if store == nil {
 		return errors.New("archive: store is required")
 	}
-	infos, err := store.List(ctx)
-	if err != nil {
-		return err
-	}
-	var expected string
-	for _, info := range infos {
-		if info.Ref == ref {
-			expected = info.SHA256
-			break
-		}
-	}
-	decoded, err := hex.DecodeString(expected)
-	if err != nil || len(decoded) != sha256.Size {
-		return fmt.Errorf("archive: missing or invalid seal for %s", ref)
+	want, err := hex.DecodeString(expected)
+	if err != nil || len(want) != sha256.Size {
+		return fmt.Errorf("archive: no durable SHA-256 digest to verify %s against", ref)
 	}
 	rc, err := store.Get(ctx, ref)
 	if err != nil {
@@ -241,9 +249,11 @@ func Verify(ctx context.Context, store ArchiveStore, ref string) error {
 	if err := rc.Close(); err != nil {
 		return fmt.Errorf("archive: close %s: %w", ref, err)
 	}
-	got := hex.EncodeToString(h.Sum(nil))
-	if got != expected {
-		return fmt.Errorf("archive: integrity seal MISMATCH for %s — the artifact has been tampered with", ref)
+	// Compare decoded bytes so a differently-cased hex digest cannot
+	// read as a mismatch.
+	if !bytes.Equal(h.Sum(nil), want) {
+		return fmt.Errorf(
+			"archive: %s does not match the digest recorded for it — the archived artifact has been replaced or altered", ref)
 	}
 	return nil
 }

--- a/internal/authoring/actions.go
+++ b/internal/authoring/actions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"connectrpc.com/connect"
+	"github.com/oklog/ulid/v2"
 
 	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
 	"github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1/powermanagev1connect"
@@ -23,13 +24,15 @@ func (h *Handlers) CreateAction(ctx context.Context, req *connect.Request[pmv1.C
 	if err := h.authorize(ctx, "CreateAction", ""); err != nil {
 		return nil, err
 	}
-	params, err := requestParams(req.Msg, req.Msg.Type)
+	actionID := ulid.Make().String()
+	params, err := h.requestParams(req.Msg, req.Msg.Type, actionID, nil)
 	if err != nil {
 		return nil, h.actionError(ctx, "validate create action params", err)
 	}
 	row, err := h.state.CreateAction(ctx, h.operation(req, actor,
 		powermanagev1connect.ControlServiceCreateActionProcedure, "CreateAction"), CreateActionParams{
 		Name: req.Msg.Name, Description: req.Msg.Description, CreatedBy: actor.ID,
+		ID:   actionID,
 		Type: req.Msg.Type, DesiredState: req.Msg.DesiredState, Params: params,
 		TimeoutSeconds: req.Msg.TimeoutSeconds, Schedule: req.Msg.Schedule,
 	})
@@ -167,7 +170,7 @@ func (h *Handlers) UpdateActionParams(ctx context.Context, req *connect.Request[
 	if err != nil {
 		return nil, err
 	}
-	params, err := requestParams(req.Msg, pmv1.ActionType(row.ActionType))
+	params, err := h.requestParams(req.Msg, pmv1.ActionType(row.ActionType), req.Msg.Id, row.Params)
 	if err != nil {
 		return nil, h.actionError(ctx, "validate updated action params", err)
 	}

--- a/internal/authoring/handlers.go
+++ b/internal/authoring/handlers.go
@@ -10,12 +10,10 @@ import (
 	"connectrpc.com/connect"
 	"github.com/go-playground/validator/v10"
 	"github.com/oklog/ulid/v2"
-	"google.golang.org/protobuf/proto"
 
-	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
 	sdkvalidate "github.com/manchtools/power-manage-sdk/validate"
-	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -25,6 +23,7 @@ const defaultAuthoringPageSize = int32(50)
 // used by the authoring RPC handlers.
 type HandlersConfig struct {
 	Store  *store.Store
+	AtRest *pmcrypto.Encryptor
 	Logger *slog.Logger
 	Now    func() time.Time
 }
@@ -36,19 +35,20 @@ type Handlers struct {
 	state     *Service
 	logger    *slog.Logger
 	validator *validator.Validate
+	atRest    *pmcrypto.Encryptor
 }
 
 // NewHandlers constructs the explicit authoring RPC handlers.
 func NewHandlers(cfg HandlersConfig) *Handlers {
-	if cfg.Store == nil {
-		panic("authoring: handler store is required")
+	if cfg.Store == nil || cfg.AtRest == nil {
+		panic("authoring: handler store and at-rest cipher are required")
 	}
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
 	return &Handlers{
 		store: cfg.Store, state: New(Config{Store: cfg.Store, Now: cfg.Now}),
-		logger: cfg.Logger, validator: sdkvalidate.NewValidator(),
+		logger: cfg.Logger, validator: sdkvalidate.NewValidator(), atRest: cfg.AtRest,
 	}
 }
 
@@ -99,21 +99,6 @@ func (h *Handlers) operation(req connect.AnyRequest, actor *auth.UserContext, pr
 		op.OriginFingerprint = auth.Fingerprint(ip)
 	}
 	return op
-}
-
-func requestParams(message proto.Message, actionType pmv1.ActionType) ([]byte, error) {
-	params := actionparams.ExtractParamsMsg(message)
-	if params == nil {
-		return []byte("{}"), nil
-	}
-	if !actionparams.ParamsMatchType(message, actionType) {
-		return nil, ErrInvalidInput
-	}
-	raw, err := actionparams.MarshalActionParams(params)
-	if err != nil {
-		return nil, ErrInvalidInput
-	}
-	return raw, nil
 }
 
 func (h *Handlers) actionError(ctx context.Context, operation string, err error) error {

--- a/internal/authoring/proto.go
+++ b/internal/authoring/proto.go
@@ -27,7 +27,7 @@ func ActionToProto(row store.ActionRow) (*pmv1.ManagedAction, error) {
 	if row.UpdatedAt != nil {
 		action.UpdatedAt = timestamppb.New(*row.UpdatedAt)
 	}
-	if err := actionparams.PopulateManagedAction(action, action.Type, row.Params); err != nil {
+	if err := populateManagedParams(action, action.Type, row.Params); err != nil {
 		return nil, fmt.Errorf("authoring: decode stored action params: %w", err)
 	}
 	schedule, err := actionparams.ParseSchedule(row.Schedule)

--- a/internal/authoring/secrets.go
+++ b/internal/authoring/secrets.go
@@ -48,7 +48,7 @@ func (h *Handlers) prepareEncryptionParams(actionID string, input *pmv1.Encrypti
 		}
 		prepared.PresharedKey = stringPointer(stored.GetPresharedKey())
 	} else {
-		if prepared.GetPresharedKey() == "" {
+		if prepared.GetPresharedKey() == "" || pmcrypto.IsEncryptedValue(prepared.GetPresharedKey()) {
 			return nil, ErrInvalidInput
 		}
 		ciphertext, err := h.atRest.EncryptWithContext(prepared.GetPresharedKey(),
@@ -100,7 +100,7 @@ func (h *Handlers) prepareOptionalSecret(actionID string, supplied, stored *stri
 		}
 		return stringPointer(*stored), nil
 	}
-	if *supplied == "" {
+	if *supplied == "" || pmcrypto.IsEncryptedValue(*supplied) {
 		return nil, ErrInvalidInput
 	}
 	ciphertext, err := h.atRest.EncryptWithContext(*supplied, pmcrypto.RowAAD(actionID, purpose))

--- a/internal/authoring/secrets.go
+++ b/internal/authoring/secrets.go
@@ -1,0 +1,147 @@
+package authoring
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
+	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
+)
+
+func (h *Handlers) requestParams(message proto.Message, actionType pmv1.ActionType, actionID string, current []byte) ([]byte, error) {
+	params := actionparams.ExtractParamsMsg(message)
+	if params == nil {
+		if actionType == pmv1.ActionType_ACTION_TYPE_ENCRYPTION || actionType == pmv1.ActionType_ACTION_TYPE_WIFI {
+			return nil, ErrInvalidInput
+		}
+		return []byte("{}"), nil
+	}
+	if !actionparams.ParamsMatchType(message, actionType) {
+		return nil, ErrInvalidInput
+	}
+	switch value := params.(type) {
+	case *pmv1.EncryptionAuthoringParams:
+		return h.prepareEncryptionParams(actionID, value, current)
+	case *pmv1.WifiAuthoringParams:
+		return h.prepareWifiParams(actionID, value, current)
+	default:
+		raw, err := actionparams.MarshalActionParams(params)
+		if err != nil {
+			return nil, ErrInvalidInput
+		}
+		return raw, nil
+	}
+}
+
+func (h *Handlers) prepareEncryptionParams(actionID string, input *pmv1.EncryptionAuthoringParams, current []byte) ([]byte, error) {
+	prepared := proto.Clone(input).(*pmv1.EncryptionAuthoringParams)
+	if prepared.PresharedKey == nil {
+		if len(current) == 0 {
+			return nil, ErrInvalidInput
+		}
+		stored := &pmv1.EncryptionAuthoringParams{}
+		if err := actionparams.UnmarshalActionParams(current, stored); err != nil || stored.PresharedKey == nil ||
+			!pmcrypto.IsEncryptedValue(stored.GetPresharedKey()) {
+			return nil, ErrInvalidInput
+		}
+		prepared.PresharedKey = stringPointer(stored.GetPresharedKey())
+	} else {
+		if prepared.GetPresharedKey() == "" {
+			return nil, ErrInvalidInput
+		}
+		ciphertext, err := h.atRest.EncryptWithContext(prepared.GetPresharedKey(),
+			pmcrypto.RowAAD(actionID, pmcrypto.PurposeActionEncryptionPresharedKey))
+		if err != nil {
+			return nil, fmt.Errorf("authoring: encrypt encryption pre-shared key: %w", err)
+		}
+		prepared.PresharedKey = stringPointer(ciphertext)
+	}
+	return actionparams.MarshalActionParams(prepared)
+}
+
+func (h *Handlers) prepareWifiParams(actionID string, input *pmv1.WifiAuthoringParams, current []byte) ([]byte, error) {
+	prepared := proto.Clone(input).(*pmv1.WifiAuthoringParams)
+	stored := &pmv1.WifiAuthoringParams{}
+	if len(current) > 0 {
+		if err := actionparams.UnmarshalActionParams(current, stored); err != nil {
+			return nil, ErrInvalidInput
+		}
+	}
+
+	switch prepared.AuthType {
+	case pmv1.WifiAuthType_WIFI_AUTH_TYPE_PSK:
+		prepared.ClientKey = nil
+		secret, err := h.prepareOptionalSecret(actionID, prepared.Psk, stored.Psk,
+			stored.AuthType == pmv1.WifiAuthType_WIFI_AUTH_TYPE_PSK, pmcrypto.PurposeActionWifiPSK)
+		if err != nil {
+			return nil, err
+		}
+		prepared.Psk = secret
+	case pmv1.WifiAuthType_WIFI_AUTH_TYPE_EAP_TLS:
+		prepared.Psk = nil
+		secret, err := h.prepareOptionalSecret(actionID, prepared.ClientKey, stored.ClientKey,
+			stored.AuthType == pmv1.WifiAuthType_WIFI_AUTH_TYPE_EAP_TLS, pmcrypto.PurposeActionWifiClientKey)
+		if err != nil {
+			return nil, err
+		}
+		prepared.ClientKey = secret
+	default:
+		return nil, ErrInvalidInput
+	}
+	return actionparams.MarshalActionParams(prepared)
+}
+
+func (h *Handlers) prepareOptionalSecret(actionID string, supplied, stored *string, mayPreserve bool, purpose string) (*string, error) {
+	if supplied == nil {
+		if !mayPreserve || stored == nil || !pmcrypto.IsEncryptedValue(*stored) {
+			return nil, ErrInvalidInput
+		}
+		return stringPointer(*stored), nil
+	}
+	if *supplied == "" {
+		return nil, ErrInvalidInput
+	}
+	ciphertext, err := h.atRest.EncryptWithContext(*supplied, pmcrypto.RowAAD(actionID, purpose))
+	if err != nil {
+		return nil, fmt.Errorf("authoring: encrypt action credential: %w", err)
+	}
+	return stringPointer(ciphertext), nil
+}
+
+func populateManagedParams(action *pmv1.ManagedAction, actionType pmv1.ActionType, raw []byte) error {
+	switch actionType {
+	case pmv1.ActionType_ACTION_TYPE_ENCRYPTION:
+		stored := &pmv1.EncryptionAuthoringParams{}
+		if err := actionparams.UnmarshalActionParams(raw, stored); err != nil {
+			return err
+		}
+		action.Params = &pmv1.ManagedAction_Encryption{Encryption: &pmv1.ManagedEncryptionParams{
+			PresharedKeyConfigured: stored.PresharedKey != nil && pmcrypto.IsEncryptedValue(stored.GetPresharedKey()),
+			RotationIntervalDays:   stored.RotationIntervalDays, MinWords: stored.MinWords,
+			DeviceBoundKeyType:       stored.DeviceBoundKeyType,
+			UserPassphraseMinLength:  stored.UserPassphraseMinLength,
+			UserPassphraseComplexity: stored.UserPassphraseComplexity,
+		}}
+		return nil
+	case pmv1.ActionType_ACTION_TYPE_WIFI:
+		stored := &pmv1.WifiAuthoringParams{}
+		if err := actionparams.UnmarshalActionParams(raw, stored); err != nil {
+			return err
+		}
+		action.Params = &pmv1.ManagedAction_Wifi{Wifi: &pmv1.ManagedWifiParams{
+			Ssid: stored.Ssid, AuthType: stored.AuthType,
+			PskConfigured: stored.Psk != nil && pmcrypto.IsEncryptedValue(stored.GetPsk()),
+			CaCert:        stored.CaCert, ClientCert: stored.ClientCert,
+			ClientKeyConfigured: stored.ClientKey != nil && pmcrypto.IsEncryptedValue(stored.GetClientKey()),
+			Identity:            stored.Identity, AutoConnect: stored.AutoConnect,
+			Hidden: stored.Hidden, Priority: stored.Priority,
+		}}
+		return nil
+	default:
+		return actionparams.PopulateManagedAction(action, actionType, raw)
+	}
+}
+
+func stringPointer(value string) *string { return &value }

--- a/internal/authoring/state.go
+++ b/internal/authoring/state.go
@@ -19,6 +19,7 @@ import (
 	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
 	sdkvalidate "github.com/manchtools/power-manage-sdk/validate"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/store"
 	db "github.com/manchtools/power-manage/server/internal/store/generated"
 	"github.com/manchtools/power-manage/server/internal/store/sqlitetype"
@@ -61,6 +62,7 @@ func New(cfg Config) *Service {
 
 // CreateActionParams is the complete stored shape of a new Action.
 type CreateActionParams struct {
+	ID             string
 	Name           string
 	Description    string
 	CreatedBy      string
@@ -94,7 +96,13 @@ func (s *Service) CreateAction(ctx context.Context, op store.AuditOperation, p C
 	if timeout == 0 {
 		timeout = defaultActionTimeout
 	}
-	params, err := validateActionData("pending", p.Type, p.DesiredState, timeout, p.Schedule, p.Params)
+	id := p.ID
+	if id == "" {
+		id = ulid.Make().String()
+	} else if !validID(id) {
+		return store.ActionRow{}, ErrInvalidInput
+	}
+	params, err := validateActionData(id, p.Type, p.DesiredState, timeout, p.Schedule, p.Params)
 	if err != nil {
 		return store.ActionRow{}, err
 	}
@@ -103,7 +111,6 @@ func (s *Service) CreateAction(ctx context.Context, op store.AuditOperation, p C
 		return store.ActionRow{}, fmt.Errorf("authoring: encode action schedule: %w", err)
 	}
 
-	id := ulid.Make().String()
 	now := s.now().UTC()
 	var out store.ActionRow
 	_, err = s.store.WithAudit(ctx, op, func(ctx context.Context, tx *store.Tx, rec *store.AuditRecorder) error {
@@ -292,23 +299,52 @@ func validateActionData(id string, actionType pmv1.ActionType, desired pmv1.Desi
 	if !validID(actionID) {
 		actionID = ulid.Make().String()
 	}
-	action := &pmv1.Action{
-		Id: &pmv1.ActionId{Value: actionID}, Type: actionType,
-		DesiredState: desired, TimeoutSeconds: timeout, Schedule: schedule,
+	request := &pmv1.UpdateActionParamsRequest{
+		Id: actionID, DesiredState: desired, TimeoutSeconds: timeout, Schedule: schedule,
 	}
-	if err := actionparams.PopulateAction(action, int32(actionType), canonical); err != nil {
+	if err := actionparams.PopulateUpdateActionParams(request, actionType, canonical); err != nil {
 		return nil, fmt.Errorf("authoring: validate action params: %w", err)
 	}
-	if actionparams.ExtractParamsMsg(action) == nil && !bytes.Equal(canonical, []byte("{}")) {
+	params := actionparams.ExtractParamsMsg(request)
+	if params == nil && !bytes.Equal(canonical, []byte("{}")) {
 		return nil, ErrInvalidInput
 	}
-	if detail, ok := sdkvalidate.Struct(actionValidator, action); !ok {
+	if err := normalizeStoredSecretsForValidation(params); err != nil {
+		return nil, err
+	}
+	if detail, ok := sdkvalidate.Struct(actionValidator, request); !ok {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidInput, detail)
 	}
-	if err := validateActionSafety(actionparams.ExtractParamsMsg(action)); err != nil {
+	if err := validateActionSafety(params); err != nil {
 		return nil, err
 	}
 	return canonical, nil
+}
+
+func normalizeStoredSecretsForValidation(params proto.Message) error {
+	switch value := params.(type) {
+	case *pmv1.EncryptionAuthoringParams:
+		if value.PresharedKey == nil || !pmcrypto.IsEncryptedValue(value.GetPresharedKey()) {
+			return ErrInvalidInput
+		}
+		value.PresharedKey = stringPointer("configured")
+	case *pmv1.WifiAuthoringParams:
+		switch value.AuthType {
+		case pmv1.WifiAuthType_WIFI_AUTH_TYPE_PSK:
+			if value.Psk == nil || !pmcrypto.IsEncryptedValue(value.GetPsk()) || value.ClientKey != nil {
+				return ErrInvalidInput
+			}
+			value.Psk = stringPointer("configured")
+		case pmv1.WifiAuthType_WIFI_AUTH_TYPE_EAP_TLS:
+			if value.ClientKey == nil || !pmcrypto.IsEncryptedValue(value.GetClientKey()) || value.Psk != nil {
+				return ErrInvalidInput
+			}
+			value.ClientKey = stringPointer("configured")
+		default:
+			return ErrInvalidInput
+		}
+	}
+	return nil
 }
 
 // ValidateExecutableAction applies the same type, parameter, and safety rules

--- a/internal/authoring/state.go
+++ b/internal/authoring/state.go
@@ -255,11 +255,16 @@ func (s *Service) DeleteAction(ctx context.Context, op store.AuditOperation, id 
 		if _, err := tx.DeleteCompliancePolicyRulesForAction(ctx, id); err != nil {
 			return fmt.Errorf("authoring: delete compliance policy rules: %w", err)
 		}
-		if _, err := tx.DeleteCompliancePolicyEvaluationsForAction(ctx, id); err != nil {
+		evaluationDevices, err := tx.DeleteCompliancePolicyEvaluationsForAction(ctx, id)
+		if err != nil {
 			return fmt.Errorf("authoring: delete compliance policy evaluations: %w", err)
 		}
-		if _, err := tx.DeleteComplianceResultsForAction(ctx, id); err != nil {
+		resultDevices, err := tx.DeleteComplianceResultsForAction(ctx, id)
+		if err != nil {
 			return fmt.Errorf("authoring: delete compliance results: %w", err)
+		}
+		if err := store.RefreshDeviceCompliance(ctx, tx, rec, evaluationDevices, resultDevices); err != nil {
+			return err
 		}
 		if _, err := tx.SoftDeleteAuthoringAction(ctx, db.SoftDeleteAuthoringActionParams{
 			ID: id, UpdatedAt: &now, AllowSystem: allowSystem,

--- a/internal/ca/ca.go
+++ b/internal/ca/ca.go
@@ -265,8 +265,29 @@ func (ca *CA) issueFromCSR(deviceID string, csrPEM []byte, class mtls.PeerClass,
 // either CA are accepted during the transition period.
 func (ca *CA) SetTrustBundle(pemData []byte) error {
 	pool := x509.NewCertPool()
-	if !pool.AppendCertsFromPEM(pemData) {
-		return fmt.Errorf("failed to parse any certificates from trust bundle")
+	foundActive := false
+	rest := bytes.TrimSpace(pemData)
+	for len(rest) > 0 {
+		block, remaining := pem.Decode(rest)
+		if block == nil || block.Type != "CERTIFICATE" {
+			return fmt.Errorf("CA trust bundle contains invalid PEM data")
+		}
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return fmt.Errorf("parse CA trust bundle certificate: %w", err)
+		}
+		if !cert.IsCA || cert.KeyUsage&x509.KeyUsageCertSign == 0 {
+			return fmt.Errorf("CA trust bundle contains a certificate that cannot sign certificates")
+		}
+		pool.AddCert(cert)
+		foundActive = foundActive || bytes.Equal(cert.Raw, ca.cert.Raw)
+		rest = bytes.TrimSpace(remaining)
+	}
+	if len(pemData) == 0 {
+		return fmt.Errorf("CA trust bundle is empty")
+	}
+	if !foundActive {
+		return fmt.Errorf("CA trust bundle does not contain the active CA certificate")
 	}
 	ca.trustPool = pool
 	return nil

--- a/internal/ca/ca_test.go
+++ b/internal/ca/ca_test.go
@@ -51,6 +51,36 @@ func generateTestCA(t *testing.T) (certPEM, keyPEM []byte) {
 	return certPEM, keyPEM
 }
 
+func generateSuccessorCA(t *testing.T, parentCertPEM, parentKeyPEM []byte) (certPEM, keyPEM []byte) {
+	t.Helper()
+	parentBlock, _ := pem.Decode(parentCertPEM)
+	require.NotNil(t, parentBlock)
+	parent, err := x509.ParseCertificate(parentBlock.Bytes)
+	require.NoError(t, err)
+	keyBlock, _ := pem.Decode(parentKeyPEM)
+	require.NotNil(t, keyBlock)
+	parsedKey, err := x509.ParsePKCS8PrivateKey(keyBlock.Bytes)
+	require.NoError(t, err)
+	parentKey, ok := parsedKey.(ed25519.PrivateKey)
+	require.True(t, ok)
+
+	public, private, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "Successor CA", Organization: []string{"Test"}},
+		NotBefore:    time.Now().Add(-time.Hour), NotAfter: time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true, IsCA: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, parent, public, parentKey)
+	require.NoError(t, err)
+	encodedKey, err := x509.MarshalPKCS8PrivateKey(private)
+	require.NoError(t, err)
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}),
+		pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: encodedKey})
+}
+
 // generateCSR creates a CSR PEM for a given device ID.
 func generateCSR(t *testing.T, deviceID string) (csrPEM []byte, key ed25519.PrivateKey) {
 	t.Helper()
@@ -524,32 +554,32 @@ func TestDeviceIDFromPEM_InvalidPEM(t *testing.T) {
 }
 
 func TestSetTrustBundle(t *testing.T) {
-	certPEM1, keyPEM1 := generateTestCA(t)
-	c1, err := ca.NewFromPEM(certPEM1, keyPEM1, 24*time.Hour)
+	oldCertPEM, oldKeyPEM := generateTestCA(t)
+	oldCA, err := ca.NewFromPEM(oldCertPEM, oldKeyPEM, 24*time.Hour)
+	require.NoError(t, err)
+	successorCertPEM, successorKeyPEM := generateSuccessorCA(t, oldCertPEM, oldKeyPEM)
+	activeCA, err := ca.NewFromPEM(successorCertPEM, successorKeyPEM, 24*time.Hour)
 	require.NoError(t, err)
 
-	certPEM2, keyPEM2 := generateTestCA(t)
-	c2, err := ca.NewFromPEM(certPEM2, keyPEM2, 24*time.Hour)
-	require.NoError(t, err)
-
-	// Issue cert with CA2
 	csrPEM, _ := generateCSR(t, "device-001")
-	issued, err := c2.IssueCertificateFromCSR("device-001", csrPEM)
+	oldLeaf, err := oldCA.IssueCertificateFromCSR("device-001", csrPEM)
 	require.NoError(t, err)
-
-	// CA1 cannot verify CA2-issued cert
-	_, err = c1.VerifyCertificate(issued.CertPEM)
+	_, err = activeCA.VerifyCertificate(oldLeaf.CertPEM)
 	assert.Error(t, err)
 
-	// Add CA2 cert to CA1's trust bundle
-	bundle := append(certPEM1, certPEM2...)
-	err = c1.SetTrustBundle(bundle)
+	bundle := append(append([]byte(nil), oldCertPEM...), successorCertPEM...)
+	err = activeCA.SetTrustBundle(bundle)
 	require.NoError(t, err)
 
-	// Now CA1 can verify CA2-issued cert
-	deviceID, err := c1.VerifyCertificate(issued.CertPEM)
+	deviceID, err := activeCA.VerifyCertificate(oldLeaf.CertPEM)
 	require.NoError(t, err)
 	assert.Equal(t, "device-001", deviceID)
+
+	successorLeaf, err := activeCA.IssueCertificateFromCSR("device-002", csrPEM)
+	require.NoError(t, err)
+	deviceID, err = activeCA.VerifyCertificate(successorLeaf.CertPEM)
+	require.NoError(t, err)
+	assert.Equal(t, "device-002", deviceID)
 }
 
 func TestSetTrustBundle_InvalidPEM(t *testing.T) {
@@ -559,6 +589,10 @@ func TestSetTrustBundle_InvalidPEM(t *testing.T) {
 
 	err = c.SetTrustBundle([]byte("not a certificate"))
 	assert.Error(t, err)
+
+	otherCert, _ := generateTestCA(t)
+	err = c.SetTrustBundle(otherCert)
+	assert.ErrorContains(t, err, "active CA")
 }
 
 func TestTrustPool(t *testing.T) {

--- a/internal/ca/csr_interop_test.go
+++ b/internal/ca/csr_interop_test.go
@@ -1,0 +1,103 @@
+package ca_test
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	sdkcrypto "github.com/manchtools/power-manage-sdk/crypto"
+
+	"github.com/manchtools/power-manage/server/internal/ca"
+	"github.com/manchtools/power-manage/server/internal/mtls"
+)
+
+// The CSR the agent actually sends comes from the SDK, and every other test in
+// this package hand-builds one instead. Both suites stayed green while the SDK
+// emitted a key type the CA refuses, so enrolment and renewal were dead in every
+// shipping configuration. These two tests are the only place where the real
+// producer meets the real consumer; they must never be replaced by a local
+// fixture.
+
+// The device id is minted by the control server, so it is deliberately not the
+// hostname the agent puts in the CSR — an issued leaf carrying the CSR's CN
+// would mean the agent chose its own identity.
+const (
+	interopHostname = "workstation-17.lan"
+	interopDeviceID = "01JQK8P3ZBQ0FN2W6TXY4RC9DA"
+)
+
+func TestIssueCertificateFromCSR_AcceptsSDKEnrolmentCSR(t *testing.T) {
+	caCertPEM, caKeyPEM := generateTestCA(t)
+	c, err := ca.NewFromPEM(caCertPEM, caKeyPEM, 24*time.Hour)
+	require.NoError(t, err)
+
+	csrPEM, keyPEM, err := sdkcrypto.GenerateCSR(interopHostname)
+	require.NoError(t, err)
+
+	issued, err := c.IssueCertificateFromCSR(interopDeviceID, csrPEM)
+	require.NoError(t, err, "the control CA must accept the CSR the SDK actually produces")
+
+	assertAgentLeaf(t, c, issued, keyPEM)
+}
+
+func TestIssueCertificateFromCSR_AcceptsSDKRenewalCSR(t *testing.T) {
+	caCertPEM, caKeyPEM := generateTestCA(t)
+	c, err := ca.NewFromPEM(caCertPEM, caKeyPEM, 24*time.Hour)
+	require.NoError(t, err)
+
+	enrolCSR, keyPEM, err := sdkcrypto.GenerateCSR(interopHostname)
+	require.NoError(t, err)
+	enrolled, err := c.IssueCertificateFromCSR(interopDeviceID, enrolCSR)
+	require.NoError(t, err)
+
+	renewalCSR, err := sdkcrypto.GenerateCSRFromKey(interopHostname, keyPEM)
+	require.NoError(t, err)
+
+	// Renewal reuses the enrolment key, so the same key file must satisfy the
+	// proof-of-possession gate the renewal handler applies before issuing.
+	require.NoError(t, ca.AssertCSRMatchesCertKey(enrolled.CertPEM, renewalCSR))
+
+	renewed, err := c.IssueCertificateFromCSR(interopDeviceID, renewalCSR)
+	require.NoError(t, err, "the control CA must accept the renewal CSR the SDK actually produces")
+
+	assertAgentLeaf(t, c, renewed, keyPEM)
+}
+
+// assertAgentLeaf pins the three properties §12.5 depends on for an issued agent
+// certificate, plus that the agent can actually use it with the key it kept.
+func assertAgentLeaf(t *testing.T, c *ca.CA, issued *ca.Certificate, keyPEM []byte) {
+	t.Helper()
+
+	block, _ := pem.Decode(issued.CertPEM)
+	require.NotNil(t, block)
+	parsed, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	assert.Equal(t, interopDeviceID, parsed.Subject.CommonName, "CN must be the server-minted device id")
+	assert.Equal(t, interopDeviceID, parsed.Subject.SerialNumber)
+	assert.NotEqual(t, interopHostname, parsed.Subject.CommonName, "the CSR's CN must never become the identity")
+
+	require.Len(t, parsed.URIs, 1, "an issued agent cert must carry exactly one URI SAN")
+	assert.Equal(t, "spiffe://power-manage/agent", parsed.URIs[0].String())
+	class, err := mtls.PeerClassFromCert(parsed)
+	require.NoError(t, err)
+	assert.Equal(t, mtls.PeerClassAgent, class)
+
+	assert.Equal(t, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, parsed.ExtKeyUsage,
+		"an agent cert must be client-auth only")
+
+	verified, err := c.VerifyCertificate(issued.CertPEM)
+	require.NoError(t, err)
+	assert.Equal(t, interopDeviceID, verified)
+
+	// X509KeyPair is format-agnostic and pairs the leaf with the key the SDK
+	// returned, so it proves the agent can present this certificate rather than
+	// merely that the CA signed something.
+	_, err = tls.X509KeyPair(issued.CertPEM, keyPEM)
+	require.NoError(t, err, "the SDK's key must load together with the issued leaf")
+}

--- a/internal/compliance/state.go
+++ b/internal/compliance/state.go
@@ -177,6 +177,15 @@ func (s *State) RemoveRule(ctx context.Context, op store.AuditOperation, policyI
 		}); err != nil {
 			return err
 		}
+		evaluationDevices, err := tx.DeleteCompliancePolicyEvaluationsForRule(ctx, db.DeleteCompliancePolicyEvaluationsForRuleParams{
+			PolicyID: policyID, ActionID: actionID,
+		})
+		if err != nil {
+			return fmt.Errorf("compliance: delete rule evaluations: %w", err)
+		}
+		if err := store.RefreshDeviceCompliance(ctx, tx, rec, evaluationDevices); err != nil {
+			return err
+		}
 		before := actionID
 		effect := policyEffect(policyID, "UPDATE", "rules")
 		effect.BeforeRef = &before
@@ -224,8 +233,12 @@ func (s *State) Delete(ctx context.Context, op store.AuditOperation, id string) 
 		for _, actionID := range actionIDs {
 			rec.RefreshSearch("action", actionID)
 		}
-		if _, err := tx.DeleteCompliancePolicyEvaluations(ctx, id); err != nil {
+		evaluationDevices, err := tx.DeleteCompliancePolicyEvaluations(ctx, id)
+		if err != nil {
 			return fmt.Errorf("compliance: delete policy evaluations: %w", err)
+		}
+		if err := store.RefreshDeviceCompliance(ctx, tx, rec, evaluationDevices); err != nil {
+			return err
 		}
 		if _, err := tx.DeleteCompliancePolicyAssignments(ctx, id); err != nil {
 			return fmt.Errorf("compliance: delete policy assignments: %w", err)
@@ -237,6 +250,13 @@ func (s *State) Delete(ctx context.Context, op store.AuditOperation, id string) 
 		return nil
 	})
 	return translateNotFound(err)
+}
+
+// IsComplianceAction reports whether an authored action is a compliance check.
+// Result ingestion asks this rather than re-deriving the rule, so the set of
+// actions that can produce a finding is exactly the set attachment accepts.
+func IsComplianceAction(row store.ActionRow) bool {
+	return validateComplianceAction(row) == nil
 }
 
 func validateComplianceAction(row store.ActionRow) error {

--- a/internal/controlruntime/runtime.go
+++ b/internal/controlruntime/runtime.go
@@ -151,7 +151,7 @@ func New(cfg Config) *Runtime {
 			ControlURL: cfg.AgentURL, ControlSealingPublicKey: cfg.ControlSealingPrivateKey.PublicKey().Bytes(),
 			CloseStream: manager.Unregister,
 		}),
-		Authoring:    authoring.NewHandlers(authoring.HandlersConfig{Store: cfg.Store, Logger: cfg.Logger, Now: cfg.Now}),
+		Authoring:    authoring.NewHandlers(authoring.HandlersConfig{Store: cfg.Store, AtRest: cfg.AtRest, Logger: cfg.Logger, Now: cfg.Now}),
 		Assignments:  assignment.New(assignment.Config{Store: cfg.Store, Logger: cfg.Logger, Now: cfg.Now}),
 		DeviceGroups: devicegroup.NewHandlers(devicegroup.HandlersConfig{Store: cfg.Store, Logger: cfg.Logger, Now: cfg.Now}),
 		Devices:      deviceHandlers,
@@ -159,7 +159,7 @@ func New(cfg Config) *Runtime {
 			Store: cfg.Store, Logger: cfg.Logger, Now: cfg.Now, CAFingerprint: caFingerprint,
 		}),
 		Compliance: compliance.NewHandlers(compliance.HandlersConfig{Store: cfg.Store, Logger: cfg.Logger, Now: cfg.Now}),
-		Dispatch:   dispatch.NewHandlers(dispatch.HandlersConfig{Store: cfg.Store, Waker: dispatcher, Logger: cfg.Logger, Now: cfg.Now}),
+		Dispatch:   dispatch.NewHandlers(dispatch.HandlersConfig{Store: cfg.Store, AtRest: cfg.AtRest, Waker: dispatcher, Logger: cfg.Logger, Now: cfg.Now}),
 		Search:     searchrpc.NewHandlers(cfg.Store, cfg.Logger, cfg.Now),
 	}.Mount(publicMux, controlOptions...)
 

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -33,8 +33,16 @@ const prefix = "enc:v1:"
 // Purpose tags for RowAAD — shared constants so the write and read
 // paths can never drift apart on the AAD purpose dimension.
 const (
-	PurposeIdPClientSecret = "idp-client-secret"
+	PurposeIdPClientSecret              = "idp-client-secret"
+	PurposeActionEncryptionPresharedKey = "action-encryption-preshared-key"
+	PurposeActionWifiPSK                = "action-wifi-psk"
+	PurposeActionWifiClientKey          = "action-wifi-client-key"
 )
+
+// IsEncryptedValue reports whether value uses the only supported at-rest
+// envelope. It is a shape check for metadata-only read paths; authenticated
+// validity is established only by DecryptWithContext at the execution sink.
+func IsEncryptedValue(value string) bool { return strings.HasPrefix(value, prefix) }
 
 // SecretAAD builds the additional-authenticated-data that binds a
 // device-scoped at-rest secret to its row context. deviceID and actionID

--- a/internal/device/secrets.go
+++ b/internal/device/secrets.go
@@ -306,9 +306,19 @@ func (h *Handlers) CreateLuksToken(ctx context.Context, req *connect.Request[pmv
 		return nil, h.internal(ctx, "create LUKS token", err)
 	}
 	return connect.NewResponse(&pmv1.CreateLuksTokenResponse{
-		Token:      token,
-		Uri:        "power-manage://luks/set-passphrase?token=" + token,
-		CliCommand: "sudo power-manage-agent luks set-passphrase --token " + token,
+		Token: token,
+		Uri:   "power-manage://luks/set-passphrase?token=" + token,
+		// The advertised command carries NEITHER the token nor sudo (F2).
+		// /proc/<pid>/cmdline is world-readable and the client collects the
+		// passphrase before it dials, so a token on argv was exposed for the
+		// whole typing window while being the sole authorization for a root
+		// daemon that writes LUKS keyslots. The client prompts for the token
+		// instead (or takes --token-file / $PM_LUKS_TOKEN). sudo is gone
+		// because the sudoers rule was removed to make this client
+		// unprivileged; an operator copying it back would reinstate the
+		// escalation the daemon exists to remove. Token is returned as its own
+		// field for the UI to display.
+		CliCommand: "power-manage-agent luks set-passphrase",
 	}), nil
 }
 

--- a/internal/device/secrets.go
+++ b/internal/device/secrets.go
@@ -11,11 +11,11 @@ import (
 
 	"connectrpc.com/connect"
 	"github.com/oklog/ulid/v2"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
 	"github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1/powermanagev1connect"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/store"
@@ -260,8 +260,8 @@ func (h *Handlers) CreateLuksToken(ctx context.Context, req *connect.Request[pmv
 		return nil, rpcError(ctx, errValidationFailed, connect.CodeInvalidArgument,
 			"action is not an encryption action")
 	}
-	var params pmv1.EncryptionParams
-	if err := protojson.Unmarshal(action.Params, &params); err != nil {
+	var params pmv1.EncryptionAuthoringParams
+	if err := actionparams.UnmarshalActionParams(action.Params, &params); err != nil {
 		return nil, h.internal(ctx, "decode encryption action params", err)
 	}
 	minLength := params.UserPassphraseMinLength

--- a/internal/devicegroup/state.go
+++ b/internal/devicegroup/state.go
@@ -128,27 +128,32 @@ func (s *State) UpdateQuery(ctx context.Context, op store.AuditOperation, id str
 	if err != nil {
 		return store.DeviceGroupView{}, err
 	}
-	current, err := s.store.GetDeviceGroup(ctx, id)
-	if err != nil {
+	if _, err := s.store.GetDeviceGroup(ctx, id); err != nil {
 		return store.DeviceGroupView{}, translateNotFound(err)
-	}
-	if !current.IsDynamic {
-		return store.DeviceGroupView{}, ErrStaticGroup
 	}
 	_, err = s.store.WithAudit(ctx, op, func(ctx context.Context, tx *store.Tx, rec *store.AuditRecorder) error {
 		current, err := tx.GetDeviceGroup(ctx, id)
 		if err != nil {
 			return err
 		}
-		if !current.IsDynamic {
-			return ErrStaticGroup
+		fields := []string{"is_dynamic", "dynamic_query"}
+		// Converting a curated group hands membership to the rule, so the rows it
+		// was hand-picked from go in the SAME transaction that sets the mode.
+		// Left behind, they would make the group report members its own rule does
+		// not select until somebody evaluated it. The reverse direction keeps its
+		// rows on purpose: materializing freezes the membership the rule produced.
+		if dynamic && !current.IsDynamic {
+			if _, err := tx.DeleteDeviceGroupMembers(ctx, id); err != nil {
+				return err
+			}
+			fields = append(fields, "members")
 		}
 		if _, err := tx.UpdateDeviceGroupQuery(ctx, db.UpdateDeviceGroupQueryParams{
 			ID: id, IsDynamic: dynamic, DynamicQuery: query,
 		}); err != nil {
 			return err
 		}
-		rec.Effect(groupEffect(id, "UPDATE", "is_dynamic", "dynamic_query"))
+		rec.Effect(groupEffect(id, "UPDATE", fields...))
 		return nil
 	})
 	return s.readAfter(ctx, id, err)

--- a/internal/dispatch/assigned.go
+++ b/internal/dispatch/assigned.go
@@ -59,7 +59,7 @@ func (h *Handlers) assignedManifests(ctx context.Context, deviceID string) ([]Ma
 		if !visible {
 			return nil, errAssignedSourceNotVisible
 		}
-		compiled, err := h.compiler.Definition(ctx, source.Row.SourceID)
+		compiled, err := h.compiler.DefinitionForDevice(ctx, deviceID, source.Row.SourceID)
 		if err != nil {
 			return nil, err
 		}
@@ -91,7 +91,7 @@ func (h *Handlers) assignedManifests(ctx context.Context, deviceID string) ([]Ma
 		if !visible {
 			return nil, errAssignedSourceNotVisible
 		}
-		compiled, err := h.compiler.ActionSet(ctx, source.Row.SourceID)
+		compiled, err := h.compiler.ActionSetForDevice(ctx, deviceID, source.Row.SourceID)
 		if err != nil {
 			return nil, err
 		}
@@ -118,7 +118,7 @@ func (h *Handlers) assignedManifests(ctx context.Context, deviceID string) ([]Ma
 		if !visible {
 			return nil, errAssignedSourceNotVisible
 		}
-		compiled, err := h.compiler.Action(ctx, source.Row.SourceID)
+		compiled, err := h.compiler.ActionForDevice(ctx, deviceID, source.Row.SourceID)
 		if err != nil {
 			return nil, err
 		}
@@ -152,7 +152,7 @@ func (h *Handlers) assignedManifests(ctx context.Context, deviceID string) ([]Ma
 			if !visible {
 				return nil, errAssignedSourceNotVisible
 			}
-			compiled, err := h.compiler.Action(ctx, rule.ActionID)
+			compiled, err := h.compiler.ActionForDevice(ctx, deviceID, rule.ActionID)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/dispatch/handlers.go
+++ b/internal/dispatch/handlers.go
@@ -359,6 +359,9 @@ func (h *Handlers) DispatchToGroup(ctx context.Context, req *connect.Request[pmv
 	if !auth.AuthorizeContext(ctx, "DispatchToGroup", req.Msg.GroupId) {
 		return nil, rpcError(ctx, errPermissionDenied, connect.CodePermissionDenied, "permission denied")
 	}
+	if req.Msg.ActionSource == nil {
+		return nil, rpcError(ctx, errValidationFailed, connect.CodeInvalidArgument, "an action source is required")
+	}
 	if _, err := h.store.GetDeviceGroup(ctx, req.Msg.GroupId); err != nil {
 		if store.IsNotFound(err) {
 			return nil, notFound(ctx, errDeviceGroupMissing, "device group not found")

--- a/internal/dispatch/handlers.go
+++ b/internal/dispatch/handlers.go
@@ -17,6 +17,7 @@ import (
 	sdkvalidate "github.com/manchtools/power-manage-sdk/validate"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/authoring"
+	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/manifest"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
@@ -24,6 +25,7 @@ import (
 // HandlersConfig supplies the durable store and bounded dispatcher wake seam.
 type HandlersConfig struct {
 	Store  *store.Store
+	AtRest *pmcrypto.Encryptor
 	Waker  Waker
 	Logger *slog.Logger
 	Now    func() time.Time
@@ -41,14 +43,14 @@ type Handlers struct {
 // NewHandlers constructs direct dispatch handlers. Missing durable state or a
 // wake target is a boot-time wiring defect.
 func NewHandlers(cfg HandlersConfig) *Handlers {
-	if cfg.Store == nil || cfg.Waker == nil {
-		panic("dispatch: handler store and waker are required")
+	if cfg.Store == nil || cfg.Waker == nil || cfg.AtRest == nil {
+		panic("dispatch: handler store, waker, and at-rest cipher are required")
 	}
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
 	return &Handlers{
-		store: cfg.Store, compiler: manifest.New(cfg.Store),
+		store: cfg.Store, compiler: manifest.New(cfg.Store, cfg.AtRest),
 		submitter: New(Config{Store: cfg.Store, Waker: cfg.Waker, Now: cfg.Now}),
 		logger:    cfg.Logger, validator: sdkvalidate.NewValidator(),
 	}
@@ -151,7 +153,7 @@ func (h *Handlers) DispatchAction(ctx context.Context, req *connect.Request[pmv1
 	var input ManifestInput
 	switch source := req.Msg.ActionSource.(type) {
 	case *pmv1.DispatchActionRequest_ActionId:
-		compiled, err := h.catalogActionTemplate(ctx, source.ActionId)
+		compiled, err := h.catalogActionTemplate(ctx, req.Msg.DeviceId, source.ActionId)
 		if err != nil {
 			return nil, err
 		}
@@ -245,7 +247,7 @@ func (h *Handlers) DispatchActionSet(ctx context.Context, req *connect.Request[p
 	if err := h.target(ctx, actor, "DispatchActionSet", req.Msg.DeviceId); err != nil {
 		return nil, err
 	}
-	compiled, err := h.catalogActionSetTemplate(ctx, req.Msg.ActionSetId)
+	compiled, err := h.catalogActionSetTemplate(ctx, req.Msg.DeviceId, req.Msg.ActionSetId)
 	if err != nil {
 		return nil, err
 	}
@@ -274,7 +276,7 @@ func (h *Handlers) DispatchDefinition(ctx context.Context, req *connect.Request[
 	if err := h.target(ctx, actor, "DispatchDefinition", req.Msg.DeviceId); err != nil {
 		return nil, err
 	}
-	compiled, err := h.catalogDefinitionTemplates(ctx, req.Msg.DefinitionId)
+	compiled, err := h.catalogDefinitionTemplates(ctx, req.Msg.DeviceId, req.Msg.DefinitionId)
 	if err != nil {
 		return nil, err
 	}
@@ -308,28 +310,29 @@ func (h *Handlers) DispatchToMultiple(ctx context.Context, req *connect.Request[
 		}
 	}
 
-	var templates []*pmv1.Manifest
-	persistActionIDs := false
+	var targets []TargetInput
 	switch source := req.Msg.ActionSource.(type) {
 	case *pmv1.DispatchToMultipleRequest_ActionId:
-		compiled, err := h.catalogActionTemplate(ctx, source.ActionId)
-		if err != nil {
-			return nil, err
+		targets = make([]TargetInput, len(req.Msg.DeviceIds))
+		for i, deviceID := range req.Msg.DeviceIds {
+			compiled, err := h.catalogActionTemplate(ctx, deviceID, source.ActionId)
+			if err != nil {
+				return nil, err
+			}
+			targets[i] = TargetInput{DeviceID: deviceID, Manifests: catalogManifests(compiled)}
 		}
-		templates, persistActionIDs = []*pmv1.Manifest{compiled}, true
 	case *pmv1.DispatchToMultipleRequest_InlineAction:
 		compiled, err := h.inlineTemplate(ctx, source.InlineAction)
 		if err != nil {
 			return nil, err
 		}
-		templates = []*pmv1.Manifest{compiled}
+		targets, err = freshTargets(req.Msg.DeviceIds, []*pmv1.Manifest{compiled}, false)
+		if err != nil {
+			return nil, h.internal(ctx, "prepare multi-device dispatch", err)
+		}
 	default:
 		return nil, rpcError(ctx, errValidationFailed, connect.CodeInvalidArgument,
 			"either action_id or inline_action is required")
-	}
-	targets, err := freshTargets(req.Msg.DeviceIds, templates, persistActionIDs)
-	if err != nil {
-		return nil, h.internal(ctx, "prepare multi-device dispatch", err)
 	}
 	result, err := h.submitter.SubmitBatch(ctx, SubmitBatchParams{
 		Operation: h.operation(req, actor, powermanagev1connect.ControlServiceDispatchToMultipleProcedure, "DispatchToMultiple"),
@@ -380,35 +383,6 @@ func (h *Handlers) DispatchToGroup(ctx context.Context, req *connect.Request[pmv
 		}
 	}
 
-	var templates []*pmv1.Manifest
-	persistActionIDs := true
-	switch source := req.Msg.ActionSource.(type) {
-	case *pmv1.DispatchToGroupRequest_ActionId:
-		compiled, err := h.catalogActionTemplate(ctx, source.ActionId)
-		if err != nil {
-			return nil, err
-		}
-		templates = []*pmv1.Manifest{compiled}
-	case *pmv1.DispatchToGroupRequest_ActionSetId:
-		compiled, err := h.catalogActionSetTemplate(ctx, source.ActionSetId)
-		if err != nil {
-			return nil, err
-		}
-		templates = []*pmv1.Manifest{compiled}
-	case *pmv1.DispatchToGroupRequest_DefinitionId:
-		templates, err = h.catalogDefinitionTemplates(ctx, source.DefinitionId)
-		if err != nil {
-			return nil, err
-		}
-	case *pmv1.DispatchToGroupRequest_InlineAction:
-		compiled, err := h.inlineTemplate(ctx, source.InlineAction)
-		if err != nil {
-			return nil, err
-		}
-		templates, persistActionIDs = []*pmv1.Manifest{compiled}, false
-	default:
-		return nil, rpcError(ctx, errValidationFailed, connect.CodeInvalidArgument, "an action source is required")
-	}
 	op := h.operation(req, actor, powermanagev1connect.ControlServiceDispatchToGroupProcedure, "DispatchToGroup")
 	if len(deviceIDs) == 0 {
 		_, err := h.store.RecordOperation(ctx, op, store.AuditEffect{
@@ -420,9 +394,38 @@ func (h *Handlers) DispatchToGroup(ctx context.Context, req *connect.Request[pmv
 		}
 		return connect.NewResponse(&pmv1.DispatchToGroupResponse{}), nil
 	}
-	targets, err := freshTargets(deviceIDs, templates, persistActionIDs)
-	if err != nil {
-		return nil, h.internal(ctx, "prepare group dispatch", err)
+	targets := make([]TargetInput, len(deviceIDs))
+	for i, deviceID := range deviceIDs {
+		var inputs []ManifestInput
+		switch source := req.Msg.ActionSource.(type) {
+		case *pmv1.DispatchToGroupRequest_ActionId:
+			compiled, err := h.catalogActionTemplate(ctx, deviceID, source.ActionId)
+			if err != nil {
+				return nil, err
+			}
+			inputs = catalogManifests(compiled)
+		case *pmv1.DispatchToGroupRequest_ActionSetId:
+			compiled, err := h.catalogActionSetTemplate(ctx, deviceID, source.ActionSetId)
+			if err != nil {
+				return nil, err
+			}
+			inputs = catalogManifests(compiled)
+		case *pmv1.DispatchToGroupRequest_DefinitionId:
+			compiled, err := h.catalogDefinitionTemplates(ctx, deviceID, source.DefinitionId)
+			if err != nil {
+				return nil, err
+			}
+			inputs = catalogManifests(compiled...)
+		case *pmv1.DispatchToGroupRequest_InlineAction:
+			compiled, err := h.inlineTemplate(ctx, source.InlineAction)
+			if err != nil {
+				return nil, err
+			}
+			inputs = []ManifestInput{{Manifest: compiled}}
+		default:
+			return nil, rpcError(ctx, errValidationFailed, connect.CodeInvalidArgument, "an action source is required")
+		}
+		targets[i] = TargetInput{DeviceID: deviceID, Manifests: inputs}
 	}
 	result, err := h.submitter.SubmitBatch(ctx, SubmitBatchParams{Operation: op, Targets: targets})
 	if err != nil {
@@ -520,8 +523,8 @@ func catalogManifests(manifests ...*pmv1.Manifest) []ManifestInput {
 	return inputs
 }
 
-func (h *Handlers) catalogActionTemplate(ctx context.Context, actionID string) (*pmv1.Manifest, error) {
-	compiled, err := h.compiler.Action(ctx, actionID)
+func (h *Handlers) catalogActionTemplate(ctx context.Context, deviceID, actionID string) (*pmv1.Manifest, error) {
+	compiled, err := h.compiler.ActionForDevice(ctx, deviceID, actionID)
 	if err != nil {
 		return nil, h.compileError(ctx, "compile dispatched action", err)
 	}
@@ -535,8 +538,8 @@ func (h *Handlers) catalogActionTemplate(ctx context.Context, actionID string) (
 	return manifest.AsOneShot(compiled), nil
 }
 
-func (h *Handlers) catalogActionSetTemplate(ctx context.Context, setID string) (*pmv1.Manifest, error) {
-	compiled, err := h.compiler.ActionSet(ctx, setID)
+func (h *Handlers) catalogActionSetTemplate(ctx context.Context, deviceID, setID string) (*pmv1.Manifest, error) {
+	compiled, err := h.compiler.ActionSetForDevice(ctx, deviceID, setID)
 	if err != nil {
 		return nil, h.collectionCompileError(ctx, "action set", errActionSetMissing, "compile dispatched action set", err)
 	}
@@ -550,8 +553,8 @@ func (h *Handlers) catalogActionSetTemplate(ctx context.Context, setID string) (
 	return manifest.AsOneShot(compiled), nil
 }
 
-func (h *Handlers) catalogDefinitionTemplates(ctx context.Context, definitionID string) ([]*pmv1.Manifest, error) {
-	compiled, err := h.compiler.Definition(ctx, definitionID)
+func (h *Handlers) catalogDefinitionTemplates(ctx context.Context, deviceID, definitionID string) ([]*pmv1.Manifest, error) {
+	compiled, err := h.compiler.DefinitionForDevice(ctx, deviceID, definitionID)
 	if err != nil {
 		return nil, h.collectionCompileError(ctx, "definition", errDefinitionMissing, "compile dispatched definition", err)
 	}
@@ -571,6 +574,10 @@ func (h *Handlers) catalogDefinitionTemplates(ctx context.Context, definitionID 
 func (h *Handlers) inlineTemplate(ctx context.Context, action *pmv1.Action) (*pmv1.Manifest, error) {
 	if action == nil {
 		return nil, rpcError(ctx, errValidationFailed, connect.CodeInvalidArgument, "invalid inline action")
+	}
+	if action.Type == pmv1.ActionType_ACTION_TYPE_ENCRYPTION || action.Type == pmv1.ActionType_ACTION_TYPE_WIFI {
+		return nil, rpcError(ctx, errValidationFailed, connect.CodeInvalidArgument,
+			"credential-bearing actions must be authored before dispatch")
 	}
 	inline := proto.Clone(action).(*pmv1.Action)
 	if inline.TimeoutSeconds == 0 {

--- a/internal/execution/compliance.go
+++ b/internal/execution/compliance.go
@@ -1,0 +1,120 @@
+package execution
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
+	"github.com/manchtools/power-manage/server/internal/compliance"
+	"github.com/manchtools/power-manage/server/internal/store"
+	db "github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// complianceFinding is one terminal agent result seen as compliance evidence.
+type complianceFinding struct {
+	deviceID string
+	// actionID is the catalogue action the occurrence carried. An ad-hoc
+	// dispatch has none, and a finding with no authored action has nothing a
+	// policy could reference.
+	actionID *string
+	// status is the stored execution status, not the agent's compliant flag.
+	// Compliance checks are detection-only, so only a detection script that
+	// ran and passed is evidence of compliance; everything else fails closed.
+	status          string
+	compliant       bool
+	detectionOutput []byte
+	checkedAt       time.Time
+}
+
+// recordComplianceFinding writes the compliance state a detection-only action
+// just produced. It runs inside the execution result's own transaction and
+// records its own effect, so the compliance surface and the execution evidence
+// it is derived from commit together or not at all.
+func recordComplianceFinding(ctx context.Context, tx *store.Tx, rec *store.AuditRecorder, finding complianceFinding) error {
+	if finding.actionID == nil {
+		return nil
+	}
+	actionID := *finding.actionID
+	action, err := tx.GetManifestAction(ctx, actionID)
+	if err != nil {
+		if store.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("read compliance action: %w", err)
+	}
+	if !compliance.IsComplianceAction(action) {
+		return nil
+	}
+
+	compliant := finding.compliant && finding.status == "success"
+	checkedAt := finding.checkedAt
+	n, err := tx.UpsertDeviceComplianceResult(ctx, db.UpsertDeviceComplianceResultParams{
+		DeviceID: finding.deviceID, ActionID: actionID, Compliant: compliant,
+		DetectionOutput: finding.detectionOutput, CheckedAt: checkedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("record compliance result: %w", err)
+	}
+	if n != 1 {
+		return fmt.Errorf("record compliance result: action %s is not live", actionID)
+	}
+
+	targets, err := tx.ListComplianceRuleEvaluationTargets(ctx, db.ListComplianceRuleEvaluationTargetsParams{
+		DeviceID: finding.deviceID, ActionID: actionID,
+	})
+	if err != nil {
+		return fmt.Errorf("list compliance rules: %w", err)
+	}
+	for _, target := range targets {
+		firstFailedAt := target.FirstFailedAt
+		switch {
+		case compliant:
+			firstFailedAt = nil
+		case firstFailedAt == nil:
+			firstFailedAt = &checkedAt
+		}
+		if err := tx.UpsertCompliancePolicyEvaluation(ctx, db.UpsertCompliancePolicyEvaluationParams{
+			DeviceID: finding.deviceID, PolicyID: target.PolicyID, ActionID: actionID,
+			Compliant: compliant, FirstFailedAt: firstFailedAt,
+			Status:    ruleStatus(compliant, firstFailedAt, target.GracePeriodHours, checkedAt),
+			CheckedAt: &checkedAt,
+		}); err != nil {
+			return fmt.Errorf("record compliance evaluation: %w", err)
+		}
+	}
+
+	if _, err := tx.RefreshDeviceComplianceStatus(ctx, db.RefreshDeviceComplianceStatusParams{
+		DeviceID: finding.deviceID, CheckedAt: &checkedAt,
+	}); err != nil {
+		return fmt.Errorf("refresh device compliance status: %w", err)
+	}
+
+	// A device effect is what the audit log owes a state change here, and it is
+	// also what refreshes the device search document in this transaction — the
+	// fleet list reads compliance_status from there.
+	rec.Effect(store.AuditEffect{
+		ResourceType: "device", ResourceID: finding.deviceID, Action: "COMPLIANCE",
+		Outcome:  store.EffectApplied,
+		AfterRef: &actionID, AfterFlag: &compliant,
+		ChangedFields: []string{
+			"compliance_status", "compliance_checked_at",
+			"compliance_total", "compliance_passing",
+		},
+	})
+	return nil
+}
+
+// ruleStatus places one rule on the lifecycle: a failing check enters its
+// grace period from the first failure and stays there until the period is
+// spent, measured against the check that produced the finding.
+func ruleStatus(compliant bool, firstFailedAt *time.Time, graceHours int32, checkedAt time.Time) int32 {
+	if compliant {
+		return int32(pmv1.ComplianceStatus_COMPLIANCE_STATUS_COMPLIANT)
+	}
+	if firstFailedAt != nil && graceHours > 0 &&
+		checkedAt.Before(firstFailedAt.Add(time.Duration(graceHours)*time.Hour)) {
+		return int32(pmv1.ComplianceStatus_COMPLIANCE_STATUS_IN_GRACE_PERIOD)
+	}
+	return int32(pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT)
+}

--- a/internal/execution/result.go
+++ b/internal/execution/result.go
@@ -165,7 +165,11 @@ func (s *Service) ApplyActionResult(ctx context.Context, deviceID string, result
 		}
 		rec.Effect(executionEffect(row.ID, "RESULT",
 			"status", "error", "output", "detection_output", "changed", "compliant", "completed_at", "duration_ms"))
-		return nil
+		return recordComplianceFinding(ctx, tx, rec, complianceFinding{
+			deviceID: deviceID, actionID: row.ActionID, status: status,
+			compliant: result.Compliant, detectionOutput: detectionOutput,
+			checkedAt: completedAt,
+		})
 	})
 	if err == nil {
 		return nil

--- a/internal/identity/groups.go
+++ b/internal/identity/groups.go
@@ -553,18 +553,36 @@ func (h *Handlers) UpdateUserGroupQuery(ctx context.Context, req *connect.Reques
 			if err != nil {
 				return err
 			}
+			managed, err := tx.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
+			if err != nil {
+				return err
+			}
+			if managed {
+				return errUserGroupSCIMManaged
+			}
 			fields := []string{"is_dynamic", "dynamic_query"}
 			if req.Msg.IsDynamic && !current.IsDynamic {
-				// A SCIM-managed group's membership belongs to its directory, so it
-				// is not the operator's to hand to a rule. This used to fall out of
-				// "static groups cannot be converted"; conversion works now, so the
-				// refusal has to be stated.
-				managed, err := tx.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
+				members, err := tx.ListUserGroupMembers(ctx, req.Msg.Id)
 				if err != nil {
 					return err
 				}
-				if managed {
-					return errUserGroupSCIMManaged
+				userIDs := make([]string, len(members))
+				for i, member := range members {
+					userIDs[i] = member.UserID
+				}
+				if len(userIDs) > 0 {
+					affected, err := tx.BumpUserSessionsByIDs(ctx, db.BumpUserSessionsByIDsParams{
+						UpdatedAt: &at, UserIds: userIDs,
+					})
+					if err != nil {
+						return err
+					}
+					effect := userGroupEffect(req.Msg.Id, "INVALIDATE_MEMBER_SESSIONS", "session_version")
+					effect.AfterCount = &affected
+					rec.Effect(effect)
+					for _, userID := range userIDs {
+						rec.RefreshSearch("user", userID)
+					}
 				}
 				// Converting hands membership to the rule, so the hand-picked rows go
 				// in the SAME transaction that sets the mode — otherwise the group

--- a/internal/identity/groups.go
+++ b/internal/identity/groups.go
@@ -521,8 +521,10 @@ func (h *Handlers) ListUserGroupsForUser(ctx context.Context, req *connect.Reque
 	return connect.NewResponse(resp), nil
 }
 
-// UpdateUserGroupQuery changes the query or materializes an existing dynamic
-// group as static. Static groups cannot be converted through this RPC.
+// UpdateUserGroupQuery sets the membership mode and its query in either
+// direction: a curated group becomes rule-driven (which clears the curated
+// members), and a rule-driven group is materialized as static (which keeps the
+// membership the rule produced). SCIM-managed groups are refused.
 func (h *Handlers) UpdateUserGroupQuery(ctx context.Context, req *connect.Request[pmv1.UpdateUserGroupQueryRequest]) (*connect.Response[pmv1.UpdateUserGroupQueryResponse], error) {
 	if err := h.validate(ctx, req.Msg); err != nil {
 		return nil, err
@@ -551,19 +553,42 @@ func (h *Handlers) UpdateUserGroupQuery(ctx context.Context, req *connect.Reques
 			if err != nil {
 				return err
 			}
-			if !current.IsDynamic {
-				return errUserGroupNotDynamic
+			fields := []string{"is_dynamic", "dynamic_query"}
+			if req.Msg.IsDynamic && !current.IsDynamic {
+				// A SCIM-managed group's membership belongs to its directory, so it
+				// is not the operator's to hand to a rule. This used to fall out of
+				// "static groups cannot be converted"; conversion works now, so the
+				// refusal has to be stated.
+				managed, err := tx.IsUserGroupSCIMManaged(ctx, req.Msg.Id)
+				if err != nil {
+					return err
+				}
+				if managed {
+					return errUserGroupSCIMManaged
+				}
+				// Converting hands membership to the rule, so the hand-picked rows go
+				// in the SAME transaction that sets the mode — otherwise the group
+				// reports members its own rule does not select until someone
+				// evaluates it. Materializing back to static keeps its rows on
+				// purpose: it freezes the membership the rule produced.
+				if _, err := tx.DeleteUserGroupMembers(ctx, req.Msg.Id); err != nil {
+					return err
+				}
+				fields = append(fields, "members")
 			}
 			if _, err := tx.UpdateUserGroupQuery(ctx, db.UpdateUserGroupQueryParams{
 				ID: req.Msg.Id, IsDynamic: req.Msg.IsDynamic, DynamicQuery: query, UpdatedAt: at,
 			}); err != nil {
 				return err
 			}
-			rec.Effect(userGroupEffect(req.Msg.Id, "UPDATE", "is_dynamic", "dynamic_query"))
+			rec.Effect(userGroupEffect(req.Msg.Id, "UPDATE", fields...))
 			return nil
 		})
 	if err != nil {
 		switch {
+		case errors.Is(err, errUserGroupSCIMManaged):
+			return nil, rpcError(ctx, ErrSCIMManagedResource, connect.CodeFailedPrecondition,
+				"SCIM-managed group membership is owned by its identity provider")
 		case errors.Is(err, errUserGroupNotDynamic):
 			return nil, rpcError(ctx, ErrGroupNotDynamic, connect.CodeFailedPrecondition, "group is not dynamic")
 		case store.IsNotFound(err):

--- a/internal/identity/groups_test.go
+++ b/internal/identity/groups_test.go
@@ -248,3 +248,79 @@ func TestEvaluateDynamicUserGroup_AllowsRemovingFinalAdminMembership(t *testing.
 	assert.Empty(t, members)
 	assert.Len(t, f.operationsFor(powermanagev1connect.ControlServiceEvaluateDynamicUserGroupProcedure), 1)
 }
+
+// Converting a curated user group into a rule-driven one is supported in both
+// directions (target design §5.1), with one asymmetry that is deliberate:
+// converting TO a rule clears the hand-picked membership, because the rule
+// becomes the single source of it, while materializing back to static keeps
+// what the rule last produced.
+//
+// A SCIM-managed group is not the operator's to convert: its membership belongs
+// to the directory, and the refusal that used to fall out of "static groups
+// cannot be converted" has to be stated on its own now that conversion works.
+func TestUpdateUserGroupQuery_ConvertsCuratedGroupAndRefusesSCIMManaged(t *testing.T) {
+	t.Parallel()
+	f := newFixture(t)
+	operator := f.seedActor(grant{Permissions: []string{
+		"CreateStaticUserGroup", "CreateDynamicUserGroup", "UpdateDynamicUserGroupQuery",
+		"AddUserToGroup", "GetUserGroup",
+	}})
+	member := f.seedSubject()
+
+	curated, err := f.client.CreateUserGroup(f.ctx(), authed(&pmv1.CreateUserGroupRequest{
+		Name: "Hand picked",
+	}, operator.Token))
+	require.NoError(t, err)
+	groupID := curated.Msg.Group.Id
+	require.False(t, curated.Msg.Group.IsDynamic)
+
+	_, err = f.client.AddUserToGroup(f.ctx(), authed(&pmv1.AddUserToGroupRequest{
+		GroupId: groupID, UserId: member.ID,
+	}, operator.Token))
+	require.NoError(t, err)
+
+	// An invalid query is refused before anything is written, so a rejected
+	// conversion leaves a curated group exactly as it was.
+	_, err = f.client.UpdateUserGroupQuery(f.ctx(), authed(&pmv1.UpdateUserGroupQueryRequest{
+		Id: groupID, IsDynamic: true, DynamicQuery: "(",
+	}, operator.Token))
+	assert.Equal(t, connect.CodeInvalidArgument, connectCodeOf(t, err))
+	intact, err := f.client.GetUserGroup(f.ctx(), authed(&pmv1.GetUserGroupRequest{Id: groupID}, operator.Token))
+	require.NoError(t, err)
+	assert.False(t, intact.Msg.Group.IsDynamic)
+	require.Len(t, intact.Msg.Members, 1)
+
+	converted, err := f.client.UpdateUserGroupQuery(f.ctx(), authed(&pmv1.UpdateUserGroupQueryRequest{
+		Id: groupID, IsDynamic: true, DynamicQuery: `user.disabled equals "true"`,
+	}, operator.Token))
+	require.NoError(t, err, "a curated group is convertible to a rule")
+	assert.True(t, converted.Msg.Group.IsDynamic)
+	assert.Equal(t, `user.disabled equals "true"`, converted.Msg.Group.DynamicQuery)
+	assert.Zero(t, converted.Msg.Group.MemberCount, "the curated membership does not survive the rule")
+
+	after, err := f.client.GetUserGroup(f.ctx(), authed(&pmv1.GetUserGroupRequest{Id: groupID}, operator.Token))
+	require.NoError(t, err)
+	assert.Empty(t, after.Msg.Members, "membership has one source once the group is a rule")
+
+	// A SCIM-managed group stays the directory's. The web hides its Rule tab, but
+	// this RPC is reachable on its own and must fail closed.
+	managed, err := f.client.CreateUserGroup(f.ctx(), authed(&pmv1.CreateUserGroupRequest{
+		Name: "Directory owned",
+	}, operator.Token))
+	require.NoError(t, err)
+	providerID := f.insertProvider("scim-convert", nil)
+	_, err = f.raw.Exec(f.ctx(),
+		`INSERT INTO scim_group_mapping (id, provider_id, scim_group_id, scim_display_name, user_group_id)
+		 VALUES ($1, $2, 'grp-directory', 'Directory owned', $3)`,
+		newULID(), providerID, managed.Msg.Group.Id)
+	require.NoError(t, err)
+
+	_, err = f.client.UpdateUserGroupQuery(f.ctx(), authed(&pmv1.UpdateUserGroupQueryRequest{
+		Id: managed.Msg.Group.Id, IsDynamic: true, DynamicQuery: `user.disabled equals "true"`,
+	}, operator.Token))
+	assert.Equal(t, connect.CodeFailedPrecondition, connectCodeOf(t, err),
+		"a SCIM-managed group's membership belongs to its directory")
+	stillManaged, err := f.client.GetUserGroup(f.ctx(), authed(&pmv1.GetUserGroupRequest{Id: managed.Msg.Group.Id}, operator.Token))
+	require.NoError(t, err)
+	assert.False(t, stillManaged.Msg.Group.IsDynamic)
+}

--- a/internal/identity/groups_test.go
+++ b/internal/identity/groups_test.go
@@ -278,6 +278,9 @@ func TestUpdateUserGroupQuery_ConvertsCuratedGroupAndRefusesSCIMManaged(t *testi
 		GroupId: groupID, UserId: member.ID,
 	}, operator.Token))
 	require.NoError(t, err)
+	var versionBeforeConversion int32
+	require.NoError(t, f.raw.QueryRow(f.ctx(),
+		`SELECT session_version FROM users WHERE id = $1`, member.ID).Scan(&versionBeforeConversion))
 
 	// An invalid query is refused before anything is written, so a rejected
 	// conversion leaves a curated group exactly as it was.
@@ -297,10 +300,22 @@ func TestUpdateUserGroupQuery_ConvertsCuratedGroupAndRefusesSCIMManaged(t *testi
 	assert.True(t, converted.Msg.Group.IsDynamic)
 	assert.Equal(t, `user.disabled equals "true"`, converted.Msg.Group.DynamicQuery)
 	assert.Zero(t, converted.Msg.Group.MemberCount, "the curated membership does not survive the rule")
+	var versionAfterConversion int32
+	require.NoError(t, f.raw.QueryRow(f.ctx(),
+		`SELECT session_version FROM users WHERE id = $1`, member.ID).Scan(&versionAfterConversion))
+	assert.Equal(t, versionBeforeConversion+1, versionAfterConversion,
+		"removing a membership invalidates authority already baked into sessions")
 
 	after, err := f.client.GetUserGroup(f.ctx(), authed(&pmv1.GetUserGroupRequest{Id: groupID}, operator.Token))
 	require.NoError(t, err)
 	assert.Empty(t, after.Msg.Members, "membership has one source once the group is a rule")
+	operations := f.operationsFor(powermanagev1connect.ControlServiceUpdateUserGroupQueryProcedure)
+	require.Len(t, operations, 1)
+	effects := f.effectsOf(operations[0].OperationID)
+	assert.Contains(t, f.effectWithAction(effects, "UPDATE").ChangedFields, "members")
+	invalidation := f.effectWithAction(effects, "INVALIDATE_MEMBER_SESSIONS")
+	require.NotNil(t, invalidation.AfterCount)
+	assert.Equal(t, int64(1), *invalidation.AfterCount)
 
 	// A SCIM-managed group stays the directory's. The web hides its Rule tab, but
 	// this RPC is reachable on its own and must fail closed.
@@ -314,6 +329,11 @@ func TestUpdateUserGroupQuery_ConvertsCuratedGroupAndRefusesSCIMManaged(t *testi
 		 VALUES ($1, $2, 'grp-directory', 'Directory owned', $3)`,
 		newULID(), providerID, managed.Msg.Group.Id)
 	require.NoError(t, err)
+	_, err = f.client.UpdateUserGroupQuery(f.ctx(), authed(&pmv1.UpdateUserGroupQueryRequest{
+		Id: managed.Msg.Group.Id, IsDynamic: false,
+	}, operator.Token))
+	assert.Equal(t, connect.CodeFailedPrecondition, connectCodeOf(t, err),
+		"SCIM ownership rejects every query update, including a same-mode request")
 
 	_, err = f.client.UpdateUserGroupQuery(f.ctx(), authed(&pmv1.UpdateUserGroupQueryRequest{
 		Id: managed.Msg.Group.Id, IsDynamic: true, DynamicQuery: `user.disabled equals "true"`,

--- a/internal/maintenance/service.go
+++ b/internal/maintenance/service.go
@@ -148,22 +148,131 @@ func (s *Service) EnsureScheduled(ctx context.Context) error {
 	return nil
 }
 
-// VerifyAudit checks the local chain against the newest externally stored
-// anchor when one exists.
+// VerifyAudit checks the local chain against the durable evidence that is
+// supposed to exist outside it, and fails closed whenever that evidence is
+// gone.
+//
+// "Nothing has ever been anchored" is legitimate — it is what a fresh
+// deployment looks like — and is the only case in which the pass proceeds
+// without an expected anchor. Once an anchor row exists, this database has
+// asserted that a chain position was published somewhere it does not control;
+// if that object is missing, the assertion cannot be checked. Reporting
+// success there would make a chain proven intact indistinguishable from one
+// whose off-host evidence has been destroyed, which is the failure an auditor
+// is relying on this job to catch.
 func (s *Service) VerifyAudit(ctx context.Context, _ jobs.Job) error {
 	opts := store.AuditVerifyOptions{CheckStoredAnchors: true}
-	external, found, err := s.latestExternalAnchor(ctx)
+
+	// Look for the object this database recorded as published, and fall back
+	// to the fixed publication name when it recorded none — an anchor written
+	// just before a crash, before its row landed, is still evidence and the
+	// chain still has to reproduce it.
+	ref, recorded := externalAnchorRef, false
+	published, err := s.store.LatestAuditAnchor(ctx, store.DefaultAuditStream)
+	switch {
+	case err == nil:
+		ref, recorded = published.ExternalRef, true
+	case store.IsNotFound(err):
+		// Nothing has ever been anchored. Nothing can be missing.
+	default:
+		return err
+	}
+
+	external, found, err := s.externalAnchor(ctx, ref)
 	if err != nil {
 		return err
 	}
-	if found {
+	switch {
+	case recorded && !found:
+		return fmt.Errorf(
+			"audit anchor %q is recorded as published at chain position %d but is absent from the archive: "+
+				"the off-host anchor has been lost or removed and the chain can no longer be verified against it",
+			ref, published.ChainSeq)
+	case recorded && found && contradicts(external, published):
+		return fmt.Errorf(
+			"archived audit anchor %q (stream %q, chain position %d) contradicts the anchor recorded for it "+
+				"(stream %q, chain position %d): the off-host anchor has been rolled back or rewritten",
+			ref, external.Stream, external.ChainSeq, published.Stream, published.ChainSeq)
+	case found:
 		opts.ExpectedAnchor = &store.AuditAnchor{
 			AnchorID: external.Ref, Stream: external.Stream,
 			ChainSeq: external.ChainSeq, RowHash: external.RowHash,
 		}
 	}
+
+	if err := s.requireArchivedPrefixes(ctx); err != nil {
+		return err
+	}
 	_, err = s.store.VerifyAuditChain(ctx, opts)
 	return err
+}
+
+// contradicts reports whether an archived anchor disagrees with the anchor row
+// recorded for it.
+//
+// Running AHEAD is not a contradiction: publishing writes the object first and
+// records the row second, so a crash in between leaves a newer object that the
+// next anchor pass adopts, and the chain still has to reproduce it. Running
+// behind, or carrying a different hash at the same position, means the object
+// was rolled back or rewritten.
+func contradicts(external externalAnchor, published store.AuditAnchor) bool {
+	return external.Stream != published.Stream ||
+		external.ChainSeq < published.ChainSeq ||
+		(external.ChainSeq == published.ChainSeq && !bytes.Equal(external.RowHash, published.RowHash))
+}
+
+// requireArchivedPrefixes fails closed when a retention checkpoint names an
+// archived prefix the archive no longer holds. Those live rows were deleted on
+// the strength of that object, so its absence is destroyed evidence and not a
+// bookkeeping discrepancy.
+//
+// Presence only. Re-hashing every retained prefix costs the whole archive on
+// every pass; that check belongs to the retention job, which pays it once a
+// day and only in order to earn the right to delete more.
+func (s *Service) requireArchivedPrefixes(ctx context.Context) error {
+	checkpoints, err := s.store.ListAuditCheckpoints(ctx, store.DefaultAuditStream)
+	if err != nil {
+		return err
+	}
+	if len(checkpoints) == 0 {
+		return nil
+	}
+	infos, err := s.archive.List(ctx)
+	if err != nil {
+		return fmt.Errorf("list audit archive: %w", err)
+	}
+	present := make(map[string]struct{}, len(infos))
+	for _, info := range infos {
+		present[info.Ref] = struct{}{}
+	}
+	for _, checkpoint := range checkpoints {
+		if _, ok := present[checkpoint.ArchiveRef]; !ok {
+			return fmt.Errorf(
+				"archived audit prefix %q for checkpoint %s (boundary %d) is absent from the archive: "+
+					"the audit rows it covers were deleted on the strength of that object",
+				checkpoint.ArchiveRef, checkpoint.CheckpointID, checkpoint.BoundarySeq)
+		}
+	}
+	return nil
+}
+
+// verifyArchivedPrefixes re-hashes every retained prefix and compares it with
+// the digest its checkpoint recorded. That digest is the durable copy: the
+// checkpoint table is append-only and lives in the database, not on the
+// archive mount, so it is the one value an attacker who owns the mount cannot
+// bring into agreement with a substituted artifact.
+func (s *Service) verifyArchivedPrefixes(ctx context.Context) error {
+	checkpoints, err := s.store.ListAuditCheckpoints(ctx, store.DefaultAuditStream)
+	if err != nil {
+		return err
+	}
+	for _, checkpoint := range checkpoints {
+		if err := archive.Verify(ctx, s.archive, checkpoint.ArchiveRef, checkpoint.ArchiveDigest); err != nil {
+			return fmt.Errorf("verify archived audit prefix for checkpoint %s (boundary %d): %w",
+				checkpoint.CheckpointID, checkpoint.BoundarySeq, err)
+		}
+	}
+	return nil
 }
 
 // AnchorAudit verifies the current chain, writes its tip to the configured
@@ -176,7 +285,7 @@ func (s *Service) AnchorAudit(ctx context.Context, _ jobs.Job) error {
 	if err != nil || tip.Height == 0 {
 		return err
 	}
-	external, found, err := s.latestExternalAnchor(ctx)
+	external, found, err := s.externalAnchor(ctx, externalAnchorRef)
 	if err != nil {
 		return err
 	}
@@ -201,10 +310,13 @@ func (s *Service) AnchorAudit(ctx context.Context, _ jobs.Job) error {
 		return fmt.Errorf("marshal audit anchor: %w", err)
 	}
 	payload = append(payload, '\n')
-	if _, err := s.archive.Put(ctx, ref, bytes.NewReader(payload)); err != nil {
+	info, err := s.archive.Put(ctx, ref, bytes.NewReader(payload))
+	if err != nil {
 		return fmt.Errorf("publish audit anchor: %w", err)
 	}
-	if err := archive.Verify(ctx, s.archive, ref); err != nil {
+	// Read the object back against the digest computed from the bytes that
+	// went out, which is held here in memory and never on the archive mount.
+	if err := archive.Verify(ctx, s.archive, ref, info.SHA256); err != nil {
 		return fmt.Errorf("verify published audit anchor: %w", err)
 	}
 	_, err = s.store.RecordPublishedAuditAnchor(ctx, tip, ref)
@@ -215,6 +327,14 @@ func (s *Service) AnchorAudit(ctx context.Context, _ jobs.Job) error {
 // older than policy, verifies the archived object, and only then prunes it.
 func (s *Service) RetainAudit(ctx context.Context, _ jobs.Job) error {
 	if err := s.AnchorAudit(ctx, jobs.Job{}); err != nil {
+		return err
+	}
+	// Earn the right to delete more evidence: every prefix already archived
+	// must still hash to the digest its checkpoint recorded. Retention is the
+	// one job that destroys live audit rows, so it is where the full re-hash
+	// of the archive is worth its cost — and refusing here leaves every
+	// remaining row in the database.
+	if err := s.verifyArchivedPrefixes(ctx); err != nil {
 		return err
 	}
 	boundary, err := s.store.FindAuditRetentionBoundary(ctx, store.DefaultAuditStream, s.now().UTC().Add(-s.retention))
@@ -253,7 +373,10 @@ func (s *Service) RetainAudit(ctx context.Context, _ jobs.Job) error {
 	if write.summary.Rows == 0 || len(write.summary.BoundaryHash) != sha256.Size {
 		return errors.New("audit archive wrote no usable boundary")
 	}
-	if err := archive.Verify(ctx, s.archive, ref); err != nil {
+	// info.SHA256 was computed from the bytes as they streamed out and is the
+	// value PruneAuditPrefix is about to record durably, so verifying against
+	// it proves the archive holds what the checkpoint will claim it holds.
+	if err := archive.Verify(ctx, s.archive, ref, info.SHA256); err != nil {
 		return fmt.Errorf("verify audit archive: %w", err)
 	}
 	_, err = s.store.PruneAuditPrefix(ctx, store.AuditRetentionRequest{
@@ -359,14 +482,25 @@ type externalAnchor struct {
 	RowHash  []byte
 }
 
-func (s *Service) latestExternalAnchor(ctx context.Context) (externalAnchor, bool, error) {
+// externalAnchor reads the anchor object stored under ref, reporting whether
+// the archive holds it at all.
+//
+// It performs no digest check against the archive's own sidecar: that would
+// compare the object with a claim written beside it, which proves nothing.
+// The anchor's authority comes from its content being reproduced by the local
+// chain (AuditVerifyOptions.ExpectedAnchor) and, for a position this database
+// has already recorded, from agreeing with that append-only row.
+func (s *Service) externalAnchor(ctx context.Context, ref string) (externalAnchor, bool, error) {
+	if ref == "" {
+		return externalAnchor{}, false, errors.New("external audit anchor reference is empty")
+	}
 	infos, err := s.archive.List(ctx)
 	if err != nil {
 		return externalAnchor{}, false, fmt.Errorf("list external audit anchors: %w", err)
 	}
 	var latest *archive.ArchiveInfo
 	for _, info := range infos {
-		if info.Ref == externalAnchorRef {
+		if info.Ref == ref {
 			copy := info
 			latest = &copy
 			break
@@ -377,10 +511,6 @@ func (s *Service) latestExternalAnchor(ctx context.Context) (externalAnchor, boo
 	}
 	if latest.Size <= 0 || latest.Size > maxAnchorBytes {
 		return externalAnchor{}, false, errors.New("external audit anchor has an invalid size")
-	}
-	ref := latest.Ref
-	if err := archive.Verify(ctx, s.archive, ref); err != nil {
-		return externalAnchor{}, false, fmt.Errorf("verify external audit anchor: %w", err)
 	}
 	rc, err := s.archive.Get(ctx, ref)
 	if err != nil {

--- a/internal/maintenance/service_test.go
+++ b/internal/maintenance/service_test.go
@@ -1,0 +1,226 @@
+package maintenance_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/archive"
+	"github.com/manchtools/power-manage/server/internal/jobs"
+	"github.com/manchtools/power-manage/server/internal/maintenance"
+	"github.com/manchtools/power-manage/server/internal/store"
+)
+
+// evidenceFixture is one control deployment's durable evidence: the live
+// database, the archive mount it publishes to, and the maintenance service
+// that moves rows between them. Tests reach into archiveDir directly because
+// the threat this package defends against is someone who can write there.
+type evidenceFixture struct {
+	service    *maintenance.Service
+	store      *store.Store
+	archive    archive.ArchiveStore
+	archiveDir string
+}
+
+// newEvidenceFixture builds a service whose clock is far enough ahead of the
+// seeded rows that retention considers them expired.
+func newEvidenceFixture(t *testing.T) evidenceFixture {
+	t.Helper()
+	// context.Background: test lifecycle root, not a request path.
+	ctx := context.Background()
+	st, err := store.New(ctx, filepath.Join(t.TempDir(), "control.db"))
+	require.NoError(t, err)
+	t.Cleanup(st.Close)
+
+	archiveDir := t.TempDir()
+	archives, err := archive.New(archive.Config{
+		Backend: archive.BackendFilesystem, FilesystemPath: archiveDir,
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC().Add(120 * 24 * time.Hour)
+	return evidenceFixture{
+		service: maintenance.New(maintenance.Config{
+			Store: st, Archive: archives, Retention: 90 * 24 * time.Hour,
+			Now:        func() time.Time { return now },
+			BackupPath: t.TempDir(), BackupMaxLag: 26 * time.Hour,
+		}),
+		store: st, archive: archives, archiveDir: archiveDir,
+	}
+}
+
+// seedAuditRow appends one audited background operation so the chain has
+// something to anchor, archive and prune.
+func seedAuditRow(t *testing.T, st *store.Store) {
+	t.Helper()
+	operationID := ulid.Make().String()
+	_, err := st.RecordOperation(context.Background(), store.AuditOperation{
+		OperationID: operationID, Class: store.ClassBackgroundWriter,
+		ActorType: "control_worker", Origin: "in_process",
+		RequestDescriptor:    "maintenance.test.seed",
+		AuthorizationOutcome: store.AuthorizationNotApplicable,
+		Result:               store.ResultSuccess, ResultCode: "OK",
+	}, store.AuditEffect{
+		ResourceType: "security_posture", ResourceID: operationID,
+		Action: "INSPECT", Outcome: store.EffectApplied,
+	})
+	require.NoError(t, err)
+}
+
+// archivedRef returns the single archived object whose ref starts with prefix.
+func archivedRef(t *testing.T, archives archive.ArchiveStore, prefix string) string {
+	t.Helper()
+	infos, err := archives.List(context.Background())
+	require.NoError(t, err)
+	var found []string
+	for _, info := range infos {
+		if len(info.Ref) >= len(prefix) && info.Ref[:len(prefix)] == prefix {
+			found = append(found, info.Ref)
+		}
+	}
+	require.Len(t, found, 1, "matches-zero guard: exactly one %q object must be archived", prefix)
+	return found[0]
+}
+
+// TestVerifyAudit_FailsClosedWhenThePublishedAnchorIsMissing holds F19. An
+// anchor row asserts that a chain position was published where this database
+// cannot reach. If the object it names is gone, the assertion is unverifiable
+// — and a verification pass that returns success for it makes an intact chain
+// indistinguishable from one whose off-host evidence has been destroyed.
+func TestVerifyAudit_FailsClosedWhenThePublishedAnchorIsMissing(t *testing.T) {
+	fixture := newEvidenceFixture(t)
+	ctx := context.Background()
+	seedAuditRow(t, fixture.store)
+	require.NoError(t, fixture.service.AnchorAudit(ctx, jobs.Job{}))
+
+	anchorRef := archivedRef(t, fixture.archive, "audit-anchor-")
+	published, err := fixture.store.LatestAuditAnchor(ctx, store.DefaultAuditStream)
+	require.NoError(t, err)
+	require.Equal(t, anchorRef, published.ExternalRef)
+
+	// Remove the anchor object and its sidecar, exactly as losing or
+	// wiping the archive mount would.
+	require.NoError(t, os.Remove(filepath.Join(fixture.archiveDir, anchorRef)))
+	require.NoError(t, os.Remove(filepath.Join(fixture.archiveDir, anchorRef+".sha256")))
+
+	err = fixture.service.VerifyAudit(ctx, jobs.Job{})
+	require.Error(t, err, "a published anchor whose object is gone must fail verification")
+	assert.ErrorContains(t, err, anchorRef, "the operator must be told which object is missing")
+}
+
+// TestVerifyAudit_FailsClosedWhenThePublishedAnchorWasRewritten covers the
+// other half of the same trust boundary: the object is present but no longer
+// says what this database recorded it saying. Nothing in the archive can
+// settle that disagreement, because the archive is the side under suspicion.
+func TestVerifyAudit_FailsClosedWhenThePublishedAnchorWasRewritten(t *testing.T) {
+	fixture := newEvidenceFixture(t)
+	ctx := context.Background()
+	seedAuditRow(t, fixture.store)
+	require.NoError(t, fixture.service.AnchorAudit(ctx, jobs.Job{}))
+
+	published, err := fixture.store.LatestAuditAnchor(ctx, store.DefaultAuditStream)
+	require.NoError(t, err)
+	anchorPath := filepath.Join(fixture.archiveDir, published.ExternalRef)
+	raw, err := os.ReadFile(anchorPath)
+	require.NoError(t, err)
+
+	var document map[string]any
+	require.NoError(t, json.Unmarshal(raw, &document))
+	forgedHash := hex.EncodeToString(bytes.Repeat([]byte{0xAB}, sha256.Size))
+	require.NotEqual(t, document["row_hash"], forgedHash,
+		"matches-zero guard: the forged head must actually differ from the published one")
+	document["row_hash"] = forgedHash
+	rewritten, err := json.Marshal(document)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(anchorPath, append(rewritten, '\n'), 0o600))
+
+	err = fixture.service.VerifyAudit(ctx, jobs.Job{})
+	require.Error(t, err, "an anchor object that contradicts its recorded row must fail verification")
+	assert.ErrorContains(t, err, published.ExternalRef)
+}
+
+// TestVerifyAudit_SucceedsBeforeAnythingHasEverBeenAnchored is the positive
+// control for the branch above: on a fresh deployment no anchor has been
+// published, so there is no off-host object to be missing. Without this,
+// "fails closed" could be satisfied by refusing every deployment.
+func TestVerifyAudit_SucceedsBeforeAnythingHasEverBeenAnchored(t *testing.T) {
+	fixture := newEvidenceFixture(t)
+	ctx := context.Background()
+	seedAuditRow(t, fixture.store)
+
+	_, err := fixture.store.LatestAuditAnchor(ctx, store.DefaultAuditStream)
+	require.True(t, store.IsNotFound(err), "the fixture must have no anchor row yet")
+	infos, err := fixture.archive.List(ctx)
+	require.NoError(t, err)
+	require.Empty(t, infos, "the fixture must have an empty archive")
+
+	assert.NoError(t, fixture.service.VerifyAudit(ctx, jobs.Job{}),
+		"a never-anchored deployment is not a tampered one")
+}
+
+// TestVerifyAudit_FailsClosedWhenAnArchivedPrefixIsMissing extends the same
+// property to retention: the live rows a checkpoint covers were deleted on the
+// strength of the archived object, so its absence is destroyed evidence.
+func TestVerifyAudit_FailsClosedWhenAnArchivedPrefixIsMissing(t *testing.T) {
+	fixture := newEvidenceFixture(t)
+	ctx := context.Background()
+	seedAuditRow(t, fixture.store)
+	seedAuditRow(t, fixture.store)
+	require.NoError(t, fixture.service.RetainAudit(ctx, jobs.Job{}))
+
+	prefixRef := archivedRef(t, fixture.archive, "audit-prefix-")
+	checkpoints, err := fixture.store.ListAuditCheckpoints(ctx, store.DefaultAuditStream)
+	require.NoError(t, err)
+	require.Len(t, checkpoints, 1)
+	require.Equal(t, prefixRef, checkpoints[0].ArchiveRef)
+
+	require.NoError(t, os.Remove(filepath.Join(fixture.archiveDir, prefixRef)))
+	require.NoError(t, os.Remove(filepath.Join(fixture.archiveDir, prefixRef+".sha256")))
+
+	err = fixture.service.VerifyAudit(ctx, jobs.Job{})
+	require.Error(t, err, "a checkpoint whose archived prefix is gone must fail verification")
+	assert.ErrorContains(t, err, prefixRef)
+}
+
+// TestRetainAudit_RefusesToPruneWhenAnArchivedPrefixWasRewritten holds C2's
+// other half: the checkpoint's archive_digest is the durable, append-only copy
+// of what was archived, and it must be what verification compares against.
+// Rewriting the artifact and its colocated sidecar together leaves the archive
+// mount self-consistent, so any check that reads its expected value from the
+// mount passes — and more live evidence is then deleted on the strength of an
+// artifact nobody can vouch for.
+func TestRetainAudit_RefusesToPruneWhenAnArchivedPrefixWasRewritten(t *testing.T) {
+	fixture := newEvidenceFixture(t)
+	ctx := context.Background()
+	seedAuditRow(t, fixture.store)
+	seedAuditRow(t, fixture.store)
+	require.NoError(t, fixture.service.RetainAudit(ctx, jobs.Job{}))
+
+	prefixRef := archivedRef(t, fixture.archive, "audit-prefix-")
+	checkpoints, err := fixture.store.ListAuditCheckpoints(ctx, store.DefaultAuditStream)
+	require.NoError(t, err)
+	require.Len(t, checkpoints, 1)
+
+	forged := []byte(`{"operation_id":"the record the auditor was never meant to see"}` + "\n")
+	forgedSum := sha256.Sum256(forged)
+	require.NotEqual(t, checkpoints[0].ArchiveDigest, hex.EncodeToString(forgedSum[:]),
+		"matches-zero guard: the forged prefix must actually differ from the archived one")
+	require.NoError(t, os.WriteFile(filepath.Join(fixture.archiveDir, prefixRef), forged, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(fixture.archiveDir, prefixRef+".sha256"),
+		[]byte(hex.EncodeToString(forgedSum[:])), 0o600))
+
+	seedAuditRow(t, fixture.store)
+	err = fixture.service.RetainAudit(ctx, jobs.Job{})
+	require.Error(t, err, "retention must not delete more evidence while an archived prefix disagrees with its checkpoint")
+	assert.ErrorContains(t, err, prefixRef)
+}

--- a/internal/manifest/compiler.go
+++ b/internal/manifest/compiler.go
@@ -4,14 +4,17 @@ package manifest
 
 import (
 	"context"
+	"crypto/ecdh"
 	"errors"
 	"fmt"
 
 	"github.com/oklog/ulid/v2"
 
+	sdkcrypto "github.com/manchtools/power-manage-sdk/crypto"
 	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
 	sdkvalidate "github.com/manchtools/power-manage-sdk/validate"
 	"github.com/manchtools/power-manage/server/internal/actionparams"
+	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/store"
 	"google.golang.org/protobuf/proto"
 )
@@ -29,19 +32,34 @@ var validator = sdkvalidate.NewValidator()
 
 // Compiler turns an Action, ActionSet or Definition into complete manifests.
 type Compiler struct {
-	store *store.Store
+	store  *store.Store
+	atRest *pmcrypto.Encryptor
 }
 
 // New constructs a compiler. A missing store is a boot-time wiring error.
-func New(st *store.Store) *Compiler {
+func New(st *store.Store, atRest ...*pmcrypto.Encryptor) *Compiler {
 	if st == nil {
 		panic("manifest: store is required")
 	}
-	return &Compiler{store: st}
+	compiler := &Compiler{store: st}
+	if len(atRest) > 0 {
+		compiler.atRest = atRest[0]
+	}
+	return compiler
 }
 
 // Action creates the singleton manifest for one authored Action.
 func (c *Compiler) Action(ctx context.Context, id string) (*pmv1.Manifest, error) {
+	return c.action(ctx, "", id)
+}
+
+// ActionForDevice creates an agent-ready manifest whose classified fields are
+// sealed to deviceID before the caller can persist it.
+func (c *Compiler) ActionForDevice(ctx context.Context, deviceID, id string) (*pmv1.Manifest, error) {
+	return c.action(ctx, deviceID, id)
+}
+
+func (c *Compiler) action(ctx context.Context, deviceID, id string) (*pmv1.Manifest, error) {
 	if !validInput(ctx, id) {
 		return nil, ErrInvalidInput
 	}
@@ -49,7 +67,7 @@ func (c *Compiler) Action(ctx context.Context, id string) (*pmv1.Manifest, error
 	if err != nil {
 		return nil, err
 	}
-	action, err := compileAction(row)
+	action, err := c.compileAction(ctx, row, deviceID)
 	if err != nil {
 		return nil, err
 	}
@@ -68,6 +86,14 @@ func (c *Compiler) Action(ctx context.Context, id string) (*pmv1.Manifest, error
 
 // ActionSet flattens one set into a manifest in authored member order.
 func (c *Compiler) ActionSet(ctx context.Context, id string) (*pmv1.Manifest, error) {
+	return c.actionSet(ctx, "", id)
+}
+
+func (c *Compiler) ActionSetForDevice(ctx context.Context, deviceID, id string) (*pmv1.Manifest, error) {
+	return c.actionSet(ctx, deviceID, id)
+}
+
+func (c *Compiler) actionSet(ctx context.Context, deviceID, id string) (*pmv1.Manifest, error) {
 	if !validInput(ctx, id) {
 		return nil, ErrInvalidInput
 	}
@@ -79,12 +105,20 @@ func (c *Compiler) ActionSet(ctx context.Context, id string) (*pmv1.Manifest, er
 	if err != nil {
 		return nil, err
 	}
-	return compileSet(set, rows, &pmv1.ManifestProvenance{ActionSetId: id}, nil)
+	return c.compileSet(ctx, deviceID, set, rows, &pmv1.ManifestProvenance{ActionSetId: id}, nil)
 }
 
 // Definition creates one manifest per contained ActionSet. The Definition
 // schedule overrides each emitted manifest without rewriting its ActionSet.
 func (c *Compiler) Definition(ctx context.Context, id string) ([]*pmv1.Manifest, error) {
+	return c.definition(ctx, "", id)
+}
+
+func (c *Compiler) DefinitionForDevice(ctx context.Context, deviceID, id string) ([]*pmv1.Manifest, error) {
+	return c.definition(ctx, deviceID, id)
+}
+
+func (c *Compiler) definition(ctx context.Context, deviceID, id string) ([]*pmv1.Manifest, error) {
 	if !validInput(ctx, id) {
 		return nil, ErrInvalidInput
 	}
@@ -110,7 +144,7 @@ func (c *Compiler) Definition(ctx context.Context, id string) ([]*pmv1.Manifest,
 
 	manifests := make([]*pmv1.Manifest, 0, len(sets))
 	for _, set := range sets {
-		compiled, err := compileSet(set, actionsBySet[set.ID], &pmv1.ManifestProvenance{
+		compiled, err := c.compileSet(ctx, deviceID, set, actionsBySet[set.ID], &pmv1.ManifestProvenance{
 			DefinitionId: id,
 			ActionSetId:  set.ID,
 		}, definition.Schedule)
@@ -179,7 +213,7 @@ func FreshCopy(compiled *pmv1.Manifest) (*pmv1.Manifest, error) {
 	return finish(cloned)
 }
 
-func compileSet(set store.ActionSetRow, rows []store.ActionRow, provenance *pmv1.ManifestProvenance, scheduleOverride []byte) (*pmv1.Manifest, error) {
+func (c *Compiler) compileSet(ctx context.Context, deviceID string, set store.ActionSetRow, rows []store.ActionRow, provenance *pmv1.ManifestProvenance, scheduleOverride []byte) (*pmv1.Manifest, error) {
 	if len(rows) == 0 {
 		return nil, ErrEmptyManifest
 	}
@@ -203,7 +237,7 @@ func compileSet(set store.ActionSetRow, rows []store.ActionRow, provenance *pmv1
 		Occurrences:      make([]*pmv1.ManifestOccurrence, 0, len(rows)),
 	}
 	for _, row := range rows {
-		action, err := compileAction(row)
+		action, err := c.compileAction(ctx, row, deviceID)
 		if err != nil {
 			return nil, err
 		}
@@ -212,7 +246,7 @@ func compileSet(set store.ActionSetRow, rows []store.ActionRow, provenance *pmv1
 	return finish(manifest)
 }
 
-func compileAction(row store.ActionRow) (*pmv1.Action, error) {
+func (c *Compiler) compileAction(ctx context.Context, row store.ActionRow, deviceID string) (*pmv1.Action, error) {
 	schedule, err := actionparams.ParseSchedule(row.Schedule)
 	if err != nil {
 		return nil, fmt.Errorf("manifest: action %s schedule: %w", row.ID, err)
@@ -224,13 +258,104 @@ func compileAction(row store.ActionRow) (*pmv1.Action, error) {
 		TimeoutSeconds: row.TimeoutSeconds,
 		Schedule:       schedule,
 	}
-	if err := actionparams.PopulateAction(action, row.ActionType, row.Params); err != nil {
-		return nil, fmt.Errorf("manifest: action %s params: %w", row.ID, err)
+	switch action.Type {
+	case pmv1.ActionType_ACTION_TYPE_ENCRYPTION:
+		params, err := c.encryptionParams(ctx, deviceID, row)
+		if err != nil {
+			return nil, fmt.Errorf("manifest: action %s params: %w", row.ID, err)
+		}
+		action.Params = &pmv1.Action_Encryption{Encryption: params}
+	case pmv1.ActionType_ACTION_TYPE_WIFI:
+		params, err := c.wifiParams(ctx, deviceID, row)
+		if err != nil {
+			return nil, fmt.Errorf("manifest: action %s params: %w", row.ID, err)
+		}
+		action.Params = &pmv1.Action_Wifi{Wifi: params}
+	default:
+		if err := actionparams.PopulateAction(action, row.ActionType, row.Params); err != nil {
+			return nil, fmt.Errorf("manifest: action %s params: %w", row.ID, err)
+		}
 	}
 	if detail, ok := sdkvalidate.Struct(validator, action); !ok {
 		return nil, fmt.Errorf("manifest: action %s invalid: %s", row.ID, detail)
 	}
 	return action, nil
+}
+
+func (c *Compiler) encryptionParams(ctx context.Context, deviceID string, row store.ActionRow) (*pmv1.EncryptionParams, error) {
+	stored := &pmv1.EncryptionAuthoringParams{}
+	if err := actionparams.UnmarshalActionParams(row.Params, stored); err != nil {
+		return nil, err
+	}
+	sealed, err := c.sealActionField(ctx, deviceID, row.ID, "powermanage.v1.EncryptionParams",
+		"preshared_key", stored.GetPresharedKey(), pmcrypto.PurposeActionEncryptionPresharedKey)
+	if err != nil {
+		return nil, err
+	}
+	return &pmv1.EncryptionParams{
+		PresharedKey: sealed, RotationIntervalDays: stored.RotationIntervalDays,
+		MinWords: stored.MinWords, DeviceBoundKeyType: stored.DeviceBoundKeyType,
+		UserPassphraseMinLength:  stored.UserPassphraseMinLength,
+		UserPassphraseComplexity: stored.UserPassphraseComplexity,
+	}, nil
+}
+
+func (c *Compiler) wifiParams(ctx context.Context, deviceID string, row store.ActionRow) (*pmv1.WifiParams, error) {
+	stored := &pmv1.WifiAuthoringParams{}
+	if err := actionparams.UnmarshalActionParams(row.Params, stored); err != nil {
+		return nil, err
+	}
+	params := &pmv1.WifiParams{
+		Ssid: stored.Ssid, AuthType: stored.AuthType, CaCert: stored.CaCert,
+		ClientCert: stored.ClientCert, Identity: stored.Identity,
+		AutoConnect: stored.AutoConnect, Hidden: stored.Hidden, Priority: stored.Priority,
+	}
+	var err error
+	switch stored.AuthType {
+	case pmv1.WifiAuthType_WIFI_AUTH_TYPE_PSK:
+		params.Psk, err = c.sealActionField(ctx, deviceID, row.ID, "powermanage.v1.WifiParams",
+			"psk", stored.GetPsk(), pmcrypto.PurposeActionWifiPSK)
+	case pmv1.WifiAuthType_WIFI_AUTH_TYPE_EAP_TLS:
+		params.ClientKey, err = c.sealActionField(ctx, deviceID, row.ID, "powermanage.v1.WifiParams",
+			"client_key", stored.GetClientKey(), pmcrypto.PurposeActionWifiClientKey)
+	default:
+		return nil, errors.New("unsupported WiFi authentication type")
+	}
+	return params, err
+}
+
+func (c *Compiler) sealActionField(ctx context.Context, deviceID, actionID, message, field, ciphertext, purpose string) (*pmv1.SealedValue, error) {
+	if c.atRest == nil || !validInput(ctx, deviceID) || !pmcrypto.IsEncryptedValue(ciphertext) {
+		return nil, errors.New("action secret compiler requires encrypted storage and a target device")
+	}
+	plaintext, err := c.atRest.DecryptWithContext(ciphertext, pmcrypto.RowAAD(actionID, purpose))
+	if err != nil {
+		return nil, fmt.Errorf("decrypt action credential: %w", err)
+	}
+	secret := []byte(plaintext)
+	defer clear(secret)
+	recipient, err := c.deviceRecipient(ctx, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	aad, info, err := sdkcrypto.FieldSealContext(sdkcrypto.DirectionControlToAgent,
+		message, field, deviceID, actionID)
+	if err != nil {
+		return nil, err
+	}
+	sealed, err := sdkcrypto.SealToPublicKey(recipient, secret, aad, info)
+	if err != nil {
+		return nil, fmt.Errorf("seal action credential: %w", err)
+	}
+	return &pmv1.SealedValue{Version: 1, Ciphertext: sealed}, nil
+}
+
+func (c *Compiler) deviceRecipient(ctx context.Context, deviceID string) (*ecdh.PublicKey, error) {
+	device, err := c.store.GetDevice(ctx, deviceID)
+	if err != nil {
+		return nil, err
+	}
+	return sdkcrypto.ParseX25519PublicKey(device.AgentSealingPublicKey)
 }
 
 func requiredSchedule(raw []byte) (*pmv1.ActionSchedule, error) {

--- a/internal/store/action_handlers_test.go
+++ b/internal/store/action_handlers_test.go
@@ -16,8 +16,10 @@ import (
 
 	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
 	"github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1/powermanagev1connect"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
 	"github.com/manchtools/power-manage/server/internal/auth"
 	"github.com/manchtools/power-manage/server/internal/authoring"
+	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
 
@@ -35,8 +37,10 @@ func newActionHandlerFixture(t *testing.T) *actionHandlerFixture {
 	st, raw := setupSQLite(t)
 	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
 	f := &actionHandlerFixture{t: t, store: st, raw: raw, now: now, actorID: newID()}
+	atRest, err := pmcrypto.NewEncryptor("0202020202020202020202020202020202020202020202020202020202020202")
+	require.NoError(t, err)
 	f.handlers = authoring.NewHandlers(authoring.HandlersConfig{
-		Store: st, Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Store: st, AtRest: atRest, Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Now: func() time.Time { return now },
 	})
 	return f
@@ -126,6 +130,87 @@ func TestActionHandlers_CRUDIsDirectAuditedState(t *testing.T) {
 		require.NoError(t, err, procedure)
 		assert.NotEmpty(t, effects, procedure)
 	}
+}
+
+func TestActionHandlers_ActionCredentialsAreWriteOnlyAndEncryptedAtRest(t *testing.T) {
+	f := newActionHandlerFixture(t)
+	ctx := f.actor("CreateAction", "GetAction", "UpdateActionParams")
+	_, err := f.handlers.CreateAction(ctx, connect.NewRequest(&pmv1.CreateActionRequest{
+		Name: "missing key", Type: pmv1.ActionType_ACTION_TYPE_ENCRYPTION,
+		DesiredState: pmv1.DesiredState_DESIRED_STATE_PRESENT,
+	}))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+
+	diskKey := "correct horse battery staple"
+	created, err := f.handlers.CreateAction(ctx, connect.NewRequest(&pmv1.CreateActionRequest{
+		Name: "disk ownership", Type: pmv1.ActionType_ACTION_TYPE_ENCRYPTION,
+		DesiredState: pmv1.DesiredState_DESIRED_STATE_PRESENT,
+		Params: &pmv1.CreateActionRequest_Encryption{Encryption: &pmv1.EncryptionAuthoringParams{
+			PresharedKey: &diskKey, RotationIntervalDays: 30, MinWords: 5,
+		}},
+	}))
+	require.NoError(t, err)
+	require.True(t, created.Msg.Action.GetEncryption().PresharedKeyConfigured)
+
+	var before string
+	require.NoError(t, f.raw.QueryRow(context.Background(),
+		`SELECT params FROM actions WHERE id = $1`, created.Msg.Action.Id).Scan(&before))
+	assert.NotContains(t, before, diskKey)
+	assert.Contains(t, before, "enc:v1:")
+	beforeParams := &pmv1.EncryptionAuthoringParams{}
+	require.NoError(t, actionparams.UnmarshalActionParams([]byte(before), beforeParams))
+
+	updated, err := f.handlers.UpdateActionParams(ctx, connect.NewRequest(&pmv1.UpdateActionParamsRequest{
+		Id: created.Msg.Action.Id, DesiredState: pmv1.DesiredState_DESIRED_STATE_PRESENT,
+		Params: &pmv1.UpdateActionParamsRequest_Encryption{Encryption: &pmv1.EncryptionAuthoringParams{
+			RotationIntervalDays: 60, MinWords: 6,
+		}},
+	}))
+	require.NoError(t, err)
+	assert.True(t, updated.Msg.Action.GetEncryption().PresharedKeyConfigured)
+	var after string
+	require.NoError(t, f.raw.QueryRow(context.Background(),
+		`SELECT params FROM actions WHERE id = $1`, created.Msg.Action.Id).Scan(&after))
+	assert.Contains(t, after, "enc:v1:")
+	afterParams := &pmv1.EncryptionAuthoringParams{}
+	require.NoError(t, actionparams.UnmarshalActionParams([]byte(after), afterParams))
+	assert.Equal(t, beforeParams.GetPresharedKey(), afterParams.GetPresharedKey(),
+		"omitting the write-only input must preserve the existing ciphertext")
+
+	wifiPSK := "wireless-secret"
+	wifi, err := f.handlers.CreateAction(ctx, connect.NewRequest(&pmv1.CreateActionRequest{
+		Name: "office WiFi", Type: pmv1.ActionType_ACTION_TYPE_WIFI,
+		DesiredState: pmv1.DesiredState_DESIRED_STATE_PRESENT,
+		Params: &pmv1.CreateActionRequest_Wifi{Wifi: &pmv1.WifiAuthoringParams{
+			Ssid: "office", AuthType: pmv1.WifiAuthType_WIFI_AUTH_TYPE_PSK,
+			Psk: &wifiPSK, AutoConnect: true,
+		}},
+	}))
+	require.NoError(t, err)
+	assert.True(t, wifi.Msg.Action.GetWifi().PskConfigured)
+	assert.False(t, wifi.Msg.Action.GetWifi().ClientKeyConfigured)
+
+	clientKey := "-----BEGIN PRIVATE KEY-----\nsecret\n-----END PRIVATE KEY-----"
+	updatedWifi, err := f.handlers.UpdateActionParams(ctx, connect.NewRequest(&pmv1.UpdateActionParamsRequest{
+		Id: wifi.Msg.Action.Id, DesiredState: pmv1.DesiredState_DESIRED_STATE_PRESENT,
+		Params: &pmv1.UpdateActionParamsRequest_Wifi{Wifi: &pmv1.WifiAuthoringParams{
+			Ssid: "office", AuthType: pmv1.WifiAuthType_WIFI_AUTH_TYPE_EAP_TLS,
+			ClientKey: &clientKey, Identity: "device@example.test", AutoConnect: true,
+		}},
+	}))
+	require.NoError(t, err)
+	assert.False(t, updatedWifi.Msg.Action.GetWifi().PskConfigured)
+	assert.True(t, updatedWifi.Msg.Action.GetWifi().ClientKeyConfigured)
+	var wifiStored string
+	require.NoError(t, f.raw.QueryRow(context.Background(),
+		`SELECT params FROM actions WHERE id = $1`, updatedWifi.Msg.Action.Id).Scan(&wifiStored))
+	assert.NotContains(t, wifiStored, wifiPSK)
+	assert.NotContains(t, wifiStored, clientKey)
+	storedWifi := &pmv1.WifiAuthoringParams{}
+	require.NoError(t, actionparams.UnmarshalActionParams([]byte(wifiStored), storedWifi))
+	assert.Nil(t, storedWifi.Psk, "switching auth mode clears the now-irrelevant secret")
+	assert.True(t, pmcrypto.IsEncryptedValue(storedWifi.GetClientKey()))
 }
 
 func TestActionHandlers_KeysetFiltersAndObjectScope(t *testing.T) {

--- a/internal/store/action_handlers_test.go
+++ b/internal/store/action_handlers_test.go
@@ -141,6 +141,24 @@ func TestActionHandlers_ActionCredentialsAreWriteOnlyAndEncryptedAtRest(t *testi
 	}))
 	require.Error(t, err)
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	alreadyEncrypted := "enc:v1:caller-supplied-envelope"
+	_, err = f.handlers.CreateAction(ctx, connect.NewRequest(&pmv1.CreateActionRequest{
+		Name: "double wrapped disk key", Type: pmv1.ActionType_ACTION_TYPE_ENCRYPTION,
+		DesiredState: pmv1.DesiredState_DESIRED_STATE_PRESENT,
+		Params: &pmv1.CreateActionRequest_Encryption{Encryption: &pmv1.EncryptionAuthoringParams{
+			PresharedKey: &alreadyEncrypted,
+		}},
+	}))
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
+		"a client cannot smuggle an envelope through the plaintext authoring boundary")
+	_, err = f.handlers.CreateAction(ctx, connect.NewRequest(&pmv1.CreateActionRequest{
+		Name: "double wrapped WiFi key", Type: pmv1.ActionType_ACTION_TYPE_WIFI,
+		DesiredState: pmv1.DesiredState_DESIRED_STATE_PRESENT,
+		Params: &pmv1.CreateActionRequest_Wifi{Wifi: &pmv1.WifiAuthoringParams{
+			Ssid: "office", AuthType: pmv1.WifiAuthType_WIFI_AUTH_TYPE_PSK, Psk: &alreadyEncrypted,
+		}},
+	}))
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 
 	diskKey := "correct horse battery staple"
 	created, err := f.handlers.CreateAction(ctx, connect.NewRequest(&pmv1.CreateActionRequest{

--- a/internal/store/audit.go
+++ b/internal/store/audit.go
@@ -73,6 +73,13 @@ var (
 	// ErrAuditEffectRequired means a continuation appended no effect,
 	// so it would have recorded nothing.
 	ErrAuditEffectRequired = errors.New("audit effect required")
+	// ErrAuditEffectInvalid means an effect carried a reference that is
+	// not a row id. The schema enforces the same shape, but only at
+	// INSERT time — by then the effect and the operation are inside one
+	// transaction, so the whole audited call rolls back and the caller
+	// sees a database error rather than the bad reference. Refusing in
+	// Go makes the offending call site fail where it can be read.
+	ErrAuditEffectInvalid = errors.New("audit effect is invalid")
 	// ErrAuditChainBroken means verification found a row whose hash,
 	// linkage or position does not follow from its predecessor.
 	ErrAuditChainBroken = errors.New("audit chain broken")
@@ -264,6 +271,9 @@ func (s *Store) WithAudit(
 		prev = hash
 
 		for i, e := range rec.effects {
+			if err := e.validate(); err != nil {
+				return fmt.Errorf("audit: effect %d: %w", i, err)
+			}
 			seq++
 			effectID := ulid.Make().String()
 			ec := e.canonical(op.Stream, op.OperationID, effectID, seq, int64(i), at)
@@ -304,6 +314,13 @@ func (s *Store) WithAudit(
 // mutation. Sensitive reads and rejected authentication attempts use
 // it; they are audited operations that change nothing.
 func (s *Store) RecordOperation(ctx context.Context, op AuditOperation, effects ...AuditEffect) (AuditRecord, error) {
+	// Every effect is known here, so a malformed one is refused before the
+	// transaction opens — the same standing rule op.validate() follows.
+	for i, e := range effects {
+		if err := e.validate(); err != nil {
+			return AuditRecord{}, fmt.Errorf("audit: effect %d: %w", i, err)
+		}
+	}
 	return s.WithAudit(ctx, op, func(_ context.Context, _ *Tx, rec *AuditRecorder) error {
 		for _, e := range effects {
 			rec.Effect(e)
@@ -370,6 +387,9 @@ func (s *Store) WithAuditEffects(
 		at := s.auditNow()
 		prev, seq := head.HeadHash, head.Height
 		for i, e := range rec.effects {
+			if err := e.validate(); err != nil {
+				return fmt.Errorf("audit: effect %d: %w", i, err)
+			}
 			seq++
 			effectID := ulid.Make().String()
 			pos := nextEffectSeq + int64(i)
@@ -426,6 +446,32 @@ func (op AuditOperation) validate() error {
 		return fmt.Errorf("%w: authorization outcome is unset", ErrAuditOperationRequired)
 	case op.Result == "":
 		return fmt.Errorf("%w: result is unset", ErrAuditOperationRequired)
+	}
+	return nil
+}
+
+// validate rejects an effect whose reference columns are not row ids.
+//
+// before_ref and after_ref name ANOTHER ROW; they are the one part of an
+// effect the schema constrains to a ULID, and they are therefore the one
+// part a caller can quietly misuse as a free-text field. When that happens
+// the INSERT aborts inside the audited transaction and takes the operation
+// row with it, so the call site's only symptom is an error it usually logs
+// and swallows — the audit record simply never exists. A discriminator
+// belongs in the operation's result code or in the effect's action.
+func (e AuditEffect) validate() error {
+	for _, ref := range []struct {
+		column string
+		value  *string
+	}{{"before_ref", e.BeforeRef}, {"after_ref", e.AfterRef}} {
+		if ref.value == nil {
+			continue
+		}
+		if _, err := ulid.ParseStrict(*ref.value); err != nil {
+			// The value itself stays out of the message: it is the caller's
+			// data, and this error reaches ordinary error logs.
+			return fmt.Errorf("%w: %s must be a ULID naming another row", ErrAuditEffectInvalid, ref.column)
+		}
 	}
 	return nil
 }

--- a/internal/store/compliance.go
+++ b/internal/store/compliance.go
@@ -1,0 +1,38 @@
+package store
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/manchtools/power-manage/server/internal/store/generated"
+)
+
+// RefreshDeviceCompliance recomputes each named device's compliance summary
+// from the rows that remain and refreshes its search document, in the caller's
+// transaction.
+//
+// Compliance evidence is removed from more than one place — an action retires,
+// a policy retires — and the summary derived from it must not outlive the rows
+// it summarises: a device left reporting NON_COMPLIANT with no failing check to
+// point at is as wrong as one reporting UNKNOWN after it failed.
+//
+// Deletion carries no check time, so the stored one is left alone unless the
+// device has no live check at all, in which case it is cleared with the rest.
+func RefreshDeviceCompliance(ctx context.Context, tx *Tx, rec *AuditRecorder, deviceIDs ...[]string) error {
+	seen := make(map[string]struct{})
+	for _, ids := range deviceIDs {
+		for _, id := range ids {
+			if _, done := seen[id]; done {
+				continue
+			}
+			seen[id] = struct{}{}
+			if _, err := tx.RefreshDeviceComplianceStatus(ctx, generated.RefreshDeviceComplianceStatusParams{
+				DeviceID: id,
+			}); err != nil {
+				return fmt.Errorf("refresh device compliance: %w", err)
+			}
+			rec.RefreshSearch("device", id)
+		}
+	}
+	return nil
+}

--- a/internal/store/compliance_ingest_test.go
+++ b/internal/store/compliance_ingest_test.go
@@ -1,0 +1,400 @@
+package store_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
+	"github.com/manchtools/power-manage/server/internal/authoring"
+	"github.com/manchtools/power-manage/server/internal/compliance"
+	"github.com/manchtools/power-manage/server/internal/delivery"
+	"github.com/manchtools/power-manage/server/internal/execution"
+)
+
+// complianceIngestFixture drives the real ingestion path: an agent result
+// arrives at the execution service and the answer is read back through the
+// mounted compliance RPCs. No test in this package writes compliance_results
+// or compliance_policy_evaluation itself, so a missing writer cannot be masked
+// by a manufactured row. TestComplianceStateHasOneWriter guards that.
+type complianceIngestFixture struct {
+	*deviceHandlerFixture
+	service *execution.Service
+	ctx     context.Context
+}
+
+func newComplianceIngestFixture(t *testing.T) *complianceIngestFixture {
+	t.Helper()
+	f := newDeviceHandlerFixture(t)
+	return &complianceIngestFixture{
+		deviceHandlerFixture: f,
+		service:              execution.New(execution.Config{Store: f.store, Now: func() time.Time { return f.now }}),
+		ctx:                  f.actor("GetDeviceCompliance", "GetDeviceCompliancePolicyStatus"),
+	}
+}
+
+// complianceAction authors a detection-only SHELL action exactly as the
+// authoring layer would: is_compliance with a non-empty detection script.
+func (f *complianceIngestFixture) complianceAction(t *testing.T, name string) string {
+	t.Helper()
+	return f.shellAction(t, name, &pmv1.ShellParams{DetectionScript: "test -f /etc/os-release", IsCompliance: true})
+}
+
+func (f *complianceIngestFixture) shellAction(t *testing.T, name string, shell *pmv1.ShellParams) string {
+	t.Helper()
+	id := newID()
+	params, err := actionparams.MarshalActionParams(shell)
+	require.NoError(t, err)
+	_, err = f.raw.Exec(context.Background(), `
+		INSERT INTO actions (id, name, action_type, params, created_at, created_by)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		id, name, int32(pmv1.ActionType_ACTION_TYPE_SHELL), string(params), f.now, f.actorID)
+	require.NoError(t, err)
+	return id
+}
+
+func (f *complianceIngestFixture) policy(t *testing.T, name string, rules map[string]int32) string {
+	t.Helper()
+	id := newID()
+	_, err := f.raw.Exec(context.Background(), `
+		INSERT INTO compliance_policies (id, name, created_at, created_by)
+		VALUES ($1, $2, $3, $4)`, id, name, f.now, f.actorID)
+	require.NoError(t, err)
+	for actionID, grace := range rules {
+		_, err = f.raw.Exec(context.Background(), `
+			INSERT INTO compliance_policy_rules (policy_id, action_id, grace_period_hours, added_at)
+			VALUES ($1, $2, $3, $4)`, id, actionID, grace, f.now)
+		require.NoError(t, err)
+	}
+	return id
+}
+
+// report runs one occurrence of an action on a device end to end: a delivery
+// the agent acknowledged, an execution row, and the agent's ActionResult
+// applied through the real execution service.
+func (f *complianceIngestFixture) report(
+	t *testing.T, deviceID, actionID string,
+	status pmv1.ExecutionStatus, compliant bool,
+	detection *pmv1.CommandOutput, at time.Time,
+) {
+	t.Helper()
+	occurrenceID, deliveryID, manifestID := newID(), newID(), newID()
+	manifest, err := protojson.Marshal(&pmv1.Manifest{
+		ManifestId: manifestID,
+		Occurrences: []*pmv1.ManifestOccurrence{{
+			OccurrenceId: occurrenceID,
+			Action: &pmv1.Action{
+				Id: &pmv1.ActionId{Value: actionID}, Type: pmv1.ActionType_ACTION_TYPE_SHELL,
+			},
+		}},
+	})
+	require.NoError(t, err)
+	_, err = f.raw.Exec(context.Background(), `
+		INSERT INTO deliveries (
+			delivery_id, device_id, manifest_id, manifest, state,
+			created_at, available_at, pushed_at, acked_receipt_at
+		) VALUES ($1, $2, $3, $4, $5, $6, $6, $6, $6)`,
+		deliveryID, deviceID, manifestID, string(manifest), delivery.StateAckedReceipt, f.now)
+	require.NoError(t, err)
+	_, err = f.raw.Exec(context.Background(), `
+		INSERT INTO executions (
+			id, delivery_id, device_id, action_id, action_type, desired_state, params,
+			timeout_seconds, status, created_at, created_by_type, created_by_id
+		) VALUES ($1, $2, $3, $4, $5, 0, '{}', 300, 'pending', $6, 'user', $7)`,
+		occurrenceID, deliveryID, deviceID, actionID,
+		int32(pmv1.ActionType_ACTION_TYPE_SHELL), f.now, f.actorID)
+	require.NoError(t, err)
+
+	result := &pmv1.ActionResult{
+		ActionId: &pmv1.ActionId{Value: actionID}, Status: status,
+		DeliveryId: deliveryID, OccurrenceId: occurrenceID,
+		CompletedAt: timestamppb.New(at), Compliant: compliant, DetectionOutput: detection,
+	}
+	require.NoError(t, f.service.ApplyActionResult(context.Background(), deviceID, result))
+}
+
+func (f *complianceIngestFixture) compliance(t *testing.T, deviceID string) *pmv1.GetDeviceComplianceResponse {
+	t.Helper()
+	response, err := f.handlers.GetDeviceCompliance(f.ctx,
+		connect.NewRequest(&pmv1.GetDeviceComplianceRequest{DeviceId: deviceID}))
+	require.NoError(t, err)
+	return response.Msg
+}
+
+func (f *complianceIngestFixture) policyStatus(t *testing.T, deviceID string) *pmv1.GetDeviceCompliancePolicyStatusResponse {
+	t.Helper()
+	response, err := f.handlers.GetDeviceCompliancePolicyStatus(f.ctx,
+		connect.NewRequest(&pmv1.GetDeviceCompliancePolicyStatusRequest{DeviceId: deviceID}))
+	require.NoError(t, err)
+	return response.Msg
+}
+
+func (f *complianceIngestFixture) searchStatus(t *testing.T, deviceID string) string {
+	t.Helper()
+	var status string
+	require.NoError(t, f.raw.QueryRow(context.Background(), `
+		SELECT json_extract(fields, '$.compliance_status') FROM search_documents
+		WHERE scope = 'devices' AND entity_id = $1`, deviceID).Scan(&status))
+	return status
+}
+
+// A device that ran a compliance check and failed it must report failing —
+// through the RPC an auditor reads, and in the search document the fleet list
+// renders. Reporting UNKNOWN with zero checks is a confident wrong answer.
+func TestComplianceIngest_FailedCheckIsReadableThroughTheRPCs(t *testing.T) {
+	f := newComplianceIngestFixture(t)
+	actionID := f.complianceAction(t, "os-release present")
+	policyID := f.policy(t, "baseline", map[string]int32{actionID: 0})
+
+	f.report(t, f.groupID, actionID, pmv1.ExecutionStatus_EXECUTION_STATUS_FAILED, false,
+		&pmv1.CommandOutput{ExitCode: 1, Stderr: "missing"}, f.now)
+
+	compliance := f.compliance(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, compliance.Status)
+	require.Len(t, compliance.Checks, 1)
+	assert.Equal(t, actionID, compliance.Checks[0].ActionId)
+	assert.Equal(t, "os-release present", compliance.Checks[0].ActionName)
+	assert.False(t, compliance.Checks[0].Compliant)
+	require.NotNil(t, compliance.Checks[0].DetectionOutput)
+	assert.Equal(t, int32(1), compliance.Checks[0].DetectionOutput.ExitCode)
+	assert.True(t, compliance.Checks[0].CheckedAt.AsTime().Equal(f.now))
+
+	status := f.policyStatus(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, status.OverallStatus)
+	require.Len(t, status.Policies, 1)
+	assert.Equal(t, policyID, status.Policies[0].PolicyId)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, status.Policies[0].Status)
+	require.Len(t, status.Policies[0].Rules, 1)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, status.Policies[0].Rules[0].Status)
+	assert.False(t, status.Policies[0].Rules[0].Compliant)
+	require.NotNil(t, status.Policies[0].Rules[0].FirstFailedAt)
+	assert.True(t, status.Policies[0].Rules[0].FirstFailedAt.AsTime().Equal(f.now))
+
+	assert.Equal(t, "2", f.searchStatus(t, f.groupID),
+		"the device search document must carry the real status, not a default")
+
+	device, err := f.store.GetDevice(context.Background(), f.groupID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(1), device.ComplianceTotal)
+	assert.Equal(t, int32(0), device.CompliancePassing)
+	require.NotNil(t, device.ComplianceCheckedAt)
+	assert.True(t, device.ComplianceCheckedAt.Equal(f.now))
+
+	assert.Contains(t, auditActions(t, f.raw, "device", f.groupID), "COMPLIANCE",
+		"a compliance state change is a mutation and needs audit evidence")
+}
+
+// Never-checked and checked-and-failed must not collapse into the same answer.
+func TestComplianceIngest_UncheckedDeviceStaysUnknown(t *testing.T) {
+	f := newComplianceIngestFixture(t)
+	actionID := f.complianceAction(t, "os-release present")
+	f.policy(t, "baseline", map[string]int32{actionID: 0})
+
+	unchecked := f.compliance(t, f.directID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_UNKNOWN, unchecked.Status)
+	assert.Empty(t, unchecked.Checks)
+	assert.Empty(t, f.policyStatus(t, f.directID).Policies)
+
+	f.report(t, f.groupID, actionID, pmv1.ExecutionStatus_EXECUTION_STATUS_SUCCESS, true,
+		&pmv1.CommandOutput{ExitCode: 0, Stdout: "ok"}, f.now)
+
+	checked := f.compliance(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_COMPLIANT, checked.Status)
+	require.Len(t, checked.Checks, 1)
+	assert.True(t, checked.Checks[0].Compliant)
+	assert.Equal(t, "1", f.searchStatus(t, f.groupID))
+
+	still := f.compliance(t, f.directID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_UNKNOWN, still.Status,
+		"one device's finding must not be attributed to another")
+	assert.Empty(t, still.Checks)
+	assert.Equal(t, "0", f.searchStatus(t, f.directID))
+}
+
+// The grace period runs from the first failure, survives a re-check, and is
+// discarded the moment the device comes back into compliance.
+func TestComplianceIngest_GracePeriodTracksRecheckAndRecovery(t *testing.T) {
+	f := newComplianceIngestFixture(t)
+	actionID := f.complianceAction(t, "graced check")
+	f.policy(t, "baseline", map[string]int32{actionID: 4})
+	firstFailure := f.now.Add(-3 * time.Hour)
+
+	f.report(t, f.groupID, actionID, pmv1.ExecutionStatus_EXECUTION_STATUS_FAILED, false,
+		&pmv1.CommandOutput{ExitCode: 1}, firstFailure)
+	rule := f.policyStatus(t, f.groupID).Policies[0].Rules[0]
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_IN_GRACE_PERIOD, rule.Status)
+	require.NotNil(t, rule.FirstFailedAt)
+	assert.True(t, rule.FirstFailedAt.AsTime().Equal(firstFailure))
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_IN_GRACE_PERIOD,
+		f.compliance(t, f.groupID).Status)
+	assert.Equal(t, "3", f.searchStatus(t, f.groupID))
+
+	// Still failing two hours later: inside the four-hour grace, and the clock
+	// must not restart on the re-check.
+	f.report(t, f.groupID, actionID, pmv1.ExecutionStatus_EXECUTION_STATUS_FAILED, false,
+		&pmv1.CommandOutput{ExitCode: 1}, firstFailure.Add(2*time.Hour))
+	rule = f.policyStatus(t, f.groupID).Policies[0].Rules[0]
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_IN_GRACE_PERIOD, rule.Status)
+	assert.True(t, rule.FirstFailedAt.AsTime().Equal(firstFailure))
+
+	// Still failing after the grace expires.
+	f.report(t, f.groupID, actionID, pmv1.ExecutionStatus_EXECUTION_STATUS_FAILED, false,
+		&pmv1.CommandOutput{ExitCode: 1}, firstFailure.Add(5*time.Hour))
+	rule = f.policyStatus(t, f.groupID).Policies[0].Rules[0]
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, rule.Status)
+	assert.True(t, rule.FirstFailedAt.AsTime().Equal(firstFailure))
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT,
+		f.compliance(t, f.groupID).Status)
+
+	// Recovery clears the failure entirely.
+	f.report(t, f.groupID, actionID, pmv1.ExecutionStatus_EXECUTION_STATUS_SUCCESS, true,
+		&pmv1.CommandOutput{ExitCode: 0}, firstFailure.Add(6*time.Hour))
+	rule = f.policyStatus(t, f.groupID).Policies[0].Rules[0]
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_COMPLIANT, rule.Status)
+	assert.Nil(t, rule.FirstFailedAt)
+	compliance := f.compliance(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_COMPLIANT, compliance.Status)
+	require.Len(t, compliance.Checks, 1)
+	assert.True(t, compliance.Checks[0].Compliant)
+	assert.Equal(t, "1", f.searchStatus(t, f.groupID))
+}
+
+// Detection-only means the only evidence of compliance is a detection script
+// that ran and passed. Every other terminal outcome fails closed.
+func TestComplianceIngest_FailsClosedWhenDetectionNeverRan(t *testing.T) {
+	f := newComplianceIngestFixture(t)
+	actionID := f.complianceAction(t, "unrunnable check")
+	f.policy(t, "baseline", map[string]int32{actionID: 24})
+
+	// The agent could not run the detection script at all: no detection output,
+	// and the compliance flag it reports is the zero value.
+	f.report(t, f.groupID, actionID, pmv1.ExecutionStatus_EXECUTION_STATUS_FAILED, false, nil, f.now)
+
+	compliance := f.compliance(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_IN_GRACE_PERIOD, compliance.Status)
+	require.Len(t, compliance.Checks, 1)
+	assert.False(t, compliance.Checks[0].Compliant)
+	assert.Nil(t, compliance.Checks[0].DetectionOutput)
+
+	// A timeout is not evidence of compliance either, even if the agent's
+	// compliant flag were somehow set.
+	other := f.complianceAction(t, "timed out check")
+	f.policy(t, "second", map[string]int32{other: 0})
+	f.report(t, f.groupID, other, pmv1.ExecutionStatus_EXECUTION_STATUS_TIMEOUT, true,
+		&pmv1.CommandOutput{ExitCode: 0}, f.now)
+	checks := f.compliance(t, f.groupID).Checks
+	require.Len(t, checks, 2)
+	for _, check := range checks {
+		assert.False(t, check.Compliant, "no terminal outcome but success proves compliance")
+	}
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, f.compliance(t, f.groupID).Status)
+}
+
+// Deleting the check or the policy it belongs to removes the evidence, so the
+// device summary derived from that evidence has to follow. A device left
+// reporting NON_COMPLIANT with nothing to point at is the same confident wrong
+// answer in the other direction.
+func TestComplianceIngest_RemovingTheEvidenceClearsTheDeviceStatus(t *testing.T) {
+	f := newComplianceIngestFixture(t)
+	actions := authoring.New(authoring.Config{Store: f.store, Now: func() time.Time { return f.now }})
+	policies := compliance.NewState(compliance.StateConfig{Store: f.store, Now: func() time.Time { return f.now }})
+
+	policyActionID := f.complianceAction(t, "policy check")
+	directActionID := f.complianceAction(t, "direct check")
+	policyID := f.policy(t, "baseline", map[string]int32{policyActionID: 0})
+	f.report(t, f.groupID, policyActionID, pmv1.ExecutionStatus_EXECUTION_STATUS_FAILED, false,
+		&pmv1.CommandOutput{ExitCode: 1}, f.now)
+	f.report(t, f.groupID, directActionID, pmv1.ExecutionStatus_EXECUTION_STATUS_SUCCESS, true,
+		&pmv1.CommandOutput{ExitCode: 0}, f.now)
+	require.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, f.compliance(t, f.groupID).Status)
+
+	require.NoError(t, policies.Delete(context.Background(), mutationOp(), policyID))
+	afterPolicy := f.compliance(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, afterPolicy.Status,
+		"the failing check itself survives its policy")
+	assert.Len(t, afterPolicy.Checks, 2)
+	assert.Empty(t, f.policyStatus(t, f.groupID).Policies)
+
+	require.NoError(t, actions.DeleteAction(context.Background(), mutationOp(), policyActionID, false))
+	afterAction := f.compliance(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_COMPLIANT, afterAction.Status,
+		"the only failing check is gone, so the device is not failing")
+	require.Len(t, afterAction.Checks, 1)
+	assert.Equal(t, directActionID, afterAction.Checks[0].ActionId)
+	assert.Equal(t, "1", f.searchStatus(t, f.groupID))
+
+	require.NoError(t, actions.DeleteAction(context.Background(), mutationOp(), directActionID, false))
+	afterAll := f.compliance(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_UNKNOWN, afterAll.Status,
+		"no checks left is not-checked, which is UNKNOWN")
+	assert.Empty(t, afterAll.Checks)
+	assert.Equal(t, "0", f.searchStatus(t, f.groupID))
+
+	device, err := f.store.GetDevice(context.Background(), f.groupID)
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), device.ComplianceTotal)
+	assert.Equal(t, int32(0), device.CompliancePassing)
+	assert.Nil(t, device.ComplianceCheckedAt, "a device with no check has no check time")
+}
+
+// Detaching a rule from its policy retires that evaluation. Leaving the row
+// behind would let a stale status reappear the moment the rule is reattached.
+func TestComplianceIngest_DetachingARuleRetiresItsEvaluation(t *testing.T) {
+	f := newComplianceIngestFixture(t)
+	policies := compliance.NewState(compliance.StateConfig{Store: f.store, Now: func() time.Time { return f.now }})
+	actionID := f.complianceAction(t, "graced check")
+	policyID := f.policy(t, "baseline", map[string]int32{actionID: 24})
+
+	f.report(t, f.groupID, actionID, pmv1.ExecutionStatus_EXECUTION_STATUS_FAILED, false,
+		&pmv1.CommandOutput{ExitCode: 1}, f.now)
+	require.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_IN_GRACE_PERIOD, f.compliance(t, f.groupID).Status)
+
+	require.NoError(t, policies.RemoveRule(context.Background(), mutationOp(), policyID, actionID))
+	detached := f.compliance(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, detached.Status,
+		"a failing check with no rule has no grace period to sit in")
+	require.Len(t, detached.Checks, 1)
+	assert.Empty(t, f.policyStatus(t, f.groupID).Policies)
+	assert.Equal(t, "2", f.searchStatus(t, f.groupID))
+
+	var orphans int
+	require.NoError(t, f.raw.QueryRow(context.Background(), `
+		SELECT COUNT(*) FROM compliance_policy_evaluation
+		WHERE device_id = $1 AND action_id = $2`, f.groupID, actionID).Scan(&orphans))
+	assert.Equal(t, 0, orphans, "the detached rule leaves no evaluation behind")
+}
+
+// The ingestion path recognises exactly the actions the policy layer accepts:
+// an ordinary shell action never becomes compliance evidence, and a check that
+// belongs to no rule still reports through the direct surface.
+func TestComplianceIngest_OnlyDetectionOnlyActionsProduceFindings(t *testing.T) {
+	f := newComplianceIngestFixture(t)
+	ordinary := f.shellAction(t, "ordinary shell", &pmv1.ShellParams{Script: "true"})
+	f.report(t, f.groupID, ordinary, pmv1.ExecutionStatus_EXECUTION_STATUS_SUCCESS, false,
+		nil, f.now)
+	assert.Empty(t, f.compliance(t, f.groupID).Checks,
+		"a non-compliance action must not manufacture a compliance finding")
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_UNKNOWN, f.compliance(t, f.groupID).Status)
+
+	// A policy with no rules evaluates nothing and must not claim otherwise.
+	unattached := f.complianceAction(t, "unattached check")
+	f.policy(t, "empty", nil)
+	f.report(t, f.groupID, unattached, pmv1.ExecutionStatus_EXECUTION_STATUS_FAILED, false,
+		&pmv1.CommandOutput{ExitCode: 3}, f.now)
+
+	compliance := f.compliance(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, compliance.Status)
+	require.Len(t, compliance.Checks, 1)
+	assert.Equal(t, unattached, compliance.Checks[0].ActionId)
+
+	status := f.policyStatus(t, f.groupID)
+	assert.Equal(t, pmv1.ComplianceStatus_COMPLIANCE_STATUS_NON_COMPLIANT, status.OverallStatus)
+	assert.Empty(t, status.Policies, "a rule-less policy evaluates nothing")
+}

--- a/internal/store/delivery_sweep_test.go
+++ b/internal/store/delivery_sweep_test.go
@@ -1,0 +1,282 @@
+package store_test
+
+// The durable half of dispatch, and the placeholder-numbering rule it depends
+// on.
+//
+// sqlc expands sqlc.slice into bare `?` placeholders at run time. SQLite
+// numbers a bare `?` one above the highest parameter index assigned so far, so
+// any numbered parameter written after a slice collides with the slice's own
+// expansion as soon as the slice carries more than one element. The statement
+// then declares fewer parameters than the generated Go supplies and every call
+// fails. These tests exercise the sweep at one, two and three connected
+// devices, and then hold the whole generated slice-bearing corpus to the same
+// rule.
+
+import (
+	"context"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/manchtools/power-manage/server/internal/testdb"
+)
+
+// seedDueDelivery inserts one PENDING delivery whose availability the caller
+// chooses, which the shared seedDelivery helper pins to the insert instant.
+func seedDueDelivery(t *testing.T, raw *testdb.DB, deviceID string, availableAt time.Time) string {
+	t.Helper()
+	deliveryID := newID()
+	_, err := raw.Exec(context.Background(), `
+		INSERT INTO deliveries
+			(delivery_id, device_id, manifest_id, manifest, state, created_at, available_at)
+		VALUES ($1, $2, $3, '{}', 'PENDING', $4, $5)`,
+		deliveryID, deviceID, newID(), availableAt, availableAt)
+	require.NoError(t, err)
+	return deliveryID
+}
+
+// TestListDueDeliveries_SweepsEveryConnectedDevice drives the sweep exactly as
+// delivery.Dispatcher.queueDue does: one bounded page covering every currently
+// connected device. One device is the degenerate case; two and three are the
+// ordinary fleet.
+func TestListDueDeliveries_SweepsEveryConnectedDevice(t *testing.T) {
+	for _, connectedCount := range []int{1, 2, 3} {
+		t.Run(fmt.Sprintf("%d connected devices", connectedCount), func(t *testing.T) {
+			st, raw := setupSQLite(t)
+			ctx := context.Background()
+			now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+
+			connected := make([]string, 0, connectedCount)
+			due := make([]string, 0, connectedCount)
+			for range connectedCount {
+				device := seedDevice(t, raw)
+				connected = append(connected, device)
+				due = append(due, seedDueDelivery(t, raw, device, now.Add(-time.Minute)))
+				// Scheduled for later. Its exclusion is what proves the sweep
+				// instant reached the available_at comparison rather than a
+				// device id shifted into that slot by the expanded slice.
+				seedDueDelivery(t, raw, device, now.Add(time.Hour))
+			}
+			// Durable work for a device that is not connected stays behind; a
+			// reconnect queues it directly.
+			offline := seedDueDelivery(t, raw, seedDevice(t, raw), now.Add(-time.Minute))
+
+			rows, err := st.ListDueDeliveries(ctx, connected, now, 100)
+			require.NoError(t, err)
+
+			got := make([]string, 0, len(rows))
+			for _, row := range rows {
+				got = append(got, row.DeliveryID)
+			}
+			assert.ElementsMatch(t, due, got)
+			assert.NotContains(t, got, offline, "an offline device's due row is not swept")
+		})
+	}
+}
+
+// TestListDueDeliveries_BoundsThePage pins the page-size argument, the last
+// parameter of the statement and the one the expanded slice overruns first.
+func TestListDueDeliveries_BoundsThePage(t *testing.T) {
+	st, raw := setupSQLite(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+
+	connected := make([]string, 0, 3)
+	oldest := make([]string, 0, 3)
+	for i := range 3 {
+		device := seedDevice(t, raw)
+		connected = append(connected, device)
+		oldest = append(oldest, seedDueDelivery(t, raw, device, now.Add(-time.Duration(3-i)*time.Hour)))
+	}
+
+	rows, err := st.ListDueDeliveries(ctx, connected, now, 2)
+	require.NoError(t, err)
+	require.Len(t, rows, 2, "the sweep page is bounded by the requested size")
+	assert.Equal(t, oldest[0], rows[0].DeliveryID)
+	assert.Equal(t, oldest[1], rows[1].DeliveryID)
+}
+
+// sliceStatement is one generated statement that expands at least one
+// sqlc.slice at run time.
+type sliceStatement struct {
+	name    string
+	sql     string
+	markers int
+	// scalars counts every parameter the generated Go supplies besides the
+	// slice elements: the distinct numbered placeholders plus any bare one.
+	scalars int
+}
+
+var (
+	sliceMarkerPattern   = regexp.MustCompile(`/\*SLICE:[A-Za-z0-9_]+\*/\?`)
+	numberedParamPattern = regexp.MustCompile(`\?\d+`)
+	parameterPattern     = regexp.MustCompile(`\?\d*`)
+	stringLiteralPattern = regexp.MustCompile(`'(?:[^']|'')*'`)
+)
+
+// expand mirrors the substitution the generated wrapper performs, and returns
+// the arguments that wrapper would supply alongside it. Every argument is the
+// integer one so that each is legal wherever it lands — including a LIMIT,
+// which rejects a NULL or a string outright.
+func (s sliceStatement) expand(elements int) (string, []any) {
+	expanded := sliceMarkerPattern.ReplaceAllString(s.sql, strings.Repeat(",?", elements)[1:])
+	args := make([]any, s.scalars+s.markers*elements)
+	for i := range args {
+		args[i] = int64(1)
+	}
+	return expanded, args
+}
+
+// TestGeneratedSliceQueries_NumberEveryArgument holds every generated
+// slice-bearing statement to the rule the delivery sweep broke: expanded with
+// two and three slice elements, the statement must declare exactly as many
+// placeholders as the generated wrapper supplies arguments, numbered 1..N with
+// none claimed twice.
+//
+// The placeholder count, not the execution, is the discriminator. The SQLite
+// driver reports no fixed parameter count to database/sql, so a surplus
+// argument is discarded in silence and a statement whose numbered parameter
+// collides with an expanded slice still runs — against whichever value landed
+// in that slot. Execution is kept because it proves the expanded statement is
+// valid against the real schema at that argument count.
+func TestGeneratedSliceQueries_NumberEveryArgument(t *testing.T) {
+	statements := discoverSliceStatements(t)
+	require.NotEmpty(t, statements,
+		"discovery found no generated slice statement: the discovery is broken, not the queries")
+
+	discovered := 0
+	for _, statement := range statements {
+		discovered += statement.markers
+	}
+	require.Equal(t, countQuerySliceDirectives(t), discovered,
+		"every sqlc.slice in queries/ must reach the generated corpus this test covers")
+
+	_, raw := setupSQLite(t)
+	ctx := context.Background()
+	for _, statement := range statements {
+		t.Run(statement.name, func(t *testing.T) {
+			for _, elements := range []int{2, 3} {
+				expanded, args := statement.expand(elements)
+				distinct, highest := sqliteParameterIndexes(expanded)
+				assert.Equalf(t, len(args), distinct,
+					"%s with %d slice elements binds %d arguments to %d placeholders",
+					statement.name, elements, len(args), distinct)
+				assert.Equalf(t, len(args), highest,
+					"%s with %d slice elements numbers placeholders beyond its argument list",
+					statement.name, elements)
+				_, err := raw.Exec(ctx, expanded, args...)
+				require.NoErrorf(t, err, "%s with %d slice elements", statement.name, elements)
+			}
+		})
+	}
+}
+
+// sqliteParameterIndexes applies SQLite's numbering rule to a statement: `?N`
+// claims index N, and a bare `?` claims one above the highest index assigned so
+// far. It returns how many distinct indexes the statement declares and the
+// highest of them. Both equal the supplied argument count only when every
+// argument reaches a placeholder of its own.
+func sqliteParameterIndexes(query string) (distinct, highest int) {
+	stripped := stringLiteralPattern.ReplaceAllString(query, "''")
+	indexes := make(map[int]struct{})
+	for _, placeholder := range parameterPattern.FindAllString(stripped, -1) {
+		index := highest + 1
+		if digits := strings.TrimPrefix(placeholder, "?"); digits != "" {
+			parsed, err := strconv.Atoi(digits)
+			if err != nil {
+				continue
+			}
+			index = parsed
+		}
+		indexes[index] = struct{}{}
+		if index > highest {
+			highest = index
+		}
+	}
+	return len(indexes), highest
+}
+
+// discoverSliceStatements reads the generated package source and returns every
+// query constant carrying a slice marker. Parsing the emitted constants rather
+// than listing query names keeps the sweep honest as queries come and go.
+func discoverSliceStatements(t *testing.T) []sliceStatement {
+	t.Helper()
+	sources, err := filepath.Glob(filepath.Join("generated", "*.go"))
+	require.NoError(t, err)
+	require.NotEmpty(t, sources, "no generated sources found")
+
+	fileSet := token.NewFileSet()
+	statements := make([]sliceStatement, 0)
+	for _, source := range sources {
+		file, err := parser.ParseFile(fileSet, source, nil, 0)
+		require.NoError(t, err)
+		for _, declaration := range file.Decls {
+			general, ok := declaration.(*ast.GenDecl)
+			if !ok || general.Tok != token.CONST {
+				continue
+			}
+			for _, spec := range general.Specs {
+				value, ok := spec.(*ast.ValueSpec)
+				if !ok || len(value.Names) != 1 || len(value.Values) != 1 {
+					continue
+				}
+				literal, ok := value.Values[0].(*ast.BasicLit)
+				if !ok || literal.Kind != token.STRING {
+					continue
+				}
+				query, err := strconv.Unquote(literal.Value)
+				require.NoError(t, err)
+				markers := len(sliceMarkerPattern.FindAllString(query, -1))
+				if markers == 0 {
+					continue
+				}
+				statements = append(statements, sliceStatement{
+					name: value.Names[0].Name, sql: query,
+					markers: markers, scalars: countScalarParameters(query),
+				})
+			}
+		}
+	}
+	return statements
+}
+
+// countScalarParameters counts the parameters a slice-bearing statement binds
+// besides its slice elements. Numbered placeholders are counted once per
+// distinct index because sqlc reuses one index for a repeated named argument.
+func countScalarParameters(query string) int {
+	stripped := sliceMarkerPattern.ReplaceAllString(stringLiteralPattern.ReplaceAllString(query, "''"), "")
+	indexes := make(map[string]struct{})
+	for _, numbered := range numberedParamPattern.FindAllString(stripped, -1) {
+		indexes[numbered] = struct{}{}
+	}
+	bare := strings.Count(numberedParamPattern.ReplaceAllString(stripped, ""), "?")
+	return len(indexes) + bare
+}
+
+// countQuerySliceDirectives counts sqlc.slice across the query sources, giving
+// the generated-corpus discovery an independent expectation to meet.
+func countQuerySliceDirectives(t *testing.T) int {
+	t.Helper()
+	sources, err := filepath.Glob(filepath.Join("queries", "*.sql"))
+	require.NoError(t, err)
+	require.NotEmpty(t, sources, "no query sources found")
+
+	directives := 0
+	for _, source := range sources {
+		content, err := os.ReadFile(source)
+		require.NoError(t, err)
+		directives += strings.Count(string(content), "sqlc.slice(")
+	}
+	return directives
+}

--- a/internal/store/device_group_handlers_test.go
+++ b/internal/store/device_group_handlers_test.go
@@ -104,10 +104,25 @@ func TestDeviceGroupHandlers_CRUDMembershipAndAudit(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, windowed.Msg.Group.MaintenanceWindow.Schedule, 1)
 
-	_, err = f.handlers.UpdateDeviceGroupQuery(ctx, connect.NewRequest(&pmv1.UpdateDeviceGroupQueryRequest{
+	// The mode is a property the owner may change in either direction (target
+	// design §5.1). This group still has one hand-picked member; converting it
+	// hands membership to the rule, so that member does not survive the call.
+	converted, err := f.handlers.UpdateDeviceGroupQuery(ctx, connect.NewRequest(&pmv1.UpdateDeviceGroupQueryRequest{
 		Id: id, IsDynamic: true, DynamicQuery: `device.labels.env equals prod`,
 	}))
-	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+	require.NoError(t, err, "a curated group is convertible to a rule")
+	assert.True(t, converted.Msg.Group.IsDynamic)
+	assert.Equal(t, `device.labels.env equals prod`, converted.Msg.Group.DynamicQuery)
+	assert.Zero(t, converted.Msg.Group.MemberCount, "the curated membership does not survive the rule")
+	convertedGroup, err := f.handlers.GetDeviceGroup(ctx, connect.NewRequest(&pmv1.GetDeviceGroupRequest{Id: id}))
+	require.NoError(t, err)
+	assert.Empty(t, convertedGroup.Msg.Devices)
+	assert.Empty(t, convertedGroup.Msg.DeviceIds)
+	// An invalid query is still refused, and refusing it changes nothing.
+	_, err = f.handlers.UpdateDeviceGroupQuery(ctx, connect.NewRequest(&pmv1.UpdateDeviceGroupQueryRequest{
+		Id: id, IsDynamic: true, DynamicQuery: "(",
+	}))
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 	dynamic, err := f.handlers.CreateDeviceGroup(ctx, connect.NewRequest(&pmv1.CreateDeviceGroupRequest{
 		Name: "dynamic workstations", IsDynamic: true, DynamicQuery: `device.labels.env equals prod`,
 	}))

--- a/internal/store/device_group_state_test.go
+++ b/internal/store/device_group_state_test.go
@@ -158,3 +158,88 @@ func TestDeviceGroupState_DynamicShapeAndBoundsFailClosed(t *testing.T) {
 	_, err = state.UpdateQuery(ctx, deviceGroupOperation(), dynamic.ID, true, "(")
 	assert.True(t, errors.Is(err, devicegroup.ErrInvalidQuery))
 }
+
+// Converting a curated group into a rule-driven one is a supported mode change
+// (target design §5.1): the group keeps its identifier, assignments, schedules
+// and windows, which is the whole reason to convert rather than delete and
+// recreate. The membership it had as a static group is NOT kept — a group that
+// still listed hand-picked devices while claiming to be defined by a rule would
+// report members its own rule does not select, for as long as it took someone
+// to evaluate it.
+//
+// The opposite direction stays as it was: materializing a rule-driven group
+// freezes the membership the rule last produced (see the user-group handler
+// test, "materializing preserves the compiled membership").
+func TestDeviceGroupState_ConvertingCuratedGroupToRuleClearsItsMembers(t *testing.T) {
+	st, _ := setupSQLite(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 6, 9, 0, 0, 0, time.UTC)
+	state := devicegroup.NewState(devicegroup.Config{Store: st, Now: func() time.Time { return now }})
+
+	deviceIDs := []string{newID(), newID()}
+	_, err := st.WithAudit(ctx, deviceGroupOperation(), func(ctx context.Context, tx *store.Tx, rec *store.AuditRecorder) error {
+		for i, id := range deviceIDs {
+			if _, err := tx.InsertDevice(ctx, generated.InsertDeviceParams{
+				ID: id, Hostname: "curated-" + string(rune('a'+i)),
+				AgentSealingPublicKey: make([]byte, 32), RegisteredAt: &now,
+			}); err != nil {
+				return err
+			}
+			rec.Effect(store.AuditEffect{
+				ResourceType: "device", ResourceID: id, Action: "CREATE", Outcome: store.EffectApplied,
+				ChangedFields: []string{"hostname"},
+			})
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	createOp := deviceGroupOperation()
+	group, err := state.Create(ctx, createOp, devicegroup.CreateParams{
+		Name: "hand picked", CreatedBy: createOp.ActorID,
+	})
+	require.NoError(t, err)
+	added, err := state.AddDevices(ctx, deviceGroupOperation(), group.ID, deviceIDs)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), added)
+
+	// A rejected query must not be a half-conversion: the mode, the query and the
+	// membership all still have to be the ones the operator started with.
+	_, err = state.UpdateQuery(ctx, deviceGroupOperation(), group.ID, true, "(")
+	assert.ErrorIs(t, err, devicegroup.ErrInvalidQuery)
+	_, err = state.UpdateQuery(ctx, deviceGroupOperation(), group.ID, true, "")
+	assert.ErrorIs(t, err, devicegroup.ErrInvalidQuery)
+	unchanged, err := st.GetDeviceGroup(ctx, group.ID)
+	require.NoError(t, err)
+	assert.False(t, unchanged.IsDynamic, "a rejected query cannot convert the group")
+	assert.Equal(t, int64(2), unchanged.LiveMemberCount, "a rejected query cannot drop members")
+
+	convertOp := deviceGroupOperation()
+	converted, err := state.UpdateQuery(ctx, convertOp, group.ID, true, `device.labels.env equals prod`)
+	require.NoError(t, err, "a curated group must be convertible to a rule")
+	assert.True(t, converted.IsDynamic)
+	require.NotNil(t, converted.DynamicQuery)
+	assert.Equal(t, `device.labels.env equals prod`, *converted.DynamicQuery)
+	assert.Equal(t, int64(0), converted.LiveMemberCount, "the curated membership does not survive the rule")
+
+	members, err := st.ListDeviceGroupMembers(ctx, group.ID)
+	require.NoError(t, err)
+	assert.Empty(t, members, "membership has exactly one source once the group is a rule")
+
+	// The mode change, the query and the member clearing are one audited operation.
+	recorded, err := st.GetAuditOperation(ctx, convertOp.OperationID)
+	require.NoError(t, err)
+	effects, err := st.ListAuditEffects(ctx, recorded.OperationID)
+	require.NoError(t, err)
+	assert.NotEmpty(t, effects)
+
+	// Manual membership is closed while the rule owns it…
+	_, err = state.AddDevices(ctx, deviceGroupOperation(), group.ID, []string{deviceIDs[0]})
+	assert.ErrorIs(t, err, devicegroup.ErrDynamicGroup)
+
+	// …and the reverse direction still works, so the mode is genuinely a property
+	// the owner controls rather than a one-way door.
+	materialized, err := state.UpdateQuery(ctx, deviceGroupOperation(), group.ID, false, "")
+	require.NoError(t, err)
+	assert.False(t, materialized.IsDynamic)
+}

--- a/internal/store/device_group_state_test.go
+++ b/internal/store/device_group_state_test.go
@@ -232,6 +232,14 @@ func TestDeviceGroupState_ConvertingCuratedGroupToRuleClearsItsMembers(t *testin
 	effects, err := st.ListAuditEffects(ctx, recorded.OperationID)
 	require.NoError(t, err)
 	assert.NotEmpty(t, effects)
+	var changedFields []string
+	for _, effect := range effects {
+		if effect.ResourceType == "device_group" && effect.Action == "UPDATE" {
+			changedFields = effect.ChangedFields
+			break
+		}
+	}
+	assert.Contains(t, changedFields, "members", "the conversion audit must record the membership deletion")
 
 	// Manual membership is closed while the rule owns it…
 	_, err = state.AddDevices(ctx, deviceGroupOperation(), group.ID, []string{deviceIDs[0]})

--- a/internal/store/device_handlers_test.go
+++ b/internal/store/device_handlers_test.go
@@ -887,7 +887,7 @@ func TestDeviceHandlers_CreateLuksTokenIsOwnerOnlyHashedAndAudited(t *testing.T)
 	_, err := f.raw.Exec(context.Background(), `
 		INSERT INTO actions (id, name, action_type, params, created_by)
 		VALUES ($1, 'Encryption', $2,
-			'{"userPassphraseMinLength":24,"userPassphraseComplexity":"LPS_PASSWORD_COMPLEXITY_COMPLEX"}', $3)`,
+			'{"presharedKey":"enc:v1:stored","userPassphraseMinLength":24,"userPassphraseComplexity":"LPS_PASSWORD_COMPLEXITY_COMPLEX"}', $3)`,
 		actionID, int32(pmv1.ActionType_ACTION_TYPE_ENCRYPTION), f.actorID)
 	require.NoError(t, err)
 	ctx := f.actor("CreateLuksToken")

--- a/internal/store/device_handlers_test.go
+++ b/internal/store/device_handlers_test.go
@@ -927,7 +927,19 @@ func TestDeviceHandlers_CreateLuksTokenIsOwnerOnlyHashedAndAudited(t *testing.T)
 	_, err = ulid.ParseStrict(issued.Msg.Token)
 	require.NoError(t, err)
 	assert.Contains(t, issued.Msg.Uri, issued.Msg.Token)
-	assert.Contains(t, issued.Msg.CliCommand, issued.Msg.Token)
+	// F2: the advertised command must NOT carry the token on argv —
+	// /proc/<pid>/cmdline is world-readable and the client reads the passphrase
+	// before it dials, so an argv token is exposed for the whole typing window
+	// while being the sole authorization for a root daemon that writes LUKS
+	// keyslots. It must not advertise sudo either: the sudoers rule was removed
+	// precisely so this client is unprivileged, and an operator copying the
+	// string back would reinstate the escalation.
+	assert.NotContains(t, issued.Msg.CliCommand, issued.Msg.Token,
+		"CliCommand must not put the one-time LUKS token on argv")
+	assert.NotContains(t, issued.Msg.CliCommand, "sudo",
+		"the LUKS passphrase client is unprivileged; advertising sudo reinstates the removed escalation")
+	assert.Contains(t, issued.Msg.CliCommand, "luks set-passphrase",
+		"CliCommand must still name the command the operator runs")
 	hash := sha256.Sum256([]byte(issued.Msg.Token))
 	var storedHash string
 	var minLength, complexity int32

--- a/internal/store/device_handlers_test.go
+++ b/internal/store/device_handlers_test.go
@@ -566,46 +566,16 @@ func TestDeviceHandlers_GetDeviceLogResultReadsDirectState(t *testing.T) {
 }
 
 func TestDeviceHandlers_GetDeviceComplianceReadsDirectState(t *testing.T) {
-	f := newDeviceHandlerFixture(t)
-	policyID, graceActionID, failedActionID := newID(), newID(), newID()
+	f := newComplianceIngestFixture(t)
 	firstFailed := f.now.Add(-2 * time.Hour)
-	_, err := f.raw.Exec(context.Background(), `
-		UPDATE devices
-		SET compliance_status = 2, compliance_checked_at = $2,
-			compliance_total = 2, compliance_passing = 0
-		WHERE id = $1`, f.groupID, f.now)
-	require.NoError(t, err)
-	_, err = f.raw.Exec(context.Background(), `
-		INSERT INTO actions (id, name, action_type, params, created_by)
-		VALUES
-			($1, 'grace check', 1, '{}', $3),
-			($2, 'failed check', 1, '{}', $3)`, graceActionID, failedActionID, f.actorID)
-	require.NoError(t, err)
-	_, err = f.raw.Exec(context.Background(), `
-		INSERT INTO compliance_policies (id, name, created_by)
-		VALUES ($1, 'baseline', $2)`, policyID, f.actorID)
-	require.NoError(t, err)
-	_, err = f.raw.Exec(context.Background(), `
-		INSERT INTO compliance_policy_rules (policy_id, action_id, grace_period_hours)
-		VALUES ($1, $2, 4), ($1, $3, 0)`, policyID, graceActionID, failedActionID)
-	require.NoError(t, err)
-	_, err = f.raw.Exec(context.Background(), `
-		INSERT INTO compliance_results
-			(device_id, action_id, compliant, detection_output, checked_at)
-		VALUES
-			($1, $2, FALSE, '{"exitCode":1,"stdout":"grace drift"}', $4),
-			($1, $3, FALSE, '{"exitCode":2,"stderr":"failed drift"}', $4)`,
-		f.groupID, graceActionID, failedActionID, f.now)
-	require.NoError(t, err)
-	_, err = f.raw.Exec(context.Background(), `
-		INSERT INTO compliance_policy_evaluation
-			(device_id, policy_id, action_id, compliant, first_failed_at, status, checked_at)
-		VALUES
-			($1, $2, $3, FALSE, $5, 3, $6),
-			($1, $2, $4, FALSE, $5, 2, $6)`,
-		f.groupID, policyID, graceActionID, failedActionID, firstFailed, f.now)
-	require.NoError(t, err)
-	ctx := f.actor("GetDeviceCompliance", "GetDeviceCompliancePolicyStatus")
+	graceActionID := f.complianceAction(t, "grace check")
+	failedActionID := f.complianceAction(t, "failed check")
+	policyID := f.policy(t, "baseline", map[string]int32{graceActionID: 4, failedActionID: 0})
+	f.report(t, f.groupID, graceActionID, pmv1.ExecutionStatus_EXECUTION_STATUS_FAILED, false,
+		&pmv1.CommandOutput{ExitCode: 1, Stdout: "grace drift"}, firstFailed)
+	f.report(t, f.groupID, failedActionID, pmv1.ExecutionStatus_EXECUTION_STATUS_FAILED, false,
+		&pmv1.CommandOutput{ExitCode: 2, Stderr: "failed drift"}, firstFailed)
+	ctx := f.ctx
 
 	complianceResponse, err := f.handlers.GetDeviceCompliance(ctx,
 		connect.NewRequest(&pmv1.GetDeviceComplianceRequest{DeviceId: f.groupID}))
@@ -634,9 +604,11 @@ func TestDeviceHandlers_GetDeviceComplianceReadsDirectState(t *testing.T) {
 			assert.True(t, rule.GraceExpiresAt.AsTime().Equal(firstFailed.Add(4*time.Hour)))
 		}
 	}
-	assertSensitiveDeviceRead(t, f, powermanagev1connect.ControlServiceGetDeviceComplianceProcedure,
+	assertSensitiveDeviceRead(t, f.deviceHandlerFixture,
+		powermanagev1connect.ControlServiceGetDeviceComplianceProcedure,
 		"device_compliance", f.groupID)
-	assertSensitiveDeviceRead(t, f, powermanagev1connect.ControlServiceGetDeviceCompliancePolicyStatusProcedure,
+	assertSensitiveDeviceRead(t, f.deviceHandlerFixture,
+		powermanagev1connect.ControlServiceGetDeviceCompliancePolicyStatusProcedure,
 		"device_compliance_policy_status", f.groupID)
 
 	_, err = f.raw.Exec(context.Background(), `

--- a/internal/store/dispatch_handlers_test.go
+++ b/internal/store/dispatch_handlers_test.go
@@ -18,6 +18,7 @@ import (
 	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
 	"github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1/powermanagev1connect"
 	"github.com/manchtools/power-manage/server/internal/auth"
+	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
 	"github.com/manchtools/power-manage/server/internal/dispatch"
 	"github.com/manchtools/power-manage/server/internal/store"
 )
@@ -87,8 +88,10 @@ func newDispatchHandlerFixture(t *testing.T) *dispatchHandlerFixture {
 			($1, $2, 0, $4), ($1, $3, 1, $4)`, f.definition, f.set1, f.set2, now)
 	require.NoError(t, err)
 	f.waker = &committedWaker{store: st}
+	atRest, err := pmcrypto.NewEncryptor("0202020202020202020202020202020202020202020202020202020202020202")
+	require.NoError(t, err)
 	f.handlers = dispatch.NewHandlers(dispatch.HandlersConfig{
-		Store: st, Waker: f.waker,
+		Store: st, AtRest: atRest, Waker: f.waker,
 		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
 		Now:    func() time.Time { return now },
 	})

--- a/internal/store/dispatch_handlers_test.go
+++ b/internal/store/dispatch_handlers_test.go
@@ -448,6 +448,14 @@ func TestDispatchHandlers_RefuseUnauthorizedAndMissingTargetsWithoutWork(t *test
 			},
 		}))
 	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	emptyGroup := newID()
+	_, err = f.raw.Exec(context.Background(), `
+		INSERT INTO device_groups (id, name, created_at) VALUES ($1, 'empty', $2)`, emptyGroup, f.now)
+	require.NoError(t, err)
+	_, err = f.handlers.DispatchToGroup(f.actor("DispatchToGroup"),
+		connect.NewRequest(&pmv1.DispatchToGroupRequest{GroupId: emptyGroup}))
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err),
+		"an empty group must not make a missing action source look successful")
 	assert.Empty(t, f.waker.ids)
 }
 

--- a/internal/store/generated/compliance_policies.sql.go
+++ b/internal/store/generated/compliance_policies.sql.go
@@ -193,11 +193,14 @@ func (q *Queries) DeleteCompliancePolicyEvaluations(ctx context.Context, policyI
 }
 
 const deleteCompliancePolicyEvaluationsForAction = `-- name: DeleteCompliancePolicyEvaluationsForAction :many
+
 DELETE FROM compliance_policy_evaluation
 WHERE action_id = ?
-RETURNING policy_id
+RETURNING device_id
 `
 
+// Compliance evidence deletes return the devices whose summary was derived from
+// the rows they remove, so the caller can recompute it in the same transaction.
 func (q *Queries) DeleteCompliancePolicyEvaluationsForAction(ctx context.Context, actionID string) ([]string, error) {
 	rows, err := q.db.QueryContext(ctx, deleteCompliancePolicyEvaluationsForAction, actionID)
 	if err != nil {
@@ -206,11 +209,45 @@ func (q *Queries) DeleteCompliancePolicyEvaluationsForAction(ctx context.Context
 	defer rows.Close()
 	items := []string{}
 	for rows.Next() {
-		var policy_id string
-		if err := rows.Scan(&policy_id); err != nil {
+		var device_id string
+		if err := rows.Scan(&device_id); err != nil {
 			return nil, err
 		}
-		items = append(items, policy_id)
+		items = append(items, device_id)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const deleteCompliancePolicyEvaluationsForRule = `-- name: DeleteCompliancePolicyEvaluationsForRule :many
+DELETE FROM compliance_policy_evaluation
+WHERE policy_id = ?1 AND action_id = ?2
+RETURNING device_id
+`
+
+type DeleteCompliancePolicyEvaluationsForRuleParams struct {
+	PolicyID string `json:"policy_id"`
+	ActionID string `json:"action_id"`
+}
+
+func (q *Queries) DeleteCompliancePolicyEvaluationsForRule(ctx context.Context, arg DeleteCompliancePolicyEvaluationsForRuleParams) ([]string, error) {
+	rows, err := q.db.QueryContext(ctx, deleteCompliancePolicyEvaluationsForRule, arg.PolicyID, arg.ActionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []string{}
+	for rows.Next() {
+		var device_id string
+		if err := rows.Scan(&device_id); err != nil {
+			return nil, err
+		}
+		items = append(items, device_id)
 	}
 	if err := rows.Close(); err != nil {
 		return nil, err

--- a/internal/store/generated/deliveries.sql.go
+++ b/internal/store/generated/deliveries.sql.go
@@ -98,25 +98,35 @@ func (q *Queries) InsertDelivery(ctx context.Context, arg InsertDeliveryParams) 
 
 const listDueDeliveriesForDevices = `-- name: ListDueDeliveriesForDevices :many
 SELECT delivery_id, device_id, manifest_id, manifest, state, operation_id, push_epoch, attempt_count, created_at, available_at, expires_at, pushed_at, acked_receipt_at, terminal_at, result_code FROM deliveries
-WHERE device_id IN (/*SLICE:device_ids*/?)
+WHERE available_at <= ?1
+  AND ?2 > 0
   AND state IN ('PENDING', 'PUSHED')
-  AND available_at <= ?2
+  AND device_id IN (/*SLICE:device_ids*/?)
 ORDER BY available_at
-LIMIT ?3
+LIMIT ?2
 `
 
 type ListDueDeliveriesForDevicesParams struct {
-	DeviceIds   []string  `json:"device_ids"`
 	AvailableAt time.Time `json:"available_at"`
 	PageSize    int64     `json:"page_size"`
+	DeviceIds   []string  `json:"device_ids"`
 }
 
 // The sweep only considers live connections. Offline rows stay durable and a
 // reconnect queues them directly; excluding them here prevents a large offline
 // backlog from monopolising every bounded sweep page.
+//
+// Placeholder order is load-bearing. sqlc expands sqlc.slice into bare
+// placeholders at run time and SQLite numbers a bare placeholder one above the
+// highest index assigned so far, so a numbered argument written after the slice
+// is overrun the moment the slice carries a second element. Every argument
+// therefore takes its number before the slice: page_size is bound by the guard
+// below, where a non-positive page asks for nothing, and only reused by LIMIT.
 func (q *Queries) ListDueDeliveriesForDevices(ctx context.Context, arg ListDueDeliveriesForDevicesParams) ([]Delivery, error) {
 	query := listDueDeliveriesForDevices
 	var queryParams []interface{}
+	queryParams = append(queryParams, arg.AvailableAt)
+	queryParams = append(queryParams, arg.PageSize)
 	if len(arg.DeviceIds) > 0 {
 		for _, v := range arg.DeviceIds {
 			queryParams = append(queryParams, v)
@@ -125,8 +135,6 @@ func (q *Queries) ListDueDeliveriesForDevices(ctx context.Context, arg ListDueDe
 	} else {
 		query = strings.Replace(query, "/*SLICE:device_ids*/?", "NULL", 1)
 	}
-	queryParams = append(queryParams, arg.AvailableAt)
-	queryParams = append(queryParams, arg.PageSize)
 	rows, err := q.db.QueryContext(ctx, query, queryParams...)
 	if err != nil {
 		return nil, err

--- a/internal/store/generated/results.sql.go
+++ b/internal/store/generated/results.sql.go
@@ -573,6 +573,51 @@ func (q *Queries) InsertPendingOSQueryResult(ctx context.Context, arg InsertPend
 	return err
 }
 
+const listComplianceRuleEvaluationTargets = `-- name: ListComplianceRuleEvaluationTargets :many
+SELECT r.policy_id, r.grace_period_hours, e.first_failed_at
+FROM compliance_policy_rules r
+JOIN compliance_policies p ON p.id = r.policy_id AND p.is_deleted = FALSE
+LEFT JOIN compliance_policy_evaluation e
+       ON e.policy_id = r.policy_id AND e.action_id = r.action_id
+      AND e.device_id = ?1
+WHERE r.action_id = ?2
+ORDER BY r.policy_id
+`
+
+type ListComplianceRuleEvaluationTargetsParams struct {
+	DeviceID string `json:"device_id"`
+	ActionID string `json:"action_id"`
+}
+
+type ListComplianceRuleEvaluationTargetsRow struct {
+	PolicyID         string     `json:"policy_id"`
+	GracePeriodHours int32      `json:"grace_period_hours"`
+	FirstFailedAt    *time.Time `json:"first_failed_at"`
+}
+
+func (q *Queries) ListComplianceRuleEvaluationTargets(ctx context.Context, arg ListComplianceRuleEvaluationTargetsParams) ([]ListComplianceRuleEvaluationTargetsRow, error) {
+	rows, err := q.db.QueryContext(ctx, listComplianceRuleEvaluationTargets, arg.DeviceID, arg.ActionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []ListComplianceRuleEvaluationTargetsRow{}
+	for rows.Next() {
+		var i ListComplianceRuleEvaluationTargetsRow
+		if err := rows.Scan(&i.PolicyID, &i.GracePeriodHours, &i.FirstFailedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listDeviceComplianceEvaluations = `-- name: ListDeviceComplianceEvaluations :many
 SELECT e.policy_id, p.name AS policy_name,
        e.action_id, a.name AS action_name,
@@ -893,6 +938,160 @@ func (q *Queries) MarkExecutionRunning(ctx context.Context, arg MarkExecutionRun
 		arg.ID,
 		arg.DeliveryID,
 		arg.DeviceID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const refreshDeviceComplianceStatus = `-- name: RefreshDeviceComplianceStatus :execrows
+
+UPDATE devices
+SET compliance_total = (
+        SELECT COUNT(*)
+        FROM compliance_results cr
+        JOIN actions a ON a.id = cr.action_id AND a.is_deleted = FALSE
+        WHERE cr.device_id = ?1
+    ),
+    compliance_passing = (
+        SELECT COUNT(*)
+        FROM compliance_results cr
+        JOIN actions a ON a.id = cr.action_id AND a.is_deleted = FALSE
+        WHERE cr.device_id = ?1 AND cr.compliant
+    ),
+    compliance_checked_at = CASE
+        WHEN NOT EXISTS (
+            SELECT 1
+            FROM compliance_results cr
+            JOIN actions a ON a.id = cr.action_id AND a.is_deleted = FALSE
+            WHERE cr.device_id = ?1
+        ) THEN NULL
+        WHEN compliance_checked_at IS NULL OR compliance_checked_at < ?2
+        THEN ?2
+        ELSE compliance_checked_at
+    END,
+    compliance_status = (
+        SELECT CASE
+                   WHEN COUNT(*) = 0 THEN 0
+                   WHEN MAX(severity) = 3 THEN 2
+                   WHEN MAX(severity) = 2 THEN 3
+                   WHEN MAX(severity) = 1 THEN 0
+                   ELSE 1
+               END
+        FROM (
+            SELECT CASE e.status WHEN 2 THEN 3 WHEN 3 THEN 2 WHEN 0 THEN 1 ELSE 0 END AS severity
+            FROM compliance_policy_evaluation e
+            JOIN compliance_policies p ON p.id = e.policy_id AND p.is_deleted = FALSE
+            JOIN compliance_policy_rules r ON r.policy_id = e.policy_id AND r.action_id = e.action_id
+            JOIN actions a ON a.id = e.action_id AND a.is_deleted = FALSE
+            WHERE e.device_id = ?1
+            UNION ALL
+            SELECT CASE WHEN cr.compliant THEN 0 ELSE 3 END
+            FROM compliance_results cr
+            JOIN actions a ON a.id = cr.action_id AND a.is_deleted = FALSE
+            WHERE cr.device_id = ?1
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM compliance_policy_rules r
+                  JOIN compliance_policies p ON p.id = r.policy_id AND p.is_deleted = FALSE
+                  WHERE r.action_id = cr.action_id
+              )
+        )
+    )
+WHERE id = ?1 AND is_deleted = FALSE
+`
+
+type RefreshDeviceComplianceStatusParams struct {
+	DeviceID  string     `json:"device_id"`
+	CheckedAt *time.Time `json:"checked_at"`
+}
+
+// Rolls the device summary up from the rows just written. severity orders the
+// statuses by how bad they are (non-compliant worst, then grace, then unknown,
+// then compliant) because the stored enum is not in that order. A check that
+// belongs to no live policy rule has no grace period, so it contributes
+// directly. No rows at all leaves the device UNKNOWN, which is what
+// distinguishes "never checked" from "checked and failed".
+func (q *Queries) RefreshDeviceComplianceStatus(ctx context.Context, arg RefreshDeviceComplianceStatusParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, refreshDeviceComplianceStatus, arg.DeviceID, arg.CheckedAt)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
+const upsertCompliancePolicyEvaluation = `-- name: UpsertCompliancePolicyEvaluation :exec
+INSERT INTO compliance_policy_evaluation (
+    device_id, policy_id, action_id, compliant, first_failed_at, status, checked_at
+) VALUES (
+    ?1, ?2, ?3,
+    ?4, ?5, ?6, ?7
+)
+ON CONFLICT (device_id, policy_id, action_id) DO UPDATE
+SET compliant = excluded.compliant,
+    first_failed_at = excluded.first_failed_at,
+    status = excluded.status,
+    checked_at = excluded.checked_at
+`
+
+type UpsertCompliancePolicyEvaluationParams struct {
+	DeviceID      string     `json:"device_id"`
+	PolicyID      string     `json:"policy_id"`
+	ActionID      string     `json:"action_id"`
+	Compliant     bool       `json:"compliant"`
+	FirstFailedAt *time.Time `json:"first_failed_at"`
+	Status        int32      `json:"status"`
+	CheckedAt     *time.Time `json:"checked_at"`
+}
+
+func (q *Queries) UpsertCompliancePolicyEvaluation(ctx context.Context, arg UpsertCompliancePolicyEvaluationParams) error {
+	_, err := q.db.ExecContext(ctx, upsertCompliancePolicyEvaluation,
+		arg.DeviceID,
+		arg.PolicyID,
+		arg.ActionID,
+		arg.Compliant,
+		arg.FirstFailedAt,
+		arg.Status,
+		arg.CheckedAt,
+	)
+	return err
+}
+
+const upsertDeviceComplianceResult = `-- name: UpsertDeviceComplianceResult :execrows
+
+INSERT INTO compliance_results (
+    device_id, action_id, action_name, compliant, detection_output, checked_at
+)
+SELECT ?1, a.id, a.name, ?2,
+       ?3, ?4
+FROM actions a
+WHERE a.id = ?5 AND a.is_deleted = FALSE
+ON CONFLICT (device_id, action_id) DO UPDATE
+SET action_name = excluded.action_name,
+    compliant = excluded.compliant,
+    detection_output = excluded.detection_output,
+    checked_at = excluded.checked_at
+`
+
+type UpsertDeviceComplianceResultParams struct {
+	DeviceID        string          `json:"device_id"`
+	Compliant       bool            `json:"compliant"`
+	DetectionOutput sqlitetype.JSON `json:"detection_output"`
+	CheckedAt       time.Time       `json:"checked_at"`
+	ActionID        string          `json:"action_id"`
+}
+
+// Compliance ingestion is this statement and the three below it. All four run
+// inside the execution-result transaction, so the compliance surface cannot
+// disagree with the execution evidence it is derived from.
+func (q *Queries) UpsertDeviceComplianceResult(ctx context.Context, arg UpsertDeviceComplianceResultParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, upsertDeviceComplianceResult,
+		arg.DeviceID,
+		arg.Compliant,
+		arg.DetectionOutput,
+		arg.CheckedAt,
+		arg.ActionID,
 	)
 	if err != nil {
 		return 0, err

--- a/internal/store/maintenance_integration_test.go
+++ b/internal/store/maintenance_integration_test.go
@@ -276,8 +276,17 @@ func TestMaintenance_ExternalAnchorAndArchiveBeforeDeleteRunEndToEnd(t *testing.
 	require.NotEmpty(t, anchorRef)
 	assert.Equal(t, 1, anchorCount, "only the newest external head anchor is retained")
 	require.NotEmpty(t, prefixRef)
-	require.NoError(t, archive.Verify(ctx, archives, anchorRef))
-	require.NoError(t, archive.Verify(ctx, archives, prefixRef))
+
+	// The archived prefix is verified against the digest the checkpoint
+	// recorded, not against the sidecar sitting beside it on the same mount.
+	checkpoints, err := st.ListAuditCheckpoints(ctx, store.DefaultAuditStream)
+	require.NoError(t, err)
+	require.Len(t, checkpoints, 1)
+	require.Equal(t, prefixRef, checkpoints[0].ArchiveRef)
+	require.NoError(t, archive.Verify(ctx, archives, prefixRef, checkpoints[0].ArchiveDigest))
+
+	// The anchor object has no recorded digest; its content is authenticated
+	// by the chain reproducing it, which is what VerifyAudit checks.
 	require.NoError(t, service.VerifyAudit(ctx, jobs.Job{}),
 		"the external anchor must authenticate the now-archived boundary through its checkpoint")
 }

--- a/internal/store/manifest_compiler_test.go
+++ b/internal/store/manifest_compiler_test.go
@@ -2,14 +2,20 @@ package store_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/manchtools/power-manage/server/internal/testdb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	sdkcrypto "github.com/manchtools/power-manage-sdk/crypto"
 	pmv1 "github.com/manchtools/power-manage-sdk/gen/go/powermanage/v1"
+	"github.com/manchtools/power-manage/server/internal/actionparams"
+	pmcrypto "github.com/manchtools/power-manage/server/internal/crypto"
+	"github.com/manchtools/power-manage/server/internal/dispatch"
 	"github.com/manchtools/power-manage/server/internal/manifest"
+	"google.golang.org/protobuf/encoding/protojson"
 )
 
 type manifestFixture struct {
@@ -186,4 +192,71 @@ func TestManifestCompiler_RejectsMalformedStoredParams(t *testing.T) {
 	require.NoError(t, err)
 	_, err = f.compiler.Action(context.Background(), f.action2)
 	require.Error(t, err)
+}
+
+func TestManifestCompiler_SealsActionCredentialBeforeDeliveryPersistence(t *testing.T) {
+	st, raw := setupSQLite(t)
+	ctx := context.Background()
+	deviceID := seedDevice(t, raw)
+	agentKey, err := sdkcrypto.GenerateX25519()
+	require.NoError(t, err)
+	_, err = raw.Exec(ctx, `UPDATE devices SET agent_sealing_public_key = $2 WHERE id = $1`,
+		deviceID, agentKey.PublicKey().Bytes())
+	require.NoError(t, err)
+
+	atRest, err := pmcrypto.NewEncryptor("0303030303030303030303030303030303030303030303030303030303030303")
+	require.NoError(t, err)
+	actionID := newID()
+	const plaintext = "initial-volume-secret"
+	ciphertext, err := atRest.EncryptWithContext(plaintext,
+		pmcrypto.RowAAD(actionID, pmcrypto.PurposeActionEncryptionPresharedKey))
+	require.NoError(t, err)
+	stored, err := actionparams.MarshalActionParams(&pmv1.EncryptionAuthoringParams{
+		PresharedKey: &ciphertext, RotationIntervalDays: 30, MinWords: 5,
+	})
+	require.NoError(t, err)
+	_, err = raw.Exec(ctx, `
+		INSERT INTO actions
+			(id, name, action_type, desired_state, params, timeout_seconds, schedule, created_at)
+		VALUES ($1, 'encrypted disk', $2, $3, $4, 300, '{}', CURRENT_TIMESTAMP)`,
+		actionID, int32(pmv1.ActionType_ACTION_TYPE_ENCRYPTION),
+		int32(pmv1.DesiredState_DESIRED_STATE_PRESENT), stored)
+	require.NoError(t, err)
+
+	compiled, err := manifest.New(st, atRest).ActionForDevice(ctx, deviceID, actionID)
+	require.NoError(t, err)
+	sealed := compiled.Occurrences[0].Action.GetEncryption().PresharedKey
+	require.NotNil(t, sealed)
+	aad, info, err := sdkcrypto.FieldSealContext(sdkcrypto.DirectionControlToAgent,
+		"powermanage.v1.EncryptionParams", "preshared_key", deviceID, actionID)
+	require.NoError(t, err)
+	opened, err := sdkcrypto.OpenWithPrivateKey(agentKey, sealed.Ciphertext, aad, info)
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, string(opened))
+	clear(opened)
+
+	waker := &committedWaker{store: st}
+	service := dispatch.New(dispatch.Config{Store: st, Waker: waker})
+	op := mutationOp()
+	op.RequestDescriptor = "/powermanage.v1.ControlService/DispatchAction"
+	result, err := service.Submit(ctx, dispatch.SubmitParams{
+		Operation: op, DeviceID: deviceID,
+		Manifests: []dispatch.ManifestInput{{Manifest: compiled, PersistActionIDs: true}},
+	})
+	require.NoError(t, err)
+
+	delivery, err := st.GetDelivery(ctx, result.DeliveryIDs[0])
+	require.NoError(t, err)
+	var executionParams string
+	require.NoError(t, raw.QueryRow(ctx, `SELECT params FROM executions WHERE id = $1`,
+		result.Executions[0].ID).Scan(&executionParams))
+	for name, value := range map[string]string{
+		"delivery manifest": string(delivery.Manifest), "execution params": executionParams,
+	} {
+		assert.False(t, strings.Contains(value, plaintext), name)
+		assert.False(t, strings.Contains(value, ciphertext), name)
+	}
+	var persisted pmv1.EncryptionParams
+	require.NoError(t, protojson.Unmarshal([]byte(executionParams), &persisted))
+	assert.Equal(t, sealed.Ciphertext, persisted.GetPresharedKey().GetCiphertext())
 }

--- a/internal/store/queries/compliance_policies.sql
+++ b/internal/store/queries/compliance_policies.sql
@@ -125,6 +125,11 @@ DELETE FROM compliance_policy_rules
 WHERE policy_id = sqlc.arg(policy_id) AND action_id = sqlc.arg(action_id)
 RETURNING *;
 
+-- name: DeleteCompliancePolicyEvaluationsForRule :many
+DELETE FROM compliance_policy_evaluation
+WHERE policy_id = sqlc.arg(policy_id) AND action_id = sqlc.arg(action_id)
+RETURNING device_id;
+
 -- name: UpdateAuthoringCompliancePolicyRule :one
 UPDATE compliance_policy_rules
 SET grace_period_hours = sqlc.arg(grace_period_hours)
@@ -151,10 +156,13 @@ DELETE FROM compliance_policy_rules
 WHERE action_id = ?
 RETURNING policy_id;
 
+-- Compliance evidence deletes return the devices whose summary was derived from
+-- the rows they remove, so the caller can recompute it in the same transaction.
+
 -- name: DeleteCompliancePolicyEvaluationsForAction :many
 DELETE FROM compliance_policy_evaluation
 WHERE action_id = ?
-RETURNING policy_id;
+RETURNING device_id;
 
 -- name: DeleteComplianceResultsForAction :many
 DELETE FROM compliance_results

--- a/internal/store/queries/deliveries.sql
+++ b/internal/store/queries/deliveries.sql
@@ -62,10 +62,18 @@ WHERE delivery_id = sqlc.arg(delivery_id)
 -- The sweep only considers live connections. Offline rows stay durable and a
 -- reconnect queues them directly; excluding them here prevents a large offline
 -- backlog from monopolising every bounded sweep page.
+--
+-- Placeholder order is load-bearing. sqlc expands sqlc.slice into bare
+-- placeholders at run time and SQLite numbers a bare placeholder one above the
+-- highest index assigned so far, so a numbered argument written after the slice
+-- is overrun the moment the slice carries a second element. Every argument
+-- therefore takes its number before the slice: page_size is bound by the guard
+-- below, where a non-positive page asks for nothing, and only reused by LIMIT.
 SELECT * FROM deliveries
-WHERE device_id IN (sqlc.slice(device_ids))
+WHERE available_at <= sqlc.arg(available_at)
+  AND sqlc.arg(page_size) > 0
   AND state IN ('PENDING', 'PUSHED')
-  AND available_at <= sqlc.arg(available_at)
+  AND device_id IN (sqlc.slice(device_ids))
 ORDER BY available_at
 LIMIT sqlc.arg(page_size);
 

--- a/internal/store/queries/results.sql
+++ b/internal/store/queries/results.sql
@@ -82,6 +82,109 @@ LEFT JOIN compliance_results cr ON cr.device_id = e.device_id AND cr.action_id =
 WHERE e.device_id = ?
 ORDER BY e.policy_id, e.action_id;
 
+-- Compliance ingestion is this statement and the three below it. All four run
+-- inside the execution-result transaction, so the compliance surface cannot
+-- disagree with the execution evidence it is derived from.
+
+-- name: UpsertDeviceComplianceResult :execrows
+INSERT INTO compliance_results (
+    device_id, action_id, action_name, compliant, detection_output, checked_at
+)
+SELECT sqlc.arg(device_id), a.id, a.name, sqlc.arg(compliant),
+       sqlc.narg(detection_output), sqlc.arg(checked_at)
+FROM actions a
+WHERE a.id = sqlc.arg(action_id) AND a.is_deleted = FALSE
+ON CONFLICT (device_id, action_id) DO UPDATE
+SET action_name = excluded.action_name,
+    compliant = excluded.compliant,
+    detection_output = excluded.detection_output,
+    checked_at = excluded.checked_at;
+
+-- name: ListComplianceRuleEvaluationTargets :many
+SELECT r.policy_id, r.grace_period_hours, e.first_failed_at
+FROM compliance_policy_rules r
+JOIN compliance_policies p ON p.id = r.policy_id AND p.is_deleted = FALSE
+LEFT JOIN compliance_policy_evaluation e
+       ON e.policy_id = r.policy_id AND e.action_id = r.action_id
+      AND e.device_id = sqlc.arg(device_id)
+WHERE r.action_id = sqlc.arg(action_id)
+ORDER BY r.policy_id;
+
+-- name: UpsertCompliancePolicyEvaluation :exec
+INSERT INTO compliance_policy_evaluation (
+    device_id, policy_id, action_id, compliant, first_failed_at, status, checked_at
+) VALUES (
+    sqlc.arg(device_id), sqlc.arg(policy_id), sqlc.arg(action_id),
+    sqlc.arg(compliant), sqlc.narg(first_failed_at), sqlc.arg(status), sqlc.arg(checked_at)
+)
+ON CONFLICT (device_id, policy_id, action_id) DO UPDATE
+SET compliant = excluded.compliant,
+    first_failed_at = excluded.first_failed_at,
+    status = excluded.status,
+    checked_at = excluded.checked_at;
+
+-- Rolls the device summary up from the rows just written. severity orders the
+-- statuses by how bad they are (non-compliant worst, then grace, then unknown,
+-- then compliant) because the stored enum is not in that order. A check that
+-- belongs to no live policy rule has no grace period, so it contributes
+-- directly. No rows at all leaves the device UNKNOWN, which is what
+-- distinguishes "never checked" from "checked and failed".
+
+-- name: RefreshDeviceComplianceStatus :execrows
+UPDATE devices
+SET compliance_total = (
+        SELECT COUNT(*)
+        FROM compliance_results cr
+        JOIN actions a ON a.id = cr.action_id AND a.is_deleted = FALSE
+        WHERE cr.device_id = sqlc.arg(device_id)
+    ),
+    compliance_passing = (
+        SELECT COUNT(*)
+        FROM compliance_results cr
+        JOIN actions a ON a.id = cr.action_id AND a.is_deleted = FALSE
+        WHERE cr.device_id = sqlc.arg(device_id) AND cr.compliant
+    ),
+    compliance_checked_at = CASE
+        WHEN NOT EXISTS (
+            SELECT 1
+            FROM compliance_results cr
+            JOIN actions a ON a.id = cr.action_id AND a.is_deleted = FALSE
+            WHERE cr.device_id = sqlc.arg(device_id)
+        ) THEN NULL
+        WHEN compliance_checked_at IS NULL OR compliance_checked_at < sqlc.arg(checked_at)
+        THEN sqlc.arg(checked_at)
+        ELSE compliance_checked_at
+    END,
+    compliance_status = (
+        SELECT CASE
+                   WHEN COUNT(*) = 0 THEN 0
+                   WHEN MAX(severity) = 3 THEN 2
+                   WHEN MAX(severity) = 2 THEN 3
+                   WHEN MAX(severity) = 1 THEN 0
+                   ELSE 1
+               END
+        FROM (
+            SELECT CASE e.status WHEN 2 THEN 3 WHEN 3 THEN 2 WHEN 0 THEN 1 ELSE 0 END AS severity
+            FROM compliance_policy_evaluation e
+            JOIN compliance_policies p ON p.id = e.policy_id AND p.is_deleted = FALSE
+            JOIN compliance_policy_rules r ON r.policy_id = e.policy_id AND r.action_id = e.action_id
+            JOIN actions a ON a.id = e.action_id AND a.is_deleted = FALSE
+            WHERE e.device_id = sqlc.arg(device_id)
+            UNION ALL
+            SELECT CASE WHEN cr.compliant THEN 0 ELSE 3 END
+            FROM compliance_results cr
+            JOIN actions a ON a.id = cr.action_id AND a.is_deleted = FALSE
+            WHERE cr.device_id = sqlc.arg(device_id)
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM compliance_policy_rules r
+                  JOIN compliance_policies p ON p.id = r.policy_id AND p.is_deleted = FALSE
+                  WHERE r.action_id = cr.action_id
+              )
+        )
+    )
+WHERE id = sqlc.arg(device_id) AND is_deleted = FALSE;
+
 -- name: GetExecutionView :one
 SELECT e.*, COALESCE(a.name, '') AS action_name
 FROM executions e

--- a/internal/store/search_documents.go
+++ b/internal/store/search_documents.go
@@ -109,6 +109,10 @@ SELECT 'actions', a.id, a.name, COALESCE(a.description, ''),
        a.id || ' ' || CAST(a.action_type AS TEXT), lower(a.name),
 	       json_object(
 	         'type', CAST(a.action_type AS TEXT),
+	         -- The actions list renders this. Omitting it left the web adapter with
+	         -- no honest value and it hardcoded PRESENT, so every remove-action read
+	         -- as "Install" in the list while the detail page said "Remove".
+	         'desired_state', CAST(a.desired_state AS TEXT),
 	         'is_compliance', CASE WHEN EXISTS (SELECT 1 FROM compliance_policy_rules r WHERE r.action_id = a.id) THEN 'true' ELSE 'false' END,
          'assigned', CASE WHEN EXISTS (SELECT 1 FROM assignments x WHERE x.source_type = 'action' AND x.source_id = a.id AND x.is_deleted = false) THEN 'true' ELSE 'false' END,
          'created_at', COALESCE(strftime('%s', a.created_at), '0'),

--- a/internal/store/search_documents.go
+++ b/internal/store/search_documents.go
@@ -81,7 +81,7 @@ func refreshSearchDocument(ctx context.Context, tx *sql.Tx, scope, id string) er
 	if _, err := tx.ExecContext(ctx, `DELETE FROM search_documents WHERE scope = ? AND entity_id = ?`, scope, id); err != nil {
 		return fmt.Errorf("refresh %s search document: delete: %w", scope, err)
 	}
-	if _, err := tx.ExecContext(ctx, statement, id, id); err != nil {
+	if _, err := tx.ExecContext(ctx, statement, id); err != nil {
 		return fmt.Errorf("refresh %s search document: insert: %w", scope, err)
 	}
 	return nil
@@ -91,19 +91,70 @@ func rebuildSearchDocuments(ctx context.Context, tx *sql.Tx) error {
 	if _, err := tx.ExecContext(ctx, `DELETE FROM search_documents`); err != nil {
 		return fmt.Errorf("rebuild search documents: clear: %w", err)
 	}
-	for _, scope := range []string{
-		"actions", "action_sets", "definitions", "compliance_policies", "devices",
-		"device_groups", "users", "user_groups", "executions", "audit_events",
-	} {
-		if _, err := tx.ExecContext(ctx, searchDocumentStatements[scope], "", ""); err != nil {
-			return fmt.Errorf("rebuild %s search documents: %w", scope, err)
+	for _, spec := range searchDocumentSpecs {
+		if _, err := tx.ExecContext(ctx, searchDocumentRebuildStatements[spec.scope]); err != nil {
+			return fmt.Errorf("rebuild %s search documents: %w", spec.scope, err)
 		}
 	}
 	return nil
 }
 
-var searchDocumentStatements = map[string]string{
-	"actions": `
+// searchDocumentSpec states one scope's projection exactly once. The
+// single-entity and full-rebuild statements are derived from the same body, so
+// a refresh and a rebuild cannot drift into differently shaped documents.
+//
+// The split exists because one dual-purpose predicate cannot serve both. A
+// refresh runs inside the process-wide writer lock on every audited mutation,
+// and a predicate that disables itself on an empty bind is not sargable:
+// SQLite drives the outermost loop with a scan and applies the id as a residual
+// filter, so the executions refresh walked every execution row of every device,
+// a cost that grows without bound because executions are never pruned.
+type searchDocumentSpec struct {
+	scope string
+	// body is the INSERT ... SELECT ... FROM ... prefix, with no WHERE clause.
+	body string
+	// key is the single-entity predicate. It must be a bare equality on the
+	// source table's primary key and it is emitted first, because that is the
+	// form measured to make SQLite seek rather than scan. search_plan_test.go
+	// asserts the resulting plan against the real schema.
+	key string
+	// filter is the rebuild-time predicate, empty when the scope has none.
+	filter string
+}
+
+func (spec searchDocumentSpec) singleEntityStatement() string {
+	if spec.filter == "" {
+		return spec.body + "\nWHERE " + spec.key
+	}
+	return spec.body + "\nWHERE " + spec.key + " AND " + spec.filter
+}
+
+func (spec searchDocumentSpec) rebuildStatement() string {
+	if spec.filter == "" {
+		return spec.body
+	}
+	return spec.body + "\nWHERE " + spec.filter
+}
+
+var searchDocumentStatements, searchDocumentRebuildStatements = buildSearchDocumentStatements()
+
+func buildSearchDocumentStatements() (single, rebuild map[string]string) {
+	single = make(map[string]string, len(searchDocumentSpecs))
+	rebuild = make(map[string]string, len(searchDocumentSpecs))
+	for _, spec := range searchDocumentSpecs {
+		single[spec.scope] = spec.singleEntityStatement()
+		rebuild[spec.scope] = spec.rebuildStatement()
+	}
+	return single, rebuild
+}
+
+// One registration point per scope: rebuildSearchDocuments walks this slice in
+// order, and both statement maps are derived from it, so no scope can be
+// refreshable without also being rebuildable.
+var searchDocumentSpecs = []searchDocumentSpec{{
+	scope: "actions",
+	key:   "a.id = ?",
+	body: `
 INSERT INTO search_documents (scope, entity_id, primary_text, description, related_text, sort_text, fields)
 SELECT 'actions', a.id, a.name, COALESCE(a.description, ''),
        a.id || ' ' || CAST(a.action_type AS TEXT), lower(a.name),
@@ -117,9 +168,12 @@ SELECT 'actions', a.id, a.name, COALESCE(a.description, ''),
          'assigned', CASE WHEN EXISTS (SELECT 1 FROM assignments x WHERE x.source_type = 'action' AND x.source_id = a.id AND x.is_deleted = false) THEN 'true' ELSE 'false' END,
          'created_at', COALESCE(strftime('%s', a.created_at), '0'),
          'updated_at', COALESCE(strftime('%s', a.updated_at), '0'))
-FROM actions a WHERE a.is_deleted = false AND (? = '' OR a.id = ?)`,
-
-	"action_sets": `
+FROM actions a`,
+	filter: "a.is_deleted = false",
+}, {
+	scope: "action_sets",
+	key:   "s.id = ?",
+	body: `
 INSERT INTO search_documents (scope, entity_id, primary_text, description, related_text, sort_text, member_count, fields)
 SELECT 'action_sets', s.id, s.name, s.description,
        COALESCE((SELECT group_concat(a.name, ' ') FROM action_set_members m JOIN actions a ON a.id = m.action_id WHERE m.set_id = s.id AND a.is_deleted = false), ''),
@@ -131,9 +185,12 @@ SELECT 'action_sets', s.id, s.name, s.description,
          'action_names', COALESCE((SELECT group_concat(a.name, ', ') FROM action_set_members m JOIN actions a ON a.id = m.action_id WHERE m.set_id = s.id AND a.is_deleted = false), ''),
          'created_at', COALESCE(strftime('%s', s.created_at), '0'),
          'updated_at', COALESCE(strftime('%s', s.updated_at), '0'))
-FROM action_sets s WHERE s.is_deleted = false AND (? = '' OR s.id = ?)`,
-
-	"definitions": `
+FROM action_sets s`,
+	filter: "s.is_deleted = false",
+}, {
+	scope: "definitions",
+	key:   "d.id = ?",
+	body: `
 INSERT INTO search_documents (scope, entity_id, primary_text, description, related_text, sort_text, member_count, fields)
 SELECT 'definitions', d.id, d.name, d.description,
        COALESCE((SELECT group_concat(
@@ -147,9 +204,12 @@ SELECT 'definitions', d.id, d.name, d.description,
          'set_names', COALESCE((SELECT group_concat(s.name, ', ') FROM definition_members m JOIN action_sets s ON s.id = m.action_set_id WHERE m.definition_id = d.id AND s.is_deleted = false), ''),
          'created_at', COALESCE(strftime('%s', d.created_at), '0'),
          'updated_at', COALESCE(strftime('%s', d.updated_at), '0'))
-FROM definitions d WHERE d.is_deleted = false AND (? = '' OR d.id = ?)`,
-
-	"compliance_policies": `
+FROM definitions d`,
+	filter: "d.is_deleted = false",
+}, {
+	scope: "compliance_policies",
+	key:   "p.id = ?",
+	body: `
 INSERT INTO search_documents (scope, entity_id, primary_text, description, related_text, sort_text, member_count, fields)
 SELECT 'compliance_policies', p.id, p.name, p.description,
 	       COALESCE((SELECT group_concat(a.name || ' ' || COALESCE(a.description, ''), ' ') FROM compliance_policy_rules r JOIN actions a ON a.id = r.action_id WHERE r.policy_id = p.id), ''),
@@ -160,9 +220,12 @@ SELECT 'compliance_policies', p.id, p.name, p.description,
          'assigned', CASE WHEN EXISTS (SELECT 1 FROM assignments x WHERE x.source_type = 'compliance_policy' AND x.source_id = p.id AND x.is_deleted = false) THEN 'true' ELSE 'false' END,
 	         'action_names', COALESCE((SELECT group_concat(a.name, ', ') FROM compliance_policy_rules r JOIN actions a ON a.id = r.action_id WHERE r.policy_id = p.id), ''),
          'created_at', COALESCE(strftime('%s', p.created_at), '0'))
-FROM compliance_policies p WHERE p.is_deleted = false AND (? = '' OR p.id = ?)`,
-
-	"devices": `
+FROM compliance_policies p`,
+	filter: "p.is_deleted = false",
+}, {
+	scope: "devices",
+	key:   "d.id = ?",
+	body: `
 INSERT INTO search_documents (scope, entity_id, primary_text, description, related_text, sort_text, fields)
 SELECT 'devices', d.id, d.hostname, '',
 	       d.id || ' ' || d.agent_version || ' ' ||
@@ -182,9 +245,12 @@ SELECT 'devices', d.id, d.hostname, '',
          'labels', COALESCE((SELECT group_concat(key || '=' || value, ',') FROM device_labels l WHERE l.device_id = d.id), ''),
          'registered_at', COALESCE(strftime('%s', d.registered_at), '0'),
          'last_seen_at', COALESCE(strftime('%s', d.last_seen_at), '0'))
-FROM devices d WHERE d.is_deleted = false AND (? = '' OR d.id = ?)`,
-
-	"device_groups": `
+FROM devices d`,
+	filter: "d.is_deleted = false",
+}, {
+	scope: "device_groups",
+	key:   "g.id = ?",
+	body: `
 INSERT INTO search_documents (scope, entity_id, primary_text, description, related_text, sort_text, member_count, fields)
 SELECT 'device_groups', g.id, g.name, g.description, g.id, lower(g.name),
        (SELECT count(*) FROM device_group_members m WHERE m.group_id = g.id),
@@ -192,9 +258,12 @@ SELECT 'device_groups', g.id, g.name, g.description, g.id, lower(g.name),
          'is_dynamic', CASE WHEN g.is_dynamic THEN 'true' ELSE 'false' END,
          'member_count', CAST((SELECT count(*) FROM device_group_members m WHERE m.group_id = g.id) AS TEXT),
          'created_at', COALESCE(strftime('%s', g.created_at), '0'))
-FROM device_groups g WHERE g.is_deleted = false AND (? = '' OR g.id = ?)`,
-
-	"users": `
+FROM device_groups g`,
+	filter: "g.is_deleted = false",
+}, {
+	scope: "users",
+	key:   "u.id = ?",
+	body: `
 INSERT INTO search_documents (scope, entity_id, primary_text, description, related_text, sort_text, fields)
 SELECT 'users', u.id, CASE WHEN u.display_name <> '' THEN u.display_name ELSE u.email END, u.email,
        u.id || ' ' || u.given_name || ' ' || u.family_name || ' ' || u.preferred_username || ' ' || u.linux_username || ' ' ||
@@ -210,9 +279,12 @@ SELECT 'users', u.id, CASE WHEN u.display_name <> '' THEN u.display_name ELSE u.
            UNION SELECT r.name FROM user_group_members gm JOIN user_groups g ON g.id = gm.group_id AND g.is_deleted = false JOIN user_group_roles gr ON gr.group_id = gm.group_id JOIN roles r ON r.id = gr.role_id WHERE gm.user_id = u.id AND r.is_deleted = false)), ''),
          'created_at', COALESCE(strftime('%s', u.created_at), '0'),
          'last_login_at', COALESCE(strftime('%s', u.last_login_at), '0'))
-FROM users u WHERE u.is_deleted = false AND (? = '' OR u.id = ?)`,
-
-	"user_groups": `
+FROM users u`,
+	filter: "u.is_deleted = false",
+}, {
+	scope: "user_groups",
+	key:   "g.id = ?",
+	body: `
 INSERT INTO search_documents (scope, entity_id, primary_text, description, related_text, sort_text, member_count, fields)
 SELECT 'user_groups', g.id, g.name, g.description, g.id, lower(g.name),
        (SELECT count(*) FROM user_group_members m WHERE m.group_id = g.id),
@@ -220,9 +292,12 @@ SELECT 'user_groups', g.id, g.name, g.description, g.id, lower(g.name),
          'is_dynamic', CASE WHEN g.is_dynamic THEN 'true' ELSE 'false' END,
          'member_count', CAST((SELECT count(*) FROM user_group_members m WHERE m.group_id = g.id) AS TEXT),
          'created_at', COALESCE(strftime('%s', g.created_at), '0'))
-FROM user_groups g WHERE g.is_deleted = false AND (? = '' OR g.id = ?)`,
-
-	"executions": `
+FROM user_groups g`,
+	filter: "g.is_deleted = false",
+}, {
+	scope: "executions",
+	key:   "e.id = ?",
+	body: `
 INSERT INTO search_documents (scope, entity_id, primary_text, description, related_text, sort_text, fields)
 SELECT 'executions', e.id, COALESCE(d.hostname, e.device_id), COALESCE(a.name, ''),
 	   e.id || ' ' || e.device_id || ' ' || COALESCE(e.action_id, '') || ' ' || COALESCE(a.name, '') || ' ' || COALESCE(d.hostname, ''),
@@ -239,10 +314,12 @@ SELECT 'executions', e.id, COALESCE(d.hostname, e.device_id), COALESCE(a.name, '
          'completed_at', COALESCE(strftime('%s', e.completed_at), '0'))
 FROM executions e
 JOIN devices d ON d.id = e.device_id
-LEFT JOIN actions a ON a.id = e.action_id
-WHERE d.is_deleted = false AND (? = '' OR e.id = ?)`,
-
-	"audit_events": `
+LEFT JOIN actions a ON a.id = e.action_id`,
+	filter: "d.is_deleted = false",
+}, {
+	scope: "audit_events",
+	key:   "o.operation_id = ?",
+	body: `
 INSERT INTO search_documents (scope, entity_id, primary_text, description, related_text, sort_text, fields)
 SELECT 'audit_events', o.operation_id, o.request_descriptor, o.authorization_detail,
        o.origin || ' ' || o.operation_class || ' ' || o.actor_type || ' ' || o.result || ' ' ||
@@ -254,5 +331,5 @@ SELECT 'audit_events', o.operation_id, o.request_descriptor, o.authorization_det
          'stream_id', COALESCE((SELECT e.resource_id FROM audit_effects e WHERE e.operation_id = o.operation_id ORDER BY e.effect_seq LIMIT 1), o.operation_id),
          'actor_type', o.actor_type, 'actor_id', o.actor_id,
          'occurred_at', COALESCE(strftime('%s', o.occurred_at), '0'))
-FROM audit_operations o WHERE (? = '' OR o.operation_id = ?)`,
-}
+FROM audit_operations o`,
+}}

--- a/internal/store/search_plan_test.go
+++ b/internal/store/search_plan_test.go
@@ -1,0 +1,158 @@
+package store
+
+// A single-entity search-document refresh runs inside the process-wide writer
+// lock on every audited mutation, so its query plan is an availability
+// property rather than a micro-optimization: if SQLite drives the outermost
+// loop with a scan, every mutation costs O(that table) and the executions
+// scope, which is never pruned, makes that cost grow without bound.
+//
+// The plan is asserted against SQLite's real planner and the real baseline
+// schema because only a measured plan decides whether a predicate is sargable.
+// Statement text alone cannot show it.
+
+import (
+	"database/sql"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The outermost FROM is the only one that begins a line; every correlated
+// subquery in these statements is written inline.
+var searchDocumentSourceExpression = regexp.MustCompile(`(?m)^FROM\s+(\w+)\s+(\w+)`)
+
+// SQLite renders a seek as "SEARCH <alias> USING [COVERING ]INDEX <name>
+// (<column>=?)". A trailing qualifier such as " LEFT-JOIN" may follow, so the
+// expression is deliberately unanchored at the end.
+var indexSeekExpression = regexp.MustCompile(`^SEARCH (\w+) USING [^(]*\((\w+)=\?`)
+
+type queryPlanRow struct {
+	id     int64
+	parent int64
+	detail string
+}
+
+func TestSearchDocumentStatementsSeekTheSingleEntityByPrimaryKey(t *testing.T) {
+	t.Parallel()
+
+	require.NotEmpty(t, searchDocumentStatements,
+		"matches-zero guard: no search-document statements were discovered")
+
+	db := openSearchPlanDatabase(t)
+
+	for scope, statement := range searchDocumentStatements {
+		t.Run(scope, func(t *testing.T) {
+			table, alias := searchDocumentSource(t, statement)
+			key := primaryKeyColumn(t, db, table)
+
+			plan := explainQueryPlan(t, db, statement)
+			require.NotEmpty(t, plan,
+				"matches-zero guard: EXPLAIN QUERY PLAN returned no rows for scope %q", scope)
+
+			outer := make([]queryPlanRow, 0, len(plan))
+			for _, row := range plan {
+				if row.parent == 0 {
+					outer = append(outer, row)
+				}
+			}
+			require.NotEmpty(t, outer,
+				"matches-zero guard: EXPLAIN QUERY PLAN reported no outer loop for scope %q", scope)
+
+			seeksEntity := false
+			for _, row := range outer {
+				assert.Falsef(t, strings.HasPrefix(row.detail, "SCAN "),
+					"scope %q scans a joined table in the outer loop; the refresh predicate is not sargable: %s",
+					scope, row.detail)
+				match := indexSeekExpression.FindStringSubmatch(row.detail)
+				if match != nil && match[1] == alias && match[2] == key {
+					seeksEntity = true
+				}
+			}
+			assert.Truef(t, seeksEntity,
+				"scope %q must seek %s.%s (%s) from the bound entity id; plan was:\n%s",
+				scope, alias, key, table, formatQueryPlan(plan))
+		})
+	}
+}
+
+// searchDocumentSource reports the table and alias the statement's outermost
+// FROM names. Requiring exactly one match keeps a reformatted statement from
+// silently retargeting the assertion at a subquery.
+func searchDocumentSource(t *testing.T, statement string) (table, alias string) {
+	t.Helper()
+	matches := searchDocumentSourceExpression.FindAllStringSubmatch(statement, -1)
+	require.Lenf(t, matches, 1,
+		"expected exactly one line-leading FROM clause, found %d", len(matches))
+	return matches[0][1], matches[0][2]
+}
+
+// primaryKeyColumn reads the target table's single-column primary key from the
+// live catalog, so the assertion follows the schema instead of a copied list.
+func primaryKeyColumn(t *testing.T, db *sql.DB, table string) string {
+	t.Helper()
+	rows, err := db.QueryContext(t.Context(),
+		`SELECT name FROM pragma_table_info(?) WHERE pk > 0 ORDER BY pk`, table)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	columns := make([]string, 0, 1)
+	for rows.Next() {
+		var name string
+		require.NoError(t, rows.Scan(&name))
+		columns = append(columns, name)
+	}
+	require.NoError(t, rows.Err())
+	require.Lenf(t, columns, 1,
+		"matches-zero guard: table %q must have a single-column primary key, got %v", table, columns)
+	return columns[0]
+}
+
+func explainQueryPlan(t *testing.T, db *sql.DB, statement string) []queryPlanRow {
+	t.Helper()
+	// Binding is arity-driven so the assertion holds for whatever parameter
+	// shape the statement uses. SQLite plans at prepare time, so the bound
+	// values do not influence the result.
+	arguments := make([]any, strings.Count(statement, "?"))
+	for i := range arguments {
+		arguments[i] = ""
+	}
+	rows, err := db.QueryContext(t.Context(), "EXPLAIN QUERY PLAN "+statement, arguments...)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rows.Close()) }()
+
+	names, err := rows.Columns()
+	require.NoError(t, err)
+	require.Len(t, names, 4, "EXPLAIN QUERY PLAN shape changed")
+
+	plan := make([]queryPlanRow, 0, 8)
+	for rows.Next() {
+		var row queryPlanRow
+		var unused int64
+		require.NoError(t, rows.Scan(&row.id, &row.parent, &unused, &row.detail))
+		plan = append(plan, row)
+	}
+	require.NoError(t, rows.Err())
+	return plan
+}
+
+func formatQueryPlan(plan []queryPlanRow) string {
+	var out strings.Builder
+	for _, row := range plan {
+		out.WriteString("  ")
+		out.WriteString(row.detail)
+		out.WriteString("\n")
+	}
+	return out.String()
+}
+
+func openSearchPlanDatabase(t *testing.T) *sql.DB {
+	t.Helper()
+	store, err := New(t.Context(), filepath.Join(t.TempDir(), "control.sqlite"))
+	require.NoError(t, err)
+	t.Cleanup(store.Close)
+	return store.db
+}

--- a/internal/store/search_test.go
+++ b/internal/store/search_test.go
@@ -463,3 +463,38 @@ func requireOneSearchRow(t *testing.T, rows []store.SearchRow) store.SearchRow {
 	require.Len(t, rows, 1)
 	return rows[0]
 }
+
+// The actions LIST is rendered from search documents, not from ListActions, so
+// any field the list shows has to be IN the document. `desired_state` was not,
+// and the web adapter had no honest value to fall back on: it hardcoded
+// PRESENT, so every action in the list read "Install" no matter what it was —
+// including the remove-actions the detail page correctly showed as "Remove".
+//
+// A field the UI renders but the document omits is a fabrication waiting to
+// happen, which is why this asserts the document rather than the rendering.
+func TestSQLiteSearch_ActionDocumentCarriesDesiredState(t *testing.T) {
+	st, raw := setupSQLite(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	installID, removeID := newID(), newID()
+
+	_, err := raw.Exec(ctx, `INSERT INTO actions (id, name, description, action_type, desired_state, params, created_at, updated_at) VALUES
+		($1, 'install-curl', 'present', 100, 0, '{}', $3, $3),
+		($2, 'remove-curl', 'absent', 100, 1, '{}', $3, $3)`, installID, removeID, now)
+	require.NoError(t, err)
+	rebuildSearchFixture(t, st)
+
+	search := func(query string) []store.SearchRow {
+		t.Helper()
+		rows, _, err := st.Search(ctx, store.SearchParams{Scope: "actions", Query: query, Limit: 50})
+		require.NoError(t, err)
+		return rows
+	}
+
+	install := requireOneSearchRow(t, search("install-curl"))
+	assert.Equal(t, "0", install.Fields["desired_state"], "an install action is PRESENT")
+
+	remove := requireOneSearchRow(t, search("remove-curl"))
+	assert.Equal(t, "1", remove.Fields["desired_state"],
+		"a remove action must not be indexed as an install")
+}


### PR DESCRIPTION
## Summary

- encrypt authored action credentials at rest and seal them per assigned agent
- restore restart-based CA trust-bundle rotation from the proven historical design
- make audit evidence durable, verifiable, and deployable only on separate archive storage
- preserve rejected agent streams and fix search, identity, and group state transitions
- retain the build-tagged development authentication path for local UI work

Depends on https://github.com/manchtools/power-manage-sdk/pull/330.

## Validation

- `./scripts/verify.sh`
- Go build, vet, staticcheck, tests, and docref all pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved audit archive integrity verification and requires separate database and archive filesystems.
  * Added stricter CA trust-bundle validation and startup support.
  * Encrypts sensitive action and Wi-Fi credentials before delivery.

* **New Features**
  * Added compliance evidence tracking, grace periods, and refreshed device compliance status.
  * Supports converting curated groups to rule-driven groups.
  * Added development authentication and device-specific action delivery.

* **Bug Fixes**
  * Corrected stream authorization, search results, audit verification, and secure LUKS command output.

* **Documentation**
  * Updated deployment and configuration guidance for storage isolation and trust bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->