### PR TITLE
fix(release): publish native container platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,10 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - uses: actions/checkout@v5
+      - uses: docker/setup-qemu-action@v3
+        if: matrix.arch != 'amd64'
+        with:
+          platforms: ${{ matrix.arch }}
       - uses: actions/download-artifact@v5
         with:
           name: control-${{ matrix.arch }}
@@ -64,7 +68,7 @@ jobs:
       - name: Build and push control image
         run: |
           chmod +x dist/control-linux-${{ matrix.arch }}
-          docker build --provenance=false -f deploy/Containerfile.control \
+          docker build --platform "linux/${{ matrix.arch }}" --provenance=false -f deploy/Containerfile.control \
             --build-arg BINARY=dist/control-linux-${{ matrix.arch }} \
             -t ghcr.io/manchtools/power-manage-control:${GITHUB_REF_NAME#v}-${{ matrix.arch }} .
           docker push ghcr.io/manchtools/power-manage-control:${GITHUB_REF_NAME#v}-${{ matrix.arch }}

--- a/internal/architecture/deploy_test.go
+++ b/internal/architecture/deploy_test.go
@@ -84,6 +84,29 @@ func TestDeploymentIsTheTwoServiceTarget(t *testing.T) {
 	}
 }
 
+func TestReleaseBuildsEachContainerForItsTargetPlatform(t *testing.T) {
+	root := repositoryRoot(t)
+	raw, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "release.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workflow := string(raw)
+	start := strings.Index(workflow, "  containers:\n")
+	end := strings.Index(workflow, "\n  smoke:\n")
+	if start < 0 || end <= start {
+		t.Fatal("release workflow containers job not found")
+	}
+	containers := workflow[start:end]
+	for _, required := range []string{
+		"docker/setup-qemu-action@v3",
+		`--platform "linux/${{ matrix.arch }}"`,
+	} {
+		if !strings.Contains(containers, required) {
+			t.Errorf("release containers job is missing %q", required)
+		}
+	}
+}
+
 func repositoryRoot(t *testing.T) string {
 	t.Helper()
 	_, file, _, ok := runtime.Caller(0)

--- a/internal/architecture/deploy_test.go
+++ b/internal/architecture/deploy_test.go
@@ -99,6 +99,8 @@ func TestReleaseBuildsEachContainerForItsTargetPlatform(t *testing.T) {
 	containers := workflow[start:end]
 	for _, required := range []string{
 		"docker/setup-qemu-action@v3",
+		"if: matrix.arch != 'amd64'",
+		"platforms: ${{ matrix.arch }}",
 		`--platform "linux/${{ matrix.arch }}"`,
 	} {
 		if !strings.Contains(containers, required) {


### PR DESCRIPTION
## Summary
- build each container image for its declared matrix platform
- install QEMU for the arm64 Alpine build step
- guard the release container job against dropping target-platform handling

## Root cause
The RC1 manifest advertised both child images as `linux/amd64` because `docker build` inherited the amd64 runner platform even for the arm64 binary.

## Verification
- `go test ./...`
- `go vet ./...`
- `docref check` (20 up-to-date, 0 errors)
- focused architecture regression test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved container image builds for non-amd64 architectures.
  * Builds now explicitly target each configured platform.

* **Tests**
  * Added validation to ensure multi-architecture build settings remain correctly configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->